### PR TITLE
docs: fix MCP server test description typo

### DIFF
--- a/Library/Homebrew/mcp_server.rb
+++ b/Library/Homebrew/mcp_server.rb
@@ -147,7 +147,7 @@ module Homebrew
           properties: {
             only:      {
               type:        "string",
-              description: "Specific tests to run (comma-seperated) e.g. for `<file>_spec.rb` pass `<file>`. " \
+              description: "Specific tests to run (comma-separated) e.g. for `<file>_spec.rb` pass `<file>`. " \
                            "Appending `:<line_number>` will start at a specific line",
             },
             fail_fast: {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI usage:
- Used Codex to identify a typo candidate and prepare the one-line patch.
- Manually reviewed the surrounding MCP schema text to confirm the diff only changes wording.

Summary:
- Fixes a typo in the MCP server test description by changing `comma-seperated` to `comma-separated`.

Related issue:
- N/A

Guideline alignment:
- https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md
- https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request

Validation:
- `git diff --check`
- No tests added; wording-only change.
