### PR TITLE
dev-cmd/tests: remove HOMEBREW_REALLY_USE_INTERNAL_API from environment

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -265,6 +265,9 @@ module Homebrew
           ENV.delete(env)
         end
 
+        # TODO: remove this once we kill `HOMEBREW_REALLY_USE_INTERNAL_API`.
+        ENV.delete("HOMEBREW_REALLY_USE_INTERNAL_API")
+
         # Fetch JSON API files if needed.
         require "api"
         Homebrew::API.fetch_api_files!


### PR DESCRIPTION
This isn't an official variable yet but it's still happy to break tests if it's set.

CC @Rylan12 FYI