### PR TITLE
docs: fix Common Issues typo

### DIFF
--- a/docs/Common-Issues.md
+++ b/docs/Common-Issues.md
@@ -27,7 +27,7 @@ You don't have a `/usr/bin/ruby` or it is not executable. It's not recommended t
 
 After running `brew update`, you receive a Git error warning about untracked files or local changes that would be overwritten by a checkout or merge, followed by a list of files inside your Homebrew installation.
 
-This is caused by an old bug in in the `update` code that has long since been fixed. However, the nature of the bug requires that you do the following:
+This is caused by an old bug in the `update` code that has long since been fixed. However, the nature of the bug requires that you do the following:
 
 ```sh
 cd "$(brew --repository)"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI usage:
- Used Codex to identify the duplicate word and prepare the one-line patch.
- Manually reviewed the surrounding Common Issues section to confirm the diff only changes wording.

Summary:
- Fixes a typo in `docs/Common-Issues.md` by changing `in in` to `in`.

Related issue:
- N/A

Guideline alignment:
- https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md
- https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request

Validation:
- `git diff --check`
- No tests added; wording-only change.
