### PR TITLE
tap-new: use `run_as_real_uid:` instead of `Utils::UID.drop_euid`

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -4,6 +4,7 @@
 require "abstract_command"
 require "erb"
 require "fileutils"
+require "system_command"
 require "tap"
 require "utils/uid"
 
@@ -11,6 +12,7 @@ module Homebrew
   module DevCmd
     class TapNew < AbstractCommand
       include FileUtils
+      include SystemCommand::Mixin
 
       cmd_args do
         usage_banner "`tap-new` [<options>] <user>`/`<repo>"
@@ -216,15 +218,14 @@ module Homebrew
             end
 
             # Use the configuration of the original user, which will have author information and signing keys.
-            Utils::UID.drop_euid do
-              env = { HOME: Utils::UID.uid_home }.compact
-              env[:TMPDIR] = nil if (tmpdir = ENV.fetch("TMPDIR", nil)) && !File.writable?(tmpdir)
-              with_env(env) do
-                safe_system "git", *args, "add", "--all"
-                safe_system "git", *args, "commit", "-m", "Create #{tap} tap"
-                safe_system "git", *args, "branch", "-m", branch
-              end
-            end
+            env = { "HOME" => Utils::UID.uid_home }.compact
+            env["TMPDIR"] = nil if (tmpdir = ENV.fetch("TMPDIR", nil)) && !File.writable?(tmpdir)
+            system_command!("git", args: [*args, "add", "--all"], env:,
+                            print_stdout: true, run_as_real_uid: true)
+            system_command!("git", args: [*args, "commit", "-m", "Create #{tap} tap"], env:,
+                            print_stdout: true, run_as_real_uid: true)
+            system_command!("git", args: [*args, "branch", "-m", branch], env:,
+                            print_stdout: true, run_as_real_uid: true)
           end
         end
 

--- a/Library/Homebrew/utils/uid.rb
+++ b/Library/Homebrew/utils/uid.rb
@@ -3,19 +3,6 @@
 
 module Utils
   module UID
-    sig { type_parameters(:U).params(_block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
-    def self.drop_euid(&_block)
-      return yield if Process.euid == Process.uid
-
-      original_euid = Process.euid
-      begin
-        Process::Sys.seteuid(Process.uid)
-        yield
-      ensure
-        Process::Sys.seteuid(original_euid)
-      end
-    end
-
     sig { returns(T.nilable(String)) }
     def self.uid_home
       require "etc"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Now that `SystemCommand` supports `run_as_real_uid:`, replace the
`Utils::UID.drop_euid` block in `tap-new` with `system_command!` calls
using `run_as_real_uid: true`, and remove the now-unused `drop_euid` method.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

-----

As seen above, I used Claude to generate this PR. I reviewed the diff and ran `brew lgtm` manually.

This is a follow-up to #21838. We should remove `Utils::UID.drop_euid` because it is prone to race conditions.
