### PR TITLE
Do not allow setting `HOMEBREW_EXPERIMENTAL_RUST_FRONTEND` in env file

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -136,6 +136,12 @@ export_homebrew_env_file() {
     # forbid overriding variables that are set in this file
     [[ "${line}" =~ ${BIN_BREW_EXPORTED_VARS_REGEX} ]] && continue
 
+    if [[ "${line}" == HOMEBREW_EXPERIMENTAL_RUST_FRONTEND=* ]]
+    then
+      echo "Warning: Ignoring HOMEBREW_EXPERIMENTAL_RUST_FRONTEND. This cannot be set in an env file." >&2
+      continue
+    fi
+
     export "${line?}"
   done <"${env_file}"
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

We rely on being able to `unset` this environment variable when handing
back to Ruby, but we won't be able to unset this if we got it from an
env file.
