### PR TITLE
docker: use 24.04 for ghcr.io/homebrew/brew

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,7 +71,7 @@ jobs:
                 "ghcr.io/homebrew/ubuntu${version}:${brew_version}"
                 "ghcr.io/homebrew/ubuntu${version}:latest"
               )
-              if [[ "${version}" == "22.04" ]]; then
+              if [[ "${version}" == "24.04" ]]; then
                 tags+=(
                   "ghcr.io/homebrew/brew:${brew_version}"
                   "ghcr.io/homebrew/brew:latest"
@@ -79,7 +79,7 @@ jobs:
               fi
             elif [[ "${GITHUB_EVENT_NAME}" == "push" &&
                     ("${GITHUB_REF}" == "refs/heads/main") ]]; then
-              if [[ "${version}" == "22.04" ]]; then
+              if [[ "${version}" == "24.04" ]]; then
                 tags+=("ghcr.io/homebrew/brew:main")
               fi
               tags+=("ghcr.io/homebrew/ubuntu${version}:main")

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG version=22.04
+ARG version=24.04
 # version is passed through by Docker.
 # shellcheck disable=SC2154
 FROM ubuntu:"${version}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Part of #21761.

Dockerfile default should be no/low impact change as we don't use the default `ARG version`.

Searching Homebrew org for `ghcr.io/homebrew/brew` usage: https://github.com/search?q=org%3AHomebrew+ghcr.io%2Fhomebrew%2Fbrew&type=code, seems to only impact:
- .devcontainer/devcontainer.json (developer-specific, low impact)
- Homebrew/brew tests.yml `formula-audit`, seems safe to run on Ubuntu 24.04:
  https://github.com/Homebrew/brew/blob/4b1bc6ba6aeef6adcee077bca942d37e571cabbf/.github/workflows/tests.yml#L115-L137