### PR TITLE
Formula, Cask: add livecheck_defined hash value

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -425,6 +425,7 @@ module Cask
         "version"                         => version,
         "autobump"                        => autobump?,
         "no_autobump_message"             => no_autobump_message,
+        "livecheck_defined"               => livecheck_defined?,
         "skip_livecheck"                  => livecheck.skip?,
         "installed"                       => installed_version,
         "installed_time"                  => install_time&.to_i,

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2864,6 +2864,7 @@ class Formula
       "compatibility_version"           => compatibility_version,
       "autobump"                        => autobump?,
       "no_autobump_message"             => no_autobump_message,
+      "livecheck_defined"               => livecheck_defined?,
       "skip_livecheck"                  => livecheck.skip?,
       "bottle"                          => {},
       "pour_bottle_only_if"             => self.class.pour_bottle_only_if&.to_s,

--- a/Library/Homebrew/test/support/fixtures/cask/everything.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything.json
@@ -18,6 +18,7 @@
   "version": "1.2.3",
   "autobump": true,
   "no_autobump_message": null,
+  "livecheck_defined": false,
   "skip_livecheck": false,
   "installed": null,
   "installed_time": null,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The `Tap.autobump` logic was recently updated to not skip deprecated packages but this has lead to autobump checking packages that livecheck will automatically skip as deprecated. We want autobump to only check deprecated packages that are checkable and that effectively means only checking those with a `livecheck` block. To be able to do this, we need to include the `livecheck_defined?` value in the JSON API data.

This adds a `livecheck_defined` value to `Cask#to_h` and `Formula#to_hash` as a preliminary step. We need to add this value and for it to be present in the latest JSON API data before we can use it in `Tap.autobump`.

An alternative approach is to modify `skip_livecheck` to also factor in automatic skips from `Livecheck::SkipConditions` (or add a different boolean field for that). I didn't go that route because it's much more involved due to needing to identify and check formulae/casks that are referenced in a `livecheck` block, so it ends up being a fair amount of code. That may be a more robust approach in the long-term (as there are skip conditions other than deprecation) but this `livecheck_defined` approach should be a simple improvement in the interim time.

-----

This is a follow-up to https://github.com/Homebrew/brew/pull/21651, as I didn't manage to review it before it was merged. I didn't think anything of it until I was reviewing autobump output and saw a dramatically higher number of "unable to get versions" output, due to deprecated packages without a `livecheck` block being checked but automatically skipped.