### PR TITLE
rubocop: Avoid duplicate arch-specific versions (and more) in casks

### DIFF
--- a/Library/Homebrew/rubocops/cask/on_system_conditionals.rb
+++ b/Library/Homebrew/rubocops/cask/on_system_conditionals.rb
@@ -64,7 +64,8 @@ module RuboCop
 
           sha256_on_arch_stanzas(cask_body) do |node, method, value|
             arch = method.to_s.delete_prefix("on_").to_sym
-            grouped_nodes[node.parent][arch] = { node:, value: }
+            ast_node = T.cast(node, RuboCop::AST::Node)
+            grouped_nodes[ast_node.parent][arch] = { node: ast_node, value: }
           end
 
           grouped_nodes.each_value do |nodes|
@@ -72,6 +73,10 @@ module RuboCop
 
             offending_node(nodes[:arm][:node])
             replacement_string = "sha256 arm: #{nodes[:arm][:value].inspect}, intel: #{nodes[:intel][:value].inspect}"
+            if comments_in_node_ranges?(nodes[:arm][:node], nodes[:intel][:node])
+              problem "Don't nest only the `sha256` stanzas in `on_intel` and `on_arm` blocks"
+              next
+            end
 
             problem "Don't nest only the `sha256` stanzas in `on_intel` and `on_arm` blocks" do |corrector|
               corrector.replace(nodes[:arm][:node].source_range, replacement_string)
@@ -86,7 +91,12 @@ module RuboCop
 
           version_and_sha256_on_arch_stanzas(cask_body) do |block_node, arch_method, version_value, sha256_value|
             arch = arch_method.to_s.delete_prefix("on_").to_sym
-            grouped_nodes[block_node.parent][arch] = { node: block_node, version_value:, sha256_value: }
+            ast_block_node = T.cast(block_node, RuboCop::AST::Node)
+            grouped_nodes[ast_block_node.parent][arch] = {
+              node:          ast_block_node,
+              version_value:,
+              sha256_value:,
+            }
           end
 
           grouped_nodes.each_value do |nodes|
@@ -112,9 +122,26 @@ module RuboCop
             replacement = "#{version_str}\n#{indent}#{sha256_str}"
 
             offending_node(arm_node)
+            if comments_in_node_ranges?(arm_node, intel_node)
+              problem "Don't nest identical `version` stanzas in `on_intel` and `on_arm` blocks"
+              next
+            end
+
             problem "Don't nest identical `version` stanzas in `on_intel` and `on_arm` blocks" do |corrector|
               corrector.replace(arm_node.source_range, replacement)
               corrector.remove(range_by_whole_lines(intel_node.source_range, include_final_newline: true))
+            end
+          end
+        end
+
+        sig { params(nodes: RuboCop::AST::Node).returns(T::Boolean) }
+        def comments_in_node_ranges?(*nodes)
+          processed_source.comments.any? do |comment|
+            comment_range = comment.loc.expression
+
+            nodes.any? do |node|
+              node_range = node.source_range
+              node_range.begin_pos <= comment_range.begin_pos && comment_range.end_pos <= node_range.end_pos
             end
           end
         end

--- a/Library/Homebrew/rubocops/cask/on_system_conditionals.rbi
+++ b/Library/Homebrew/rubocops/cask/on_system_conditionals.rbi
@@ -15,7 +15,8 @@ module RuboCop
         sig {
           params(
             base_node: Parser::AST::Node,
-            block:     T.proc.params(block_node: Parser::AST::Node, arch_method: Symbol, version_value: String, sha256_value: String).void,
+            block:     T.proc.params(block_node: Parser::AST::Node, arch_method: Symbol, version_value: String,
+                                     sha256_value: String).void,
           ).void
         }
         def version_and_sha256_on_arch_stanzas(base_node, &block); end

--- a/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
@@ -142,6 +142,23 @@ RSpec.describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
       CASK
     end
 
+    it "reports an offense but does not autocorrect when an `on_arch` block includes comments" do
+      expect_offense <<~CASK
+        cask 'foo' do
+          on_intel do
+            # comment
+            sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+          end
+          on_arm do
+          ^^^^^^^^^ Don't nest only the `sha256` stanzas in `on_intel` and `on_arm` blocks
+            sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+          end
+        end
+      CASK
+
+      expect_no_corrections
+    end
+
     it "accepts when there is also a `version` stanza inside the `on_arch` blocks with different versions" do
       expect_no_offenses <<~CASK
         cask 'foo' do
@@ -217,6 +234,25 @@ RSpec.describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
           sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
         end
       CASK
+    end
+
+    it "reports an offense but does not autocorrect when an `on_arch` block includes comments" do
+      expect_offense <<~CASK
+        cask 'foo' do
+          on_intel do
+            version "1.0.0"
+            # comment
+            sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+          end
+          on_arm do
+          ^^^^^^^^^ Don't nest identical `version` stanzas in `on_intel` and `on_arm` blocks
+            version "1.0.0"
+            sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+          end
+        end
+      CASK
+
+      expect_no_corrections
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

- Out of curiosity I gave the task to Copilot with context from [the PR with the manual fixes](https://github.com/Homebrew/homebrew-cask/pull/252975), plus the Slack thread that requested the RuboCop rule for this.
- _Immensely_ unsatisfying compared to doing it myself (@issyl0), to be honest, although much more efficient for getting started!
- Supersedes #21723 which got into a weird state.

-----

- Casks sometimes end up with `on_arm`/`on_intel` blocks whose `version` values are identical, such as if at some point they released an ARM-only version which had to have its own stanza.
- Making this an autocorrecting RuboCop means that it'll save maintainer time spent manually editing these like in https://github.com/Homebrew/homebrew-cask/pull/252975.
