### PR TITLE
formula: add `:urfave` completion and fix else case

### DIFF
--- a/Library/Homebrew/utils/shell_completion.rb
+++ b/Library/Homebrew/utils/shell_completion.rb
@@ -25,7 +25,7 @@ module Utils
       ).returns(T.nilable(T.any(String, T::Array[String])))
     }
     def self.completion_shell_parameter(format, shell, executable, env)
-      # Go's cobra and Rust's clap accept "powershell".
+      # Converts :pwsh to "powershell" for formats that expect the full shell name.
       shell_parameter = (shell == :pwsh) ? "powershell" : shell.to_s
 
       case format
@@ -49,8 +49,10 @@ module Utils
       when :typer
         env["_TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION"] = "1"
         ["--show-completion", shell_parameter]
+      when :urfave
+        ["completion", shell.to_s]
       else
-        "#{format}#{shell}"
+        "#{format}#{shell_parameter}"
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

~This will add `:powershell` competion type for explicitely split `:pwsh` and `:powershell`. Of course they are same but package owners are using them mixed.~

- https://github.com/Homebrew/homebrew-core/pull/276063
- https://github.com/Homebrew/homebrew-core/blob/a420ab142fd59e16433268fb5c118b168d389925/Formula/r/rip2.rb#L27

~It is not much but is better to apply I think.~

~This can break current `:pwsh`, so my plan is this.~
- ~First, add `:powershell` and use it only in `:cobra` and `:typer`.~
- ~Migrate `:pwsh` usage in formulae to `:powershell` if they are fit to it.~
- ~Remove https://github.com/Homebrew/brew/blob/d56b31376b977c4117e5c2bd732df4c0dc330ff9/Library/Homebrew/utils/shell_completion.rb#L29 at the following PR to preserve `:pwsh` as `pwsh`.~
- ~Now we can use both for sutible cases.~

--- 

It seems that `stencil` is the only usage for `pwsh` with specific go library, so let's add it as a case.
- https://github.com/Homebrew/homebrew-core/pull/276063

 And fix the else case to match with others. This will fix `solana` completion.
- https://github.com/Homebrew/homebrew-core/blob/5602d0a99fe13902c1f1a05b0330a02857b4fd0c/Formula/s/solana.rb#L82

`rip2` case is false positive, it can be merged to the `:cobra` format.
- https://github.com/Homebrew/homebrew-core/pull/276415