### PR TITLE
join multiple skip messages and improve output formatting

### DIFF
--- a/Library/Homebrew/livecheck/skip_conditions.rb
+++ b/Library/Homebrew/livecheck/skip_conditions.rb
@@ -325,11 +325,11 @@ module Homebrew
         return unless name
 
         if skip_hash[:messages].is_a?(Array) && skip_hash[:messages].any?
-          # TODO: Handle multiple messages, only if needed in the future
+          messages = skip_hash[:messages].join(", ")
           if skip_hash[:status] == "skipped"
-            puts "#{Tty.red}#{name}#{Tty.reset}: skipped - #{skip_hash[:messages][0]}"
+            puts "#{Tty.red}#{name}#{Tty.reset}: skipped - #{messages}"
           else
-            puts "#{Tty.red}#{name}#{Tty.reset}: #{skip_hash[:messages][0]}"
+            puts "#{Tty.red}#{name}#{Tty.reset}: #{messages}"
           end
         elsif skip_hash[:status].present?
           puts "#{Tty.red}#{name}#{Tty.reset}: #{skip_hash[:status]}"

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -615,6 +615,17 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:skip_with_message]) }
           .to output("test_skip_with_message: skipped - Not maintained\n").to_stdout
           .and not_to_output.to_stderr
+
+        expect do
+          skip_conditions.print_skip_information(
+            formula:  "test_skip_with_messages",
+            status:   "skipped",
+            messages: ["Not maintained", "Archived upstream"],
+          )
+        end.to output(
+          "test_skip_with_messages: skipped - Not maintained, Archived upstream\n",
+        ).to_stdout
+          .and not_to_output.to_stderr
       end
     end
 


### PR DESCRIPTION
Join multiple skip messages with ", " instead of displaying only the first
message. This ensures all skip reasons are shown when multiple apply
(e.g. "Not maintained, Archived upstream").

Also update the output formatting for both skipped and non-skipped
statuses to improve consistency.

A test was added to verify that multiple skip messages are joined and
displayed correctly.

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes?
- [x] Have you successfully run `brew lgtm` with your changes locally?
- [x] AI was used to assist with generating this PR.

Codex was used to help speed up implementing the change and drafting the
update. The code and tests were manually reviewed and verified locally,
and `brew lgtm` was run to ensure all checks pass (on my machine).