### PR TITLE
Fix flaky `run_actionlint!` tests

### DIFF
--- a/Library/Homebrew/test/style_spec.rb
+++ b/Library/Homebrew/test/style_spec.rb
@@ -54,6 +54,8 @@ RSpec.describe Homebrew::Style do
   describe ".run_actionlint!" do
     before do
       allow(described_class).to receive_messages(actionlint: "actionlint", shellcheck: "shellcheck")
+      # Run a trivial command so $CHILD_STATUS is non-nil after the stubbed `system` call.
+      system("true")
       allow(described_class).to receive(:system).and_return(true)
     end
 


### PR DESCRIPTION
- Seed `$CHILD_STATUS` with `system("true")` before stubbing so it is non-nil when the code calls `$CHILD_STATUS.success?` after the stubbed `system`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

OpenAI Codex with manual/local review and testing.

-----
