### PR TITLE
GitDownloadStrategy: fix slow repo_valid? by using -C flag

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1062,7 +1062,7 @@ class GitDownloadStrategy < VCSDownloadStrategy # rubocop:todo Style/OneClassPer
 
   sig { override.returns(T::Boolean) }
   def repo_valid?
-    silent_command("git", args: ["--git-dir", git_dir, "status", "-s"]).success?
+    silent_command("git", args: ["-C", cached_location, "status", "-s"]).success?
   end
 
   sig { returns(T::Boolean) }


### PR DESCRIPTION
## Summary

`repo_valid?` runs `git status -s` without specifying `-C`, so git falls back to the current working directory. If CWD happens to be a large directory (e.g. the user's home directory), this causes git to scan the entire tree, making the call unexpectedly slow.

Fix by using `git -C cached_location status -s` so git always operates in the correct directory regardless of CWD.

## Test plan

- [x] Verify `brew style --fix Library/Homebrew/download_strategy.rb` passes
- [x] Verify `brew typecheck` passes

## Before

Takes more than 10 minutes.

```
; timeout 10m git --git-dir ~/.cache/Homebrew/helix--git/.git status -s
; echo $?
124
```

## After
```
; time git -C ~/.cache/Homebrew/helix--git status -s
git -C ~/.cache/Homebrew/helix--git status -  0.00s user 0.01s system 121% cpu 0.007 total
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----