### PR TITLE
bundle: add krew (kubectl plugin manager) support

### DIFF
--- a/Library/Homebrew/bundle/extensions/extension.rb
+++ b/Library/Homebrew/bundle/extensions/extension.rb
@@ -74,6 +74,11 @@ module Homebrew
         which(package_manager_name, ORIGINAL_PATHS)
       end
 
+      sig { params(executable: Pathname).returns(T::Hash[String, String]) }
+      def self.package_manager_env(executable)
+        { "PATH" => "#{executable.dirname}:#{ORIGINAL_PATHS.join(":")}" }
+      end
+
       sig { returns(String) }
       def self.package_description
         check_label.downcase

--- a/Library/Homebrew/bundle/extensions/krew.rb
+++ b/Library/Homebrew/bundle/extensions/krew.rb
@@ -30,8 +30,8 @@ module Homebrew
 
           kubectl = package_manager_executable
           result = if kubectl.present?
-            env = { "PATH" => "#{kubectl.dirname}:#{ORIGINAL_PATHS.join(":")}" }
-            Kernel.system(env, kubectl.to_s, "krew", "version", out: File::NULL, err: File::NULL) == true
+            Kernel.system(package_manager_env(kubectl), kubectl.to_s, "krew", "version",
+                          out: File::NULL, err: File::NULL) == true
           else
             false
           end
@@ -46,8 +46,7 @@ module Homebrew
 
           kubectl = package_manager_executable
           @packages = if package_manager_installed? && kubectl
-            env = { "PATH" => "#{kubectl.dirname}:#{ORIGINAL_PATHS.join(":")}" }
-            output = with_env(env) { `#{kubectl} krew list 2>/dev/null` }
+            output = with_env(package_manager_env(kubectl)) { `#{kubectl} krew list 2>/dev/null` }
             parse_plugin_list(output)
           else
             []
@@ -67,8 +66,7 @@ module Homebrew
           kubectl = package_manager_executable
           return false if kubectl.nil?
 
-          env = { "PATH" => "#{kubectl.dirname}:#{ENV.fetch("PATH")}" }
-          with_env(env) do
+          with_env(package_manager_env(kubectl)) do
             Bundle.system(kubectl.to_s, "krew", "install", name, verbose:)
           end
         end

--- a/Library/Homebrew/test/bundle/krew_spec.rb
+++ b/Library/Homebrew/test/bundle/krew_spec.rb
@@ -14,11 +14,8 @@ RSpec.describe Homebrew::Bundle::Krew do
         allow(described_class).to receive(:package_manager_installed?).and_return(false)
       end
 
-      it "returns an empty list" do
+      it "returns an empty list and dumps an empty string" do
         expect(dumper.packages).to be_empty
-      end
-
-      it "dumps an empty string" do # rubocop:todo RSpec/AggregateExamples
         expect(dumper.dump).to eql("")
       end
     end

--- a/docs/Brew-Bundle-and-Brewfile.md
+++ b/docs/Brew-Bundle-and-Brewfile.md
@@ -331,7 +331,7 @@ This must be done with solutions outside or built on top of `brew bundle` instea
 
 ## Adding New Packages Support
 
-`brew bundle` currently supports Homebrew, Homebrew Cask, Mac App Store, Visual Studio Code (and forks/variants), Go packages, Cargo packages, uv tools, Flatpak packages and krew (kubectl plugins).
+`brew bundle` currently supports Homebrew, Homebrew Cask, Mac App Store, Visual Studio Code (and forks/variants), Go packages, Cargo packages, uv tools, Flatpak packages and krew kubectl plugins.
 
 We are interested in contributions for other packages' installers/checkers/dumpers but they must:
 


### PR DESCRIPTION
Add `krew` as a new bundle extension type for managing kubectl plugins in Brewfiles. Users can declare kubectl plugins alongside their other packages:

```ruby
brew "krew"
krew "ctx"
krew "ns"
krew "neat"
```

The extension follows the established pattern (cargo, go, uv, flatpak):
- Lists installed plugins via `kubectl krew list`
- Installs plugins via `kubectl krew install <name>`
- Auto-installs the `krew` formula via Homebrew if not available
- Supports `brew bundle dump`, `check`, `install`, `list`, and `cleanup`

Closes #21793

<img width="1309" alt="Screenshot showing brew bundle dump, install, check, and list with krew plugins" src="https://github.com/user-attachments/assets/abaa7d8a-c86e-4aff-bcf7-f09198c0b640" />

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. Claude was used to scaffold the extension class following the existing cargo/go/uv pattern. All code was manually reviewed and tested. Style and typechecking pass locally (`brew style --changed` and `brew typecheck`). Tests require Ruby 4.0.1 which is validated by CI.

-----