### PR TITLE
docs: outdated macOS tools imply tier 2

### DIFF
--- a/docs/Support-Tiers.md
+++ b/docs/Support-Tiers.md
@@ -66,6 +66,7 @@ The following conditions typically apply:
 Tier 2 configurations include:
 
 - macOS prerelease versions before they are promoted to Tier 1
+- macOS systems with outdated versions of Xcode Command Line Tools
 - Linux systems with `glibc` versions between 2.13 and 2.34 (Homebrew’s own `glibc` formula will be installed automatically)
 - Homebrew installed outside the default prefix, requiring source builds for official packages (i.e. installing outside `/opt/homebrew`, `/usr/local`, or `/home/linuxbrew/.linuxbrew`)
 - Architectures not yet officially supported by Homebrew


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Right after a `brew doctor` complaint that `A newer Command Line Tools release is available.` I noticed `This is a Tier 2 configuration` with a link to https://docs.brew.sh/Support-Tiers#tier-2. When I didn't see outdated macOS tools in the list of Tier 2 configurations, I started to wonder if there was another reason for the Tier 2 message, but then I found the [code that generated that message](https://github.com/Homebrew/brew/blob/e864e85c7e6efc76262a5de3f8415315eb40bcf0/Library/Homebrew/extend/os/mac/diagnostic.rb#L228-L231) and confirmed that is the reason. Also, I saw that `Xcode Command Line Tools installed and up to date` is listed as a requirement for Tier 1 in these docs, so I think this is correct.