### PR TITLE
Use ubuntu-latest and add constant for arm linux runner

### DIFF
--- a/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
+++ b/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
@@ -68,12 +68,12 @@ module Homebrew
         end
 
         if args.linux?
-          runners << "ubuntu-22.04"
+          runners << "ubuntu-latest"
         elsif args.linux_self_hosted?
           runners << "linux-self-hosted-1"
         end
 
-        runners << "ubuntu-22.04-arm" if args.linux_arm64?
+        runners << OS::LINUX_CI_ARM_RUNNER if args.linux_arm64?
 
         if runners.empty?
           raise UsageError, "Must specify `--macos`, `--linux`, `--linux-arm64`, or `--linux-self-hosted` option."

--- a/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
@@ -17,7 +17,7 @@ module Homebrew
         { symbol: :sequoia, name: "macos-15-intel", arch: :intel } => 1.0,
       }.freeze, T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
       X86_LINUX_RUNNERS = T.let({
-        { symbol: :linux, name: "ubuntu-22.04", arch: :intel } => 1.0,
+        { symbol: :linux, name: "ubuntu-latest", arch: :intel } => 1.0,
       }.freeze, T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
       ARM_MACOS_RUNNERS = T.let({
         { symbol: :sonoma,  name: "macos-14", arch: :arm } => 0.0,
@@ -25,7 +25,7 @@ module Homebrew
         { symbol: :tahoe,   name: "macos-26", arch: :arm } => 1.0,
       }.freeze, T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
       ARM_LINUX_RUNNERS = T.let({
-        { symbol: :linux, name: "ubuntu-22.04-arm", arch: :arm } => 1.0,
+        { symbol: :linux, name: OS::LINUX_CI_ARM_RUNNER, arch: :arm } => 1.0,
       }.freeze, T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
       MACOS_RUNNERS = T.let(X86_MACOS_RUNNERS.merge(ARM_MACOS_RUNNERS).freeze,
                             T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -90,7 +90,7 @@ class GitHubRunnerMatrix
   sig { params(arch: Symbol).returns(LinuxRunnerSpec) }
   def linux_runner_spec(arch)
     linux_runner = case arch
-    when :arm64 then "ubuntu-22.04-arm"
+    when :arm64 then OS::LINUX_CI_ARM_RUNNER
     when :x86_64 then ENV.fetch("HOMEBREW_LINUX_RUNNER", "ubuntu-latest")
     else raise "Unknown Linux architecture: #{arch}"
     end

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -47,6 +47,7 @@ module OS
 
   # See Linux-CI.md
   LINUX_CI_OS_VERSION = "Ubuntu 22.04"
+  LINUX_CI_ARM_RUNNER = "ubuntu-22.04-arm"
   LINUX_GLIBC_CI_VERSION = "2.35"
   LINUX_GLIBC_NEXT_CI_VERSION = "2.39" # users below this version will be warned by `brew doctor`
   LINUX_GCC_CI_VERSION = "12" # https://packages.ubuntu.com/jammy/gcc-12

--- a/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Homebrew::DevCmd::DetermineTestRunners do
     FileUtils.rm_f github_output
   end
 
-  let(:linux_runner) { "ubuntu-22.04" }
+  let(:arm_linux_runner) { OS::LINUX_CI_ARM_RUNNER }
+  let(:linux_runner) { "ubuntu-latest" }
   # We need to make sure we write to a different path for each example.
   let(:github_output) { "#{TEST_TMPDIR}/github_output#{DetermineRunnerTestHelper.new.number}" }
   let(:ephemeral_suffix) { "-12345" }
@@ -41,7 +42,7 @@ RSpec.describe Homebrew::DevCmd::DetermineTestRunners do
     end
 
     out << linux_runner
-    out << "#{linux_runner}-arm"
+    out << arm_linux_runner
 
     out
   end

--- a/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
   it_behaves_like "parseable arguments"
 
   describe "::filter_runners" do
+    let(:arm_linux_runner) { OS::LINUX_CI_ARM_RUNNER }
     # We simulate a macOS version older than the newest, as the method will use
     # the host macOS version instead of the default (the newest macOS version).
     let(:older_macos) { :big_sur }
@@ -153,9 +154,9 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
             { arch: :arm, name: "macos-14", symbol: :sonoma }          => 0.0,
             { arch: :arm, name: "macos-15", symbol: :sequoia }         => 0.0,
             { arch: :arm, name: "macos-26", symbol: :tahoe }           => 1.0,
-            { arch: :arm, name: "ubuntu-22.04-arm", symbol: :linux }   => 1.0,
+            { arch: :arm, name: arm_linux_runner, symbol: :linux }     => 1.0,
             { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
-            { arch: :intel, name: "ubuntu-22.04", symbol: :linux }     => 1.0,
+            { arch: :intel, name: "ubuntu-latest", symbol: :linux }    => 1.0,
           })
 
         expect(generate_matrix.filter_runners(c_app_only_macos))
@@ -163,9 +164,9 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
             { arch: :arm, name: "macos-14", symbol: :sonoma }          => 0.0,
             { arch: :arm, name: "macos-15", symbol: :sequoia }         => 0.0,
             { arch: :arm, name: "macos-26", symbol: :tahoe }           => 1.0,
-            { arch: :arm, name: "ubuntu-22.04-arm", symbol: :linux }   => 1.0,
+            { arch: :arm, name: arm_linux_runner, symbol: :linux }     => 1.0,
             { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
-            { arch: :intel, name: "ubuntu-22.04", symbol: :linux }     => 1.0,
+            { arch: :intel, name: "ubuntu-latest", symbol: :linux }    => 1.0,
           })
       end
     end
@@ -196,9 +197,9 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
             { arch: :arm, name: "macos-14", symbol: :sonoma }          => 0.0,
             { arch: :arm, name: "macos-15", symbol: :sequoia }         => 0.0,
             { arch: :arm, name: "macos-26", symbol: :tahoe }           => 1.0,
-            { arch: :arm, name: "ubuntu-22.04-arm", symbol: :linux }   => 1.0,
+            { arch: :arm, name: arm_linux_runner, symbol: :linux }     => 1.0,
             { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
-            { arch: :intel, name: "ubuntu-22.04", symbol: :linux }     => 1.0,
+            { arch: :intel, name: "ubuntu-latest", symbol: :linux }    => 1.0,
           })
       end
     end
@@ -208,7 +209,7 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
         expect(generate_matrix.filter_runners(c_on_system_depends_on_intel))
           .to eq({
             { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
-            { arch: :intel, name: "ubuntu-22.04", symbol: :linux }     => 1.0,
+            { arch: :intel, name: "ubuntu-latest", symbol: :linux }    => 1.0,
           })
 
         expect(generate_matrix.filter_runners(c_on_linux_depends_on_intel))
@@ -217,19 +218,19 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
             { arch: :arm, name: "macos-15", symbol: :sequoia }         => 0.0,
             { arch: :arm, name: "macos-26", symbol: :tahoe }           => 1.0,
             { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
-            { arch: :intel, name: "ubuntu-22.04", symbol: :linux }     => 1.0,
+            { arch: :intel, name: "ubuntu-latest", symbol: :linux }    => 1.0,
           })
 
         expect(generate_matrix.filter_runners(c_on_macos_depends_on_intel))
           .to eq({
             { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
-            { arch: :intel, name: "ubuntu-22.04", symbol: :linux }     => 1.0,
-            { arch: :arm, name: "ubuntu-22.04-arm", symbol: :linux }   => 1.0,
+            { arch: :intel, name: "ubuntu-latest", symbol: :linux }    => 1.0,
+            { arch: :arm, name: arm_linux_runner, symbol: :linux }     => 1.0,
           })
 
         expect(generate_matrix.filter_runners(c_on_system_depends_on_mixed))
           .to eq({
-            { arch: :arm, name: "ubuntu-22.04-arm", symbol: :linux }   => 1.0,
+            { arch: :arm, name: arm_linux_runner, symbol: :linux }     => 1.0,
             { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
           })
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

For ubuntu-latest:
* Not sure why dispatch bottle is using `ubuntu-22.04` when all other workflows use `ubuntu-latest` so switched it
* Trying out if it works for Cask CI. Can switch this one back if any issues.

For ubuntu-22.04-arm:
* There is no "latest" label so creating a constant to reuse. Particularly want to use cross-repo like at https://github.com/Homebrew/homebrew-core/blob/main/cmd/determine-rebottle-runners.rb#L25
* This doesn't have to be updated at same time as migration (as we run in container) but we do need to update it every 2 years as GitHub has historically removed images outside standard support so I expect a similar situation for partner images.