### PR TITLE
bin/brew: tighten regex for variable exclusion

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -121,7 +121,7 @@ export_homebrew_env_file() {
   bin_brew_exported_vars_regex="^($(
     IFS='|'
     echo "${BIN_BREW_EXPORTED_VARS[*]}"
-  ))"
+  ))(=|$)"
 
   while read -r line
   do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This will ensure that we don't inadvertently filter out future
environment variables that start with text contained in
`BIN_BREW_EXPORTED_VARS` (e.g. `HOMEBREW_REPOSITORY_*`).
