### PR TITLE
Fix bundle  check for tap-qualified formula services

### DIFF
--- a/Library/Homebrew/bundle/brew_services.rb
+++ b/Library/Homebrew/bundle/brew_services.rb
@@ -100,9 +100,16 @@ module Homebrew
           _ = no_upgrade
 
           return true unless formula_needs_to_start?(entry_to_formula(formula))
-          return true if self.class.started?(formula.name)
 
-          old_name = lookup_old_name(formula.name)
+          name = formula.name
+          return true if self.class.started?(name)
+
+          # `brew services list` returns base names, so fall back to the last
+          # path component for tap-qualified entries (e.g., "user/tap/formula").
+          base_name = name.split("/").last
+          return true if base_name != name && self.class.started?(base_name)
+
+          old_name = lookup_old_name(name)
           return true if old_name && self.class.started?(old_name)
 
           false

--- a/Library/Homebrew/test/bundle/brew_services_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_services_spec.rb
@@ -88,6 +88,32 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
     end
   end
 
+  describe "#installed_and_up_to_date?" do
+    subject(:services) { described_class.new }
+
+    before do
+      described_class.reset!
+      allow(described_class).to receive(:started_services).and_return(%w[mailhog])
+      allow(services).to receive(:formula_needs_to_start?).and_return(true)
+      allow(Homebrew::Bundle::Brew).to receive(:formula_oldnames).and_return({})
+    end
+
+    it "matches a tap-qualified formula by base name" do
+      entry = double(name: "some-tap/tap/mailhog", options: { restart_service: true })
+      expect(services.installed_and_up_to_date?(entry)).to be(true)
+    end
+
+    it "matches a non-tap-qualified formula by name" do
+      entry = double(name: "mailhog", options: { restart_service: true })
+      expect(services.installed_and_up_to_date?(entry)).to be(true)
+    end
+
+    it "returns false when service is not started" do
+      entry = double(name: "some-tap/tap/nginx", options: { restart_service: true })
+      expect(services.installed_and_up_to_date?(entry)).to be(false)
+    end
+  end
+
   describe ".versioned_service_file" do
     let(:foo) do
       instance_double(


### PR DESCRIPTION
`brew bundle check` fails for tap formulas with `restart_service: true` even when the service is running. `brew services list --json` returns base names (e.g., `mailhog`), but `installed_and_up_to_date?` compared the full tap-qualified entry name (e.g., `some-tap/tap/mailhog`), so the lookup never matched.

(As you might be able to tell, I encountered this when moving `mailhog` to a private tap so that our dev environments can keep running while we replace it.)

Strip the tap prefix and check the base name before falling through to the old-name lookup.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. Implementation and tests were drafted with Claude Opus 4.6 via Claude Code, then reviewed manually.