### PR TITLE
bundle: unify bundle package type classes

### DIFF
--- a/Library/Homebrew/bundle.rb
+++ b/Library/Homebrew/bundle.rb
@@ -39,75 +39,6 @@ module Homebrew
         system(HOMEBREW_BREW_FILE, *args, verbose:)
       end
 
-      # TODO: Move these extension-specific executable helpers into the
-      # extension classes once the remaining direct spec stubs can be removed.
-      sig { returns(T::Boolean) }
-      def mas_installed?
-        @mas_installed ||= which_mas.present?
-      end
-
-      sig { returns(T.nilable(Pathname)) }
-      def which_mas
-        @which_mas ||= which("mas", ORIGINAL_PATHS)
-      end
-
-      sig { returns(T::Boolean) }
-      def vscode_installed?
-        @vscode_installed ||= which_vscode.present?
-      end
-
-      sig { returns(T.nilable(Pathname)) }
-      def which_vscode
-        @which_vscode ||= which("code", ORIGINAL_PATHS)
-        @which_vscode ||= which("codium", ORIGINAL_PATHS)
-        @which_vscode ||= which("cursor", ORIGINAL_PATHS)
-        @which_vscode ||= which("code-insiders", ORIGINAL_PATHS)
-      end
-
-      # TODO: Remove these go helpers once the bundle extension specs stop
-      # stubbing them directly.
-      sig { returns(T.nilable(Pathname)) }
-      def which_go
-        @which_go ||= which("go", ORIGINAL_PATHS)
-      end
-
-      sig { returns(T::Boolean) }
-      def go_installed?
-        @go_installed ||= which_go.present?
-      end
-
-      sig { returns(T.nilable(Pathname)) }
-      def which_cargo
-        @which_cargo ||= which("cargo", ORIGINAL_PATHS)
-      end
-
-      sig { returns(T::Boolean) }
-      def cargo_installed?
-        @cargo_installed ||= which_cargo.present?
-      end
-
-      # TODO: Remove these uv helpers once the bundle extension specs stop
-      # stubbing them directly.
-      sig { returns(T.nilable(Pathname)) }
-      def which_uv
-        @which_uv ||= which("uv", ORIGINAL_PATHS)
-      end
-
-      sig { returns(T::Boolean) }
-      def uv_installed?
-        @uv_installed ||= which_uv.present?
-      end
-
-      sig { returns(T.nilable(Pathname)) }
-      def which_flatpak
-        @which_flatpak ||= which("flatpak", ORIGINAL_PATHS)
-      end
-
-      sig { returns(T::Boolean) }
-      def flatpak_installed?
-        @flatpak_installed ||= which_flatpak.present?
-      end
-
       sig { returns(T::Boolean) }
       def cask_installed?
         @cask_installed ||= File.directory?("#{HOMEBREW_PREFIX}/Caskroom") &&
@@ -191,18 +122,6 @@ module Homebrew
 
       sig { void }
       def reset!
-        @which_mas = T.let(nil, T.nilable(Pathname))
-        @mas_installed = T.let(nil, T.nilable(T::Boolean))
-        @vscode_installed = T.let(nil, T.nilable(T::Boolean))
-        @which_vscode = T.let(nil, T.nilable(Pathname))
-        @which_go = T.let(nil, T.nilable(Pathname))
-        @go_installed = T.let(nil, T.nilable(T::Boolean))
-        @which_cargo = T.let(nil, T.nilable(Pathname))
-        @cargo_installed = T.let(nil, T.nilable(T::Boolean))
-        @which_uv = T.let(nil, T.nilable(Pathname))
-        @uv_installed = T.let(nil, T.nilable(T::Boolean))
-        @which_flatpak = T.let(nil, T.nilable(Pathname))
-        @flatpak_installed = T.let(nil, T.nilable(T::Boolean))
         @cask_installed = T.let(nil, T.nilable(T::Boolean))
         @formula_versions_from_env = T.let(nil, T.nilable(T::Hash[String, String]))
         @upgrade_formulae = T.let(nil, T.nilable(T::Array[String]))

--- a/Library/Homebrew/bundle/brew.rb
+++ b/Library/Homebrew/bundle/brew.rb
@@ -8,7 +8,6 @@ require "bundle/package_type"
 
 module Homebrew
   module Bundle
-    # TODO: refactor into multiple modules
     class Brew < Homebrew::Bundle::PackageType
       extend Utils::Output::Mixin
 
@@ -154,7 +153,7 @@ module Homebrew
 
             args = f[:args].map { |arg| "\"#{arg}\"" }.sort.join(", ")
             brewline += ", args: [#{args}]" unless f[:args].empty?
-            brewline += ", restart_service: :changed" if !no_restart && BrewServices.started?(f[:full_name])
+            brewline += ", restart_service: :changed" if !no_restart && Services.started?(f[:full_name])
             brewline += ", link: #{f[:link?]}" unless f[:link?].nil?
             brewline
           end.join("\n")
@@ -415,7 +414,7 @@ module Homebrew
 
       def start_service_needed?
         require "bundle/brew_services"
-        start_service? && !BrewServices.started?(@full_name)
+        start_service? && !Services.started?(@full_name)
       end
 
       def restart_service?
@@ -436,14 +435,14 @@ module Homebrew
       def service_change_state!(verbose:)
         require "bundle/brew_services"
 
-        file = BrewServices.versioned_service_file(@name)
+        file = Services.versioned_service_file(@name)
 
         if restart_service_needed?
           puts "Restarting #{@name} service." if verbose
-          BrewServices.restart(@full_name, file:, verbose:)
+          Services.restart(@full_name, file:, verbose:)
         elsif start_service_needed?
           puts "Starting #{@name} service." if verbose
-          BrewServices.start(@full_name, file:, verbose:)
+          Services.start(@full_name, file:, verbose:)
         else
           true
         end
@@ -539,7 +538,7 @@ module Homebrew
 
           require "bundle/brew_services"
           puts "Stopping #{conflict} service (if it is running)." if verbose
-          BrewServices.stop(conflict, verbose:)
+          Services.stop(conflict, verbose:)
         end
 
         true
@@ -587,17 +586,6 @@ module Homebrew
           fetch(node.downcase).sort.each(&block)
         end
       end
-    end
-
-    # TODO: Remove these compatibility aliases once bundle callers and tests
-    # stop requiring separate brew dumper/installer/checker constants.
-    FormulaInstaller = Brew
-    FormulaDumper = Brew
-
-    module Checker
-      # TODO: Remove this compatibility alias once bundle callers and tests stop
-      # requiring a separate brew checker constant.
-      BrewChecker = Homebrew::Bundle::Brew
     end
   end
 end

--- a/Library/Homebrew/bundle/brew_checker.rb
+++ b/Library/Homebrew/bundle/brew_checker.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/brew"

--- a/Library/Homebrew/bundle/brew_service_checker.rb
+++ b/Library/Homebrew/bundle/brew_service_checker.rb
@@ -1,4 +1,0 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
-# frozen_string_literal: true
-
-require "bundle/brew_services"

--- a/Library/Homebrew/bundle/brew_services.rb
+++ b/Library/Homebrew/bundle/brew_services.rb
@@ -129,13 +129,5 @@ module Homebrew
         end
       end
     end
-
-    BrewServices = Brew::Services
-
-    module Checker
-      # TODO: Remove this compatibility alias once bundle callers and tests stop
-      # requiring a separate brew service checker constant.
-      BrewServiceChecker = Homebrew::Bundle::Brew::Services
-    end
   end
 end

--- a/Library/Homebrew/bundle/cargo.rb
+++ b/Library/Homebrew/bundle/cargo.rb
@@ -1,5 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/dsl"
-require "bundle/extensions/cargo"

--- a/Library/Homebrew/bundle/cargo_checker.rb
+++ b/Library/Homebrew/bundle/cargo_checker.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/cargo"

--- a/Library/Homebrew/bundle/cargo_dumper.rb
+++ b/Library/Homebrew/bundle/cargo_dumper.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/cargo"

--- a/Library/Homebrew/bundle/cargo_installer.rb
+++ b/Library/Homebrew/bundle/cargo_installer.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/cargo"

--- a/Library/Homebrew/bundle/cask.rb
+++ b/Library/Homebrew/bundle/cask.rb
@@ -236,16 +236,5 @@ module Homebrew
         self.class.cask_installed_and_up_to_date?(cask, no_upgrade:)
       end
     end
-
-    # TODO: Remove these compatibility aliases once bundle callers and tests
-    # stop requiring separate cask dumper/installer/checker constants.
-    CaskInstaller = Cask
-    CaskDumper = Cask
-
-    module Checker
-      # TODO: Remove this compatibility alias once bundle callers and tests stop
-      # requiring a separate cask checker constant.
-      CaskChecker = Homebrew::Bundle::Cask
-    end
   end
 end

--- a/Library/Homebrew/bundle/cask_checker.rb
+++ b/Library/Homebrew/bundle/cask_checker.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/cask"

--- a/Library/Homebrew/bundle/cask_dumper.rb
+++ b/Library/Homebrew/bundle/cask_dumper.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/cask"

--- a/Library/Homebrew/bundle/cask_installer.rb
+++ b/Library/Homebrew/bundle/cask_installer.rb
@@ -1,4 +1,0 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
-# frozen_string_literal: true
-
-require "bundle/cask"

--- a/Library/Homebrew/bundle/checker.rb
+++ b/Library/Homebrew/bundle/checker.rb
@@ -1,7 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "bundle/checker/base"
 require "bundle/dsl"
 require "bundle/package_types"
 require "bundle/brew_services"
@@ -28,8 +27,8 @@ module Homebrew
         errors = []
         enumerator = exit_on_first_error ? :find : :map
 
-        work_to_be_done = check_steps.public_send(enumerator) do |check_step|
-          check_errors = run_check_step(check_step, exit_on_first_error:, no_upgrade:, verbose:)
+        work_to_be_done = CORE_CHECKS.public_send(enumerator) do |check_step|
+          check_errors = public_send(check_step, exit_on_first_error:, no_upgrade:, verbose:)
           any_errors = check_errors.any?
           errors.concat(check_errors) if any_errors
           any_errors
@@ -44,20 +43,7 @@ module Homebrew
         extension_errors(:apps_to_install, exit_on_first_error:, no_upgrade:, verbose:)
       end
 
-      def self.extensions_to_install(exit_on_first_error: false, no_upgrade: false, verbose: false)
-        _ = exit_on_first_error
-        _ = no_upgrade
-        _ = verbose
-
-        # TODO: Remove this legacy no-op once callers and tests stop referencing
-        # the old dedicated extension check phase.
-        []
-      end
-
       def self.formulae_to_start(exit_on_first_error: false, no_upgrade: false, verbose: false)
-        # TODO: Keep this separate until service checks can be modeled as part of
-        # the `brew` package type without pretending services are standalone
-        # package entries.
         Homebrew::Bundle::Brew::Services.new.find_actionable(
           @dsl.entries,
           exit_on_first_error:, no_upgrade:, verbose:,
@@ -65,26 +51,18 @@ module Homebrew
       end
 
       def self.taps_to_tap(exit_on_first_error: false, no_upgrade: false, verbose: false)
-        # TODO: Remove this legacy wrapper once callers and tests stop
-        # referencing the old dedicated tap check phase.
         package_type_errors(:tap, exit_on_first_error:, no_upgrade:, verbose:)
       end
 
       def self.casks_to_install(exit_on_first_error: false, no_upgrade: false, verbose: false)
-        # TODO: Remove this legacy wrapper once callers and tests stop
-        # referencing the old dedicated cask check phase.
         package_type_errors(:cask, exit_on_first_error:, no_upgrade:, verbose:)
       end
 
       def self.formulae_to_install(exit_on_first_error: false, no_upgrade: false, verbose: false)
-        # TODO: Remove this legacy wrapper once callers and tests stop
-        # referencing the old dedicated formula check phase.
         package_type_errors(:brew, exit_on_first_error:, no_upgrade:, verbose:)
       end
 
       def self.registered_extensions_to_install(exit_on_first_error: false, no_upgrade: false, verbose: false)
-        # TODO: Remove this legacy wrapper once callers and tests stop
-        # referencing the old dedicated extension check phase.
         extension_errors(:registered_extensions_to_install, exit_on_first_error:, no_upgrade:, verbose:)
       end
 
@@ -121,11 +99,6 @@ module Homebrew
         Homebrew::Bundle.extensions.each(&:reset!)
       end
 
-      sig { returns(T::Array[CheckStep]) }
-      def self.check_steps
-        CORE_CHECKS
-      end
-
       sig {
         params(
           type:                Symbol,
@@ -139,18 +112,6 @@ module Homebrew
         return [] if package_type.nil?
 
         package_type.check(@dsl.entries, exit_on_first_error:, no_upgrade:, verbose:)
-      end
-
-      sig {
-        params(
-          check_step:          CheckStep,
-          exit_on_first_error: T::Boolean,
-          no_upgrade:          T::Boolean,
-          verbose:             T::Boolean,
-        ).returns(T::Array[Object])
-      }
-      def self.run_check_step(check_step, exit_on_first_error:, no_upgrade:, verbose:)
-        public_send(check_step, exit_on_first_error:, no_upgrade:, verbose:)
       end
     end
   end

--- a/Library/Homebrew/bundle/checker/base.rb
+++ b/Library/Homebrew/bundle/checker/base.rb
@@ -1,6 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-# TODO: Remove this compatibility require once the remaining bundle callers load
-# `bundle/extensions/extension` directly.
-require "bundle/extensions/extension"

--- a/Library/Homebrew/bundle/commands/cleanup.rb
+++ b/Library/Homebrew/bundle/commands/cleanup.rb
@@ -9,47 +9,37 @@ module Homebrew
   module Bundle
     module Commands
       # Uninstalls formulae, casks, taps, VSCode extensions and Flatpak packages not listed in the Brewfile.
-      # TODO: refactor into multiple modules
       module Cleanup
         def self.reset!
-          require "bundle/cask_dumper"
-          require "bundle/formula_dumper"
-          require "bundle/tap_dumper"
+          require "bundle/cask"
+          require "bundle/brew"
+          require "bundle/tap"
           require "bundle/brew_services"
 
           @dsl = nil
           @kept_casks = nil
           @kept_formulae = nil
-          Homebrew::Bundle::CaskDumper.reset!
-          Homebrew::Bundle::FormulaDumper.reset!
-          Homebrew::Bundle::TapDumper.reset!
-          Homebrew::Bundle::BrewServices.reset!
+          Homebrew::Bundle::Cask.reset!
+          Homebrew::Bundle::Brew.reset!
+          Homebrew::Bundle::Tap.reset!
+          Homebrew::Bundle::Brew::Services.reset!
           Homebrew::Bundle.extensions.each(&:reset!)
         end
 
         def self.run(global: false, file: nil, force: false, zap: false, dsl: nil,
-                     formulae: true, casks: true, taps: true, extension_types: {}, **extra_extension_types)
+                     formulae: true, casks: true, taps: true, extension_types: {})
           read_dsl_from_brewfile!(global:, file:, dsl:)
 
-          # TODO: Remove `extra_extension_types` once all callers pass a single
-          # `extension_types:` hash instead of legacy per-extension keywords.
           extension_types = Homebrew::Bundle.extensions.select(&:cleanup_supported?).to_h do |extension|
             [extension.type, true]
           end.merge(extension_types)
-             .merge(extra_extension_types)
           casks = casks ? casks_to_uninstall(global:, file:) : []
           formulae = formulae ? formulae_to_uninstall(global:, file:) : []
           taps = taps ? taps_to_untap(global:, file:) : []
           cleanup_extensions = Homebrew::Bundle.extensions.select(&:cleanup_supported?).filter_map do |extension|
             next unless extension_types.fetch(extension.type, false)
 
-            cleanup_method = extension.legacy_cleanup_method
-            items = if cleanup_method.nil?
-              extension.cleanup_items(@dsl.entries)
-            else
-              public_send(cleanup_method, global:, file:)
-            end
-            [extension, items]
+            [extension, extension.cleanup_items(@dsl.entries)]
           end
           if force
             if casks.any?
@@ -134,8 +124,8 @@ module Homebrew
         def self.casks_to_uninstall(global: false, file: nil)
           raise ArgumentError, "@dsl is unset!" unless @dsl
 
-          require "bundle/cask_dumper"
-          Homebrew::Bundle::CaskDumper.cask_names - kept_casks(global:, file:)
+          require "bundle/cask"
+          Homebrew::Bundle::Cask.cask_names - kept_casks(global:, file:)
         end
 
         def self.formulae_to_uninstall(global: false, file: nil)
@@ -143,11 +133,10 @@ module Homebrew
 
           kept_formulae = self.kept_formulae(global:, file:)
 
-          require "bundle/formula_dumper"
-          require "bundle/formula_installer"
-          current_formulae = Homebrew::Bundle::FormulaDumper.formulae
+          require "bundle/brew"
+          current_formulae = Homebrew::Bundle::Brew.formulae
           current_formulae.reject! do |f|
-            Homebrew::Bundle::FormulaInstaller.formula_in_array?(f[:full_name], kept_formulae)
+            Homebrew::Bundle::Brew.formula_in_array?(f[:full_name], kept_formulae)
           end
 
           # Don't try to uninstall formulae with keepme references
@@ -160,20 +149,20 @@ module Homebrew
         end
 
         private_class_method def self.kept_formulae(global: false, file: nil)
-          require "bundle/formula_dumper"
-          require "bundle/cask_dumper"
+          require "bundle/brew"
+          require "bundle/cask"
 
           @kept_formulae ||= begin
             kept_formulae = @dsl.entries.select { |e| e.type == :brew }.map(&:name)
-            kept_formulae += Homebrew::Bundle::CaskDumper.formula_dependencies(kept_casks)
+            kept_formulae += Homebrew::Bundle::Cask.formula_dependencies(kept_casks)
             kept_formulae.map! do |f|
-              Homebrew::Bundle::FormulaDumper.formula_aliases.fetch(
+              Homebrew::Bundle::Brew.formula_aliases.fetch(
                 f,
-                Homebrew::Bundle::FormulaDumper.formula_oldnames.fetch(f, f),
+                Homebrew::Bundle::Brew.formula_oldnames.fetch(f, f),
               )
             end
 
-            kept_formulae + recursive_dependencies(Homebrew::Bundle::FormulaDumper.formulae, kept_formulae)
+            kept_formulae + recursive_dependencies(Homebrew::Bundle::Brew.formulae, kept_formulae)
           end
         end
 
@@ -182,7 +171,7 @@ module Homebrew
 
           kept_casks = @dsl.entries.select { |e| e.type == :cask }.flat_map(&:name)
           kept_casks.map! do |c|
-            Homebrew::Bundle::CaskDumper.cask_oldnames.fetch(c, c)
+            Homebrew::Bundle::Cask.cask_oldnames.fetch(c, c)
           end
           @kept_casks = kept_casks
         end
@@ -218,12 +207,12 @@ module Homebrew
         def self.taps_to_untap(global: false, file: nil)
           raise ArgumentError, "@dsl is unset!" unless @dsl
 
-          require "bundle/tap_dumper"
+          require "bundle/tap"
 
           kept_formulae = self.kept_formulae(global:, file:).filter_map { lookup_formula(it) }
           kept_taps = @dsl.entries.select { |e| e.type == :tap }.map(&:name)
           kept_taps += kept_formulae.filter_map(&:tap).map(&:name)
-          current_taps = Homebrew::Bundle::TapDumper.tap_names
+          current_taps = Homebrew::Bundle::Tap.tap_names
           current_taps - kept_taps - IGNORED_TAPS
         end
 

--- a/Library/Homebrew/bundle/commands/dump.rb
+++ b/Library/Homebrew/bundle/commands/dump.rb
@@ -10,16 +10,11 @@ module Homebrew
         sig {
           params(global: T::Boolean, file: T.nilable(String), describe: T::Boolean, force: T::Boolean,
                  no_restart: T::Boolean, taps: T::Boolean, formulae: T::Boolean, casks: T::Boolean,
-                 extension_types: Homebrew::Bundle::ExtensionTypes,
-                 extra_extension_types: Homebrew::Bundle::ExtensionTypes).void.checked(:never)
+                 extension_types: Homebrew::Bundle::ExtensionTypes).void
         }
-        def self.run(global:, file:, describe:, force:, no_restart:, taps:, formulae:, casks:, extension_types: {},
-                     **extra_extension_types)
-          # TODO: Remove `extra_extension_types` once all callers pass a single
-          # `extension_types:` hash instead of legacy per-extension keywords.
+        def self.run(global:, file:, describe:, force:, no_restart:, taps:, formulae:, casks:, extension_types: {})
           Homebrew::Bundle::Dumper.dump_brewfile(
             global:, file:, describe:, force:, no_restart:, taps:, formulae:, casks:, extension_types:,
-            **extra_extension_types
           )
         end
       end

--- a/Library/Homebrew/bundle/commands/exec.rb
+++ b/Library/Homebrew/bundle/commands/exec.rb
@@ -269,7 +269,7 @@ module Homebrew
           )
 
           entries_formulae.filter_map do |entry, formula|
-            service_file = Bundle::BrewServices.versioned_service_file(entry.name)
+            service_file = Bundle::Brew::Services.versioned_service_file(entry.name)
 
             unless service_file&.file?
               prefix = formula.any_installed_prefix
@@ -307,19 +307,19 @@ module Homebrew
             loaded_file = Pathname.new(info["loaded_file"].to_s)
             next if info["running"] && loaded_file.file? && loaded_file.realpath == service_file.realpath
 
-            if info["running"] && !Bundle::BrewServices.stop(info["name"], keep: true)
+            if info["running"] && !Bundle::Brew::Services.stop(info["name"], keep: true)
               opoo "Failed to stop #{info["name"]} service"
             end
 
             conflicting_services.each do |conflict|
-              if Bundle::BrewServices.stop(conflict["name"], keep: true)
+              if Bundle::Brew::Services.stop(conflict["name"], keep: true)
                 services_to_restart << conflict["name"] if conflict["registered"]
               else
                 opoo "Failed to stop #{conflict["name"]} service"
               end
             end
 
-            unless Bundle::BrewServices.run(info["name"], file: service_file)
+            unless Bundle::Brew::Services.run(info["name"], file: service_file)
               opoo "Failed to start #{info["name"]} service"
             end
 
@@ -335,7 +335,7 @@ module Homebrew
             stop_services(entries_to_stop)
 
             services_to_restart.each do |service|
-              next if Bundle::BrewServices.run(service)
+              next if Bundle::Brew::Services.run(service)
 
               opoo "Failed to restart #{service} service"
             end
@@ -350,7 +350,7 @@ module Homebrew
             # Try avoid services not started by `brew bundle services`
             next if Homebrew::Services::System.launchctl? && info["registered"]
 
-            if info["running"] && !Bundle::BrewServices.stop(info["name"], keep: true)
+            if info["running"] && !Bundle::Brew::Services.stop(info["name"], keep: true)
               opoo "Failed to stop #{info["name"]} service"
             end
           end

--- a/Library/Homebrew/bundle/commands/list.rb
+++ b/Library/Homebrew/bundle/commands/list.rb
@@ -10,15 +10,12 @@ module Homebrew
       module List
         sig {
           params(global: T::Boolean, file: T.nilable(String), formulae: T::Boolean, casks: T::Boolean,
-                 taps: T::Boolean, extension_types: Homebrew::Bundle::ExtensionTypes,
-                 extra_extension_types: Homebrew::Bundle::ExtensionTypes).void.checked(:never)
+                 taps: T::Boolean, extension_types: Homebrew::Bundle::ExtensionTypes).void
         }
-        def self.run(global:, file:, formulae:, casks:, taps:, extension_types: {}, **extra_extension_types)
-          # TODO: Remove `extra_extension_types` once all callers pass a single
-          # `extension_types:` hash instead of legacy per-extension keywords.
+        def self.run(global:, file:, formulae:, casks:, taps:, extension_types: {})
           parsed_entries = Brewfile.read(global:, file:).entries
           Homebrew::Bundle::Lister.list(
-            parsed_entries, formulae:, casks:, taps:, extension_types:, **extra_extension_types
+            parsed_entries, formulae:, casks:, taps:, extension_types:
           )
         end
       end

--- a/Library/Homebrew/bundle/dsl.rb
+++ b/Library/Homebrew/bundle/dsl.rb
@@ -1,18 +1,29 @@
 # typed: true # rubocop:todo Sorbet/StrictSigil
 # frozen_string_literal: true
 
+require "bundle/package_type"
+
 module Homebrew
   module Bundle
     class Dsl
       class Entry
-        attr_reader :type, :name, :options
+        sig { returns(Symbol) }
+        attr_reader :type
 
+        sig { returns(String) }
+        attr_reader :name
+
+        sig { returns(Homebrew::Bundle::EntryOptions) }
+        attr_reader :options
+
+        sig { params(type: Symbol, name: String, options: Homebrew::Bundle::EntryOptions).void }
         def initialize(type, name, options = {})
           @type = type
           @name = name
           @options = options
         end
 
+        sig { returns(String) }
         def to_s
           name
         end

--- a/Library/Homebrew/bundle/dumper.rb
+++ b/Library/Homebrew/bundle/dumper.rb
@@ -17,23 +17,16 @@ module Homebrew
 
       sig {
         params(
-          describe:              T::Boolean,
-          no_restart:            T::Boolean,
-          formulae:              T::Boolean,
-          taps:                  T::Boolean,
-          casks:                 T::Boolean,
-          extension_types:       Homebrew::Bundle::ExtensionTypes,
-          extra_extension_types: Homebrew::Bundle::ExtensionTypes,
-        ).returns(String).checked(:never)
+          describe:        T::Boolean,
+          no_restart:      T::Boolean,
+          formulae:        T::Boolean,
+          taps:            T::Boolean,
+          casks:           T::Boolean,
+          extension_types: Homebrew::Bundle::ExtensionTypes,
+        ).returns(String)
       }
-      def self.build_brewfile(describe:, no_restart:, formulae:, taps:, casks:, extension_types: {},
-                              **extra_extension_types)
-        # TODO: Remove `extra_extension_types` once all callers pass a single
-        # `extension_types:` hash instead of legacy per-extension keywords.
-        selected_package_types = extension_types.merge(extra_extension_types)
-        # TODO: Remove this legacy core-type mapping once the dump command
-        # passes a single package-type selection hash instead of separate
-        # `taps`, `formulae`, and `casks` booleans.
+      def self.build_brewfile(describe:, no_restart:, formulae:, taps:, casks:, extension_types: {})
+        selected_package_types = extension_types.dup
         selected_package_types[:tap] = taps
         selected_package_types[:brew] = formulae
         selected_package_types[:cask] = casks
@@ -48,24 +41,23 @@ module Homebrew
 
       sig {
         params(
-          global:                T::Boolean,
-          file:                  T.nilable(String),
-          describe:              T::Boolean,
-          force:                 T::Boolean,
-          no_restart:            T::Boolean,
-          formulae:              T::Boolean,
-          taps:                  T::Boolean,
-          casks:                 T::Boolean,
-          extension_types:       Homebrew::Bundle::ExtensionTypes,
-          extra_extension_types: Homebrew::Bundle::ExtensionTypes,
-        ).void.checked(:never)
+          global:          T::Boolean,
+          file:            T.nilable(String),
+          describe:        T::Boolean,
+          force:           T::Boolean,
+          no_restart:      T::Boolean,
+          formulae:        T::Boolean,
+          taps:            T::Boolean,
+          casks:           T::Boolean,
+          extension_types: Homebrew::Bundle::ExtensionTypes,
+        ).void
       }
       def self.dump_brewfile(global:, file:, describe:, force:, no_restart:, formulae:, taps:, casks:,
-                             extension_types: {}, **extra_extension_types)
+                             extension_types: {})
         path = brewfile_path(global:, file:)
         can_write_to_brewfile?(path, force:)
         content = build_brewfile(
-          describe:, no_restart:, taps:, formulae:, casks:, extension_types:, **extra_extension_types,
+          describe:, no_restart:, taps:, formulae:, casks:, extension_types:,
         )
         write_file path, content
       end

--- a/Library/Homebrew/bundle/extension.rb
+++ b/Library/Homebrew/bundle/extension.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/extensions/extension"

--- a/Library/Homebrew/bundle/extensions.rb
+++ b/Library/Homebrew/bundle/extensions.rb
@@ -4,8 +4,7 @@
 require "bundle/extensions/extension"
 
 extensions_dir = File.join(__dir__, "extensions")
-# TODO: Remove this legacy load order once the dump output order no longer
-# needs to match the pre-extension refactor section ordering.
+# Preserve the historical Brewfile section order for dumped extension entries.
 legacy_order = %w[mac_app_store vscode_extension go cargo uv flatpak].freeze
 extension_files = Dir.glob(File.join(extensions_dir, "*.rb")).sort_by do |file|
   basename = File.basename(file, ".rb")

--- a/Library/Homebrew/bundle/extensions/cargo.rb
+++ b/Library/Homebrew/bundle/extensions/cargo.rb
@@ -22,20 +22,23 @@ module Homebrew
           "rust"
         end
 
+        sig { override.returns(T.nilable(Pathname)) }
+        def package_manager_executable
+          which("cargo", ORIGINAL_PATHS)
+        end
+
         sig { override.returns(T::Array[String]) }
         def packages
           packages = @packages
           return packages if packages
 
-          @packages = if Bundle.cargo_installed?
-            cargo = Bundle.which_cargo
-            return [] if cargo.nil?
-            return [] if cargo.to_s.start_with?("/") && !cargo.exist?
-
+          @packages = if (cargo = package_manager_executable) &&
+                         (!cargo.to_s.start_with?("/") || cargo.exist?)
             parse_package_list(`#{cargo} install --list`)
-          else
-            []
           end
+          return [] if @packages.nil?
+
+          @packages
         end
 
         sig {
@@ -76,17 +79,6 @@ module Homebrew
         end
         private :parse_package_list
       end
-    end
-
-    # TODO: Remove these compatibility aliases once bundle callers and tests
-    # stop requiring separate cargo dumper/installer/checker constants.
-    CargoDumper = Cargo
-    CargoInstaller = Cargo
-
-    module Checker
-      # TODO: Remove this compatibility alias once bundle callers and tests stop
-      # requiring a separate cargo checker constant.
-      CargoChecker = Homebrew::Bundle::Cargo
     end
   end
 end

--- a/Library/Homebrew/bundle/extensions/extension.rb
+++ b/Library/Homebrew/bundle/extensions/extension.rb
@@ -1,212 +1,14 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "bundle/package_type"
+
 module Homebrew
   module Bundle
-    module Checker
-      class Base
-        # Implement these in any subclass
-        # PACKAGE_TYPE = :pkg
-        # PACKAGE_TYPE_NAME = "Package"
-        # TODO: Replace these `T.untyped` checker-base signatures once the
-        # remaining non-extension checkers share a typed package model.
-
-        sig { params(packages: T.untyped, no_upgrade: T::Boolean).returns(T::Array[T.untyped]) }
-        def exit_early_check(packages, no_upgrade:)
-          work_to_be_done = packages.find do |pkg|
-            !installed_and_up_to_date?(pkg, no_upgrade:)
-          end
-
-          Array(work_to_be_done)
-        end
-
-        sig { params(name: T.untyped, no_upgrade: T::Boolean).returns(String) }
-        def failure_reason(name, no_upgrade:)
-          reason = if no_upgrade && Bundle.upgrade_formulae.exclude?(name)
-            "needs to be installed."
-          else
-            "needs to be installed or updated."
-          end
-          "#{self.class.const_get(:PACKAGE_TYPE_NAME)} #{name} #{reason}"
-        end
-
-        sig { params(packages: T.untyped, no_upgrade: T::Boolean).returns(T::Array[String]) }
-        def full_check(packages, no_upgrade:)
-          packages.reject { |pkg| installed_and_up_to_date?(pkg, no_upgrade:) }
-                  .map { |pkg| failure_reason(pkg, no_upgrade:) }
-        end
-
-        sig { params(all_entries: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-        def checkable_entries(all_entries)
-          require "bundle/skipper"
-          all_entries.filter_map do |entry|
-            entry = T.cast(entry, Dsl::Entry)
-            next if entry.type != self.class.const_get(:PACKAGE_TYPE)
-            next if Bundle::Skipper.skip?(entry)
-
-            entry
-          end
-        end
-
-        sig { params(entries: T::Array[T.untyped]).returns(T.untyped) }
-        def format_checkable(entries)
-          checkable_entries(entries).map do |entry|
-            entry = T.cast(entry, Dsl::Entry)
-            entry.name
-          end
-        end
-
-        sig { params(_pkg: T.untyped, no_upgrade: T::Boolean).returns(T::Boolean) }
-        def installed_and_up_to_date?(_pkg, no_upgrade: false)
-          raise NotImplementedError
-        end
-
-        sig {
-          params(
-            entries:             T::Array[T.untyped],
-            exit_on_first_error: T::Boolean,
-            no_upgrade:          T::Boolean,
-            verbose:             T::Boolean,
-          ).returns(T::Array[T.untyped])
-        }
-        def find_actionable(entries, exit_on_first_error: false, no_upgrade: false, verbose: false)
-          requested = format_checkable(entries)
-
-          if exit_on_first_error
-            exit_early_check(requested, no_upgrade:)
-          else
-            full_check(requested, no_upgrade:)
-          end
-        end
-      end
-    end
-
     ExtensionTypes = T.type_alias { T::Hash[Symbol, T::Boolean] }
-
-    class PackageType < Homebrew::Bundle::Checker::Base
-      extend T::Helpers
-
-      abstract!
-
-      sig { params(subclass: T.class_of(Homebrew::Bundle::PackageType)).void }
-      def self.inherited(subclass)
-        super
-        return if subclass.name == "Homebrew::Bundle::Extension"
-
-        Homebrew::Bundle.register_package_type(subclass)
-      end
-
-      sig { returns(Symbol) }
-      def self.type
-        T.cast(const_get(:PACKAGE_TYPE), Symbol)
-      end
-
-      sig { returns(T::Boolean) }
-      def self.dump_supported?
-        true
-      end
-
-      sig { returns(T::Boolean) }
-      def self.install_supported?
-        true
-      end
-
-      sig { params(_name: String, _options: T::Hash[Symbol, Object]).returns(String) }
-      def self.install_verb(_name = "", _options = {})
-        "Installing"
-      end
-
-      sig {
-        params(
-          name:       String,
-          options:    T::Hash[Symbol, Object],
-          no_upgrade: T::Boolean,
-        ).returns(T.nilable(String))
-      }
-      def self.fetchable_name(name, options = {}, no_upgrade: false)
-        _ = name
-        _ = options
-        _ = no_upgrade
-
-        nil
-      end
-
-      sig { returns(T::Boolean) }
-      def self.check_supported?
-        true
-      end
-
-      sig { abstract.void }
-      def self.reset!; end
-
-      sig {
-        params(
-          entries:             T::Array[Object],
-          exit_on_first_error: T::Boolean,
-          no_upgrade:          T::Boolean,
-          verbose:             T::Boolean,
-        ).returns(T::Array[Object])
-      }
-      def self.check(entries, exit_on_first_error: false, no_upgrade: false, verbose: false)
-        new.find_actionable(entries, exit_on_first_error:, no_upgrade:, verbose:)
-      end
-
-      sig { abstract.returns(String) }
-      def self.dump; end
-
-      sig { params(describe: T::Boolean, no_restart: T::Boolean).returns(String) }
-      def self.dump_output(describe: false, no_restart: false)
-        _ = describe
-        _ = no_restart
-
-        dump
-      end
-    end
-
-    class << self
-      sig { params(package_type: T.class_of(PackageType)).void }
-      def register_package_type(package_type)
-        @package_types ||= T.let([], T.nilable(T::Array[T.class_of(PackageType)]))
-        @package_types.reject! { |registered| registered.name == package_type.name }
-        @package_types << package_type
-      end
-
-      sig { returns(T::Array[T.class_of(PackageType)]) }
-      def package_types
-        @package_types ||= T.let([], T.nilable(T::Array[T.class_of(PackageType)]))
-        @package_types
-      end
-
-      sig { params(type: T.any(Symbol, String)).returns(T.nilable(T.class_of(PackageType))) }
-      def package_type(type)
-        requested_type = type.to_sym
-        package_types.find { |registered| registered.type == requested_type }
-      end
-
-      sig { returns(T::Array[T.class_of(PackageType)]) }
-      def dump_package_types
-        core_package_types = [:tap, :brew, :cask].filter_map { |type| package_type(type) }
-        (core_package_types + (package_types - core_package_types)).uniq
-      end
-
-      sig { returns(T::Array[T.class_of(PackageType)]) }
-      def check_package_types
-        # TODO: Remove this legacy ordering shim once package-type order can be
-        # inferred entirely from registration without changing `brew bundle check`
-        # behavior for taps, casks, extensions, and formulae.
-        taps = package_type(:tap)
-        casks = package_type(:cask)
-        formulae = package_type(:brew)
-        core_package_types = [taps, casks, formulae].compact
-
-        [taps, casks, *(package_types - core_package_types), formulae].compact
-      end
-    end
 
     class Extension < Homebrew::Bundle::PackageType
       extend T::Helpers
-
-      EntryOptions = T.type_alias { T::Hash[Symbol, Object] }
 
       abstract!
 
@@ -240,7 +42,7 @@ module Homebrew
         end
       end
 
-      sig { params(name: String, options: EntryOptions).returns(Dsl::Entry) }
+      sig { params(name: String, options: Homebrew::Bundle::EntryInputOptions).returns(Dsl::Entry) }
       def self.entry(name, options = {})
         raise "unknown options(#{options.keys.inspect}) for #{type}" if options.present?
 
@@ -262,16 +64,14 @@ module Homebrew
         flag
       end
 
-      # TODO: Route these through each extension once the go/uv specs stop
-      # stubbing `Homebrew::Bundle.which_*` and `*_installed?` directly.
       sig { returns(T::Boolean) }
       def self.package_manager_installed?
-        Bundle.public_send(:"#{type}_installed?")
+        package_manager_executable.present?
       end
 
       sig { returns(T.nilable(Pathname)) }
       def self.package_manager_executable
-        Bundle.public_send(:"which_#{type}")
+        which(package_manager_name, ORIGINAL_PATHS)
       end
 
       sig { returns(String) }
@@ -319,7 +119,7 @@ module Homebrew
         true
       end
 
-      sig { params(_name: String, _options: T::Hash[Symbol, Object]).returns(String) }
+      sig { params(_name: String, _options: Homebrew::Bundle::EntryOptions).returns(String) }
       def self.install_verb(_name = "", _options = {})
         "Installing"
       end
@@ -327,7 +127,7 @@ module Homebrew
       sig {
         params(
           name:       String,
-          options:    T::Hash[Symbol, Object],
+          options:    Homebrew::Bundle::EntryOptions,
           no_upgrade: T::Boolean,
         ).returns(T.nilable(String))
       }
@@ -352,8 +152,6 @@ module Homebrew
       sig { abstract.void }
       def self.reset!; end
 
-      # TODO: Replace these `T.untyped` package collections once extensions can
-      # share a typed package interface without breaking Sorbet override checks.
       sig { abstract.returns(T::Array[T.untyped]) }
       def self.packages; end
 
@@ -410,14 +208,9 @@ module Homebrew
         new.find_actionable(entries, exit_on_first_error:, no_upgrade:, verbose:)
       end
 
-      sig { params(_entries: T::Array[Object]).returns(T::Array[String]) }
+      sig { params(_entries: T::Array[Dsl::Entry]).returns(T::Array[String]) }
       def self.cleanup_items(_entries)
         []
-      end
-
-      sig { returns(T.nilable(Symbol)) }
-      def self.legacy_cleanup_method
-        nil
       end
 
       sig { returns(Symbol) }
@@ -441,14 +234,15 @@ module Homebrew
       end
 
       sig {
-        params(
+        override.params(
           name:       String,
           with:       T.nilable(T::Array[String]),
           no_upgrade: T::Boolean,
           verbose:    T::Boolean,
+          _options:   Homebrew::Bundle::EntryOption,
         ).returns(T::Boolean)
       }
-      def self.preinstall!(name, with: nil, no_upgrade: false, verbose: false)
+      def self.preinstall!(name, with: nil, no_upgrade: false, verbose: false, **_options)
         _ = no_upgrade
 
         unless package_manager_installed?
@@ -479,16 +273,18 @@ module Homebrew
       end
 
       sig {
-        params(
+        override.params(
           name:       String,
           with:       T.nilable(T::Array[String]),
           preinstall: T::Boolean,
           no_upgrade: T::Boolean,
           verbose:    T::Boolean,
           force:      T::Boolean,
+          _options:   Homebrew::Bundle::EntryOption,
         ).returns(T::Boolean)
       }
-      def self.install!(name, with: nil, preinstall: true, no_upgrade: false, verbose: false, force: false)
+      def self.install!(name, with: nil, preinstall: true, no_upgrade: false, verbose: false, force: false,
+                        **_options)
         _ = no_upgrade
         _ = force
 
@@ -552,7 +348,7 @@ module Homebrew
       sig {
         params(
           type: T.any(Symbol, String),
-        ).returns(T.nilable(T.any(T.class_of(PackageType), T.class_of(Extension))))
+        ).returns(T.nilable(T.class_of(PackageType)))
       }
       def installable(type)
         package_type(type) || extension(type)

--- a/Library/Homebrew/bundle/extensions/flatpak.rb
+++ b/Library/Homebrew/bundle/extensions/flatpak.rb
@@ -23,14 +23,7 @@ module Homebrew
           "flatpaks"
         end
 
-        sig { override.returns(T.nilable(Symbol)) }
-        def legacy_cleanup_method
-          # TODO: Remove this legacy cleanup hook once the direct cleanup specs
-          # stop stubbing the old command-level flatpak helper.
-          :flatpaks_to_uninstall
-        end
-
-        sig { override.params(name: String, options: Homebrew::Bundle::Extension::EntryOptions).returns(Dsl::Entry) }
+        sig { override.params(name: String, options: Homebrew::Bundle::EntryInputOptions).returns(Dsl::Entry) }
         def entry(name, options = {})
           unknown_options = options.keys - [:remote, :url]
           raise "unknown options(#{unknown_options.inspect}) for flatpak" if unknown_options.present?
@@ -67,10 +60,7 @@ module Homebrew
           remote_urls = @remote_urls
           return remote_urls if remote_urls
 
-          @remote_urls = if Bundle.flatpak_installed?
-            flatpak = Bundle.which_flatpak
-            return {} if flatpak.nil?
-
+          @remote_urls = if (flatpak = package_manager_executable)
             output = `#{flatpak} remote-list --system --columns=name,url 2>/dev/null`.chomp
             urls = {}
             output.split("\n").each do |line|
@@ -82,9 +72,10 @@ module Homebrew
               urls[name] = url if name && url
             end
             urls
-          else
-            {}
           end
+          return {} if @remote_urls.nil?
+
+          @remote_urls
         end
 
         sig { returns(T::Array[Package]) }
@@ -92,10 +83,7 @@ module Homebrew
           packages_with_remotes = @packages_with_remotes
           return packages_with_remotes if packages_with_remotes
 
-          @packages_with_remotes = if Bundle.flatpak_installed?
-            flatpak = Bundle.which_flatpak
-            return [] if flatpak.nil?
-
+          @packages_with_remotes = if (flatpak = package_manager_executable)
             # List applications with their origin remote
             # Using --app to filter applications only
             # Using --columns=application,origin to get app IDs and their remotes
@@ -113,9 +101,10 @@ module Homebrew
               package
             end
             packages.sort_by { |pkg| pkg[:name].to_s }
-          else
-            []
           end
+          return [] if @packages_with_remotes.nil?
+
+          @packages_with_remotes
         end
 
         sig { override.returns(T::Array[String]) }
@@ -174,7 +163,7 @@ module Homebrew
             verbose:    T::Boolean,
             remote:     String,
             url:        T.nilable(String),
-            _options:   T.anything,
+            _options:   Homebrew::Bundle::EntryOption,
           ).returns(T::Boolean)
         }
         def preinstall!(name, with: nil, no_upgrade: false, verbose: false, remote: "flathub", url: nil, **_options)
@@ -182,7 +171,7 @@ module Homebrew
           _ = no_upgrade
           _ = url
 
-          return false unless Bundle.flatpak_installed?
+          return false unless package_manager_installed?
 
           # Check if package is installed at all (regardless of remote)
           if package_installed?(name)
@@ -194,7 +183,7 @@ module Homebrew
         end
 
         sig {
-          params(
+          override.params(
             name:       String,
             with:       T.nilable(T::Array[String]),
             preinstall: T::Boolean,
@@ -203,7 +192,7 @@ module Homebrew
             force:      T::Boolean,
             remote:     String,
             url:        T.nilable(String),
-            _options:   T.anything,
+            _options:   Homebrew::Bundle::EntryOption,
           ).returns(T::Boolean)
         }
         def install!(name, with: nil, preinstall: true, no_upgrade: false, verbose: false, force: false,
@@ -212,10 +201,10 @@ module Homebrew
           _ = no_upgrade
           _ = force
 
-          return true unless Bundle.flatpak_installed?
+          return true unless package_manager_installed?
           return true unless preinstall
 
-          flatpak = Bundle.which_flatpak.to_s
+          flatpak = package_manager_executable.to_s
 
           # 3-tier remote handling:
           # - Tier 1: no URL → use named remote (default: flathub)
@@ -364,7 +353,7 @@ module Homebrew
 
         sig { params(entries: T::Array[Object]).returns(T::Array[String]) }
         def cleanup_items(entries)
-          return [].freeze unless Bundle.flatpak_installed?
+          return [].freeze unless package_manager_installed?
 
           kept_flatpaks = entries.filter_map do |entry|
             entry = T.cast(entry, Dsl::Entry)
@@ -389,7 +378,7 @@ module Homebrew
       def format_checkable(entries)
         checkable_entries(entries).map do |entry|
           entry = T.cast(entry, Dsl::Entry)
-          { name: entry.name, options: entry.options || {} }
+          { name: entry.name, options: entry.options }
         end
       end
 
@@ -433,35 +422,6 @@ module Homebrew
         end
 
         self.class.package_installed?(name, remote: actual_remote)
-      end
-    end
-
-    # TODO: Remove these compatibility aliases once bundle callers and tests
-    # stop requiring separate flatpak dumper/installer/checker constants.
-    FlatpakDumper = Flatpak
-    FlatpakInstaller = Flatpak
-
-    module Checker
-      # TODO: Remove this compatibility alias once bundle callers and tests stop
-      # requiring a separate flatpak checker constant.
-      FlatpakChecker = Homebrew::Bundle::Flatpak
-    end
-
-    module Commands
-      module Cleanup
-        class << self
-          # TODO: Remove this legacy helper once the direct cleanup specs stop
-          # stubbing the old command-level flatpak helper.
-          sig { params(global: T::Boolean, file: T.nilable(String)).returns(T::Array[String]) }
-          def flatpaks_to_uninstall(global: false, file: nil)
-            _ = global
-            _ = file
-            dsl = Homebrew::Bundle::Commands::Cleanup.dsl
-            raise "call `run` or `read_dsl_from_brewfile!` first" if dsl.nil?
-
-            Homebrew::Bundle::Flatpak.cleanup_items(dsl.entries)
-          end
-        end
       end
     end
   end

--- a/Library/Homebrew/bundle/extensions/go.rb
+++ b/Library/Homebrew/bundle/extensions/go.rb
@@ -22,47 +22,44 @@ module Homebrew
           packages = @packages
           return packages if packages
 
-          @packages = if Bundle.go_installed?
-            go = Bundle.which_go
-            return [] if go.nil?
-
+          @packages = if (go = package_manager_executable)
             ENV["GOBIN"] = ENV.fetch("HOMEBREW_GOBIN", nil)
             ENV["GOPATH"] = ENV.fetch("HOMEBREW_GOPATH", nil)
             gobin = `#{go} env GOBIN`.chomp
             gopath = `#{go} env GOPATH`.chomp
             bin_dir = gobin.empty? ? "#{gopath}/bin" : gobin
+            if File.directory?(bin_dir)
+              binaries = Dir.glob("#{bin_dir}/*").select do |file|
+                File.executable?(file) && !File.directory?(file) && !File.symlink?(file)
+              end
 
-            return [] unless File.directory?(bin_dir)
+              binaries.filter_map do |binary|
+                output = `#{go} version -m "#{binary}" 2>/dev/null`
+                next if output.empty?
 
-            binaries = Dir.glob("#{bin_dir}/*").select do |file|
-              File.executable?(file) && !File.directory?(file) && !File.symlink?(file)
+                lines = output.split("\n")
+                path_line = lines.find { |line| line.strip.start_with?("path\t") }
+                next unless path_line
+
+                # Parse the output to find the path line
+                # Format: "\tpath\tgithub.com/user/repo"
+                parts = path_line.split("\t")
+                # Extract the package path (second field after splitting by tab)
+                # The line format is: "\tpath\tgithub.com/user/repo"
+                path = parts[2]&.strip
+
+                # `command-line-arguments` is a dummy package name for binaries built
+                # from a list of source files instead of a specific package name.
+                # https://github.com/golang/go/issues/36043
+                next if path == "command-line-arguments"
+
+                path
+              end.uniq
             end
-
-            binaries.filter_map do |binary|
-              output = `#{go} version -m "#{binary}" 2>/dev/null`
-              next if output.empty?
-
-              lines = output.split("\n")
-              path_line = lines.find { |line| line.strip.start_with?("path\t") }
-              next unless path_line
-
-              # Parse the output to find the path line
-              # Format: "\tpath\tgithub.com/user/repo"
-              parts = path_line.split("\t")
-              # Extract the package path (second field after splitting by tab)
-              # The line format is: "\tpath\tgithub.com/user/repo"
-              path = parts[2]&.strip
-
-              # `command-line-arguments` is a dummy package name for binaries built
-              # from a list of source files instead of a specific package name.
-              # https://github.com/golang/go/issues/36043
-              next if path == "command-line-arguments"
-
-              path
-            end.uniq
-          else
-            []
           end
+          return [] if @packages.nil?
+
+          @packages
         end
 
         sig {
@@ -89,17 +86,6 @@ module Homebrew
           @installed_packages = packages.dup
         end
       end
-    end
-
-    # TODO: Remove these compatibility aliases once bundle callers and tests
-    # stop requiring separate go dumper/installer/checker constants.
-    GoDumper = Go
-    GoInstaller = Go
-
-    module Checker
-      # TODO: Remove this compatibility alias once bundle callers and tests stop
-      # requiring a separate go checker constant.
-      GoChecker = Homebrew::Bundle::Go
     end
   end
 end

--- a/Library/Homebrew/bundle/extensions/mac_app_store.rb
+++ b/Library/Homebrew/bundle/extensions/mac_app_store.rb
@@ -6,7 +6,11 @@ require "bundle/extensions/extension"
 module Homebrew
   module Bundle
     class MacAppStore < Extension
-      App = T.type_alias { { id: String, name: String } }
+      class App < T::Struct
+        const :id, String
+        const :name, String
+      end
+      CheckablePackages = T.type_alias { T.any(T::Array[Object], T::Hash[Integer, String]) }
 
       PACKAGE_TYPE = :mas
       PACKAGE_TYPE_NAME = "App"
@@ -28,7 +32,7 @@ module Homebrew
           false
         end
 
-        sig { override.params(name: String, options: Homebrew::Bundle::Extension::EntryOptions).returns(Dsl::Entry) }
+        sig { override.params(name: String, options: Homebrew::Bundle::EntryInputOptions).returns(Dsl::Entry) }
         def entry(name, options = {})
           id = options[:id]
           raise "options[:id](#{id}) should be an Integer object" unless id.is_a? Integer
@@ -49,10 +53,7 @@ module Homebrew
           apps = @apps
           return apps if apps
 
-          @apps = if Bundle.mas_installed?
-            mas = Bundle.which_mas
-            return [] if mas.nil?
-
+          @apps = if (mas = package_manager_executable)
             `#{mas} list 2>/dev/null`.split("\n").filter_map do |app|
               app_details = app.match(/\A\s*(?<id>\d+)\s+(?<name>.*?)\s+\((?<version>[\d.]*)\)\Z/)
               next if app_details.nil?
@@ -65,9 +66,10 @@ module Homebrew
               # Strip unprintable characters
               [id, name.gsub(/[[:cntrl:]]|\p{C}/, "")]
             end
-          else
-            []
           end
+          return [] if @apps.nil?
+
+          @apps
         end
 
         sig { returns(T::Array[String]) }
@@ -80,7 +82,7 @@ module Homebrew
           packages = @packages
           return packages if packages
 
-          @packages = apps.sort_by { |_, name| name.downcase }.map { |id, name| { id:, name: } }
+          @packages = apps.sort_by { |_, name| name.downcase }.map { |id, name| App.new(id:, name:) }
         end
 
         sig { override.returns(T::Array[App]) }
@@ -99,7 +101,7 @@ module Homebrew
         sig { override.params(package: Object).returns(String) }
         def dump_entry(package)
           app = T.cast(package, App)
-          "mas #{quote(app[:name])}, id: #{app[:id]}"
+          "mas #{quote(app.name)}, id: #{app.id}"
         end
 
         sig { params(id: Integer).returns(T::Boolean) }
@@ -125,26 +127,24 @@ module Homebrew
           outdated_app_ids = @outdated_app_ids
           return outdated_app_ids if outdated_app_ids
 
-          @outdated_app_ids = if Bundle.mas_installed?
-            mas = Bundle.which_mas
-            return [] if mas.nil?
-
+          @outdated_app_ids = if (mas = package_manager_executable)
             `#{mas} outdated 2>/dev/null`.split("\n").map do |app|
               app.split(" ", 2).first.to_s
             end
-          else
-            []
           end
+          return [] if @outdated_app_ids.nil?
+
+          @outdated_app_ids
         end
 
         sig {
-          params(
+          override.params(
             name:       String,
             id:         T.nilable(Integer),
             with:       T.nilable(T::Array[String]),
             no_upgrade: T::Boolean,
             verbose:    T::Boolean,
-            options:    Object,
+            options:    Homebrew::Bundle::EntryOption,
           ).returns(T::Boolean)
         }
         def preinstall!(name, id = nil, with: nil, no_upgrade: false, verbose: false, **options)
@@ -152,10 +152,10 @@ module Homebrew
           id ||= T.cast(options[:id], T.nilable(Integer))
           raise ArgumentError, "missing keyword: id" if id.nil?
 
-          unless Bundle.mas_installed?
+          unless package_manager_installed?
             puts "Installing mas. It is not currently installed." if verbose
             Bundle.system(HOMEBREW_BREW_FILE, "install", "mas", verbose:)
-            raise "Unable to install #{name} app. mas installation failed." unless Bundle.mas_installed?
+            raise "Unable to install #{name} app. mas installation failed." unless package_manager_installed?
           end
 
           if app_id_installed?(id) &&
@@ -168,7 +168,7 @@ module Homebrew
         end
 
         sig {
-          params(
+          override.params(
             name:       String,
             id:         T.nilable(Integer),
             with:       T.nilable(T::Array[String]),
@@ -176,7 +176,7 @@ module Homebrew
             no_upgrade: T::Boolean,
             verbose:    T::Boolean,
             force:      T::Boolean,
-            options:    Object,
+            options:    Homebrew::Bundle::EntryOption,
           ).returns(T::Boolean)
         }
         def install!(name, id = nil, with: nil, preinstall: true, no_upgrade: false, verbose: false, force: false,
@@ -190,7 +190,7 @@ module Homebrew
 
           return true unless preinstall
 
-          mas = Bundle.which_mas
+          mas = package_manager_executable
           return false if mas.nil?
 
           if app_id_installed?(id)
@@ -204,33 +204,34 @@ module Homebrew
           return false unless Bundle.system(mas, "get", id.to_s, verbose:)
 
           apps << [id.to_s, name] unless apps.any? { |app_id, _app_name| app_id.to_i == id }
-          packages << { id: id.to_s, name: } unless packages.any? { |app| app[:id].to_i == id }
+          packages << App.new(id: id.to_s, name:) unless packages.any? { |app| app.id.to_i == id }
           installed_app_ids << id.to_s unless installed_app_ids.include?(id.to_s)
           true
         end
       end
 
-      sig { override.params(entries: T::Array[Object]).returns(T.untyped) }
+      sig { override.params(entries: T::Array[Object]).returns(T::Array[Object]) }
       def format_checkable(entries)
-        checkable_entries(entries).to_h do |entry|
+        checkable_entries(entries).map do |entry|
           entry = T.cast(entry, Dsl::Entry)
           [T.cast(entry.options.fetch(:id), Integer), entry.name]
         end
       end
 
-      sig { override.params(packages: T.untyped, no_upgrade: T::Boolean).returns(T::Array[T.untyped]) }
+      sig { override.params(packages: CheckablePackages, no_upgrade: T::Boolean).returns(T::Array[Object]) }
       def exit_early_check(packages, no_upgrade:)
-        work_to_be_done = packages.find do |id, _name|
+        work_to_be_done = (packages.is_a?(Hash) ? packages.to_a : packages).find do |id, _name|
           !installed_and_up_to_date?(id, no_upgrade:)
         end
 
         Array(work_to_be_done)
       end
 
-      sig { override.params(packages: T.untyped, no_upgrade: T::Boolean).returns(T::Array[String]) }
+      sig { override.params(packages: CheckablePackages, no_upgrade: T::Boolean).returns(T::Array[String]) }
       def full_check(packages, no_upgrade:)
-        packages.reject { |id, _name| installed_and_up_to_date?(id, no_upgrade:) }
-                .map { |_id, name| failure_reason(name, no_upgrade:) }
+        (packages.is_a?(Hash) ? packages.to_a : packages)
+          .reject { |id, _name| installed_and_up_to_date?(id, no_upgrade:) }
+          .map { |_id, name| failure_reason(name, no_upgrade:) }
       end
 
       sig { override.params(package: Object, no_upgrade: T::Boolean).returns(String) }
@@ -243,17 +244,6 @@ module Homebrew
       def installed_and_up_to_date?(package, no_upgrade: false)
         self.class.app_id_installed_and_up_to_date?(T.cast(package, Integer), no_upgrade:)
       end
-    end
-
-    # TODO: Remove these compatibility aliases once bundle callers and tests
-    # stop requiring separate Mac App Store dumper/installer/checker constants.
-    MacAppStoreDumper = MacAppStore
-    MacAppStoreInstaller = MacAppStore
-
-    module Checker
-      # TODO: Remove this compatibility alias once bundle callers and tests stop
-      # requiring a separate Mac App Store checker constant.
-      MacAppStoreChecker = Homebrew::Bundle::MacAppStore
     end
   end
 end

--- a/Library/Homebrew/bundle/extensions/uv.rb
+++ b/Library/Homebrew/bundle/extensions/uv.rb
@@ -16,7 +16,7 @@ module Homebrew
       BANNER_NAME = "uv tools"
 
       class << self
-        sig { override.params(name: String, options: Homebrew::Bundle::Extension::EntryOptions).returns(Dsl::Entry) }
+        sig { override.params(name: String, options: Homebrew::Bundle::EntryInputOptions).returns(Dsl::Entry) }
         def entry(name, options = {})
           unknown_options = options.keys - [:with]
           raise "unknown options(#{unknown_options.inspect}) for uv" if unknown_options.present?
@@ -44,15 +44,13 @@ module Homebrew
           packages = @packages
           return packages if packages
 
-          @packages = if Bundle.uv_installed?
-            uv = Bundle.which_uv
-            return [] if uv.nil?
-
+          @packages = if (uv = package_manager_executable)
             output = `#{uv} tool list --show-with --show-extras 2>/dev/null`
             parse_tool_list(output)
-          else
-            []
           end
+          return [] if @packages.nil?
+
+          @packages
         end
 
         sig { override.params(package: Object).returns(String) }
@@ -231,17 +229,6 @@ module Homebrew
           self.class.package_record(entry.name, with:)
         end
       end
-    end
-
-    # TODO: Remove these compatibility aliases once bundle callers and tests
-    # stop requiring separate uv dumper/installer/checker constants.
-    UvDumper = Uv
-    UvInstaller = Uv
-
-    module Checker
-      # TODO: Remove this compatibility alias once bundle callers and tests stop
-      # requiring a separate uv checker constant.
-      UvChecker = Homebrew::Bundle::Uv
     end
   end
 end

--- a/Library/Homebrew/bundle/extensions/vscode_extension.rb
+++ b/Library/Homebrew/bundle/extensions/vscode_extension.rb
@@ -22,13 +22,6 @@ module Homebrew
           "VSCode extensions"
         end
 
-        sig { override.returns(T.nilable(Symbol)) }
-        def legacy_cleanup_method
-          # TODO: Remove this legacy cleanup hook once the direct cleanup specs
-          # stop stubbing the old command-level VSCode helper.
-          :vscode_extensions_to_uninstall
-        end
-
         sig { override.params(name: String, with: T.nilable(T::Array[String])).returns(Object) }
         def package_record(name, with: nil)
           _ = with
@@ -36,22 +29,28 @@ module Homebrew
           name.downcase
         end
 
+        sig { override.returns(T.nilable(Pathname)) }
+        def package_manager_executable
+          which("code", ORIGINAL_PATHS) ||
+            which("codium", ORIGINAL_PATHS) ||
+            which("cursor", ORIGINAL_PATHS) ||
+            which("code-insiders", ORIGINAL_PATHS)
+        end
+
         sig { returns(T::Array[String]) }
         def extensions
           extensions = @extensions
           return extensions if extensions
 
-          @extensions = if Bundle.vscode_installed?
-            vscode = Bundle.which_vscode
-            return [] if vscode.nil?
-
+          @extensions = if (vscode = package_manager_executable)
             Bundle.exchange_uid_if_needed! do
               ENV["WSL_DISTRO_NAME"] = ENV.fetch("HOMEBREW_WSL_DISTRO_NAME", nil)
               `"#{vscode}" --list-extensions 2>/dev/null`
             end.split("\n").map(&:downcase)
-          else
-            []
           end
+          return [] if @extensions.nil?
+
+          @extensions
         end
 
         sig { override.returns(T::Array[String]) }
@@ -85,18 +84,19 @@ module Homebrew
         end
 
         sig {
-          params(
+          override.params(
             name:       String,
             with:       T.nilable(T::Array[String]),
             no_upgrade: T::Boolean,
             verbose:    T::Boolean,
+            _options:   Homebrew::Bundle::EntryOption,
           ).returns(T::Boolean)
         }
-        def preinstall!(name, with: nil, no_upgrade: false, verbose: false)
+        def preinstall!(name, with: nil, no_upgrade: false, verbose: false, **_options)
           _ = with
           _ = no_upgrade
 
-          if !Bundle.vscode_installed? && Bundle.cask_installed?
+          if !package_manager_installed? && Bundle.cask_installed?
             puts "Installing visual-studio-code. It is not currently installed." if verbose
             Bundle.system(HOMEBREW_BREW_FILE, "install", "--cask", "visual-studio-code", verbose:)
           end
@@ -106,7 +106,9 @@ module Homebrew
             return false
           end
 
-          raise "Unable to install #{name} VSCode extension. VSCode is not installed." unless Bundle.vscode_installed?
+          unless package_manager_installed?
+            raise "Unable to install #{name} VSCode extension. VSCode is not installed."
+          end
 
           true
         end
@@ -121,7 +123,7 @@ module Homebrew
         def install_package!(name, with: nil, verbose: false)
           _ = with
 
-          vscode = Bundle.which_vscode
+          vscode = package_manager_executable
           return false if vscode.nil?
 
           Bundle.exchange_uid_if_needed! do
@@ -130,16 +132,18 @@ module Homebrew
         end
 
         sig {
-          params(
+          override.params(
             name:       String,
             with:       T.nilable(T::Array[String]),
             preinstall: T::Boolean,
             no_upgrade: T::Boolean,
             verbose:    T::Boolean,
             force:      T::Boolean,
+            _options:   Homebrew::Bundle::EntryOption,
           ).returns(T::Boolean)
         }
-        def install!(name, with: nil, preinstall: true, no_upgrade: false, verbose: false, force: false)
+        def install!(name, with: nil, preinstall: true, no_upgrade: false, verbose: false, force: false,
+                     **_options)
           _ = with
           _ = no_upgrade
           _ = force
@@ -174,42 +178,13 @@ module Homebrew
 
         sig { params(extensions: T::Array[String]).void }
         def cleanup!(extensions)
-          vscode = Bundle.which_vscode
+          vscode = package_manager_executable
           return if vscode.nil?
 
           Bundle.exchange_uid_if_needed! do
             extensions.each do |extension|
               Kernel.system(vscode.to_s, "--uninstall-extension", extension)
             end
-          end
-        end
-      end
-    end
-
-    # TODO: Remove these compatibility aliases once bundle callers and tests
-    # stop requiring separate vscode extension dumper/installer/checker constants.
-    VscodeExtensionDumper = VscodeExtension
-    VscodeExtensionInstaller = VscodeExtension
-
-    module Checker
-      # TODO: Remove this compatibility alias once bundle callers and tests stop
-      # requiring a separate vscode extension checker constant.
-      VscodeExtensionChecker = Homebrew::Bundle::VscodeExtension
-    end
-
-    module Commands
-      module Cleanup
-        class << self
-          # TODO: Remove this legacy helper once the direct cleanup specs stop
-          # stubbing the old command-level VSCode helper.
-          sig { params(global: T::Boolean, file: T.nilable(String)).returns(T::Array[String]) }
-          def vscode_extensions_to_uninstall(global: false, file: nil)
-            _ = global
-            _ = file
-            dsl = Homebrew::Bundle::Commands::Cleanup.dsl
-            raise ArgumentError, "@dsl is unset!" if dsl.nil?
-
-            Homebrew::Bundle::VscodeExtension.cleanup_items(dsl.entries)
           end
         end
       end

--- a/Library/Homebrew/bundle/flatpak.rb
+++ b/Library/Homebrew/bundle/flatpak.rb
@@ -1,5 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/dsl"
-require "bundle/extensions/flatpak"

--- a/Library/Homebrew/bundle/flatpak_checker.rb
+++ b/Library/Homebrew/bundle/flatpak_checker.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/flatpak"

--- a/Library/Homebrew/bundle/flatpak_dumper.rb
+++ b/Library/Homebrew/bundle/flatpak_dumper.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/flatpak"

--- a/Library/Homebrew/bundle/flatpak_installer.rb
+++ b/Library/Homebrew/bundle/flatpak_installer.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/flatpak"

--- a/Library/Homebrew/bundle/formula_dumper.rb
+++ b/Library/Homebrew/bundle/formula_dumper.rb
@@ -1,4 +1,0 @@
-# typed: true
-# frozen_string_literal: true
-
-require "bundle/brew"

--- a/Library/Homebrew/bundle/formula_installer.rb
+++ b/Library/Homebrew/bundle/formula_installer.rb
@@ -1,4 +1,0 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
-# frozen_string_literal: true
-
-require "bundle/brew"

--- a/Library/Homebrew/bundle/go.rb
+++ b/Library/Homebrew/bundle/go.rb
@@ -1,5 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/dsl"
-require "bundle/extensions/go"

--- a/Library/Homebrew/bundle/go_checker.rb
+++ b/Library/Homebrew/bundle/go_checker.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/go"

--- a/Library/Homebrew/bundle/go_dumper.rb
+++ b/Library/Homebrew/bundle/go_dumper.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/go"

--- a/Library/Homebrew/bundle/go_installer.rb
+++ b/Library/Homebrew/bundle/go_installer.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/go"

--- a/Library/Homebrew/bundle/installer.rb
+++ b/Library/Homebrew/bundle/installer.rb
@@ -8,6 +8,13 @@ require "bundle/skipper"
 module Homebrew
   module Bundle
     module Installer
+      class InstallableEntry < T::Struct
+        const :name, String
+        const :options, Homebrew::Bundle::EntryOptions
+        const :verb, String
+        const :cls, T.class_of(Homebrew::Bundle::PackageType)
+      end
+
       sig {
         params(
           entries:    T::Array[Dsl::Entry],
@@ -29,13 +36,12 @@ module Homebrew
           next if Homebrew::Bundle::Skipper.skip? entry
 
           name = entry.name
-          args = [name]
-          options = T.cast(entry.options, T::Hash[Symbol, Object])
+          options = entry.options
           type = entry.type
           cls = Homebrew::Bundle.installable(type)
           next if cls.nil? || !cls.install_supported?
 
-          { name:, args:, options:, verb: cls.install_verb(name, options), type:, cls: }
+          InstallableEntry.new(name:, options:, verb: cls.install_verb(name, options), cls:)
         end
 
         if (fetchable_names = fetchable_formulae_and_casks(installable_entries, no_upgrade:).presence)
@@ -48,13 +54,12 @@ module Homebrew
         end
 
         installable_entries.each do |entry|
-          name = entry.fetch(:name)
-          args = entry.fetch(:args)
-          options = entry.fetch(:options)
-          verb = entry.fetch(:verb)
-          cls = entry.fetch(:cls)
+          name = entry.name
+          options = entry.options
+          verb = entry.verb
+          cls = entry.cls
 
-          preinstall = if cls.preinstall!(*args, **options, no_upgrade:, verbose:)
+          preinstall = if cls.preinstall!(name, **options, no_upgrade:, verbose:)
             puts Formatter.success("#{verb} #{name}")
             true
           else
@@ -62,7 +67,7 @@ module Homebrew
             false
           end
 
-          if cls.install!(*args, **options,
+          if cls.install!(name, **options,
                          preinstall:, no_upgrade:, verbose:, force:)
             success += 1
           else
@@ -89,22 +94,13 @@ module Homebrew
 
       sig {
         params(
-          entries:    T::Array[{ name:    String,
-                                 args:    T::Array[T.anything],
-                                 options: T::Hash[Symbol, Object],
-                                 verb:    String,
-                                 type:    Symbol,
-                                 cls:     T.any(T.class_of(Homebrew::Bundle::PackageType),
-                                                T.class_of(Homebrew::Bundle::Extension)) }],
+          entries:    T::Array[InstallableEntry],
           no_upgrade: T::Boolean,
         ).returns(T::Array[String])
       }
       def self.fetchable_formulae_and_casks(entries, no_upgrade:)
         entries.filter_map do |entry|
-          name = entry.fetch(:name)
-          options = entry.fetch(:options)
-          cls = entry.fetch(:cls)
-          cls.fetchable_name(name, options, no_upgrade:)
+          entry.cls.fetchable_name(entry.name, entry.options, no_upgrade:)
         end
       end
     end

--- a/Library/Homebrew/bundle/lister.rb
+++ b/Library/Homebrew/bundle/lister.rb
@@ -8,18 +8,12 @@ module Homebrew
   module Bundle
     module Lister
       sig {
-        params(entries: T::Array[Object], formulae: T::Boolean, casks: T::Boolean, taps: T::Boolean,
-               extension_types: Homebrew::Bundle::ExtensionTypes,
-               extra_extension_types: Homebrew::Bundle::ExtensionTypes).void.checked(:never)
+        params(entries: T::Array[Dsl::Entry], formulae: T::Boolean, casks: T::Boolean, taps: T::Boolean,
+               extension_types: Homebrew::Bundle::ExtensionTypes).void
       }
-      def self.list(entries, formulae:, casks:, taps:, extension_types: {}, **extra_extension_types)
-        # TODO: Remove `extra_extension_types` once all callers pass a single
-        # `extension_types:` hash instead of legacy per-extension keywords.
-        merged_extension_types = T.cast(extension_types.merge(extra_extension_types),
-                                        Homebrew::Bundle::ExtensionTypes)
+      def self.list(entries, formulae:, casks:, taps:, extension_types: {})
         entries.each do |entry|
-          entry = T.cast(entry, Dsl::Entry)
-          puts entry.name if show?(entry.type, formulae:, casks:, taps:, extension_types: merged_extension_types)
+          puts entry.name if show?(entry.type, formulae:, casks:, taps:, extension_types:)
         end
       end
 

--- a/Library/Homebrew/bundle/mac_app_store.rb
+++ b/Library/Homebrew/bundle/mac_app_store.rb
@@ -1,5 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/dsl"
-require "bundle/extensions/mac_app_store"

--- a/Library/Homebrew/bundle/mac_app_store_checker.rb
+++ b/Library/Homebrew/bundle/mac_app_store_checker.rb
@@ -1,4 +1,0 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
-# frozen_string_literal: true
-
-require "bundle/mac_app_store"

--- a/Library/Homebrew/bundle/mac_app_store_dumper.rb
+++ b/Library/Homebrew/bundle/mac_app_store_dumper.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/mac_app_store"

--- a/Library/Homebrew/bundle/mac_app_store_installer.rb
+++ b/Library/Homebrew/bundle/mac_app_store_installer.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/mac_app_store"

--- a/Library/Homebrew/bundle/package_type.rb
+++ b/Library/Homebrew/bundle/package_type.rb
@@ -1,6 +1,218 @@
 # typed: strict
 # frozen_string_literal: true
 
-# TODO: Remove this compatibility require once bundle callers load
-# `bundle/extensions/extension` directly.
-require "bundle/extensions/extension"
+module Homebrew
+  module Bundle
+    EntryOptionScalar = T.type_alias { T.nilable(T.any(String, Integer, Symbol, TrueClass, FalseClass)) }
+    NestedEntryOptionValue = T.type_alias { T.any(EntryOptionScalar, T::Array[String]) }
+    NestedEntryOptions = T.type_alias { T::Hash[Symbol, NestedEntryOptionValue] }
+    EntryOption = T.type_alias { T.any(EntryOptionScalar, T::Array[String], NestedEntryOptions) }
+    EntryOptions = T.type_alias { T::Hash[Symbol, EntryOption] }
+    EntryInputOptions = T.type_alias { T::Hash[Symbol, Object] }
+
+    class PackageType
+      extend T::Helpers
+
+      abstract!
+
+      sig { params(subclass: T.class_of(Homebrew::Bundle::PackageType)).void }
+      def self.inherited(subclass)
+        super
+        return if subclass.name == "Homebrew::Bundle::Extension"
+
+        Homebrew::Bundle.register_package_type(subclass)
+      end
+
+      sig { returns(Symbol) }
+      def self.type
+        T.cast(const_get(:PACKAGE_TYPE), Symbol)
+      end
+
+      sig { returns(T::Boolean) }
+      def self.dump_supported?
+        true
+      end
+
+      sig { returns(T::Boolean) }
+      def self.install_supported?
+        true
+      end
+
+      sig { params(_name: String, _options: Homebrew::Bundle::EntryOptions).returns(String) }
+      def self.install_verb(_name = "", _options = {})
+        "Installing"
+      end
+
+      sig {
+        params(
+          name:       String,
+          options:    Homebrew::Bundle::EntryOptions,
+          no_upgrade: T::Boolean,
+        ).returns(T.nilable(String))
+      }
+      def self.fetchable_name(name, options = {}, no_upgrade: false)
+        _ = name
+        _ = options
+        _ = no_upgrade
+
+        nil
+      end
+
+      sig { abstract.void }
+      def self.reset!; end
+
+      sig {
+        abstract.params(
+          name:       String,
+          no_upgrade: T::Boolean,
+          verbose:    T::Boolean,
+          options:    Homebrew::Bundle::EntryOption,
+        ).returns(T::Boolean)
+      }
+      def self.preinstall!(name, no_upgrade: false, verbose: false, **options); end
+
+      sig {
+        abstract.params(
+          name:       String,
+          preinstall: T::Boolean,
+          no_upgrade: T::Boolean,
+          verbose:    T::Boolean,
+          force:      T::Boolean,
+          options:    Homebrew::Bundle::EntryOption,
+        ).returns(T::Boolean)
+      }
+      def self.install!(name, preinstall: true, no_upgrade: false, verbose: false, force: false, **options); end
+
+      sig {
+        params(
+          entries:             T::Array[Object],
+          exit_on_first_error: T::Boolean,
+          no_upgrade:          T::Boolean,
+          verbose:             T::Boolean,
+        ).returns(T::Array[Object])
+      }
+      def self.check(entries, exit_on_first_error: false, no_upgrade: false, verbose: false)
+        new.find_actionable(entries, exit_on_first_error:, no_upgrade:, verbose:)
+      end
+
+      sig { abstract.returns(String) }
+      def self.dump; end
+
+      sig { params(describe: T::Boolean, no_restart: T::Boolean).returns(String) }
+      def self.dump_output(describe: false, no_restart: false)
+        _ = describe
+        _ = no_restart
+
+        dump
+      end
+
+      sig { params(packages: T::Array[Object], no_upgrade: T::Boolean).returns(T::Array[Object]) }
+      def exit_early_check(packages, no_upgrade:)
+        work_to_be_done = packages.find do |pkg|
+          !installed_and_up_to_date?(pkg, no_upgrade:)
+        end
+
+        Array(work_to_be_done)
+      end
+
+      sig { params(name: Object, no_upgrade: T::Boolean).returns(String) }
+      def failure_reason(name, no_upgrade:)
+        reason = if no_upgrade && Bundle.upgrade_formulae.exclude?(name)
+          "needs to be installed."
+        else
+          "needs to be installed or updated."
+        end
+        "#{self.class.const_get(:PACKAGE_TYPE_NAME)} #{name} #{reason}"
+      end
+
+      sig { params(packages: T::Array[Object], no_upgrade: T::Boolean).returns(T::Array[String]) }
+      def full_check(packages, no_upgrade:)
+        packages.reject { |pkg| installed_and_up_to_date?(pkg, no_upgrade:) }
+                .map { |pkg| failure_reason(pkg, no_upgrade:) }
+      end
+
+      sig { params(all_entries: T::Array[Object]).returns(T::Array[Object]) }
+      def checkable_entries(all_entries)
+        require "bundle/skipper"
+        all_entries.filter_map do |entry|
+          entry = T.cast(entry, Dsl::Entry)
+          next if entry.type != self.class.const_get(:PACKAGE_TYPE)
+          next if Bundle::Skipper.skip?(entry)
+
+          entry
+        end
+      end
+
+      sig { params(entries: T::Array[Object]).returns(T::Array[Object]) }
+      def format_checkable(entries)
+        checkable_entries(entries).map do |entry|
+          entry = T.cast(entry, Dsl::Entry)
+          entry.name
+        end
+      end
+
+      sig { params(_pkg: Object, no_upgrade: T::Boolean).returns(T::Boolean) }
+      def installed_and_up_to_date?(_pkg, no_upgrade: false)
+        raise NotImplementedError
+      end
+
+      sig {
+        params(
+          entries:             T::Array[Object],
+          exit_on_first_error: T::Boolean,
+          no_upgrade:          T::Boolean,
+          verbose:             T::Boolean,
+        ).returns(T::Array[Object])
+      }
+      def find_actionable(entries, exit_on_first_error: false, no_upgrade: false, verbose: false)
+        requested = format_checkable(entries)
+
+        if exit_on_first_error
+          exit_early_check(requested, no_upgrade:)
+        else
+          full_check(requested, no_upgrade:)
+        end
+      end
+    end
+
+    class << self
+      sig { params(package_type: T.class_of(PackageType)).void }
+      def register_package_type(package_type)
+        @package_types ||= T.let([], T.nilable(T::Array[T.class_of(PackageType)]))
+        @package_types.reject! { |registered| registered.name == package_type.name }
+        @package_types << package_type
+      end
+
+      sig { returns(T::Array[T.class_of(PackageType)]) }
+      def package_types
+        @package_types ||= T.let([], T.nilable(T::Array[T.class_of(PackageType)]))
+        @package_types
+      end
+
+      sig { params(type: T.any(Symbol, String)).returns(T.nilable(T.class_of(PackageType))) }
+      def package_type(type)
+        requested_type = type.to_sym
+        package_types.find { |registered| registered.type == requested_type }
+      end
+
+      sig { returns(T::Array[T.class_of(PackageType)]) }
+      def dump_package_types
+        core_package_types = [:tap, :brew, :cask].filter_map { |type| package_type(type) }
+        (core_package_types + (package_types - core_package_types)).uniq
+      end
+
+      sig { returns(T::Array[T.class_of(PackageType)]) }
+      def check_package_types
+        taps = package_type(:tap)
+        casks = package_type(:cask)
+        formulae = package_type(:brew)
+        leading_package_types = [taps, casks].compact
+        trailing_package_types = [formulae].compact
+
+        leading_package_types +
+          (package_types - leading_package_types - trailing_package_types) +
+          trailing_package_types
+      end
+    end
+  end
+end

--- a/Library/Homebrew/bundle/skipper.rb
+++ b/Library/Homebrew/bundle/skipper.rb
@@ -9,11 +9,12 @@ module Homebrew
       class << self
         sig { params(entry: Dsl::Entry, silent: T::Boolean).returns(T::Boolean) }
         def skip?(entry, silent: false)
-          require "bundle/formula_dumper"
+          require "bundle/brew"
 
+          full_name = entry.options[:full_name]
           return true if @failed_taps&.any? do |tap|
             prefix = "#{tap}/"
-            entry.name.start_with?(prefix) || entry.options[:full_name]&.start_with?(prefix)
+            entry.name.start_with?(prefix) || (full_name.is_a?(String) && full_name.start_with?(prefix))
           end
 
           entry_type_skips = Array(skipped_entries[entry.type])

--- a/Library/Homebrew/bundle/tap.rb
+++ b/Library/Homebrew/bundle/tap.rb
@@ -17,8 +17,17 @@ module Homebrew
           @installed_taps = T.let(nil, T.nilable(T::Array[String]))
         end
 
-        sig { params(name: String, verbose: T::Boolean, _options: T.anything).returns(T::Boolean) }
-        def preinstall!(name, verbose: false, **_options)
+        sig {
+          override.params(
+            name:       String,
+            no_upgrade: T::Boolean,
+            verbose:    T::Boolean,
+            _options:   Homebrew::Bundle::EntryOption,
+          ).returns(T::Boolean)
+        }
+        def preinstall!(name, no_upgrade: false, verbose: false, **_options)
+          _ = no_upgrade
+
           if installed_taps.include? name
             puts "Skipping install of #{name} tap. It is already installed." if verbose
             return false
@@ -28,16 +37,20 @@ module Homebrew
         end
 
         sig {
-          params(
+          override.params(
             name:         String,
             preinstall:   T::Boolean,
+            no_upgrade:   T::Boolean,
             verbose:      T::Boolean,
             force:        T::Boolean,
             clone_target: T.nilable(String),
-            _options:     T.anything,
+            _options:     Homebrew::Bundle::EntryOption,
           ).returns(T::Boolean)
         }
-        def install!(name, preinstall: true, verbose: false, force: false, clone_target: nil, **_options)
+        def install!(name, preinstall: true, no_upgrade: false, verbose: false, force: false, clone_target: nil,
+                     **_options)
+          _ = no_upgrade
+
           return true unless preinstall
 
           puts "Installing #{name} tap. It is not currently installed." if verbose
@@ -61,7 +74,7 @@ module Homebrew
           true
         end
 
-        sig { override.params(_name: String, _options: T::Hash[Symbol, Object]).returns(String) }
+        sig { override.params(_name: String, _options: Homebrew::Bundle::EntryOptions).returns(String) }
         def install_verb(_name = "", _options = {})
           "Tapping"
         end
@@ -128,23 +141,12 @@ module Homebrew
         (requested_taps - current_taps).map { |entry| "Tap #{entry} needs to be tapped." }
       end
 
-      sig { override.params(package: T.untyped, no_upgrade: T::Boolean).returns(T::Boolean) }
+      sig { override.params(package: Object, no_upgrade: T::Boolean).returns(T::Boolean) }
       def installed_and_up_to_date?(package, no_upgrade: false)
         _ = no_upgrade
 
         self.class.installed_taps.include?(T.cast(package, String))
       end
-    end
-
-    # TODO: Remove these compatibility aliases once bundle callers and tests
-    # stop requiring separate tap dumper/installer/checker constants.
-    TapInstaller = Tap
-    TapDumper = Tap
-
-    module Checker
-      # TODO: Remove this compatibility alias once bundle callers and tests stop
-      # requiring a separate tap checker constant.
-      TapChecker = Homebrew::Bundle::Tap
     end
   end
 end

--- a/Library/Homebrew/bundle/tap_checker.rb
+++ b/Library/Homebrew/bundle/tap_checker.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/tap"

--- a/Library/Homebrew/bundle/tap_dumper.rb
+++ b/Library/Homebrew/bundle/tap_dumper.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/tap"

--- a/Library/Homebrew/bundle/tap_installer.rb
+++ b/Library/Homebrew/bundle/tap_installer.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/tap"

--- a/Library/Homebrew/bundle/uv.rb
+++ b/Library/Homebrew/bundle/uv.rb
@@ -1,5 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/dsl"
-require "bundle/extensions/uv"

--- a/Library/Homebrew/bundle/uv_checker.rb
+++ b/Library/Homebrew/bundle/uv_checker.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/uv"

--- a/Library/Homebrew/bundle/uv_dumper.rb
+++ b/Library/Homebrew/bundle/uv_dumper.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/uv"

--- a/Library/Homebrew/bundle/uv_installer.rb
+++ b/Library/Homebrew/bundle/uv_installer.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/uv"

--- a/Library/Homebrew/bundle/vscode_extension.rb
+++ b/Library/Homebrew/bundle/vscode_extension.rb
@@ -1,5 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/dsl"
-require "bundle/extensions/vscode_extension"

--- a/Library/Homebrew/bundle/vscode_extension_checker.rb
+++ b/Library/Homebrew/bundle/vscode_extension_checker.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/vscode_extension"

--- a/Library/Homebrew/bundle/vscode_extension_dumper.rb
+++ b/Library/Homebrew/bundle/vscode_extension_dumper.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/vscode_extension"

--- a/Library/Homebrew/bundle/vscode_extension_installer.rb
+++ b/Library/Homebrew/bundle/vscode_extension_installer.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "bundle/vscode_extension"

--- a/Library/Homebrew/test/bundle/brew_services_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_services_spec.rb
@@ -3,7 +3,7 @@
 require "bundle"
 require "bundle/brew_services"
 
-RSpec.describe Homebrew::Bundle::BrewServices do
+RSpec.describe Homebrew::Bundle::Brew::Services do
   describe ".started_services" do
     before do
       described_class.reset!

--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -291,12 +291,12 @@ RSpec.describe Homebrew::Bundle::Brew do
 
         context "when service is already running" do
           before do
-            allow(Homebrew::Bundle::BrewServices).to receive(:started?).with(formula_name).and_return(true)
+            allow(Homebrew::Bundle::Brew::Services).to receive(:started?).with(formula_name).and_return(true)
           end
 
           context "with a successful installation" do
             it "start service" do
-              expect(Homebrew::Bundle::BrewServices).not_to receive(:start)
+              expect(Homebrew::Bundle::Brew::Services).not_to receive(:start)
               described_class.preinstall!(formula_name, start_service: true)
               described_class.install!(formula_name, start_service: true)
             end
@@ -304,7 +304,7 @@ RSpec.describe Homebrew::Bundle::Brew do
 
           context "with a skipped installation" do
             it "start service" do
-              expect(Homebrew::Bundle::BrewServices).not_to receive(:start)
+              expect(Homebrew::Bundle::Brew::Services).not_to receive(:start)
               described_class.install!(formula_name, preinstall: false, start_service: true)
             end
           end
@@ -312,12 +312,12 @@ RSpec.describe Homebrew::Bundle::Brew do
 
         context "when service is not running" do
           before do
-            allow(Homebrew::Bundle::BrewServices).to receive(:started?).with(formula_name).and_return(false)
+            allow(Homebrew::Bundle::Brew::Services).to receive(:started?).with(formula_name).and_return(false)
           end
 
           context "with a successful installation" do
             it "start service" do
-              expect(Homebrew::Bundle::BrewServices).to \
+              expect(Homebrew::Bundle::Brew::Services).to \
                 receive(:start).with(formula_name, file: nil, verbose: false).and_return(true)
               described_class.preinstall!(formula_name, start_service: true)
               described_class.install!(formula_name, start_service: true)
@@ -326,7 +326,7 @@ RSpec.describe Homebrew::Bundle::Brew do
 
           context "with a skipped installation" do
             it "start service" do
-              expect(Homebrew::Bundle::BrewServices).to \
+              expect(Homebrew::Bundle::Brew::Services).to \
                 receive(:start).with(formula_name, file: nil, verbose: false).and_return(true)
               described_class.install!(formula_name, preinstall: false, start_service: true)
             end
@@ -343,7 +343,7 @@ RSpec.describe Homebrew::Bundle::Brew do
 
         context "with a successful installation" do
           it "restart service" do
-            expect(Homebrew::Bundle::BrewServices).to \
+            expect(Homebrew::Bundle::Brew::Services).to \
               receive(:restart).with(formula_name, file: nil, verbose: false).and_return(true)
             described_class.preinstall!(formula_name, restart_service: :always)
             described_class.install!(formula_name, restart_service: :always)
@@ -352,7 +352,7 @@ RSpec.describe Homebrew::Bundle::Brew do
 
         context "with a skipped installation" do
           it "restart service" do
-            expect(Homebrew::Bundle::BrewServices).to \
+            expect(Homebrew::Bundle::Brew::Services).to \
               receive(:restart).with(formula_name, file: nil, verbose: false).and_return(true)
             described_class.install!(formula_name, preinstall: false, restart_service: :always)
           end
@@ -460,10 +460,10 @@ RSpec.describe Homebrew::Bundle::Brew do
                                                             verbose:).and_return(true)
           expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "unlink", "mysql56",
                                                             verbose:).and_return(true)
-          expect(Homebrew::Bundle::BrewServices).to receive(:stop).with("mysql55", verbose:).and_return(true)
-          expect(Homebrew::Bundle::BrewServices).to receive(:stop).with("mysql56", verbose:).and_return(true)
-          expect(Homebrew::Bundle::BrewServices).to receive(:restart).with(formula_name, file:    nil,
-                                                                                         verbose:).and_return(true)
+          expect(Homebrew::Bundle::Brew::Services).to receive(:stop).with("mysql55", verbose:).and_return(true)
+          expect(Homebrew::Bundle::Brew::Services).to receive(:stop).with("mysql56", verbose:).and_return(true)
+          expect(Homebrew::Bundle::Brew::Services).to receive(:restart).with(formula_name, file:    nil,
+                                                                                           verbose:).and_return(true)
           described_class.preinstall!(formula_name, restart_service: :always, conflicts_with: ["mysql56"])
           described_class.install!(formula_name, restart_service: :always, conflicts_with: ["mysql56"])
         end
@@ -476,10 +476,10 @@ RSpec.describe Homebrew::Bundle::Brew do
                                                             verbose:).and_return(true)
           expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "unlink", "mysql56",
                                                             verbose:).and_return(true)
-          expect(Homebrew::Bundle::BrewServices).to receive(:stop).with("mysql55", verbose:).and_return(true)
-          expect(Homebrew::Bundle::BrewServices).to receive(:stop).with("mysql56", verbose:).and_return(true)
-          expect(Homebrew::Bundle::BrewServices).to receive(:restart).with(formula_name, file:    nil,
-                                                                                         verbose:).and_return(true)
+          expect(Homebrew::Bundle::Brew::Services).to receive(:stop).with("mysql55", verbose:).and_return(true)
+          expect(Homebrew::Bundle::Brew::Services).to receive(:stop).with("mysql56", verbose:).and_return(true)
+          expect(Homebrew::Bundle::Brew::Services).to receive(:restart).with(formula_name, file:    nil,
+                                                                                           verbose:).and_return(true)
           described_class.preinstall!(formula_name, restart_service: :always, conflicts_with: ["mysql56"],
           verbose: true)
           described_class.install!(formula_name, restart_service: :always, conflicts_with: ["mysql56"],
@@ -567,7 +567,7 @@ RSpec.describe Homebrew::Bundle::Brew do
       end
 
       it "did not call restart service" do
-        expect(Homebrew::Bundle::BrewServices).not_to receive(:restart)
+        expect(Homebrew::Bundle::Brew::Services).not_to receive(:restart)
         described_class.preinstall!(formula_name, restart_service: true)
       end
     end
@@ -737,7 +737,7 @@ RSpec.describe Homebrew::Bundle::Brew do
     describe "#start_service_needed?" do
       context "when a service is already started" do
         before do
-          allow(Homebrew::Bundle::BrewServices).to receive(:started?).with(formula_name).and_return(true)
+          allow(Homebrew::Bundle::Brew::Services).to receive(:started?).with(formula_name).and_return(true)
         end
 
         it "is false by default" do
@@ -763,7 +763,7 @@ RSpec.describe Homebrew::Bundle::Brew do
 
       context "when a service is not started" do
         before do
-          allow(Homebrew::Bundle::BrewServices).to receive(:started?).with(formula_name).and_return(false)
+          allow(Homebrew::Bundle::Brew::Services).to receive(:started?).with(formula_name).and_return(false)
         end
 
         it "is false by default" do

--- a/Library/Homebrew/test/bundle/bundle_spec.rb
+++ b/Library/Homebrew/test/bundle/bundle_spec.rb
@@ -40,19 +40,6 @@ RSpec.describe Homebrew::Bundle do
     end
   end
 
-  context "when checking for mas", :needs_macos do
-    before do
-      described_class.instance_variable_set(:@mas_installed, nil)
-      described_class.instance_variable_set(:@which_mas, nil)
-    end
-
-    it "finds it when present" do
-      allow(described_class).to receive(:which).with("mas",
-                                                     ORIGINAL_PATHS).and_return(Pathname("/opt/homebrew/bin/mas"))
-      expect(described_class.mas_installed?).to be(true)
-    end
-  end
-
   describe ".mark_as_installed_on_request!", :no_api do
     subject(:mark_installed!) { described_class.mark_as_installed_on_request!(entries) }
 

--- a/Library/Homebrew/test/bundle/cargo_spec.rb
+++ b/Library/Homebrew/test/bundle/cargo_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require "bundle"
-require "bundle/cargo"
+require "bundle/dsl"
+require "bundle/extensions/cargo"
 
 RSpec.describe Homebrew::Bundle::Cargo do
   describe "dumping" do
@@ -10,7 +11,7 @@ RSpec.describe Homebrew::Bundle::Cargo do
     context "when cargo is not installed" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive(:cargo_installed?).and_return(false)
+        allow(described_class).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "returns an empty list" do
@@ -25,7 +26,7 @@ RSpec.describe Homebrew::Bundle::Cargo do
     context "when cargo is installed" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive_messages(cargo_installed?: true, which_cargo: Pathname.new("cargo"))
+        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("cargo"))
       end
 
       it "returns package list" do
@@ -49,7 +50,7 @@ RSpec.describe Homebrew::Bundle::Cargo do
     context "when Cargo is not installed" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive(:cargo_installed?).and_return(false)
+        allow(described_class).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "tries to install rust" do
@@ -62,7 +63,7 @@ RSpec.describe Homebrew::Bundle::Cargo do
 
     context "when Cargo is installed" do
       before do
-        allow(Homebrew::Bundle).to receive(:cargo_installed?).and_return(true)
+        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("cargo"))
       end
 
       context "when package is installed" do
@@ -79,8 +80,8 @@ RSpec.describe Homebrew::Bundle::Cargo do
 
       context "when package is not installed" do
         before do
-          allow(Homebrew::Bundle).to receive(:which_cargo).and_return(Pathname.new("/tmp/rust/bin/cargo"))
-          allow(described_class).to receive(:installed_packages).and_return([])
+          allow(described_class).to receive_messages(package_manager_executable: Pathname.new("/tmp/rust/bin/cargo"),
+                                                     installed_packages:         [])
         end
 
         it "installs package" do

--- a/Library/Homebrew/test/bundle/commands/check_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/check_spec.rb
@@ -2,13 +2,6 @@
 
 require "bundle"
 require "bundle/commands/check"
-require "bundle/brew_checker"
-require "bundle/cask_checker"
-require "bundle/mac_app_store_checker"
-require "bundle/vscode_extension_checker"
-require "bundle/formula_installer"
-require "bundle/cask_installer"
-require "bundle/mac_app_store_installer"
 require "bundle/dsl"
 require "bundle/skipper"
 
@@ -29,11 +22,10 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
     it "does not raise an error" do
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
       nothing = []
-      allow(Homebrew::Bundle::Checker).to receive_messages(casks_to_install:      nothing,
-                                                           formulae_to_install:   nothing,
-                                                           apps_to_install:       nothing,
-                                                           taps_to_tap:           nothing,
-                                                           extensions_to_install: nothing)
+      allow(Homebrew::Bundle::Checker).to receive_messages(casks_to_install:    nothing,
+                                                           formulae_to_install: nothing,
+                                                           apps_to_install:     nothing,
+                                                           taps_to_tap:         nothing)
       expect { do_check }.not_to raise_error
     end
   end
@@ -49,8 +41,8 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
   context "when casks are not installed", :needs_macos do
     it "raises an error" do
       allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(true)
-      allow(Homebrew::Bundle::CaskDumper).to receive(:casks).and_return([])
-      allow(Homebrew::Bundle::FormulaInstaller).to receive(:upgradable_formulae).and_return([])
+      allow(Homebrew::Bundle::Cask).to receive(:casks).and_return([])
+      allow(Homebrew::Bundle::Brew).to receive(:upgradable_formulae).and_return([])
       allow_any_instance_of(Pathname).to receive(:read).and_return("cask 'abc'")
       expect { do_check }.to raise_error(SystemExit)
     end
@@ -60,16 +52,16 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
     let(:verbose) { true }
 
     it "raises an error and outputs to stdout" do
-      allow(Homebrew::Bundle::CaskDumper).to receive(:casks).and_return([])
-      allow(Homebrew::Bundle::FormulaInstaller).to receive(:upgradable_formulae).and_return([])
+      allow(Homebrew::Bundle::Cask).to receive(:casks).and_return([])
+      allow(Homebrew::Bundle::Brew).to receive(:upgradable_formulae).and_return([])
       allow_any_instance_of(Pathname).to receive(:read).and_return("brew 'abc'")
       expect { do_check }.to raise_error(SystemExit).and \
         output(/brew bundle can't satisfy your Brewfile's dependencies/).to_stdout
     end
 
     it "partially outputs when HOMEBREW_BUNDLE_CHECK_ALREADY_OUTPUT_FORMULAE_ERRORS is set" do
-      allow(Homebrew::Bundle::CaskDumper).to receive(:casks).and_return([])
-      allow(Homebrew::Bundle::FormulaInstaller).to receive(:upgradable_formulae).and_return([])
+      allow(Homebrew::Bundle::Cask).to receive(:casks).and_return([])
+      allow(Homebrew::Bundle::Brew).to receive(:upgradable_formulae).and_return([])
       allow_any_instance_of(Pathname).to receive(:read).and_return("brew 'abc'")
       ENV["HOMEBREW_BUNDLE_CHECK_ALREADY_OUTPUT_FORMULAE_ERRORS"] = "abc"
       expect { do_check }.to raise_error(SystemExit).and \
@@ -77,8 +69,8 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
     end
 
     it "does not raise error on skippable formula" do
-      allow(Homebrew::Bundle::CaskDumper).to receive(:casks).and_return([])
-      allow(Homebrew::Bundle::FormulaInstaller).to receive(:upgradable_formulae).and_return([])
+      allow(Homebrew::Bundle::Cask).to receive(:casks).and_return([])
+      allow(Homebrew::Bundle::Brew).to receive(:upgradable_formulae).and_return([])
       allow(Homebrew::Bundle::Skipper).to receive(:skip?).and_return(true)
       allow_any_instance_of(Pathname).to receive(:read).and_return("brew 'abc'")
       expect { do_check }.not_to raise_error
@@ -87,8 +79,8 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
 
   context "when taps are not tapped" do
     it "raises an error" do
-      allow(Homebrew::Bundle::CaskDumper).to receive(:casks).and_return([])
-      allow(Homebrew::Bundle::FormulaInstaller).to receive(:upgradable_formulae).and_return([])
+      allow(Homebrew::Bundle::Cask).to receive(:casks).and_return([])
+      allow(Homebrew::Bundle::Brew).to receive(:upgradable_formulae).and_return([])
       allow_any_instance_of(Pathname).to receive(:read).and_return("tap 'abc/def'")
       expect { do_check }.to raise_error(SystemExit)
     end
@@ -96,8 +88,8 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
 
   context "when apps are not installed", :needs_macos do
     it "raises an error" do
-      allow(Homebrew::Bundle::MacAppStoreDumper).to receive(:app_ids).and_return([])
-      allow(Homebrew::Bundle::FormulaInstaller).to receive(:upgradable_formulae).and_return([])
+      allow(Homebrew::Bundle::MacAppStore).to receive(:app_ids).and_return([])
+      allow(Homebrew::Bundle::Brew).to receive(:upgradable_formulae).and_return([])
       allow_any_instance_of(Pathname).to receive(:read).and_return("mas 'foo', id: 123")
       expect { do_check }.to raise_error(SystemExit)
     end
@@ -116,21 +108,21 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
 
     before do
       Homebrew::Bundle::Checker.reset!
-      allow_any_instance_of(Homebrew::Bundle::Checker::MacAppStoreChecker).to \
+      allow_any_instance_of(Homebrew::Bundle::MacAppStore).to \
         receive(:installed_and_up_to_date?).and_return(false)
-      allow(Homebrew::Bundle::FormulaInstaller).to receive_messages(installed_formulae:  ["abc", "def"],
-                                                                    upgradable_formulae: [])
-      allow(Homebrew::Bundle::BrewServices).to receive(:started?).with("abc").and_return(true)
-      allow(Homebrew::Bundle::BrewServices).to receive(:started?).with("def").and_return(false)
+      allow(Homebrew::Bundle::Brew).to receive_messages(installed_formulae:  ["abc", "def"],
+                                                        upgradable_formulae: [])
+      allow(Homebrew::Bundle::Brew::Services).to receive(:started?).with("abc").and_return(true)
+      allow(Homebrew::Bundle::Brew::Services).to receive(:started?).with("def").and_return(false)
     end
 
     it "does not raise error when no service needs to be started" do
       Homebrew::Bundle::Checker.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("brew 'abc'")
 
-      expect(Homebrew::Bundle::FormulaInstaller.installed_formulae).to include("abc")
-      expect(Homebrew::Bundle::CaskInstaller.installed_casks).not_to include("abc")
-      expect(Homebrew::Bundle::BrewServices.started?("abc")).to be(true)
+      expect(Homebrew::Bundle::Brew.installed_formulae).to include("abc")
+      expect(Homebrew::Bundle::Cask.installed_casks).not_to include("abc")
+      expect(Homebrew::Bundle::Brew::Services.started?("abc")).to be(true)
 
       expect { do_check }.not_to raise_error
     end
@@ -139,7 +131,7 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
       it "raises an error" do
         allow_any_instance_of(Pathname)
           .to receive(:read).and_return("brew 'abc', restart_service: true\nbrew 'def', restart_service: true")
-        allow_any_instance_of(Homebrew::Bundle::Checker::MacAppStoreChecker)
+        allow_any_instance_of(Homebrew::Bundle::MacAppStore)
           .to receive(:format_checkable).and_return(1 => "foo")
         expect { do_check }.to raise_error(SystemExit).and output(expected_output).to_stdout
       end
@@ -149,7 +141,7 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
       it "raises an error" do
         allow_any_instance_of(Pathname)
           .to receive(:read).and_return("brew 'abc', start_service: true\nbrew 'def', start_service: true")
-        allow_any_instance_of(Homebrew::Bundle::Checker::MacAppStoreChecker)
+        allow_any_instance_of(Homebrew::Bundle::MacAppStore)
           .to receive(:format_checkable).and_return(1 => "foo")
         expect { do_check }.to raise_error(SystemExit).and output(expected_output).to_stdout
       end
@@ -169,14 +161,14 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
 
     before do
       Homebrew::Bundle::Checker.reset!
-      allow_any_instance_of(Homebrew::Bundle::Checker::MacAppStoreChecker).to \
+      allow_any_instance_of(Homebrew::Bundle::MacAppStore).to \
         receive(:installed_and_up_to_date?).and_return(false)
-      allow(Homebrew::Bundle::FormulaInstaller).to receive(:installed_formulae).and_return(["abc", "def"])
+      allow(Homebrew::Bundle::Brew).to receive(:installed_formulae).and_return(["abc", "def"])
     end
 
     it "raises an error that doesn't mention upgrade" do
       allow_any_instance_of(Pathname).to receive(:read).and_return("brew 'abc'")
-      allow_any_instance_of(Homebrew::Bundle::Checker::MacAppStoreChecker).to \
+      allow_any_instance_of(Homebrew::Bundle::MacAppStore).to \
         receive(:format_checkable).and_return(1 => "foo")
       expect { do_check }.to raise_error(SystemExit).and output(expected_output).to_stdout
     end
@@ -194,7 +186,7 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
 
     before do
       Homebrew::Bundle::Checker.reset!
-      allow_any_instance_of(Homebrew::Bundle::Checker::VscodeExtensionChecker).to \
+      allow_any_instance_of(Homebrew::Bundle::VscodeExtension).to \
         receive(:installed_and_up_to_date?).and_return(false)
     end
 
@@ -261,11 +253,11 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
 
   context "when verbose mode is not enabled" do
     it "stops checking after the first missing formula" do
-      allow(Homebrew::Bundle::CaskDumper).to receive(:casks).and_return([])
-      allow(Homebrew::Bundle::FormulaInstaller).to receive(:upgradable_formulae).and_return([])
+      allow(Homebrew::Bundle::Cask).to receive(:casks).and_return([])
+      allow(Homebrew::Bundle::Brew).to receive(:upgradable_formulae).and_return([])
       allow_any_instance_of(Pathname).to receive(:read).and_return("brew 'abc'\nbrew 'def'")
 
-      expect_any_instance_of(Homebrew::Bundle::Checker::BrewChecker).to \
+      expect_any_instance_of(Homebrew::Bundle::Brew).to \
         receive(:exit_early_check).once.and_call_original
       expect { do_check }.to raise_error(SystemExit)
     end
@@ -273,7 +265,7 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
     it "stops checking after the first missing cask", :needs_macos do
       allow_any_instance_of(Pathname).to receive(:read).and_return("cask 'abc'\ncask 'def'")
 
-      expect_any_instance_of(Homebrew::Bundle::Checker::CaskChecker).to \
+      expect_any_instance_of(Homebrew::Bundle::Cask).to \
         receive(:exit_early_check).once.and_call_original
       expect { do_check }.to raise_error(SystemExit)
     end
@@ -281,7 +273,7 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
     it "stops checking after the first missing mac app", :needs_macos do
       allow_any_instance_of(Pathname).to receive(:read).and_return("mas 'foo', id: 123\nmas 'bar', id: 456")
 
-      expect_any_instance_of(Homebrew::Bundle::Checker::MacAppStoreChecker).to \
+      expect_any_instance_of(Homebrew::Bundle::MacAppStore).to \
         receive(:exit_early_check).once.and_call_original
       expect { do_check }.to raise_error(SystemExit)
     end
@@ -289,7 +281,7 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
     it "stops checking after the first VSCode extension" do
       allow_any_instance_of(Pathname).to receive(:read).and_return("vscode 'abc'\nvscode 'def'")
 
-      expect_any_instance_of(Homebrew::Bundle::Checker::VscodeExtensionChecker).to \
+      expect_any_instance_of(Homebrew::Bundle::VscodeExtension).to \
         receive(:exit_early_check).once.and_call_original
       expect { do_check }.to raise_error(SystemExit)
     end
@@ -297,8 +289,31 @@ RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
 
   context "when a new checker fails to implement installed_and_up_to_date" do
     it "raises an exception" do
-      stub_const("TestChecker", Class.new(Homebrew::Bundle::Checker::Base) do
+      stub_const("TestChecker", Class.new(Homebrew::Bundle::PackageType) do
         class_eval("PACKAGE_TYPE = :test", __FILE__, __LINE__)
+        class_eval("PACKAGE_TYPE_NAME = 'Test'", __FILE__, __LINE__)
+
+        def self.reset!; end
+
+        def self.preinstall!(name, no_upgrade: false, verbose: false, **options)
+          _ = name
+          _ = no_upgrade
+          _ = verbose
+          _ = options
+        end
+
+        def self.install!(name, preinstall: true, no_upgrade: false, verbose: false, force: false, **options)
+          _ = name
+          _ = preinstall
+          _ = no_upgrade
+          _ = verbose
+          _ = force
+          _ = options
+        end
+
+        def self.dump
+          ""
+        end
       end.freeze)
 
       test_entry = Homebrew::Bundle::Dsl::Entry.new(:test, "test")

--- a/Library/Homebrew/test/bundle/commands/check_spec.rbi
+++ b/Library/Homebrew/test/bundle/commands/check_spec.rbi
@@ -1,4 +1,4 @@
 # typed: strict
 
-class TestChecker < Homebrew::Bundle::Checker::Base
+class TestChecker < Homebrew::Bundle::PackageType
 end

--- a/Library/Homebrew/test/bundle/commands/cleanup_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/cleanup_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     it "computes which casks to uninstall" do
       cask_123 = instance_double(Cask::Cask, to_s: "123", old_tokens: [])
       cask_456 = instance_double(Cask::Cask, to_s: "456", old_tokens: [])
-      allow(Homebrew::Bundle::CaskDumper).to receive(:casks).and_return([cask_123, cask_456])
+      allow(Homebrew::Bundle::Cask).to receive(:casks).and_return([cask_123, cask_456])
       expect(described_class.casks_to_uninstall).to eql(%w[456])
     end
 
@@ -73,7 +73,7 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
         { name: "builddependency2", full_name: "builddependency2" },
         { name: "caskdependency", full_name: "homebrew/tap/caskdependency" },
       ].map { |formula| dependencies_arrays_hash.merge(formula) }
-      allow(Homebrew::Bundle::FormulaDumper).to receive(:formulae).and_return(formulae_hash)
+      allow(Homebrew::Bundle::Brew).to receive(:formulae).and_return(formulae_hash)
 
       formulae_hash.each do |hash_formula|
         name = hash_formula[:name]
@@ -84,7 +84,7 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
         stub_formula_loader f, full_name
       end
 
-      allow(Homebrew::Bundle::CaskDumper).to receive(:formula_dependencies).and_return(%w[caskdependency])
+      allow(Homebrew::Bundle::Cask).to receive(:formula_dependencies).and_return(%w[caskdependency])
       expect(described_class.formulae_to_uninstall).to eql %w[
         c
         homebrew/tap/e
@@ -94,7 +94,7 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     end
 
     it "computes which tap to untap" do
-      allow(Homebrew::Bundle::TapDumper).to \
+      allow(Homebrew::Bundle::Tap).to \
         receive(:tap_names).and_return(%w[z homebrew/core homebrew/tap])
       expect(described_class.taps_to_untap).to eql(%w[z])
     end
@@ -102,14 +102,14 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     it "ignores unavailable formulae when computing which taps to keep" do
       allow(Formulary).to \
         receive(:factory).and_raise(TapFormulaUnavailableError.new(Tap.fetch("homebrew/tap"), "foo"))
-      allow(Homebrew::Bundle::TapDumper).to \
+      allow(Homebrew::Bundle::Tap).to \
         receive(:tap_names).and_return(%w[z homebrew/core homebrew/tap])
       expect(described_class.taps_to_untap).to eql(%w[z homebrew/tap])
     end
 
     it "ignores formulae with .keepme references when computing which formulae to uninstall" do
       name = full_name ="c"
-      allow(Homebrew::Bundle::FormulaDumper).to receive(:formulae).and_return([{ name:, full_name: }])
+      allow(Homebrew::Bundle::Brew).to receive(:formulae).and_return([{ name:, full_name: }])
       f = formula(name) { url "#{name}-1.0" }
       stub_formula_loader f, name
 
@@ -121,13 +121,13 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     end
 
     it "computes which VSCode extensions to uninstall" do
-      allow(Homebrew::Bundle::VscodeExtensionDumper).to receive(:extensions).and_return(%w[z])
-      expect(described_class.vscode_extensions_to_uninstall).to eql(%w[z])
+      allow(Homebrew::Bundle::VscodeExtension).to receive(:extensions).and_return(%w[z])
+      expect(Homebrew::Bundle::VscodeExtension.cleanup_items(described_class.dsl.entries)).to eql(%w[z])
     end
 
     it "computes which VSCode extensions to uninstall irrespective of case of the extension name" do
-      allow(Homebrew::Bundle::VscodeExtensionDumper).to receive(:extensions).and_return(%w[z vscodeextension1])
-      expect(described_class.vscode_extensions_to_uninstall).to eql(%w[z])
+      allow(Homebrew::Bundle::VscodeExtension).to receive(:extensions).and_return(%w[z vscodeextension1])
+      expect(Homebrew::Bundle::VscodeExtension.cleanup_items(described_class.dsl.entries)).to eql(%w[z])
     end
 
     it "computes which flatpaks to uninstall", :needs_linux do
@@ -135,10 +135,11 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
         flatpak 'org.gnome.Calculator'
       EOS
       described_class.read_dsl_from_brewfile!
-      allow(Homebrew::Bundle).to receive(:flatpak_installed?).and_return(true)
-      allow(Homebrew::Bundle::FlatpakDumper).to receive(:packages).and_return(%w[org.gnome.Calculator
-                                                                                 org.mozilla.firefox])
-      expect(described_class.flatpaks_to_uninstall).to eql(%w[org.mozilla.firefox])
+      allow(Homebrew::Bundle::Flatpak).to receive_messages(
+        package_manager_installed?: true,
+        packages:                   %w[org.gnome.Calculator org.mozilla.firefox],
+      )
+      expect(Homebrew::Bundle::Flatpak.cleanup_items(described_class.dsl.entries)).to eql(%w[org.mozilla.firefox])
     end
   end
 
@@ -146,11 +147,9 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     before do
       described_class.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(described_class).to receive_messages(casks_to_uninstall:             [],
-                                                 formulae_to_uninstall:          [],
-                                                 taps_to_untap:                  [],
-                                                 vscode_extensions_to_uninstall: [],
-                                                 flatpaks_to_uninstall:          [])
+      allow(described_class).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: [], taps_to_untap: [])
+      allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
+      allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
     end
 
     it "does nothing" do
@@ -164,11 +163,10 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     before do
       described_class.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(described_class).to receive_messages(casks_to_uninstall:             %w[a b],
-                                                 formulae_to_uninstall:          [],
-                                                 taps_to_untap:                  [],
-                                                 vscode_extensions_to_uninstall: [],
-                                                 flatpaks_to_uninstall:          [])
+      allow(described_class).to receive_messages(casks_to_uninstall: %w[a b], formulae_to_uninstall: [],
+                                                 taps_to_untap: [])
+      allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
+      allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
     end
 
     it "uninstalls casks" do
@@ -188,11 +186,10 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     before do
       described_class.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(described_class).to receive_messages(casks_to_uninstall:             %w[a b],
-                                                 formulae_to_uninstall:          [],
-                                                 taps_to_untap:                  [],
-                                                 vscode_extensions_to_uninstall: [],
-                                                 flatpaks_to_uninstall:          [])
+      allow(described_class).to receive_messages(casks_to_uninstall: %w[a b], formulae_to_uninstall: [],
+                                                 taps_to_untap: [])
+      allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
+      allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
     end
 
     it "uninstalls casks" do
@@ -211,11 +208,10 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
   context "when there are formulae to uninstall" do
     before do
       described_class.reset!
-      allow(described_class).to receive_messages(casks_to_uninstall:             [],
-                                                 formulae_to_uninstall:          %w[a b],
-                                                 taps_to_untap:                  [],
-                                                 vscode_extensions_to_uninstall: [],
-                                                 flatpaks_to_uninstall:          [])
+      allow(described_class).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: %w[a b],
+                                                 taps_to_untap: [])
+      allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
+      allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
       allow(Homebrew::Bundle).to receive(:mark_as_installed_on_request!)
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
     end
@@ -237,11 +233,10 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     before do
       described_class.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(described_class).to receive_messages(casks_to_uninstall:             [],
-                                                 formulae_to_uninstall:          [],
-                                                 taps_to_untap:                  %w[a b],
-                                                 vscode_extensions_to_uninstall: [],
-                                                 flatpaks_to_uninstall:          [])
+      allow(described_class).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: [],
+                                                 taps_to_untap: %w[a b])
+      allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
+      allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
     end
 
     it "untaps taps" do
@@ -261,12 +256,10 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     before do
       described_class.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(Homebrew::Bundle).to receive(:which_vscode).and_return(Pathname("code"))
-      allow(described_class).to receive_messages(casks_to_uninstall:             [],
-                                                 formulae_to_uninstall:          [],
-                                                 taps_to_untap:                  [],
-                                                 vscode_extensions_to_uninstall: %w[GitHub.codespaces],
-                                                 flatpaks_to_uninstall:          [])
+      allow(described_class).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: [], taps_to_untap: [])
+      allow(Homebrew::Bundle::VscodeExtension).to receive_messages(package_manager_executable: Pathname("code"),
+                                                                   cleanup_items:              %w[GitHub.codespaces])
+      allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
     end
 
     it "uninstalls extensions" do
@@ -278,7 +271,7 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     it "does not uninstall extensions if --vscode is disabled" do
       expect(Kernel).not_to receive(:system)
       expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      described_class.run(force: true, vscode: false)
+      described_class.run(force: true, extension_types: { vscode: false })
     end
   end
 
@@ -286,11 +279,9 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     before do
       described_class.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(described_class).to receive_messages(casks_to_uninstall:             [],
-                                                 formulae_to_uninstall:          [],
-                                                 taps_to_untap:                  [],
-                                                 vscode_extensions_to_uninstall: [],
-                                                 flatpaks_to_uninstall:          %w[org.gnome.Calculator])
+      allow(described_class).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: [], taps_to_untap: [])
+      allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
+      allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return(%w[org.gnome.Calculator])
     end
 
     it "uninstalls flatpaks" do
@@ -302,7 +293,7 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     it "does not uninstall flatpaks if --flatpak is disabled" do
       expect(Kernel).not_to receive(:system)
       expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      described_class.run(force: true, flatpak: false)
+      described_class.run(force: true, extension_types: { flatpak: false })
     end
   end
 
@@ -310,11 +301,11 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     before do
       described_class.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(described_class).to receive_messages(casks_to_uninstall:             %w[a b],
-                                                 formulae_to_uninstall:          %w[a b],
-                                                 taps_to_untap:                  %w[a b],
-                                                 vscode_extensions_to_uninstall: %w[a b],
-                                                 flatpaks_to_uninstall:          %w[a b])
+      allow(described_class).to receive_messages(casks_to_uninstall:    %w[a b],
+                                                 formulae_to_uninstall: %w[a b],
+                                                 taps_to_untap:         %w[a b])
+      allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return(%w[a b])
+      allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return(%w[a b])
     end
 
     it "lists casks, formulae and taps" do
@@ -337,11 +328,9 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     before do
       described_class.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(described_class).to receive_messages(casks_to_uninstall:             [],
-                                                 formulae_to_uninstall:          [],
-                                                 taps_to_untap:                  [],
-                                                 vscode_extensions_to_uninstall: [],
-                                                 flatpaks_to_uninstall:          [])
+      allow(described_class).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: [], taps_to_untap: [])
+      allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
+      allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
     end
 
     define_method(:sane?) do
@@ -374,12 +363,12 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     before do
       described_class.reset!
       allow(described_class).to receive_messages(
-        casks_to_uninstall:             [],
-        formulae_to_uninstall:          %w[some_formula],
-        taps_to_untap:                  [],
-        vscode_extensions_to_uninstall: [],
-        flatpaks_to_uninstall:          [],
+        casks_to_uninstall:    [],
+        formulae_to_uninstall: %w[some_formula],
+        taps_to_untap:         [],
       )
+      allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
+      allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
       allow(Kernel).to receive(:system)
       allow(described_class).to receive(:system_output_no_stderr).and_return("")
       allow_any_instance_of(Pathname).to receive(:read).and_return("")

--- a/Library/Homebrew/test/bundle/commands/dump_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/dump_spec.rb
@@ -2,30 +2,24 @@
 
 require "bundle"
 require "bundle/commands/dump"
-require "bundle/cask_dumper"
-require "bundle/formula_dumper"
-require "bundle/tap_dumper"
-require "bundle/vscode_extension_dumper"
-require "bundle/cargo_dumper"
-require "bundle/uv_dumper"
 
 RSpec.describe Homebrew::Bundle::Commands::Dump do
   subject(:dump) do
     described_class.run(global:, file: nil, describe: false, force:, no_restart: false, taps: true, formulae: true,
-                        casks: true, mas: true, vscode: true, cargo: true, flatpak: false,
-                        extension_types: { go: true, uv: true })
+                        casks: true, extension_types: { mas: true, vscode: true, cargo: true, flatpak: false,
+                                                       go: true, uv: true })
   end
 
   let(:force) { false }
   let(:global) { false }
 
   before do
-    Homebrew::Bundle::CaskDumper.reset!
-    Homebrew::Bundle::FormulaDumper.reset!
-    Homebrew::Bundle::TapDumper.reset!
-    Homebrew::Bundle::VscodeExtensionDumper.reset!
-    allow(Homebrew::Bundle::CargoDumper).to receive(:dump).and_return("")
-    allow(Homebrew::Bundle::UvDumper).to receive(:dump).and_return("")
+    Homebrew::Bundle::Cask.reset!
+    Homebrew::Bundle::Brew.reset!
+    Homebrew::Bundle::Tap.reset!
+    Homebrew::Bundle::VscodeExtension.reset!
+    allow(Homebrew::Bundle::Cargo).to receive(:dump).and_return("")
+    allow(Homebrew::Bundle::Uv).to receive(:dump).and_return("")
     allow(Formulary).to receive(:factory).and_call_original
     allow(Formulary).to receive(:factory).with("rust").and_return(
       instance_double(Formula, opt_bin: Pathname.new("/tmp/rust/bin")),
@@ -45,9 +39,9 @@ RSpec.describe Homebrew::Bundle::Commands::Dump do
     end
 
     it "exits before doing any work" do
-      expect(Homebrew::Bundle::TapDumper).not_to receive(:dump)
-      expect(Homebrew::Bundle::FormulaDumper).not_to receive(:dump)
-      expect(Homebrew::Bundle::CaskDumper).not_to receive(:dump)
+      expect(Homebrew::Bundle::Tap).not_to receive(:dump)
+      expect(Homebrew::Bundle::Brew).not_to receive(:dump)
+      expect(Homebrew::Bundle::Cask).not_to receive(:dump)
       expect do
         dump
       end.to raise_error(RuntimeError)

--- a/Library/Homebrew/test/bundle/commands/exec_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/exec_spec.rb
@@ -225,25 +225,25 @@ RSpec.describe Homebrew::Bundle::Commands::Exec do
             .and_return(services_info_pre.to_json)
 
           # Stop original nginx
-          expect(Homebrew::Bundle::BrewServices).to receive(:stop)
+          expect(Homebrew::Bundle::Brew::Services).to receive(:stop)
             .with("nginx", keep: true).and_return(true).ordered
 
           # Stop nginx conflicts
-          expect(Homebrew::Bundle::BrewServices).to receive(:stop)
+          expect(Homebrew::Bundle::Brew::Services).to receive(:stop)
             .with("httpd", keep: true).and_return(true).ordered
 
           # Start new nginx
-          expect(Homebrew::Bundle::BrewServices).to receive(:run)
+          expect(Homebrew::Bundle::Brew::Services).to receive(:run)
             .with("nginx", file: nginx_service_file).and_return(true).ordered
 
           # No need to stop original redis (not started)
 
           # Stop redis conflicts
-          expect(Homebrew::Bundle::BrewServices).to receive(:stop)
+          expect(Homebrew::Bundle::Brew::Services).to receive(:stop)
             .with("redis@6.2", keep: true).and_return(true).ordered
 
           # Start new redis
-          expect(Homebrew::Bundle::BrewServices).to receive(:run)
+          expect(Homebrew::Bundle::Brew::Services).to receive(:run)
             .with("redis", file: redis_service_file).and_return(true).ordered
 
           # Run exec commands
@@ -255,13 +255,13 @@ RSpec.describe Homebrew::Bundle::Commands::Exec do
             .and_return(services_info_post.to_json)
 
           # Stop new services
-          expect(Homebrew::Bundle::BrewServices).to receive(:stop)
+          expect(Homebrew::Bundle::Brew::Services).to receive(:stop)
             .with("nginx", keep: true).and_return(true).ordered
-          expect(Homebrew::Bundle::BrewServices).to receive(:stop)
+          expect(Homebrew::Bundle::Brew::Services).to receive(:stop)
             .with("redis", keep: true).and_return(true).ordered
 
           # Restart registered services we stopped due to conflicts (skip httpd as not registered)
-          expect(Homebrew::Bundle::BrewServices).to receive(:run).with("redis@6.2").and_return(true).ordered
+          expect(Homebrew::Bundle::Brew::Services).to receive(:run).with("redis@6.2").and_return(true).ordered
 
           described_class.run("/usr/bin/true", services: true)
         end

--- a/Library/Homebrew/test/bundle/commands/install_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/install_spec.rb
@@ -2,7 +2,6 @@
 
 require "bundle"
 require "bundle/commands/install"
-require "bundle/cask_dumper"
 require "bundle/skipper"
 
 RSpec.describe Homebrew::Bundle::Commands::Install do
@@ -19,11 +18,11 @@ RSpec.describe Homebrew::Bundle::Commands::Install do
 
   context "when a Brewfile is found", :no_api do
     before do
-      Homebrew::Bundle::CaskDumper.reset!
+      Homebrew::Bundle::Cask.reset!
       allow(Homebrew::Bundle).to receive(:brew).and_return(true)
-      allow(Homebrew::Bundle::FormulaInstaller).to receive(:formula_installed_and_up_to_date?).and_return(false)
-      allow(Homebrew::Bundle::CaskInstaller).to receive(:installable_or_upgradable?).and_return(true)
-      allow(Homebrew::Bundle::TapInstaller).to receive(:installed_taps).and_return([])
+      allow(Homebrew::Bundle::Brew).to receive(:formula_installed_and_up_to_date?).and_return(false)
+      allow(Homebrew::Bundle::Cask).to receive(:installable_or_upgradable?).and_return(true)
+      allow(Homebrew::Bundle::Tap).to receive(:installed_taps).and_return([])
     end
 
     let(:brewfile_contents) do
@@ -38,30 +37,30 @@ RSpec.describe Homebrew::Bundle::Commands::Install do
     end
 
     it "does not raise an error" do
-      allow(Homebrew::Bundle::TapInstaller).to receive(:preinstall!).and_return(false)
-      allow(Homebrew::Bundle::VscodeExtensionInstaller).to receive(:preinstall!).and_return(false)
-      allow(Homebrew::Bundle::FlatpakInstaller).to receive(:preinstall!).and_return(false)
-      allow(Homebrew::Bundle::FormulaInstaller).to receive_messages(preinstall!: true, install!: true)
-      allow(Homebrew::Bundle::CaskInstaller).to receive_messages(preinstall!: true, install!: true)
-      allow(Homebrew::Bundle::MacAppStoreInstaller).to receive_messages(preinstall!: true, install!: true)
+      allow(Homebrew::Bundle::Tap).to receive(:preinstall!).and_return(false)
+      allow(Homebrew::Bundle::VscodeExtension).to receive(:preinstall!).and_return(false)
+      allow(Homebrew::Bundle::Flatpak).to receive(:preinstall!).and_return(false)
+      allow(Homebrew::Bundle::Brew).to receive_messages(preinstall!: true, install!: true)
+      allow(Homebrew::Bundle::Cask).to receive_messages(preinstall!: true, install!: true)
+      allow(Homebrew::Bundle::MacAppStore).to receive_messages(preinstall!: true, install!: true)
       allow_any_instance_of(Pathname).to receive(:read).and_return(brewfile_contents)
       expect { described_class.run }.not_to raise_error
     end
 
     it "#dsl returns a valid DSL" do
-      allow(Homebrew::Bundle::TapInstaller).to receive(:preinstall!).and_return(false)
-      allow(Homebrew::Bundle::VscodeExtensionInstaller).to receive(:preinstall!).and_return(false)
-      allow(Homebrew::Bundle::FlatpakInstaller).to receive(:preinstall!).and_return(false)
-      allow(Homebrew::Bundle::FormulaInstaller).to receive_messages(preinstall!: true, install!: true)
-      allow(Homebrew::Bundle::CaskInstaller).to receive_messages(preinstall!: true, install!: true)
-      allow(Homebrew::Bundle::MacAppStoreInstaller).to receive_messages(preinstall!: true, install!: true)
+      allow(Homebrew::Bundle::Tap).to receive(:preinstall!).and_return(false)
+      allow(Homebrew::Bundle::VscodeExtension).to receive(:preinstall!).and_return(false)
+      allow(Homebrew::Bundle::Flatpak).to receive(:preinstall!).and_return(false)
+      allow(Homebrew::Bundle::Brew).to receive_messages(preinstall!: true, install!: true)
+      allow(Homebrew::Bundle::Cask).to receive_messages(preinstall!: true, install!: true)
+      allow(Homebrew::Bundle::MacAppStore).to receive_messages(preinstall!: true, install!: true)
       allow_any_instance_of(Pathname).to receive(:read).and_return(brewfile_contents)
       described_class.run
       expect(described_class.dsl.entries.first.name).to eql("phinze/cask")
     end
 
     it "does not raise an error when skippable" do
-      expect(Homebrew::Bundle::FormulaInstaller).not_to receive(:install!)
+      expect(Homebrew::Bundle::Brew).not_to receive(:install!)
 
       allow(Homebrew::Bundle::Skipper).to receive(:skip?).and_return(true)
       allow_any_instance_of(Pathname).to receive(:read)
@@ -70,36 +69,36 @@ RSpec.describe Homebrew::Bundle::Commands::Install do
     end
 
     it "exits on failures" do
-      allow(Homebrew::Bundle::FormulaInstaller).to receive_messages(preinstall!: true, install!: false)
-      allow(Homebrew::Bundle::CaskInstaller).to receive_messages(preinstall!: true, install!: false)
-      allow(Homebrew::Bundle::MacAppStoreInstaller).to receive_messages(preinstall!: true, install!: false)
-      allow(Homebrew::Bundle::TapInstaller).to receive_messages(preinstall!: true, install!: false)
-      allow(Homebrew::Bundle::VscodeExtensionInstaller).to receive_messages(preinstall!: true, install!: false)
-      allow(Homebrew::Bundle::FlatpakInstaller).to receive_messages(preinstall!: true, install!: false)
+      allow(Homebrew::Bundle::Brew).to receive_messages(preinstall!: true, install!: false)
+      allow(Homebrew::Bundle::Cask).to receive_messages(preinstall!: true, install!: false)
+      allow(Homebrew::Bundle::MacAppStore).to receive_messages(preinstall!: true, install!: false)
+      allow(Homebrew::Bundle::Tap).to receive_messages(preinstall!: true, install!: false)
+      allow(Homebrew::Bundle::VscodeExtension).to receive_messages(preinstall!: true, install!: false)
+      allow(Homebrew::Bundle::Flatpak).to receive_messages(preinstall!: true, install!: false)
       allow_any_instance_of(Pathname).to receive(:read).and_return(brewfile_contents)
 
       expect { described_class.run }.to raise_error(SystemExit)
     end
 
     it "skips installs from failed taps" do
-      allow(Homebrew::Bundle::CaskInstaller).to receive(:preinstall!).and_return(false)
-      allow(Homebrew::Bundle::TapInstaller).to receive_messages(preinstall!: true, install!: false)
-      allow(Homebrew::Bundle::FormulaInstaller).to receive_messages(preinstall!: true, install!: true)
-      allow(Homebrew::Bundle::MacAppStoreInstaller).to receive_messages(preinstall!: true, install!: true)
-      allow(Homebrew::Bundle::VscodeExtensionInstaller).to receive_messages(preinstall!: true, install!: true)
-      allow(Homebrew::Bundle::FlatpakInstaller).to receive_messages(preinstall!: true, install!: true)
+      allow(Homebrew::Bundle::Cask).to receive(:preinstall!).and_return(false)
+      allow(Homebrew::Bundle::Tap).to receive_messages(preinstall!: true, install!: false)
+      allow(Homebrew::Bundle::Brew).to receive_messages(preinstall!: true, install!: true)
+      allow(Homebrew::Bundle::MacAppStore).to receive_messages(preinstall!: true, install!: true)
+      allow(Homebrew::Bundle::VscodeExtension).to receive_messages(preinstall!: true, install!: true)
+      allow(Homebrew::Bundle::Flatpak).to receive_messages(preinstall!: true, install!: true)
       allow_any_instance_of(Pathname).to receive(:read).and_return(brewfile_contents)
 
       expect { described_class.run }.to raise_error(SystemExit)
     end
 
     it "marks Brewfile formulae as installed_on_request after installing" do
-      allow(Homebrew::Bundle::TapInstaller).to receive(:preinstall!).and_return(false)
-      allow(Homebrew::Bundle::VscodeExtensionInstaller).to receive(:preinstall!).and_return(false)
-      allow(Homebrew::Bundle::FlatpakInstaller).to receive(:preinstall!).and_return(false)
-      allow(Homebrew::Bundle::FormulaInstaller).to receive_messages(preinstall!: true, install!: true)
-      allow(Homebrew::Bundle::CaskInstaller).to receive_messages(preinstall!: true, install!: true)
-      allow(Homebrew::Bundle::MacAppStoreInstaller).to receive_messages(preinstall!: true, install!: true)
+      allow(Homebrew::Bundle::Tap).to receive(:preinstall!).and_return(false)
+      allow(Homebrew::Bundle::VscodeExtension).to receive(:preinstall!).and_return(false)
+      allow(Homebrew::Bundle::Flatpak).to receive(:preinstall!).and_return(false)
+      allow(Homebrew::Bundle::Brew).to receive_messages(preinstall!: true, install!: true)
+      allow(Homebrew::Bundle::Cask).to receive_messages(preinstall!: true, install!: true)
+      allow(Homebrew::Bundle::MacAppStore).to receive_messages(preinstall!: true, install!: true)
       allow_any_instance_of(Pathname).to receive(:read).and_return("brew 'test_formula'")
 
       expect(Homebrew::Bundle).to receive(:mark_as_installed_on_request!)

--- a/Library/Homebrew/test/bundle/commands/list_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/list_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe Homebrew::Bundle::Commands::List do
       formulae:        formulae,
       casks:           casks,
       taps:            taps,
-      mas:             mas,
-      vscode:          vscode,
-      cargo:           cargo,
-      flatpak:         false,
       extension_types: {
-        go: go,
-        uv: uv,
+        mas:     mas,
+        vscode:  vscode,
+        cargo:   cargo,
+        flatpak: false,
+        go:      go,
+        uv:      uv,
       },
     )
   end

--- a/Library/Homebrew/test/bundle/dumper_spec.rb
+++ b/Library/Homebrew/test/bundle/dumper_spec.rb
@@ -2,16 +2,7 @@
 
 require "bundle"
 require "bundle/dumper"
-require "bundle/formula_dumper"
-require "bundle/tap_dumper"
-require "bundle/cask_dumper"
-require "bundle/mac_app_store_dumper"
-require "bundle/vscode_extension_dumper"
 require "bundle/brew_services"
-require "bundle/go_dumper"
-require "bundle/cargo_dumper"
-require "bundle/flatpak_dumper"
-require "bundle/uv_dumper"
 require "cask"
 
 RSpec.describe Homebrew::Bundle::Dumper do
@@ -20,18 +11,18 @@ RSpec.describe Homebrew::Bundle::Dumper do
   before do
     ENV["HOMEBREW_BUNDLE_FILE"] = ""
 
-    allow(Homebrew::Bundle).to \
-      receive_messages(cask_installed?: true, mas_installed?: false, vscode_installed?: false)
-    allow(Homebrew::Bundle).to receive_messages(go_installed?: false, cargo_installed?: false, uv_installed?: false)
-    Homebrew::Bundle::FormulaDumper.reset!
-    Homebrew::Bundle::TapDumper.reset!
-    Homebrew::Bundle::CaskDumper.reset!
-    Homebrew::Bundle::MacAppStoreDumper.reset!
-    Homebrew::Bundle::VscodeExtensionDumper.reset!
-    Homebrew::Bundle::GoDumper.reset!
-    Homebrew::Bundle::CargoDumper.reset!
-    Homebrew::Bundle::UvDumper.reset!
-    Homebrew::Bundle::BrewServices.reset!
+    allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(true)
+    allow(Homebrew::Bundle::MacAppStore).to receive(:package_manager_executable).and_return(nil)
+    allow(Homebrew::Bundle::VscodeExtension).to receive(:package_manager_executable).and_return(nil)
+    Homebrew::Bundle::Brew.reset!
+    Homebrew::Bundle::Tap.reset!
+    Homebrew::Bundle::Cask.reset!
+    Homebrew::Bundle::MacAppStore.reset!
+    Homebrew::Bundle::VscodeExtension.reset!
+    Homebrew::Bundle::Go.reset!
+    Homebrew::Bundle::Cargo.reset!
+    Homebrew::Bundle::Uv.reset!
+    Homebrew::Bundle::Brew::Services.reset!
 
     chrome     = instance_double(Cask::Cask,
                                  full_name: "google-chrome",
@@ -47,16 +38,16 @@ RSpec.describe Homebrew::Bundle::Dumper do
                                  config:    nil)
 
     allow(Cask::Caskroom).to receive(:casks).and_return([chrome, java, iterm2beta])
-    allow(Homebrew::Bundle::GoDumper).to receive(:`).and_return("")
-    allow(Homebrew::Bundle::CargoDumper).to receive(:`).and_return("")
-    allow(Homebrew::Bundle::UvDumper).to receive(:`).and_return("")
+    allow(Homebrew::Bundle::Go).to receive_messages(package_manager_executable: nil, "`": "")
+    allow(Homebrew::Bundle::Cargo).to receive_messages(package_manager_executable: nil, "`": "")
+    allow(Homebrew::Bundle::Uv).to receive_messages(package_manager_executable: nil, "`": "")
     allow(Tap).to receive(:select).and_return([])
   end
 
   it "generates output" do
     expect(dumper.build_brewfile(
-             describe: false, no_restart: false, formulae: true, taps: true, casks: true, mas: true,
-             vscode: true, cargo: true, flatpak: false, extension_types: { go: true, uv: true }
+             describe: false, no_restart: false, formulae: true, taps: true, casks: true,
+             extension_types: { mas: true, vscode: true, cargo: true, flatpak: false, go: true, uv: true }
            )).to eql("cask \"google-chrome\"\ncask \"java\"\ncask \"homebrew/cask-versions/iterm2-beta\"\n")
   end
 
@@ -65,14 +56,14 @@ RSpec.describe Homebrew::Bundle::Dumper do
   end
 
   it "preserves the legacy extension dump order" do
-    allow(Homebrew::Bundle::GoDumper).to receive(:dump).and_return('go "github.com/charmbracelet/crush"')
-    allow(Homebrew::Bundle::CargoDumper).to receive(:dump).and_return('cargo "ripgrep"')
-    allow(Homebrew::Bundle::UvDumper).to receive(:dump).and_return('uv "mkdocs"')
-    allow(Homebrew::Bundle::FlatpakDumper).to receive(:dump).and_return('flatpak "org.gnome.Calculator"')
+    allow(Homebrew::Bundle::Go).to receive(:dump).and_return('go "github.com/charmbracelet/crush"')
+    allow(Homebrew::Bundle::Cargo).to receive(:dump).and_return('cargo "ripgrep"')
+    allow(Homebrew::Bundle::Uv).to receive(:dump).and_return('uv "mkdocs"')
+    allow(Homebrew::Bundle::Flatpak).to receive(:dump).and_return('flatpak "org.gnome.Calculator"')
 
     expect(dumper.build_brewfile(
-             describe: false, no_restart: false, formulae: false, taps: false, casks: false, mas: false,
-             vscode: false, cargo: true, flatpak: true, extension_types: { go: true, uv: true }
+             describe: false, no_restart: false, formulae: false, taps: false, casks: false,
+             extension_types: { mas: false, vscode: false, cargo: true, flatpak: true, go: true, uv: true }
            )).to eql(<<~BREWFILE)
              go "github.com/charmbracelet/crush"
              cargo "ripgrep"

--- a/Library/Homebrew/test/bundle/flatpak_spec.rb
+++ b/Library/Homebrew/test/bundle/flatpak_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require "bundle"
-require "bundle/flatpak"
+require "bundle/dsl"
+require "bundle/extensions/flatpak"
 
 RSpec.describe Homebrew::Bundle::Flatpak do
   describe "checking" do
@@ -94,7 +95,7 @@ RSpec.describe Homebrew::Bundle::Flatpak do
 
     context "when on macOS", :needs_macos do
       it "flatpak is not available" do
-        expect(Homebrew::Bundle.flatpak_installed?).to be(false)
+        expect(described_class.package_manager_installed?).to be(false)
       end
     end
   end
@@ -105,7 +106,7 @@ RSpec.describe Homebrew::Bundle::Flatpak do
     context "when flatpak is not installed" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive(:flatpak_installed?).and_return(false)
+        allow(described_class).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "returns an empty list and dumps an empty string" do
@@ -117,8 +118,7 @@ RSpec.describe Homebrew::Bundle::Flatpak do
     context "when flatpak is installed", :needs_linux do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive_messages(flatpak_installed?: true,
-                                                    which_flatpak:      Pathname.new("flatpak"))
+        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("flatpak"))
       end
 
       it "returns remote URLs" do
@@ -232,7 +232,7 @@ RSpec.describe Homebrew::Bundle::Flatpak do
     context "when Flatpak is not installed", :needs_linux do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive(:flatpak_installed?).and_return(false)
+        allow(described_class).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "returns false without attempting installation" do
@@ -244,7 +244,7 @@ RSpec.describe Homebrew::Bundle::Flatpak do
 
     context "when Flatpak is installed", :needs_linux do
       before do
-        allow(Homebrew::Bundle).to receive(:flatpak_installed?).and_return(true)
+        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("flatpak"))
       end
 
       context "when package is installed" do
@@ -261,7 +261,6 @@ RSpec.describe Homebrew::Bundle::Flatpak do
 
       context "when package is not installed" do
         before do
-          allow(Homebrew::Bundle).to receive(:which_flatpak).and_return(Pathname.new("flatpak"))
           allow(described_class).to receive(:installed_packages).and_return([])
         end
 

--- a/Library/Homebrew/test/bundle/go_spec.rb
+++ b/Library/Homebrew/test/bundle/go_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require "bundle"
-require "bundle/go"
+require "bundle/dsl"
+require "bundle/extensions/go"
 
 RSpec.describe Homebrew::Bundle::Go do
   describe "dumping" do
@@ -10,7 +11,7 @@ RSpec.describe Homebrew::Bundle::Go do
     context "when go is not installed" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive(:go_installed?).and_return(false)
+        allow(described_class).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "returns an empty list" do
@@ -25,7 +26,7 @@ RSpec.describe Homebrew::Bundle::Go do
     context "when go is installed" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive(:which_go).and_return(Pathname.new("go"))
+        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("go"))
       end
 
       it "returns package list" do
@@ -51,7 +52,7 @@ RSpec.describe Homebrew::Bundle::Go do
     context "when Go is not installed" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive(:go_installed?).and_return(false)
+        allow(described_class).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "tries to install go" do
@@ -74,7 +75,7 @@ RSpec.describe Homebrew::Bundle::Go do
 
     context "when Go is installed" do
       before do
-        allow(Homebrew::Bundle).to receive(:go_installed?).and_return(true)
+        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("go"))
       end
 
       context "when package is installed" do
@@ -91,7 +92,6 @@ RSpec.describe Homebrew::Bundle::Go do
 
       context "when package is not installed" do
         before do
-          allow(Homebrew::Bundle).to receive(:which_go).and_return(Pathname.new("go"))
           allow(described_class).to receive_messages(packages: [], installed_packages: [])
         end
 

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -11,30 +11,30 @@ RSpec.describe Homebrew::Bundle::Installer do
 
   before do
     allow(Homebrew::Bundle::Skipper).to receive(:skip?).and_return(false)
-    allow(Homebrew::Bundle::FormulaInstaller).to receive_messages(formula_upgradable?: false, install!: true)
-    allow(Homebrew::Bundle::FormulaInstaller).to receive_messages(formula_installed_and_up_to_date?: false,
-                                                                  preinstall!:                       true)
-    allow(Homebrew::Bundle::CaskInstaller).to receive_messages(cask_upgradable?: false, install!: true)
-    allow(Homebrew::Bundle::CaskInstaller).to receive_messages(installable_or_upgradable?: true, preinstall!: true)
-    allow(Homebrew::Bundle::TapInstaller).to receive_messages(preinstall!: true, install!: true, installed_taps: [])
+    allow(Homebrew::Bundle::Brew).to receive_messages(formula_upgradable?: false, install!: true)
+    allow(Homebrew::Bundle::Brew).to receive_messages(formula_installed_and_up_to_date?: false,
+                                                      preinstall!:                       true)
+    allow(Homebrew::Bundle::Cask).to receive_messages(cask_upgradable?: false, install!: true)
+    allow(Homebrew::Bundle::Cask).to receive_messages(installable_or_upgradable?: true, preinstall!: true)
+    allow(Homebrew::Bundle::Tap).to receive_messages(preinstall!: true, install!: true, installed_taps: [])
   end
 
   it "prefetches installable formulae and casks before installing" do
-    allow(Homebrew::Bundle::TapInstaller).to receive(:installed_taps).and_return(["homebrew/cask"])
-    allow(Homebrew::Bundle::FormulaInstaller).to receive(:formula_installed_and_up_to_date?)
+    allow(Homebrew::Bundle::Tap).to receive(:installed_taps).and_return(["homebrew/cask"])
+    allow(Homebrew::Bundle::Brew).to receive(:formula_installed_and_up_to_date?)
       .with("mysql", no_upgrade: false).and_return(false)
-    allow(Homebrew::Bundle::CaskInstaller).to receive(:installable_or_upgradable?)
+    allow(Homebrew::Bundle::Cask).to receive(:installable_or_upgradable?)
       .with("google-chrome", no_upgrade: false, **cask_options).and_return(true)
 
     expect(Homebrew::Bundle).to receive(:brew)
       .with("fetch", "mysql", "homebrew/cask/google-chrome", verbose: false)
       .ordered
       .and_return(true)
-    expect(Homebrew::Bundle::FormulaInstaller).to receive(:preinstall!)
+    expect(Homebrew::Bundle::Brew).to receive(:preinstall!)
       .with("mysql", no_upgrade: false, verbose: false)
       .ordered
       .and_return(true)
-    expect(Homebrew::Bundle::CaskInstaller).to receive(:preinstall!)
+    expect(Homebrew::Bundle::Cask).to receive(:preinstall!)
       .with("google-chrome", **cask_options, no_upgrade: false, verbose: false)
       .ordered
       .and_return(true)
@@ -43,7 +43,7 @@ RSpec.describe Homebrew::Bundle::Installer do
   end
 
   it "skips fetching when no formulae or casks need installation or upgrade" do
-    allow(Homebrew::Bundle::FormulaInstaller).to receive(:formula_installed_and_up_to_date?)
+    allow(Homebrew::Bundle::Brew).to receive(:formula_installed_and_up_to_date?)
       .with("mysql", no_upgrade: true).and_return(true)
 
     expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
@@ -55,7 +55,7 @@ RSpec.describe Homebrew::Bundle::Installer do
     tap_entry = Homebrew::Bundle::Dsl::Entry.new(:tap, "homebrew/foo")
     tapped_formula_entry = Homebrew::Bundle::Dsl::Entry.new(:brew, "homebrew/foo/bar")
 
-    allow(Homebrew::Bundle::FormulaInstaller).to receive(:formula_installed_and_up_to_date?)
+    allow(Homebrew::Bundle::Brew).to receive(:formula_installed_and_up_to_date?)
       .with("homebrew/foo/bar", no_upgrade: false).and_return(false)
 
     expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)

--- a/Library/Homebrew/test/bundle/mac_app_store_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require "bundle"
-require "bundle/mac_app_store"
+require "bundle/dsl"
+require "bundle/extensions/mac_app_store"
 
 RSpec.describe Homebrew::Bundle::MacAppStore do
   describe "dumping" do
@@ -10,7 +11,7 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
     context "when mas is not installed" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive(:mas_installed?).and_return(false)
+        allow(described_class).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "returns empty list" do
@@ -25,8 +26,7 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
     context "when there is no apps" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive_messages(mas_installed?: true, which_mas: Pathname.new("mas"))
-        allow(described_class).to receive(:`).and_return("")
+        allow(described_class).to receive_messages(package_manager_executable: Pathname.new("mas"), "`": "")
       end
 
       it "returns empty list" do
@@ -41,8 +41,12 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
     context "when apps `foo`, `bar` and `baz` are installed" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive_messages(mas_installed?: true, which_mas: Pathname.new("mas"))
-        allow(described_class).to receive(:`).and_return("123 foo (1.0)\n456 bar (2.0)\n789 baz (3.0)")
+        allow(described_class).to receive_messages(
+          package_manager_executable: Pathname.new("mas"),
+          "`":                        "123 foo (1.0)\n" \
+                                      "456 bar (2.0)\n" \
+                                      "789 baz (3.0)",
+        )
       end
 
       it "returns list %w[foo bar baz]" do
@@ -53,7 +57,7 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
     context "when apps `foo`, `bar`, `baz` and `qux` are installed including right-justified IDs" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive_messages(mas_installed?: true, which_mas: Pathname.new("mas"))
+        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("mas"))
         allow(described_class).to receive(:`).and_return("123 foo (1.0)\n456 bar (2.0)\n789 baz (3.0)")
         allow(described_class).to receive(:`).and_return("123 foo (1.0)\n456 bar (2.0)\n789 baz (3.0)\n 10 qux (4.0)")
       end
@@ -138,8 +142,8 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
 
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive_messages(mas_installed?: true, which_mas: Pathname.new("mas"))
-        allow(described_class).to receive(:`).and_return(invalid_mas_output)
+        allow(described_class).to receive_messages(package_manager_executable: Pathname.new("mas"),
+                                                   "`":                        invalid_mas_output)
       end
 
       it "returns only valid apps" do
@@ -170,8 +174,8 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
 
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive_messages(mas_installed?: true, which_mas: Pathname.new("mas"))
-        allow(described_class).to receive(:`).and_return(new_mas_output)
+        allow(described_class).to receive_messages(package_manager_executable: Pathname.new("mas"),
+                                                   "`":                        new_mas_output)
       end
 
       it "parses the app names without trailing whitespace" do
@@ -201,7 +205,7 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
 
     context "when mas is not installed" do
       before do
-        allow(Homebrew::Bundle).to receive(:mas_installed?).and_return(false)
+        allow(described_class).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "tries to install mas" do
@@ -221,7 +225,7 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
 
     context "when mas is installed" do
       before do
-        allow(Homebrew::Bundle).to receive_messages(mas_installed?: true, which_mas: Pathname.new("mas"))
+        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("mas"))
       end
 
       describe ".outdated_app_ids" do

--- a/Library/Homebrew/test/bundle/uv_spec.rb
+++ b/Library/Homebrew/test/bundle/uv_spec.rb
@@ -2,7 +2,7 @@
 
 require "bundle"
 require "bundle/dsl"
-require "bundle/uv"
+require "bundle/extensions/uv"
 
 RSpec.describe Homebrew::Bundle::Uv do
   describe "checking" do
@@ -86,7 +86,7 @@ RSpec.describe Homebrew::Bundle::Uv do
     context "when uv is not installed" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive(:uv_installed?).and_return(false)
+        allow(described_class).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "returns empty packages and dump output" do
@@ -98,7 +98,7 @@ RSpec.describe Homebrew::Bundle::Uv do
     context "when uv is installed" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive_messages(uv_installed?: true, which_uv: Pathname.new("uv"))
+        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("uv"))
       end
 
       it "returns normalized package entries sorted by package name" do
@@ -181,7 +181,7 @@ RSpec.describe Homebrew::Bundle::Uv do
     context "when uv is not installed" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive(:uv_installed?).and_return(false)
+        allow(described_class).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "tries to install uv" do
@@ -194,7 +194,7 @@ RSpec.describe Homebrew::Bundle::Uv do
 
     context "when uv is installed" do
       before do
-        allow(Homebrew::Bundle).to receive(:uv_installed?).and_return(true)
+        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("uv"))
       end
 
       context "when package is installed with matching options" do
@@ -273,7 +273,7 @@ RSpec.describe Homebrew::Bundle::Uv do
 
       context "when package is not installed" do
         before do
-          allow(Homebrew::Bundle).to receive(:which_uv).and_return(Pathname.new("/tmp/uv/bin/uv"))
+          allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("/tmp/uv/bin/uv"))
           allow(described_class).to receive_messages(packages: [], installed_packages: [])
         end
 

--- a/Library/Homebrew/test/bundle/vscode_extension_spec.rb
+++ b/Library/Homebrew/test/bundle/vscode_extension_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require "bundle"
-require "bundle/vscode_extension"
+require "bundle/dsl"
+require "bundle/extensions/vscode_extension"
 require "extend/kernel"
 
 RSpec.describe Homebrew::Bundle::VscodeExtension do
@@ -11,8 +12,7 @@ RSpec.describe Homebrew::Bundle::VscodeExtension do
     context "when vscode is not installed" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive(:vscode_installed?).and_return(false)
-        allow(described_class).to receive(:`).and_return("")
+        allow(described_class).to receive_messages(package_manager_executable: nil, "`": "")
       end
 
       it "returns an empty list" do
@@ -27,7 +27,7 @@ RSpec.describe Homebrew::Bundle::VscodeExtension do
     context "when vscode is installed" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive(:which_vscode).and_return(Pathname.new("code"))
+        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("code"))
       end
 
       it "returns package list" do
@@ -55,7 +55,8 @@ RSpec.describe Homebrew::Bundle::VscodeExtension do
     context "when VSCode is not installed" do
       before do
         described_class.reset!
-        allow(Homebrew::Bundle).to receive_messages(vscode_installed?: false, cask_installed?: true)
+        allow(described_class).to receive(:package_manager_executable).and_return(nil)
+        allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(true)
       end
 
       it "tries to install vscode" do
@@ -68,7 +69,7 @@ RSpec.describe Homebrew::Bundle::VscodeExtension do
 
     context "when VSCode is installed" do
       before do
-        allow(Homebrew::Bundle).to receive(:which_vscode).and_return(Pathname("code"))
+        allow(described_class).to receive(:package_manager_executable).and_return(Pathname("code"))
       end
 
       context "when extension is installed" do


### PR DESCRIPTION
- move brew, cask, tap, and extension package types to single implementation classes and files
- remove legacy checker, dumper, and installer wrappers plus the old bundle helper seams they kept alive
- simplify checker and package type dispatch, and clean up extension package-manager caching and typing

----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Use OpenAI Codex GPT-5.4 xhigh with ~3 rounds of feedback and manual review from Fork.app.

-----
