### PR TITLE
upgrade: auto-tap formulae or casks before upgrading

### DIFF
--- a/Library/Homebrew/test/upgrade_spec.rb
+++ b/Library/Homebrew/test/upgrade_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "upgrade"
+
+RSpec.describe Homebrew::Upgrade do
+  describe ".build_dependency_graph" do
+    let(:formulae) { [instance_double(Formula)] }
+    let(:graph) { instance_double(Utils::TopologicalHash) }
+    let(:tap) { instance_double(Tap, user: "test", repository: "tap") }
+
+    it "returns the dependency graph when no tap errors occur" do
+      allow(Utils::TopologicalHash).to receive(:graph_package_dependencies).with(formulae).and_return(graph)
+
+      expect(described_class.send(:build_dependency_graph, formulae)).to eq(graph)
+    end
+
+    it "installs the tap and retries when a dependency's tap is not installed" do
+      error = TapFormulaUnavailableError.new(tap, "formula")
+      attempts = 0
+
+      allow(tap).to receive(:installed?).and_return(false, true)
+      expect(tap).to receive(:ensure_installed!)
+      allow(Utils::TopologicalHash).to receive(:graph_package_dependencies).with(formulae) do
+        attempts += 1
+        raise error if attempts == 1
+
+        graph
+      end
+
+      expect(described_class.send(:build_dependency_graph, formulae)).to eq(graph)
+    end
+
+    it "re-raises when the dependency's tap is already installed" do
+      allow(tap).to receive(:installed?).and_return(true)
+      error = TapFormulaUnavailableError.new(tap, "formula")
+
+      allow(Utils::TopologicalHash).to receive(:graph_package_dependencies).with(formulae).and_raise(error)
+
+      expect { described_class.send(:build_dependency_graph, formulae) }.to raise_error(TapFormulaUnavailableError)
+    end
+
+    it "re-raises when the tap cannot be installed" do
+      allow(tap).to receive(:installed?).and_return(false)
+      error = TapFormulaUnavailableError.new(tap, "formula")
+
+      expect(tap).to receive(:ensure_installed!)
+      allow(Utils::TopologicalHash).to receive(:graph_package_dependencies).with(formulae).and_raise(error)
+
+      expect { described_class.send(:build_dependency_graph, formulae) }.to raise_error(TapFormulaUnavailableError)
+    end
+  end
+end

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -60,7 +60,7 @@ module Homebrew
           end
         end
 
-        dependency_graph = Utils::TopologicalHash.graph_package_dependencies(formulae_to_install)
+        dependency_graph = build_dependency_graph(formulae_to_install)
         begin
           formulae_to_install = dependency_graph.tsort & formulae_to_install
         rescue TSort::Cyclic
@@ -111,6 +111,19 @@ module Homebrew
           end
         end
       end
+
+      sig { params(formulae: T::Array[Formula]).returns(Utils::TopologicalHash) }
+      def build_dependency_graph(formulae)
+        Utils::TopologicalHash.graph_package_dependencies(formulae)
+      rescue TapFormulaUnavailableError => e
+        raise if e.tap.installed?
+
+        e.tap.ensure_installed!
+        retry if e.tap.installed? # It may have not installed if it's a core tap.
+
+        raise
+      end
+      private :build_dependency_graph
 
       sig {
         params(formula_installers: T::Array[FormulaInstaller], dry_run: T::Boolean, verbose: T::Boolean,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?
- [x] AI was used to generate or assist with generating this PR. Claude wrote 

When you `brew install org/tap/formula-name`, it automatically taps the
repo if not present. Mirror this behaviour in `brew upgrade` so that
specifying a tap-prefixed name works the same way.

The use-case here is a formula adding a `depends_on
my-org/my-tap/my-formula` line. This will work fine for people who `brew
install` the formula fresh, but not for people who `brew upgrade` an
existing formula.

I made a similar change for `brew bundle install` in 451eda1b3ffef890642ba7fb30fcdfee2b4c1ea3