### PR TITLE
Add brew-rs fetch support

### DIFF
--- a/.github/workflows/brew-rs.yml
+++ b/.github/workflows/brew-rs.yml
@@ -93,7 +93,8 @@ jobs:
           if-no-files-found: ignore
 
       - name: Prepare smoke test formula
-        run: brew uninstall --force hello || true
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        run: Library/Homebrew/rust/brew-rs/run-brew-rs-experimental.sh uninstall --force hello || true
 
       - name: Smoke-test brew-rs install
         run: brew install hello

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -301,14 +301,9 @@ rust-frontend-enabled() {
   fi
 
   case "${HOMEBREW_COMMAND}" in
-    search | info | list | install | reinstall | update | upgrade | uninstall) ;;
+    fetch | search | info | list | install | reinstall | update | upgrade | uninstall) ;;
     *) return 1 ;;
   esac
-
-  if [[ -z "${HOMEBREW_INTEGRATION_TEST:-}" && "${HOMEBREW_PREFIX}" != "${HOMEBREW_DEFAULT_PREFIX}" ]]
-  then
-    return 1
-  fi
 
   if [[ -n "${HOMEBREW_MACOS}" ]]
   then

--- a/Library/Homebrew/rust/brew-rs/AGENTS.md
+++ b/Library/Homebrew/rust/brew-rs/AGENTS.md
@@ -4,11 +4,19 @@
 - Keep the vendored binary at `Library/Homebrew/vendor/brew-rs/brew-rs`.
 - `brew.sh` should stay a thin gate and dispatch layer.
 - Prefer reusing existing Homebrew Ruby and Bash behavior for correctness in v1 instead of mirroring complex logic in Rust.
+- Keep the Rust `fetch` command bottle-only for simple named `homebrew/core` formulae; anything that needs source fetching, cask support, flags, or more complex argument handling should delegate back to Ruby with an explicit reason.
+- When changing Rust `fetch`, keep its bottle naming, cache paths, retry behavior, and fallback boundaries aligned with `Library/Homebrew/cmd/fetch.rb`, `Library/Homebrew/fetch.rb`, `Library/Homebrew/bottle.rb`, `Library/Homebrew/download_queue.rb`, `Library/Homebrew/retryable_download.rb`, and `Library/Homebrew/download_strategy.rb`.
 - Respect existing Homebrew cache, Cellar, Caskroom, logs, temp, and metadata paths.
 - Keep Rust command entrypoints in `src/commands/` with one file per command where practical.
 - From the repository root, prepend `Library/Homebrew/vendor/portable-ruby/current/bin` to `PATH` and install `rake` there if it is missing.
 - From the repository root, run `./bin/brew vendor-install brew-rs` to vendor the binary locally.
+- Use `./run-brew-rs-experimental.sh ...` from `Library/Homebrew/rust/brew-rs` when you want a self-locating helper that skips `vendor-install` entirely when the vendored `brew-rs` binary is already up-to-date, rebuilds only when `Cargo.toml`, `Cargo.lock`, or `src/` changed, runs `brew update` when the Rust-backed API cache is missing, and then runs `brew` with `HOMEBREW_EXPERIMENTAL_RUST_FRONTEND=1`.
+- Adding a Rust command implementation is not enough on its own; update `rust-frontend-enabled` in `Library/Homebrew/brew.sh` as well or `brew` will keep routing that command to the Ruby frontend even when the experimental helper is used.
+- Keep local Rust frontend development working from this repository checkout too; do not reintroduce a `HOMEBREW_PREFIX == HOMEBREW_DEFAULT_PREFIX` gate in `rust-frontend-enabled` unless that behavior is intentionally being reverted.
+- Keep `run-brew-rs-experimental.sh` free of `brew ruby`; if Rust needs more API compatibility, fix that in `brew-rs` itself instead of synthesizing cache entries in Bash.
 - Run `cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked` from `Library/Homebrew/rust/brew-rs`.
+- During development and testing, compare Rust commands against their Ruby equivalents and keep stdout, stderr, exit status, and user-facing progress output as close to Ruby as practical.
+- For TTY-heavy commands, match Ruby's status/message split and output policy from `Library/Homebrew/download_queue.rb`: single downloads should still be able to render a live bar when they take long enough to matter, but fast paths should collapse to the final success line instead of flashing noisy placeholder output.
 - Before adding Rust parity tests or benchmarks for a command, inspect `Library/Homebrew/brew.sh` for shell fast paths and gate/dispatch behavior so you target invocations that actually reach `brew-rs`.
 - Use `BREW_RS_STAGE_REPOSITORY=/path/to/Homebrew rake stage` to stage into another checkout.
 - Use `rake benchmark` for Ruby vs Rust benchmarks.
@@ -19,3 +27,4 @@
 - In GitHub Actions, `setup-homebrew` provides the checkout that the job should use; paths under `GITHUB_WORKSPACE` may point at a different tree.
 - Run `./bin/brew typecheck` and `./bin/brew lgtm` for repo-wide verification.
 - Outside the default prefix, benchmarks should cover read commands and skip mutating commands.
+- For API-backed Rust commands, accept the tap spelling the cached API data already uses, including both `homebrew/core` and `Homebrew/homebrew-core`.

--- a/Library/Homebrew/rust/brew-rs/Cargo.lock
+++ b/Library/Homebrew/rust/brew-rs/Cargo.lock
@@ -18,15 +18,470 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "brew-rs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "rayon",
  "regex",
+ "reqwest",
  "rust-fuzzy-search",
  "serde",
  "serde_json",
+ "sha2",
+ "url",
  "walkdir",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -36,10 +491,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -51,12 +593,122 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -89,10 +741,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rust-fuzzy-search"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a157657054ffe556d8858504af8a672a054a6e0bd9e8ee531059100c0fa11bb2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -147,6 +906,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,10 +980,205 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -174,12 +1191,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -190,11 +1319,273 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Library/Homebrew/rust/brew-rs/Cargo.toml
+++ b/Library/Homebrew/rust/brew-rs/Cargo.toml
@@ -7,6 +7,10 @@ rust-version = "1.85"
 [dependencies]
 # Ergonomic error propagation for the CLI and command dispatch layers.
 anyhow = "1.0.100"
+# Download multiple bottles in parallel without hand-rolled worker plumbing.
+rayon = "1.11.0"
+# Perform bottle and API downloads over HTTP(S).
+reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "rustls-tls"] }
 # Supports `brew search /REGEX/` matching.
 regex = "1.12.2"
 # Adds fuzzy fallback suggestions for plain `brew search` queries.
@@ -15,5 +19,9 @@ rust-fuzzy-search = "0.1.1"
 serde = { version = "1.0.228", features = ["derive"] }
 # Read and write JSON API cache entries and command output.
 serde_json = "1.0.145"
+# Verify downloaded payloads against Homebrew's SHA-256 metadata.
+sha2 = "0.10.9"
+# Parse file:// and HTTPS bottle URLs consistently.
+url = "2.5.7"
 # Traverse installed formula and cask state under existing Homebrew paths.
 walkdir = "2.5.0"

--- a/Library/Homebrew/rust/brew-rs/run-brew-rs-experimental.sh
+++ b/Library/Homebrew/rust/brew-rs/run-brew-rs-experimental.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ -z "${HOMEBREW_DEVELOPER:-}" ]]
+then
+  echo "Error: HOMEBREW_DEVELOPER must already be set." >&2
+  exit 1
+fi
+
+script_dir="$(
+  cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P
+)"
+repository_root="$(
+  cd -- "${script_dir}/../../../.." && pwd -P
+)"
+brew_file="${repository_root}/bin/brew"
+vendor_binary="${repository_root}/Library/Homebrew/vendor/brew-rs/bin/brew-rs"
+
+if [[ ! -x "${repository_root}/Library/Homebrew/vendor/brew-rs/brew-rs" ||
+      ! -x "${vendor_binary}" ||
+   "${script_dir}/Cargo.toml" -nt "${vendor_binary}" ||
+   "${script_dir}/Cargo.lock" -nt "${vendor_binary}" ||
+      -n "$(find "${script_dir}/src" -type f -newer "${vendor_binary}" -print -quit)" ]]
+then
+  HOMEBREW_EXPERIMENTAL_RUST_FRONTEND=1 \
+    "${brew_file}" vendor-install brew-rs
+fi
+
+case "${1:-}" in
+  fetch | search)
+    cache_root="${HOMEBREW_CACHE:-$("${brew_file}" --cache)}"
+    names_path="${cache_root}/api/formula_names.txt"
+    cask_names_path="${cache_root}/api/cask_names.txt"
+    formula_api_path="${cache_root}/api/formula.jws.json"
+
+    if [[ ! -f "${names_path}" ||
+          ! -f "${cask_names_path}" ||
+          ("${1}" == "fetch" && ! -f "${formula_api_path}") ]]
+    then
+      HOMEBREW_EXPERIMENTAL_RUST_FRONTEND=1 \
+        "${brew_file}" update
+    fi
+    ;;
+  *) ;;
+esac
+
+exec env \
+  HOMEBREW_EXPERIMENTAL_RUST_FRONTEND=1 \
+  "${brew_file}" "$@"

--- a/Library/Homebrew/rust/brew-rs/src/app.rs
+++ b/Library/Homebrew/rust/brew-rs/src/app.rs
@@ -21,6 +21,7 @@ fn run() -> BrewResult<ExitCode> {
     }
 
     match args[0].as_str() {
+        "fetch" => commands::fetch::run(&args),
         "search" => commands::search::run(&args),
         "info" => commands::info::run(&args),
         "list" => commands::list::run(&args),

--- a/Library/Homebrew/rust/brew-rs/src/commands/fetch.rs
+++ b/Library/Homebrew/rust/brew-rs/src/commands/fetch.rs
@@ -1,0 +1,1277 @@
+use crate::BrewResult;
+use crate::delegate;
+use crate::homebrew;
+use anyhow::{Context, anyhow, bail};
+use rayon::prelude::*;
+use reqwest::blocking::Client;
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::ffi::OsString;
+use std::fs::{self, File};
+use std::io::{self, IsTerminal, Read, Write};
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, available_parallelism};
+use std::time::{Duration, Instant};
+use url::Url;
+
+const FETCH_RETRIES: usize = 2;
+const ANSI_BLUE: &str = "\x1b[34m";
+const ANSI_GREEN: &str = "\x1b[32m";
+const ANSI_RESET: &str = "\x1b[0m";
+const CONNECT_TIMEOUT_SECS: u64 = 15;
+const REQUEST_TIMEOUT_SECS: u64 = 600;
+const FALSY_ENV_VALUES: [&str; 5] = ["false", "no", "off", "nil", "0"];
+
+pub fn run(args: &[String]) -> BrewResult<ExitCode> {
+    if args.len() < 2 {
+        return delegate::run_with_reason(
+            args,
+            "fetch",
+            "only simple named formula arguments are supported.",
+        );
+    }
+    if args[1..].iter().any(|arg| arg.starts_with('-')) {
+        return delegate::run_with_reason(args, "fetch", "flags are not yet supported.");
+    }
+    if args[1..].iter().any(|arg| !is_simple_formula_name(arg)) {
+        return delegate::run_with_reason(
+            args,
+            "fetch",
+            "only simple named formula arguments are supported.",
+        );
+    }
+
+    let api_cache = homebrew::cache_api_path()?;
+    let aliases = load_aliases(&api_cache.join("formula_aliases.txt"))?;
+    let bottle_tag = current_bottle_tag()?;
+    let client = Arc::new(build_client()?);
+    let mut signed_cache_formulae = None;
+    let mut bottles = Vec::with_capacity(args.len() - 1);
+    let mut cached_downloads = HashSet::with_capacity(args.len() - 1);
+
+    for name in &args[1..] {
+        match resolve_bottle(
+            name,
+            &aliases,
+            &api_cache,
+            &mut signed_cache_formulae,
+            &bottle_tag,
+            &client,
+        )? {
+            Resolution::Bottle(bottle) => {
+                if cached_downloads.insert(bottle.cached_download.clone()) {
+                    bottles.push(bottle);
+                }
+            }
+            Resolution::Delegate(reason) => {
+                return delegate::run_with_reason(args, "fetch", &reason);
+            }
+        }
+    }
+
+    if bottles.len() > 1 {
+        println!(
+            "Fetching: {}",
+            bottles
+                .iter()
+                .map(|bottle| bottle.formula_name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+
+    let tty_output = io::stdout().is_terminal();
+    let download_threads = download_concurrency(bottles.len());
+    let show_progress = should_render_progress(download_progress_enabled(), download_threads);
+    let progress = bottles
+        .iter()
+        .map(|bottle| {
+            Arc::new(Mutex::new(DownloadProgress {
+                message: format!(
+                    "Bottle {} ({})",
+                    bottle.display_name, bottle.display_version
+                ),
+                phase: "downloading",
+                fetched_size: 0,
+                total_size: None,
+                done: false,
+            }))
+        })
+        .collect::<Vec<_>>();
+    let renderer = show_progress.then(|| ProgressRenderer::start(&progress));
+
+    let result = rayon::ThreadPoolBuilder::new()
+        .num_threads(download_threads)
+        .build()
+        .context("Failed to configure download concurrency")?
+        .install(|| {
+            bottles
+                .par_iter()
+                .zip(progress.par_iter())
+                .try_for_each(|(bottle, progress)| {
+                    fetch_bottle(bottle, client.as_ref(), progress, show_progress, tty_output)
+                })
+        });
+
+    if let Some(renderer) = renderer {
+        renderer.stop();
+    }
+
+    result?;
+
+    Ok(ExitCode::SUCCESS)
+}
+
+enum Resolution {
+    Bottle(BottleFetch),
+    Delegate(String),
+}
+
+#[derive(Clone, Debug)]
+struct BottleFetch {
+    formula_name: String,
+    display_name: String,
+    display_version: String,
+    bottle_url: String,
+    bottle_sha256: String,
+    cached_download: PathBuf,
+    symlink_path: PathBuf,
+}
+
+#[derive(Clone)]
+struct DownloadProgress {
+    message: String,
+    phase: &'static str,
+    fetched_size: u64,
+    total_size: Option<u64>,
+    done: bool,
+}
+
+#[derive(Deserialize, Clone)]
+struct FormulaJson {
+    name: String,
+    full_name: String,
+    tap: String,
+    versions: Versions,
+    revision: u32,
+    bottle: Option<BottleMetadata>,
+}
+
+#[derive(Deserialize, Clone)]
+struct Versions {
+    stable: String,
+}
+
+#[derive(Deserialize, Clone)]
+struct BottleMetadata {
+    stable: Option<BottleStable>,
+}
+
+#[derive(Deserialize, Clone)]
+struct BottleStable {
+    rebuild: u32,
+    files: HashMap<String, BottleFile>,
+}
+
+#[derive(Deserialize, Clone)]
+struct BottleFile {
+    url: String,
+    sha256: String,
+}
+
+#[derive(Deserialize)]
+struct SignedPayload {
+    payload: String,
+}
+
+fn resolve_bottle(
+    name: &str,
+    aliases: &HashMap<String, String>,
+    api_cache: &Path,
+    signed_cache_formulae: &mut Option<HashMap<String, FormulaJson>>,
+    bottle_tag: &str,
+    client: &Client,
+) -> BrewResult<Resolution> {
+    let resolved_name = aliases.get(name).map(String::as_str).unwrap_or(name);
+    let Some(formula) = load_formula_json(resolved_name, api_cache, signed_cache_formulae, client)?
+    else {
+        return Ok(Resolution::Delegate(format!(
+            "formula metadata for `{name}` is not available in the Homebrew API cache."
+        )));
+    };
+
+    if !is_homebrew_core_tap(&formula.tap) {
+        return Ok(Resolution::Delegate(format!(
+            "`{}` is not a homebrew/core formula.",
+            formula.full_name
+        )));
+    }
+
+    let Some(bottle) = formula
+        .bottle
+        .as_ref()
+        .and_then(|bottle| bottle.stable.as_ref())
+    else {
+        return Ok(Resolution::Delegate(format!(
+            "`{}` does not have a bottle.",
+            formula.full_name
+        )));
+    };
+
+    let Some((selected_tag, bottle_file)) = bottle
+        .files
+        .get_key_value(bottle_tag)
+        .or_else(|| bottle.files.get_key_value("all"))
+    else {
+        return Ok(Resolution::Delegate(format!(
+            "`{}` does not have a bottle for `{bottle_tag}`.",
+            formula.full_name
+        )));
+    };
+
+    let cache_path = homebrew::cache_path()?;
+    let bottle_name = bottle_basename(
+        &formula.name,
+        &formula.versions.stable,
+        formula.revision,
+        selected_tag,
+        bottle.rebuild,
+        &bottle_file.url,
+    );
+
+    // Match the path split used by `Bottle#root_url` and `AbstractFileDownloadStrategy`
+    // in `Library/Homebrew/bottle.rb`, `Library/Homebrew/utils/bottles.rb`,
+    // and `Library/Homebrew/download_strategy.rb`.
+    Ok(Resolution::Bottle(BottleFetch {
+        formula_name: formula.full_name.clone(),
+        display_name: formula.name.clone(),
+        display_version: pkg_version(&formula.versions.stable, formula.revision),
+        bottle_url: bottle_file.url.clone(),
+        bottle_sha256: bottle_file.sha256.to_ascii_lowercase(),
+        cached_download: cache_path.join("downloads").join(format!(
+            "{}--{bottle_name}",
+            sha256_hex_str(&bottle_file.url)
+        )),
+        symlink_path: cache_path.join(format!(
+            "{}--{}",
+            formula.name,
+            pkg_version(&formula.versions.stable, formula.revision)
+        )),
+    }))
+}
+
+fn load_formula_json(
+    name: &str,
+    api_cache: &Path,
+    signed_cache_formulae: &mut Option<HashMap<String, FormulaJson>>,
+    client: &Client,
+) -> BrewResult<Option<FormulaJson>> {
+    let path = api_cache.join("formula").join(format!("{name}.json"));
+    if path.exists() {
+        return Ok(Some(read_formula_json(&path)?));
+    }
+
+    let aggregate_path = api_cache.join("formula.jws.json");
+    if aggregate_path.exists() {
+        if signed_cache_formulae.is_none() {
+            *signed_cache_formulae = Some(load_signed_cache_formulae(&aggregate_path)?);
+        }
+
+        return Ok(signed_cache_formulae
+            .as_ref()
+            .and_then(|formulae| formulae.get(name).cloned()));
+    }
+    if env_flag("HOMEBREW_USE_INTERNAL_API") {
+        return Ok(None);
+    }
+
+    let Some(body) = download_formula_json(name, client)? else {
+        return Ok(None);
+    };
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+    fs::write(&path, body).with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(Some(read_formula_json(&path)?))
+}
+
+fn read_formula_json(path: &Path) -> BrewResult<FormulaJson> {
+    serde_json::from_str(
+        &fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?,
+    )
+    .with_context(|| format!("Failed to parse {}", path.display()))
+}
+
+fn load_signed_cache_formulae(path: &Path) -> BrewResult<HashMap<String, FormulaJson>> {
+    parse_formulae_from_signed_cache(
+        &fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?,
+    )
+    .with_context(|| format!("Failed to parse {}", path.display()))
+}
+
+#[cfg(test)]
+fn parse_formula_json_from_signed_cache(
+    contents: &str,
+    name: &str,
+) -> BrewResult<Option<FormulaJson>> {
+    Ok(parse_formulae_from_signed_cache(contents)?
+        .get(name)
+        .cloned())
+}
+
+fn parse_formulae_from_signed_cache(contents: &str) -> BrewResult<HashMap<String, FormulaJson>> {
+    let signed_payload: SignedPayload = serde_json::from_str(contents)?;
+    let formulae: Vec<FormulaJson> = serde_json::from_str(&signed_payload.payload)?;
+    let mut indexed_formulae = HashMap::with_capacity(formulae.len() * 2);
+
+    for formula in formulae {
+        indexed_formulae.insert(formula.name.clone(), formula.clone());
+        indexed_formulae.insert(formula.full_name.clone(), formula);
+    }
+
+    Ok(indexed_formulae)
+}
+
+fn download_formula_json(name: &str, client: &Client) -> BrewResult<Option<Vec<u8>>> {
+    let mut last_error = None;
+
+    for domain in api_domains() {
+        let response = match client.get(format!("{domain}/formula/{name}.json")).send() {
+            Ok(response) => response,
+            Err(error) => {
+                last_error = Some(
+                    anyhow!(error)
+                        .context(format!("Failed to download formula metadata for `{name}`")),
+                );
+                continue;
+            }
+        };
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            continue;
+        }
+        match response.error_for_status() {
+            Ok(response) => {
+                return Ok(Some(
+                    response
+                        .bytes()
+                        .with_context(|| format!("Failed to read formula metadata for `{name}`"))?
+                        .to_vec(),
+                ));
+            }
+            Err(error) => {
+                last_error = Some(
+                    anyhow!(error)
+                        .context(format!("Failed to download formula metadata for `{name}`")),
+                );
+            }
+        }
+    }
+
+    if let Some(error) = last_error {
+        return Err(error);
+    }
+
+    Ok(None)
+}
+
+fn fetch_bottle(
+    bottle: &BottleFetch,
+    client: &Client,
+    progress: &Arc<Mutex<DownloadProgress>>,
+    show_progress: bool,
+    tty_output: bool,
+) -> BrewResult<()> {
+    if bottle.cached_download.exists() {
+        update_download_phase(progress, "verifying");
+        verify_checksum(&bottle.cached_download, &bottle.bottle_sha256)?;
+        ensure_symlink(bottle)?;
+        mark_download_complete(progress);
+        if !show_progress {
+            print_downloaded_bottle(bottle, tty_output);
+        }
+        return Ok(());
+    }
+
+    let temporary_path = temporary_download_path(&bottle.cached_download);
+    let mut last_error = None;
+
+    for _ in 0..FETCH_RETRIES {
+        let result = (|| {
+            if let Some(parent) = bottle.cached_download.parent() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("Failed to create {}", parent.display()))?;
+            }
+            if temporary_path.exists() {
+                fs::remove_file(&temporary_path)
+                    .with_context(|| format!("Failed to remove {}", temporary_path.display()))?;
+            }
+
+            update_download_phase(progress, "downloading");
+            match Url::parse(&bottle.bottle_url).context("Failed to parse bottle URL")? {
+                url if url.scheme() == "file" => {
+                    copy_file_url(&url, &temporary_path, progress)?;
+                }
+                url => {
+                    download_http_url(client, &url, &temporary_path, progress)?;
+                }
+            }
+
+            update_download_phase(progress, "verifying");
+            verify_checksum(&temporary_path, &bottle.bottle_sha256)?;
+            fs::rename(&temporary_path, &bottle.cached_download).with_context(|| {
+                format!(
+                    "Failed to move {} to {}",
+                    temporary_path.display(),
+                    bottle.cached_download.display()
+                )
+            })?;
+            ensure_symlink(bottle)?;
+            mark_download_complete(progress);
+            if !show_progress {
+                print_downloaded_bottle(bottle, tty_output);
+            }
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                last_error = Some(error);
+                let _ = fs::remove_file(&temporary_path);
+                let _ = fs::remove_file(&bottle.cached_download);
+                let _ = fs::remove_file(&bottle.symlink_path);
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| anyhow!("Failed to fetch {}", bottle.formula_name)))
+}
+
+fn print_downloaded_bottle(bottle: &BottleFetch, tty_output: bool) {
+    let status = if tty_output {
+        format!("{ANSI_GREEN}✔︎{ANSI_RESET}")
+    } else {
+        "✔︎".to_string()
+    };
+    println!(
+        "{status} Bottle {} ({})",
+        bottle.display_name, bottle.display_version
+    );
+}
+
+fn copy_file_url(
+    url: &Url,
+    destination: &Path,
+    progress: &Arc<Mutex<DownloadProgress>>,
+) -> BrewResult<()> {
+    let source = url
+        .to_file_path()
+        .map_err(|_| anyhow!("Failed to convert {url} to a file path"))?;
+    let mut input =
+        File::open(&source).with_context(|| format!("Failed to open {}", source.display()))?;
+    update_download_total(
+        progress,
+        input.metadata().ok().map(|metadata| metadata.len()),
+    );
+    let mut output = File::create(destination)
+        .with_context(|| format!("Failed to create {}", destination.display()))?;
+    copy_stream(&mut input, &mut output, progress)?;
+    Ok(())
+}
+
+fn download_http_url(
+    client: &Client,
+    url: &Url,
+    destination: &Path,
+    progress: &Arc<Mutex<DownloadProgress>>,
+) -> BrewResult<()> {
+    let mut request = client.get(url.as_str());
+    if should_send_github_packages_auth(url) {
+        if let Some(auth) = env_value("HOMEBREW_GITHUB_PACKAGES_AUTH") {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&auth)
+                    .context("Failed to build GitHub Packages authorization header")?,
+            );
+            request = request.headers(headers);
+        }
+    }
+
+    let mut response = request
+        .send()
+        .with_context(|| format!("Failed to download {}", url))?
+        .error_for_status()
+        .with_context(|| format!("Failed to download {}", url))?;
+    update_download_total(progress, response.content_length());
+    let mut output = File::create(destination)
+        .with_context(|| format!("Failed to create {}", destination.display()))?;
+    copy_stream(&mut response, &mut output, progress)?;
+    Ok(())
+}
+
+fn copy_stream(
+    input: &mut dyn Read,
+    output: &mut dyn Write,
+    progress: &Arc<Mutex<DownloadProgress>>,
+) -> BrewResult<()> {
+    let mut buffer = [0_u8; 16 * 1024];
+    loop {
+        let read = input
+            .read(&mut buffer)
+            .context("Failed to read download data")?;
+        if read == 0 {
+            break;
+        }
+        output
+            .write_all(&buffer[..read])
+            .context("Failed to write download data")?;
+        increment_downloaded_size(progress, read as u64);
+    }
+    output.flush().context("Failed to flush download data")?;
+    Ok(())
+}
+
+fn update_download_total(progress: &Arc<Mutex<DownloadProgress>>, total_size: Option<u64>) {
+    if let Ok(mut progress) = progress.lock() {
+        progress.total_size = total_size;
+        progress.fetched_size = 0;
+    }
+}
+
+fn update_download_phase(progress: &Arc<Mutex<DownloadProgress>>, phase: &'static str) {
+    if let Ok(mut progress) = progress.lock() {
+        progress.phase = phase;
+    }
+}
+
+fn increment_downloaded_size(progress: &Arc<Mutex<DownloadProgress>>, bytes: u64) {
+    if let Ok(mut progress) = progress.lock() {
+        progress.fetched_size += bytes;
+    }
+}
+
+fn mark_download_complete(progress: &Arc<Mutex<DownloadProgress>>) {
+    if let Ok(mut progress) = progress.lock() {
+        progress.done = true;
+    }
+}
+
+fn ensure_symlink(bottle: &BottleFetch) -> BrewResult<()> {
+    if let Some(parent) = bottle.symlink_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+    if bottle.symlink_path.exists() || bottle.symlink_path.is_symlink() {
+        fs::remove_file(&bottle.symlink_path)
+            .with_context(|| format!("Failed to remove {}", bottle.symlink_path.display()))?;
+    }
+    symlink(
+        Path::new("downloads").join(
+            bottle
+                .cached_download
+                .file_name()
+                .ok_or_else(|| anyhow!("Missing cached bottle name for {}", bottle.formula_name))?,
+        ),
+        &bottle.symlink_path,
+    )
+    .with_context(|| format!("Failed to create {}", bottle.symlink_path.display()))?;
+    Ok(())
+}
+
+fn verify_checksum(path: &Path, expected: &str) -> BrewResult<()> {
+    let mut file =
+        File::open(path).with_context(|| format!("Failed to open {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 16 * 1024];
+
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+
+    let actual = format!("{:x}", hasher.finalize());
+    if actual == expected {
+        return Ok(());
+    }
+
+    bail!(
+        "SHA-256 mismatch for {}: expected {}, got {}",
+        path.display(),
+        expected,
+        actual
+    )
+}
+
+fn load_aliases(path: &Path) -> BrewResult<HashMap<String, String>> {
+    if !path.exists() {
+        return Ok(HashMap::new());
+    }
+
+    Ok(homebrew::read_lines(path)?
+        .into_iter()
+        .filter_map(|line| {
+            line.split_once('|')
+                .map(|(alias, canonical)| (alias.to_string(), canonical.to_string()))
+        })
+        .collect())
+}
+
+fn build_client() -> BrewResult<Client> {
+    Client::builder()
+        .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
+        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .build()
+        .context("Failed to build an HTTP client")
+}
+
+fn api_domains() -> Vec<String> {
+    let default_domain = env::var("HOMEBREW_API_DEFAULT_DOMAIN")
+        .unwrap_or_else(|_| "https://formulae.brew.sh/api".to_string());
+    match env::var("HOMEBREW_API_DOMAIN") {
+        Ok(domain) if domain != default_domain => vec![domain, default_domain],
+        Ok(domain) => vec![domain],
+        Err(_) => vec![default_domain],
+    }
+}
+
+fn current_bottle_tag() -> BrewResult<String> {
+    if env_flag("HOMEBREW_LINUX")
+        || env::var("HOMEBREW_SYSTEM")
+            .map(|system| system == "Linux")
+            .unwrap_or(false)
+    {
+        return Ok(format!(
+            "{}_linux",
+            env::var("HOMEBREW_PHYSICAL_PROCESSOR")
+                .or_else(|_| env::var("HOMEBREW_PROCESSOR"))
+                .context("HOMEBREW_PHYSICAL_PROCESSOR is not set")?
+        ));
+    }
+
+    let processor = env::var("HOMEBREW_PHYSICAL_PROCESSOR")
+        .or_else(|_| env::var("HOMEBREW_PROCESSOR"))
+        .context("HOMEBREW_PHYSICAL_PROCESSOR is not set")?;
+    let version = env::var("HOMEBREW_MACOS_VERSION_NUMERIC")
+        .context("HOMEBREW_MACOS_VERSION_NUMERIC is not set")?
+        .parse::<u32>()
+        .context("HOMEBREW_MACOS_VERSION_NUMERIC is invalid")?;
+    let macos = macos_version_name(version).ok_or_else(|| anyhow!("Unsupported macOS version"))?;
+
+    if processor == "x86_64" {
+        Ok(macos.to_string())
+    } else {
+        Ok(format!("{processor}_{macos}"))
+    }
+}
+
+fn macos_version_name(version: u32) -> Option<&'static str> {
+    if version >= 260000 {
+        Some("tahoe")
+    } else if version >= 150000 {
+        Some("sequoia")
+    } else if version >= 140000 {
+        Some("sonoma")
+    } else if version >= 130000 {
+        Some("ventura")
+    } else if version >= 120000 {
+        Some("monterey")
+    } else if version >= 110000 {
+        Some("big_sur")
+    } else if version >= 101500 {
+        Some("catalina")
+    } else {
+        None
+    }
+}
+
+fn bottle_basename(
+    name: &str,
+    version: &str,
+    revision: u32,
+    tag: &str,
+    rebuild: u32,
+    url: &str,
+) -> String {
+    let pkg_version = pkg_version(version, revision);
+    let ext = if rebuild == 0 {
+        format!(".{tag}.bottle.tar.gz")
+    } else {
+        format!(".{tag}.bottle.{rebuild}.tar.gz")
+    };
+    let filename = format!("{name}--{pkg_version}{ext}");
+
+    if url.contains("/blobs/sha256:") {
+        filename
+    } else {
+        url::form_urlencoded::byte_serialize(filename.as_bytes()).collect()
+    }
+}
+
+fn pkg_version(version: &str, revision: u32) -> String {
+    if revision == 0 {
+        version.to_string()
+    } else {
+        format!("{version}_{revision}")
+    }
+}
+
+fn download_concurrency(requested_downloads: usize) -> usize {
+    parse_download_concurrency(
+        env::var("HOMEBREW_DOWNLOAD_CONCURRENCY").ok().as_deref(),
+        available_parallelism().map(usize::from).unwrap_or(1),
+        requested_downloads,
+    )
+}
+
+fn is_simple_formula_name(name: &str) -> bool {
+    !name.is_empty()
+        && !name.contains('/')
+        && !name.contains(':')
+        && !name.contains("://")
+        && name.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '@' | '+' | '.' | '_' | '-')
+        })
+}
+
+fn is_homebrew_core_tap(tap: &str) -> bool {
+    tap.eq_ignore_ascii_case("homebrew/core") || tap.eq_ignore_ascii_case("homebrew/homebrew-core")
+}
+
+fn env_value(name: &str) -> Option<String> {
+    env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+fn env_flag(name: &str) -> bool {
+    is_truthy_env_value(env_value(name).as_deref())
+}
+
+fn is_truthy_env_value(value: Option<&str>) -> bool {
+    value
+        .map(|value| {
+            FALSY_ENV_VALUES
+                .iter()
+                .all(|falsy| !value.eq_ignore_ascii_case(falsy))
+        })
+        .unwrap_or(false)
+}
+
+fn parse_download_concurrency(
+    value: Option<&str>,
+    available_threads: usize,
+    requested_downloads: usize,
+) -> usize {
+    let concurrency = match value {
+        Some("auto") | None => available_threads.saturating_mul(2),
+        Some(value) => value
+            .parse::<usize>()
+            .ok()
+            .filter(|value| *value > 0)
+            .unwrap_or(1),
+    };
+
+    concurrency.max(1).min(requested_downloads.max(1))
+}
+
+fn should_send_github_packages_auth(url: &Url) -> bool {
+    should_send_github_packages_auth_for_host(
+        url.host_str(),
+        env_value("HOMEBREW_GITHUB_PACKAGES_AUTH").is_some(),
+        env_value("HOMEBREW_ARTIFACT_DOMAIN").is_some(),
+        env_value("HOMEBREW_DOCKER_REGISTRY_BASIC_AUTH_TOKEN").is_some(),
+        env_value("HOMEBREW_DOCKER_REGISTRY_TOKEN").is_some(),
+    )
+}
+
+fn should_send_github_packages_auth_for_host(
+    host: Option<&str>,
+    github_packages_auth_present: bool,
+    artifact_domain_present: bool,
+    docker_registry_basic_auth_token_present: bool,
+    docker_registry_token_present: bool,
+) -> bool {
+    host.is_some_and(|host| host.eq_ignore_ascii_case("ghcr.io"))
+        && github_packages_auth_present
+        && (!artifact_domain_present
+            || docker_registry_basic_auth_token_present
+            || docker_registry_token_present)
+}
+
+fn temporary_download_path(path: &Path) -> PathBuf {
+    let mut incomplete = OsString::from(path.as_os_str());
+    incomplete.push(".incomplete");
+    PathBuf::from(incomplete)
+}
+
+fn download_progress_enabled() -> bool {
+    io::stdout().is_terminal() && env::var("TERM").map(|term| term != "dumb").unwrap_or(true)
+}
+
+fn should_render_progress(tty_with_cursor_support: bool, _download_threads: usize) -> bool {
+    tty_with_cursor_support
+}
+
+fn terminal_width() -> usize {
+    env::var("COLUMNS")
+        .ok()
+        .and_then(|columns| columns.parse::<usize>().ok())
+        .or_else(|| {
+            tty_command_output("/bin/stty size </dev/tty 2>/dev/null").and_then(|size| {
+                size.split_whitespace()
+                    .nth(1)
+                    .and_then(|width| width.parse::<usize>().ok())
+            })
+        })
+        .or_else(|| {
+            tty_command_output("/usr/bin/tput cols 2>/dev/null")
+                .and_then(|width| width.parse::<usize>().ok())
+        })
+        .filter(|columns| *columns > 0)
+        .unwrap_or(80)
+}
+
+fn tty_command_output(command: &str) -> Option<String> {
+    let output = Command::new("/bin/sh")
+        .arg("-c")
+        .arg(command)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let output = String::from_utf8(output.stdout).ok()?;
+    let output = output.trim();
+    if output.is_empty() {
+        return None;
+    }
+
+    Some(output.to_string())
+}
+
+fn format_progress_message(
+    message: &str,
+    phase: &str,
+    fetched_size: u64,
+    total_size: Option<u64>,
+    width: usize,
+    message_length_max: usize,
+) -> String {
+    let available_width = width.saturating_sub(2);
+    let formatted_fetched_size = format_disk_usage_readable_size(fetched_size);
+    let formatted_total_size = total_size
+        .map(format_disk_usage_readable_size)
+        .unwrap_or_else(|| "-".repeat(7));
+    let mut progress = format!(
+        " {:phase_width$} {formatted_fetched_size}/{formatted_total_size}",
+        capitalize_phase(phase),
+        phase_width = 11,
+    );
+    let bar_length = 4
+        .max(available_width.saturating_sub(progress.len() + message_length_max.saturating_add(1)));
+
+    if phase == "downloading" && total_size.is_some() {
+        let total_size = total_size.unwrap_or(1);
+        let percent = (fetched_size as f64 / total_size.max(1) as f64).clamp(0.0, 1.0);
+        let used = ((percent * bar_length as f64).round() as usize).min(bar_length);
+        progress = format!(
+            " {}{}{}",
+            "#".repeat(used),
+            " ".repeat(bar_length - used),
+            progress
+        );
+    }
+
+    let message_width = available_width.saturating_sub(progress.len());
+    let mut truncated_message = message.chars().take(message_width).collect::<String>();
+    let padding = message_width.saturating_sub(truncated_message.chars().count());
+    truncated_message.push_str(&" ".repeat(padding));
+
+    format!("{truncated_message}{progress}")
+}
+
+fn capitalize_phase(phase: &str) -> String {
+    let mut characters = phase.chars();
+    match characters.next() {
+        Some(first) => format!("{}{}", first.to_ascii_uppercase(), characters.as_str()),
+        None => String::new(),
+    }
+}
+
+fn format_disk_usage_readable_size(size_in_bytes: u64) -> String {
+    let (size, unit) = disk_usage_readable_size_unit(size_in_bytes as f64);
+    format!("{size:>5.1}{unit:>2}")
+}
+
+fn disk_usage_readable_size_unit(size_in_bytes: f64) -> (f64, &'static str) {
+    let mut size = size_in_bytes;
+    let mut unit = "B";
+
+    for next_unit in ["KB", "MB", "GB"] {
+        if round_to_precision(size, 1) < 1000.0 {
+            break;
+        }
+
+        size /= 1000.0;
+        unit = next_unit;
+    }
+
+    (size, unit)
+}
+
+fn round_to_precision(value: f64, precision: u32) -> f64 {
+    let multiplier = 10_f64.powi(precision as i32);
+    (value * multiplier).round() / multiplier
+}
+
+struct ProgressRenderer {
+    active: Arc<AtomicBool>,
+    handle: thread::JoinHandle<()>,
+}
+
+impl ProgressRenderer {
+    fn start(progress: &[Arc<Mutex<DownloadProgress>>]) -> Self {
+        let active = Arc::new(AtomicBool::new(true));
+        let progress = progress.to_vec();
+        let thread_active = Arc::clone(&active);
+
+        let handle = thread::spawn(move || {
+            let mut stdout = io::stdout();
+            let mut spinner = Spinner::new();
+            let mut initial_render = true;
+            let terminal_width = terminal_width();
+            let message_length_max = progress
+                .iter()
+                .filter_map(|entry| entry.lock().ok().map(|entry| entry.message.len()))
+                .max()
+                .unwrap_or(0);
+            let _ = write!(stdout, "\x1b[?25l");
+            let mut rendered_lines = 0;
+            let mut printed_done = vec![false; progress.len()];
+
+            loop {
+                if initial_render {
+                    thread::sleep(Duration::from_millis(50));
+                    initial_render = false;
+                }
+
+                clear_rendered_lines(&mut stdout, rendered_lines);
+
+                let snapshots = progress
+                    .iter()
+                    .filter_map(|entry| entry.lock().ok().map(|entry| entry.clone()))
+                    .collect::<Vec<_>>();
+                let pending_lines = snapshots
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, entry)| {
+                        if entry.done {
+                            if !printed_done[index] {
+                                let _ =
+                                    writeln!(stdout, "{ANSI_GREEN}✔︎{ANSI_RESET} {}", entry.message);
+                                printed_done[index] = true;
+                            }
+                            return None;
+                        }
+
+                        Some(format!(
+                            "{ANSI_BLUE}{}{ANSI_RESET} {}",
+                            spinner.frame(),
+                            format_progress_message(
+                                &entry.message,
+                                entry.phase,
+                                entry.fetched_size,
+                                entry.total_size,
+                                terminal_width,
+                                message_length_max,
+                            )
+                        ))
+                    })
+                    .collect::<Vec<_>>();
+
+                rendered_lines = pending_lines.len();
+                for (index, line) in pending_lines.iter().enumerate() {
+                    let _ = write!(stdout, "{line}\x1b[K");
+                    if index + 1 < pending_lines.len() {
+                        let _ = writeln!(stdout);
+                    }
+                }
+                let _ = stdout.flush();
+
+                if !thread_active.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                if rendered_lines == 1 {
+                    let _ = write!(stdout, "\r");
+                } else if rendered_lines > 1 {
+                    let _ = write!(stdout, "\x1b[{}A\r", rendered_lines - 1);
+                }
+
+                thread::sleep(Duration::from_millis(50));
+            }
+
+            clear_rendered_lines(&mut stdout, rendered_lines);
+            let _ = write!(stdout, "\x1b[?25h");
+            let _ = stdout.flush();
+        });
+
+        Self { active, handle }
+    }
+
+    fn stop(self) {
+        self.active.store(false, Ordering::Relaxed);
+        let _ = self.handle.join();
+    }
+}
+
+fn clear_rendered_lines(stdout: &mut impl Write, lines: usize) {
+    if lines == 0 {
+        return;
+    }
+
+    let _ = write!(stdout, "\r");
+    if lines > 1 {
+        let _ = write!(stdout, "\x1b[{}A", lines - 1);
+    }
+
+    for index in 0..lines {
+        let _ = write!(stdout, "\x1b[2K");
+        if index + 1 < lines {
+            let _ = writeln!(stdout);
+        }
+    }
+
+    if lines > 1 {
+        let _ = write!(stdout, "\x1b[{}A", lines - 1);
+    }
+    let _ = write!(stdout, "\r");
+}
+
+struct Spinner {
+    start: Instant,
+    index: usize,
+}
+
+impl Spinner {
+    fn new() -> Self {
+        Self {
+            start: Instant::now(),
+            index: 0,
+        }
+    }
+
+    fn frame(&mut self) -> &'static str {
+        const FRAMES: [&str; 10] = ["⠋", "⠙", "⠚", "⠞", "⠖", "⠦", "⠴", "⠲", "⠳", "⠓"];
+
+        if self.start.elapsed() >= Duration::from_millis(100) {
+            self.start = Instant::now();
+            self.index = (self.index + 1) % FRAMES.len();
+        }
+
+        FRAMES[self.index]
+    }
+}
+
+fn sha256_hex_str(value: &str) -> String {
+    format!("{:x}", Sha256::digest(value.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        bottle_basename, format_disk_usage_readable_size, format_progress_message,
+        is_homebrew_core_tap, is_simple_formula_name, is_truthy_env_value,
+        parse_download_concurrency, parse_formula_json_from_signed_cache, pkg_version,
+        should_render_progress, should_send_github_packages_auth_for_host, temporary_download_path,
+    };
+    use std::ffi::OsString;
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+    use std::path::PathBuf;
+
+    #[test]
+    fn allows_simple_formula_names() {
+        assert!(is_simple_formula_name("python@3.12"));
+        assert!(is_simple_formula_name("llvm+mlir"));
+        assert!(!is_simple_formula_name("homebrew/core/jq"));
+        assert!(!is_simple_formula_name("https://example.com/foo.rb"));
+    }
+
+    #[test]
+    fn appends_formula_revisions_to_pkg_versions() {
+        assert_eq!(pkg_version("1.2.3", 0), "1.2.3");
+        assert_eq!(pkg_version("1.2.3", 1), "1.2.3_1");
+    }
+
+    #[test]
+    fn uses_github_packages_bottle_names_for_ghcr_urls() {
+        assert_eq!(
+            bottle_basename(
+                "jq",
+                "1.8.1",
+                0,
+                "x86_64_linux",
+                0,
+                "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:deadbeef",
+            ),
+            "jq--1.8.1.x86_64_linux.bottle.tar.gz"
+        );
+    }
+
+    #[test]
+    fn url_encodes_non_ghcr_bottle_names() {
+        assert_eq!(
+            bottle_basename(
+                "openssl@3",
+                "3.6.1",
+                0,
+                "x86_64_linux",
+                0,
+                "https://example.com/bottles/openssl%403--3.6.1.x86_64_linux.bottle.tar.gz",
+            ),
+            "openssl%403--3.6.1.x86_64_linux.bottle.tar.gz"
+        );
+    }
+
+    #[test]
+    fn caps_download_concurrency_at_the_number_of_requested_downloads() {
+        assert_eq!(parse_download_concurrency(Some("auto"), 4, 3), 3);
+        assert_eq!(parse_download_concurrency(None, 4, 10), 8);
+        assert_eq!(parse_download_concurrency(Some("2"), 4, 10), 2);
+    }
+
+    #[test]
+    fn accepts_both_homebrew_core_tap_spellings() {
+        assert!(is_homebrew_core_tap("homebrew/core"));
+        assert!(is_homebrew_core_tap("Homebrew/homebrew-core"));
+        assert!(is_homebrew_core_tap("HoMeBrEw/CoRe"));
+        assert!(is_homebrew_core_tap("hOmEbReW/HoMeBrEw-CoRe"));
+        assert!(!is_homebrew_core_tap("someone/else"));
+    }
+
+    #[test]
+    fn reads_formulae_from_the_signed_api_cache() {
+        let formula = parse_formula_json_from_signed_cache(
+            r#"{"payload":"[{\"name\":\"wget\",\"full_name\":\"wget\",\"tap\":\"Homebrew/homebrew-core\",\"versions\":{\"stable\":\"1.25.0\"},\"revision\":0,\"bottle\":{\"stable\":{\"rebuild\":0,\"files\":{}}}}]"}"#,
+            "wget",
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(formula.tap, "Homebrew/homebrew-core");
+    }
+
+    #[test]
+    fn treats_falsey_homebrew_boolean_env_values_as_false() {
+        assert!(!is_truthy_env_value(None));
+        assert!(!is_truthy_env_value(Some("0")));
+        assert!(!is_truthy_env_value(Some("false")));
+        assert!(!is_truthy_env_value(Some("No")));
+        assert!(is_truthy_env_value(Some("1")));
+        assert!(is_truthy_env_value(Some("true")));
+    }
+
+    #[test]
+    fn matches_homebrews_disk_usage_alignment() {
+        assert_eq!(format_disk_usage_readable_size(0), "  0.0 B");
+        assert_eq!(format_disk_usage_readable_size(11_700_000), " 11.7MB");
+    }
+
+    #[test]
+    fn formats_progress_lines_like_homebrews_download_queue() {
+        assert_eq!(
+            format_progress_message(
+                "Bottle ffmpeg (8.1)",
+                "downloading",
+                11_000_000,
+                Some(11_700_000),
+                80,
+                19,
+            ),
+            "Bottle ffmpeg (8.1) ############################   Downloading  11.0MB/ 11.7MB"
+        );
+    }
+
+    #[test]
+    fn progress_messages_fill_the_available_width() {
+        assert_eq!(
+            format_progress_message(
+                "Bottle ffmpeg (8.1)",
+                "downloading",
+                11_000_000,
+                Some(11_700_000),
+                120,
+                19,
+            )
+            .chars()
+            .count(),
+            118
+        );
+    }
+
+    #[test]
+    fn renders_live_progress_for_single_downloads_when_tty_support_is_available() {
+        assert!(should_render_progress(true, 1));
+        assert!(!should_render_progress(false, 1));
+    }
+
+    #[test]
+    fn limits_github_packages_auth_to_ghcr_when_ruby_would_send_it() {
+        assert!(should_send_github_packages_auth_for_host(
+            Some("ghcr.io"),
+            true,
+            false,
+            false,
+            false,
+        ));
+        assert!(!should_send_github_packages_auth_for_host(
+            Some("example.com"),
+            true,
+            false,
+            false,
+            false,
+        ));
+        assert!(!should_send_github_packages_auth_for_host(
+            Some("ghcr.io"),
+            true,
+            true,
+            false,
+            false,
+        ));
+        assert!(should_send_github_packages_auth_for_host(
+            Some("ghcr.io"),
+            true,
+            true,
+            false,
+            true,
+        ));
+    }
+
+    #[test]
+    fn preserves_non_utf8_bytes_in_temporary_download_paths() {
+        let path = PathBuf::from(OsString::from_vec(vec![0x66, 0x6f, 0x80, 0x6f]));
+        let temporary_path = temporary_download_path(&path);
+
+        assert_eq!(
+            temporary_path.as_os_str().as_bytes(),
+            &[
+                0x66, 0x6f, 0x80, 0x6f, b'.', b'i', b'n', b'c', b'o', b'm', b'p', b'l', b'e', b't',
+                b'e'
+            ]
+        );
+    }
+}

--- a/Library/Homebrew/rust/brew-rs/src/commands/mod.rs
+++ b/Library/Homebrew/rust/brew-rs/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod fetch;
 pub mod info;
 pub mod install;
 pub mod list;

--- a/Library/Homebrew/rust/brew-rs/src/delegate.rs
+++ b/Library/Homebrew/rust/brew-rs/src/delegate.rs
@@ -13,6 +13,15 @@ pub(crate) fn run_with_warning(args: &[String], command_name: &str) -> BrewResul
     run_command(args)
 }
 
+pub(crate) fn run_with_reason(
+    args: &[String],
+    command_name: &str,
+    reason: &str,
+) -> BrewResult<ExitCode> {
+    eprintln!("Warning: brew-rs is handing {command_name} back to the Ruby backend: {reason}");
+    run_command(args)
+}
+
 fn run_command(args: &[String]) -> BrewResult<ExitCode> {
     let status = Command::new(homebrew::brew_file()?)
         .args(args)

--- a/Library/Homebrew/rust/brew-rs/src/homebrew.rs
+++ b/Library/Homebrew/rust/brew-rs/src/homebrew.rs
@@ -10,6 +10,10 @@ pub(crate) fn cache_api_path() -> BrewResult<PathBuf> {
     Ok(env_path("HOMEBREW_CACHE")?.join("api"))
 }
 
+pub(crate) fn cache_path() -> BrewResult<PathBuf> {
+    env_path("HOMEBREW_CACHE")
+}
+
 pub(crate) fn cellar_path() -> BrewResult<PathBuf> {
     env_path("HOMEBREW_CELLAR")
 }

--- a/Library/Homebrew/rust/brew-rs/tests/cli.rs
+++ b/Library/Homebrew/rust/brew-rs/tests/cli.rs
@@ -56,12 +56,26 @@ end
         path
     }
 
+    fn formula_api_path(&self, name: &str) -> PathBuf {
+        self.cache.join("api/formula").join(format!("{name}.json"))
+    }
+
     fn ruby_command(&self) -> Command {
         let mut command = Command::new(&self.brew_file);
         command.current_dir(repo_root());
         for (key, value) in self.common_env() {
             command.env(key, value);
         }
+        command
+    }
+
+    fn gated_rust_command(&self) -> Command {
+        let mut command = Command::new(&self.brew_file);
+        command.current_dir(repo_root());
+        for (key, value) in self.common_env() {
+            command.env(key, value);
+        }
+        command.env("HOMEBREW_EXPERIMENTAL_RUST_FRONTEND", "1");
         command
     }
 
@@ -74,7 +88,7 @@ end
         command
     }
 
-    fn common_env(&self) -> [(OsString, OsString); 9] {
+    fn common_env(&self) -> [(OsString, OsString); 13] {
         [
             (
                 "HOMEBREW_BREW_FILE".into(),
@@ -90,13 +104,23 @@ end
                 self.cellar.clone().into_os_string(),
             ),
             ("HOMEBREW_DEVELOPER".into(), OsString::from("1")),
+            ("HOMEBREW_LINUX".into(), OsString::from("1")),
+            (
+                "HOMEBREW_MACOS_VERSION_NUMERIC".into(),
+                OsString::from("000000"),
+            ),
             ("HOMEBREW_NO_AUTO_UPDATE".into(), OsString::from("1")),
             ("HOMEBREW_NO_COLOR".into(), OsString::from("1")),
             ("HOMEBREW_NO_ENV_HINTS".into(), OsString::from("1")),
             (
+                "HOMEBREW_PHYSICAL_PROCESSOR".into(),
+                OsString::from("x86_64"),
+            ),
+            (
                 "HOMEBREW_PREFIX".into(),
                 self.prefix.clone().into_os_string(),
             ),
+            ("HOMEBREW_SYSTEM".into(), OsString::from("Linux")),
         ]
     }
 }
@@ -120,6 +144,30 @@ fn search_uses_the_rust_search_flow() {
     assert_eq!(
         String::from_utf8(output.stdout).unwrap(),
         "testball\n\nlocal-caffeine\n"
+    );
+}
+
+#[test]
+fn brew_sh_routes_supported_commands_to_brew_rs_outside_the_default_prefix() {
+    let context = TestContext::new();
+    let api_cache = context.cache.join("api");
+
+    fs::create_dir_all(&api_cache).unwrap();
+    fs::write(api_cache.join("formula_names.txt"), "testball\n").unwrap();
+    fs::write(api_cache.join("cask_names.txt"), "").unwrap();
+
+    let output = context
+        .gated_rust_command()
+        .args(["search", "testbal"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), "testball\n");
+    assert!(
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .contains("using the experimental brew-rs Rust frontend."),
     );
 }
 
@@ -225,6 +273,241 @@ fn list_uses_the_linked_keg_when_listing_formula_files() {
     assert_eq!(rust_output.stdout, ruby_output.stdout);
 }
 
+#[test]
+fn fetch_downloads_a_homebrew_core_bottle_to_the_homebrew_cache() {
+    let context = TestContext::new();
+    let bottle_source = context
+        .prefix
+        .join("testball--1.0.x86_64_linux.bottle.tar.gz");
+    let bottle_contents = b"testball bottle";
+    let bottle_sha256 = sha256_hex(bottle_contents);
+    let bottle_url_sha256 = sha256_hex(format!("file://{}", bottle_source.display()).as_bytes());
+
+    fs::write(&bottle_source, bottle_contents).unwrap();
+    fs::create_dir_all(context.formula_api_path("testball").parent().unwrap()).unwrap();
+    fs::write(
+        context.formula_api_path("testball"),
+        format!(
+            r#"{{
+  "name": "testball",
+  "full_name": "testball",
+  "tap": "homebrew/core",
+  "versions": {{
+    "stable": "1.0"
+  }},
+  "revision": 0,
+  "bottle": {{
+    "stable": {{
+      "rebuild": 0,
+      "files": {{
+        "x86_64_linux": {{
+          "url": "file://{}",
+          "sha256": "{}"
+        }}
+      }}
+    }}
+  }}
+}}"#,
+            bottle_source.display(),
+            bottle_sha256,
+        ),
+    )
+    .unwrap();
+
+    let output = context
+        .rust_command()
+        .args(["fetch", "testball"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout.clone()).unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert!(stdout.contains("Bottle testball (1.0)"), "{stdout}");
+    assert!(context.cache.join("testball--1.0").is_symlink());
+    assert_eq!(
+        fs::read_link(context.cache.join("testball--1.0")).unwrap(),
+        PathBuf::from(format!(
+            "downloads/{bottle_url_sha256}--testball--1.0.x86_64_linux.bottle.tar.gz"
+        ))
+    );
+    assert_eq!(
+        fs::read(context.cache.join("downloads").join(format!(
+            "{bottle_url_sha256}--testball--1.0.x86_64_linux.bottle.tar.gz"
+        )),)
+        .unwrap(),
+        bottle_contents
+    );
+}
+
+#[test]
+fn fetch_downloads_multiple_bottles_in_one_invocation() {
+    let context = TestContext::new();
+
+    for name in ["testball1", "testball2"] {
+        let bottle_source = context
+            .prefix
+            .join(format!("{name}--1.0.x86_64_linux.bottle.tar.gz"));
+        let bottle_contents = format!("{name} bottle");
+        let bottle_sha256 = sha256_hex(bottle_contents.as_bytes());
+
+        fs::write(&bottle_source, bottle_contents).unwrap();
+        fs::create_dir_all(context.formula_api_path(name).parent().unwrap()).unwrap();
+        fs::write(
+            context.formula_api_path(name),
+            format!(
+                r#"{{
+  "name": "{name}",
+  "full_name": "{name}",
+  "tap": "homebrew/core",
+  "versions": {{
+    "stable": "1.0"
+  }},
+  "revision": 0,
+  "bottle": {{
+    "stable": {{
+      "rebuild": 0,
+      "files": {{
+        "x86_64_linux": {{
+          "url": "file://{}",
+          "sha256": "{}"
+        }}
+      }}
+    }}
+  }}
+}}"#,
+                bottle_source.display(),
+                bottle_sha256,
+            ),
+        )
+        .unwrap();
+    }
+
+    let output = context
+        .rust_command()
+        .env("HOMEBREW_DOWNLOAD_CONCURRENCY", "2")
+        .args(["fetch", "testball1", "testball2"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout.clone()).unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert!(stdout.contains("Bottle testball1 (1.0)"), "{stdout}");
+    assert!(stdout.contains("Bottle testball2 (1.0)"), "{stdout}");
+    assert!(context.cache.join("testball1--1.0").is_symlink());
+    assert!(context.cache.join("testball2--1.0").is_symlink());
+}
+
+#[test]
+fn fetch_deduplicates_duplicate_formula_names() {
+    let context = TestContext::new();
+
+    let bottle_source = context
+        .prefix
+        .join("testball--1.0.x86_64_linux.bottle.tar.gz");
+    let bottle_contents = b"testball bottle";
+    let bottle_sha256 = sha256_hex(bottle_contents);
+
+    fs::write(&bottle_source, bottle_contents).unwrap();
+    fs::create_dir_all(context.formula_api_path("testball").parent().unwrap()).unwrap();
+    fs::write(
+        context.formula_api_path("testball"),
+        format!(
+            r#"{{
+  "name": "testball",
+  "full_name": "testball",
+  "tap": "homebrew/core",
+  "versions": {{
+    "stable": "1.0"
+  }},
+  "revision": 0,
+  "bottle": {{
+    "stable": {{
+      "rebuild": 0,
+      "files": {{
+        "x86_64_linux": {{
+          "url": "file://{}",
+          "sha256": "{}"
+        }}
+      }}
+    }}
+  }}
+}}"#,
+            bottle_source.display(),
+            bottle_sha256,
+        ),
+    )
+    .unwrap();
+
+    let output = context
+        .rust_command()
+        .args(["fetch", "testball", "testball"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout.clone()).unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        stdout.matches("Bottle testball (1.0)").count(),
+        1,
+        "{stdout}"
+    );
+}
+
+#[test]
+fn fetch_delegates_to_ruby_with_a_reason_when_flags_are_used() {
+    let context = TestContext::new();
+
+    let output = context
+        .rust_command()
+        .args(["fetch", "--help"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert!(String::from_utf8(output.stderr).unwrap().contains(
+        "Warning: brew-rs is handing fetch back to the Ruby backend: flags are not yet supported."
+    ),);
+}
+
+#[test]
+fn fetch_delegates_to_ruby_with_a_reason_when_a_bottle_is_unavailable() {
+    let context = TestContext::new();
+
+    fs::create_dir_all(context.formula_api_path("testball").parent().unwrap()).unwrap();
+    fs::write(
+        context.formula_api_path("testball"),
+        r#"{
+  "name": "testball",
+  "full_name": "testball",
+  "tap": "homebrew/core",
+  "versions": {
+    "stable": "1.0"
+  },
+  "revision": 0,
+  "bottle": {
+    "stable": {
+      "rebuild": 0,
+      "files": {}
+    }
+  }
+}"#,
+    )
+    .unwrap();
+
+    let output = context
+        .rust_command()
+        .args(["fetch", "testball"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{output:?}");
+    assert!(
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .contains("Warning: brew-rs is handing fetch back to the Ruby backend: `testball` does not have a bottle for `x86_64_linux`."),
+    );
+}
+
 fn new_tempdir() -> TestDir {
     let root = repo_root().join("tmp");
     fs::create_dir_all(&root).unwrap();
@@ -259,6 +542,12 @@ impl TestDir {
     fn path(&self) -> &Path {
         &self.0
     }
+}
+
+fn sha256_hex(input: impl AsRef<[u8]>) -> String {
+    use sha2::Digest;
+
+    format!("{:x}", sha2::Sha256::digest(input.as_ref()))
 }
 
 impl Drop for TestDir {


### PR DESCRIPTION
- implement bottle-only fetch for simple homebrew/core formulae
- match fetch output and progress more closely to Ruby
- add helper and AGENTS guidance for local Rust frontend work

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

OpenAI Codex 5.4 xhigh with several local review and testing passes.

-----
