### PR TITLE
formula_auditor: reject claude-agent-sdk

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -454,6 +454,28 @@ module Homebrew
       EOS
     end
 
+    sig { void }
+    def audit_node_modules
+      return unless @core_tap
+
+      node_modules = formula.libexec/"lib/node_modules"
+      return unless node_modules.directory?
+
+      incompatible_license_packages = %w[
+        @anthropic-ai/claude-agent-sdk
+      ]
+
+      incompatible_license_packages.each do |package|
+        # Search for package in all nested node_modules. Also including dot match for .pnpm hoisted packages
+        next if node_modules.glob("{**/node_modules/,}#{package}/", File::FNM_DOTMATCH).empty?
+
+        problem <<~EOS
+          Formula #{formula.name} uses #{package} which has an incompatible license.
+          All installed npm dependencies must satisfy #{Formatter.url("https://docs.brew.sh/License-Guidelines")}
+        EOS
+      end
+    end
+
     def audit_conflicts
       tap = formula.tap
       formula.conflicts.each do |conflict|

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -485,6 +485,60 @@ RSpec.describe Homebrew::FormulaAuditor do
     end
   end
 
+  describe "#audit_node_modules" do
+    let(:fa) do
+      formula_auditor("foo", <<~RUBY, core_tap:)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
+        end
+      RUBY
+    end
+    let(:node_modules) { fa.formula.libexec/"lib/node_modules" }
+    let(:reject_package) { "@anthropic-ai/claude-agent-sdk" }
+    let(:audit_message) { "uses #{reject_package} which has an incompatible license" }
+
+    context "when core tap" do
+      let(:core_tap) { true }
+
+      it "detects unacceptable npm packages" do
+        (node_modules/reject_package).mkpath
+        fa.audit_node_modules
+        expect(fa.problems.first[:message]).to match audit_message
+      end
+
+      it "detects unacceptable npm packages in nested node_modules" do
+        (node_modules/"foo/node_modules/bar/node_modules"/reject_package).mkpath
+        fa.audit_node_modules
+        expect(fa.problems.first[:message]).to match audit_message
+      end
+
+      it "detects unacceptable npm packages in .pnpm hoisted directory" do
+        (node_modules/".pnpm/node_modules"/reject_package).mkpath
+        fa.audit_node_modules
+        expect(fa.problems.first[:message]).to match audit_message
+      end
+
+      it "skips audit when no node_modules" do
+        fa.formula.libexec.mkpath
+        fa.audit_node_modules
+        expect(fa.problems).to be_empty
+      end
+    end
+
+    context "when non-core tap" do
+      let(:core_tap) { false }
+
+      it "skips audit" do
+        (node_modules/reject_package).mkpath
+        (node_modules/"foo/node_modules/bar/node_modules"/reject_package).mkpath
+        (node_modules/".pnpm/node_modules"/reject_package).mkpath
+        fa.audit_node_modules
+        expect(fa.problems).to be_empty
+      end
+    end
+  end
+
   describe "#audit_file" do
     specify "no issue" do
       fa = formula_auditor "foo", <<~RUBY


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Audit to detect
- https://github.com/Homebrew/homebrew-core/pull/273635

Example output after `brew install promptfoo` with timing (run in Linux container):
```console
$ time (brew audit --only node_modules promptfoo)
promptfoo
  * Formula promptfoo uses @anthropic-ai/claude-agent-sdk which has an incompatible license.
    All installed npm dependencies must satisfy https://docs.brew.sh/License-Guidelines
Error: 1 problem in 1 formula detected.

real	0m2.998s
user	0m2.186s
sys	0m0.876s
```

Using an array to extend this with other npm packages.

---

### Future ideas

In future, may consider moving this to a JSON file we store in Homebrew/core so it can be implemented as a tap-specific blacklist. Then can also be used in 3rd-party taps to detect unwanted dependencies.

And in further future, may want to analyze SPDX licenses of all installed npm packages to automatically detect disallowed licenses. May need a whitelist in this case when an npm package doesn't use SPDX.