### PR TITLE
Json: set allow_duplicate_key in JSON.parse call

### DIFF
--- a/Library/Homebrew/livecheck/strategy/json.rb
+++ b/Library/Homebrew/livecheck/strategy/json.rb
@@ -55,7 +55,7 @@ module Homebrew
           require "json"
 
           begin
-            JSON.parse(content)
+            JSON.parse(content, allow_duplicate_key: true)
           rescue JSON::ParserError
             raise "Content could not be parsed as JSON."
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`brew livecheck querious` is producing a warning in reference to the `JSON.parse` call in livecheck's `Json.parse_json` method: 'warning: detected duplicate key "prerelease" in JSON object. This will raise an error in json 3.0 unless enabled via `allow_duplicate_key: true` at line 1 column 1'. We don't have any control over upstream JSON data, so this adds an `allow_duplicate_key: true` option to the `JSON.parse` call to resolve this issue and maintain the current behavior.