### PR TITLE
formula: restore using replacement from `disable!`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4674,29 +4674,33 @@ class Formula
         raise ArgumentError, "more than one of replacement, replacement_formula and/or replacement_cask specified!"
       end
 
+      @deprecate_args = T.let(
+        { date:, because:, replacement_formula:, replacement_cask: },
+        T.nilable(T::Hash[Symbol, T.nilable(T.any(String, Symbol))]),
+      )
+
       if replacement
+        replacement_formula ||= replacement
+        replacement_cask ||= replacement
         odeprecated(
           "deprecate!(:replacement)",
           "deprecate!(:replacement_formula) or deprecate!(:replacement_cask)",
         )
       end
 
-      @deprecate_args = T.let(
-        { date:, because:, replacement_formula:, replacement_cask: },
-        T.nilable(T::Hash[Symbol, T.nilable(T.any(String, Symbol))]),
-      )
+      deprecation_date = Date.parse(date)
+      @deprecation_date = T.let(deprecation_date, T.nilable(Date))
+      @deprecated = T.let(deprecation_date <= Date.today, T.nilable(T::Boolean))
 
-      @deprecation_date = T.let(Date.parse(date), T.nilable(Date))
-      @deprecated = T.let(T.must(@deprecation_date) <= Date.today, T.nilable(T::Boolean))
       if @deprecated
-        @deprecation_reason = T.let(because, T.nilable(T.any(String, Symbol)))
-        @deprecation_replacement_formula = T.let(replacement_formula.presence || replacement, T.nilable(String))
-        @deprecation_replacement_cask = T.let(replacement_cask.presence || replacement, T.nilable(String))
+        @deprecation_reason = because if because
+        @deprecation_replacement_formula = replacement_formula if replacement_formula
+        @deprecation_replacement_cask = replacement_cask if replacement_cask
       else
         # Reset these to handle disable! before deprecate!
-        @deprecation_reason = nil
-        @deprecation_replacement_formula = nil
-        @deprecation_replacement_cask = nil
+        @deprecation_reason = T.let(nil, T.nilable(T.any(String, Symbol)))
+        @deprecation_replacement_formula = T.let(nil, T.nilable(String))
+        @deprecation_replacement_cask = T.let(nil, T.nilable(String))
       end
     end
 
@@ -4784,27 +4788,31 @@ class Formula
         raise ArgumentError, "more than one of replacement, replacement_formula and/or replacement_cask specified!"
       end
 
+      @disable_args = T.let(
+        { date:, because:, replacement_formula:, replacement_cask: },
+        T.nilable(T::Hash[Symbol, T.nilable(T.any(String, Symbol))]),
+      )
+
       if replacement
+        replacement_formula ||= replacement
+        replacement_cask ||= replacement
         odeprecated(
           "disable!(:replacement)",
           "disable!(:replacement_formula) or disable!(:replacement_cask)",
         )
       end
 
-      @disable_args = T.let(
-        { date:, because:, replacement_formula:, replacement_cask: },
-        T.nilable(T::Hash[Symbol, T.nilable(T.any(String, Symbol))]),
-      )
+      disable_date = Date.parse(date)
+      @disable_date = T.let(disable_date, T.nilable(Date))
 
-      @disable_date = T.let(Date.parse(date), T.nilable(Date))
+      if disable_date > Date.today
+        return if @deprecation_date.present? && !@deprecated
 
-      if T.must(@disable_date) > Date.today
-        return if @deprecation_date.present?
-
-        @deprecation_reason = T.let(because, T.nilable(T.any(String, Symbol)))
-        @deprecation_replacement_formula = T.let(replacement_formula.presence || replacement, T.nilable(String))
-        @deprecation_replacement_cask = T.let(replacement_cask.presence || replacement, T.nilable(String))
-        @deprecated = T.let(true, T.nilable(T::Boolean))
+        # Use `disable!` information if not set in `deprecate!`
+        @deprecation_reason ||= because
+        @deprecation_replacement_formula ||= replacement_formula
+        @deprecation_replacement_cask ||= replacement_cask
+        @deprecated ||= true
         return
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Previous behavior before Homebrew/brew#21644

This allows providing a single `replacement_formula:` on the `disable!` stanza rather than duplicating it in both `disable!` and `deprecate!`

e.g.
```rb
deprecate! date: "2026-03-06", because: :unmaintained
disable! date: "2026-03-06", because: :unmaintained, replacement_formula: "foo"
```

---

Also remove some `T.must` and move some `T.let` to the simpler (nil) case for readability.