### PR TITLE
rubocops: disallow `libiconv` dependency in homebrew/core

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -316,6 +316,19 @@ module RuboCop
         end
       end
 
+      # This cop makes sure that formulae do not depend on `libiconv` in homebrew/core.
+      class LibiconvCheck < FormulaCop
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          return if formula_nodes.body_node.nil?
+          return if formula_tap != "homebrew-core"
+          return if @formula_name == "neomutt"
+          return unless depends_on?("libiconv")
+
+          problem "Formulae in homebrew/core should not use `#{T.must(@offensive_node).source}`."
+        end
+      end
+
       # This cop makes sure that formulae do not depend on `*-full` formulae in homebrew/core.
       class FullDependencyCheck < FormulaCop
         sig { override.params(formula_nodes: FormulaNodes).void }

--- a/Library/Homebrew/test/rubocops/lines/libiconv_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/libiconv_check_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rubocops/lines"
+
+RSpec.describe RuboCop::Cop::FormulaAudit::LibiconvCheck do
+  subject(:cop) { described_class.new }
+
+  context "when auditing libiconv dependencies in homebrew/core" do
+    it "reports an offense when a formula depends on `libiconv`" do
+      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          desc "foo"
+          url 'https://brew.sh/foo-1.0.tgz'
+
+          depends_on "libiconv"
+          ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/LibiconvCheck: Formulae in homebrew/core should not use `depends_on "libiconv"`.
+        end
+      RUBY
+    end
+
+    it "reports no offenses for `neomutt`" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/n/neomutt.rb")
+        class Neomutt < Formula
+          desc "neomutt"
+          url 'https://brew.sh/neomutt-1.0.tgz'
+
+          depends_on "libiconv"
+        end
+      RUBY
+    end
+  end
+
+  context "when auditing outside homebrew/core" do
+    it "reports no offenses for libiconv dependencies" do
+      expect_no_offenses(<<~RUBY, "/homebrew-cask/Formula/foo.rb")
+        class Foo < Formula
+          desc "foo"
+          url 'https://brew.sh/foo-1.0.tgz'
+
+          depends_on "libiconv"
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`libiconv` is provided by macOS, so formulae in homebrew/core should
not depend on it directly. Add a `LibiconvCheck` cop to enforce this,
with a hardcoded exception for `neomutt`.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

-----

Claude did essentially all the work here. I reviewed each line of the new `LibiconvCheck` cop. ~I skimmed the tests, but have not reviewed them carefully. (I will do so now.)~
