### PR TITLE
utils/pypi: allow bumping mix of livecheck-defined and PyPI resources

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -330,8 +330,11 @@ module PyPI
       input_packages << extra_package unless input_packages.include? extra_package
     end
 
-    formula.resources.each do |resource|
-      if !print_only && !resource.url.start_with?(PYTHONHOSTED_URL_PREFIX)
+    unless print_only
+      formula.resources.each do |resource|
+        next if resource.url.start_with?(PYTHONHOSTED_URL_PREFIX)
+        next if resource.livecheck_defined?
+
         odie "\"#{formula.name}\" contains non-PyPI resources. Please update the resources manually."
       end
     end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This is specifically for handling resources outside of PyPI resolver like for `aws-sam-cli` formula resource for Go-based `aws-lambda-rie`.

This should not be used for GitHub-source resources that are used to work around missing/broken PyPI sdist.

---

The existing inreplace is able to handle this as we will not capture `livecheck do` resources,
https://github.com/Homebrew/brew/blob/b473a6355b2efaacb4bc4bb9e722ec2b00a64612/Library/Homebrew/utils/pypi.rb#L442-L446

Example run:
- https://github.com/Homebrew/homebrew-core/pull/274788/changes