### PR TITLE
Adjust update to honor custom SSH command

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -618,7 +618,10 @@ EOS
   fi
 
   export GIT_TERMINAL_PROMPT="0"
-  export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh} -oBatchMode=yes"
+  # Set GIT_SSH_COMMAND only when user haven't set custom SSH command
+  if [[ -z "${GIT_SSH_COMMAND}" ]] && ! git config --get core.sshCommand &>/dev/null; then
+    export GIT_SSH_COMMAND="ssh -oBatchMode=yes"
+  fi
 
   if [[ -n "${HOMEBREW_GIT_NAME}" ]]
   then

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -619,7 +619,8 @@ EOS
 
   export GIT_TERMINAL_PROMPT="0"
   # Set GIT_SSH_COMMAND only when user haven't set custom SSH command
-  if [[ -z "${GIT_SSH_COMMAND}" ]] && ! git config --get core.sshCommand &>/dev/null; then
+  if [[ -z "${GIT_SSH_COMMAND}" ]] && ! git config --get core.sshCommand &>/dev/null
+  then
     export GIT_SSH_COMMAND="ssh -oBatchMode=yes"
   fi
 

--- a/bin/brew
+++ b/bin/brew
@@ -292,7 +292,7 @@ PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 FILTERED_ENV=()
 ENV_VAR_NAMES=(
   HOME SHELL PATH TERM TERMINFO TERMINFO_DIRS COLUMNS DISPLAY LOGNAME USER CI SSH_AUTH_SOCK SUDO_ASKPASS
-  http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY
+  http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY GIT_SSH_COMMAND
 )
 # Filter all but the specific variables.
 for VAR in "${ENV_VAR_NAMES[@]}" "${!HOMEBREW_@}"


### PR DESCRIPTION
In my use case I use custom ssh command to access homebrew repositories (set as a global config in `~/.gitconfig` file). Current `brew update` doesn't work with my custom repository because of wrong credentials. Tapping still works as expected.
It turned out that setting up explicit `GIT_SSH_COMMAND=${GIT_SSH_COMMAND:-ssh} -oBatchMode=yes` overrides global git config. Additionally, I couldn't override the default `ssh` command by exporting `GIT_SSH_COMMAND`. It happened because the flag wasn't whitelisted.

I propose to fix two things:
1. Add GIT_SSH_COMMAND to whitelisted list of envs. Currently passing this flag is dead logic without whitelisting.
2. Check whether the git config have custom ssh command. If so, doesn't override it. Use `-oBatchMode` only when default ssh implementation is used. Otherwise brew can break custom wrapper by adding ssh-only flag.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb). Couldn't find bash scripts tests for `update.sh`.
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
Used for searching the code through and diagnosing the problem with passing the flag to update (comparison between tap and update, suggesting the change when problem was pinned down by local modification).

-----
