### PR TITLE
generate-cask-ci-matrix: fix Linux runner for single-arch casks

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
@@ -154,6 +154,31 @@ module Homebrew
         filtered_runners.merge(linux_runners)
       end
 
+      sig {
+        params(
+          runners:  T::Array[T::Hash[Symbol, T.any(Symbol, String)]],
+          multi_os: T::Boolean,
+        ).returns(T::Array[[T::Hash[Symbol, T.any(Symbol, String)], T.any(Symbol, String), T::Boolean]])
+      }
+      def runner_arch_pairs(runners:, multi_os:)
+        macos_archs = runners.reject { |r| r.fetch(:symbol) == :linux }.map { |r| r.fetch(:arch) }.uniq
+        linux_archs = runners.select { |r| r.fetch(:symbol) == :linux }.map { |r| r.fetch(:arch) }.uniq
+        product_archs = macos_archs | linux_archs
+        runners.product(product_archs).filter_map do |runner, arch|
+          native_runner_arch = arch == runner.fetch(:arch)
+          # we don't need to run simulated archs on Linux or macOS Sequoia
+          # because they exist as real GitHub hosted runners
+          next if runner.fetch(:symbol) == :linux && !native_runner_arch
+          next if runner.fetch(:symbol) == :sequoia && !native_runner_arch
+          # skip macOS runners simulating architectures not supported on macOS
+          next if runner.fetch(:symbol) != :linux && !native_runner_arch && macos_archs.exclude?(arch)
+          # if it's just a single OS test then we can just use the two real arch runners
+          next if !native_runner_arch && !multi_os
+
+          [runner, arch, native_runner_arch]
+        end
+      end
+
       private
 
       sig { params(cask: Cask::Cask, os: Symbol).returns(T::Array[Symbol]) }
@@ -274,16 +299,7 @@ module Homebrew
           cask = Cask::CaskLoader.load(path.expand_path)
 
           runners, multi_os = runners(cask:)
-          runners.product(architectures(cask:, os: :macos)).filter_map do |runner, arch|
-            native_runner_arch = arch == runner.fetch(:arch)
-            # we don't need to run simulated archs on Linux or macOS Sequoia
-            # because they exist as real GitHub hosted runner
-            next if runner.fetch(:symbol) == :linux && !native_runner_arch
-            next if runner.fetch(:symbol) == :sequoia && !native_runner_arch
-
-            # If it's just a single OS test then we can just use the two real arch runners.
-            next if !native_runner_arch && !multi_os
-
+          runner_arch_pairs(runners:, multi_os:).map do |runner, arch, native_runner_arch|
             arch_args = native_runner_arch ? [] : ["--arch=#{arch}"]
             runner_output = {
               name:         "test #{cask_token} (#{runner.fetch(:name)}, #{arch})",

--- a/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
@@ -85,6 +85,22 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
       homepage "https://brew.sh"
     end
   end
+  let(:c_on_macos_depends_on_arm) do
+    Cask::Cask.new("test-on-macos-depends-on-arm") do
+      os macos: "darwin", linux: "linux"
+
+      version "0.0.1,2"
+
+      url "https://brew.sh/test-0.0.1.dmg"
+      name "Test"
+      desc "Test cask"
+      homepage "https://brew.sh"
+
+      on_macos do
+        depends_on arch: :arm64
+      end
+    end
+  end
   let(:c_depends_macos_on_intel) do
     Cask::Cask.new("test-depends-on-intel") do
       version "0.0.1,2"
@@ -229,12 +245,42 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
             { arch: :arm, name: arm_linux_runner, symbol: :linux }     => 1.0,
           })
 
+        expect(generate_matrix.filter_runners(c_on_macos_depends_on_arm))
+          .to eq({
+            { arch: :arm, name: "macos-14", symbol: :sonoma }       => 0.0,
+            { arch: :arm, name: "macos-15", symbol: :sequoia }      => 0.0,
+            { arch: :arm, name: "macos-26", symbol: :tahoe }        => 1.0,
+            { arch: :arm, name: arm_linux_runner, symbol: :linux }  => 1.0,
+            { arch: :intel, name: "ubuntu-latest", symbol: :linux } => 1.0,
+          })
+
         expect(generate_matrix.filter_runners(c_on_system_depends_on_mixed))
           .to eq({
             { arch: :arm, name: arm_linux_runner, symbol: :linux }     => 1.0,
             { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
           })
       end
+    end
+  end
+
+  describe "::runner_arch_pairs" do
+    let(:arm_linux_runner) { OS::LINUX_CI_ARM_RUNNER }
+
+    it "emits both Linux runners and no cross-arch macOS jobs when macOS is single-arch" do
+      runners = generate_matrix.filter_runners(c_on_macos_depends_on_arm).keys
+      pairs = generate_matrix.runner_arch_pairs(runners:, multi_os: true)
+      archs_by_runner = pairs.each_with_object({}) do |(runner, arch, _), h|
+        (h[runner.fetch(:name)] ||= []) << arch
+      end
+
+      # both Linux runners produce jobs for their native arch
+      expect(archs_by_runner[arm_linux_runner]).to eq([:arm])
+      expect(archs_by_runner["ubuntu-latest"]).to eq([:intel])
+
+      # macOS runners only get their native :arm, never simulated :intel
+      expect(archs_by_runner["macos-14"]).to eq([:arm])
+      expect(archs_by_runner["macos-15"]).to eq([:arm])
+      expect(archs_by_runner["macos-26"]).to eq([:arm])
     end
   end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used Claude Code, manually reviewed the code, validated locally.

-----

Casks that only support one macOS architecture (`arm64`-only) but both Linux architectures were missing the second Linux runner from the CI matrix. The runner product only used macOS architectures, an Intel Linux runner paired with `arm64` was skipped as non-native.

Fix by including Linux architectures in the product and guarding against macOS runners simulating architectures that don't exist on macOS.