### PR TITLE
cmd/search: resolve error with regex

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -156,6 +156,7 @@ module Homebrew
       sig { params(query: String, found_matches: T::Boolean).void }
       def print_missing_formula_help(query, found_matches)
         return unless $stdout.tty?
+        return if query.match?(Search::QUERY_REGEX)
 
         reason = MissingFormula.reason(query, silent: true)
         return if reason.nil?

--- a/Library/Homebrew/search.rb
+++ b/Library/Homebrew/search.rb
@@ -9,6 +9,8 @@ module Homebrew
   module Search
     extend Utils::Output::Mixin
 
+    QUERY_REGEX = %r{^/(.*)/$}
+
     SearchBlockType = T.type_alias do
       T.nilable(
         T.proc
@@ -35,7 +37,7 @@ module Homebrew
 
     sig { params(query: String).returns(T.any(Regexp, String)) }
     def self.query_regexp(query)
-      if (m = query.match(%r{^/(.*)/$}))
+      if (m = query.match(QUERY_REGEX))
         Regexp.new(T.must(m[1]))
       else
         query

--- a/Library/Homebrew/test/cmd/search_spec.rb
+++ b/Library/Homebrew/test/cmd/search_spec.rb
@@ -13,4 +13,44 @@ RSpec.describe Homebrew::Cmd::SearchCmd do
       .to output(/testball/).to_stdout
       .and be_a_success
   end
+
+  describe "::print_missing_formula_help" do
+    let(:search_cmd) { described_class.new([""]) }
+
+    context "when $stdout is not a TTY" do
+      before { allow_any_instance_of(StringIO).to receive(:tty?).and_return(false) }
+
+      it "skips" do
+        expect { search_cmd.send(:print_missing_formula_help, "formula", false) }
+          .not_to output.to_stdout
+      end
+    end
+
+    context "when $stdout is a TTY" do
+      before { allow_any_instance_of(StringIO).to receive(:tty?).and_return(true) }
+
+      it "skips a regex query" do
+        expect { search_cmd.send(:print_missing_formula_help, "/formula/", false) }
+          .not_to output.to_stdout
+      end
+
+      it "skips if there is not a reason" do
+        allow(Homebrew::MissingFormula).to receive(:reason).and_return(nil)
+        expect { search_cmd.send(:print_missing_formula_help, "formula", false) }
+          .not_to output.to_stdout
+      end
+
+      it "prints additional output if `found_matches` is true" do
+        allow(Homebrew::MissingFormula).to receive(:reason).and_return("Reason")
+        expect { search_cmd.send(:print_missing_formula_help, "formula", true) }
+          .to output("\nIf you meant \"formula\" specifically:\nReason\n").to_stdout
+      end
+
+      it "only prints reason if `found_matches` is false" do
+        allow(Homebrew::MissingFormula).to receive(:reason).and_return("Reason")
+        expect { search_cmd.send(:print_missing_formula_help, "formula", false) }
+          .to output("Reason\n").to_stdout
+      end
+    end
+  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

When a regex string like `/jq/` is provided to `brew search`, it can sometimes produce an error like "Error: /opt/homebrew/opt//jq/ is not a valid keg". So far I've only seen this with a very small number of installed formulae (I only stumbled upon this by chance). I'm not sure why some regexes trigger this and others don't but it traces back to the `Formulary.path` call in `MissingFormula.deleted_reason`. Either way, `MissingFormula.reason` shouldn't be called when the `query` value is a regex string, so this adds a guard to prevent it.