### PR TITLE
generate-cask-ci-matrix.rb: better ci-skip-repository coverage

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
@@ -261,9 +261,9 @@ module Homebrew
           audit_exceptions << "min_os" if labels.include?("ci-skip-livecheck-min-os")
 
           if labels.include?("ci-skip-repository")
-            audit_exceptions << %w[github_repository github_repository_archived github_prerelease_version
-                                   gitlab_repository gitlab_repository_archived gitlab_prerelease_version
-                                   forgejo_repository forgejo_repository_archived forgejo_prerelease_version
+            audit_exceptions << %w[github_repository github_prerelease_version
+                                   gitlab_repository gitlab_prerelease_version
+                                   forgejo_repository forgejo_prerelease_version
                                    bitbucket_repository]
           end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Make sure that `ci-skip-repository` also skips Forgejo audits ~~and archived repository audits~~.  Unblocks Homebrew/homebrew-cask#252371.