### PR TITLE
github/workflows: add cache-homebrew-prefix workflow keys.

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: Homebrew/actions/cache-homebrew-prefix@main
         with:
           install: actionlint shellcheck zizmor
+          workflow-key: actionlint
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/command-not-found-db-update.yml
+++ b/.github/workflows/command-not-found-db-update.yml
@@ -29,6 +29,7 @@ jobs:
         uses: Homebrew/actions/cache-homebrew-prefix@main
         with:
           install: oras
+          workflow-key: command-not-found-db-update
           uninstall: true
 
       - name: Pull executables.txt from GitHub Packages

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: Homebrew/actions/cache-homebrew-prefix@main
         with:
           install: shellcheck shfmt gh gnu-tar subversion curl
+          workflow-key: copilot-setup-steps
 
       # brew tests doesn't like world writable directories
       - run: sudo chmod -R g-w,o-w /home/linuxbrew/.linuxbrew/Homebrew

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,7 @@ jobs:
         uses: Homebrew/actions/cache-homebrew-prefix@main
         with:
           install: vale ruby
+          workflow-key: docs
 
       - name: Cleanup Homebrew/brew docs
         if: github.repository == 'Homebrew/brew'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
         uses: Homebrew/actions/cache-homebrew-prefix@main
         with:
           install: pandoc
+          workflow-key: release
           uninstall: true
 
       - name: Create and unlock temporary macOS keychain

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,7 @@ jobs:
         uses: Homebrew/actions/cache-homebrew-prefix@main
         with:
           install: shellcheck shfmt
+          workflow-key: tests-syntax
 
       - name: Cache style cache
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -268,12 +269,14 @@ jobs:
         uses: Homebrew/actions/cache-homebrew-prefix@main
         with:
           install: subversion curl
+          workflow-key: tests-tests-online
 
       - name: Install brew tests macOS dependencies
         if: runner.os != 'Linux'
         uses: Homebrew/actions/cache-homebrew-prefix@main
         with:
           install: subversion gnupg
+          workflow-key: tests-tests-macos
           uninstall: true
 
         # brew tests doesn't like world writable directories
@@ -380,6 +383,7 @@ jobs:
       - uses: Homebrew/actions/cache-homebrew-prefix@main
         with:
           install: gnu-tar
+          workflow-key: test-bot
           uninstall: true
 
       - name: Setup environment variables


### PR DESCRIPTION
This should avoid the multiple uses of Homebrew/actions/cache-homebrew-prefix in this repository overwriting the caches of others.