### PR TITLE
bottles: fix nil built_on crash in load_tab

### DIFF
--- a/Library/Homebrew/test/utils/bottles/bottles_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/bottles_spec.rb
@@ -15,6 +15,31 @@ RSpec.describe Utils::Bottles do
   end
 
   describe ".load_tab" do
+    context "when bottle_tab_attributes are present but built_on is nil" do
+      before do
+        formula_name = "testball1"
+        formula_path = CoreTap.instance.new_formula_path(formula_name)
+        formula_path.write <<~RUBY
+          class #{Formulary.class_s(formula_name)} < Formula
+            url "testball1"
+            version "0.1"
+          end
+        RUBY
+        Formulary.cache.delete(formula_path)
+      end
+
+      it "does not raise when built_on is nil" do
+        formula = Formula["testball1"]
+        formula.prefix.mkpath
+
+        # Simulate API-served tab attributes that lack a built_on key
+        tab_attributes = { "homebrew_version" => "4.0.0" }
+        allow(formula).to receive(:bottle_tab_attributes).and_return(tab_attributes)
+
+        expect { described_class.load_tab(formula) }.not_to raise_error
+      end
+    end
+
     context "when tab_attributes and tabfile are missing" do
       before do
         # setup a testball1

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -124,7 +124,7 @@ module Utils
 
         if (tab_attributes = formula.bottle_tab_attributes.presence)
           tab = Tab.from_file_content(tab_attributes.to_json, tabfile)
-          return tab if tab.built_on["os"] == HOMEBREW_SYSTEM
+          return tab if tab.built_on&.[]("os") == HOMEBREW_SYSTEM
         elsif !tabfile.exist? && bottle_json_path&.exist?
           _, tag, = Utils::Bottles.extname_tag_rebuild(formula.local_bottle_path.to_s)
           bottle_hash = JSON.parse(File.read(bottle_json_path))


### PR DESCRIPTION
When bottle_tab_attributes from the API lack a 'built_on' key, Tab.from_file_content creates a Tab with built_on set to nil. Calling built_on["os"] then raises 'undefined method [] for nil'.

Add safe navigation (&.) so nil built_on falls through to the alternative code paths instead of crashing.

Summary:
`Utils::Bottles.load_tab` crashes with `undefined method '[]' for nil` when `bottle_tab_attributes` from the API lack a `built_on` key.

Problem:
In `Library/Homebrew/utils/bottles.rb:127`, the code calls:
`return tab if tab.built_on["os"] == HOMEBREW_SYSTEM`
When `built_on` is nil (because the API-served tab attributes don't include it), this raises `NoMethodError`. This affects bottle pours on Tier 3 macOS configurations where the API tab data may be incomplete.

Reproducing the problem - install a bottle lacking the `built_on` key:
```
$ brew install rkhunter   # on macOS 10.15 Catalina
==> Pouring rkhunter--1.4.6.catalina.bottle.tar.gz
Error: undefined method '[]' for nil
  utils/bottles.rb:127:in 'Utils::Bottles.load_tab'
```

Solution:
Add safe navigation (&.) so nil falls through to the alternative code paths:
`return tab if tab.built_on&.[]("os") == HOMEBREW_SYSTEM`

While arguably this could be an upstream problem where bottle maintainers ought to include the key, the solution provides a defensive programming solution that would otherwise render such bottles uninstallable.

- [ X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ X] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [X ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI (Warp's Oz agent) assisted with diagnosing the crash, writing the one-line fix, authoring the test case, and drafting this PR description. All changes were manually reviewed, and verified locally: `brew typecheck` passes, `brew style` reports no offenses on the changed files, and `brew tests --only=utils/bottles/bottles` passes (3 examples, 0 failures).
-----
