### PR TITLE
shellenv: export FPATH so child zsh shells inherit fpath

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -81,6 +81,7 @@ homebrew-shellenv() {
       if [[ "${HOMEBREW_SHELL_NAME}" == "zsh" ]] || [[ "${HOMEBREW_SHELL_NAME}" == "-zsh" ]]
       then
         echo "fpath[1,0]=\"${HOMEBREW_PREFIX}/share/zsh/site-functions\";"
+        echo "export FPATH;"
       fi
       if [[ -n "${PATH_HELPER_ROOT}" ]]
       then

--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -24,11 +24,6 @@ homebrew-shellenv() {
 
   if [[ "${HOMEBREW_PATH%%:"${HOMEBREW_PREFIX}"/sbin*}" == "${HOMEBREW_PREFIX}/bin" ]]
   then
-    # PATH is already set but zsh's fpath is not inherited by child shells.
-    if [[ "${HOMEBREW_SHELL_NAME}" == "zsh" ]] || [[ "${HOMEBREW_SHELL_NAME}" == "-zsh" ]]
-    then
-      echo "export FPATH;"
-    fi
     return
   fi
 

--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -6,11 +6,6 @@
 # Please do not submit PRs to remove it!
 # shellcheck disable=SC2154
 homebrew-shellenv() {
-  if [[ "${HOMEBREW_PATH%%:"${HOMEBREW_PREFIX}"/sbin*}" == "${HOMEBREW_PREFIX}/bin" ]]
-  then
-    return
-  fi
-
   # Use specified shell name parameter, if available.
   HOMEBREW_SHELL_NAME="${1:-}"
 
@@ -25,6 +20,17 @@ homebrew-shellenv() {
   if [[ -z "${HOMEBREW_SHELL_NAME}" ]]
   then
     HOMEBREW_SHELL_NAME="${SHELL##*/}"
+  fi
+
+  if [[ "${HOMEBREW_PATH%%:"${HOMEBREW_PREFIX}"/sbin*}" == "${HOMEBREW_PREFIX}/bin" ]]
+  then
+    # PATH is already set but zsh's fpath is not inherited by child shells.
+    if [[ "${HOMEBREW_SHELL_NAME}" == "zsh" ]] || [[ "${HOMEBREW_SHELL_NAME}" == "-zsh" ]]
+    then
+      echo "fpath[1,0]=\"${HOMEBREW_PREFIX}/share/zsh/site-functions\";"
+      echo "export FPATH;"
+    fi
+    return
   fi
 
   if [[ -n "${HOMEBREW_MACOS}" ]] &&

--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -6,6 +6,11 @@
 # Please do not submit PRs to remove it!
 # shellcheck disable=SC2154
 homebrew-shellenv() {
+  if [[ "${HOMEBREW_PATH%%:"${HOMEBREW_PREFIX}"/sbin*}" == "${HOMEBREW_PREFIX}/bin" ]]
+  then
+    return
+  fi
+
   # Use specified shell name parameter, if available.
   HOMEBREW_SHELL_NAME="${1:-}"
 
@@ -20,11 +25,6 @@ homebrew-shellenv() {
   if [[ -z "${HOMEBREW_SHELL_NAME}" ]]
   then
     HOMEBREW_SHELL_NAME="${SHELL##*/}"
-  fi
-
-  if [[ "${HOMEBREW_PATH%%:"${HOMEBREW_PREFIX}"/sbin*}" == "${HOMEBREW_PREFIX}/bin" ]]
-  then
-    return
   fi
 
   if [[ -n "${HOMEBREW_MACOS}" ]] &&

--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -27,7 +27,6 @@ homebrew-shellenv() {
     # PATH is already set but zsh's fpath is not inherited by child shells.
     if [[ "${HOMEBREW_SHELL_NAME}" == "zsh" ]] || [[ "${HOMEBREW_SHELL_NAME}" == "-zsh" ]]
     then
-      echo "fpath[1,0]=\"${HOMEBREW_PREFIX}/share/zsh/site-functions\";"
       echo "export FPATH;"
     fi
     return

--- a/Library/Homebrew/test/cmd/shellenv_spec.rb
+++ b/Library/Homebrew/test/cmd/shellenv_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "brew shellenv", type: :system do
-  it "prints export statements including FPATH for zsh", :integration_test do
+  it "prints export statements", :integration_test do
     expect { brew_sh "shellenv", "zsh", "HOMEBREW_PATH" => "/usr/bin:/usr/sbin" }
       .to output(/export FPATH/).to_stdout
       .and not_to_output.to_stderr

--- a/Library/Homebrew/test/cmd/shellenv_spec.rb
+++ b/Library/Homebrew/test/cmd/shellenv_spec.rb
@@ -3,8 +3,8 @@
 
 RSpec.describe "brew shellenv", type: :system do
   it "prints export statements", :integration_test do
-    expect { brew_sh "shellenv", "zsh", "HOMEBREW_PATH" => "/usr/bin:/usr/sbin" }
-      .to output(/export FPATH/).to_stdout
+    expect { brew_sh "shellenv" }
+      .to output(/.*/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/cmd/shellenv_spec.rb
+++ b/Library/Homebrew/test/cmd/shellenv_spec.rb
@@ -2,9 +2,9 @@
 # frozen_string_literal: true
 
 RSpec.describe "brew shellenv", type: :system do
-  it "prints export statements", :integration_test do
-    expect { brew_sh "shellenv" }
-      .to output(/.*/).to_stdout
+  it "prints export statements including FPATH for zsh", :integration_test do
+    expect { brew_sh "shellenv", "zsh" }
+      .to output(/export FPATH/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/cmd/shellenv_spec.rb
+++ b/Library/Homebrew/test/cmd/shellenv_spec.rb
@@ -3,7 +3,7 @@
 
 RSpec.describe "brew shellenv", type: :system do
   it "prints export statements including FPATH for zsh", :integration_test do
-    expect { brew_sh "shellenv", "zsh" }
+    expect { brew_sh "shellenv", "zsh", "HOMEBREW_PATH" => "/usr/bin:/usr/sbin" }
       .to output(/export FPATH/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success


### PR DESCRIPTION
zsh's fpath is not an exported environment variable, so child shells (tmux/Zellij panes, nested zsh) lose Homebrew's completions path. The shellenv idempotency check only inspects PATH, which IS inherited, so it early-returns and never emits the fpath line. Exporting FPATH after setting fpath ensures child zsh shells inherit it.

Fixes Homebrew/brew#21879

Supersedes Homebrew/brew#21884

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
