### PR TITLE
bump: don't error when checking casks with `version :latest`

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -230,9 +230,13 @@ module Homebrew
           name = formula_or_cask.name
           text = "Formula is #{formula_or_cask.disabled? ? "disabled" : "HEAD-only"} so not accepting updates.\n"
         else
-          skip = formula_or_cask.disabled?
+          skip = formula_or_cask.disabled? || formula_or_cask.version.latest?
           name = formula_or_cask.token
-          text = "Cask is disabled so not accepting updates.\n"
+          text = if formula_or_cask.disabled?
+            "Cask is disabled so not accepting updates.\n"
+          else
+            "Cask uses `version :latest` so `brew bump` cannot check it.\n"
+          end
         end
         if (tap = formula_or_cask.tap) && !tap.allow_bump?(name)
           skip = true

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe Homebrew::DevCmd::Bump do
     RUBY
   end
 
+  let(:c_latest) do
+    Cask::CaskLoader.load(+<<-RUBY)
+      cask "latest_cask" do
+        version :latest
+        sha256 :no_check
+
+        url "https://brew.sh/test.dmg"
+        name "Latest Cask"
+        desc "Latest cask"
+        homepage "https://brew.sh"
+      end
+    RUBY
+  end
+
   it_behaves_like "parseable arguments"
 
   describe "formula", :integration_test, :needs_homebrew_curl, :needs_network do
@@ -48,6 +62,14 @@ RSpec.describe Homebrew::DevCmd::Bump do
       .to output(/Invalid usage/).to_stderr
       .and not_to_output.to_stdout
       .and be_a_failure
+  end
+
+  describe "::skip_ineligible_formulae!" do
+    it "prints a legible message for casks using `version :latest`" do
+      expect { expect(bump.send(:skip_ineligible_formulae!, c_latest)).to be(true) }
+        .to output(/Cask uses `version :latest` so `brew bump` cannot check it\./).to_stdout
+        .and not_to_output.to_stderr
+    end
   end
 
   describe "::compare_versions" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used `codex` to find and resolve the Sorbet issue.

-----


There was a sorbet error being exposed when running `brew bump` against a Cask that uses `version :latest`.


<details>
<summary>`brew bump font-bevan` output before this pr;</summary>

```
  Error: Parameter 'version': Expected type Version, got type Cask::DSL::Version with value "latest"
  Caller: /opt/homebrew/Library/Homebrew/dev-cmd/bump.rb:750
  Definition: /opt/homebrew/Library/Homebrew/livecheck/livecheck_version.rb:13 (Homebrew::Livecheck::LivecheckVersion.create)
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/configuration.rb:293:in
  'T::Configuration.call_validation_error_handler_default'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/configuration.rb:300:in 'T::Configuration.call_validation_error_handler'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/call_validation.rb:322:in
  'T::Private::Methods::CallValidation.report_error'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/call_validation_2_7.rb:1003:in 'block in
  Homebrew::Livecheck::LivecheckVersion.create_validator_method_medium2'
  /opt/homebrew/Library/Homebrew/dev-cmd/bump.rb:750:in 'block in Homebrew::DevCmd::Bump#compare_versions'
  /opt/homebrew/Library/Homebrew/dev-cmd/bump.rb:737:in 'Array#each'
  /opt/homebrew/Library/Homebrew/dev-cmd/bump.rb:737:in 'Homebrew::DevCmd::Bump#compare_versions'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/call_validation.rb:282:in
  'T::Private::Methods::CallValidation.validate_call'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/_methods.rb:259:in 'block in
  Homebrew::DevCmd::Bump#_on_method_added'
  /opt/homebrew/Library/Homebrew/dev-cmd/bump.rb:415:in 'Homebrew::DevCmd::Bump#retrieve_versions_by_arch'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/call_validation.rb:282:in
  'T::Private::Methods::CallValidation.validate_call'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/_methods.rb:259:in 'block in
  Homebrew::DevCmd::Bump#_on_method_added'
  /opt/homebrew/Library/Homebrew/dev-cmd/bump.rb:550:in 'Homebrew::DevCmd::Bump#retrieve_and_display_info_and_open_pr'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/call_validation.rb:282:in
  'T::Private::Methods::CallValidation.validate_call'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/_methods.rb:259:in 'block in
  Homebrew::DevCmd::Bump#_on_method_added'
  /opt/homebrew/Library/Homebrew/dev-cmd/bump.rb:215:in 'block in Homebrew::DevCmd::Bump#handle_formulae_and_casks'
  /opt/homebrew/Library/Homebrew/dev-cmd/bump.rb:201:in 'Array#each'
  /opt/homebrew/Library/Homebrew/dev-cmd/bump.rb:201:in 'Enumerable#each_with_index'
  /opt/homebrew/Library/Homebrew/dev-cmd/bump.rb:201:in 'Homebrew::DevCmd::Bump#handle_formulae_and_casks'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/call_validation.rb:282:in
  'T::Private::Methods::CallValidation.validate_call'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/_methods.rb:259:in 'block in
  Homebrew::DevCmd::Bump#_on_method_added'
  /opt/homebrew/Library/Homebrew/dev-cmd/bump.rb:164:in 'block in Homebrew::DevCmd::Bump#run'
  /opt/homebrew/Library/Homebrew/api.rb:368:in 'Homebrew.with_no_api_env'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/call_validation.rb:282:in
  'T::Private::Methods::CallValidation.validate_call'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/_methods.rb:259:in 'block in Homebrew._on_method_added'
  /opt/homebrew/Library/Homebrew/dev-cmd/bump.rb:88:in 'Homebrew::DevCmd::Bump#run'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/call_validation.rb:282:in
  'T::Private::Methods::CallValidation.validate_call'
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.12971/lib/types/private/methods/_methods.rb:259:in 'block in
  Homebrew::DevCmd::Bump#_on_method_added'
  /opt/homebrew/Library/Homebrew/brew.rb:102:in '<main>'
  Please report this issue:
    https://docs.brew.sh/Troubleshooting
```
</details>

`brew bump font-bevan` output after;

```
==> font-bevan
Cask uses `version :latest` so `brew bump` cannot check it.
```


If the test is deemed unnecessary it can be removed.