### PR TITLE
github: change artifact selection order

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -337,7 +337,7 @@ module GitHub
       artifacts
       .group_by { |art| art["name"] }
       .select { |name| File.fnmatch?(artifact_pattern, name, File::FNM_EXTGLOB) }
-      .map { |_, arts| arts.last }
+      .map { |_, arts| arts.max_by { |art| art["created_at"] } }
 
     if matching_artifacts.empty?
       raise API::Error, <<~EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I have used `Claude Code` to find which part can cause the selection of wrong artifact and it suggests me to check `matching_artifacts`.

-----

When we find and select bottle artifact, the last one is selected if there are bottles with same name (which means the CI runs multiple times). Recently, the default order of the github api response seems changed reversely, so it is better to pick the artifact by the maximum value of `created_at` field not just first or last.

Cross check is needed, this will fix some missing bottle case I think.

- https://github.com/Homebrew/homebrew-core/pull/270985
- https://github.com/Homebrew/homebrew-core/pull/270992
- https://github.com/Homebrew/homebrew-core/pull/270999
- https://github.com/Homebrew/homebrew-core/pull/271002
- https://github.com/Homebrew/homebrew-core/pull/271017
- https://github.com/Homebrew/homebrew-core/pull/271018

I am not sure this is always happen or those only specific cases, but the change makes our CI much safer anyway.