### PR TITLE
Add Genesis first-loop local workflow scripts

### DIFF
--- a/.claude/genesis/daily-sync-report.sh
+++ b/.claude/genesis/daily-sync-report.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+REPORT_DIR="$ROOT/.claude/genesis/reports"
+TODAY="$(date +%F)"
+REPORT_FILE="$REPORT_DIR/$TODAY.md"
+
+mkdir -p "$REPORT_DIR"
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+status="$(git status --short --branch)"
+recent_commits="$(git log --oneline -5)"
+
+cat > "$REPORT_FILE" <<EOF
+# Genesis Daily Sync Report ($TODAY)
+
+## Branch
+
+$branch
+
+## Status
+
+\`\`\`
+$status
+\`\`\`
+
+## Recent commits
+
+\`\`\`
+$recent_commits
+\`\`\`
+EOF
+
+echo "[genesis] report written: ${REPORT_FILE#$ROOT/}"

--- a/.claude/genesis/health-check-sync.sh
+++ b/.claude/genesis/health-check-sync.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+required_files=(
+  "$ROOT/.claude/genesis/worktree-first-loop.sh"
+  "$ROOT/.claude/genesis/health-check-sync.sh"
+  "$ROOT/.claude/genesis/daily-sync-report.sh"
+)
+
+echo "[genesis] health-check-sync"
+echo "- repo root: $ROOT"
+echo "- branch: $(git rev-parse --abbrev-ref HEAD)"
+
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "- git: ok"
+else
+  echo "- git: failed"
+  exit 1
+fi
+
+if [ -n "$(git status --short)" ]; then
+  echo "- working tree: dirty"
+else
+  echo "- working tree: clean"
+fi
+
+missing=0
+for file in "${required_files[@]}"; do
+  if [ -f "$file" ]; then
+    echo "- file exists: ${file#$ROOT/}"
+  else
+    echo "- file missing: ${file#$ROOT/}"
+    missing=1
+  fi
+done
+
+if [ "$missing" -ne 0 ]; then
+  echo "[genesis] health-check failed"
+  exit 1
+fi
+
+echo "[genesis] health-check passed"

--- a/.claude/genesis/worktree-first-loop.sh
+++ b/.claude/genesis/worktree-first-loop.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "" ]; then
+  echo "usage: $0 <feature-branch-name>"
+  echo "example: $0 feature/genesis-task-001"
+  exit 1
+fi
+
+branch="$1"
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$current_branch" != "$branch" ]; then
+  if git show-ref --verify --quiet "refs/heads/$branch"; then
+    git switch "$branch"
+  else
+    git switch -c "$branch"
+  fi
+fi
+
+"$(git rev-parse --show-toplevel)/.claude/genesis/health-check-sync.sh"
+"$(git rev-parse --show-toplevel)/.claude/genesis/daily-sync-report.sh"
+
+echo "[genesis] first-loop ready on $branch"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,7 @@
 @AGENTS.md
+
+## Genesis workflow (first loop)
+
+- `./.claude/genesis/worktree-first-loop.sh <feature-branch-name>`: ensure branch is active, then run health check and daily report.
+- `./.claude/genesis/health-check-sync.sh`: verify worktree state and required Genesis scripts.
+- `./.claude/genesis/daily-sync-report.sh`: generate a dated status report under `.claude/genesis/reports/`.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Features, usage and installation instructions are [summarised on the homepage](h
 
 `brew help`, `man brew` or check [our documentation](https://docs.brew.sh/).
 
+## Genesis Workflow (Local)
+
+For local Genesis rollout in this worktree, use the scripts under `.claude/genesis/`:
+
+- `./.claude/genesis/worktree-first-loop.sh <feature-branch-name>`
+- `./.claude/genesis/health-check-sync.sh`
+- `./.claude/genesis/daily-sync-report.sh`
+
 ## Troubleshooting
 
 First, please run `brew update` and `brew doctor`.


### PR DESCRIPTION
## Summary
- add a minimal `.claude/genesis/` first-loop workflow script to ensure a target feature branch is active and run local Genesis checks
- add `health-check-sync.sh` and `daily-sync-report.sh` to standardize local verification and daily reporting in worktree sessions
- document the local Genesis workflow entrypoints in `CLAUDE.md` and `README.md`

## Test plan
- [x] Run `./bin/brew lgtm` (fails in this environment due to local Swift toolchain/SDK mismatch, unrelated to these script/docs changes)
- [x] Verify scripts are executable and committed
- [ ] Reviewer validates workflow by running `./.claude/genesis/worktree-first-loop.sh feature/<name>` in a writable local worktree