### PR TITLE
upgrade: sort package list alphabetically

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -176,6 +176,7 @@ module Cask
       caught_exceptions = []
 
       puts upgradable_casks
+        .sort_by { |(_, new_cask)| new_cask.full_name }
         .map { |(old_cask, new_cask)| "#{new_cask.full_name} #{old_cask.version} -> #{new_cask.version}" }
         .join("\n")
       return true if dry_run

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -282,7 +282,7 @@ module Homebrew
           verb = args.dry_run? ? "Would upgrade" : "Upgrading"
           oh1 "#{verb} #{formulae_to_install.count} outdated #{Utils.pluralize("package",
                                                                                formulae_to_install.count)}:"
-          formulae_upgrades = formulae_to_install.map do |f|
+          formulae_upgrades = formulae_to_install.sort_by(&:full_specified_name).map do |f|
             if f.optlinked?
               "#{f.full_specified_name} #{Keg.new(f.opt_prefix).version} -> #{f.pkg_version}"
             else

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -255,7 +255,7 @@ module Homebrew
           ohai "#{upgrade_verb} #{Utils.pluralize("dependent", upgradeable.count,
                                                   include_count: true)} of upgraded #{formula_plural}:"
           puts_no_installed_dependents_check_disable_message_if_not_already!
-          formulae_upgrades = upgradeable.map do |f|
+          formulae_upgrades = upgradeable.sort_by(&:full_specified_name).map do |f|
             name = f.full_specified_name
             if f.optlinked?
               "#{name} #{Keg.new(f.opt_prefix).version} -> #{f.pkg_version}"


### PR DESCRIPTION
## Summary
- Sort the displayed list of packages to upgrade alphabetically by name for easier scanning
- Applies to formulae, casks, and dependent formulae lists
- Does not affect upgrade execution order

This helps the user when upgrading many packages, as the list is now sorted for easier readability.

Generated with the help of Claude Code Opus 4.6