### PR TITLE
Print download error details when using concurrency

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -512,8 +512,8 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy # rubocop:todo Style/O
         else
           begin
             _fetch(url:, resolved_url: T.must(resolved_url), timeout: Utils::Timer.remaining!(end_time))
-          rescue ErrorDuringExecution
-            raise CurlDownloadStrategyError, url
+          rescue ErrorDuringExecution => e
+            raise CurlDownloadStrategyError.new(url, e.stderr.strip)
           end
           cached_location.dirname.mkpath
           temporary_path.rename(cached_location.to_s)
@@ -646,8 +646,9 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy # rubocop:todo Style/O
 
     if Homebrew::EnvConfig.no_insecure_redirect? &&
        url.start_with?("https://") && !resolved_url.start_with?("https://")
-      $stderr.puts "HTTPS to HTTP redirect detected and `$HOMEBREW_NO_INSECURE_REDIRECT` is set."
-      raise CurlDownloadStrategyError, url
+      error_message = "HTTPS to HTTP redirect detected and `$HOMEBREW_NO_INSECURE_REDIRECT` is set."
+      $stderr.puts error_message unless quiet?
+      raise CurlDownloadStrategyError.new(url, error_message)
     end
 
     _curl_download resolved_url, temporary_path, timeout
@@ -801,7 +802,7 @@ class CurlApacheMirrorDownloadStrategy < CurlDownloadStrategy # rubocop:todo Sty
     json = curl_output("--silent", "--location", "#{url}&asjson=1").stdout
     T.must(@apache_mirrors = T.let(JSON.parse(json), T.nilable(T::Hash[String, T.untyped])))
   rescue JSON::ParserError
-    raise CurlDownloadStrategyError, "Couldn't determine mirror, try again later."
+    raise CurlDownloadStrategyError.new(url, "Couldn't determine mirror, try again later.")
   end
 end
 

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -658,18 +658,21 @@ end
 
 # Raised in {CurlDownloadStrategy#fetch}.
 class CurlDownloadStrategyError < RuntimeError
-  def initialize(url)
+  sig { params(url: String, details: T.nilable(String)).void }
+  def initialize(url, details = nil)
+    suffix = "\n#{details}" if details.present?
     case url
     when %r{^file://(.+)}
-      super "File does not exist: #{Regexp.last_match(1)}"
+      super "File cannot be read: #{Regexp.last_match(1)}#{suffix}"
     else
-      super "Download failed: #{url}"
+      super "Download failed: #{url}#{suffix}"
     end
   end
 end
 
 # Raised in {HomebrewCurlDownloadStrategy#fetch}.
 class HomebrewCurlDownloadStrategyError < CurlDownloadStrategyError
+  sig { params(url: String).void }
   def initialize(url)
     super "Homebrew-installed `curl` is not installed for: #{url}"
   end

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe "Exception" do
     context "when the file does not exist" do
       subject(:error) { described_class.new("file:///tmp/foo") }
 
-      it(:to_s) { expect(error.to_s).to eq("File does not exist: /tmp/foo") }
+      it(:to_s) { expect(error.to_s).to eq("File cannot be read: /tmp/foo") }
     end
 
     context "when the download failed" do


### PR DESCRIPTION
Right now, download errors have very limited usefulness when concurrency is enabled (the default):

```console
$ brew fetch -s hello
✘ Formula hello (2.12.2)
Error: Failed to download resource "hello (2.12.2)"
Download failed: https://example.com/nonexistent
```

The behaviour without the queue was much more useful:

```console
$ HOMEBREW_DOWNLOAD_CONCURRENCY=1 brew fetch -s hello
==> Downloading https://example.com/nonexistent
curl: (56) The requested URL returned error: 404                                

==> Retrying download in 2s... (1 try left)
==> Downloading https://example.com/nonexistent
curl: (56) The requested URL returned error: 404                                

Error: Failed to download resource "hello (2.12.2)"
Download failed: https://example.com/nonexistent
```

So let's fix up the concurrent version to display things like this:

```console
$ brew fetch -s hello
✘ Formula hello (2.12.2)
Error: Failed to download resource "hello (2.12.2)"
Download failed: https://example.com/nonexistent
curl: (56) The requested URL returned error: 404 
```
