### PR TITLE
docs: fix Ronn parser compatibility typo

### DIFF
--- a/Library/Homebrew/manpages/parser/ronn.rb
+++ b/Library/Homebrew/manpages/parser/ronn.rb
@@ -6,7 +6,7 @@ require "kramdown/parser/kramdown"
 module Homebrew
   module Manpages
     module Parser
-      # Kramdown parser with compatiblity for ronn variable syntax.
+      # Kramdown parser with compatibility for ronn variable syntax.
       class Ronn < ::Kramdown::Parser::Kramdown
         def initialize(*)
           super


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI usage:
- Used Codex to identify a typo candidate and prepare the one-line patch.
- Manually reviewed the surrounding code to confirm the diff is comment-only and does not affect behavior.

Summary:
- Fixes a typo in the Ronn parser comment by changing `compatiblity` to `compatibility`.

Related issue:
- N/A

Guideline alignment:
- https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md
- https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request

Validation:
- `git diff --check`
- No tests added; comment-only change.
