### PR TITLE
style: use per-tap actionlint config when available

### DIFF
--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -4,6 +4,7 @@
 require "shellwords"
 require "source_location"
 require "system_command"
+require "tap"
 require "utils/output"
 
 module Homebrew
@@ -289,9 +290,24 @@ module Homebrew
 
     def self.run_actionlint!(files)
       files = github_workflow_files if files.blank?
+
+      tap_configs = files.filter_map do |f|
+        tap = Tap.from_path(f)
+        next unless tap
+
+        tap_config = tap.path/".github/actionlint.yaml"
+        tap_config if tap_config.exist?
+      end.uniq
+
+      config_file = if tap_configs.one?
+        tap_configs.first
+      else
+        HOMEBREW_REPOSITORY/".github/actionlint.yaml"
+      end
+
       # the ignore is to avoid false positives in e.g. actions, homebrew-test-bot
       system actionlint, "-shellcheck", shellcheck,
-             "-config-file", HOMEBREW_REPOSITORY/".github/actionlint.yaml",
+             "-config-file", config_file,
              "-ignore", "image: string; options: string",
              "-ignore", "label .* is unknown",
              *files

--- a/Library/Homebrew/test/style_spec.rb
+++ b/Library/Homebrew/test/style_spec.rb
@@ -50,6 +50,76 @@ RSpec.describe Homebrew::Style do
     end
   end
 
+  describe ".run_actionlint!" do
+    before do
+      allow(described_class).to receive_messages(actionlint: "actionlint", shellcheck: "shellcheck")
+      allow(described_class).to receive(:system).and_return(true)
+    end
+
+    it "uses a tap's actionlint config when present" do
+      tap_path = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo"
+      workflows_dir = tap_path/".github/workflows"
+      workflows_dir.mkpath
+      workflow = workflows_dir/"ci.yml"
+      workflow.write "name: CI"
+
+      tap_config = tap_path/".github/actionlint.yaml"
+      tap_config.write "self-hosted-runner:\n  labels: []\n"
+
+      expect(described_class).to receive(:system).with(
+        "actionlint", "-shellcheck", "shellcheck",
+        "-config-file", tap_config,
+        "-ignore", "image: string; options: string",
+        "-ignore", "label .* is unknown",
+        workflow
+      )
+
+      described_class.run_actionlint!([workflow])
+    end
+
+    it "falls back to HOMEBREW_REPOSITORY config when no tap config exists" do
+      tap_path = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo"
+      workflows_dir = tap_path/".github/workflows"
+      workflows_dir.mkpath
+      workflow = workflows_dir/"ci.yml"
+      workflow.write "name: CI"
+
+      expect(described_class).to receive(:system).with(
+        "actionlint", "-shellcheck", "shellcheck",
+        "-config-file", HOMEBREW_REPOSITORY/".github/actionlint.yaml",
+        "-ignore", "image: string; options: string",
+        "-ignore", "label .* is unknown",
+        workflow
+      )
+
+      described_class.run_actionlint!([workflow])
+    end
+
+    it "falls back to HOMEBREW_REPOSITORY config when files span multiple taps" do
+      tap1_path = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo"
+      (tap1_path/".github/workflows").mkpath
+      (tap1_path/".github/actionlint.yaml").write "self-hosted-runner:\n  labels: []\n"
+      workflow1 = tap1_path/".github/workflows/ci.yml"
+      workflow1.write "name: CI"
+
+      tap2_path = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-bar"
+      (tap2_path/".github/workflows").mkpath
+      (tap2_path/".github/actionlint.yaml").write "self-hosted-runner:\n  labels: []\n"
+      workflow2 = tap2_path/".github/workflows/ci.yml"
+      workflow2.write "name: CI"
+
+      expect(described_class).to receive(:system).with(
+        "actionlint", "-shellcheck", "shellcheck",
+        "-config-file", HOMEBREW_REPOSITORY/".github/actionlint.yaml",
+        "-ignore", "image: string; options: string",
+        "-ignore", "label .* is unknown",
+        workflow1, workflow2
+      )
+
+      described_class.run_actionlint!([workflow1, workflow2])
+    end
+  end
+
   describe ".run_rubocop" do
     let(:dir) { mktmpdir }
     let(:ruby_file) { dir/"test.rb" }


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used Claude to identify the location of this code and verified my changes through local testing.

-----

actionlint is notoriously slow to merge PR's. This often results in a state where new GitHub Actions features or labels cause errors since actionlint doesn't know about them. We work around this by using a config file.

My personal tap is using a new feature that is causing actionlint failures again. This PR introduces the ability for taps to have their own actionlint config so that tap maintainers have more control over their own workflows.