### PR TITLE
services: fix `timed?` and `keep_alive?` return type to   `T::Boolean`

### DIFF
--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -50,17 +50,27 @@ module Homebrew
       end
 
       # Delegate access to `formula.service.timed?`.
-      # TODO: this should either be T::Boolean or renamed to `timed`
-      sig { returns(T.nilable(T::Boolean)) }
+      sig { returns(T::Boolean) }
       def timed?
-        @timed ||= T.let((load_service.timed? if service?), T.nilable(T::Boolean))
+        @timed ||= T.let(
+          if service?
+            load_service.timed?
+          else
+            false
+          end, T.nilable(T::Boolean)
+        )
       end
 
       # Delegate access to `formula.service.keep_alive?`.
-      # TODO: this should either be T::Boolean or renamed to `keep_alive`
-      sig { returns(T.nilable(T::Boolean)) }
+      sig { returns(T::Boolean) }
       def keep_alive?
-        @keep_alive ||= T.let((load_service.keep_alive? if service?), T.nilable(T::Boolean))
+        @keep_alive ||= T.let(
+          if service?
+            load_service.keep_alive?
+          else
+            false
+          end, T.nilable(T::Boolean)
+        )
       end
 
       # service_name delegates with formula.plist_name or formula.service_name

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -52,25 +52,19 @@ module Homebrew
       # Delegate access to `formula.service.timed?`.
       sig { returns(T::Boolean) }
       def timed?
-        @timed ||= T.let(
-          if service?
-            load_service.timed?
-          else
-            false
-          end, T.nilable(T::Boolean)
-        )
+        return @timed unless @timed.nil?
+
+        @timed = T.let(service? && load_service.timed?, T.nilable(T::Boolean))
+        T.must(@timed)
       end
 
       # Delegate access to `formula.service.keep_alive?`.
       sig { returns(T::Boolean) }
       def keep_alive?
-        @keep_alive ||= T.let(
-          if service?
-            load_service.keep_alive?
-          else
-            false
-          end, T.nilable(T::Boolean)
-        )
+        return @keep_alive unless @keep_alive.nil?
+
+        @keep_alive = T.let(service? && load_service.keep_alive?, T.nilable(T::Boolean))
+        T.must(@keep_alive)
       end
 
       # service_name delegates with formula.plist_name or formula.service_name

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -55,7 +55,7 @@ module Homebrew
         return @timed unless @timed.nil?
 
         @timed = T.let(service? && load_service.timed?, T.nilable(T::Boolean))
-        T.must(@timed)
+        @timed || false
       end
 
       # Delegate access to `formula.service.keep_alive?`.
@@ -64,7 +64,7 @@ module Homebrew
         return @keep_alive unless @keep_alive.nil?
 
         @keep_alive = T.let(service? && load_service.keep_alive?, T.nilable(T::Boolean))
-        T.must(@keep_alive)
+        @keep_alive || false
       end
 
       # service_name delegates with formula.plist_name or formula.service_name

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -55,7 +55,7 @@ module Homebrew
         return @timed unless @timed.nil?
 
         @timed = T.let(service? && load_service.timed?, T.nilable(T::Boolean))
-        @timed || false
+        @timed ||= false
       end
 
       # Delegate access to `formula.service.keep_alive?`.
@@ -64,7 +64,7 @@ module Homebrew
         return @keep_alive unless @keep_alive.nil?
 
         @keep_alive = T.let(service? && load_service.keep_alive?, T.nilable(T::Boolean))
-        @keep_alive || false
+        @keep_alive ||= false
       end
 
       # service_name delegates with formula.plist_name or formula.service_name

--- a/Library/Homebrew/test/services/formula_wrapper_spec.rb
+++ b/Library/Homebrew/test/services/formula_wrapper_spec.rb
@@ -324,10 +324,10 @@ RSpec.describe Homebrew::Services::FormulaWrapper do
       expect(service.timed?).to be(false)
     end
 
-    it "returns nil if no service" do
+    it "returns false if no service" do
       allow(service).to receive(:service?).once.and_return(false)
 
-      expect(service.timed?).to be_nil
+      expect(service.timed?).to be(false)
     end
   end
 
@@ -350,10 +350,10 @@ RSpec.describe Homebrew::Services::FormulaWrapper do
       expect(service.keep_alive?).to be(false)
     end
 
-    it "returns nil if no service" do
+    it "returns false if no service" do
       allow(service).to receive(:service?).once.and_return(false)
 
-      expect(service.keep_alive?).to be_nil
+      expect(service.keep_alive?).to be(false)
     end
   end
 
@@ -383,7 +383,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper do
         pid:          nil,
         registered:   false,
         running:      false,
-        schedulable:  nil,
+        schedulable:  false,
         service_name: "plist-mysql-test",
         status:       :none,
         user:         nil,
@@ -405,7 +405,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper do
         pid:          nil,
         registered:   true,
         running:      false,
-        schedulable:  nil,
+        schedulable:  false,
         service_name: "plist-mysql-test",
         status:       :none,
         user:         nil,


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
solve https://github.com/Homebrew/brew/blob/ac782bcd32ff3fb93fbac38ee5785dd2ccd95bad/Library/Homebrew/services/formula_wrapper.rb#L53
- Change the method signatures from `T.nilable(T::Boolean)`  to `T::Boolean`