### PR TITLE
brew-rs: unset HOMEBREW_NO_INSTALL_FROM_API env

### DIFF
--- a/Library/Homebrew/rust/brew-rs/Rakefile
+++ b/Library/Homebrew/rust/brew-rs/Rakefile
@@ -75,6 +75,7 @@ module BrewRsTasks
       "HOMEBREW_EXPERIMENTAL_RUST_FRONTEND" => nil,
       "HOMEBREW_NO_AUTO_UPDATE"             => "1",
       "HOMEBREW_NO_INSTALL_CLEANUP"         => "1",
+      "HOMEBREW_NO_INSTALL_FROM_API"        => nil,
     }
     env["HOMEBREW_INTEGRATION_TEST"] = "1" if current_prefix != default_prefix
     env


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The benchmarks in the brew-rs `Rakefile` don't exercise the Rust implementation if `HOMEBREW_NO_INSTALL_FROM_API` is set in the execution environment. This addresses the issue by unsetting the environment variable in `benchmark_env`.