### PR TITLE
workflows/docs: remove cache-homebrew-prefix usage in formulae.brew.sh

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,10 +38,16 @@ jobs:
           persist-credentials: false
 
       - name: Install Vale and Ruby
+        # Don't cache the prefix for the formulae.brew.sh repository as it won't download its own JSON API files
+        if: github.repository != 'Homebrew/formulae.brew.sh'
         uses: Homebrew/actions/cache-homebrew-prefix@main
         with:
           install: vale ruby
           workflow-key: docs
+
+      - name: Install Vale and Ruby for formulae.brew.sh
+        if: github.repository == 'Homebrew/formulae.brew.sh'
+        run: brew install vale ruby
 
       - name: Cleanup Homebrew/brew docs
         if: github.repository == 'Homebrew/brew'


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This unblocks formulae.brew.sh CI. For reasoning, see Homebrew/formulae.brew.sh#2155.
