### PR TITLE
test_bot: avoid deferring when only running dependent tests

### DIFF
--- a/Library/Homebrew/test_bot/formulae_dependents.rb
+++ b/Library/Homebrew/test_bot/formulae_dependents.rb
@@ -207,9 +207,11 @@ module Homebrew
 
         # Defer formulae which could be tested later
         # i.e. formulae that also depend on something else yet to be built in this test run.
-        dependents.reject! do |_, deps|
-          still_to_test = @dependent_testing_formulae - @testing_formulae_with_tested_dependents
-          deps.map { |d| d.to_formula.full_name }.intersect?(still_to_test)
+        unless args.only_formulae_dependents?
+          dependents.reject! do |_, deps|
+            still_to_test = @dependent_testing_formulae - @testing_formulae_with_tested_dependents
+            deps.map { |d| d.to_formula.full_name }.intersect?(still_to_test)
+          end
         end
 
         # Split into dependents that we could potentially be building from source and those


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This avoids issue of accidentally skipping some dependent tests.

For example, when `lua` and `luarocks` were modified in same PR, some direct dependents like `luacheck` got skipped as:

1. `lua` dependents were deferred to be handled by `luarocks`
2. `luarocks` dependents were skipped as build-only dependency

The defer logic is still needed if test-bot runs both formulae and dependent tests together to make sure bottles exist before tests.
