### PR TITLE
bundle/brew_services: tolerate missing launchctl/systemctl

### DIFF
--- a/Library/Homebrew/bundle/brew_services.rb
+++ b/Library/Homebrew/bundle/brew_services.rb
@@ -59,10 +59,10 @@ module Homebrew
           end
 
           def started_services
-            @started_services ||= begin
-              if !Homebrew::Services::System.launchctl? && !Homebrew::Services::System.systemctl?
-                odie Homebrew::Services::System::MISSING_DAEMON_MANAGER_EXCEPTION_MESSAGE
-              end
+            @started_services ||= if !Homebrew::Services::System.launchctl? && !Homebrew::Services::System.systemctl?
+              opoo "Skipping `brew services list` due to missing launchctl/systemctl"
+              []
+            else
               states_to_skip = %w[stopped none]
 
               services_list = JSON.parse(Utils.safe_popen_read(HOMEBREW_BREW_FILE, "services", "list", "--json"))

--- a/Library/Homebrew/test/bundle/brew_services_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_services_spec.rb
@@ -34,12 +34,9 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
       expect(described_class.started_services).to eq([])
     end
 
-    it "exits with error when no daemon manager is available" do
+    it "returns empty array when no daemon manager is available" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: false)
-      expect do
-        described_class.started_services
-      end.to raise_error(SystemExit)
-        .and output(/supported only on macOS or Linux/).to_stderr
+      expect(described_class.started_services).to eq([])
     end
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Different approach to fix #21720 by not treating a missing `systemctl` as a fatal error, which I found surprising

See also https://github.com/Homebrew/brew/pull/21722#issuecomment-4053841360