### PR TITLE
dev-cmd/bump-formula-pr: support underscores in version

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -422,7 +422,7 @@ module Homebrew
 
           formula_checkboxes = []
 
-          if resources_checked.nil? && (failed_updates.any? || unchecked_resources.any?)
+          if failed_updates.any? || (resources_checked.nil? && unchecked_resources.any?)
             formula_checkboxes << "- [ ] `resource` blocks have been checked for updates."
 
             if failed_updates.any?
@@ -579,6 +579,8 @@ module Homebrew
       sig { params(old_url: String, old_version: String, new_version: String).returns(String) }
       def update_url(old_url, old_version, new_version)
         new_url = old_url.gsub(old_version, new_version)
+        new_url.gsub!(old_version.tr(".", "_"), new_version.tr(".", "_")) if old_version.include?(".")
+
         return new_url if (old_version_parts = old_version.split(".")).length < 2
         return new_url if (new_version_parts = new_version.split(".")).length != old_version_parts.length
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`Version.parse` converts underscores to dots so add this to bump which allows us to enable autobump support in multiple formulae (see https://github.com/Homebrew/homebrew-core/pull/274891)

There is a small chance of false-positives in URL. There didn't seem to be any in Homebrew/core, but can improve bump in future to either be "smarter" than just gsub and/or to attempt multiple possible URLs.

Also always show failed resource bumps as checkbox. This allows showing failure for non-PyPI resources when formula has mix of both.

