### PR TITLE
diagnostic: reword issue reporting guidelines

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -146,15 +146,15 @@ module Homebrew
         return if tier.to_s == "1"
 
         tier_title, tier_slug, tier_issues = if tier.to_s == "unsupported"
-          ["Unsupported", "unsupported", "Do not report any"]
+          ["Unsupported", "unsupported", "Do not report any issues"]
         else
-          ["Tier #{tier}", "tier-#{tier.to_s.downcase}", "You can report Tier #{tier} unrelated"]
+          ["Tier #{tier}", "tier-#{tier.to_s.downcase}", "You can report issues with Tier #{tier} configurations"]
         end
 
         <<~EOS
           This is a #{tier_title} configuration:
             #{Formatter.url("https://docs.brew.sh/Support-Tiers##{tier_slug}")}
-          #{Formatter.bold("#{tier_issues} issues to Homebrew/* repositories!")}
+          #{Formatter.bold("#{tier_issues} to Homebrew/* repositories!")}
           Read the above document before opening any issues or PRs.
         EOS
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

I recently saw a `brew doctor` complaint about an outdated command line tools with the following support tier message:

~~~
This is a Tier 2 configuration:
  https://docs.brew.sh/Support-Tiers#tier-2
You can report Tier 2 unrelated issues to Homebrew/* repositories!
Read the above document before opening any issues or PRs.
~~~

I find the phrasing of "You can report Tier 2 unrelated issues" a bit confusing (in particular the word `unrelated`), and my best guess for alternate phrasing is "You can report issues with Tier 2 configurations" so I opened a PR to suggest that wording.

If you prefer the current wording, can you clarify if it means:

* You can report issues observed on a system with a Tier 2 configuration that are unrelated to the diagnostic complaint that triggered this message
* You can report issues unrelated to your Tier 2 configuration
* Something else

Thanks!
