### PR TITLE
brew-rs: default to anonymous GHCR bearer token in fetch

### DIFF
--- a/Library/Homebrew/rust/brew-rs/src/commands/fetch.rs
+++ b/Library/Homebrew/rust/brew-rs/src/commands/fetch.rs
@@ -529,29 +529,39 @@ fn download_http_url(
     destination: &Path,
     progress: &Arc<Mutex<DownloadProgress>>,
 ) -> BrewResult<()> {
+    let auth_header = resolve_http_auth(url);
     let mut request = client.get(url.as_str());
-    if should_send_github_packages_auth(url) {
-        if let Some(auth) = env_value("HOMEBREW_GITHUB_PACKAGES_AUTH") {
-            let mut headers = HeaderMap::new();
-            headers.insert(
-                AUTHORIZATION,
-                HeaderValue::from_str(&auth)
-                    .context("Failed to build GitHub Packages authorization header")?,
-            );
-            request = request.headers(headers);
-        }
+    if let Some(auth) = &auth_header {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(auth).context("Failed to build authorization header")?,
+        );
+        request = request.headers(headers);
     }
 
     let mut response = request
         .send()
-        .with_context(|| format!("Failed to download {}", url))?
+        .with_context(|| format!("Failed to download {url}"))?
         .error_for_status()
-        .with_context(|| format!("Failed to download {}", url))?;
+        .with_context(|| format!("Failed to download {url}"))?;
     update_download_total(progress, response.content_length());
     let mut output = File::create(destination)
         .with_context(|| format!("Failed to create {}", destination.display()))?;
     copy_stream(&mut response, &mut output, progress)?;
     Ok(())
+}
+
+const GHCR_ANONYMOUS_TOKEN: &str = "Bearer QQ==";
+
+fn resolve_http_auth(url: &Url) -> Option<String> {
+    if !should_send_github_packages_auth(url) {
+        return None;
+    }
+    Some(
+        env_value("HOMEBREW_GITHUB_PACKAGES_AUTH")
+            .unwrap_or_else(|| GHCR_ANONYMOUS_TOKEN.to_string()),
+    )
 }
 
 fn copy_stream(


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

I initally thought there was something going on with the redirect/Accept header interaction, but it just looks like the rust downloader depends on `brew.sh` setting `HOMEBREW_GITHUB_PACKAGES_AUTH` for GHCR bottle downloads. so when this variable isn't present (direct binary invocation, testing), GHCR returns 401 and the download fails silently.

this PR ~~adds OCI bearer token negotiation as a fallback. essentially, when a GHCR blob request gets a 401 with a www-authenticate challenge, we now just fetch an anonymous bearer token from the token endpoint and retry. this falls in line with how standard OCI/Docker clients authenticate with public registries.~~ falls back to `Bearer QQ==` when the env var is not set.

the existing `HOMEBREW_GITHUB_PACKAGES_AUTH` path is still of course, preferred when available.