### PR TITLE
feat(formula): allow skipping relocation

### DIFF
--- a/Library/Homebrew/ast_constants.rb
+++ b/Library/Homebrew/ast_constants.rb
@@ -40,6 +40,7 @@ FORMULA_COMPONENT_PRECEDENCE_LIST = T.let([
   [{ name: :on_intel, type: :block_call }],
   [{ name: :conflicts_with, type: :method_call }],
   [{ name: :preserve_rpath, type: :method_call }],
+  [{ name: :skip_relocation, type: :method_call }],
   [{ name: :skip_clean, type: :method_call }],
   [{ name: :cxxstdlib_check, type: :method_call }],
   [{ name: :link_overwrite, type: :method_call }],

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -365,6 +365,9 @@ class Formula
   sig { returns(T::Boolean) }
   def preserve_rpath? = self.class.preserve_rpath?
 
+  sig { returns(T::Boolean) }
+  def skip_relocation? = self.class.skip_relocation?
+
   private
 
   # Allow full name logic to be re-used between names, aliases and installed aliases.
@@ -3657,6 +3660,7 @@ class Formula
           [phase, DEFAULT_NETWORK_ACCESS_ALLOWED]
         end, T.nilable(T::Hash[Symbol, T::Boolean]))
         @preserve_rpath = T.let(false, T.nilable(T::Boolean))
+        @skip_relocation = T.let(false, T.nilable(T::Boolean))
         @pypi_packages_info = T.let(nil, T.nilable(PypiPackages))
       end
     end
@@ -3669,6 +3673,7 @@ class Formula
       @skip_clean_paths.freeze
       @link_overwrite_paths.freeze
       @preserve_rpath&.freeze
+      @skip_relocation&.freeze
       super
     end
 
@@ -4461,6 +4466,28 @@ class Formula
     sig { returns(T::Boolean) }
     def preserve_rpath?
       @preserve_rpath == true
+    end
+
+    # Call this method to skip rewriting dynamic linkage after install.
+    #
+    # ### Example
+    #
+    # ```ruby
+    # skip_relocation
+    # ```
+    #
+    # @api public
+    sig { params(value: T::Boolean).returns(T::Boolean) }
+    def skip_relocation(value: true)
+      @skip_relocation = value
+    end
+
+    # Check if dynamic linkage rewriting should be skipped after install.
+    #
+    # @api internal
+    sig { returns(T::Boolean) }
+    def skip_relocation?
+      @skip_relocation == true
     end
 
     # Software that will not be symlinked into the `brew --prefix` and will

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -977,7 +977,9 @@ on_request: installed_on_request?, options:)
 
     install_service
 
-    fix_dynamic_linkage(keg) if !@poured_bottle || !formula.bottle_specification.skip_relocation?
+    if (!@poured_bottle || !formula.bottle_specification.skip_relocation?) && !formula.skip_relocation?
+      fix_dynamic_linkage(keg)
+    end
 
     require "install"
     Homebrew::Install.global_post_install


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?
- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Used Claude to write it, and reviewed the changes and tested that they worked myself.

Happy to write tests if this feature makes sense.

-----

Many third-party formula have dependencies on binaries that cannot be easily
moved, e.g. due to the below error, or due to use of signed binaries. I
understand why we want to enforce relocation for homebrew-core, but for
external formulae I have found that being able to opt out is useful.

```
Error: Failed changing dylib ID of /opt/homebrew/Cellar/myformula/1.2.3/libexec/lib/python3.14/site-packages/cryptography/hazmat/bindings/_rust.abi3.so
  from @rpath/cryptography.hazmat.bindings._rust.abi3.so
    to /opt/homebrew/opt/myformula/libexec/lib/python3.14/site-packages/cryptography/hazmat/bindings/cryptography.hazmat.bindings._rust.abi3.so
Error: Failed to fix install linkage
Updated load commands do not fit in the header of .  needs to be relinked, possibly with -headerpad or -headerpad_max_install_names
The formula built, but you may encounter issues using it or linking other
formulae against it.
```