### PR TITLE
formulary: soften deprecation errors from FromBottleLoader

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -499,7 +499,19 @@ module Formulary
     def initialize(bottle_name, warn: false)
       @bottle_path = T.let(Pathname(bottle_name).realpath, Pathname)
       name, full_name = Utils::Bottles.resolve_formula_names(@bottle_path)
-      super name, Formulary.path(full_name)
+      tap, = Tap.with_formula_name(full_name)
+
+      # We might not have tap information with --only-json-tab bottles.
+      # In this scenario we make a best effort guess, assuming Homebrew/core
+      # unless we find it in another tap we have installed.
+      fallback_path = Formulary.path(full_name)
+      tap ||= Tap.from_path(fallback_path)
+
+      # Mimic a Cellar path to simulate relaxed deprecation behaviour shared with postinstalls.
+      version = Utils::Bottles.resolve_version(@bottle_path)
+      @cellar_formula_path = T.let(HOMEBREW_CELLAR/name/version/".brew"/"#{name}.rb", Pathname)
+
+      super name, fallback_path, tap:
     end
 
     sig {
@@ -514,8 +526,8 @@ module Formulary
     def get_formula(spec, alias_path: nil, force_bottle: false, flags: [], ignore_errors: false)
       formula = begin
         contents = Utils::Bottles.formula_contents(@bottle_path, name:)
-        Formulary.from_contents(name, path, contents, spec, force_bottle:,
-                                flags:, ignore_errors:)
+        Formulary.from_contents(name, @cellar_formula_path, contents, spec,
+                                tap:, force_bottle:, flags:, ignore_errors:)
       rescue FormulaUnreadableError => e
         opoo <<~EOS
           Unreadable formula in #{@bottle_path}:
@@ -816,10 +828,10 @@ module Formulary
     sig { returns(String) }
     attr_reader :contents
 
-    sig { params(name: String, path: Pathname, contents: String).void }
-    def initialize(name, path, contents)
+    sig { params(name: String, path: Pathname, contents: String, tap: T.nilable(Tap)).void }
+    def initialize(name, path, contents, tap: nil)
       @contents = contents
-      super name, path
+      super name, path, tap:
     end
 
     sig { override.params(flags: T::Array[String], ignore_errors: T::Boolean).returns(T.class_of(Formula)) }
@@ -1052,6 +1064,7 @@ module Formulary
       contents:      String,
       spec:          Symbol,
       alias_path:    T.nilable(Pathname),
+      tap:           T.nilable(Tap),
       force_bottle:  T::Boolean,
       flags:         T::Array[String],
       ignore_errors: T::Boolean,
@@ -1063,11 +1076,12 @@ module Formulary
     contents,
     spec = :stable,
     alias_path: nil,
+    tap: nil,
     force_bottle: false,
     flags: [],
     ignore_errors: false
   )
-    FormulaContentsLoader.new(name, path, contents)
+    FormulaContentsLoader.new(name, path, contents, tap:)
                          .get_formula(spec, alias_path:, force_bottle:, flags:, ignore_errors:)
   end
 


### PR DESCRIPTION
We deprecated `no_autobump! because: :requires_manual_review` but did not rebuild any bottles when removing it. This has lead to current bottles having stale formulae that are now erroring after the latest deprecations.

For `postinstall` we usually soften this by excluding paths in `.brew`: https://github.com/Homebrew/brew/blob/e864e85c7e6efc76262a5de3f8415315eb40bcf0/Library/Homebrew/utils/output.rb#L154-L158

Let's do the same in FromBottleLoader by mimicking a `.brew` path rather than mimicking a tap path.

The behaviour of determining the tap a bottle belongs to has largely remained the same to reduce any additional churn here, with one improvement that was obvious to make: if it has a INSTALL_RECEIPT then use the tap from there. This doesn't work for any bottles built with `--only-json-tab` so the existing logic of scanning the name among installed taps applies there. Arguably we probably should just use a `nil` tap here at some point.