### PR TITLE
Fix doubled words in comments and docs

### DIFF
--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -166,7 +166,7 @@ module Homebrew
         formulae = Array(formulae).reject { |f| f.deprecated? || f.disabled? } if formulae.present?
         all_formulae = Array(all_formulae).reject { |f| f.deprecated? || f.disabled? } if all_formulae.present?
 
-        # Remove portable formulae as they are are handled differently
+        # Remove portable formulae as they are handled differently
         formulae = formulae.reject { |f| PORTABLE_FORMULAE.include?(f.name) } if formulae.present?
         all_formulae = all_formulae.reject { |f| PORTABLE_FORMULAE.include?(f.name) } if all_formulae.present?
 

--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -329,7 +329,7 @@ class Migrator
     old_pin_link_record = self.old_pin_link_record
     return unless old_pin_link_record
 
-    # `old_pin_record` is a relative symlink and when we try to to read it
+    # `old_pin_record` is a relative symlink and when we try to read it
     # from <dir> we actually try to find file
     # <dir>/../<...>/../Cellar/name/version.
     # To repin formula we need to update the link thus that it points to

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -527,7 +527,7 @@ module Utils
       file = Tempfile.new.tap(&:close)
 
       # Convert specs to options. This is mostly key-value options,
-      # unless the value is a boolean in which case treat as as flag.
+      # unless the value is a boolean in which case treat as a flag.
       specs = specs.flat_map do |option, argument|
         next [] if argument == false # No flag.
 

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -256,7 +256,7 @@ Behaviour and usage of `target:` is [the same as with `app`](#renaming-the-targe
 ### Stanza: `rename`
 
 The `rename` stanza provides a convenience method to rename files to provide more practical access to them.
-This stanza should be used sparingly, and is reserved for scenarios where a the path of a file/directory is impossible to pre-determine.
+This stanza should be used sparingly, and is reserved for scenarios where the path of a file/directory is impossible to pre-determine.
 
 The example below can be used when the `pkg` path has a value such as timestamp that can't be detected without extracting the archive it is distributed within.
 


### PR DESCRIPTION
## Summary
Fix doubled words and extraneous articles in comments and documentation:

- Fix `to to` → `to` in `migrator.rb`
- Fix `as as` → `as a` in `utils/curl.rb`
- Fix `are are` → `are` in `unbottled.rb`
- Fix `a the` → `the` in `Cask-Cookbook.md`

No functional changes. All fixes are in comments and documentation.