### PR TITLE
sorbet: enable experimental RSpec mode

### DIFF
--- a/Library/Homebrew/formula-analytics/pycall-setup.rbi
+++ b/Library/Homebrew/formula-analytics/pycall-setup.rbi
@@ -1,7 +1,7 @@
 # typed: true
 
 class InfluxDBClient3
-  def self.initialize(*args); end
+  def initialize(*args); end
 
   def query(*args); end
 end

--- a/Library/Homebrew/sorbet/config
+++ b/Library/Homebrew/sorbet/config
@@ -1,5 +1,6 @@
 --dir=.
 --enable-experimental-requires-ancestor
+--enable-experimental-rspec
 --ignore=/vendor/bundle
 --ignore=/vendor/gems
 --ignore=/vendor/ruby


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude Code was used to draft the commit message and PR description. The changes themselves were authored by the human. The diff was reviewed manually before committing.

-----

Adds `--enable-experimental-rspec` to the Sorbet config so that Sorbet type-checks RSpec spec files. This is an isolated piece of #21690, separated so that the follow-up work of dialling up the `typed:` level of individual specs can land independently.

Enabling the flag surfaced a pre-existing type error in `formula-analytics/pycall-setup.rbi` where `InfluxDBClient3#initialize` was incorrectly declared as a singleton method (`def self.initialize`) rather than an instance method (`def initialize`).

No new tests are needed — the change is to Sorbet configuration and an RBI stub file; correctness is verified by `brew typecheck` passing.