### PR TITLE
dev-cmd/irb: use irb executable instead of gem

### DIFF
--- a/Library/Homebrew/brew_irb_helpers.rb
+++ b/Library/Homebrew/brew_irb_helpers.rb
@@ -1,0 +1,36 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Helper methods for the Homebrew IRB/PRY shell run by `brew irb`
+
+require "formula"
+require "formulary"
+require "cask/cask_loader"
+
+class String
+  # @!visibility private
+  sig { params(args: Integer).returns(Formula) }
+  def f(*args)
+    Formulary.factory(self, *args)
+  end
+
+  # @!visibility private
+  sig { params(config: T.nilable(T::Hash[Symbol, T.untyped])).returns(Cask::Cask) }
+  def c(config: nil)
+    Cask::CaskLoader.load(self, config:)
+  end
+end
+
+class Symbol
+  # @!visibility private
+  sig { params(args: Integer).returns(Formula) }
+  def f(*args)
+    to_s.f(*args)
+  end
+
+  # @!visibility private
+  sig { params(config: T.nilable(T::Hash[Symbol, T.untyped])).returns(Cask::Cask) }
+  def c(config: nil)
+    to_s.c(config:)
+  end
+end

--- a/Library/Homebrew/brew_irbrc
+++ b/Library/Homebrew/brew_irbrc
@@ -2,7 +2,9 @@
 #       other IRB config files like `.irbrc`.
 # NOTE: This doesn't work with system Ruby for some reason.
 
-require 'irb/completion'
+require_relative "global"
+require_relative "brew_irb_helpers"
+require "irb/completion"
 
 IRB.conf[:HISTORY_FILE] = "#{Dir.home}/.brew_irb_history"
 IRB.conf[:IRB_NAME] = "brew"

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -2,37 +2,6 @@
 # frozen_string_literal: true
 
 require "abstract_command"
-require "formula"
-require "formulary"
-require "cask/cask_loader"
-
-class String
-  # @!visibility private
-  sig { params(args: Integer).returns(Formula) }
-  def f(*args)
-    Formulary.factory(self, *args)
-  end
-
-  # @!visibility private
-  sig { params(config: T.nilable(T::Hash[Symbol, T.untyped])).returns(Cask::Cask) }
-  def c(config: nil)
-    Cask::CaskLoader.load(self, config:)
-  end
-end
-
-class Symbol
-  # @!visibility private
-  sig { params(args: Integer).returns(Formula) }
-  def f(*args)
-    to_s.f(*args)
-  end
-
-  # @!visibility private
-  sig { params(config: T.nilable(T::Hash[Symbol, T.untyped])).returns(Cask::Cask) }
-  def c(config: nil)
-    to_s.c(config:)
-  end
-end
 
 module Homebrew
   module DevCmd
@@ -54,8 +23,6 @@ module Homebrew
 
       sig { override.void }
       def run
-        clean_argv
-
         if args.examples?
           puts <<~EOS
             'v8'.f # => instance of the v8 formula
@@ -72,8 +39,6 @@ module Homebrew
         if args.pry?
           Homebrew.install_bundler_gems!(groups: ["pry"])
           require "pry"
-        else
-          require "irb"
         end
 
         require "keg"
@@ -85,24 +50,16 @@ module Homebrew
           Pry.config.history_file = "#{Dir.home}/.brew_pry_history"
           Pry.config.prompt_name = "brew"
 
+          require "brew_irb_helpers"
+
           Pry.start
         else
           ENV["IRBRC"] = (HOMEBREW_LIBRARY_PATH/"brew_irbrc").to_s
 
-          IRB.start
+          $stdout.flush
+          $stderr.flush
+          exec File.join(RbConfig::CONFIG["bindir"], "irb"), "-I", $LOAD_PATH.join(File::PATH_SEPARATOR), *args.named
         end
-      end
-
-      private
-
-      # Remove the `--debug`, `--verbose` and `--quiet` options which cause problems
-      # for IRB and have already been parsed by the CLI::Parser.
-      sig { returns(T.nilable(T::Array[Symbol])) }
-      def clean_argv
-        global_options = Homebrew::CLI::Parser
-                         .global_options
-                         .flat_map { |options| options[0..1] }
-        ARGV.reject! { |arg| global_options.include?(arg) }
       end
     end
   end

--- a/Library/Homebrew/dev-cmd/ruby.rb
+++ b/Library/Homebrew/dev-cmd/ruby.rb
@@ -31,7 +31,7 @@ module Homebrew
 
         exec(*HOMEBREW_RUBY_EXEC_ARGS,
              "-I", $LOAD_PATH.join(File::PATH_SEPARATOR),
-             "-rglobal", "-rdev-cmd/irb",
+             "-rglobal", "-rbrew_irb_helpers",
              *ruby_sys_args)
       end
     end

--- a/Library/Homebrew/test/dev-cmd/irb_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/irb_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Homebrew::DevCmd::Irb do
       RUBY
 
       expect { brew "irb", irb_test }
-        .to output(/Interactive Homebrew Shell/).to_stdout
+        .to output(/Interactive Homebrew Shell.*<Formula testball \(stable\)/m).to_stdout
         .and not_to_output.to_stderr
         .and be_a_success
 


### PR DESCRIPTION
In Ruby 4.0, `irb` is no longer a default gem and is now a bundled gem which makes it difficult to use within Bundler. Installing it as a gem ourselves is messy as it installs all dependencies, even ones already as default gems, which then ends up needing to compile against libyaml etc and thus shipping even more portable formulae with the install.

Instead since the `irb` executable still exists and doesn't use Bundler, we could just use that instead to make things simpler.

TODO (by tomorrow):
- [ ] Actually test this against Ruby 4.0 to see if this approach works
- [ ] Convert the IRB path to shell to offset the cost of double Ruby startup time (not that it matters too much for `brew irb`)

Will hopefully help get Portable Ruby 4.0 over the line (https://github.com/Homebrew/brew/pull/21459).