### PR TITLE
Homebrew startup performance tweaks

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -40,9 +40,7 @@ begin
       help_flag = true
       help_cmd_index = i
     elsif !cmd && help_flag_list.exclude?(arg)
-      require "commands"
       cmd = ARGV.delete_at(i)
-      cmd = Commands::HOMEBREW_INTERNAL_COMMAND_ALIASES.fetch(cmd, cmd)
     end
   end
 
@@ -64,14 +62,26 @@ begin
   require "commands"
   require "warnings"
 
-  internal_cmd = Commands.valid_internal_cmd?(cmd) || Commands.valid_internal_dev_cmd?(cmd) if cmd
+  internal_cmd = T.let(false, T::Boolean)
+  external_ruby_v2_cmd = T.let(false, T::Boolean)
+  external_ruby_cmd_path = T.let(nil, T.nilable(Pathname))
+  external_cmd_path = T.let(nil, T.nilable(Pathname))
 
-  unless internal_cmd
-    # Add contributed commands to PATH before checking.
-    homebrew_path.append(Commands.tap_cmd_directories)
+  if cmd
+    cmd = Commands::HOMEBREW_INTERNAL_COMMAND_ALIASES.fetch(cmd, cmd)
+    internal_cmd = Commands.valid_internal_cmd?(cmd) || Commands.valid_internal_dev_cmd?(cmd)
 
-    # External commands expect a normal PATH
-    ENV["PATH"] = homebrew_path.to_s
+    unless internal_cmd
+      # Add contributed commands to PATH before checking.
+      homebrew_path.append(Commands.tap_cmd_directories)
+
+      # External commands expect a normal PATH
+      ENV["PATH"] = homebrew_path.to_s
+
+      external_ruby_v2_cmd = Commands.external_ruby_v2_cmd_path(cmd).present?
+      external_ruby_cmd_path = Commands.external_ruby_cmd_path(cmd) unless external_ruby_v2_cmd
+      external_cmd_path = Commands.external_cmd_path(cmd) if !external_ruby_v2_cmd && external_ruby_cmd_path.nil?
+    end
   end
 
   # Usage instructions should be displayed if and only if one of:
@@ -86,8 +96,11 @@ begin
 
   if cmd.nil?
     raise UsageError, "Unknown command: brew #{ARGV.join(" ")}"
-  elsif internal_cmd || Commands.external_ruby_v2_cmd_path(cmd)
+  elsif internal_cmd || external_ruby_v2_cmd
     cmd_class = Homebrew::AbstractCommand.command(cmd)
+    if cmd_class&.include?(Homebrew::ShellCommand)
+      exec (HOMEBREW_LIBRARY_PATH.parent.parent/"bin/brew").to_s, cmd, *ARGV
+    end
     Homebrew.running_command = cmd
     if cmd_class
       unless Homebrew::EnvConfig.no_install_from_api?
@@ -115,15 +128,15 @@ begin
         raise
       end
     end
-  elsif (path = Commands.external_ruby_cmd_path(cmd))
+  elsif external_ruby_cmd_path
     Homebrew.running_command = cmd
-    Homebrew.require?(path)
+    Homebrew.require?(external_ruby_cmd_path)
     exit Homebrew.failed? ? 1 : 0
-  elsif Commands.external_cmd_path(cmd)
+  elsif external_cmd_path
     %w[CACHE LIBRARY_PATH].each do |env|
       ENV["HOMEBREW_#{env}"] = Object.const_get(:"HOMEBREW_#{env}").to_s
     end
-    exec "brew-#{cmd}", *ARGV
+    exec external_cmd_path.to_s, *ARGV
   else
     raise UsageError, "Unknown command: brew #{cmd}"
   end

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -54,13 +54,6 @@ then
   HOMEBREW_DEFAULT_CACHE="${HOME}/Library/Caches/Homebrew"
   HOMEBREW_DEFAULT_LOGS="${HOME}/Library/Logs/Homebrew"
   HOMEBREW_DEFAULT_TEMP="/private/tmp"
-
-  HOMEBREW_MACOS_VERSION="$(/usr/bin/sw_vers -productVersion)"
-
-  IFS=. read -r -a MACOS_VERSION_ARRAY < <(printf '%s' "${HOMEBREW_MACOS_VERSION}")
-  printf -v HOMEBREW_MACOS_VERSION_NUMERIC "%02d%02d%02d" "${MACOS_VERSION_ARRAY[@]}"
-
-  unset MACOS_VERSION_ARRAY
 else
   CACHE_HOME="${HOMEBREW_XDG_CACHE_HOME:-${HOME}/.cache}"
   HOMEBREW_DEFAULT_CACHE="${CACHE_HOME}/Homebrew"
@@ -201,8 +194,11 @@ esac
 
 # Check `HOMEBREW_FORCE_BREW_WRAPPER` for all non-trivial commands
 # (i.e. not defined above this line e.g. formulae or --cellar).
-source "${HOMEBREW_LIBRARY}/Homebrew/utils/wrapper.sh"
-check-brew-wrapper "$1"
+if [[ -n "${HOMEBREW_FORCE_BREW_WRAPPER:-}" ]]
+then
+  source "${HOMEBREW_LIBRARY}/Homebrew/utils/wrapper.sh"
+  check-brew-wrapper "$1"
+fi
 
 # commands that take a single or no arguments and need to write to HOMEBREW_PREFIX.
 # HOMEBREW_LIBRARY set by bin/brew
@@ -498,7 +494,6 @@ setup_git() {
   fi
 }
 
-setup_curl
 setup_git
 
 GIT_DESCRIBE_CACHE="${HOMEBREW_REPOSITORY}/.git/describe-cache"
@@ -583,6 +578,21 @@ case "$1" in
     exit 0
     ;;
 esac
+
+setup_curl
+
+HOMEBREW_API_DEFAULT_DOMAIN="https://formulae.brew.sh/api"
+HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://ghcr.io/v2/homebrew/core"
+
+if [[ -n "${HOMEBREW_MACOS}" ]]
+then
+  HOMEBREW_MACOS_VERSION="$(/usr/bin/sw_vers -productVersion)"
+
+  IFS=. read -r -a MACOS_VERSION_ARRAY < <(printf '%s' "${HOMEBREW_MACOS_VERSION}")
+  printf -v HOMEBREW_MACOS_VERSION_NUMERIC "%02d%02d%02d" "${MACOS_VERSION_ARRAY[@]}"
+
+  unset MACOS_VERSION_ARRAY
+fi
 
 # TODO: bump version when new macOS is released or announced and update references in:
 # - docs/Installation.md
@@ -752,9 +762,6 @@ if [[ -n "${HOMEBREW_BOTTLE_DEFAULT_DOMAIN}" ]] &&
 then
   unset HOMEBREW_BOTTLE_DOMAIN
 fi
-
-HOMEBREW_API_DEFAULT_DOMAIN="https://formulae.brew.sh/api"
-HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://ghcr.io/v2/homebrew/core"
 
 HOMEBREW_USER_AGENT="${HOMEBREW_PRODUCT}/${HOMEBREW_USER_AGENT_VERSION} (${HOMEBREW_SYSTEM}; ${HOMEBREW_PROCESSOR} ${HOMEBREW_OS_USER_AGENT_VERSION})"
 curl_version_output="$(curl --version 2>/dev/null)"

--- a/bin/brew
+++ b/bin/brew
@@ -43,7 +43,14 @@ quiet_cd() {
 symlink_target_directory() {
   local target target_dirname
   target="$(readlink "$1")"
-  target_dirname="$(dirname "${target}")"
+  target_dirname="${target%/*}"
+  if [[ "${target_dirname}" == "${target}" ]]
+  then
+    target_dirname="."
+  elif [[ -z "${target_dirname}" ]]
+  then
+    target_dirname="/"
+  fi
   local directory="$2"
   quiet_cd "${directory}" && quiet_cd "${target_dirname}" && pwd -P
 }
@@ -109,19 +116,17 @@ BIN_BREW_EXPORTED_VARS=(
   HOMEBREW_USER_CONFIG_HOME
   HOMEBREW_ORIGINAL_BREW_FILE
 )
+BIN_BREW_EXPORTED_VARS_REGEX="^($(
+  IFS='|'
+  echo "${BIN_BREW_EXPORTED_VARS[*]}"
+))(=|$)"
 
 # Load Homebrew's variable configuration files from disk.
 export_homebrew_env_file() {
   local env_file
-  local bin_brew_exported_vars_regex
 
   env_file="${1}"
   [[ -r "${env_file}" ]] || return 0
-
-  bin_brew_exported_vars_regex="^($(
-    IFS='|'
-    echo "${BIN_BREW_EXPORTED_VARS[*]}"
-  ))(=|$)"
 
   while read -r line
   do
@@ -129,7 +134,7 @@ export_homebrew_env_file() {
     [[ "${line}" =~ ^(HOMEBREW_|SUDO_ASKPASS=|(all|no|ftp|https?)_proxy=) ]] || continue
 
     # forbid overriding variables that are set in this file
-    [[ "${line}" =~ ${bin_brew_exported_vars_regex} ]] && continue
+    [[ "${line}" =~ ${BIN_BREW_EXPORTED_VARS_REGEX} ]] && continue
 
     export "${line?}"
   done <"${env_file}"


### PR DESCRIPTION
Move some stuff around to improve cold startup performance.

`brew --prefix` went from about 16.5 ms to 9.0 ms
`brew help` went from about 16.5 ms to 8.7 ms.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Used OpenAI Codex to test with manual testing and human review passes on both high-level approach and specific code changes.

-----
