### PR TITLE
services/system: print warnings to stderr instead of stdout

### DIFF
--- a/Library/Homebrew/services/system.rb
+++ b/Library/Homebrew/services/system.rb
@@ -98,8 +98,8 @@ module Homebrew
               opoo "uid and euid do not match, using user/* instead of gui/* domain!"
             end
             unless Homebrew::EnvConfig.no_env_hints?
-              puts "Hide this warning by setting `HOMEBREW_SERVICES_NO_DOMAIN_WARNING=1`."
-              puts "Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`)."
+              $stderr.puts "Hide this warning by setting `HOMEBREW_SERVICES_NO_DOMAIN_WARNING=1`."
+              $stderr.puts "Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`)."
             end
             @output_warning = T.let(true, T.nilable(TrueClass))
           end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

in https://github.com/Homebrew/brew/pull/21830

https://github.com/Homebrew/brew/pull/21830/changes/ac06ea7e41d5ed4bdd9f0db7e097bfd6030e7937 seem to break my nix-darwin configuration as nix-darwin is executing the bundle command with root

https://github.com/nix-darwin/nix-darwin/blob/da529ac9e46f25ed5616fd634079a5f3c579135f/modules/homebrew.nix#L951

thus these two warning prints lines to stdout mess with json parsing

https://github.com/Homebrew/brew/blob/86fe878aed061345dc557ef6abb0ba61912199fd/Library/Homebrew/services/system.rb#L101

and im getting confusing errors like this:

```
Homebrew bundle...
Using stepbrobd/tap
Using resonative/proaudio
Using lyraphase/av-casks
Using nextfire/tap
Using apple-music-discord-rpc
Error: unexpected character: 'Hide' at line 1 column 1
Warning: Removed Sorbet lines from backtrace!
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/4.0.2/lib/ruby/4.0.0/json/common.rb:353:in 'JSON::Ext::Parser.parse'
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/4.0.2/lib/ruby/4.0.0/json/common.rb:353:in 'JSON.parse'
/opt/homebrew/Library/Homebrew/bundle/brew_services.rb:68:in 'Homebrew::Bundle::Brew::Services.started_services'
/opt/homebrew/Library/Homebrew/bundle/brew_services.rb:58:in 'Homebrew::Bundle::Brew::Services.started?'
/opt/homebrew/Library/Homebrew/bundle/brew.rb:417:in 'Homebrew::Bundle::Brew#start_service_needed?'
/opt/homebrew/Library/Homebrew/bundle/brew.rb:443:in 'Homebrew::Bundle::Brew#service_change_state!'
/opt/homebrew/Library/Homebrew/bundle/brew.rb:369:in 'Homebrew::Bundle::Brew#install!'
/opt/homebrew/Library/Homebrew/bundle/brew.rb:43:in 'Homebrew::Bundle::Brew.install!'
/opt/homebrew/Library/Homebrew/bundle/installer.rb:70:in 'block in Homebrew::Bundle::Installer.install!'
/opt/homebrew/Library/Homebrew/bundle/installer.rb:56:in 'Array#each'
/opt/homebrew/Library/Homebrew/bundle/installer.rb:56:in 'Homebrew::Bundle::Installer.install!'
/opt/homebrew/Library/Homebrew/bundle/commands/install.rb:25:in 'Homebrew::Bundle::Commands::Install.run'
/opt/homebrew/Library/Homebrew/cmd/bundle.rb:235:in 'Homebrew::Cmd::Bundle#run'
/opt/homebrew/Library/Homebrew/brew.rb:115:in '<main>'
```

this can be reproduced with (remember to change the username, and e> syntax is for nushell only)

```console
$ sudo --preserve-env=PATH --user=ysun --set-home env brew services list --json
Warning: running through sudo, using user/* instead of gui/* domain!
Hide this warning by setting `HOMEBREW_SERVICES_NO_DOMAIN_WARNING=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
[
  {
    "name": "apple-music-discord-rpc",
    "status": "started",
    "user": "ysun",
    "file": "/Users/ysun/Library/LaunchAgents/homebrew.mxcl.apple-music-discord-rpc.plist",
    "exit_code": 0
  }
]
$ sudo --preserve-env=PATH --user=ysun --set-home env brew services list --json e> /dev/null
Hide this warning by setting `HOMEBREW_SERVICES_NO_DOMAIN_WARNING=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
[
  {
    "name": "apple-music-discord-rpc",
    "status": "started",
    "user": "ysun",
    "file": "/Users/ysun/Library/LaunchAgents/homebrew.mxcl.apple-music-discord-rpc.plist",
    "exit_code": 0
  }
]
```


