### PR TITLE
Promote parser deprecations to disabled for 5.1.0

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -215,14 +215,12 @@ module Homebrew
         return if global_switch
 
         if disable
-          # this odeprecated should turn into odisabled in 5.1.0
-          odeprecated "disable:", "odisabled:"
+          odisabled "disable:", "odisabled:"
           odisabled = disable
         end
         if !odeprecated && !odisabled && replacement
-          # this odeprecated should turn into odisabled in 5.1.0
-          odeprecated "replacement: without :odeprecated or :odisabled",
-                      "replacement: with :odeprecated or :odisabled"
+          odisabled "replacement: without :odeprecated or :odisabled",
+                    "replacement: with :odeprecated or :odisabled"
           odeprecated = true
         end
         hidden = true if odisabled || odeprecated

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -27,6 +27,21 @@ RSpec.describe Cask::DSL, :cask, :no_api do
     end
   end
 
+  describe "when a Cask includes a historically-removed method" do
+    let(:attempt_removed_method) do
+      Cask::Cask.new("removed-method-cask") do
+        gpg "https://example.com/gpg-key"
+      end
+    end
+
+    it "raises a CaskInvalidError for the removed method" do
+      expect { attempt_removed_method }.to raise_error(
+        Cask::CaskInvalidError,
+        /undefined method 'gpg' for Cask 'removed-method-cask'/,
+      )
+    end
+  end
+
   describe "header line" do
     context "when invalid" do
       let(:token) { "invalid-header-format" }

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -306,6 +306,17 @@ RSpec.describe Homebrew::CLI::NamedArgs do
       expect(kegs.map(&:name)).to eq ["foo"]
       expect(casks).to eq [baz]
     end
+
+    it "returns a stub cask when cask is unreadable and method is keg-like", :needs_macos do
+      setup_unredable_cask "baz"
+      (Cask::Caskroom.path/"baz/1.0").mkpath
+
+      _kegs, casks = described_class.new("baz").to_kegs_to_casks
+
+      expect(casks.length).to eq 1
+      expect(casks.first).to be_a Cask::Cask
+      expect(casks.first.token).to eq "baz"
+    end
   end
 
   describe "#homebrew_tap_cask_names" do

--- a/Library/Homebrew/test/deprecate_disable_spec.rb
+++ b/Library/Homebrew/test/deprecate_disable_spec.rb
@@ -107,10 +107,16 @@ RSpec.describe DeprecateDisable do
         .to eq "deprecated because it does not build!"
     end
 
-    it "returns a deprecation message with disable date" do
+    it "returns a deprecation message with future disable date" do
       allow(Date).to receive(:today).and_return(deprecate_date + 1)
       expect(described_class.message(deprecated_formula_with_date))
         .to eq "deprecated because it does not build! It will be disabled on #{disable_date}."
+    end
+
+    it "returns a deprecation message with past disable date" do
+      allow(Date).to receive(:today).and_return(disable_date + 1)
+      expect(described_class.message(deprecated_formula_with_date))
+        .to eq "deprecated because it does not build! It was disabled on #{disable_date}."
     end
 
     it "returns a disable message with a custom reason" do


### PR DESCRIPTION
## Summary
- Upgrade two `odeprecated` calls in `cli/parser.rb` to `odisabled` as scheduled for 5.1.0: the `disable:` parameter and `replacement: without :odeprecated/:odisabled` patterns
- Add test for past-disable-date messaging in `deprecate_disable_spec`
- Add test for historically-removed cask DSL methods (e.g. `gpg`) raising `CaskInvalidError`
- Add test for named_args keg-like-cask fallback returning a stub when cask is unreadable

## Test plan
- [x] `brew style --fix` passes on all changed files
- [x] `brew typecheck` passes
- [x] `brew tests --only=cli/named_args` passes
- [x] `brew tests --only=deprecate_disable` passes
- [x] `brew tests --only=cask/dsl` passes
- [x] `brew tests --only=cask/cask_loader` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)