### PR TITLE
brew-rs: enable strip for release

### DIFF
--- a/Library/Homebrew/rust/brew-rs/Cargo.toml
+++ b/Library/Homebrew/rust/brew-rs/Cargo.toml
@@ -25,3 +25,6 @@ sha2 = "0.10.9"
 url = "2.5.7"
 # Traverse installed formula and cask state under existing Homebrew paths.
 walkdir = "2.5.0"
+
+[profile.release]
+strip = "symbols"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Unless we need (or would benefit from) symbols, stripping them reduces binary size from 6.3 MB to 5 MB without any notable change to build time.

Binary size could be further reduced to 3.9 MB by adding `codegen-units = 1` and `lto = true` to `profile.release` but it doubles compile time on my machine. It's worth doing if/when we get to a point where we compile `brew-rs` in CI and ship binaries to users but I've left those off for now to keep compile time down.

That said, feel free to pass on this if it's not beneficial at this stage.