### PR TITLE
Support (very, very) basic brew-rs installs

### DIFF
--- a/Library/Homebrew/rust/brew-rs/src/commands/fetch.rs
+++ b/Library/Homebrew/rust/brew-rs/src/commands/fetch.rs
@@ -7,6 +7,7 @@ use rayon::prelude::*;
 use reqwest::blocking::Client;
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use serde::Deserialize;
+use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -49,7 +50,7 @@ pub fn run(args: &[String]) -> BrewResult<ExitCode> {
     let api_cache = homebrew::cache_api_path()?;
     let aliases = load_aliases(&api_cache.join("formula_aliases.txt"))?;
     let bottle_tag = current_bottle_tag()?;
-    let client = Arc::new(build_client()?);
+    let client = build_client()?;
     let mut signed_cache_formulae = None;
     let mut bottles = Vec::with_capacity(args.len() - 1);
     let mut cached_downloads = HashSet::with_capacity(args.len() - 1);
@@ -63,7 +64,8 @@ pub fn run(args: &[String]) -> BrewResult<ExitCode> {
             &bottle_tag,
             &client,
         )? {
-            Resolution::Bottle(bottle) => {
+            Resolution::Bottle(resolved) => {
+                let bottle = resolved.bottle.clone();
                 if cached_downloads.insert(bottle.cached_download.clone()) {
                     bottles.push(bottle);
                 }
@@ -74,6 +76,12 @@ pub fn run(args: &[String]) -> BrewResult<ExitCode> {
         }
     }
 
+    fetch_bottles(&bottles, &client)?;
+
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn fetch_bottles(bottles: &[BottleFetch], client: &Client) -> BrewResult<()> {
     if bottles.len() > 1 {
         println!(
             "Fetching: {}",
@@ -113,7 +121,7 @@ pub fn run(args: &[String]) -> BrewResult<ExitCode> {
                 .par_iter()
                 .zip(progress.par_iter())
                 .try_for_each(|(bottle, progress)| {
-                    fetch_bottle(bottle, client.as_ref(), progress, show_progress)
+                    fetch_bottle(bottle, client, progress, show_progress)
                 })
         });
 
@@ -121,25 +129,30 @@ pub fn run(args: &[String]) -> BrewResult<ExitCode> {
         renderer.stop();
     }
 
-    result?;
-
-    Ok(ExitCode::SUCCESS)
+    result
 }
 
-enum Resolution {
-    Bottle(BottleFetch),
+pub(crate) enum Resolution {
+    Bottle(Box<ResolvedBottle>),
     Delegate(String),
 }
 
 #[derive(Clone, Debug)]
-struct BottleFetch {
-    formula_name: String,
-    display_name: String,
-    display_version: String,
-    bottle_url: String,
-    bottle_sha256: String,
-    cached_download: PathBuf,
-    symlink_path: PathBuf,
+pub(crate) struct ResolvedBottle {
+    pub(crate) formula: FormulaJson,
+    pub(crate) bottle: BottleFetch,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct BottleFetch {
+    pub(crate) formula_name: String,
+    pub(crate) display_name: String,
+    pub(crate) display_version: String,
+    pub(crate) bottle_url: String,
+    pub(crate) bottle_sha256: String,
+    pub(crate) bottle_cellar: Option<String>,
+    pub(crate) cached_download: PathBuf,
+    pub(crate) symlink_path: PathBuf,
 }
 
 #[derive(Clone)]
@@ -151,36 +164,58 @@ struct DownloadProgress {
     done: bool,
 }
 
-#[derive(Deserialize, Clone)]
-struct FormulaJson {
-    name: String,
-    full_name: String,
-    tap: String,
-    versions: Versions,
-    revision: u32,
-    bottle: Option<BottleMetadata>,
+#[derive(Deserialize, Clone, Debug)]
+pub(crate) struct FormulaJson {
+    pub(crate) name: String,
+    pub(crate) full_name: String,
+    pub(crate) tap: String,
+    pub(crate) versions: Versions,
+    pub(crate) revision: u32,
+    #[serde(default)]
+    pub(crate) post_install_defined: Option<bool>,
+    #[serde(default)]
+    pub(crate) dependencies: Vec<Value>,
+    #[serde(default)]
+    pub(crate) build_dependencies: Vec<Value>,
+    #[serde(default)]
+    pub(crate) test_dependencies: Vec<Value>,
+    #[serde(default)]
+    pub(crate) recommended_dependencies: Vec<Value>,
+    #[serde(default)]
+    pub(crate) optional_dependencies: Vec<Value>,
+    #[serde(default)]
+    pub(crate) uses_from_macos: Vec<Value>,
+    #[serde(default)]
+    pub(crate) caveats: Option<String>,
+    #[serde(default)]
+    pub(crate) keg_only_reason: Option<Value>,
+    #[serde(default)]
+    pub(crate) service: Option<Value>,
+    pub(crate) bottle: Option<BottleMetadata>,
 }
 
-#[derive(Deserialize, Clone)]
-struct Versions {
-    stable: String,
+#[derive(Deserialize, Clone, Debug)]
+pub(crate) struct Versions {
+    pub(crate) stable: String,
 }
 
-#[derive(Deserialize, Clone)]
-struct BottleMetadata {
-    stable: Option<BottleStable>,
+#[derive(Deserialize, Clone, Debug)]
+pub(crate) struct BottleMetadata {
+    pub(crate) stable: Option<BottleStable>,
 }
 
-#[derive(Deserialize, Clone)]
-struct BottleStable {
-    rebuild: u32,
-    files: HashMap<String, BottleFile>,
+#[derive(Deserialize, Clone, Debug)]
+pub(crate) struct BottleStable {
+    pub(crate) rebuild: u32,
+    pub(crate) files: HashMap<String, BottleFile>,
 }
 
-#[derive(Deserialize, Clone)]
-struct BottleFile {
-    url: String,
-    sha256: String,
+#[derive(Deserialize, Clone, Debug)]
+pub(crate) struct BottleFile {
+    pub(crate) url: String,
+    pub(crate) sha256: String,
+    #[serde(default)]
+    pub(crate) cellar: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -188,7 +223,7 @@ struct SignedPayload {
     payload: String,
 }
 
-fn resolve_bottle(
+pub(crate) fn resolve_bottle(
     name: &str,
     aliases: &HashMap<String, String>,
     api_cache: &Path,
@@ -246,25 +281,29 @@ fn resolve_bottle(
     // Match the path split used by `Bottle#root_url` and `AbstractFileDownloadStrategy`
     // in `Library/Homebrew/bottle.rb`, `Library/Homebrew/utils/bottles.rb`,
     // and `Library/Homebrew/download_strategy.rb`.
-    Ok(Resolution::Bottle(BottleFetch {
-        formula_name: formula.full_name.clone(),
-        display_name: formula.name.clone(),
-        display_version: pkg_version(&formula.versions.stable, formula.revision),
-        bottle_url: bottle_file.url.clone(),
-        bottle_sha256: bottle_file.sha256.to_ascii_lowercase(),
-        cached_download: cache_path.join("downloads").join(format!(
-            "{}--{bottle_name}",
-            sha256_hex_str(&bottle_file.url)
-        )),
-        symlink_path: cache_path.join(format!(
-            "{}--{}",
-            formula.name,
-            pkg_version(&formula.versions.stable, formula.revision)
-        )),
-    }))
+    Ok(Resolution::Bottle(Box::new(ResolvedBottle {
+        formula: formula.clone(),
+        bottle: BottleFetch {
+            formula_name: formula.full_name.clone(),
+            display_name: formula.name.clone(),
+            display_version: pkg_version(&formula.versions.stable, formula.revision),
+            bottle_url: bottle_file.url.clone(),
+            bottle_sha256: bottle_file.sha256.to_ascii_lowercase(),
+            bottle_cellar: bottle_file.cellar.clone(),
+            cached_download: cache_path.join("downloads").join(format!(
+                "{}--{bottle_name}",
+                sha256_hex_str(&bottle_file.url)
+            )),
+            symlink_path: cache_path.join(format!(
+                "{}--{}",
+                formula.name,
+                pkg_version(&formula.versions.stable, formula.revision)
+            )),
+        },
+    })))
 }
 
-fn load_formula_json(
+pub(crate) fn load_formula_json(
     name: &str,
     api_cache: &Path,
     signed_cache_formulae: &mut Option<HashMap<String, FormulaJson>>,
@@ -613,7 +652,7 @@ fn verify_checksum(path: &Path, expected: &str) -> BrewResult<()> {
     )
 }
 
-fn load_aliases(path: &Path) -> BrewResult<HashMap<String, String>> {
+pub(crate) fn load_aliases(path: &Path) -> BrewResult<HashMap<String, String>> {
     if !path.exists() {
         return Ok(HashMap::new());
     }
@@ -627,7 +666,7 @@ fn load_aliases(path: &Path) -> BrewResult<HashMap<String, String>> {
         .collect())
 }
 
-fn build_client() -> BrewResult<Client> {
+pub(crate) fn build_client() -> BrewResult<Client> {
     Client::builder()
         .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
         .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
@@ -645,7 +684,7 @@ fn api_domains() -> Vec<String> {
     }
 }
 
-fn current_bottle_tag() -> BrewResult<String> {
+pub(crate) fn current_bottle_tag() -> BrewResult<String> {
     if env_flag("HOMEBREW_LINUX")
         || env::var("HOMEBREW_SYSTEM")
             .map(|system| system == "Linux")
@@ -718,7 +757,7 @@ fn bottle_basename(
     }
 }
 
-fn pkg_version(version: &str, revision: u32) -> String {
+pub(crate) fn pkg_version(version: &str, revision: u32) -> String {
     if revision == 0 {
         version.to_string()
     } else {
@@ -734,7 +773,7 @@ fn download_concurrency(requested_downloads: usize) -> usize {
     )
 }
 
-fn is_simple_formula_name(name: &str) -> bool {
+pub(crate) fn is_simple_formula_name(name: &str) -> bool {
     !name.is_empty()
         && !name.contains('/')
         && !name.contains(':')

--- a/Library/Homebrew/rust/brew-rs/src/commands/install.rs
+++ b/Library/Homebrew/rust/brew-rs/src/commands/install.rs
@@ -1,7 +1,297 @@
 use crate::BrewResult;
+use crate::commands::fetch::{self, BottleFetch, FormulaJson, Resolution, ResolvedBottle};
 use crate::delegate;
-use std::process::ExitCode;
+use crate::homebrew;
+use crate::utils::formatter;
+use anyhow::{Context, anyhow, bail};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn run(args: &[String]) -> BrewResult<ExitCode> {
-    delegate::run_with_warning(args, "install")
+    if args.len() != 2 {
+        return delegate::run_with_reason(
+            args,
+            "install",
+            "only a single simple named formula argument is supported.",
+        );
+    }
+    if args[1].starts_with('-') {
+        return delegate::run_with_reason(args, "install", "flags are not yet supported.");
+    }
+    if !fetch::is_simple_formula_name(&args[1]) {
+        return delegate::run_with_reason(
+            args,
+            "install",
+            "only a single simple named formula argument is supported.",
+        );
+    }
+
+    let api_cache = homebrew::cache_api_path()?;
+    let aliases = fetch::load_aliases(&api_cache.join("formula_aliases.txt"))?;
+    let bottle_tag = fetch::current_bottle_tag()?;
+    let client = fetch::build_client()?;
+    let mut signed_cache_formulae = None;
+
+    let resolved = match fetch::resolve_bottle(
+        &args[1],
+        &aliases,
+        &api_cache,
+        &mut signed_cache_formulae,
+        &bottle_tag,
+        &client,
+    )? {
+        Resolution::Bottle(resolved) => resolved,
+        Resolution::Delegate(reason) => return delegate::run_with_reason(args, "install", &reason),
+    };
+
+    if let Some(reason) = basic_install_delegate_reason(&resolved)? {
+        return delegate::run_with_reason(args, "install", &reason);
+    }
+
+    // TODO: Add argument parity for multi-formula installs, local formula paths, taps, and flags.
+    // TODO: Add `FormulaInstaller#check_install_sanity`, locking, and conflict checks before mutating the Cellar.
+    // TODO: Add dependency resolution and installation instead of requiring a leaf bottle formula.
+    // TODO: Add relocation and dynamic linkage handling for bottles that are not `:any_skip_relocation`.
+    // TODO: Add `post_install`, `Tab` writes, SBOM writes, services, caveats, and global post-install hooks.
+    // TODO: Replace the temporary Ruby `brew link` reuse with Rust parity for `Keg#link`.
+    // TODO: Validate bottle archive entries before extraction instead of trusting `tar` to keep paths contained.
+
+    fetch::fetch_bottles(std::slice::from_ref(&resolved.bottle), &client)?;
+    pour_bottle(&resolved)?;
+    link_installed_keg(&resolved.formula.name)
+}
+
+fn basic_install_delegate_reason(resolved: &ResolvedBottle) -> BrewResult<Option<String>> {
+    let formula = &resolved.formula;
+
+    if !formula.dependencies.is_empty()
+        || !formula.build_dependencies.is_empty()
+        || !formula.test_dependencies.is_empty()
+        || !formula.recommended_dependencies.is_empty()
+        || !formula.optional_dependencies.is_empty()
+        || !formula.uses_from_macos.is_empty()
+    {
+        return Ok(Some(format!("`{}` has dependencies.", formula.full_name)));
+    }
+
+    match formula.post_install_defined {
+        Some(false) => {}
+        Some(true) => {
+            return Ok(Some(format!(
+                "`{}` defines `post_install`.",
+                formula.full_name
+            )));
+        }
+        None => {
+            return Ok(Some(format!(
+                "`{}` is missing install metadata for `post_install`.",
+                formula.full_name
+            )));
+        }
+    }
+
+    if !matches!(
+        resolved.bottle.bottle_cellar.as_deref(),
+        Some("any_skip_relocation" | ":any_skip_relocation")
+    ) {
+        return Ok(Some(format!(
+            "`{}` requires bottle relocation support.",
+            formula.full_name
+        )));
+    }
+
+    if formula.keg_only_reason.is_some() {
+        return Ok(Some(format!("`{}` is keg-only.", formula.full_name)));
+    }
+
+    if formula.service.is_some() {
+        return Ok(Some(format!(
+            "`{}` defines service files.",
+            formula.full_name
+        )));
+    }
+
+    if formula
+        .caveats
+        .as_deref()
+        .is_some_and(|caveats| !caveats.trim().is_empty())
+    {
+        return Ok(Some(format!("`{}` defines caveats.", formula.full_name)));
+    }
+
+    let rack = homebrew::cellar_path()?.join(&formula.name);
+    if rack.exists() {
+        return Ok(Some(format!(
+            "reinstalls and upgrades for `{}` are not yet supported.",
+            formula.full_name
+        )));
+    }
+
+    let prefix = homebrew::prefix_path()?;
+    if path_exists_or_is_symlink(&prefix.join("opt").join(&formula.name))?
+        || path_exists_or_is_symlink(&prefix.join("var/homebrew/linked").join(&formula.name))?
+    {
+        return Ok(Some(format!(
+            "`{}` already has linked install state.",
+            formula.full_name
+        )));
+    }
+
+    Ok(None)
+}
+
+fn path_exists_or_is_symlink(path: &Path) -> BrewResult<bool> {
+    Ok(path.exists()
+        || fs::symlink_metadata(path)
+            .map(|metadata| metadata.file_type().is_symlink())
+            .unwrap_or(false))
+}
+
+fn pour_bottle(resolved: &ResolvedBottle) -> BrewResult<()> {
+    let cellar = homebrew::cellar_path()?;
+    let rack = cellar.join(&resolved.formula.name);
+    let formula_prefix = installed_prefix(&resolved.formula)?;
+    let staging_root = cellar.join(format!(
+        ".brew-rs-pour-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .context("System clock is before the Unix epoch")?
+            .as_nanos()
+    ));
+
+    let result = (|| {
+        fs::create_dir_all(&cellar)
+            .with_context(|| format!("Failed to create {}", cellar.display()))?;
+        fs::create_dir(&staging_root)
+            .with_context(|| format!("Failed to create {}", staging_root.display()))?;
+
+        formatter::ohai(format!("Pouring {}", display_bottle_basename(&resolved.bottle)?).as_str());
+
+        let status = Command::new("tar")
+            .arg("--extract")
+            .arg("--no-same-owner")
+            .arg("--file")
+            .arg(&resolved.bottle.cached_download)
+            .arg("--directory")
+            .arg(&staging_root)
+            .status()
+            .with_context(|| {
+                format!(
+                    "Failed to extract {}",
+                    resolved.bottle.cached_download.display()
+                )
+            })?;
+        if !status.success() {
+            bail!(
+                "Failed to extract {}",
+                resolved.bottle.cached_download.display()
+            );
+        }
+
+        let staged_prefix = staging_root
+            .join(&resolved.formula.name)
+            .join(fetch::pkg_version(
+                &resolved.formula.versions.stable,
+                resolved.formula.revision,
+            ));
+        if !staged_prefix.is_dir() {
+            bail!(
+                "Bottle {} did not extract {}",
+                resolved.bottle.formula_name,
+                formula_prefix.display()
+            );
+        }
+
+        fs::create_dir_all(&rack)
+            .with_context(|| format!("Failed to create {}", rack.display()))?;
+        fs::rename(&staged_prefix, &formula_prefix).with_context(|| {
+            format!(
+                "Failed to move {} to {}",
+                staged_prefix.display(),
+                formula_prefix.display()
+            )
+        })?;
+        remove_install_metadata(&formula_prefix)?;
+        fs::remove_dir_all(&staging_root)
+            .with_context(|| format!("Failed to remove {}", staging_root.display()))?;
+
+        Ok(())
+    })();
+
+    if result.is_err() {
+        cleanup_failed_pour(&formula_prefix, &staging_root)?;
+    }
+
+    result
+}
+
+fn installed_prefix(formula: &FormulaJson) -> BrewResult<PathBuf> {
+    Ok(homebrew::cellar_path()?
+        .join(&formula.name)
+        .join(fetch::pkg_version(
+            &formula.versions.stable,
+            formula.revision,
+        )))
+}
+
+fn display_bottle_basename(bottle: &BottleFetch) -> BrewResult<String> {
+    let file_name = bottle
+        .cached_download
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow!("Missing bottle filename for {}", bottle.formula_name))?;
+
+    Ok(file_name
+        .split_once("--")
+        .map(|(_, basename)| basename.to_string())
+        .unwrap_or_else(|| file_name.to_string()))
+}
+
+fn remove_install_metadata(formula_prefix: &Path) -> BrewResult<()> {
+    for metadata_name in ["INSTALL_RECEIPT.json", "sbom.spdx.json"] {
+        let metadata_path = formula_prefix.join(metadata_name);
+        if metadata_path.exists() {
+            fs::remove_file(&metadata_path)
+                .with_context(|| format!("Failed to remove {}", metadata_path.display()))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn cleanup_failed_pour(formula_prefix: &Path, staging_root: &Path) -> BrewResult<()> {
+    if formula_prefix.exists() {
+        fs::remove_dir_all(formula_prefix)
+            .with_context(|| format!("Failed to remove {}", formula_prefix.display()))?;
+    }
+
+    if staging_root.exists() {
+        fs::remove_dir_all(staging_root)
+            .with_context(|| format!("Failed to remove {}", staging_root.display()))?;
+    }
+
+    if let Some(rack) = formula_prefix.parent() {
+        let _ = fs::remove_dir(rack);
+    }
+
+    Ok(())
+}
+
+fn link_installed_keg(formula_name: &str) -> BrewResult<ExitCode> {
+    let status = Command::new(homebrew::brew_file()?)
+        .arg("link")
+        .arg(formula_name)
+        .env_remove("HOMEBREW_EXPERIMENTAL_RUST_FRONTEND")
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .context("Failed to run `brew link`")?;
+
+    Ok(ExitCode::from(
+        status.code().unwrap_or(1).clamp(0, 255) as u8
+    ))
 }

--- a/Library/Homebrew/rust/brew-rs/tests/cli.rs
+++ b/Library/Homebrew/rust/brew-rs/tests/cli.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 use std::fs;
-use std::os::unix::fs::symlink;
+use std::os::unix::fs::{PermissionsExt, symlink};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::process::Command;
@@ -505,6 +505,236 @@ fn fetch_delegates_to_ruby_with_a_reason_when_a_bottle_is_unavailable() {
         String::from_utf8(output.stderr)
             .unwrap()
             .contains("Warning: brew-rs is handing fetch back to the Ruby backend: `testball` does not have a bottle for `x86_64_linux`."),
+    );
+}
+
+#[test]
+fn install_pours_and_links_a_basic_bottle_without_persisting_tab_or_sbom() {
+    let context = TestContext::new();
+    let bottle_staging_root = context.cache.join("bottle-staging");
+    let bottle_root = bottle_staging_root.join("testball/1.0");
+    let bottle_source = context
+        .cache
+        .join("testball--1.0.x86_64_linux.bottle.tar.gz");
+
+    fs::create_dir_all(bottle_root.join("bin")).unwrap();
+    fs::create_dir_all(bottle_root.join(".brew")).unwrap();
+    fs::write(bottle_root.join("INSTALL_RECEIPT.json"), "{}").unwrap();
+    fs::write(bottle_root.join("sbom.spdx.json"), "{}").unwrap();
+    fs::write(
+        bottle_root.join(".brew/testball.rb"),
+        "class Testball < Formula\nend\n",
+    )
+    .unwrap();
+    fs::write(bottle_root.join("bin/testball"), "#!/bin/sh\nexit 0\n").unwrap();
+    fs::set_permissions(
+        bottle_root.join("bin/testball"),
+        std::fs::Permissions::from_mode(0o755),
+    )
+    .unwrap();
+
+    let status = Command::new("tar")
+        .args([
+            "-czf",
+            bottle_source.to_str().unwrap(),
+            "-C",
+            bottle_staging_root.to_str().unwrap(),
+            "testball",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let bottle_sha256 = sha256_hex(fs::read(&bottle_source).unwrap());
+
+    fs::create_dir_all(context.formula_api_path("testball").parent().unwrap()).unwrap();
+    fs::write(
+        context.formula_api_path("testball"),
+        format!(
+            r#"{{
+  "name": "testball",
+  "full_name": "testball",
+  "tap": "homebrew/core",
+  "versions": {{
+    "stable": "1.0"
+  }},
+  "revision": 0,
+  "post_install_defined": false,
+  "dependencies": [],
+  "build_dependencies": [],
+  "recommended_dependencies": [],
+  "optional_dependencies": [],
+  "uses_from_macos": [],
+  "bottle": {{
+    "stable": {{
+      "rebuild": 0,
+      "files": {{
+        "x86_64_linux": {{
+          "url": "file://{}",
+          "sha256": "{}",
+          "cellar": ":any_skip_relocation"
+        }}
+      }}
+    }}
+  }}
+}}"#,
+            bottle_source.display(),
+            bottle_sha256,
+        ),
+    )
+    .unwrap();
+
+    let output = context
+        .rust_command()
+        .args(["install", "testball"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert!(
+        !String::from_utf8(output.stderr)
+            .unwrap()
+            .contains("Warning: brew-rs is handing install back to the Ruby backend."),
+    );
+    assert!(context.cellar.join("testball/1.0/bin/testball").exists());
+    assert!(context.prefix.join("bin/testball").exists());
+    assert!(context.prefix.join("opt/testball").is_symlink());
+    assert!(
+        !context
+            .cellar
+            .join("testball/1.0/INSTALL_RECEIPT.json")
+            .exists()
+    );
+    assert!(!context.cellar.join("testball/1.0/sbom.spdx.json").exists());
+}
+
+#[test]
+fn install_cleans_up_when_a_bottle_extracts_an_unexpected_prefix() {
+    let context = TestContext::new();
+    let bottle_staging_root = context.cache.join("bottle-staging");
+    let bottle_root = bottle_staging_root.join("wrongball/1.0");
+    let bottle_source = context
+        .cache
+        .join("testball--1.0.x86_64_linux.bottle.tar.gz");
+
+    fs::create_dir_all(bottle_root.join("bin")).unwrap();
+    fs::write(bottle_root.join("bin/testball"), "#!/bin/sh\nexit 0\n").unwrap();
+    fs::set_permissions(
+        bottle_root.join("bin/testball"),
+        std::fs::Permissions::from_mode(0o755),
+    )
+    .unwrap();
+
+    let status = Command::new("tar")
+        .args([
+            "-czf",
+            bottle_source.to_str().unwrap(),
+            "-C",
+            bottle_staging_root.to_str().unwrap(),
+            "wrongball",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let bottle_sha256 = sha256_hex(fs::read(&bottle_source).unwrap());
+
+    fs::create_dir_all(context.formula_api_path("testball").parent().unwrap()).unwrap();
+    fs::write(
+        context.formula_api_path("testball"),
+        format!(
+            r#"{{
+  "name": "testball",
+  "full_name": "testball",
+  "tap": "homebrew/core",
+  "versions": {{
+    "stable": "1.0"
+  }},
+  "revision": 0,
+  "post_install_defined": false,
+  "dependencies": [],
+  "build_dependencies": [],
+  "recommended_dependencies": [],
+  "optional_dependencies": [],
+  "uses_from_macos": [],
+  "bottle": {{
+    "stable": {{
+      "rebuild": 0,
+      "files": {{
+        "x86_64_linux": {{
+          "url": "file://{}",
+          "sha256": "{}",
+          "cellar": ":any_skip_relocation"
+        }}
+      }}
+    }}
+  }}
+}}"#,
+            bottle_source.display(),
+            bottle_sha256,
+        ),
+    )
+    .unwrap();
+
+    let output = context
+        .rust_command()
+        .args(["install", "testball"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{output:?}");
+    assert!(!context.cellar.join("testball").exists());
+    assert!(!context.cellar.join("wrongball").exists());
+}
+
+#[test]
+fn install_delegates_to_ruby_with_a_reason_when_post_install_is_defined() {
+    let context = TestContext::new();
+
+    fs::create_dir_all(context.formula_api_path("testball").parent().unwrap()).unwrap();
+    fs::write(
+        context.formula_api_path("testball"),
+        r#"{
+  "name": "testball",
+  "full_name": "testball",
+  "tap": "homebrew/core",
+  "versions": {
+    "stable": "1.0"
+  },
+  "revision": 0,
+  "post_install_defined": true,
+  "dependencies": [],
+  "build_dependencies": [],
+  "recommended_dependencies": [],
+  "optional_dependencies": [],
+  "uses_from_macos": [],
+  "bottle": {
+    "stable": {
+      "rebuild": 0,
+      "files": {
+        "x86_64_linux": {
+          "url": "file:///tmp/testball--1.0.x86_64_linux.bottle.tar.gz",
+          "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "cellar": ":any_skip_relocation"
+        }
+      }
+    }
+  }
+}"#,
+    )
+    .unwrap();
+
+    let output = context
+        .rust_command()
+        .args(["install", "testball"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8(output.stderr.clone()).unwrap();
+
+    assert!(
+        stderr
+            .contains("Warning: brew-rs is handing install back to the Ruby backend: `testball` defines `post_install`."),
+        "{output:?}"
     );
 }
 


### PR DESCRIPTION
- keep simple bottle-only `brew install` on the Rust path so the experimental frontend can prove out end-to-end pours before mirroring the full Ruby installer
- reuse the Rust bottle resolution and fetch flow, then call back into `brew link` after the pour while leaving `TODO` markers for relocation, dependencies, `post_install`, tabs, SBOMs and the remaining installer stages
- normalize API cellar values like `:any_skip_relocation` because the live bottle metadata uses that spelling and otherwise delegated real bottles back to Ruby

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

OpenAI Codex used locally and tested/reviewed locally.

-----
