### PR TITLE
utils/pypi: use existing non-PyPI resource if expected version

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -330,14 +330,12 @@ module PyPI
       input_packages << extra_package unless input_packages.include? extra_package
     end
 
-    unless print_only
-      formula.resources.each do |resource|
-        next if resource.url.start_with?(PYTHONHOSTED_URL_PREFIX)
-        next if resource.livecheck_defined?
+    non_pypi_resource_names = formula.resources.filter_map do |resource|
+      next if resource.url.start_with?(PYTHONHOSTED_URL_PREFIX)
+      next if resource.livecheck_defined?
 
-        odie "\"#{formula.name}\" contains non-PyPI resources. Please update the resources manually."
-      end
-    end
+      resource.name
+    end.to_set
 
     existing_resources_by_name = formula.resources.to_h { |resource| [resource.name, resource] }
     formula_contents = formula.path.read
@@ -376,7 +374,7 @@ module PyPI
       end
 
       ohai "Getting PyPI info for \"#{package}\"" if show_info
-      name, url, checksum, _, package_error = package.pypi_info(ignore_errors: ignore_errors)
+      name, url, checksum, version, package_error = package.pypi_info(ignore_errors: ignore_errors)
       if package_error.blank?
         # Fail if unable to find name, url or checksum for any resource
         if name.blank?
@@ -394,29 +392,31 @@ module PyPI
               Please update the resources for "#{formula.name}" manually.
             EOS
           end
-        end
-      end
+        else
+          existing_is_non_pypi = !non_pypi_resource_names.delete?(name).nil?
 
-      if package_error.blank?
-        if (existing_resource = existing_resources_by_name[T.must(name)]) &&
-           existing_resource.url == url &&
-           existing_resource.checksum&.hexdigest == checksum &&
-           (existing_block = existing_resource_blocks[T.must(name)])
-          new_resource_blocks += <<-EOS
+          if (existing_resource = existing_resources_by_name[name]) &&
+             (existing_block = existing_resource_blocks[name]) &&
+             ((existing_resource.url == url && existing_resource.checksum&.hexdigest == checksum) ||
+              (existing_is_non_pypi && existing_resource.version.to_s == version))
+            new_resource_blocks += <<-EOS
   #{existing_block.dup}
 
-          EOS
-          next
-        end
-        # Append indented resource block
-        new_resource_blocks += <<-EOS
+            EOS
+            next
+          end
+          # Append indented resource block
+          new_resource_blocks += <<-EOS
   resource "#{name}" do
     url "#{url}"
     sha256 "#{checksum}"
   end
 
-        EOS
-      else
+          EOS
+        end
+      end
+
+      if package_error.present?
         # Leave a placeholder for formula author to investigate
         package_errors += "  # RESOURCE-ERROR: Unable to resolve \"#{package}\" (#{package_error})\n"
       end
@@ -431,6 +431,11 @@ module PyPI
       puts resource_section.chomp
       return
     end
+
+    odie <<~EOS unless non_pypi_resource_names.empty?
+      "#{formula.name}" contains non-PyPI resources: #{non_pypi_resource_names.sort.join(", ")}
+      Please update the resources manually.
+    EOS
 
     # Check whether resources already exist (excluding virtualenv dependencies)
     if formula.resources.all? { |resource| resource.name.start_with?("homebrew-") }


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This allows autobumping formulae using tree-sitter Python packages which have incomplete sdist.

It will use PyPI sdist if a newer version is available. A maintainer may need to switch to corresponding non-PyPI tarball if issue still exists.

---

This doesn't handle case where Python dependency resource using non-PyPI url is removed. Manual bump is needed here for now, but should be visible in autobump CI run (and maybe we should autocreate an issue or output a summary in comment for general tracker issue).