### PR TITLE
brew.sh: work around non-writable cache for lgtm commands.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,10 +22,6 @@ When running commands in this repository, use `./bin/brew` (not a system `brew` 
 - Shortcut: `./bin/brew lgtm --online` runs all of the required checks above in one command.
 - All of the above can be run via the Homebrew MCP Server (launch with `./bin/brew mcp-server`).
 
-### Sandbox Setup
-
-- When working in a sandboxed environment e.g. OpenAI Codex, copy the contents of `$(./bin/brew --cache)/api/` to a writable location inside the repository (for example, `tmp/cache/api/`) and `export HOMEBREW_CACHE` to that writable directory before running `./bin/brew tests`. This avoids permission errors when the suite tries to write API cache or runtime logs.
-
 ### Development Flow
 
 - Write new code (using Sorbet `sig` type signatures and `typed: strict` for new files, but never for RSpec/test/`*_spec.rb` files)

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -890,6 +890,25 @@ case "${HOMEBREW_COMMAND}" in
   lc) HOMEBREW_COMMAND="livecheck" ;;
   tc) HOMEBREW_COMMAND="typecheck" ;;
 esac
+if [[ ("${HOMEBREW_COMMAND}" == "audit" || "${HOMEBREW_COMMAND}" == "lgtm" ||
+      "${HOMEBREW_COMMAND}" == "style" || "${HOMEBREW_COMMAND}" == "tests") &&
+      "${HOMEBREW_CACHE}" != "${HOMEBREW_REPOSITORY}/tmp/cache" ]]
+then
+  if [[ -d "${HOMEBREW_CACHE}" && ! -w "${HOMEBREW_CACHE}" ]] ||
+     [[ ! -d "${HOMEBREW_CACHE}" && ! -w "${HOMEBREW_CACHE%/*}" ]]
+  then
+    original_cache="${HOMEBREW_CACHE}"
+    HOMEBREW_CACHE="${HOMEBREW_REPOSITORY}/tmp/cache"
+    printf 'Warning: HOMEBREW_CACHE is not writable at %s; using %s for Homebrew cache files instead.\n' \
+      "${original_cache}" "${HOMEBREW_CACHE}" >&2
+    mkdir -p "${HOMEBREW_CACHE}/api"
+    if [[ -d "${original_cache}/api" ]]
+    then
+      cp -R "${original_cache}/api/." "${HOMEBREW_CACHE}/api/" &>/dev/null || true
+    fi
+    export HOMEBREW_CACHE
+  fi
+fi
 
 # Set HOMEBREW_DEV_CMD_RUN for users who have run a development command.
 # This makes them behave like HOMEBREW_DEVELOPERs for brew update.

--- a/Library/Homebrew/test/dev-cmd/lgtm_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/lgtm_spec.rb
@@ -1,8 +1,63 @@
 # frozen_string_literal: true
 
+require "open3"
+
 require "cmd/shared_examples/args_parse"
 require "dev-cmd/lgtm"
+require "utils/tty"
 
 RSpec.describe Homebrew::DevCmd::Lgtm do
   it_behaves_like "parseable arguments"
+
+  describe "cache fallback" do
+    let(:repository_root) { Pathname(__dir__).parent.parent.parent.parent }
+    let(:test_root) do
+      (repository_root/"tmp").mkpath
+      Pathname(Dir.mktmpdir("brew-lgtm-cache-fallback-", repository_root/"tmp"))
+    end
+    let(:isolated_brew) { test_root/"prefix/bin/brew" }
+    let(:read_only_cache) { test_root/"readonly-cache" }
+    let(:fallback_cache) { test_root/"prefix/tmp/cache" }
+    let(:cache_file) { read_only_cache/"api/cask_names.txt" }
+
+    before do
+      isolated_brew.dirname.mkpath
+      FileUtils.cp repository_root/"bin/brew", isolated_brew
+      isolated_brew.chmod(0755)
+      FileUtils.ln_s repository_root/"Library", test_root/"prefix/Library"
+      cache_file.dirname.mkpath
+      cache_file.write("copied-from-cache\n")
+      FileUtils.chmod("u-w", read_only_cache)
+    end
+
+    after do
+      FileUtils.chmod("u+rwx", read_only_cache)
+      FileUtils.rm_rf test_root
+    end
+
+    it "uses a repository-local cache when HOMEBREW_CACHE is not writable" do
+      stdout, stderr, status = Bundler.with_unbundled_env do
+        Open3.capture3(
+          {
+            "HOMEBREW_CACHE"              => read_only_cache.to_s,
+            "HOMEBREW_INTEGRATION_TEST"   => "1",
+            "HOMEBREW_USE_RUBY_FROM_PATH" => ENV.fetch("HOMEBREW_USE_RUBY_FROM_PATH", nil),
+          },
+          isolated_brew.to_s,
+          "lgtm",
+          "--help",
+        )
+      end
+
+      expect(status.success?).to be true
+      expect(Tty.strip_ansi(stdout)).to match(
+        /Run brew typecheck, brew style --changed and brew tests --changed in one\s+go\./,
+      )
+      expect(stderr).to match(
+        %r{HOMEBREW_CACHE is not writable at .+; using .+/tmp/cache for Homebrew cache files instead\.},
+      )
+      expect(fallback_cache/"api/cask_names.txt").to be_a_file
+      expect((fallback_cache/"api/cask_names.txt").read).to eq("copied-from-cache\n")
+    end
+  end
 end


### PR DESCRIPTION
Under some e.g. AI sandboxes HOMEBREW_CACHE is not accessible but the current working directory's `tmp` is instead. In those cases, print a warning and automatically copy and use the other cache.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

OpenAI Codex and manual review/testing/usage.

-----
