### PR TITLE
Link versioned keg-only formulae by default

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -66,6 +66,7 @@ class Caveats
   sig { params(skip_reason: T::Boolean).returns(T.nilable(String)) }
   def keg_only_text(skip_reason: false)
     return unless formula.keg_only?
+    return if formula.linked?
 
     s = if skip_reason
       ""

--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -54,10 +54,20 @@ module Homebrew
 
         kegs.freeze.each do |keg|
           keg_only = Formulary.keg_only?(keg.rack)
+          formula = begin
+            keg.to_formula
+          rescue FormulaUnavailableError
+            # Not all kegs may belong to current formulae
+            nil
+          end
+          versioned_keg_only_formula = formula.present? && formula.keg_only_reason&.versioned_formula?
 
           if keg.linked?
             opoo "Already linked: #{keg}"
-            name_and_flag = "#{"--HEAD " if args.HEAD?}#{"--force " if keg_only}#{keg.name}"
+            name_and_flag = +""
+            name_and_flag << "--HEAD " if args.HEAD?
+            name_and_flag << "--force " if keg_only && !versioned_keg_only_formula
+            name_and_flag << keg.name
             puts <<~EOS
               To relink, run:
                 brew unlink #{keg.name} && brew link #{name_and_flag}
@@ -72,15 +82,8 @@ module Homebrew
               puts "Would link:"
             end
             keg.link(**options)
-            puts_keg_only_path_message(keg) if keg_only
+            puts_keg_only_path_message(keg) if keg_only && !versioned_keg_only_formula
             next
-          end
-
-          formula = begin
-            keg.to_formula
-          rescue FormulaUnavailableError
-            # Not all kegs may belong to formulae
-            nil
           end
 
           if keg_only
@@ -94,14 +97,14 @@ module Homebrew
               next
             end
 
-            if !args.force? && (formula.blank? || !formula.keg_only_reason.versioned_formula?)
+            if !args.force? && (formula.nil? || !formula.keg_only_reason.versioned_formula?)
               opoo "#{keg.name} is keg-only and must be linked with `--force`."
               puts_keg_only_path_message(keg)
               next
             end
           end
 
-          Unlink.unlink_versioned_formulae(formula, verbose: args.verbose?) if formula
+          Unlink.unlink_link_overwrite_formulae(formula, verbose: args.verbose?) if formula
 
           keg.lock do
             print "Linking #{keg}... "
@@ -116,7 +119,9 @@ module Homebrew
               puts "#{n} symlinks created."
             end
 
-            puts_keg_only_path_message(keg) if keg_only && !Homebrew::EnvConfig.developer?
+            if keg_only && !versioned_keg_only_formula && !Homebrew::EnvConfig.developer?
+              puts_keg_only_path_message(keg)
+            end
           end
         end
       end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -626,11 +626,18 @@ class Formula
   # Returns any other `@`-versioned formulae names for any Formula (including versioned formulae).
   sig { returns(T::Array[String]) }
   def versioned_formulae_names
-    versioned_names = if tap
-      name_prefix = name.gsub(/(@[\d.]+)?$/, "")
-      T.must(tap).prefix_to_versioned_formulae_names.fetch(name_prefix, [])
+    name_prefix = unversioned_formula_name || name
+
+    versioned_names = if (formula_tap = tap)
+      formula_tap.prefix_to_versioned_formulae_names.fetch(name_prefix, [])
     elsif path.exist?
-      Pathname.glob(path.to_s.gsub(/(@[\d.]+)?\.rb$/, "@*.rb"))
+      versioned_formula_glob = if name_prefix.end_with?("-full")
+        "#{name_prefix.delete_suffix("-full")}@*-full.rb"
+      else
+        "#{name_prefix}@*.rb"
+      end
+
+      Pathname.glob((path.dirname/versioned_formula_glob).to_s)
               .map { |path| path.basename(".rb").to_s }
               .sort
     else
@@ -650,6 +657,94 @@ class Formula
     rescue FormulaUnavailableError
       nil
     end.sort_by(&:version).reverse
+  end
+
+  sig { returns(T.nilable(String)) }
+  def unversioned_formula_name
+    return unless versioned_formula?
+
+    name.sub(/@[\d.]+(?=-full$|$)/, "")
+  end
+
+  # Returns the sibling `-full` or non-`-full` formula names for any Formula.
+  sig { returns(T::Array[String]) }
+  def full_formulae_names
+    [
+      if name.end_with?("-full")
+        name.delete_suffix("-full")
+      else
+        "#{name}-full"
+      end,
+    ]
+  end
+
+  # Returns sibling `-full` or non-`-full` Formula objects for any Formula.
+  sig { returns(T::Array[Formula]) }
+  def full_formulae
+    full_formulae_names.filter_map do |formula_name|
+      Formula[formula_name]
+    rescue FormulaUnavailableError
+      nil
+    end.sort_by(&:version).reverse
+  end
+
+  sig { returns(T.nilable(String)) }
+  def link_overwrite_reason
+    installed_overwrite_formulae = link_overwrite_formulae.select(&:any_version_installed?)
+    return if installed_overwrite_formulae.empty?
+
+    reason_formulae = installed_overwrite_formulae.select(&:linked?)
+    status = if reason_formulae.empty?
+      reason_formulae = installed_overwrite_formulae
+      "installed"
+    else
+      "linked"
+    end
+
+    "#{reason_formulae.map(&:full_name).to_sentence} #{reason_formulae.one? ? "is" : "are"} already #{status}"
+  end
+
+  sig { returns(T::Array[String]) }
+  def link_overwrite_related_formula_names
+    [*versioned_formulae_names, *full_formulae_names, unversioned_formula_name].compact
+  end
+
+  # Returns sibling Formula names whose prefix links should be replaced when this Formula is linked.
+  sig { returns(T::Array[String]) }
+  def link_overwrite_formulae_names
+    formula_names = T.let(Set.new, T::Set[String])
+    pending_formula_names = T.let([name], T::Array[String])
+
+    pending_formula_names.each do |current_name|
+      current_formula = begin
+        if current_name == name
+          self
+        else
+          Formula[current_name]
+        end
+      rescue FormulaUnavailableError
+        next
+      end
+
+      current_formula.link_overwrite_related_formula_names.each do |related_formula_name|
+        next if related_formula_name == name
+        next unless formula_names.add?(related_formula_name)
+
+        pending_formula_names << related_formula_name
+      end
+    end
+
+    formula_names.to_a.sort
+  end
+
+  # Returns sibling Formulae whose prefix links should be replaced when this Formula is linked.
+  sig { returns(T::Array[Formula]) }
+  def link_overwrite_formulae
+    link_overwrite_formulae_names.filter_map do |formula_name|
+      Formula[formula_name]
+    rescue FormulaUnavailableError
+      nil
+    end
   end
 
   # Whether this {Formula} is version-synced with other formulae.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -52,7 +52,7 @@ class FormulaInstaller
   sig {
     params(
       formula:                    Formula,
-      link_keg:                   T::Boolean,
+      link_keg:                   T.nilable(T::Boolean),
       installed_as_dependency:    T::Boolean,
       installed_on_request:       T::Boolean,
       show_header:                T::Boolean,
@@ -81,7 +81,7 @@ class FormulaInstaller
   }
   def initialize(
     formula,
-    link_keg: false,
+    link_keg: nil,
     installed_as_dependency: false,
     installed_on_request: false,
     show_header: false,
@@ -113,7 +113,10 @@ class FormulaInstaller
     @overwrite = overwrite
     @keep_tmp = keep_tmp
     @debug_symbols = debug_symbols
-    @link_keg = T.let(!formula.keg_only? || link_keg, T::Boolean)
+    @installed_as_dependency = installed_as_dependency
+    @installed_on_request = installed_on_request
+    link_keg = !formula.keg_only? || auto_link_versioned_keg_only? if link_keg.nil?
+    @link_keg = T.let(link_keg, T::Boolean)
     @show_header = show_header
     @ignore_deps = ignore_deps
     @only_deps = only_deps
@@ -131,8 +134,6 @@ class FormulaInstaller
     @verbose = verbose
     @quiet = quiet
     @debug = debug
-    @installed_as_dependency = installed_as_dependency
-    @installed_on_request = installed_on_request
     @options = options
     @requirement_messages = T.let([], T::Array[String])
     @poured_bottle = T.let(false, T::Boolean)
@@ -937,6 +938,24 @@ on_request: installed_on_request?, options:)
     Homebrew.messages.record_caveats(formula.name, caveats)
   end
 
+  sig { returns(T.nilable(String)) }
+  def link_manual_command_warning
+    return if installed_as_dependency?
+    return unless formula.keg_only?
+    return unless formula.keg_only_reason.versioned_formula?
+    return if link_keg
+    return if formula.linked?
+
+    reason = formula.link_overwrite_reason
+    return if reason.blank?
+
+    <<~EOS
+      #{formula.full_name} was installed but not linked because #{reason}.
+      To link this version, run:
+        brew link #{formula.full_name}
+    EOS
+  end
+
   sig { void }
   def finish
     return if only_deps?
@@ -952,6 +971,8 @@ on_request: installed_on_request?, options:)
       end
     else
       link(keg)
+      warning = link_manual_command_warning
+      opoo warning if !quiet? && warning.present?
     end
 
     install_service
@@ -1162,7 +1183,7 @@ on_request: installed_on_request?, options:)
       keg.remove_linked_keg_record
     end
 
-    Homebrew::Unlink.unlink_versioned_formulae(formula, verbose: verbose?)
+    Homebrew::Unlink.unlink_link_overwrite_formulae(formula, verbose: verbose?)
 
     link_overwrite_backup = {} # Hash: conflict file -> backup file
     backup_dir = HOMEBREW_CACHE/"Backup"
@@ -1700,6 +1721,17 @@ on_request: installed_on_request?, options:)
   end
 
   private
+
+  sig { returns(T::Boolean) }
+  def auto_link_versioned_keg_only?
+    return false if installed_as_dependency?
+    return false unless formula.keg_only?
+    return false unless formula.keg_only_reason.versioned_formula?
+    return false if formula.any_version_installed?
+    return false if formula.link_overwrite_formulae.any?(&:any_version_installed?)
+
+    true
+  end
 
   sig { void }
   def lock

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -181,7 +181,7 @@ module Homebrew
             msg = <<~EOS
               #{msg}, it's just not linked.
               To link this version, run:
-                brew link #{formula}
+                brew link #{formula.full_name}
             EOS
           else
             msg = if quiet

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -844,7 +844,7 @@ class Tap
   def prefix_to_versioned_formulae_names
     @prefix_to_versioned_formulae_names ||= T.let(formula_names
                                                   .select { |name| name.include?("@") }
-                                                  .group_by { |name| name.gsub(/(@[\d.]+)?$/, "") }
+                                                  .group_by { |name| name.sub(/@[\d.]+(?=-full$|$)/, "") }
                                                   .transform_values(&:sort)
                                                   .freeze, T.nilable(T::Hash[String, T::Array[String]]))
   end

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -176,6 +176,12 @@ RSpec.describe Caveats do
         expect(caveats).to include("keg-only")
       end
 
+      it "omits keg-only caveats when the formula is linked" do
+        allow(f).to receive(:linked?).and_return(true)
+
+        expect(caveats).to be_empty
+      end
+
       it "gives command to be run when f.bin is a directory" do
         Pathname.new(f.bin).mkpath
         expect(caveats).to include(f.opt_bin.to_s)

--- a/Library/Homebrew/test/cmd/link_spec.rb
+++ b/Library/Homebrew/test/cmd/link_spec.rb
@@ -18,4 +18,36 @@ RSpec.describe Homebrew::Cmd::Link do
       .and be_a_success
     expect(HOMEBREW_PREFIX/"bin/testfile").to be_a_file
   end
+
+  {
+    "@-versioned" => "testball-link-output@1.0",
+    "-full"       => "testball-link-output-full",
+  }.each do |formula_type, formula_name|
+    it "does not print keg-only output when linking a #{formula_type} formula", :integration_test do
+      formula_content = <<~RUBY
+        keg_only :versioned_formula
+
+        def caveats
+          "unexpected caveat output"
+        end
+
+        def post_install
+          puts "unexpected post_install output"
+        end
+      RUBY
+
+      setup_test_formula formula_name, formula_content, tab_attributes: { installed_on_request: true }
+      Formula[formula_name].bin.mkpath
+      FileUtils.touch Formula[formula_name].bin/"link-output-test"
+      Formula[formula_name].any_installed_keg.unlink
+      unexpected_output = /unexpected caveat output|unexpected post_install output|
+                           If you need to have this software first in your PATH|keg-only/x
+
+      expect { brew "link", formula_name }
+        .to not_to_output(unexpected_output).to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+      expect(HOMEBREW_PREFIX/"bin/link-output-test").to be_a_file
+    end
+  end
 end

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -83,6 +83,185 @@ RSpec.describe FormulaInstaller do
     end
   end
 
+  describe "linking defaults" do
+    it "links non-keg-only formulae by default" do
+      ordinary_formula = formula "homebrew-link-default" do
+        url "foo-1.0"
+      end
+
+      expect(described_class.new(ordinary_formula).link_keg).to be true
+    end
+  end
+
+  describe "versioned keg-only linking defaults" do
+    let(:base_name) { "homebrew-versioned-formula" }
+    let(:formula_name) { "#{base_name}@1.0" }
+    let(:keg_only_formula) do
+      formula formula_name do
+        url "foo-1.0"
+        keg_only :versioned_formula
+      end
+    end
+
+    before do
+      allow(keg_only_formula).to receive_messages(any_version_installed?: false, link_overwrite_formulae: [])
+    end
+
+    it "links by default when no sibling variants are installed" do
+      fi = described_class.new(keg_only_formula)
+
+      expect(fi.link_keg).to be true
+    end
+
+    it "does not link by default when any version is already installed" do
+      allow(keg_only_formula).to receive(:any_version_installed?).and_return(true)
+
+      fi = described_class.new(keg_only_formula)
+
+      expect(fi.link_keg).to be false
+    end
+
+    it "links when explicitly requested" do
+      allow(keg_only_formula).to receive(:any_version_installed?).and_return(true)
+
+      fi = described_class.new(keg_only_formula, link_keg: true)
+
+      expect(fi.link_keg).to be true
+    end
+
+    it "does not link by default when another @-versioned formula is installed" do
+      other_version = formula "#{base_name}@2.0" do
+        url "foo-2.0"
+        keg_only :versioned_formula
+      end
+      allow(other_version).to receive(:any_version_installed?).and_return(true)
+      allow(keg_only_formula).to receive(:link_overwrite_formulae).and_return([other_version])
+
+      fi = described_class.new(keg_only_formula)
+
+      expect(fi.link_keg).to be false
+    end
+
+    it "does not link by default when the unversioned sibling is installed" do
+      unversioned_formula = formula base_name do
+        url "foo-1.0"
+      end
+      allow(unversioned_formula).to receive(:any_version_installed?).and_return(true)
+      allow(keg_only_formula).to receive(:link_overwrite_formulae).and_return([unversioned_formula])
+
+      fi = described_class.new(keg_only_formula)
+
+      expect(fi.link_keg).to be false
+    end
+
+    it "does not link by default when the -full variant is installed" do
+      full_variant = formula "#{base_name}-full" do
+        url "foo-full-1.0"
+        keg_only :versioned_formula
+      end
+      allow(full_variant).to receive(:any_version_installed?).and_return(true)
+      allow(keg_only_formula).to receive(:link_overwrite_formulae).and_return([full_variant])
+
+      fi = described_class.new(keg_only_formula)
+
+      expect(fi.link_keg).to be false
+    end
+
+    it "does not link by default when the non-full variant is installed" do
+      full_formula = formula "#{base_name}-full" do
+        url "foo-full-1.0"
+        keg_only :versioned_formula
+      end
+      non_full_variant = formula base_name do
+        url "foo-1.0"
+        keg_only :versioned_formula
+      end
+      allow(non_full_variant).to receive(:any_version_installed?).and_return(true)
+      allow(full_formula).to receive_messages(any_version_installed?:  false,
+                                              link_overwrite_formulae: [non_full_variant])
+
+      fi = described_class.new(full_formula)
+
+      expect(fi.link_keg).to be false
+    end
+  end
+
+  describe "#link" do
+    let(:versioned_formula) do
+      formula "homebrew-versioned-formula@1.0" do
+        url "foo-1.0"
+        keg_only :versioned_formula
+      end
+    end
+    let(:other_version) do
+      formula "homebrew-versioned-formula" do
+        url "foo-2.0"
+        keg_only :versioned_formula
+      end
+    end
+    let(:keg) do
+      instance_double(Keg, linked?: false)
+    end
+
+    before do
+      allow(Formula).to receive(:clear_cache)
+      allow(Cask::Caskroom).to receive(:path).and_return(Pathname("/tmp/nonexistent-caskroom"))
+      allow(versioned_formula).to receive_messages(link_overwrite_formulae: [other_version],
+                                                   any_version_installed?:  false)
+      allow(other_version).to receive(:any_version_installed?).and_return(true)
+    end
+
+    it "only optlinks when default linking is disabled by an installed sibling" do
+      installer = described_class.new(versioned_formula)
+
+      expect(installer.link_keg).to be false
+      expect(Homebrew::Unlink).not_to receive(:unlink_link_overwrite_formulae)
+      expect(keg).to receive(:optlink).with(verbose: false, overwrite: false)
+      expect(keg).not_to receive(:link)
+
+      installer.link(keg)
+    end
+
+    it "unlinks siblings before linking when explicitly requested" do
+      installer = described_class.new(versioned_formula, link_keg: true)
+
+      expect(installer.link_keg).to be true
+      expect(Homebrew::Unlink).to receive(:unlink_link_overwrite_formulae).with(versioned_formula,
+                                                                                verbose: false).ordered
+      expect(keg).to receive(:link).with(verbose: false, overwrite: false).ordered
+
+      installer.link(keg)
+    end
+  end
+
+  describe "#link_manual_command_warning" do
+    let(:base_name) { "homebrew-versioned-formula" }
+    let(:formula_name) { "#{base_name}@1.0" }
+    let(:keg_only_formula) do
+      formula formula_name do
+        url "foo-1.0"
+        keg_only :versioned_formula
+      end
+    end
+
+    it "explains why a versioned formula was installed but not linked" do
+      unversioned_formula = formula base_name do
+        url "foo-1.0"
+      end
+      allow(unversioned_formula).to receive_messages(any_version_installed?: true, linked?: true)
+      allow(keg_only_formula).to receive_messages(any_version_installed?: false, linked?: false,
+                                                  link_overwrite_formulae: [unversioned_formula])
+
+      installer = described_class.new(keg_only_formula)
+
+      expect(installer.send(:link_manual_command_warning)).to eq <<~EOS
+        #{formula_name} was installed but not linked because #{base_name} is already linked.
+        To link this version, run:
+          brew link #{formula_name}
+      EOS
+    end
+  end
+
   describe "#check_install_sanity" do
     it "raises on direct cyclic dependency" do
       ENV["HOMEBREW_DEVELOPER"] = "1"

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -158,12 +158,26 @@ RSpec.describe Formula do
       end
     end
 
+    let(:f_full) do
+      formula "foo-full" do
+        url "foo-full-1.0"
+      end
+    end
+
+    let(:f_full2) do
+      formula "foo@2.0-full" do
+        url "foo-full-2.0"
+      end
+    end
+
     before do
       # don't try to load/fetch gcc/glibc
       allow(DevelopmentTools).to receive_messages(needs_libc_formula?: false, needs_compiler_formula?: false)
 
       allow(Formulary).to receive(:load_formula_from_path).with(f2.name, f2.path).and_return(f2)
       allow(Formulary).to receive(:factory).with(f2.name).and_return(f2)
+      allow(Formulary).to receive(:load_formula_from_path).with(f_full2.name, f_full2.path).and_return(f_full2)
+      allow(Formulary).to receive(:factory).with(f_full2.name).and_return(f_full2)
       allow(f).to receive(:versioned_formulae_names).and_return([f2.name])
     end
 
@@ -177,6 +191,152 @@ RSpec.describe Formula do
       FileUtils.touch f.path
       FileUtils.touch f2.path
       expect(f2.versioned_formulae).to be_empty
+    end
+
+    it "returns versioned full formulae for the matching full formula" do
+      allow(f_full).to receive(:tap).and_return(nil)
+      FileUtils.touch f_full.path
+      FileUtils.touch f_full2.path
+      expect(f_full.versioned_formulae).to eq [f_full2]
+    end
+  end
+
+  describe "#full_formulae_names" do
+    let(:f) do
+      formula "foo" do
+        url "foo-1.0"
+      end
+    end
+
+    let(:f_full) do
+      formula "foo-full" do
+        url "foo-full-1.0"
+      end
+    end
+
+    let(:f_versioned) do
+      formula "foo@2.0" do
+        url "foo-2.0"
+      end
+    end
+
+    it "returns sibling full and non-full names" do
+      expect(f.full_formulae_names).to eq ["foo-full"]
+      expect(f_full.full_formulae_names).to eq ["foo"]
+      expect(f_versioned.full_formulae_names).to eq ["foo@2.0-full"]
+    end
+  end
+
+  describe "#full_formulae" do
+    let(:f) do
+      formula "foo" do
+        url "foo-1.0"
+      end
+    end
+
+    let(:f_full) do
+      formula "foo-full" do
+        url "foo-full-1.0"
+      end
+    end
+
+    before do
+      allow(Formulary).to receive(:load_formula_from_path).with(f_full.name, f_full.path).and_return(f_full)
+      allow(Formulary).to receive(:factory).with(f_full.name).and_return(f_full)
+      allow(f).to receive(:full_formulae_names).and_return([f_full.name])
+    end
+
+    it "returns array with sibling full formulae" do
+      FileUtils.touch f.path
+      FileUtils.touch f_full.path
+      expect(f.full_formulae).to eq [f_full]
+    end
+  end
+
+  describe "#unversioned_formula_name" do
+    let(:f) do
+      formula "foo" do
+        url "foo-1.0"
+      end
+    end
+
+    let(:f_full) do
+      formula "foo@2.0-full" do
+        url "foo-full-2.0"
+      end
+    end
+
+    let(:f_versioned) do
+      formula "foo@2.0" do
+        url "foo-2.0"
+      end
+    end
+
+    it "returns the matching unversioned sibling name" do
+      expect(f.unversioned_formula_name).to be_nil
+      expect(f_versioned.unversioned_formula_name).to eq("foo")
+      expect(f_full.unversioned_formula_name).to eq("foo-full")
+    end
+  end
+
+  describe "#link_overwrite_reason" do
+    it "explains why a formula was not linked" do
+      f = formula "foo@2.0" do
+        url "foo-2.0"
+      end
+      other_formula = formula "foo" do
+        url "foo-1.0"
+      end
+      allow(other_formula).to receive_messages(any_version_installed?: true, linked?: true)
+      allow(f).to receive(:link_overwrite_formulae).and_return([other_formula])
+
+      expect(f.link_overwrite_reason).to eq("foo is already linked")
+    end
+  end
+
+  describe "#link_overwrite_formulae_names" do
+    let(:f) do
+      formula "foo" do
+        url "foo-1.0"
+      end
+    end
+
+    let(:f_full) do
+      formula "foo-full" do
+        url "foo-full-1.0"
+      end
+    end
+
+    let(:f_versioned) do
+      formula "foo@2.0" do
+        url "foo-2.0"
+      end
+    end
+
+    let(:f_versioned_full) do
+      formula "foo@2.0-full" do
+        url "foo-full-2.0"
+      end
+    end
+
+    before do
+      [f, f_full, f_versioned, f_versioned_full].each do |formula|
+        allow(Formulary).to receive(:load_formula_from_path).with(formula.name, formula.path).and_return(formula)
+        allow(Formulary).to receive(:factory).with(formula.name).and_return(formula)
+        FileUtils.touch formula.path
+      end
+
+      allow(f).to receive_messages(versioned_formulae_names: [f_versioned.name], full_formulae_names: [f_full.name])
+      allow(f_full).to receive_messages(versioned_formulae_names: [], full_formulae_names: [f.name])
+      allow(f_versioned).to receive_messages(versioned_formulae_names: [],
+                                             full_formulae_names:      [f_versioned_full.name])
+      allow(f_versioned_full).to receive_messages(versioned_formulae_names: [],
+                                                  full_formulae_names:      [f_versioned.name])
+    end
+
+    it "includes direct full and unversioned siblings while excluding the current formula" do
+      expect(f_versioned.link_overwrite_formulae_names)
+        .to eq(["foo", f_full.name, f_versioned_full.name])
     end
   end
 

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -199,6 +199,16 @@ RSpec.describe Tap do
     expect(homebrew_foo_tap).not_to have_formula_file("Formula/baz.sh")
   end
 
+  describe "#prefix_to_versioned_formulae_names" do
+    it "groups versioned full formulae with their matching full formula" do
+      homebrew_foo_tap.instance_variable_set(:@prefix_to_versioned_formulae_names, nil)
+      allow(homebrew_foo_tap).to receive(:formula_names).and_return(["foo@2.0", "foo-full", "foo@2.0-full"])
+
+      expect(homebrew_foo_tap.prefix_to_versioned_formulae_names)
+        .to include("foo" => ["foo@2.0"], "foo-full" => ["foo@2.0-full"])
+    end
+  end
+
   describe "#remote" do
     it "returns the remote URL", :needs_network do
       setup_git_repo

--- a/Library/Homebrew/test/unlink_spec.rb
+++ b/Library/Homebrew/test/unlink_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "unlink"
+
+RSpec.describe Homebrew::Unlink do
+  describe ".unlink_link_overwrite_formulae" do
+    let(:formula) { instance_double(Formula) }
+    let(:linked_keg) { instance_double(Keg, directory?: true) }
+    let(:linked_formula) { instance_double(Formula, keg_only?: true, linked?: true, any_installed_keg: linked_keg) }
+    let(:linked_non_keg_only_keg) { instance_double(Keg, directory?: true) }
+    let(:linked_non_keg_only_formula) do
+      instance_double(Formula, keg_only?: false, linked?: true, any_installed_keg: linked_non_keg_only_keg)
+    end
+    let(:unlinked_formula) { instance_double(Formula, keg_only?: true, linked?: false, any_installed_keg: nil) }
+
+    it "unlinks linked sibling formulae returned by link_overwrite_formulae" do
+      allow(formula).to receive(:link_overwrite_formulae)
+        .and_return([linked_formula, linked_non_keg_only_formula, unlinked_formula])
+      expect(described_class).to receive(:unlink).with(linked_keg, verbose: true).once
+      expect(described_class).to receive(:unlink).with(linked_non_keg_only_keg, verbose: true).once
+
+      described_class.unlink_link_overwrite_formulae(formula, verbose: true)
+    end
+  end
+end

--- a/Library/Homebrew/unlink.rb
+++ b/Library/Homebrew/unlink.rb
@@ -5,9 +5,8 @@ module Homebrew
   # Provides helper methods for unlinking formulae and kegs with consistent output.
   module Unlink
     sig { params(formula: Formula, verbose: T::Boolean).void }
-    def self.unlink_versioned_formulae(formula, verbose: false)
-      formula.versioned_formulae
-             .select(&:keg_only?)
+    def self.unlink_link_overwrite_formulae(formula, verbose: false)
+      formula.link_overwrite_formulae
              .select(&:linked?)
              .filter_map(&:any_installed_keg)
              .select(&:directory?)


### PR DESCRIPTION
Link `@` versioned or `-full` formulae by default if their unversioned or unfull siblings are not installed.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Used OpenAI Codex 5.4 and manually reviewed, hand edited and tested all changes.

-----
