### PR TITLE
Fix Ruby version comparison logic for 4.0+

### DIFF
--- a/Library/Homebrew/utils/ruby_check_version_script.rb
+++ b/Library/Homebrew/utils/ruby_check_version_script.rb
@@ -10,9 +10,13 @@ require "rubygems"
 ruby_version = Gem::Version.new(RUBY_VERSION)
 homebrew_required_ruby_version = Gem::Version.new(HOMEBREW_REQUIRED_RUBY_VERSION)
 
-ruby_version_major, ruby_version_minor, = ruby_version.canonical_segments
-homebrew_required_ruby_version_major, homebrew_required_ruby_version_minor, =
-  homebrew_required_ruby_version.canonical_segments
+ruby_segments = ruby_version.canonical_segments
+ruby_version_major = ruby_segments[0].to_i
+ruby_version_minor = ruby_segments[1].to_i
+
+homebrew_required_ruby_segments = homebrew_required_ruby_version.canonical_segments
+homebrew_required_ruby_version_major = homebrew_required_ruby_segments[0].to_i
+homebrew_required_ruby_version_minor = homebrew_required_ruby_segments[1].to_i
 
 if (!ENV.fetch("HOMEBREW_DEVELOPER", "").empty? || !ENV.fetch("HOMEBREW_TESTS", "").empty?) &&
    !ENV.fetch("HOMEBREW_USE_RUBY_FROM_PATH", "").empty? &&


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
When running the latest `main` branch of Homebrew on a device with Ruby 4.0.1 installed, Homebrew attempts to download `portable-ruby` even though the system Ruby version already meets the requirements.

The root cause lies in how `Gem::Version#canonical_segments` handles trailing zeros. When the required version is "4.0", `Gem::Version` automatically strips the trailing zero to simplify comparison, resulting in segments being `[4]` instead of `[4, 0]`. During destructuring assignment, `homebrew_required_ruby_version_minor` is assigned `nil`. This causes the expression `ruby_version_minor != homebrew_required_ruby_version_minor` to always evaluate to `true`, forcing Homebrew to bypass the system Ruby.

I have verified this behavior across different environments:

* **Ruby 4.0.1 + Brew main**: `canonical_segments` for "4.0" returns `[4]`, causing a mismatch.
* **Ruby 3.4.5 + Brew 4.5.13**: `canonical_segments` for "3.4" returns `[3, 4]`, which works as expected.

This PR fixes this flaw to ensure Homebrew correctly compares Ruby version segments even when trailing zeros are omitted by the RubyGems library.