### PR TITLE
test/linux_runner_spec_spec: use unversioned container

### DIFF
--- a/Library/Homebrew/test/linux_runner_spec_spec.rb
+++ b/Library/Homebrew/test/linux_runner_spec_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe LinuxRunnerSpec do
     described_class.new(
       name:      "Linux",
       runner:    "ubuntu-latest",
-      container: { image: "ghcr.io/homebrew/ubuntu22.04:main", options: "--user=linuxbrew" },
+      container: { image: "ghcr.io/homebrew/brew:main", options: "--user=linuxbrew" },
       workdir:   "/github/home",
       timeout:   360,
       cleanup:   false,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This test doesn't verify anything related to Homebrew's CI versions so can use the unversioned container to minimize migration diff.
