### PR TITLE
bin/brew: simplify filtering of `BIN_BREW_EXPORTED_VARS`

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -113,21 +113,23 @@ BIN_BREW_EXPORTED_VARS=(
 # Load Homebrew's variable configuration files from disk.
 export_homebrew_env_file() {
   local env_file
+  local bin_brew_exported_vars_regex
 
   env_file="${1}"
   [[ -r "${env_file}" ]] || return 0
+
+  bin_brew_exported_vars_regex="^($(
+    IFS='|'
+    echo "${BIN_BREW_EXPORTED_VARS[*]}"
+  ))"
+
   while read -r line
   do
     # only load variables defined in env_config.rb
     [[ "${line}" =~ ^(HOMEBREW_|SUDO_ASKPASS=|(all|no|ftp|https?)_proxy=) ]] || continue
 
     # forbid overriding variables that are set in this file
-    local invalid_variable
-    for VAR in "${BIN_BREW_EXPORTED_VARS[@]}"
-    do
-      [[ "${line}" = "${VAR}"* ]] && invalid_variable="${VAR}"
-    done
-    [[ -n "${invalid_variable:-}" ]] && continue
+    [[ "${line}" =~ ${bin_brew_exported_vars_regex} ]] && continue
 
     export "${line?}"
   done <"${env_file}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Looping over `BIN_BREW_EXPORTED_VARS` for each line of an env file is
relatively inefficient. We can avoid this by constructing a regex before
the loop and using that regex to match against the lines we want to
skip.

