### PR TITLE
unlink: preserve non-keg-only versioned links

### DIFF
--- a/Library/Homebrew/test/unlink_spec.rb
+++ b/Library/Homebrew/test/unlink_spec.rb
@@ -4,19 +4,35 @@ require "unlink"
 
 RSpec.describe Homebrew::Unlink do
   describe ".unlink_link_overwrite_formulae" do
-    let(:formula) { instance_double(Formula) }
-    let(:linked_keg) { instance_double(Keg, directory?: true) }
-    let(:linked_formula) { instance_double(Formula, keg_only?: true, linked?: true, any_installed_keg: linked_keg) }
+    let(:formula) { instance_double(Formula, keg_only?: false) }
+    let(:linked_keg_only_keg) { instance_double(Keg, directory?: true) }
+    let(:linked_keg_only_formula) do
+      instance_double(Formula, linked?: true, keg_only?: true, any_installed_keg: linked_keg_only_keg)
+    end
     let(:linked_non_keg_only_keg) { instance_double(Keg, directory?: true) }
     let(:linked_non_keg_only_formula) do
-      instance_double(Formula, keg_only?: false, linked?: true, any_installed_keg: linked_non_keg_only_keg)
+      instance_double(Formula, linked?: true, keg_only?: false,
+                               any_installed_keg: linked_non_keg_only_keg)
     end
-    let(:unlinked_formula) { instance_double(Formula, keg_only?: true, linked?: false, any_installed_keg: nil) }
+    let(:unlinked_formula) do
+      instance_double(Formula, linked?: false, keg_only?: true, any_installed_keg: nil)
+    end
 
-    it "unlinks linked sibling formulae returned by link_overwrite_formulae" do
+    it "only unlinks linked keg-only sibling formulae for non-keg-only formulae" do
       allow(formula).to receive(:link_overwrite_formulae)
-        .and_return([linked_formula, linked_non_keg_only_formula, unlinked_formula])
-      expect(described_class).to receive(:unlink).with(linked_keg, verbose: true).once
+        .and_return([linked_keg_only_formula, linked_non_keg_only_formula, unlinked_formula])
+      expect(described_class).to receive(:unlink).with(linked_keg_only_keg, verbose: true).once
+      expect(described_class).not_to receive(:unlink).with(linked_non_keg_only_keg, verbose: true)
+
+      described_class.unlink_link_overwrite_formulae(formula, verbose: true)
+    end
+
+    it "unlinks all linked sibling formulae for keg-only formulae" do
+      allow(formula).to receive_messages(keg_only?:               true,
+                                         link_overwrite_formulae: [linked_keg_only_formula,
+                                                                   linked_non_keg_only_formula,
+                                                                   unlinked_formula])
+      expect(described_class).to receive(:unlink).with(linked_keg_only_keg, verbose: true).once
       expect(described_class).to receive(:unlink).with(linked_non_keg_only_keg, verbose: true).once
 
       described_class.unlink_link_overwrite_formulae(formula, verbose: true)

--- a/Library/Homebrew/unlink.rb
+++ b/Library/Homebrew/unlink.rb
@@ -6,12 +6,13 @@ module Homebrew
   module Unlink
     sig { params(formula: Formula, verbose: T::Boolean).void }
     def self.unlink_link_overwrite_formulae(formula, verbose: false)
-      formula.link_overwrite_formulae
-             .select(&:linked?)
-             .filter_map(&:any_installed_keg)
-             .select(&:directory?)
-             .each do |keg|
-        unlink(keg, verbose:)
+      overwrite_formulae = formula.link_overwrite_formulae.select(&:linked?)
+      overwrite_formulae.select!(&:keg_only?) unless formula.keg_only?
+
+      overwrite_formulae.filter_map(&:any_installed_keg)
+                        .select(&:directory?)
+                        .each do |keg|
+         unlink(keg, verbose:)
       end
     end
 


### PR DESCRIPTION
Adjust `unlink_link_overwrite_formulae` so non-keg-only formulae only unlink linked keg-only overwrite siblings before relinking.

This avoids removing coexistable versioned links like `python@3.13` and `python@3.14` when linking non-keg-only formula families, while keeping the existing full-unlink behaviour for keg-only formulae.

Fixes https://github.com/orgs/Homebrew/discussions/6744