### PR TITLE
bump: use semicolon skip messages delimiter

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -279,7 +279,7 @@ module Homebrew
 
         if skip_info.present?
           return "#{skip_info[:status]}" \
-                 "#{" - #{skip_info[:messages].join(", ")}" if skip_info[:messages].present?}"
+                 "#{" - #{skip_info[:messages].join("; ")}" if skip_info[:messages].present?}"
         end
 
         version_info = Livecheck.latest_version(


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

We recently updated `Livecheck::SkipConditions.print_skip_information` to join messages using a semicolon, so this updates the similar logic in `brew bump` to use the same delimiter.

This is a follow-up to https://github.com/Homebrew/brew/pull/21708, where I requested this change in review.