### PR TITLE
tests: check all of `vendor/bundle` for uncommitted changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -183,7 +183,13 @@ jobs:
 
       - name: Check for uncommitted RubyGems
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
-        run: git diff --stat --exit-code Library/Homebrew/vendor/bundle
+        run: |
+          git diff --stat --exit-code Library/Homebrew/vendor/bundle
+          if [ -n "$(git status --porcelain -- Library/Homebrew/vendor/bundle)" ]; then
+            echo "Untracked or unstaged files found:"
+            git status --porcelain -- Library/Homebrew/vendor/bundle
+            exit 1
+          fi
 
   update-test:
     name: ${{ matrix.name }}


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
The `vendored-gems` CI job checks for uncommitted changes after running `brew install-bundler-gems --groups=all`, but the `git diff` path was scoped to `Library/Homebrew/vendor/bundle/ruby` so we were missing `Library/Homebrew/vendor/bundle/bundler/setup.rb`.

This PR widens the diff check from `vendor/bundle/ruby` to `vendor/bundle` so both `ruby/` and `bundler/` are covered and unvendored gems don't slip through again.