### PR TITLE
linkage_checker: allow cyan extras

### DIFF
--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -123,9 +123,18 @@ class LinkageChecker
   sig { params(file: String).returns(T::Boolean) }
   def broken_dylibs_allowed?(file)
     formula = self.formula
-    return false if formula.nil? || formula.name != "julia"
+    return false if formula.nil?
 
-    file.start_with?("#{formula.prefix.realpath}/share/julia/compiled/")
+    case formula.name
+    when "julia"
+      file.start_with?("#{formula.prefix.realpath}/share/julia/compiled/")
+    when "cyan"
+      file.match?(
+        %r{\A#{Regexp.escape(formula.prefix.realpath.to_s)}/libexec/lib/python\d+\.\d+/site-packages/cyan/extras/},
+      )
+    else
+      false
+    end
   end
 
   sig { params(rebuild_cache: T::Boolean).void }


### PR DESCRIPTION
This is necessary because cyan injects in an IPA some frameworks that link to iOS system frameworks. These system frameworks are not on macOS but they are not needed because the IPA is to be sideloaded on an iPhone, these frameworks will never be used on macOS itself.

This is required to fix https://github.com/Homebrew/homebrew-core/pull/271929 CI.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
