### PR TITLE
rubocops/move_to_extend_os: audit OS checks in `extend/os`

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -7,7 +7,7 @@ Bundler/GemFilename:
 Homebrew/MoveToExtendOS:
   Enabled: true
   Exclude:
-    - "{extend,test,requirements}/**/*"
+    - "{test,requirements}/**/*"
     - "os.rb"
 
 # We don't use Sorbet for RSpec tests so let's disable this there.

--- a/Library/Homebrew/rubocops/move_to_extend_os.rb
+++ b/Library/Homebrew/rubocops/move_to_extend_os.rb
@@ -4,19 +4,37 @@
 module RuboCop
   module Cop
     module Homebrew
-      # This cop ensures that platform specific code ends up in `extend/os`.
+      # This cop ensures that platform specific code ends up in `extend/os`, and
+      # that `extend/os` doesn't contain incorrect or redundant OS checks.
       class MoveToExtendOS < Base
-        MSG = "Move `OS.linux?` and `OS.mac?` calls to `extend/os`."
+        NON_EXTEND_OS_MSG = "Move `OS.linux?` and `OS.mac?` calls to `extend/os`."
 
-        def_node_matcher :os_check?, <<~PATTERN
-          (send (const nil? :OS) {:mac? | :linux?})
+        def_node_matcher :os_mac?, <<~PATTERN
+          (send (const nil? :OS) :mac?)
         PATTERN
+
+        def_node_matcher :os_linux?, <<~PATTERN
+          (send (const nil? :OS) :linux?)
+        PATTERN
+
+        sig { params(extend_os: String, os_method: String).returns(String) }
+        def extend_offense_message(extend_os, os_method)
+          "Don't use `OS.#{os_method}?` in `extend/os/#{extend_os}`, it is " \
+            "always `#{(extend_os == os_method) ? "true" : "false"}`."
+        end
 
         sig { params(node: RuboCop::AST::Node).void }
         def on_send(node)
-          return unless os_check?(node)
-
-          add_offense(node)
+          file_path = processed_source.file_path
+          if file_path.include?("extend/os/mac/")
+            add_offense(node, message: extend_offense_message("mac", "mac")) if os_mac?(node)
+            add_offense(node, message: extend_offense_message("mac", "linux")) if os_linux?(node)
+          elsif file_path.include?("extend/os/linux/")
+            add_offense(node, message: extend_offense_message("linux", "mac")) if os_mac?(node)
+            add_offense(node, message: extend_offense_message("linux", "linux")) if os_linux?(node)
+          elsif !file_path.include?("extend/os/") && (os_mac?(node) || os_linux?(node))
+            add_offense(node, message: NON_EXTEND_OS_MSG)
+          end
         end
       end
     end

--- a/Library/Homebrew/sorbet/rbi/dsl/rubo_cop/cop/homebrew/move_to_extend_os.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/rubo_cop/cop/homebrew/move_to_extend_os.rbi
@@ -7,5 +7,8 @@
 
 class RuboCop::Cop::Homebrew::MoveToExtendOS
   sig { params(node: RuboCop::AST::Node, kwargs: T.untyped, block: T.untyped).returns(T.untyped) }
-  def os_check?(node, **kwargs, &block); end
+  def os_linux?(node, **kwargs, &block); end
+
+  sig { params(node: RuboCop::AST::Node, kwargs: T.untyped, block: T.untyped).returns(T.untyped) }
+  def os_mac?(node, **kwargs, &block); end
 end

--- a/Library/Homebrew/test/rubocops/move_to_extend_os_spec.rb
+++ b/Library/Homebrew/test/rubocops/move_to_extend_os_spec.rb
@@ -18,4 +18,36 @@ RSpec.describe RuboCop::Cop::Homebrew::MoveToExtendOS do
       ^^^^^^^ Homebrew/MoveToExtendOS: Move `OS.linux?` and `OS.mac?` calls to `extend/os`.
     RUBY
   end
+
+  context "when in extend/os/mac" do
+    it "registers an offense when using `OS.linux?`" do
+      expect_offense(<<~RUBY, "Library/Homebrew/extend/os/mac/foo.rb")
+        OS.linux?
+        ^^^^^^^^^ Homebrew/MoveToExtendOS: Don't use `OS.linux?` in `extend/os/mac`, it is always `false`.
+      RUBY
+    end
+
+    it "registers an offense when using `OS.mac?`" do
+      expect_offense(<<~RUBY, "Library/Homebrew/extend/os/mac/foo.rb")
+        OS.mac?
+        ^^^^^^^ Homebrew/MoveToExtendOS: Don't use `OS.mac?` in `extend/os/mac`, it is always `true`.
+      RUBY
+    end
+  end
+
+  context "when in extend/os/linux" do
+    it "registers an offense when using `OS.mac?`" do
+      expect_offense(<<~RUBY, "Library/Homebrew/extend/os/linux/foo.rb")
+        OS.mac?
+        ^^^^^^^ Homebrew/MoveToExtendOS: Don't use `OS.mac?` in `extend/os/linux`, it is always `false`.
+      RUBY
+    end
+
+    it "registers an offense when using `OS.linux?`" do
+      expect_offense(<<~RUBY, "Library/Homebrew/extend/os/linux/foo.rb")
+        OS.linux?
+        ^^^^^^^^^ Homebrew/MoveToExtendOS: Don't use `OS.linux?` in `extend/os/linux`, it is always `true`.
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Test cases were AI-generated and manually verified.

-----

Extend the `Homebrew/MoveToExtendOS` cop to identify incorrect or redundant `OS.mac?` and `OS.linux?` checks in `extend/os/{mac,linux}`.

Originally proposed in https://github.com/Homebrew/brew/pull/20738#issuecomment-3316058716.
