### PR TITLE
utils: add CommitMessage.normalize for consistent commit subjects

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -5,6 +5,7 @@ require "abstract_command"
 require "fileutils"
 require "formula"
 require "utils/bottles"
+require "utils/commit_message"
 require "tab"
 require "sbom"
 require "keg"
@@ -858,10 +859,12 @@ module Homebrew
           short_name = formula_name.split("/", -1).last
           pkg_version = bottle_hash["formula"]["pkg_version"]
 
+          commit_message = Utils::CommitMessage.normalize(
+            "#{short_name}: #{update_or_add} #{pkg_version} bottle",
+          )
           path.parent.cd do
             safe_system "git", "commit", "--no-edit", "--verbose",
-                        "--message=#{short_name}: #{update_or_add} #{pkg_version} bottle.",
-                        "--", path
+                        "--message=#{commit_message}", "--", path
           end
         end
       end

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -5,6 +5,7 @@ require "abstract_command"
 require "bump_version_parser"
 require "cask"
 require "cask/download"
+require "utils/commit_message"
 require "utils/tar"
 
 module Homebrew
@@ -133,7 +134,7 @@ module Homebrew
         old_contents = File.read(cask.sourcefile_path)
 
         if new_base_url
-          commit_message ||= "#{cask.token}: update URL"
+          commit_message ||= Utils::CommitMessage.normalize("#{cask.token}: update URL")
 
           m = /^ +url "(.+?)"\n/m.match(old_contents)
           odie "Could not find old URL in cask!" if m.nil?
@@ -152,13 +153,13 @@ module Homebrew
           if branch_version.is_a?(Cask::DSL::Version)
             commit_version = shortened_version(branch_version, cask:)
             branch_name = "bump-#{cask.token}-#{branch_version.tr(",:", "-")}"
-            commit_message ||= "#{cask.token} #{commit_version}"
+            commit_message ||= Utils::CommitMessage.normalize("#{cask.token}: #{commit_version}")
           end
           replacement_pairs = replace_version_and_checksum(cask, new_hash, new_version, replacement_pairs)
         end
         # Now that we have all replacement pairs, we will replace them further down
 
-        commit_message ||= "#{cask.token}: update checksum" if new_hash
+        commit_message ||= Utils::CommitMessage.normalize("#{cask.token}: update checksum") if new_hash
 
         # Remove nested arrays where elements are identical
         replacement_pairs = replacement_pairs.reject { |pair| pair[0] == pair[1] }.uniq.compact

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -4,6 +4,7 @@
 require "abstract_command"
 require "fileutils"
 require "formula"
+require "utils/commit_message"
 require "utils/inreplace"
 require "utils/tar"
 
@@ -437,7 +438,7 @@ module Homebrew
           {
             sourcefile_path:    commit_formula.path,
             old_contents:,
-            commit_message:     "#{commit_formula.name} #{new_formula_version}",
+            commit_message:     Utils::CommitMessage.normalize("#{commit_formula.name}: #{new_formula_version}"),
             additional_files:   alias_rename,
             formula_pr_message:,
             formula_name:       commit_formula.name,
@@ -469,11 +470,13 @@ module Homebrew
         new_formula_version = commits.fetch(0)[:new_version]
 
         pr_title = if args.bump_synced.nil?
-          "#{formula.name} #{new_formula_version}"
+          Utils::CommitMessage.normalize("#{formula.name}: #{new_formula_version}")
         else
           maximum_characters_in_title = 72
           max = maximum_characters_in_title - new_formula_version.to_s.length - 1
-          "#{Formatter.truncate(Array(args.bump_synced).join(" "), max:)} #{new_formula_version}"
+          Utils::CommitMessage.normalize(
+            "#{Formatter.truncate(Array(args.bump_synced).join(" "), max:)}: #{new_formula_version}",
+          )
         end
 
         pr_message = "Created with `brew bump-formula-pr`."

--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -3,6 +3,7 @@
 
 require "abstract_command"
 require "formula"
+require "utils/commit_message"
 
 module Homebrew
   module DevCmd
@@ -61,7 +62,9 @@ module Homebrew
             formula.path.atomic_write(formula_ast.process)
           end
 
-          message = "#{formula.name}: revision bump #{args.message}"
+          message = Utils::CommitMessage.normalize(
+            "#{formula.name}: revision bump#{" #{args.message}" if args.message}",
+          )
           if args.dry_run?
             ohai "git commit --no-edit --verbose --message=#{message} -- #{formula.path}"
           elsif !args.write_only?

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -3,6 +3,7 @@
 
 require "abstract_command"
 require "fileutils"
+require "utils/commit_message"
 require "utils/github"
 require "utils/github/artifacts"
 require "tmpdir"
@@ -259,7 +260,7 @@ module Homebrew
 
         new_package = get_package(tap, subject_name, subject_path, new_contents)
 
-        return "#{subject_name}: delete #{reason}".strip if new_package.blank?
+        return Utils::CommitMessage.normalize("#{subject_name}: delete #{reason}") if new_package.blank?
 
         old_package = get_package(tap, subject_name, subject_path, old_contents)
 
@@ -268,11 +269,11 @@ module Homebrew
         elsif old_package.version != new_package.version
           "#{subject_name} #{new_package.version}"
         elsif !is_cask && old_package.revision != new_package.revision
-          "#{subject_name}: revision #{reason}".strip
+          Utils::CommitMessage.normalize("#{subject_name}: revision #{reason}")
         elsif is_cask && old_package.sha256 != new_package.sha256
-          "#{subject_name}: checksum update #{reason}".strip
+          Utils::CommitMessage.normalize("#{subject_name}: checksum update #{reason}")
         else
-          "#{subject_name}: #{reason || "rebuild"}".strip
+          Utils::CommitMessage.normalize("#{subject_name}: #{reason || "rebuild"}")
         end
       end
 
@@ -292,7 +293,7 @@ module Homebrew
         old_package = Utils::Git.file_at_commit(git_repo.to_s, file, "HEAD^")
         new_package = Utils::Git.file_at_commit(git_repo.to_s, file, "HEAD")
 
-        bump_subject = determine_bump_subject(old_package, new_package, package_file, reason:).strip
+        bump_subject = determine_bump_subject(old_package, new_package, package_file, reason:)
         msg = git_repo.commit_message
         return if msg.blank?
 

--- a/Library/Homebrew/test/utils/commit_message_spec.rb
+++ b/Library/Homebrew/test/utils/commit_message_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "utils/commit_message"
+
+RSpec.describe Utils::CommitMessage do
+  describe ".normalize" do
+    it "preserves a well-formatted message" do
+      expect(described_class.normalize("foo: bar baz")).to eq("foo: bar baz")
+    end
+
+    it "adds colon-space separator" do
+      expect(described_class.normalize("foo:bar")).to eq("foo: bar")
+    end
+
+    it "removes trailing period" do
+      expect(described_class.normalize("foo: add 1.0 bottle.")).to eq("foo: add 1.0 bottle")
+    end
+
+    it "strips whitespace" do
+      expect(described_class.normalize("  foo: bar  ")).to eq("foo: bar")
+    end
+
+    it "lowercases the action part" do
+      expect(described_class.normalize("foo: Update URL")).to eq("foo: update url")
+    end
+
+    it "does not lowercase the name part" do
+      expect(described_class.normalize("FooBar: update")).to eq("FooBar: update")
+    end
+
+    it "handles message without colon" do
+      expect(described_class.normalize("foo 1.0")).to eq("foo 1.0")
+    end
+
+    it "handles trailing period and whitespace together" do
+      expect(described_class.normalize("foo: add 1.0 bottle. ")).to eq("foo: add 1.0 bottle")
+    end
+
+    it "handles extra spaces around colon" do
+      expect(described_class.normalize("foo :  bar")).to eq("foo: bar")
+    end
+
+    it "handles version in action part without lowercasing numbers" do
+      expect(described_class.normalize("foo: 1.2.3")).to eq("foo: 1.2.3")
+    end
+  end
+end

--- a/Library/Homebrew/utils/commit_message.rb
+++ b/Library/Homebrew/utils/commit_message.rb
@@ -1,0 +1,25 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Utils
+  # Helper for normalizing commit message subjects.
+  module CommitMessage
+    # Normalizes a commit message subject to a consistent format:
+    # - Ensures colon-space separator between name and action
+    # - Removes trailing periods
+    # - Strips leading/trailing whitespace
+    # - Lowercases the action part (after the colon)
+    sig { params(message: String).returns(String) }
+    def self.normalize(message)
+      message = message.strip
+      message = message.delete_suffix(".")
+
+      if message.include?(":")
+        name, action = message.split(":", 2)
+        "#{T.must(name).strip}: #{T.must(action).strip.downcase}"
+      else
+        message
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Introduce `Utils::CommitMessage.normalize` utility that enforces: colon-space separator, no trailing periods, stripped whitespace, lowercase action subjects
- Apply normalization across `bump-cask-pr`, `bump-formula-pr`, `bump-revision`, `bottle`, and `pr-pull` dev-commands
- Add comprehensive RSpec tests for the normalize method

## Test plan
- [x] `brew typecheck` passes
- [x] `brew style` passes on all changed files
- [x] `brew tests --only=utils/commit_message` passes (10 examples)
- [x] `brew tests --only=dev-cmd/pr-pull` passes (16 examples)

Nightshift-Task: commit-normalize
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)