### PR TITLE
bundle/brew_services: avoid shelling out to `brew`

### DIFF
--- a/Library/Homebrew/bundle/brew_services.rb
+++ b/Library/Homebrew/bundle/brew_services.rb
@@ -63,11 +63,11 @@ module Homebrew
               if !Homebrew::Services::System.launchctl? && !Homebrew::Services::System.systemctl?
                 odie Homebrew::Services::System::MISSING_DAEMON_MANAGER_EXCEPTION_MESSAGE
               end
-              states_to_skip = %w[stopped none]
+              states_to_skip = [:stopped, :none]
 
-              services_list = JSON.parse(Utils.safe_popen_read(HOMEBREW_BREW_FILE, "services", "list", "--json"))
-              services_list.filter_map do |hash|
-                hash.fetch("name") if states_to_skip.exclude?(hash.fetch("status"))
+              require "services/formulae"
+              Homebrew::Services::Formulae.services_list.filter_map do |hash|
+                hash.fetch(:name) if states_to_skip.exclude?(hash.fetch(:status))
               end
             end
           end

--- a/Library/Homebrew/test/bundle/brew_services_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_services_spec.rb
@@ -2,6 +2,7 @@
 
 require "bundle"
 require "bundle/brew_services"
+require "services/formulae"
 
 RSpec.describe Homebrew::Bundle::Brew::Services do
   describe ".started_services" do
@@ -10,27 +11,27 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
     end
 
     it "returns started services" do
-      allow(Utils).to receive(:safe_popen_read).and_return <<~EOS
+      allow(Homebrew::Services::Formulae).to receive(:services_list).and_return(
         [
           {
-            "name": "nginx",
-            "status": "started"
+            name:   "nginx",
+            status: :started,
           },
           {
-            "name": "apache",
-            "status": "stopped"
+            name:   "apache",
+            status: :stopped,
           },
           {
-            "name": "mysql",
-            "status": "started"
-          }
-        ]
-      EOS
+            name:   "mysql",
+            status: :started,
+          },
+        ],
+      )
       expect(described_class.started_services).to contain_exactly("nginx", "mysql")
     end
 
     it "returns empty array when no services exist" do
-      allow(Utils).to receive(:safe_popen_read).and_return("[]\n")
+      allow(Homebrew::Services::Formulae).to receive(:services_list).and_return([])
       expect(described_class.started_services).to eq([])
     end
 

--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -5,6 +5,7 @@ require "bundle/brew"
 require "bundle/brew_services"
 require "tsort"
 require "formula"
+require "services/formulae"
 require "tab"
 require "utils/bottles"
 
@@ -224,7 +225,7 @@ RSpec.describe Homebrew::Bundle::Brew do
     describe "#dump" do
       it "returns a dump string with installed formulae" do
         expect(Formula).to receive(:installed).and_return([foo, bar, baz])
-        allow(Utils).to receive(:safe_popen_read).and_return("[]")
+        allow(Homebrew::Services::Formulae).to receive(:services_list).and_return([])
         expected = <<~EOS
           # barfoo
           brew "bar"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`brew services` and `brew bundle` now live in this repo, so we can try
to avoid shelling out to `brew` when we don't need to.

There are still multiple other places this is happening, but I'll leave
those for future work (which I'll try to get to soon).
