### PR TITLE
sorbet: Make tests `typed: false`

### DIFF
--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "extend/ENV"

--- a/Library/Homebrew/test/PATH_spec.rb
+++ b/Library/Homebrew/test/PATH_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "PATH"

--- a/Library/Homebrew/test/abstract_command_spec.rb
+++ b/Library/Homebrew/test/abstract_command_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "abstract_command"

--- a/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
+++ b/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/api/cask_struct_spec.rb
+++ b/Library/Homebrew/test/api/cask_struct_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/api/formula/formula_struct_generator_spec.rb
+++ b/Library/Homebrew/test/api/formula/formula_struct_generator_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/api/formula_struct_spec.rb
+++ b/Library/Homebrew/test/api/formula_struct_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/api/internal_spec.rb
+++ b/Library/Homebrew/test/api/internal_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "api/internal"

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/bash_spec.rb
+++ b/Library/Homebrew/test/bash_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "open3"

--- a/Library/Homebrew/test/bottle_filename_spec.rb
+++ b/Library/Homebrew/test/bottle_filename_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/bottle_spec.rb
+++ b/Library/Homebrew/test/bottle_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bottle_specification"

--- a/Library/Homebrew/test/bottle_specification_spec.rb
+++ b/Library/Homebrew/test/bottle_specification_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bottle_specification"

--- a/Library/Homebrew/test/build_environment_spec.rb
+++ b/Library/Homebrew/test/build_environment_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "build_environment"

--- a/Library/Homebrew/test/build_options_spec.rb
+++ b/Library/Homebrew/test/build_options_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "build_options"

--- a/Library/Homebrew/test/bump_version_parser_spec.rb
+++ b/Library/Homebrew/test/bump_version_parser_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bump_version_parser"

--- a/Library/Homebrew/test/bundle/brew_services_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_services_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/brewfile_spec.rb
+++ b/Library/Homebrew/test/bundle/brewfile_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/bundle_spec.rb
+++ b/Library/Homebrew/test/bundle/bundle_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/cargo_spec.rb
+++ b/Library/Homebrew/test/bundle/cargo_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/cask_spec.rb
+++ b/Library/Homebrew/test/bundle/cask_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/commands/add_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/add_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/commands/check_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/check_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/commands/cleanup_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/cleanup_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/commands/dump_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/dump_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/commands/exec_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/exec_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/commands/install_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/install_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/commands/list_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/list_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/commands/remove_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/remove_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/dsl_spec.rb
+++ b/Library/Homebrew/test/bundle/dsl_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/dumper_spec.rb
+++ b/Library/Homebrew/test/bundle/dumper_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/flatpak_spec.rb
+++ b/Library/Homebrew/test/bundle/flatpak_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/go_spec.rb
+++ b/Library/Homebrew/test/bundle/go_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/krew_spec.rb
+++ b/Library/Homebrew/test/bundle/krew_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/mac_app_store_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/npm_spec.rb
+++ b/Library/Homebrew/test/bundle/npm_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/remover_spec.rb
+++ b/Library/Homebrew/test/bundle/remover_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/skipper_spec.rb
+++ b/Library/Homebrew/test/bundle/skipper_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/tap_spec.rb
+++ b/Library/Homebrew/test/bundle/tap_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/uv_spec.rb
+++ b/Library/Homebrew/test/bundle/uv_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/vscode_extension_spec.rb
+++ b/Library/Homebrew/test/bundle/vscode_extension_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle_version_spec.rb
+++ b/Library/Homebrew/test/bundle_version_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundle_version"

--- a/Library/Homebrew/test/cache_store_spec.rb
+++ b/Library/Homebrew/test/cache_store_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cache_store"

--- a/Library/Homebrew/test/cask/artifact/abstract_artifact_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/abstract_artifact_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::AbstractArtifact, :cask do

--- a/Library/Homebrew/test/cask/artifact/alt_target_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/alt_target_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::App, :cask do

--- a/Library/Homebrew/test/cask/artifact/app_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/app_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::App, :cask do

--- a/Library/Homebrew/test/cask/artifact/bashcompletion_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/bashcompletion_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::BashCompletion, :cask do

--- a/Library/Homebrew/test/cask/artifact/binary_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/binary_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Binary, :cask do

--- a/Library/Homebrew/test/cask/artifact/fishlcompletion_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/fishlcompletion_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::FishCompletion, :cask do

--- a/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do

--- a/Library/Homebrew/test/cask/artifact/generic_artifact_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/generic_artifact_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Artifact, :cask do

--- a/Library/Homebrew/test/cask/artifact/installer_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/installer_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Installer, :cask do

--- a/Library/Homebrew/test/cask/artifact/manpage_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/manpage_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Manpage, :cask do

--- a/Library/Homebrew/test/cask/artifact/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/pkg_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Pkg, :cask do

--- a/Library/Homebrew/test/cask/artifact/postflight_block_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/postflight_block_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::PostflightBlock, :cask do

--- a/Library/Homebrew/test/cask/artifact/preflight_block_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/preflight_block_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::PreflightBlock, :cask do

--- a/Library/Homebrew/test/cask/artifact/relocated_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/relocated_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cask/artifact/relocated"

--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "benchmark"

--- a/Library/Homebrew/test/cask/artifact/suite_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/suite_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Suite, :cask do

--- a/Library/Homebrew/test/cask/artifact/symlinked_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/symlinked_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Symlinked, :cask do

--- a/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::App, :cask do

--- a/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Zap, :cask do

--- a/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples/uninstall_zap"

--- a/Library/Homebrew/test/cask/artifact/zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/zap_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples/uninstall_zap"

--- a/Library/Homebrew/test/cask/artifact/zshcompletion_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/zshcompletion_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::ZshCompletion, :cask do

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cask/audit"

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do

--- a/Library/Homebrew/test/cask/cask_loader/from_content_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_content_loader_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromContentLoader do

--- a/Library/Homebrew/test/cask/cask_loader/from_path_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_path_loader_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromPathLoader do

--- a/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromTapLoader do

--- a/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromURILoader do

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader, :cask do

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Cask, :cask do

--- a/Library/Homebrew/test/cask/config_spec.rb
+++ b/Library/Homebrew/test/cask/config_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Config, :cask do

--- a/Library/Homebrew/test/cask/denylist_spec.rb
+++ b/Library/Homebrew/test/cask/denylist_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cask/denylist"

--- a/Library/Homebrew/test/cask/depends_on_spec.rb
+++ b/Library/Homebrew/test/cask/depends_on_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 # TODO: this test should be named after the corresponding class, once

--- a/Library/Homebrew/test/cask/download_spec.rb
+++ b/Library/Homebrew/test/cask/download_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Download, :cask do

--- a/Library/Homebrew/test/cask/dsl/caveats_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/caveats_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/container_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/container_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/postflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/postflight_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/preflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/preflight_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/rename_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/rename_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::DSL::Rename do

--- a/Library/Homebrew/test/cask/dsl/shared_examples/base.rb
+++ b/Library/Homebrew/test/cask/dsl/shared_examples/base.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cask/dsl/base"

--- a/Library/Homebrew/test/cask/dsl/shared_examples/staged.rb
+++ b/Library/Homebrew/test/cask/dsl/shared_examples/staged.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cask/staged"

--- a/Library/Homebrew/test/cask/dsl/uninstall_postflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/uninstall_postflight_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/uninstall_preflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/uninstall_preflight_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/version_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/version_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::DSL::Version, :cask do

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::DSL, :cask, :no_api do

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils"

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Installer, :cask do

--- a/Library/Homebrew/test/cask/list_spec.rb
+++ b/Library/Homebrew/test/cask/list_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cask/list"

--- a/Library/Homebrew/test/cask/macos_spec.rb
+++ b/Library/Homebrew/test/cask/macos_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe MacOS, :cask do

--- a/Library/Homebrew/test/cask/migrator_spec.rb
+++ b/Library/Homebrew/test/cask/migrator_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cask/migrator"

--- a/Library/Homebrew/test/cask/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/pkg_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Pkg, :cask do

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cask/installer"

--- a/Library/Homebrew/test/cask/tab_spec.rb
+++ b/Library/Homebrew/test/cask/tab_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cask"

--- a/Library/Homebrew/test/cask/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/uninstall_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cask/uninstall"

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cask/upgrade"

--- a/Library/Homebrew/test/cask/utils_spec.rb
+++ b/Library/Homebrew/test/cask/utils_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Cask::Utils do

--- a/Library/Homebrew/test/cask_dependent_spec.rb
+++ b/Library/Homebrew/test/cask_dependent_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cask/cask_loader"

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/checksum_spec.rb
+++ b/Library/Homebrew/test/checksum_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "checksum"

--- a/Library/Homebrew/test/checksum_verification_spec.rb
+++ b/Library/Homebrew/test/checksum_verification_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/cleaner_spec.rb
+++ b/Library/Homebrew/test/cleaner_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cleaner"

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test/support/fixtures/testball"

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cli/named_args"

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "../../cli/parser"

--- a/Library/Homebrew/test/cmd/--cache_spec.rb
+++ b/Library/Homebrew/test/cmd/--cache_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/--cache"

--- a/Library/Homebrew/test/cmd/--caskroom_spec.rb
+++ b/Library/Homebrew/test/cmd/--caskroom_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/--caskroom"

--- a/Library/Homebrew/test/cmd/--cellar_spec.rb
+++ b/Library/Homebrew/test/cmd/--cellar_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/--cellar"

--- a/Library/Homebrew/test/cmd/--env_spec.rb
+++ b/Library/Homebrew/test/cmd/--env_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/--env"

--- a/Library/Homebrew/test/cmd/--prefix_spec.rb
+++ b/Library/Homebrew/test/cmd/--prefix_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/--prefix"

--- a/Library/Homebrew/test/cmd/--repository_spec.rb
+++ b/Library/Homebrew/test/cmd/--repository_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe "brew --repository", type: :system do

--- a/Library/Homebrew/test/cmd/--version_spec.rb
+++ b/Library/Homebrew/test/cmd/--version_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe "brew --version", type: :system do

--- a/Library/Homebrew/test/cmd/alias_spec.rb
+++ b/Library/Homebrew/test/cmd/alias_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/alias"

--- a/Library/Homebrew/test/cmd/analytics_spec.rb
+++ b/Library/Homebrew/test/cmd/analytics_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/analytics"

--- a/Library/Homebrew/test/cmd/autoremove_spec.rb
+++ b/Library/Homebrew/test/cmd/autoremove_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/autoremove"

--- a/Library/Homebrew/test/cmd/bundle_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/bundle"

--- a/Library/Homebrew/test/cmd/casks_spec.rb
+++ b/Library/Homebrew/test/cmd/casks_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe "brew casks", type: :system do

--- a/Library/Homebrew/test/cmd/cleanup_spec.rb
+++ b/Library/Homebrew/test/cmd/cleanup_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/cleanup"

--- a/Library/Homebrew/test/cmd/command-not-found-init_spec.rb
+++ b/Library/Homebrew/test/cmd/command-not-found-init_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/command_spec.rb
+++ b/Library/Homebrew/test/cmd/command_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/commands_spec.rb
+++ b/Library/Homebrew/test/cmd/commands_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/commands"

--- a/Library/Homebrew/test/cmd/completions_spec.rb
+++ b/Library/Homebrew/test/cmd/completions_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/completions"

--- a/Library/Homebrew/test/cmd/config_spec.rb
+++ b/Library/Homebrew/test/cmd/config_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/config"

--- a/Library/Homebrew/test/cmd/custom-external-command_spec.rb
+++ b/Library/Homebrew/test/cmd/custom-external-command_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe "brew custom-external-command", :integration_test, type: :system do

--- a/Library/Homebrew/test/cmd/deps_spec.rb
+++ b/Library/Homebrew/test/cmd/deps_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/deps"

--- a/Library/Homebrew/test/cmd/desc_spec.rb
+++ b/Library/Homebrew/test/cmd/desc_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/desc"

--- a/Library/Homebrew/test/cmd/developer_spec.rb
+++ b/Library/Homebrew/test/cmd/developer_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/developer"

--- a/Library/Homebrew/test/cmd/docs_spec.rb
+++ b/Library/Homebrew/test/cmd/docs_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/docs"

--- a/Library/Homebrew/test/cmd/doctor_spec.rb
+++ b/Library/Homebrew/test/cmd/doctor_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/doctor"

--- a/Library/Homebrew/test/cmd/fetch_spec.rb
+++ b/Library/Homebrew/test/cmd/fetch_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/fetch"

--- a/Library/Homebrew/test/cmd/formulae_spec.rb
+++ b/Library/Homebrew/test/cmd/formulae_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe "brew formulae", type: :system do

--- a/Library/Homebrew/test/cmd/gist-logs_spec.rb
+++ b/Library/Homebrew/test/cmd/gist-logs_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/gist-logs"

--- a/Library/Homebrew/test/cmd/help_spec.rb
+++ b/Library/Homebrew/test/cmd/help_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/help"

--- a/Library/Homebrew/test/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cmd/home_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/home"

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/info"

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/install"

--- a/Library/Homebrew/test/cmd/leaves_spec.rb
+++ b/Library/Homebrew/test/cmd/leaves_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/leaves"

--- a/Library/Homebrew/test/cmd/link_spec.rb
+++ b/Library/Homebrew/test/cmd/link_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/link"

--- a/Library/Homebrew/test/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cmd/list_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/list"

--- a/Library/Homebrew/test/cmd/log_spec.rb
+++ b/Library/Homebrew/test/cmd/log_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/log"

--- a/Library/Homebrew/test/cmd/mcp-server_spec.rb
+++ b/Library/Homebrew/test/cmd/mcp-server_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe "brew mcp-server", type: :system do

--- a/Library/Homebrew/test/cmd/migrate_spec.rb
+++ b/Library/Homebrew/test/cmd/migrate_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/migrate"

--- a/Library/Homebrew/test/cmd/missing_spec.rb
+++ b/Library/Homebrew/test/cmd/missing_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/missing"

--- a/Library/Homebrew/test/cmd/nodenv-sync_spec.rb
+++ b/Library/Homebrew/test/cmd/nodenv-sync_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/nodenv-sync"

--- a/Library/Homebrew/test/cmd/options_spec.rb
+++ b/Library/Homebrew/test/cmd/options_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/options"

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/outdated"

--- a/Library/Homebrew/test/cmd/pin_spec.rb
+++ b/Library/Homebrew/test/cmd/pin_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/pin"

--- a/Library/Homebrew/test/cmd/postinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/postinstall_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/postinstall"

--- a/Library/Homebrew/test/cmd/pyenv-sync_spec.rb
+++ b/Library/Homebrew/test/cmd/pyenv-sync_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/pyenv-sync"

--- a/Library/Homebrew/test/cmd/rbenv-sync_spec.rb
+++ b/Library/Homebrew/test/cmd/rbenv-sync_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/rbenv-sync"

--- a/Library/Homebrew/test/cmd/readall_spec.rb
+++ b/Library/Homebrew/test/cmd/readall_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/readall"

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "extend/ENV"

--- a/Library/Homebrew/test/cmd/search_spec.rb
+++ b/Library/Homebrew/test/cmd/search_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/search"

--- a/Library/Homebrew/test/cmd/services_spec.rb
+++ b/Library/Homebrew/test/cmd/services_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/services"

--- a/Library/Homebrew/test/cmd/setup-ruby_spec.rb
+++ b/Library/Homebrew/test/cmd/setup-ruby_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe "brew setup-ruby", type: :system do

--- a/Library/Homebrew/test/cmd/shared_examples/args_parse.rb
+++ b/Library/Homebrew/test/cmd/shared_examples/args_parse.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.shared_examples "parseable arguments" do |command_name: nil|

--- a/Library/Homebrew/test/cmd/shellenv_spec.rb
+++ b/Library/Homebrew/test/cmd/shellenv_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe "brew shellenv", type: :system do

--- a/Library/Homebrew/test/cmd/source_spec.rb
+++ b/Library/Homebrew/test/cmd/source_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/source"

--- a/Library/Homebrew/test/cmd/tab_spec.rb
+++ b/Library/Homebrew/test/cmd/tab_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/tab"

--- a/Library/Homebrew/test/cmd/tap-info_spec.rb
+++ b/Library/Homebrew/test/cmd/tap-info_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/tap_spec.rb
+++ b/Library/Homebrew/test/cmd/tap_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/unalias_spec.rb
+++ b/Library/Homebrew/test/cmd/unalias_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/unalias"

--- a/Library/Homebrew/test/cmd/uninstall_spec.rb
+++ b/Library/Homebrew/test/cmd/uninstall_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/uninstall"

--- a/Library/Homebrew/test/cmd/unlink_spec.rb
+++ b/Library/Homebrew/test/cmd/unlink_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/unpin_spec.rb
+++ b/Library/Homebrew/test/cmd/unpin_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/untap_spec.rb
+++ b/Library/Homebrew/test/cmd/untap_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/update-report"

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/uses_spec.rb
+++ b/Library/Homebrew/test/cmd/uses_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cli/named_args"

--- a/Library/Homebrew/test/cmd/vendor-install_spec.rb
+++ b/Library/Homebrew/test/cmd/vendor-install_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "open3"

--- a/Library/Homebrew/test/cmd/version-install_spec.rb
+++ b/Library/Homebrew/test/cmd/version-install_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/which-formula_spec.rb
+++ b/Library/Homebrew/test/cmd/which-formula_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/commands_spec.rb
+++ b/Library/Homebrew/test/commands_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "commands"

--- a/Library/Homebrew/test/compiler_failure_spec.rb
+++ b/Library/Homebrew/test/compiler_failure_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "compilers"

--- a/Library/Homebrew/test/compiler_selector_spec.rb
+++ b/Library/Homebrew/test/compiler_selector_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "compilers"

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "completions"

--- a/Library/Homebrew/test/cxxstdlib_spec.rb
+++ b/Library/Homebrew/test/cxxstdlib_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/dependable_spec.rb
+++ b/Library/Homebrew/test/dependable_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "dependable"

--- a/Library/Homebrew/test/dependencies_helpers_spec.rb
+++ b/Library/Homebrew/test/dependencies_helpers_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "dependencies_helpers"

--- a/Library/Homebrew/test/dependencies_spec.rb
+++ b/Library/Homebrew/test/dependencies_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "dependencies"

--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "dependency_collector"

--- a/Library/Homebrew/test/dependency_expansion_spec.rb
+++ b/Library/Homebrew/test/dependency_expansion_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "dependency"

--- a/Library/Homebrew/test/dependency_spec.rb
+++ b/Library/Homebrew/test/dependency_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "dependency"

--- a/Library/Homebrew/test/deprecate_disable_spec.rb
+++ b/Library/Homebrew/test/deprecate_disable_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "deprecate_disable"

--- a/Library/Homebrew/test/description_cache_store_spec.rb
+++ b/Library/Homebrew/test/description_cache_store_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/update-report"

--- a/Library/Homebrew/test/descriptions_spec.rb
+++ b/Library/Homebrew/test/descriptions_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "descriptions"

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "dev-cmd/audit"

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bump-revision_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-revision_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bump-unversioned-casks_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-unversioned-casks_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/cat_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/cat_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/contributions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/contributions_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/create_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/create_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "dev-cmd/determine-test-runners"

--- a/Library/Homebrew/test/dev-cmd/dispatch-build-bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/dispatch-build-bottle_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/edit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/edit_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/extract_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/extract_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/formula-analytics_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/formula-analytics_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/formula_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/formula_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/generate-analytics-api_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-analytics-api_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/generate-cask-api_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-cask-api_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/generate-formula-api_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-formula-api_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/generate-man-completions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-man-completions_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/install-bundler-gems_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/install-bundler-gems_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/irb_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/irb_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/lgtm_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/lgtm_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "open3"

--- a/Library/Homebrew/test/dev-cmd/linkage_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/linkage_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/pr-automerge_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-automerge_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/pr-publish_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-publish_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "dev-cmd/pr-pull"

--- a/Library/Homebrew/test/dev-cmd/pr-upload_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-upload_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/prof_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/prof_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/release_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/release_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/ruby_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/ruby_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/sh_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/sh_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/style_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/style_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/test_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/test_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/typecheck_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/typecheck_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/unbottled_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/unbottled_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/unpack_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/unpack_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/update-license-data_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-license-data_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/update-maintainers_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-maintainers_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/update-perl-resources_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-perl-resources_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/update-python-resources_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-python-resources_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/update-sponsors_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-sponsors_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/update-test_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-test_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/vendor-gems_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/vendor-gems_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/verify_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/verify_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/which-update_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/which-update_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/download_strategies/abstract_spec.rb
+++ b/Library/Homebrew/test/download_strategies/abstract_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/curl_post_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_post_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/curl_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/detector_spec.rb
+++ b/Library/Homebrew/test/download_strategies/detector_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/git_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/github_git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/github_git_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/subversion_spec.rb
+++ b/Library/Homebrew/test/download_strategies/subversion_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/vcs_spec.rb
+++ b/Library/Homebrew/test/download_strategies/vcs_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/error_during_execution_spec.rb
+++ b/Library/Homebrew/test/error_during_execution_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe ErrorDuringExecution do

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "exceptions"

--- a/Library/Homebrew/test/extend/array_spec.rb
+++ b/Library/Homebrew/test/extend/array_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "extend/array"

--- a/Library/Homebrew/test/extend/blank_spec.rb
+++ b/Library/Homebrew/test/extend/blank_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "extend/blank"

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Kernel do

--- a/Library/Homebrew/test/extend/pathname/write_mkpath_extension_spec.rb
+++ b/Library/Homebrew/test/extend/pathname/write_mkpath_extension_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "extend/pathname/write_mkpath_extension"

--- a/Library/Homebrew/test/formatter_spec.rb
+++ b/Library/Homebrew/test/formatter_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/formatter"

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula_auditor"

--- a/Library/Homebrew/test/formula_creator_spec.rb
+++ b/Library/Homebrew/test/formula_creator_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula_creator"

--- a/Library/Homebrew/test/formula_info_spec.rb
+++ b/Library/Homebrew/test/formula_info_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula_info"

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/formula_pin_spec.rb
+++ b/Library/Homebrew/test/formula_pin_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula_pin"

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test/support/fixtures/testball"

--- a/Library/Homebrew/test/formula_spec_selection_spec.rb
+++ b/Library/Homebrew/test/formula_spec_selection_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/formula_validation_spec.rb
+++ b/Library/Homebrew/test/formula_validation_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/free_port_spec.rb
+++ b/Library/Homebrew/test/free_port_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "socket"

--- a/Library/Homebrew/test/git_repository_spec.rb
+++ b/Library/Homebrew/test/git_repository_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "git_repository"

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "github_runner_matrix"

--- a/Library/Homebrew/test/github_runner_spec.rb
+++ b/Library/Homebrew/test/github_runner_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "github_runner"

--- a/Library/Homebrew/test/global_spec.rb
+++ b/Library/Homebrew/test/global_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Homebrew, :integration_test do

--- a/Library/Homebrew/test/hardware/cpu_spec.rb
+++ b/Library/Homebrew/test/hardware/cpu_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "hardware"

--- a/Library/Homebrew/test/head_software_spec_spec.rb
+++ b/Library/Homebrew/test/head_software_spec_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "head_software_spec"

--- a/Library/Homebrew/test/homebrew_spec.rb
+++ b/Library/Homebrew/test/homebrew_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "homebrew"

--- a/Library/Homebrew/test/installed_dependents_spec.rb
+++ b/Library/Homebrew/test/installed_dependents_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "installed_dependents"

--- a/Library/Homebrew/test/keg_only_reason_spec.rb
+++ b/Library/Homebrew/test/keg_only_reason_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "keg_only_reason"

--- a/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "keg_relocate"

--- a/Library/Homebrew/test/keg_relocate/grep_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/grep_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "keg_relocate"

--- a/Library/Homebrew/test/keg_relocate/relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/relocation_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "keg_relocate"

--- a/Library/Homebrew/test/keg_relocate/text_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/text_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "keg_relocate"

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "keg"

--- a/Library/Homebrew/test/language/java_spec.rb
+++ b/Library/Homebrew/test/language/java_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "language/java"

--- a/Library/Homebrew/test/language/node/shebang_spec.rb
+++ b/Library/Homebrew/test/language/node/shebang_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "language/node"

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "language/node"

--- a/Library/Homebrew/test/language/perl/shebang_spec.rb
+++ b/Library/Homebrew/test/language/perl/shebang_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "language/perl"

--- a/Library/Homebrew/test/language/php/shebang_spec.rb
+++ b/Library/Homebrew/test/language/php/shebang_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "language/php"

--- a/Library/Homebrew/test/language/python/shebang_spec.rb
+++ b/Library/Homebrew/test/language/python/shebang_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "language/python"

--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "language/python"

--- a/Library/Homebrew/test/language/python_spec.rb
+++ b/Library/Homebrew/test/language/python_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "language/python"

--- a/Library/Homebrew/test/lazy_object_spec.rb
+++ b/Library/Homebrew/test/lazy_object_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "lazy_object"

--- a/Library/Homebrew/test/linkage_cache_store_spec.rb
+++ b/Library/Homebrew/test/linkage_cache_store_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "linkage_cache_store"

--- a/Library/Homebrew/test/linux_runner_spec_spec.rb
+++ b/Library/Homebrew/test/linux_runner_spec_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "linux_runner_spec"

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/livecheck"

--- a/Library/Homebrew/test/livecheck/livecheck_version_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_version_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/livecheck_version"

--- a/Library/Homebrew/test/livecheck/options_spec.rb
+++ b/Library/Homebrew/test/livecheck/options_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/options"

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/livecheck"

--- a/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/crate_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/crate_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/extract_plist_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/extract_plist_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/git_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/git_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/github_releases_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/github_releases_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/hackage_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/hackage_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/json_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/json_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/launchpad_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/launchpad_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/npm_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/npm_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/sourceforge_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sourceforge_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/locale_spec.rb
+++ b/Library/Homebrew/test/locale_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "locale"

--- a/Library/Homebrew/test/lock_file_spec.rb
+++ b/Library/Homebrew/test/lock_file_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "lock_file"

--- a/Library/Homebrew/test/macos_runner_spec_spec.rb
+++ b/Library/Homebrew/test/macos_runner_spec_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "macos_runner_spec"

--- a/Library/Homebrew/test/macos_version_spec.rb
+++ b/Library/Homebrew/test/macos_version_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "macos_version"

--- a/Library/Homebrew/test/mcp_server_spec.rb
+++ b/Library/Homebrew/test/mcp_server_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "mcp_server"

--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "messages"

--- a/Library/Homebrew/test/migrator_spec.rb
+++ b/Library/Homebrew/test/migrator_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "migrator"

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "missing_formula"

--- a/Library/Homebrew/test/options/deprecated_option_spec.rb
+++ b/Library/Homebrew/test/options/deprecated_option_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "options"

--- a/Library/Homebrew/test/options/option_spec.rb
+++ b/Library/Homebrew/test/options/option_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "options"

--- a/Library/Homebrew/test/options_spec.rb
+++ b/Library/Homebrew/test/options_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "options"

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "dependency_collector"

--- a/Library/Homebrew/test/os/linux/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/linux/diagnostic_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/os/linux/elf_spec.rb
+++ b/Library/Homebrew/test/os/linux/elf_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe OS::Linux::Elf do

--- a/Library/Homebrew/test/os/linux/formula_installer_spec.rb
+++ b/Library/Homebrew/test/os/linux/formula_installer_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula_installer"

--- a/Library/Homebrew/test/os/linux/formula_spec.rb
+++ b/Library/Homebrew/test/os/linux/formula_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test/support/fixtures/testball"

--- a/Library/Homebrew/test/os/linux/ld_spec.rb
+++ b/Library/Homebrew/test/os/linux/ld_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "os/linux/ld"

--- a/Library/Homebrew/test/os/linux/libstdcxx_spec.rb
+++ b/Library/Homebrew/test/os/linux/libstdcxx_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "os/linux/libstdcxx"

--- a/Library/Homebrew/test/os/linux/pathname_spec.rb
+++ b/Library/Homebrew/test/os/linux/pathname_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "extend/pathname"

--- a/Library/Homebrew/test/os/linux_spec.rb
+++ b/Library/Homebrew/test/os/linux_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "locale"

--- a/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "dependency_collector"

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/os/mac/formula_installer_spec.rb
+++ b/Library/Homebrew/test/os/mac/formula_installer_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula_installer"

--- a/Library/Homebrew/test/os/mac/formula_spec.rb
+++ b/Library/Homebrew/test/os/mac/formula_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test/support/fixtures/testball"

--- a/Library/Homebrew/test/os/mac/keg_spec.rb
+++ b/Library/Homebrew/test/os/mac/keg_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "keg"

--- a/Library/Homebrew/test/os/mac/mach_spec.rb
+++ b/Library/Homebrew/test/os/mac/mach_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe MachOShim do

--- a/Library/Homebrew/test/os/mac/pkgconfig_spec.rb
+++ b/Library/Homebrew/test/os/mac/pkgconfig_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 # These tests assume the needed SDKs are correctly installed, i.e. `brew doctor` passes.

--- a/Library/Homebrew/test/os/mac/sdk_spec.rb
+++ b/Library/Homebrew/test/os/mac/sdk_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe OS::Mac::CLTSDKLocator do

--- a/Library/Homebrew/test/os/mac_spec.rb
+++ b/Library/Homebrew/test/os/mac_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "locale"

--- a/Library/Homebrew/test/os/os_spec.rb
+++ b/Library/Homebrew/test/os/os_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe OS do

--- a/Library/Homebrew/test/patch_spec.rb
+++ b/Library/Homebrew/test/patch_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "patch"

--- a/Library/Homebrew/test/patching_spec.rb
+++ b/Library/Homebrew/test/patching_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "extend/pathname"

--- a/Library/Homebrew/test/pkg_version_spec.rb
+++ b/Library/Homebrew/test/pkg_version_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "pkg_version"

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "extend/ENV"

--- a/Library/Homebrew/test/requirements/arch_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/arch_requirement_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "requirements/arch_requirement"

--- a/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "requirements/codesign_requirement"

--- a/Library/Homebrew/test/requirements/linux_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/linux_requirement_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "requirements/linux_requirement"

--- a/Library/Homebrew/test/requirements/macos_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/macos_requirement_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "requirements/macos_requirement"

--- a/Library/Homebrew/test/requirements_spec.rb
+++ b/Library/Homebrew/test/requirements_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "requirements"

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "resource"

--- a/Library/Homebrew/test/rubocop_spec.rb
+++ b/Library/Homebrew/test/rubocop_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "open3"

--- a/Library/Homebrew/test/rubocops/blank_spec.rb
+++ b/Library/Homebrew/test/rubocops/blank_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/blank"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_digest_indentation_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_digest_indentation_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_format_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_format_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_order_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_tag_indentation_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_tag_indentation_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/cask/array_alphabetization_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/array_alphabetization_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/deprecate_disable_unsigned_reason_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/deprecate_disable_unsigned_reason_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/desc_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/discontinued_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/discontinued_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/homepage_url_styling_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/homepage_url_styling_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/no_autobump.rb
+++ b/Library/Homebrew/test/rubocops/cask/no_autobump.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/shared_filelist_glob_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/shared_filelist_glob_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/uninstall_methods_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/uninstall_methods_order_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/url_legacy_comma_separators_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_legacy_comma_separators_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/url_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/variables_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/variables_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/caveats_spec.rb
+++ b/Library/Homebrew/test/rubocops/caveats_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/caveats"

--- a/Library/Homebrew/test/rubocops/checksum/checksum_case_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum/checksum_case_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/checksum"

--- a/Library/Homebrew/test/rubocops/checksum/checksum_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum/checksum_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/checksum"

--- a/Library/Homebrew/test/rubocops/class/class_name_spec.rb
+++ b/Library/Homebrew/test/rubocops/class/class_name_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/class"

--- a/Library/Homebrew/test/rubocops/class/test_present.rb
+++ b/Library/Homebrew/test/rubocops/class/test_present.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/class"

--- a/Library/Homebrew/test/rubocops/class/test_spec.rb
+++ b/Library/Homebrew/test/rubocops/class/test_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/class"

--- a/Library/Homebrew/test/rubocops/compact_blank_spec.rb
+++ b/Library/Homebrew/test/rubocops/compact_blank_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/compact_blank"

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/components_order"

--- a/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/components_redundancy"

--- a/Library/Homebrew/test/rubocops/conflicts_spec.rb
+++ b/Library/Homebrew/test/rubocops/conflicts_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/conflicts"

--- a/Library/Homebrew/test/rubocops/dependency_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/dependency_order_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/dependency_order"

--- a/Library/Homebrew/test/rubocops/deprecate_disable/date_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_disable/date_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/deprecate_disable"

--- a/Library/Homebrew/test/rubocops/deprecate_disable/reason_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_disable/reason_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/deprecate_disable"

--- a/Library/Homebrew/test/rubocops/desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/desc_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/desc"

--- a/Library/Homebrew/test/rubocops/disable_comment_spec.rb
+++ b/Library/Homebrew/test/rubocops/disable_comment_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/disable_comment"

--- a/Library/Homebrew/test/rubocops/exec_shell_metacharacters_spec.rb
+++ b/Library/Homebrew/test/rubocops/exec_shell_metacharacters_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/shell_commands"

--- a/Library/Homebrew/test/rubocops/files_spec.rb
+++ b/Library/Homebrew/test/rubocops/files_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/files"

--- a/Library/Homebrew/test/rubocops/homepage_spec.rb
+++ b/Library/Homebrew/test/rubocops/homepage_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/homepage"

--- a/Library/Homebrew/test/rubocops/install_bundler_gems_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_bundler_gems_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/install_bundler_gems"

--- a/Library/Homebrew/test/rubocops/io_read_spec.rb
+++ b/Library/Homebrew/test/rubocops/io_read_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/io_read"

--- a/Library/Homebrew/test/rubocops/keg_only_spec.rb
+++ b/Library/Homebrew/test/rubocops/keg_only_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/keg_only"

--- a/Library/Homebrew/test/rubocops/lines/class_inheritance_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/class_inheritance_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/lines/full_dependency_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/full_dependency_check_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/lines/libiconv_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/libiconv_check_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/lines/quictls_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/quictls_check_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_case_insensitive_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_case_insensitive_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_extension_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_extension_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_if_page_match_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_if_page_match_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_parentheses_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_parentheses_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/skip_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/skip_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/url_symbol_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/url_symbol_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/move_to_extend_os_spec.rb
+++ b/Library/Homebrew/test/rubocops/move_to_extend_os_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/move_to_extend_os"

--- a/Library/Homebrew/test/rubocops/negate_include_spec.rb
+++ b/Library/Homebrew/test/rubocops/negate_include_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/negate_include"

--- a/Library/Homebrew/test/rubocops/no_autobump.rb
+++ b/Library/Homebrew/test/rubocops/no_autobump.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/no_autobump"

--- a/Library/Homebrew/test/rubocops/no_fileutils_rmrf_spec.rb
+++ b/Library/Homebrew/test/rubocops/no_fileutils_rmrf_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/no_fileutils_rmrf"

--- a/Library/Homebrew/test/rubocops/options_spec.rb
+++ b/Library/Homebrew/test/rubocops/options_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/options"

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/patches"

--- a/Library/Homebrew/test/rubocops/presence_spec.rb
+++ b/Library/Homebrew/test/rubocops/presence_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/presence"

--- a/Library/Homebrew/test/rubocops/present_spec.rb
+++ b/Library/Homebrew/test/rubocops/present_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/present"

--- a/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/uses_from_macos"

--- a/Library/Homebrew/test/rubocops/resource_requires_dependencies_spec.rb
+++ b/Library/Homebrew/test/rubocops/resource_requires_dependencies_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/resource_requires_dependencies"

--- a/Library/Homebrew/test/rubocops/safe_navigation_with_blank_spec.rb
+++ b/Library/Homebrew/test/rubocops/safe_navigation_with_blank_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/safe_navigation_with_blank"

--- a/Library/Homebrew/test/rubocops/service_spec.rb
+++ b/Library/Homebrew/test/rubocops/service_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/service"

--- a/Library/Homebrew/test/rubocops/shell_commands_spec.rb
+++ b/Library/Homebrew/test/rubocops/shell_commands_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/shell_commands"

--- a/Library/Homebrew/test/rubocops/text/assert_statements_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/assert_statements_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/comments_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/comments_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/license_arrays_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/license_arrays_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/licenses_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/licenses_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/macos_on_linux_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/macos_on_linux_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/make_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/make_check_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/miscellaneous_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/miscellaneous_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/mpi_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/mpi_check_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/safe_popen_commands_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/safe_popen_commands_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/shell_variables_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/shell_variables_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/std_npm_args_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/std_npm_args_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/strict_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/text"

--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/text"

--- a/Library/Homebrew/test/rubocops/urls/git_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/git_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/urls/git_strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/git_strict_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/urls/http_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/http_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/urls/pypi_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/pypi_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/uses_from_macos"

--- a/Library/Homebrew/test/rubocops/version_spec.rb
+++ b/Library/Homebrew/test/rubocops/version_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/version"

--- a/Library/Homebrew/test/rubocops/zero_zero_zero_zero_spec.rb
+++ b/Library/Homebrew/test/rubocops/zero_zero_zero_zero_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "rubocops/zero_zero_zero_zero"

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "sandbox"

--- a/Library/Homebrew/test/sbom_spec.rb
+++ b/Library/Homebrew/test/sbom_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "sbom"

--- a/Library/Homebrew/test/search_spec.rb
+++ b/Library/Homebrew/test/search_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "search"

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "services/cli"

--- a/Library/Homebrew/test/services/commands/cleanup_spec.rb
+++ b/Library/Homebrew/test/services/commands/cleanup_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "services/commands/cleanup"

--- a/Library/Homebrew/test/services/commands/info_spec.rb
+++ b/Library/Homebrew/test/services/commands/info_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "services/commands/info"

--- a/Library/Homebrew/test/services/commands/list_spec.rb
+++ b/Library/Homebrew/test/services/commands/list_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "services/commands/list"

--- a/Library/Homebrew/test/services/commands/restart_spec.rb
+++ b/Library/Homebrew/test/services/commands/restart_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "services/commands/restart"

--- a/Library/Homebrew/test/services/formula_wrapper_spec.rb
+++ b/Library/Homebrew/test/services/formula_wrapper_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "services/system"

--- a/Library/Homebrew/test/services/formulae_spec.rb
+++ b/Library/Homebrew/test/services/formulae_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "services/formulae"

--- a/Library/Homebrew/test/services/system/systemctl_spec.rb
+++ b/Library/Homebrew/test/services/system/systemctl_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "services/system"

--- a/Library/Homebrew/test/services/system_spec.rb
+++ b/Library/Homebrew/test/services/system_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "services/system"

--- a/Library/Homebrew/test/settings_spec.rb
+++ b/Library/Homebrew/test/settings_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "settings"

--- a/Library/Homebrew/test/simulate_system_spec.rb
+++ b/Library/Homebrew/test/simulate_system_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "settings"

--- a/Library/Homebrew/test/software_spec_spec.rb
+++ b/Library/Homebrew/test/software_spec_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "software_spec"

--- a/Library/Homebrew/test/sorbet/tapioca/config_spec.rb
+++ b/Library/Homebrew/test/sorbet/tapioca/config_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "bundler"

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 if ENV["HOMEBREW_TESTS_COVERAGE"]

--- a/Library/Homebrew/test/style_spec.rb
+++ b/Library/Homebrew/test/style_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "style"

--- a/Library/Homebrew/test/support/extend/cachable.rb
+++ b/Library/Homebrew/test/support/extend/cachable.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 raise "This needs to be required before Cachable gets loaded normally." if defined?(Cachable)

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/adobe-air.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/adobe-air.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "adobe-air" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/adobe-illustrator.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/adobe-illustrator.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "adobe-illustrator" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/appdir-interpolation.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/appdir-interpolation.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "appdir-interpolation" do
   version "2.61"
   sha256 "e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/arch-arm-only.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/arch-arm-only.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "arch-arm-only" do
   arch arm: "-arm"
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/auto-updates.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/auto-updates.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "auto-updates" do
   version "2.61"
   sha256 "5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/bad-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/bad-checksum.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "bad-checksum" do
   version "1.2.3"
   sha256 "badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadb"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/bad-checksum2.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/bad-checksum2.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "bad-checksum2" do
   version "1.2.3"
   sha256 "badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadb"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/basic-cask.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/basic-cask.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "basic-cask" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/compat/with-depends-on-macos-string.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/compat/with-depends-on-macos-string.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-depends-on-macos-string" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-7z.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-7z.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "container-7z" do
   version "1.2.3"
   sha256 "3f9542ace85ed5f88549e2d0ea82210f8ddc87e0defbb78469d3aed719b3c964"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-apfs-dmg.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-apfs-dmg.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "container-apfs-dmg" do
   version "1.2.3"
   sha256 "0630aa1145e8c3fa77aeb6ec414fee35204e90f224d6d06cb23e18a4d6112a5d"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-bzip2.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-bzip2.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "container-bzip2" do
   version "1.2.3"
   sha256 "eaf67b3a62cb9275f96e45d05c70b94bef9ef1dae344083e93eda6b0b388a61c"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-cab.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-cab.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "container-cab" do
   version "1.2.3"
   sha256 "c267f5cebb14814c8e612a8b7d2bda02aec913f869509b6f1d3883427c0f552b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-dmg.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-dmg.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "container-dmg" do
   version "1.2.3"
   sha256 "74d89d4fa5cef175cf43666ce11fefa3741aa1522114042ac75e656be37141a1"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-gzip.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-gzip.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "container-gzip" do
   version "1.2.3"
   sha256 "fa4ebb5246583c4b6e62e1df4e3b71b4e38a1d7d91c025665827195d36214b20"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-pkg.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-pkg.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "container-pkg" do
   version "1.2.3"
   sha256 "611c50c8a2a2098951d2cd0fd54787ed81b92cd97b4b08bd7cba17f1e1d8e40b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-tar-gz.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-tar-gz.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "container-tar-gz" do
   version "1.2.3"
   sha256 "fab685fabf73d5a9382581ce8698fce9408f5feaa49fa10d9bc6c510493300f5"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-xar.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-xar.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "container-xar" do
   version "1.2.3"
   sha256 "5bb8e09a6fc630ebeaf266b1fd2d15e2ae7d32d7e4da6668a8093426fa1ba509"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/devmate-with-livecheck.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/devmate-with-livecheck.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "devmate-with-livecheck" do
   version "1.0"
   sha256 "a69e7357bea014f4c14ac9699274f559086844ffa46563c4619bf1addfd72ad9"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/devmate-without-livecheck.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/devmate-without-livecheck.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "devmate-without-livecheck" do
   version "1.0"
   sha256 "a69e7357bea014f4c14ac9699274f559086844ffa46563c4619bf1addfd72ad9"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/generic-artifact-absolute-target.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/generic-artifact-absolute-target.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "generic-artifact-absolute-target" do
   artifact "Caffeine.app", target: "#{appdir}/Caffeine.app"
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/generic-artifact-relative-target.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/generic-artifact-relative-target.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "generic-artifact-relative-target" do
   version "1.2.3"
   sha256 "d5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/generic-artifact-user-relative-target.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/generic-artifact-user-relative-target.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "generic-artifact-user-relative-target" do
   version "1.2.3"
   sha256 "d5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/hockeyapp-with-livecheck.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/hockeyapp-with-livecheck.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "hockeyapp-with-livecheck" do
   version "1.0,123"
   sha256 "a69e7357bea014f4c14ac9699274f559086844ffa46563c4619bf1addfd72ad9"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/hockeyapp-without-livecheck.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/hockeyapp-without-livecheck.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "hockeyapp-without-livecheck" do
   version "1.0,123"
   sha256 "a69e7357bea014f4c14ac9699274f559086844ffa46563c4619bf1addfd72ad9"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/installer-with-uninstall.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/installer-with-uninstall.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "installer-with-uninstall" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid-sha256.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid-sha256.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "invalid-sha256" do
   version "1.2.3"
   sha256 "not a valid shasum"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-conflicts-with-key.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-conflicts-with-key.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "invalid-conflicts-with-key" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-arch-value.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-arch-value.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "invalid-depends-on-arch-value" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-key.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-key.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "invalid-depends-on-key" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-bad-release.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-bad-release.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "invalid-depends-on-macos-bad-release" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-conflicting-forms.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-conflicting-forms.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 cask "invalid-depends-on-macos-conflicting-forms" do

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-generic-artifact-no-target.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-generic-artifact-no-target.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "invalid-generic-artifact-no-target" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-format.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-format.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "invalid-header-format", :invalid do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-token-mismatch.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-token-mismatch.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "invalid-header-token-mismatch-this-text-does-not-belong" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-version.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "invalid-header-version" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-manpage-no-section.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-manpage-no-section.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "invalid-manpage-no-section" do
   version "1.2.3"
   sha256 "68b7e71a2ca7585b004f52652749589941e3029ff0884e8aa3b099594e0282c0"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-stage-only-conflict.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-stage-only-conflict.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "invalid-stage-only-conflict" do
   version "2.61"
   sha256 "e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-arch.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-arch.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "invalid-two-arch" do
   arch arm: "arm", intel: "intel"
   arch arm: "amd64", intel: "x86_64"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-homepage.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-homepage.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "invalid-two-homepage" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-url.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-url.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "invalid-two-url" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-version.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "invalid-two-version" do
   version "1.2.3"
   version "2.0"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/latest-with-auto-updates.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/latest-with-auto-updates.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "latest-with-auto-updates" do
   version :latest
   sha256 :no_check

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/latest-with-livecheck-skip.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/latest-with-livecheck-skip.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "latest-with-livecheck-skip" do
   version :latest
   sha256 :no_check

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/latest-with-livecheck.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/latest-with-livecheck.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "latest-with-livecheck" do
   version :latest
   sha256 :no_check

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/latest.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/latest.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "latest" do
   version :latest
   sha256 :no_check

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-deprecated-reference.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-deprecated-reference.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "livecheck-deprecated-reference" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-deprecated.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-deprecated.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "livecheck-deprecated" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-disabled-reference.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-disabled-reference.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "livecheck-disabled-reference" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-disabled.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-disabled.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "livecheck-disabled" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-extract-plist-with-url.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-extract-plist-with-url.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "livecheck-extract-plist-with-url" do
   version "1.2.3"
   sha256 "78c670559a609f5d89a5d75eee49e2a2dab48aa3ea36906d14d5f7104e483bb9"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-extract-plist.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-extract-plist.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "livecheck-extract-plist" do
   version "1.2.3"
   sha256 "78c670559a609f5d89a5d75eee49e2a2dab48aa3ea36906d14d5f7104e483bb9"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-installer-manual.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-installer-manual.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "livecheck-installer-manual" do
   version "1.2.3"
   sha256 "78c670559a609f5d89a5d75eee49e2a2dab48aa3ea36906d14d5f7104e483bb9"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-skip-reference.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-skip-reference.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "livecheck-skip-reference" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-skip.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-skip.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "livecheck-skip" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-throttle-reference.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-throttle-reference.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "livecheck-throttle-reference" do
   version "1.2.5"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-throttle.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-throttle.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "livecheck-throttle" do
   version "1.2.5"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-url-unversioned-reference.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-url-unversioned-reference.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "livecheck-url-unversioned-reference" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-url-unversioned.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-url-unversioned.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "livecheck-url-unversioned" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-version-latest-reference.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-version-latest-reference.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "livecheck-version-latest-reference" do
   version :latest
   sha256 :no_check

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-version-latest.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-version-latest.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "livecheck-version-latest" do
   version :latest
   sha256 :no_check

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/local-caffeine.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/local-caffeine.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "local-caffeine" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/local-transmission-zip.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/local-transmission-zip.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "local-transmission-zip" do
   version "2.61"
   sha256 "5e96aeb365aa8fabd51bb0d85f5f2bfe0135d392bb2f4120aa6b8171415906da"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/local-transmission.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/local-transmission.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "local-transmission" do
   version "2.61"
   sha256 "e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/many-artifacts.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/many-artifacts.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "many-artifacts" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/many-renames.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/many-renames.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "many-renames" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-checksum.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "missing-checksum" do
   version "1.2.3"
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-homepage.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-homepage.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "missing-homepage" do
   version "1.2.3"
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-name.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-name.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "missing-name" do
   version "1.2.3"
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-sha256.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-sha256.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "missing-sha256" do
   version "1.2.3"
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-url.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-url.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "missing-url" do
   version "1.2.3"
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-version.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "missing-version" do
   url "https://brew.sh/TestCask.dmg"
   homepage "https://brew.sh/"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/multiple-versions.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/multiple-versions.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "multiple-versions" do
   arch arm: "arm", intel: "intel"
   platform = on_arch_conditional arm: "darwin-arm64", intel: "darwin"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/naked-executable.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/naked-executable.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "naked-executable" do
   version "1.2.3"
   sha256 "306c6ca7407560340797866e077e053627ad409277d1b9da58106fce4cf717cb"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/nested-app.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/nested-app.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "nested-app" do
   version "1.2.3"
   sha256 "69034d000fabf804a6e140c8c632f8ce8a3bf303f5f7db2fb0cd86e3aeed9e67"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/no-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/no-checksum.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "no-checksum" do
   version "1.2.3"
   sha256 :no_check

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/no-dsl-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/no-dsl-version.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "no-dsl-version" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/osdn-urls.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/osdn-urls.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "osdn-urls" do
   version "1.2.3"
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/auto-updates.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/auto-updates.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "auto-updates" do
   version "2.57"
   sha256 "5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/bad-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/bad-checksum.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "bad-checksum" do
   version "1.2.2"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/bad-checksum2.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/bad-checksum2.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "bad-checksum2" do
   version "1.2.2"
   sha256 "fab685fabf73d5a9382581ce8698fce9408f5feaa49fa10d9bc6c510493300f5"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/local-caffeine.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/local-caffeine.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "local-caffeine" do
   version "1.2.2"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/local-transmission-zip.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/local-transmission-zip.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "local-transmission-zip" do
   version "2.60"
   sha256 "5e96aeb365aa8fabd51bb0d85f5f2bfe0135d392bb2f4120aa6b8171415906da"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/local-transmission.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/local-transmission.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "local-transmission" do
   version "2.60"
   sha256 "e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/renamed-app.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/renamed-app.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "renamed-app" do
   version "1.0.0"
   sha256 "cf001ed6c81820e049dc7a353957dab8936b91f1956ee74ff0b3eb59791f1ad9"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/version-latest.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/version-latest.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "version-latest" do
   version :latest
   sha256 :no_check

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/will-fail-if-upgraded.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/will-fail-if-upgraded.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "will-fail-if-upgraded" do
   version "1.2.2"
   sha256 "fab685fabf73d5a9382581ce8698fce9408f5feaa49fa10d9bc6c510493300f5"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/pkg-without-uninstall.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/pkg-without-uninstall.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "pkg-without-uninstall" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/placeholders.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/placeholders.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "placeholders" do
   version "2.61"
   sha256 "e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/renamed-app.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/renamed-app.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "renamed-app" do
   version "2.0.0"
   sha256 "9f88a6f3d8a7977cd3c116c56ee7a20a3c69e838a1d4946f815a926a57883299"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-arch.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-arch.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "sha256-arch" do
   arch arm: "arm", intel: "intel"
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-for-empty-string.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-for-empty-string.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "sha256-for-empty-string" do
   version "1.2.3"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-os.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-os.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "sha256-os" do
   arch arm: "arm", intel: "intel"
   os macos: "darwin", linux: "linux"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/sourceforge-correct-url-format.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/sourceforge-correct-url-format.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "sourceforge-correct-url-format" do
   version "1.2.3"
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/sourceforge-incorrect-url-format.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/sourceforge-incorrect-url-format.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "sourceforge-incorrect-url-format" do
   version "1.2.3"
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/sourceforge-version-latest-correct-url-format.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/sourceforge-version-latest-correct-url-format.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "sourceforge-version-latest-correct-url-format" do
   version :latest
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/sourceforge-with-livecheck.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/sourceforge-with-livecheck.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "sourceforge-with-livecheck" do
   version "1.2.3"
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/stage-only.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/stage-only.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "stage-only" do
   version "2.61"
   sha256 "e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/test-opera-mail.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/test-opera-mail.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "test-opera-mail" do
   version "1.0"
   sha256 "afd192e308f8ea8ddb3d426fd6663d97078570417ee78b8e1fa15f515ae3d677"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/test-opera.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/test-opera.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "test-opera" do
   version "19.0.1326.47"
   sha256 "7b91f20ab754f7b3fef8dc346e0393917e11676b74c8f577408841619f76040a"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/version-colon.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/version-colon.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "version-colon" do
   version "1.2.3:1003"
   sha256 :no_check

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest-string.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest-string.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "version-latest-string" do
   version "latest"
   sha256 :no_check

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest-with-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest-with-checksum.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "version-latest-with-checksum" do
   version :latest
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "version-latest" do
   version :latest
   sha256 :no_check

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/will-fail-if-upgraded.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/will-fail-if-upgraded.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "will-fail-if-upgraded" do
   version "1.2.3"
   sha256 "5e96aeb365aa8fabd51bb0d85f5f2bfe0135d392bb2f4120aa6b8171415906da"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-allow-untrusted.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-allow-untrusted.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-allow-untrusted" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-alt-target.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-alt-target.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-alt-target" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-auto-updates.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-auto-updates.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-auto-updates" do
   version "1.0"
   sha256 "e5be907a51cd0d5b128532284afe1c913608c584936a5e55d94c75a9f48c4322"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-autodetected-manpage-section.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-autodetected-manpage-section.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-autodetected-manpage-section" do
   version "1.2.3"
   sha256 "1f078d5fbbaf44b05d0389b14a15f6704e0e5f8f663bc38153a4d685e38baad5"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-binary.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-binary.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-binary" do
   version "1.2.3"
   sha256 "d5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-caveats.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-caveats.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-caveats" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-choices.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-choices.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-choices" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-conditional-caveats.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-conditional-caveats.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-conditional-caveats" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-conflicts-with.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-conflicts-with.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-conflicts-with" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-arch.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-arch.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-depends-on-arch" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-cyclic-helper.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-cyclic-helper.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-depends-on-cask-cyclic-helper" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-cyclic.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-cyclic.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-depends-on-cask-cyclic" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-multiple.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-multiple.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-depends-on-cask-multiple" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-depends-on-cask" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-everything.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-everything.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-depends-on-everything" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-formula-multiple.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-formula-multiple.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-depends-on-formula-multiple" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-formula.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-formula.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-depends-on-formula" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-array.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-array.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 cask "with-depends-on-macos-array" do

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-comparison.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-comparison.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 cask "with-depends-on-macos-comparison" do

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-failure.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-failure.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-depends-on-macos-failure" do
   # guarantee a mismatched release
   on_big_sur :or_older do

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-symbol.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-symbol.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-depends-on-macos-symbol" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-embedded-binary.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-embedded-binary.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-embedded-binary" do
   version "1.2.3"
   sha256 "fe052d3e77d92676775fd916ddb8942e72a565b844ea7f6d055474c99bb4e47b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-generic-artifact.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-generic-artifact.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-generic-artifact" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-installable.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-installable.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-installable" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-manual.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-manual.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-installer-manual" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-script.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-installer-script" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-languages" do
   version "1.2.3"
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-macosx-dir.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-macosx-dir.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-macosx-dir" do
   version "1.2.3"
   sha256 "5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-many-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-many-languages.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-many-languages" do
   version "1.2.3"
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-non-executable-binary.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-non-executable-binary.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-non-executable-binary" do
   version "1.2.3"
   sha256 "306c6ca7407560340797866e077e053627ad409277d1b9da58106fce4cf717cb"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-pkgutil-zap.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-pkgutil-zap.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-pkgutil-zap" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight-multi.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-postflight-multi" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-postflight" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight-multi.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-preflight-multi" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-preflight" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-shellcompletion-long.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-shellcompletion-long.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-shellcompletion-long" do
   version "1.2.3"
   sha256 "957978d9b30adfda8e1f914ba8c8019e016545c8f7e16c6ab0234d189fac8146"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-shellcompletion.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-shellcompletion.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-shellcompletion" do
   version "1.2.3"
   sha256 "957978d9b30adfda8e1f914ba8c8019e016545c8f7e16c6ab0234d189fac8146"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-suite.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-suite.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-suite" do
   version "1.2.3"
   sha256 "d95dcc12d4e5be0bc3cb9793c4b7e7f69a25f0b3c7418494b0c883957e6eeae4"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-correct.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-correct.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-two-apps-correct" do
   version "1.2.3"
   sha256 "3178fbfd1ea5d87a2a0662a4eb599ebc9a03888e73f37538d9f3f6ee69d2368e"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-subdir.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-subdir.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-two-apps-subdir" do
   version "1.2.3"
   sha256 "d687c22a21c02bd8f07da9302c8292b93a04df9a929e3f04d09aea6c76f75c65"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-both-on-upgrade.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-both-on-upgrade.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-both-on-upgrade" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-delete.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-delete.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-delete" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-early-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-early-script.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-early-script" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-kext.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-kext.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-kext" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-launchctl-wildcard.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-launchctl-wildcard.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-launchctl-wildcard" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-launchctl.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-launchctl.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-launchctl" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-login-item.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-login-item.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-login-item" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-multi.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-multi" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-pkgutil.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-pkgutil.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-pkgutil" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight-multi.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-postflight-multi" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-postflight" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight-multi.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-preflight-multi" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-preflight" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-quit-on-upgrade.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-quit-on-upgrade.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-quit-on-upgrade" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-quit-only-on-upgrade.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-quit-only-on-upgrade.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-quit-only-on-upgrade" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-quit.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-quit.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-quit" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-rmdir.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-rmdir.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-rmdir" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script-app.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script-app.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-script-app" do
   version "1.2.3"
   sha256 "5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script-user-relative.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script-user-relative.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-script-user-relative" do
   version "1.2.3"
   sha256 "5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-script" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-signal-on-upgrade.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-signal-on-upgrade.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-signal-on-upgrade" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-signal.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-signal.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-signal" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-trash.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-trash.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-uninstall-trash" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-delete.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-delete.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-zap-delete" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-early-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-early-script.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-zap-early-script" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-kext.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-kext.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-zap-kext" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-launchctl-wildcard.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-launchctl-wildcard.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-zap-launchctl-wildcard" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-launchctl.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-launchctl.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-zap-launchctl" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-login-item.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-login-item.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-zap-login-item" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-multi.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-zap-multi" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-pkgutil.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-pkgutil.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-zap-pkgutil" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-quit.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-quit.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-zap-quit" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-rmdir.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-rmdir.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-zap-rmdir" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-script.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-zap-script" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-signal.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-signal.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-zap-signal" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-trash.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-trash.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-zap-trash" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "with-zap" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/without-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/without-languages.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "without-languages" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"

--- a/Library/Homebrew/test/support/fixtures/third-party/Casks/pharo.rb
+++ b/Library/Homebrew/test/support/fixtures/third-party/Casks/pharo.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "pharo" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/third-party/Casks/third-party-cask.rb
+++ b/Library/Homebrew/test/support/fixtures/third-party/Casks/third-party-cask.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 cask "third-party-cask" do
   version "1.2.3"
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/helper/cask.rb
+++ b/Library/Homebrew/test/support/helper/cask.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cask/cask_loader"

--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "formulary"

--- a/Library/Homebrew/test/support/helper/mktmpdir.rb
+++ b/Library/Homebrew/test/support/helper/mktmpdir.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 module Test

--- a/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cask/config"

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "open3"

--- a/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.shared_examples "formulae exist" do |array|

--- a/Library/Homebrew/test/system_command_result_spec.rb
+++ b/Library/Homebrew/test/system_command_result_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "system_command"

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "system_command"

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "tab"

--- a/Library/Homebrew/test/tap_auditor_spec.rb
+++ b/Library/Homebrew/test/tap_auditor_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "tap_auditor"

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Tap do

--- a/Library/Homebrew/test/test_bot/bottles_fetch_spec.rb
+++ b/Library/Homebrew/test/test_bot/bottles_fetch_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_bot"

--- a/Library/Homebrew/test/test_bot/formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_bot"

--- a/Library/Homebrew/test/test_bot/junit_spec.rb
+++ b/Library/Homebrew/test/test_bot/junit_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_bot"

--- a/Library/Homebrew/test/test_bot/setup_spec.rb
+++ b/Library/Homebrew/test/test_bot/setup_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "dev-cmd/test-bot"

--- a/Library/Homebrew/test/test_bot/step_spec.rb
+++ b/Library/Homebrew/test/test_bot/step_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_bot"

--- a/Library/Homebrew/test/test_bot/test_cleanup_spec.rb
+++ b/Library/Homebrew/test/test_bot/test_cleanup_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "dev-cmd/test-bot"

--- a/Library/Homebrew/test/test_bot/test_formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/test_formulae_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_bot"

--- a/Library/Homebrew/test/test_bot/test_spec.rb
+++ b/Library/Homebrew/test/test_bot/test_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_bot"

--- a/Library/Homebrew/test/test_runner_formula_spec.rb
+++ b/Library/Homebrew/test/test_runner_formula_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_runner_formula"

--- a/Library/Homebrew/test/uninstall_spec.rb
+++ b/Library/Homebrew/test/uninstall_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "uninstall"

--- a/Library/Homebrew/test/unlink_spec.rb
+++ b/Library/Homebrew/test/unlink_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "unlink"

--- a/Library/Homebrew/test/unpack_strategy/bazaar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/bazaar_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/bzip2_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/bzip2_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/cvs_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/cvs_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/directory_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/directory_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/git_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/git_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/gzip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/gzip_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/jar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/jar_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/lha_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/lha_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/lzip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/lzip_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/mercurial_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/mercurial_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/p7zip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/p7zip_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/rar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/rar_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/shared_examples.rb
+++ b/Library/Homebrew/test/unpack_strategy/shared_examples.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "unpack_strategy"

--- a/Library/Homebrew/test/unpack_strategy/subversion_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/subversion_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/tar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/tar_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/uncompressed_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/uncompressed_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/xar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/xar_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/xz_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/xz_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/zip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/zip_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/zstd_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/zstd_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe UnpackStrategy do

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/analytics"

--- a/Library/Homebrew/test/utils/ast/ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/ast_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/ast"

--- a/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/ast"

--- a/Library/Homebrew/test/utils/autoremove_spec.rb
+++ b/Library/Homebrew/test/utils/autoremove_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/autoremove"

--- a/Library/Homebrew/test/utils/backtrace_spec.rb
+++ b/Library/Homebrew/test/utils/backtrace_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/backtrace"

--- a/Library/Homebrew/test/utils/bottles/bottles_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/bottles_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/bottles"

--- a/Library/Homebrew/test/utils/bottles/collector_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/collector_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/bottles"

--- a/Library/Homebrew/test/utils/bottles/tag_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/tag_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/bottles"

--- a/Library/Homebrew/test/utils/cpan_spec.rb
+++ b/Library/Homebrew/test/utils/cpan_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/cpan"

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/curl"

--- a/Library/Homebrew/test/utils/fork_spec.rb
+++ b/Library/Homebrew/test/utils/fork_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/fork"

--- a/Library/Homebrew/test/utils/git_repository_spec.rb
+++ b/Library/Homebrew/test/utils/git_repository_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/git_repository"

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/git"

--- a/Library/Homebrew/test/utils/github/actions_spec.rb
+++ b/Library/Homebrew/test/utils/github/actions_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/github/actions"

--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/github"

--- a/Library/Homebrew/test/utils/gzip_spec.rb
+++ b/Library/Homebrew/test/utils/gzip_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/gzip"

--- a/Library/Homebrew/test/utils/inreplace_spec.rb
+++ b/Library/Homebrew/test/utils/inreplace_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "tempfile"

--- a/Library/Homebrew/test/utils/linkage_spec.rb
+++ b/Library/Homebrew/test/utils/linkage_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/linkage"

--- a/Library/Homebrew/test/utils/output_spec.rb
+++ b/Library/Homebrew/test/utils/output_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/output"

--- a/Library/Homebrew/test/utils/path_spec.rb
+++ b/Library/Homebrew/test/utils/path_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/path"

--- a/Library/Homebrew/test/utils/popen_spec.rb
+++ b/Library/Homebrew/test/utils/popen_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/popen"

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/pypi"

--- a/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
+++ b/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Utils do

--- a/Library/Homebrew/test/utils/service_spec.rb
+++ b/Library/Homebrew/test/utils/service_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/service"

--- a/Library/Homebrew/test/utils/shared_audits_spec.rb
+++ b/Library/Homebrew/test/utils/shared_audits_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/shared_audits"

--- a/Library/Homebrew/test/utils/shell_completion_spec.rb
+++ b/Library/Homebrew/test/utils/shell_completion_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/shell_completion"

--- a/Library/Homebrew/test/utils/shell_spec.rb
+++ b/Library/Homebrew/test/utils/shell_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/shell"

--- a/Library/Homebrew/test/utils/spdx_spec.rb
+++ b/Library/Homebrew/test/utils/spdx_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/spdx"

--- a/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
+++ b/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/string_inreplace_extension"

--- a/Library/Homebrew/test/utils/svn_spec.rb
+++ b/Library/Homebrew/test/utils/svn_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/svn"

--- a/Library/Homebrew/test/utils/tar_spec.rb
+++ b/Library/Homebrew/test/utils/tar_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/tar"

--- a/Library/Homebrew/test/utils/timer_spec.rb
+++ b/Library/Homebrew/test/utils/timer_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/timer"

--- a/Library/Homebrew/test/utils/topological_hash_spec.rb
+++ b/Library/Homebrew/test/utils/topological_hash_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/topological_hash"

--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Tty do

--- a/Library/Homebrew/test/utils/user_spec.rb
+++ b/Library/Homebrew/test/utils/user_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils/user"

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "utils"

--- a/Library/Homebrew/test/version/parser_spec.rb
+++ b/Library/Homebrew/test/version/parser_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "version/parser"

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "version"


### PR DESCRIPTION
-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

- Now that we've enabled `--experimental-rspec-mode`[1], let's start using Sorbet in tests at its basic `typed: false` level for now.
- This will ease the migration to `typed: true` of any or all tests we want to do in the future.

[1]: https://github.com/Homebrew/brew/pull/21742