### PR TITLE
Remove `rubocop:todo` from RBI files.

### DIFF
--- a/Library/Homebrew/dependencies.rbi
+++ b/Library/Homebrew/dependencies.rbi
@@ -18,7 +18,7 @@ class Dependencies < SimpleDelegator
   def select(&blk); end
 end
 
-class Requirements < SimpleDelegator # rubocop:todo Style/OneClassPerFile
+class Requirements < SimpleDelegator
   include Enumerable
   include Kernel
 

--- a/Library/Homebrew/download_strategy.rbi
+++ b/Library/Homebrew/download_strategy.rbi
@@ -10,7 +10,7 @@ end
 
 # This is a third-party implementation.
 # rubocop:disable Style/OptionalBooleanParameter
-class Mechanize::HTTP::ContentDispositionParser # rubocop:todo Style/OneClassPerFile
+class Mechanize::HTTP::ContentDispositionParser
   sig {
     params(content_disposition: String, header: T::Boolean)
       .returns(T.nilable(Mechanize::HTTP::ContentDisposition))

--- a/Library/Homebrew/extend/ENV.rbi
+++ b/Library/Homebrew/extend/ENV.rbi
@@ -5,7 +5,7 @@ module EnvActivation
 end
 
 # @!visibility private
-class Sorbet # rubocop:todo Style/OneClassPerFile
+class Sorbet
   module Private
     module Static
       class ENVClass

--- a/Library/Homebrew/formula-analytics/pycall-setup.rbi
+++ b/Library/Homebrew/formula-analytics/pycall-setup.rbi
@@ -6,7 +6,7 @@ class InfluxDBClient3
   def query(*args); end
 end
 
-module PyCall # rubocop:todo Style/OneClassPerFile
+module PyCall
   def self.init(*args); end
 
   module Import

--- a/Library/Homebrew/on_system.rbi
+++ b/Library/Homebrew/on_system.rbi
@@ -5,7 +5,7 @@ module OnSystem::MacOSOnly
   def on_arch_conditional(arm: nil, intel: nil); end
 end
 
-module OnSystem::MacOSAndLinux # rubocop:todo Style/OneClassPerFile
+module OnSystem::MacOSAndLinux
   sig {
     params(
       macos: T.nilable(T.any(T::Array[T.any(String, Pathname)], String, Pathname)),

--- a/Library/Homebrew/sorbet/rbi/upstream.rbi
+++ b/Library/Homebrew/sorbet/rbi/upstream.rbi
@@ -16,7 +16,7 @@ class Integer
 end
 
 # https://github.com/sorbet/sorbet/pull/9847
-class IO # rubocop:todo Style/OneClassPerFile
+class IO
   # Waits until IO is readable and returns a truthy value, or a falsy value when
   # times out. Returns a truthy value immediately when buffered data is available.
   #

--- a/Library/Homebrew/startup/bootsnap.rbi
+++ b/Library/Homebrew/startup/bootsnap.rbi
@@ -22,7 +22,7 @@ module Homebrew
   end
 end
 
-module Bootsnap # rubocop:todo Style/OneClassPerFile
+module Bootsnap
   sig {
     params(
       cache_dir:          String,

--- a/Library/Homebrew/test/abstract_command_spec.rbi
+++ b/Library/Homebrew/test/abstract_command_spec.rbi
@@ -1,4 +1,4 @@
 # typed: strict
 
 class TestCat < Homebrew::AbstractCommand; end
-class Tac < Homebrew::AbstractCommand; end # rubocop:todo Style/OneClassPerFile
+class Tac < Homebrew::AbstractCommand; end

--- a/Library/Homebrew/test/support/fixtures/rubocop@x.x.x.rbi
+++ b/Library/Homebrew/test/support/fixtures/rubocop@x.x.x.rbi
@@ -7,7 +7,7 @@ class Parser::Source::Comment
   include ::RuboCop::Ext::Comment
 end
 
-class Parser::Source::Range # rubocop:todo Style/OneClassPerFile
+class Parser::Source::Range
   include ::RuboCop::Ext::Range
 end
 
@@ -17,7 +17,7 @@ RuboCop::CLI::STATUS_SUCCESS = T.let(T.unsafe(nil).freeze, Integer)
 
 RuboCop::CommentConfig::CONFIG_DISABLED_LINE_RANGE_MIN = T.let(T.unsafe(nil).freeze, Float)
 
-class RuboCop::Config # rubocop:todo Style/OneClassPerFile
+class RuboCop::Config
   include ::RuboCop::PathUtil
   include ::RuboCop::FileFinder
   extend ::RuboCop::SimpleForwardable
@@ -33,7 +33,7 @@ end
 
 RuboCop::Token = RuboCop::AST::Token
 
-class RuboCop::Cop::Base # rubocop:todo Style/OneClassPerFile
+class RuboCop::Cop::Base
   include ::RuboCop::AST::Sexp
   include ::RuboCop::PathUtil
   include ::RuboCop::Cop::Util
@@ -49,17 +49,17 @@ class RuboCop::Cop::Base # rubocop:todo Style/OneClassPerFile
   def initialize(config = T.unsafe(nil), options = T.unsafe(nil)); end
 end
 
-class RuboCop::Cop::SomeUnusedCop < RuboCop::Cop::Base # rubocop:todo Style/OneClassPerFile
+class RuboCop::Cop::SomeUnusedCop < RuboCop::Cop::Base
   def on_send(_node); end
 end
 
-module RuboCop::Cop::UnusedModule; end # rubocop:todo Style/OneClassPerFile
+module RuboCop::Cop::UnusedModule; end
 
-class CompletelyUnrelated # rubocop:todo Style/OneClassPerFile
+class CompletelyUnrelated
   def bananas; end
 end
 
-module RuboCop::Version # rubocop:todo Style/OneClassPerFile
+module RuboCop::Version
   class << self
     # @api private
     #


### PR DESCRIPTION
These were added in an earlier PR and are now unnecessary.