### PR TITLE
Fix grammar errors in comments

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -449,7 +449,7 @@ class FormulaConflictError < RuntimeError
   end
 end
 
-# Raise when the Python version cannot be detected automatically.
+# Raised when the Python version cannot be detected automatically.
 class FormulaUnknownPythonError < RuntimeError
   def initialize(formula)
     super <<~EOS
@@ -462,7 +462,7 @@ class FormulaUnknownPythonError < RuntimeError
   end
 end
 
-# Raise when two Python versions are detected simultaneously.
+# Raised when two Python versions are detected simultaneously.
 class FormulaAmbiguousPythonError < RuntimeError
   def initialize(formula)
     super <<~EOS

--- a/Library/Homebrew/manpages/parser/ronn.rb
+++ b/Library/Homebrew/manpages/parser/ronn.rb
@@ -13,7 +13,7 @@ module Homebrew
           # Disable HTML parsing and replace it with variable parsing.
           # Also disable table parsing too because it depends on HTML parsing
           # and existing command descriptions may get misinterpreted as tables.
-          # Typographic symbols is disabled as it detects `--` as en-dash.
+          # Typographic symbols are disabled as they detect `--` as en-dash.
           @block_parsers.delete(:block_html)
           @block_parsers.delete(:table)
           @span_parsers.delete(:span_html)


### PR DESCRIPTION
Fix grammar errors in comments

- Fix subject-verb disagreement in ronn.rb: 'symbols is' → 'symbols are'
- Fix 'Raise when' → 'Raised when' in two exception class comments in exceptions.rb to match the established pattern used by all other exception classes in the file

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *GitHub Copilot was used to identify the grammar inconsistencies. All changes were manually verified by running `brew style` and `brew typecheck` locally — both passed without errors. The changes are comment-only fixes (no logic changes), so no new tests are needed.*

-----