### PR TITLE
cask: refine auto_updates behaviour

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -605,6 +605,10 @@ module Cask
         return false
       end
 
+      return false if [installed_short_version, installed_bundle_version].any? do |installed_plist_version|
+        compare_version_strings(installed_plist_version, tap_short_version)&.zero?
+      end
+
       short_comparison = compare_version_strings(installed_short_version, tap_short_version)
       return true if short_comparison == -1
       return false if short_comparison == 1

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -207,13 +207,13 @@ RSpec.describe Cask::Cask, :cask do
         expect(cask.outdated_version).to eq("2.57")
       end
 
-      it "is outdated when the short version matches and the bundle version is lower than a CSV candidate" do
+      it "is not outdated when the short version matches and the bundle version is lower than a CSV candidate" do
         tap_version = "2.61,3000"
         cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
         allow(cask).to receive(:installed_version).and_return("2.57")
         write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.61", bundle_version: "2057")
 
-        expect(cask.outdated_version).to eq("2.57")
+        expect(cask.outdated_version).to be_nil
       end
 
       it "is not outdated when the short version matches and the bundle version matches any CSV candidate" do
@@ -239,6 +239,33 @@ RSpec.describe Cask::Cask, :cask do
         cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
         allow(cask).to receive(:installed_version).and_return("2.61")
         write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.57", bundle_version: "2057")
+
+        expect(cask.outdated_version).to be_nil
+      end
+
+      it "is not outdated when the installed short version directly matches the tap version" do
+        tap_version = "2.61"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.57")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.61", bundle_version: "2057")
+
+        expect(cask.outdated_version).to be_nil
+      end
+
+      it "is not outdated when the installed bundle version directly matches the tap version" do
+        tap_version = "2057"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.57")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.61", bundle_version: "2057")
+
+        expect(cask.outdated_version).to be_nil
+      end
+
+      it "is not outdated when the installed short version matches a CSV build candidate" do
+        tap_version = "2.61,2057"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.57")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2057", bundle_version: "3000")
 
         expect(cask.outdated_version).to be_nil
       end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The current behaviour for checking if Casks with `auto_updates` is a bit too optimistic. This adds a guard clause that checks `version.to_s` or `version.csv.first` with both the `CFBundleVersion` and `CFBundleShortVersionString`, and if it finds an exact match marks it as not outdated.

The downside of this implementation is that we don't pick up a change where a build number increments while the version number does not. But I think it is reasonable that the default behaviour errs on the side of not being as greedy.