### PR TITLE
dev-cmd/tap-new: use ubuntu-latest + ghcr.io/homebrew/brew:main

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -83,8 +83,12 @@ module Homebrew
             test-bot:
               strategy:
                 matrix:
-                  os: [ ubuntu-22.04, macos-15-intel, macos-26 ]
+                  os: [ macos-15-intel, macos-26 ]
+                  include:
+                    - os: ubuntu-latest
+                      container: ghcr.io/homebrew/brew:main
               runs-on: ${{ matrix.os }}
+              container: ${{ matrix.container }}
               permissions:
                 actions: read
                 checks: read
@@ -149,7 +153,7 @@ module Homebrew
           jobs:
             pr-pull:
               if: contains(github.event.pull_request.labels.*.name, '<%= label %>')
-              runs-on: ubuntu-22.04
+              runs-on: ubuntu-latest
               permissions:
                 actions: read
                 checks: read


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Similar to how we run in homebrew/core, set up tap with `ubuntu-latest` and `ghcr.io/homebrew/brew:main` which reduce 3rd party maintenance after migration or after GitHub drops support for older Ubuntu.

Would still need to update macOS versions but unavoidable as Intel macOS only has versioned runner labels.

---

Can't comment on performance. May be slower due to fetching container.