### PR TITLE
cask: upgrade `auto_updates` casks when bundle version is stale

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -339,12 +339,15 @@ module Cask
         return installed_version if (greedy || greedy_latest) && outdated_download_sha?
 
         return
-      elsif auto_updates && !greedy && !greedy_auto_updates
-        return
       end
 
-      # not outdated unless there is a different version on tap
       return if installed_version == version
+
+      if auto_updates && !greedy && !greedy_auto_updates
+        return installed_version if auto_updates_bundle_outdated?
+
+        return
+      end
 
       installed_version
     end
@@ -557,6 +560,58 @@ module Cask
                              (plist = Pathname("#{bundle}/Contents/Info.plist")) && plist.exist? && plist.readable?
         Homebrew::BundleVersion.from_info_plist(plist)
       end
+    end
+
+    sig { returns(T.nilable(Artifact::App)) }
+    def single_app_artifact
+      app_artifacts = artifacts.grep(Artifact::App)
+      return unless app_artifacts.one?
+
+      app_artifacts.first
+    end
+
+    sig { returns(T.nilable(Pathname)) }
+    def installed_app_info_plist
+      return unless (app_artifact = single_app_artifact)
+
+      info_plist = app_artifact.target/"Contents/Info.plist"
+      info_plist if info_plist.exist? && info_plist.readable?
+    end
+
+    sig { params(first: T.nilable(String), second: T.nilable(String)).returns(T.nilable(Integer)) }
+    def compare_version_strings(first, second)
+      return if first.blank? || second.blank?
+
+      Version.new(first) <=> Version.new(second)
+    rescue
+      nil
+    end
+
+    sig { returns(T::Boolean) }
+    def auto_updates_bundle_outdated?
+      return false if !auto_updates || version.latest?
+      return false unless installed_app_info_plist
+
+      tap_short_version = version.csv.first.to_s.presence || version.to_s
+
+      begin
+        installed_short_version = bundle_short_version
+        installed_bundle_version = bundle_long_version
+      rescue ErrorDuringExecution
+        return false
+      end
+
+      short_comparison = compare_version_strings(installed_short_version, tap_short_version)
+      return true if short_comparison == -1
+      return false if short_comparison == 1
+
+      build_comparisons = version.csv.filter_map do |candidate|
+        compare_version_strings(installed_bundle_version, candidate.to_s)
+      end
+      return false if build_comparisons.empty?
+      return false if build_comparisons.include?(0)
+
+      build_comparisons.include?(-1)
     end
 
     def api_to_local_hash(hash)

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -125,14 +125,14 @@ module Cask
 
       if casks.empty? && !greedy && greedy_casks.empty?
         if !greedy_auto_updates && !greedy_latest
-          ohai "Casks with 'auto_updates true' or 'version :latest' " \
-               "will not be upgraded; pass `--greedy` to upgrade them."
+          ohai "Some casks with 'auto_updates true' or 'version :latest' " \
+               "may still require '--greedy' to be upgraded."
         end
         if greedy_auto_updates && !greedy_latest
           ohai "Casks with 'version :latest' will not be upgraded; pass `--greedy-latest` to upgrade them."
         end
         if !greedy_auto_updates && greedy_latest
-          ohai "Casks with 'auto_updates true' will not be upgraded; pass `--greedy-auto-updates` to upgrade them."
+          ohai "Some casks with 'auto_updates true' may still require '--greedy-auto-updates' to be upgraded."
         end
       end
 

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -2,6 +2,58 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Cask, :cask do
+  def write_info_plist(path, short_version: nil, bundle_version: nil, contents: nil)
+    info_plist = path/"Contents/Info.plist"
+    info_plist.dirname.mkpath
+
+    if contents
+      info_plist.write(contents)
+      return
+    end
+
+    entries = []
+    if short_version
+      entries << <<~PLIST.chomp
+        <key>CFBundleShortVersionString</key>
+        <string>#{short_version}</string>
+      PLIST
+    end
+    if bundle_version
+      entries << <<~PLIST.chomp
+        <key>CFBundleVersion</key>
+        <string>#{bundle_version}</string>
+      PLIST
+    end
+
+    info_plist.write <<~PLIST
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+      #{entries.join("\n")}
+      </dict>
+      </plist>
+    PLIST
+  end
+
+  def write_auto_updates_cask(path, version:, artifacts:, token: "auto-updates-bundle-check")
+    path.write <<~RUBY
+      cask "#{token}" do
+        version "#{version}"
+        sha256 "5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d"
+
+        url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyApp.zip"
+        homepage "https://brew.sh/MyFancyApp"
+
+        auto_updates true
+
+        #{artifacts.join("\n  ")}
+      end
+    RUBY
+
+    Cask::CaskLoader.load(path)
+  end
+
   let(:cask) { described_class.new("versioned-cask") }
 
   context "when multiple versions are installed" do
@@ -138,6 +190,93 @@ RSpec.describe Cask::Cask, :cask do
         include_examples "versioned casks", "1.2.4",
                          "1.2.3" => "1.2.3",
                          "1.2.4" => nil
+      end
+    end
+
+    describe "auto-updating versioned casks with bundle metadata" do
+      let(:dir) { Pathname(mktmpdir) }
+      let(:cask_file) { dir/"auto-updates-bundle-check.rb" }
+      let(:artifacts) { ['app "MyFancyApp.app"'] }
+
+      it "is outdated when the installed short version is lower than the tap version" do
+        tap_version = "2.61"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.57")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.57", bundle_version: "2057")
+
+        expect(cask.outdated_version).to eq("2.57")
+      end
+
+      it "is outdated when the short version matches and the bundle version is lower than a CSV candidate" do
+        tap_version = "2.61,3000"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.57")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.61", bundle_version: "2057")
+
+        expect(cask.outdated_version).to eq("2.57")
+      end
+
+      it "is not outdated when the short version matches and the bundle version matches any CSV candidate" do
+        tap_version = "2.61,3000,2057"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.57")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.61", bundle_version: "2057")
+
+        expect(cask.outdated_version).to be_nil
+      end
+
+      it "is not outdated when the installed short version is higher than the tap version" do
+        tap_version = "2.61"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.57")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.62", bundle_version: "2057")
+
+        expect(cask.outdated_version).to be_nil
+      end
+
+      it "is not outdated when the installed cask version already matches the tap version" do
+        tap_version = "2.61"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.61")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.57", bundle_version: "2057")
+
+        expect(cask.outdated_version).to be_nil
+      end
+
+      it "is not outdated when the short version matches and the bundle version is higher than all CSV candidates" do
+        tap_version = "2.61,2056,2055"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.57")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.61", bundle_version: "2057")
+
+        expect(cask.outdated_version).to be_nil
+      end
+
+      it "matches a bundle version candidate that is not first in the CSV list" do
+        tap_version = "2.61,3000,2057"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.57")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.61", bundle_version: "2057")
+
+        expect(cask.version.csv.first).not_to eq("2057")
+        expect(cask.outdated_version).to be_nil
+      end
+
+      it "is not outdated when the app bundle metadata cannot be read" do
+        tap_version = "2.61"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.57")
+
+        expect(cask.outdated_version).to be_nil
+      end
+
+      it "falls back to the bundle version when the short version is missing" do
+        tap_version = "2.61,3000"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.57")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", bundle_version: "2057")
+
+        expect(cask.outdated_version).to eq("2.57")
       end
     end
 

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -4,6 +4,23 @@
 require "cask/upgrade"
 
 RSpec.describe Cask::Upgrade, :cask do
+  def write_info_plist(path, short_version:, bundle_version:)
+    info_plist = path/"Contents/Info.plist"
+    info_plist.dirname.mkpath
+    info_plist.write <<~PLIST
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>CFBundleShortVersionString</key>
+        <string>#{short_version}</string>
+        <key>CFBundleVersion</key>
+        <string>#{bundle_version}</string>
+      </dict>
+      </plist>
+    PLIST
+  end
+
   let(:version_latest_paths) do
     [
       version_latest.config.appdir.join("Caffeine Mini.app"),
@@ -40,11 +57,23 @@ RSpec.describe Cask::Upgrade, :cask do
       ].each do |cask_name|
         InstallHelper.stub_cask_installation(Cask::CaskLoader.load(cask_path(cask_name)))
       end
+
+      write_info_plist(auto_updates_path, short_version: "2.57", bundle_version: "2057")
     end
 
-    describe 'without --greedy it ignores the Casks with "version latest" or "auto_updates true"' do
-      it "would update all the installed Casks when no token is provided" do
+    describe "without --greedy" do
+      it 'includes "auto_updates true" casks when the installed bundle version is older than the tap version' do
         expect(described_class).not_to receive(:upgrade_cask)
+        expect(described_class).to receive(:show_upgrade_summary) do |cask_upgrades, dry_run:|
+          expect(dry_run).to be(true)
+          expect(cask_upgrades).to include(
+            "local-caffeine 1.2.2 -> 1.2.3",
+            "local-transmission-zip 2.60 -> 2.61",
+            "auto-updates 2.57 -> 2.61",
+            "renamed-app 1.0.0 -> 2.0.0",
+          )
+          expect(cask_upgrades.grep(/version-latest/)).to be_empty
+        end
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -75,8 +104,27 @@ RSpec.describe Cask::Upgrade, :cask do
         expect(renamed_app.installed_version).to eq "1.0.0"
       end
 
+      it 'excludes "auto_updates true" casks when the installed bundle matches the tap version' do
+        write_info_plist(auto_updates_path, short_version: "2.61", bundle_version: "2061")
+
+        expect(described_class).not_to receive(:upgrade_cask)
+        expect(described_class).to receive(:show_upgrade_summary) do |cask_upgrades, dry_run:|
+          expect(dry_run).to be(true)
+          expect(cask_upgrades).to include(
+            "local-caffeine 1.2.2 -> 1.2.3",
+            "local-transmission-zip 2.60 -> 2.61",
+            "renamed-app 1.0.0 -> 2.0.0",
+          )
+          expect(cask_upgrades.grep(/auto-updates/)).to be_empty
+        end
+
+        described_class.upgrade_casks!(dry_run: true, args:)
+      end
+
       it "would update only the Casks specified in the command line" do
         expect(described_class).not_to receive(:upgrade_cask)
+        expect(described_class).to receive(:show_upgrade_summary)
+          .with(["local-caffeine 1.2.2 -> 1.2.3"], dry_run: true)
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -99,6 +147,8 @@ RSpec.describe Cask::Upgrade, :cask do
 
       it 'would update "auto_updates" and "latest" Casks when their tokens are provided in the command line' do
         expect(described_class).not_to receive(:upgrade_cask)
+        expect(described_class).to receive(:show_upgrade_summary)
+          .with(["local-caffeine 1.2.2 -> 1.2.3", "auto-updates 2.57 -> 2.61"], dry_run: true)
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -181,6 +231,8 @@ RSpec.describe Cask::Upgrade, :cask do
 
       it 'would update outdated Casks with "auto_updates true"' do
         expect(described_class).not_to receive(:upgrade_cask)
+        expect(described_class).to receive(:show_upgrade_summary)
+          .with(["auto-updates 2.57 -> 2.61"], dry_run: true)
 
         expect(auto_updates).to be_installed
         expect(auto_updates_path).to be_a_directory
@@ -195,6 +247,8 @@ RSpec.describe Cask::Upgrade, :cask do
 
       it 'would update outdated Casks with "version latest"' do
         expect(described_class).not_to receive(:upgrade_cask)
+        expect(described_class).to receive(:show_upgrade_summary)
+          .with(["version-latest latest -> latest"], dry_run: true)
 
         expect(version_latest).to be_installed
         expect(version_latest_paths).to all be_a_directory


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used Codex to help plan out and implement the initial version of `bundle_version`. I have reviewed and tested the functionality, but anticipate that there will be some edge-cases.

-----

<details>
<summary>Outdated Description </summary>


This PR introduces an initial implementation of a `bundle_version` parameter for cask artifacts. In this first iteration, it only applies to `app` artifacts, which is the primary target for this feature.

The goal is to support metadata-only upgrades when an app has already been updated outside Homebrew, for example by an in-app updater. If a newer cask is available in Homebrew, and the installed app bundle already matches the incoming cask’s version and `bundle_version`, Homebrew updates its installed cask metadata without fetching or reinstalling the app.

Note that this **only** applies when the version matches, so `brew upgrade <cask>` would still run an installation when the installed version is greater than the Homebrew version. A future possible enhancement (out of scope here) could be to handle cases where the installed app is never than the incoming cask version.

I’ve kept this PR scoped to the MVP. For broader adoption, we would also want `brew bump` and `brew bump-cask-pr` support to detect and update `bundle_version` automatically. I intend to work on this as a follow-up, unless there is preference to include it here.

---

Included in this PR;
- Initial `bundle_version` support for `app` artifacts
- Metadata-only upgrades when the installed app matches the incoming cask’s version and `bundle_version`
- Skipping fetch when a metadata-only upgrade will be performed
- `brew audit --online` functionality to check the `bundle_version` values against the artifact

Follow-up work:
- `bundle_version` detection and update support in `brew bump` and `brew bump-cask-pr`
- Potential handling for apps already newer than the incoming cask version

</details>

This PR introduces a change to the way that we handle upgrades for simple Casks in `homebrew-cask`, with the qualifiers that they only have a single `app` artifact, and have `auto_updates true`. At present these are only ever upgraded with `brew upgrade` when the `--greedy` or `--greedy-auto-updates` flags are passed.

The PR introduces a `bundle_version` check that looks inside the installed applications `info.plist` file and compares the version numbers with the incoming latest version from the tap. If the incoming version is detected as being newer than the installed version, then we proceed with the upgrade. 

There is a level of naivety involved in the version matching, as there is a lot of inconsistent between how developers set the `CFBundleVersion` and `CFShortBundleVersionString` in `info.plist` versus how we use `version` in `homebrew-cask`. This means that we look for a broad range of matches, which may prove to be too loose. In my testing it has seemed to be ok, especially because we still look for an outdated Caskroom file, so we shouldn't ever see repeated upgrades for the same version.