### PR TITLE
resource_auditor: audit PyPI resources that exist as formulae

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -754,6 +754,14 @@ module Homebrew
     def audit_specs
       problem "HEAD-only (no stable download)" if head_only?(formula) && @core_tap
 
+      allowed_pypi_packages = formula.tap&.audit_exception(:pypi_resources_allowlist, formula.name)
+      allowed_pypi_packages = case allowed_pypi_packages
+      when String
+        allowed_pypi_packages.split(/\s+/i).to_set
+      else
+        Set.new
+      end
+
       %w[Stable HEAD].each do |name|
         spec_name = name.downcase.to_sym
         next unless (spec = formula.send(spec_name))
@@ -776,9 +784,15 @@ module Homebrew
         spec.resources.each_value do |resource|
           problem "Resource name should be different from the formula name" if resource.name == formula.name
 
+          except = if allowed_pypi_packages.include?(resource.name)
+            @except.to_a + ["pypi_resources"]
+          else
+            @except
+          end
+
           ra = ResourceAuditor.new(
             resource, spec_name,
-            online: @online, strict: @strict, only: @only, except: @except,
+            online: @online, strict: @strict, only: @only, except:,
             use_homebrew_curl: resource.using == :homebrew_curl
           ).audit
           ra.problems.each do |message|

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -786,7 +786,9 @@ module Homebrew
           problem "Resource name should be different from the formula name" if resource.name == formula.name
 
           except = @except
-          except = [*Array(except), "pypi_resources"] if allowed_pypi_packages.include?(resource.name)
+          if allowed_pypi_packages.include?(resource.name) || formula.deprecated?
+            except = [*Array(except), "pypi_resources"]
+          end
 
           ra = ResourceAuditor.new(
             resource, spec_name,

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -754,10 +754,11 @@ module Homebrew
     def audit_specs
       problem "HEAD-only (no stable download)" if head_only?(formula) && @core_tap
 
-      allowed_pypi_packages = formula.tap&.audit_exception(:pypi_resources_allowlist, formula.name)
-      allowed_pypi_packages = case allowed_pypi_packages
-      when String
-        allowed_pypi_packages.split(/\s+/i).to_set
+      allowed_pypi_packages = if (resources_allowlist = formula
+        .tap
+        &.audit_exception(:pypi_resources_allowlist, formula.name)
+        .presence)
+        Set.new(resources_allowlist.split(/\s+/i))
       else
         Set.new
       end
@@ -784,15 +785,13 @@ module Homebrew
         spec.resources.each_value do |resource|
           problem "Resource name should be different from the formula name" if resource.name == formula.name
 
-          except = if allowed_pypi_packages.include?(resource.name)
-            @except.to_a + ["pypi_resources"]
-          else
-            @except
-          end
+          except = @except
+          except = [*Array(except), "pypi_resources"] if allowed_pypi_packages.include?(resource.name)
 
           ra = ResourceAuditor.new(
             resource, spec_name,
             online: @online, strict: @strict, only: @only, except:,
+            pypi_formulae: formula.tap&.pypi_dependencies_formulae,
             use_homebrew_curl: resource.using == :homebrew_curl
           ).audit
           ra.problems.each do |message|

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -754,10 +754,8 @@ module Homebrew
     def audit_specs
       problem "HEAD-only (no stable download)" if head_only?(formula) && @core_tap
 
-      allowed_pypi_packages = if (resources_allowlist = formula
-        .tap
-        &.audit_exception(:pypi_resources_allowlist, formula.name)
-        .presence)
+      allowed_pypi_packages = if (tap = formula.tap) &&
+        (tap.audit_exception(:pypi_resources_allowlist, formula.name).presence)
         Set.new(resources_allowlist.split(/\s+/i))
       else
         Set.new

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -755,10 +755,23 @@ module Homebrew
       problem "HEAD-only (no stable download)" if head_only?(formula) && @core_tap
 
       allowed_pypi_packages = if (tap = formula.tap) &&
-        (tap.audit_exception(:pypi_resources_allowlist, formula.name).presence)
+                                 (resources_allowlist = tap&.audit_exception(:pypi_resources_allowlist, formula.name)
+                                 .presence)
         Set.new(resources_allowlist.split(/\s+/i))
       else
         Set.new
+      end
+
+      # Skip PyPI audit if formula uses old Python (2 minor versions behind the latest release)
+      python_minor_version = formula
+                             .deps
+                             .select { |dep| dep.name.start_with?("python@") }
+                             .map { |dep| dep.to_formula.version.minor&.to_i }
+                             .max
+      old_python = if python_minor_version.nil?
+        false
+      else
+        (Formula["python"].version.minor.to_i - python_minor_version) >= 2
       end
 
       %w[Stable HEAD].each do |name|
@@ -792,7 +805,7 @@ module Homebrew
             resource, spec_name,
             online: @online, strict: @strict, only: @only, except:,
             pypi_formulae: formula.tap&.pypi_dependencies_formulae,
-            use_homebrew_curl: resource.using == :homebrew_curl
+            use_homebrew_curl: resource.using == :homebrew_curl, old_python:
           ).audit
           ra.problems.each do |message|
             problem "#{name} resource #{resource.name.inspect}: #{message}"

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -8,8 +8,6 @@ module Homebrew
   class ResourceAuditor
     include Utils::Curl
 
-    DEPENDENCY_PACKAGES = Set.new(%w[certifi cffi cryptography numpy pillow pydantic rpds-py scipy torch]).freeze
-
     attr_reader :name, :version, :checksum, :url, :mirrors, :using, :specs, :owner, :spec_name, :problems
 
     def initialize(resource, spec_name, options = {})
@@ -27,6 +25,7 @@ module Homebrew
       @only      = options[:only]
       @except    = options[:except]
       @core_tap  = options[:core_tap]
+      @pypi_formulae = options[:pypi_formulae] || []
       @use_homebrew_curl = options[:use_homebrew_curl]
       @problems = []
     end
@@ -130,9 +129,12 @@ module Homebrew
         problem "`resource` name should be '#{pypi_package_name}' to match the PyPI package name"
       end
 
-      return if DEPENDENCY_PACKAGES.exclude?(pypi_package_name.to_s.downcase)
+      pypi_package_name = pypi_package_name.to_s.downcase
 
-      problem "PyPI package should be replaced with Homebrew dependency and excluded using `pypi_package` method"
+      return if @pypi_formulae.exclude?(pypi_package_name)
+
+      problem "PyPI package should be replaced with `depends_on \"#{pypi_package_name}\"` " \
+              "and excluded using `pypi_package` method"
     end
 
     def audit_urls

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -26,6 +26,7 @@ module Homebrew
       @except    = options[:except]
       @core_tap  = options[:core_tap]
       @pypi_formulae = options[:pypi_formulae] || []
+      @old_python = options[:old_python] || false
       @use_homebrew_curl = options[:use_homebrew_curl]
       @problems = []
     end
@@ -131,9 +132,9 @@ module Homebrew
 
       pypi_package_name = pypi_package_name.to_s.downcase
 
-      return if @pypi_formulae.exclude?(pypi_package_name)
+      return if @pypi_formulae.exclude?(pypi_package_name) || @old_python
 
-      problem "PyPI package should be replaced with `depends_on \"#{pypi_package_name}\"` "
+      problem "PyPI package should be replaced with `depends_on \"#{pypi_package_name}\"`"
     end
 
     def audit_urls

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -8,6 +8,8 @@ module Homebrew
   class ResourceAuditor
     include Utils::Curl
 
+    DEPENDENCY_PACKAGES = Set.new(%w[certifi cffi cryptography numpy pillow pydantic rpds-py scipy torch]).freeze
+
     attr_reader :name, :version, :checksum, :url, :mirrors, :using, :specs, :owner, :spec_name, :problems
 
     def initialize(resource, spec_name, options = {})
@@ -108,7 +110,7 @@ module Homebrew
       end
     end
 
-    def audit_resource_name_matches_pypi_package_name_in_url
+    def audit_pypi_resources
       return unless url.match?(%r{^https?://files\.pythonhosted\.org/packages/})
       return if name == owner.name # Skip the top-level package name as we only care about `resource "foo"` blocks.
 
@@ -124,9 +126,13 @@ module Homebrew
 
       T.must(pypi_package_name).gsub!(/[_.]/, "-")
 
-      return if name.casecmp(pypi_package_name).zero?
+      if name.casecmp(pypi_package_name).nonzero?
+        problem "`resource` name should be '#{pypi_package_name}' to match the PyPI package name"
+      end
 
-      problem "`resource` name should be '#{pypi_package_name}' to match the PyPI package name"
+      return if DEPENDENCY_PACKAGES.exclude?(pypi_package_name.to_s.downcase)
+
+      problem "PyPI package should be replaced with Homebrew dependency and excluded using `pypi_package` method"
     end
 
     def audit_urls

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -133,8 +133,7 @@ module Homebrew
 
       return if @pypi_formulae.exclude?(pypi_package_name)
 
-      problem "PyPI package should be replaced with `depends_on \"#{pypi_package_name}\"` " \
-              "and excluded using `pypi_package` method"
+      problem "PyPI package should be replaced with `depends_on \"#{pypi_package_name}\"` "
     end
 
     def audit_urls

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -29,6 +29,8 @@ class Tap
   private_constant :HOMEBREW_TAP_SYNCED_VERSIONS_FORMULAE_FILE
   HOMEBREW_TAP_DISABLED_NEW_USR_LOCAL_RELOCATION_FORMULAE_FILE = "disabled_new_usr_local_relocation_formulae.json"
   private_constant :HOMEBREW_TAP_DISABLED_NEW_USR_LOCAL_RELOCATION_FORMULAE_FILE
+  HOMEBREW_TAP_PYPI_DEPENDENCIES_FORMULAE = "pypi_dependencies_formulae.json"
+  private_constant :HOMEBREW_TAP_PYPI_DEPENDENCIES_FORMULAE
   HOMEBREW_TAP_AUDIT_EXCEPTIONS_DIR = "audit_exceptions"
   private_constant :HOMEBREW_TAP_AUDIT_EXCEPTIONS_DIR
   HOMEBREW_TAP_STYLE_EXCEPTIONS_DIR = "style_exceptions"
@@ -40,6 +42,7 @@ class Tap
     #{HOMEBREW_TAP_MIGRATIONS_FILE}
     #{HOMEBREW_TAP_SYNCED_VERSIONS_FORMULAE_FILE}
     #{HOMEBREW_TAP_DISABLED_NEW_USR_LOCAL_RELOCATION_FORMULAE_FILE}
+    #{HOMEBREW_TAP_PYPI_DEPENDENCIES_FORMULAE}
     #{HOMEBREW_TAP_AUDIT_EXCEPTIONS_DIR}/*.json
     #{HOMEBREW_TAP_STYLE_EXCEPTIONS_DIR}/*.json
   ].freeze, T::Array[String])
@@ -1094,6 +1097,19 @@ class Tap
   def disabled_new_usr_local_relocation_formulae
     @disabled_new_usr_local_relocation_formulae ||= T.let(
       if (synced_file = path/HOMEBREW_TAP_DISABLED_NEW_USR_LOCAL_RELOCATION_FORMULAE_FILE).file?
+        JSON.parse(synced_file.read)
+      else
+        []
+      end,
+      T.nilable(T::Array[String]),
+    )
+  end
+
+  # Array with PyPI packages that should be used as dependencies
+  sig { overridable.returns(T::Array[String]) }
+  def pypi_dependencies_formulae
+    @pypi_dependencies_formulae ||= T.let(
+      if (synced_file = path/HOMEBREW_TAP_PYPI_DEPENDENCIES_FORMULAE).file?
         JSON.parse(synced_file.read)
       else
         []

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -580,7 +580,7 @@ RSpec.describe Homebrew::FormulaAuditor do
     end
   end
 
-  describe "#audit_resource_name_matches_pypi_package_name_in_url" do
+  describe "#audit_pypi_resources" do
     it "reports a problem if the resource name does not match the python sdist name" do
       fa = formula_auditor "foo", <<~RUBY
         class Foo < Formula
@@ -617,6 +617,68 @@ RSpec.describe Homebrew::FormulaAuditor do
       fa.audit_specs
       expect(fa.problems.first[:message])
         .to match("`resource` name should be 'FooSomething' to match the PyPI package name")
+    end
+
+    it "reports a problem if the resource should be replaced with a dependency" do
+      fa = formula_auditor "foo", <<~RUBY
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          sha256 "abc123"
+          homepage "https://brew.sh"
+
+          resource "cryptography" do
+            url "https://files.pythonhosted.org/packages/00/00/aaaa/cryptography-1.0.0.tar.gz"
+            sha256 "def456"
+          end
+
+          resource "pydantic" do
+            url "https://files.pythonhosted.org/packages/00/00/aaaa/pydantic-1.0.0.tar.gz"
+            sha256 "ghi789"
+          end
+        end
+      RUBY
+
+      fa.audit_specs
+      expect(fa.problems.count).to eq(2)
+      expect(fa.problems.first[:message])
+        .to match("PyPI package should be replaced with Homebrew dependency and excluded using `pypi_package` method")
+    end
+
+    it "doesn't report a problem if there is an exception to a PyPI resource that should be a dependency" do
+      tap_audit_exceptions = { pypi_resources_allowlist: { "foo" => "cryptography pydantic" } }
+      fa = formula_auditor("foo", <<~RUBY, tap_audit_exceptions:)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          sha256 "abc123"
+          homepage "https://brew.sh"
+
+          resource "cryptography" do
+            url "https://files.pythonhosted.org/packages/60/04/aaaa/cryptography-1.0.0.tar.gz"
+            sha256 "def456"
+          end
+
+          resource "pydantic" do
+            url "https://files.pythonhosted.org/packages/00/00/aaaa/pydantic-1.0.0.tar.gz"
+            sha256 "ghi789"
+          end
+        end
+      RUBY
+
+      fa.audit_specs
+      expect(fa.problems).to be_empty
+    end
+
+    it "doesn't audit PyPI package if it is not a resource" do
+      fa = formula_auditor "cryptography", <<~RUBY
+        class Cryptography < Formula
+          url "https://files.pythonhosted.org/packages/60/04/aaaa/cryptography-1.0.0.tar.gz"
+          sha256 "abc123"
+          homepage "https://brew.sh"
+        end
+      RUBY
+
+      fa.audit_specs
+      expect(fa.problems).to be_empty
     end
   end
 

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -674,6 +674,31 @@ RSpec.describe Homebrew::FormulaAuditor do
       expect(fa.problems).to be_empty
     end
 
+    it "doesn't report a problem if formula is deprecated" do
+      fa = formula_auditor("foo", <<~RUBY, tap_audit_exceptions: {}, pypi_dependencies_formulae:)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          sha256 "abc123"
+          homepage "https://brew.sh"
+
+          deprecate! date: "2026-01-01", because: "some reasone"
+
+          resource "bar" do
+            url "https://files.pythonhosted.org/packages/00/00/aaaa/bar-1.0.0.tar.gz"
+            sha256 "def456"
+          end
+
+          resource "baz" do
+            url "https://files.pythonhosted.org/packages/00/00/aaaa/baz-1.0.0.tar.gz"
+            sha256 "ghi789"
+          end
+        end
+      RUBY
+
+      fa.audit_specs
+      expect(fa.problems).to be_empty
+    end
+
     it "doesn't audit PyPI package if it is not a resource" do
       fa = formula_auditor("bar", <<~RUBY, tap_audit_exceptions: {}, pypi_dependencies_formulae:)
         class Bar < Formula

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -30,7 +30,10 @@ RSpec.describe Homebrew::FormulaAuditor do
 
     if options.key? :tap_audit_exceptions
       tap = Tap.fetch("test/tap")
-      allow(tap).to receive(:audit_exceptions).and_return(options[:tap_audit_exceptions])
+      allow(tap).to receive_messages(
+        audit_exceptions:           options[:tap_audit_exceptions],
+        pypi_dependencies_formulae: options[:pypi_dependencies_formulae] || [],
+      )
       allow(formula).to receive(:tap).and_return(tap)
       options.delete :tap_audit_exceptions
     end
@@ -581,6 +584,8 @@ RSpec.describe Homebrew::FormulaAuditor do
   end
 
   describe "#audit_pypi_resources" do
+    let(:pypi_dependencies_formulae) { ["bar", "baz"] }
+
     it "reports a problem if the resource name does not match the python sdist name" do
       fa = formula_auditor "foo", <<~RUBY
         class Foo < Formula
@@ -620,19 +625,19 @@ RSpec.describe Homebrew::FormulaAuditor do
     end
 
     it "reports a problem if the resource should be replaced with a dependency" do
-      fa = formula_auditor "foo", <<~RUBY
+      fa = formula_auditor("foo", <<~RUBY, tap_audit_exceptions: {}, pypi_dependencies_formulae:)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
           sha256 "abc123"
           homepage "https://brew.sh"
 
-          resource "cryptography" do
-            url "https://files.pythonhosted.org/packages/00/00/aaaa/cryptography-1.0.0.tar.gz"
+          resource "bar" do
+            url "https://files.pythonhosted.org/packages/00/00/aaaa/bar-1.0.0.tar.gz"
             sha256 "def456"
           end
 
-          resource "pydantic" do
-            url "https://files.pythonhosted.org/packages/00/00/aaaa/pydantic-1.0.0.tar.gz"
+          resource "baz" do
+            url "https://files.pythonhosted.org/packages/00/00/aaaa/baz-1.0.0.tar.gz"
             sha256 "ghi789"
           end
         end
@@ -641,24 +646,25 @@ RSpec.describe Homebrew::FormulaAuditor do
       fa.audit_specs
       expect(fa.problems.count).to eq(2)
       expect(fa.problems.first[:message])
-        .to match("PyPI package should be replaced with Homebrew dependency and excluded using `pypi_package` method")
+        .to match("PyPI package should be replaced with `depends_on \"bar\"` " \
+                  "and excluded using `pypi_package` method")
     end
 
     it "doesn't report a problem if there is an exception to a PyPI resource that should be a dependency" do
-      tap_audit_exceptions = { pypi_resources_allowlist: { "foo" => "cryptography pydantic" } }
-      fa = formula_auditor("foo", <<~RUBY, tap_audit_exceptions:)
+      tap_audit_exceptions = { pypi_resources_allowlist: { "foo" => "bar baz" } }
+      fa = formula_auditor("foo", <<~RUBY, tap_audit_exceptions:, pypi_dependencies_formulae:)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
           sha256 "abc123"
           homepage "https://brew.sh"
 
-          resource "cryptography" do
-            url "https://files.pythonhosted.org/packages/60/04/aaaa/cryptography-1.0.0.tar.gz"
+          resource "bar" do
+            url "https://files.pythonhosted.org/packages/00/00/aaaa/bar-1.0.0.tar.gz"
             sha256 "def456"
           end
 
-          resource "pydantic" do
-            url "https://files.pythonhosted.org/packages/00/00/aaaa/pydantic-1.0.0.tar.gz"
+          resource "baz" do
+            url "https://files.pythonhosted.org/packages/00/00/aaaa/baz-1.0.0.tar.gz"
             sha256 "ghi789"
           end
         end
@@ -669,9 +675,9 @@ RSpec.describe Homebrew::FormulaAuditor do
     end
 
     it "doesn't audit PyPI package if it is not a resource" do
-      fa = formula_auditor "cryptography", <<~RUBY
-        class Cryptography < Formula
-          url "https://files.pythonhosted.org/packages/60/04/aaaa/cryptography-1.0.0.tar.gz"
+      fa = formula_auditor("bar", <<~RUBY, tap_audit_exceptions: {}, pypi_dependencies_formulae:)
+        class Bar < Formula
+          url "https://files.pythonhosted.org/packages/00/00/aaaa/bar-1.0.0.tar.gz"
           sha256 "abc123"
           homepage "https://brew.sh"
         end

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -646,8 +646,7 @@ RSpec.describe Homebrew::FormulaAuditor do
       fa.audit_specs
       expect(fa.problems.count).to eq(2)
       expect(fa.problems.first[:message])
-        .to match("PyPI package should be replaced with `depends_on \"bar\"` " \
-                  "and excluded using `pypi_package` method")
+        .to match("PyPI package should be replaced with `depends_on \"bar\"`")
     end
 
     it "doesn't report a problem if there is an exception to a PyPI resource that should be a dependency" do
@@ -682,6 +681,32 @@ RSpec.describe Homebrew::FormulaAuditor do
           homepage "https://brew.sh"
 
           deprecate! date: "2026-01-01", because: "some reasone"
+
+          resource "bar" do
+            url "https://files.pythonhosted.org/packages/00/00/aaaa/bar-1.0.0.tar.gz"
+            sha256 "def456"
+          end
+
+          resource "baz" do
+            url "https://files.pythonhosted.org/packages/00/00/aaaa/baz-1.0.0.tar.gz"
+            sha256 "ghi789"
+          end
+        end
+      RUBY
+
+      fa.audit_specs
+      expect(fa.problems).to be_empty
+    end
+
+    it "doesn't report a problem if formula uses old Python" do
+      old_python_version = Formula["python"].version.minor.to_i - 2
+      fa = formula_auditor("foo", <<~RUBY, tap_audit_exceptions: {}, pypi_dependencies_formulae:)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          sha256 "abc123"
+          homepage "https://brew.sh"
+
+          depends_on "python@3.#{old_python_version}"
 
           resource "bar" do
             url "https://files.pythonhosted.org/packages/00/00/aaaa/bar-1.0.0.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
Some widely-used PyPI packages are available in Homebrew as dependencies for other Python-based formulae. We encourage their use either because they take a lot of time to build (f.e. `pydantic` or `scipy`) or we don't want to do hundreds of revision bumps when new security updates come out (f.e. `cryptography` or `certifi`). The problem I see with new contributors is that they don't know it. A lot of the time, they read the cookbook, create a Python-based formula, and it passes audit and tests. They did nothing wrong, but a maintainer still have to point out, "Hey, numpy takes a lot of time to build, and it exists as a formula, let's use it instead". I'd rather add an audit for such cases and make exceptions for formulae where it cannot be used

I'd also take a look at [Python for Formula Authors](https://docs.brew.sh/Python-for-Formula-Authors) but it should be revised in another PR