### PR TITLE
Fix remote tab sometimes being used for local bottle installs

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1416,6 +1416,7 @@ on_request: installed_on_request?, options:)
   sig { params(quiet: T::Boolean, enqueue: T::Boolean).void }
   def fetch_bottle_tab(quiet: false, enqueue: false)
     return if @fetch_bottle_tab
+    return if formula.local_bottle_path.present?
 
     if (bottle = formula.bottle) &&
        (manifest_resource = bottle.github_packages_manifest_resource) &&

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -122,7 +122,7 @@ module Utils
         tabfile = keg/AbstractTab::FILENAME
         bottle_json_path = formula.local_bottle_path&.sub(/\.(\d+\.)?tar\.gz$/, ".json")
 
-        if (tab_attributes = formula.bottle_tab_attributes.presence)
+        if bottle_json_path.nil? && (tab_attributes = formula.bottle_tab_attributes.presence)
           tab = Tab.from_file_content(tab_attributes.to_json, tabfile)
           return tab if tab.built_on["os"] == HOMEBREW_SYSTEM
         elsif !tabfile.exist? && bottle_json_path&.exist?


### PR DESCRIPTION
When installing from a local bottle (`brew install ./bottle.tar.gz`), either the tab `.json` found alongside the bottle or the tab inside the bottle tarball is expected to be used. This logic was triggered under conditional on there not being a bottle block, which is normally true if you are loading the formula from the bottle tarball itself.

However, it is possible that if the formula inside the bottle tarball is unreadable it will fall back to the tap's formula which does have a bottle block. This would then fetch and use the remote tab attributes which is incorrect as that's possibly for a different version of the formula.

Instead, let's correctly add explicit `formula.local_bottle_path` checks that were previously implied under the normal scenario.

The set of circumstances described to force a fallback onto the tap formula is rare and did not happen with any first-party Homebrew/core formula. It would require using syntax that is currently not able to be bottled, such as `require_relative`.

https://github.com/orgs/Homebrew/discussions/6753