### PR TITLE
rubocops/dependency_order: fix error on dstr

### DIFF
--- a/Library/Homebrew/rubocops/dependency_order.rb
+++ b/Library/Homebrew/rubocops/dependency_order.rb
@@ -43,8 +43,10 @@ module RuboCop
         end
 
         def ensure_dependency_order(nodes)
-          ordered = nodes.sort_by { |node| dependency_name(node).downcase }
-          ordered = sort_dependencies_by_type(ordered)
+          name_node_pairs = nodes.map { |node| [dependency_name(node), node] }
+          name_node_pairs.select! { |name, _| name } # skip nodes with invalid dependency name
+          name_node_pairs.sort_by! { |name, _| name.downcase }
+          ordered = sort_dependencies_by_type(name_node_pairs.map { |_, node| node })
           sort_conditional_dependencies!(ordered)
           verify_order_in_source(ordered)
         end
@@ -143,8 +145,8 @@ module RuboCop
 
         # Node pattern method to extract `name` in `depends_on :name` or `uses_from_macos :name`
         def_node_search :dependency_name_node, <<~EOS
-          {(send nil? {:depends_on :uses_from_macos} {(hash (pair $_ _) ...) $({str sym} _) $(const nil? _)} ...)
-           (if _ (send nil? :depends_on {(hash (pair $_ _)) $({str sym} _) $(const nil? _)}) nil?)}
+          {(send nil? {:depends_on :uses_from_macos} {(hash (pair $_ _) ...) $({str sym dstr} ...) $(const nil? _)} ...)
+           (if _ (send nil? :depends_on {(hash (pair $_ _)) $({str sym dstr} ...) $(const nil? _)}) nil?)}
         EOS
 
         # Node pattern method to extract `name` in `build.with? :name`

--- a/Library/Homebrew/test/rubocops/dependency_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/dependency_order_spec.rb
@@ -279,5 +279,32 @@ RSpec.describe RuboCop::Cop::FormulaAudit::DependencyOrder do
         end
       RUBY
     end
+
+    it "handles dynamic strings in depends_on" do
+      expect_offense(<<~'RUBY')
+        class Foo < Formula
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
+
+          BAR_VERSION = 1
+
+          depends_on "foo"
+          depends_on "bar@#{BAR_VERSION}"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "bar@#{BAR_VERSION}"` (line 8) should be put before `dependency "foo"` (line 7)
+        end
+      RUBY
+    end
+
+    it "does not error on invalid depends_on" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
+          depends_on "apple"
+          depends_on 1
+          depends_on "bar"
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
While we can't truly find the string content when it is a dynamic string, we can at least best guess by sorting based on how it is literally typed out (i.e. as `python@#{PY_VER}`). Previously, the cop would crash with an internal error.

Also, let's guard against further errors by filtering out invalid nodes (e.g. `depends_on 1`).

https://github.com/orgs/Homebrew/discussions/6758