### PR TITLE
workflows/release: migrate actions/attest-build-provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,8 @@ jobs:
       HOMEBREW_MACOS_OLDEST_SUPPORTED: "14.0"
     permissions:
       contents: write # for creating tags and releases
-      attestations: write # for actions/attest-build-provenance
-      id-token: write # for actions/attest-build-provenance
+      attestations: write # for actions/attest
+      id-token: write # for actions/attest
     steps:
       - name: Remove existing API cache (to force update)
         run: rm -rvf ~/Library/Caches/Homebrew/api
@@ -155,7 +155,7 @@ jobs:
           fi
 
       - name: Generate build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: Homebrew-${{ steps.homebrew-version.outputs.version }}.pkg
 

--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -165,7 +165,7 @@ module Homebrew
       # in a single attestation, so we check every subject in each attestation
       # and select the first attestation with a matching subject.
       # In particular, this happens with v2.0.0 and later of the
-      # `actions/attest-build-provenance` action.
+      # `actions/attest` action.
       subject = bottle.filename.to_s if subject.blank?
 
       attestation = if bottle.tag.to_sym == :all


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

As of version 4, actions/attest-build-provenance is simply a wrapper on top of [actions/attest](https://github.com/actions/attest) per https://github.com/actions/attest-build-provenance#usage.