### PR TITLE
brew-rs: set reqwest user agent

### DIFF
--- a/Library/Homebrew/rust/brew-rs/src/commands/fetch.rs
+++ b/Library/Homebrew/rust/brew-rs/src/commands/fetch.rs
@@ -667,9 +667,16 @@ pub(crate) fn load_aliases(path: &Path) -> BrewResult<HashMap<String, String>> {
 }
 
 pub(crate) fn build_client() -> BrewResult<Client> {
+    let pkg_name_and_version = format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    let user_agent = match env_value("HOMEBREW_USER_AGENT") {
+        Some(brew_ua) => format!("{brew_ua} {pkg_name_and_version}"),
+        None => pkg_name_and_version,
+    };
+
     Client::builder()
         .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
         .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .user_agent(user_agent)
         .gzip(true)
         .deflate(true)
         .build()


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`brew.sh` sets various user agents, like `HOMEBREW_USER_AGENT_CURL` used by curl. This consists of the `HOMEBREW_USER_AGENT` string with the curl version appended (e.g., "Homebrew/5.1.1-73-gb54c872 (Macintosh; arm64 Mac OS X 26.4) curl/8.7.1"). `reqwest` doesn't seem to set a user agent by default, so this modifies the `build_client` function to create a similar user agent string by appending the brew-rs version (like "brew-rs/0.1.0") after `HOMEBREW_USER_AGENT`. The environment variable should always be present when executed by `brew` but this will simply fall back to the brew-rs version string if `HOMEBREW_USER_AGENT` isn't available.