### PR TITLE
utils/svn_spec: fix flaky test.

### DIFF
--- a/Library/Homebrew/test/utils/svn_spec.rb
+++ b/Library/Homebrew/test/utils/svn_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Utils::Svn do
       end
 
       it "returns true when remote exists", :needs_network, :needs_svn do
-        expect(described_class).to be_remote_exists("https://svn.apache.org/repos/asf/openoffice/trunk")
+        expect(described_class).to be_remote_exists("https://svn.code.sf.net/p/ctags/code/trunk")
       end
     end
   end


### PR DESCRIPTION
svn.apache.org is no longer reliable enough for us so let's try svn.code.sf.net.