### PR TITLE
Fix outdated greedy cask handling

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -3,6 +3,7 @@
 
 require "env_config"
 require "cask/config"
+require "deprecate_disable"
 require "utils/output"
 
 module Cask
@@ -35,6 +36,11 @@ module Cask
 
       if casks.empty?
         Caskroom.casks(config: Config.from_args(args)).select do |cask|
+          if cask.disabled?
+            opoo "Not upgrading #{cask.token}, it is #{DeprecateDisable.message(cask)}" unless quiet
+            next false
+          end
+
           cask_greedy = greedy || greedy_casks.include?(cask.token)
           cask.outdated?(greedy: cask_greedy, greedy_latest:,
                          greedy_auto_updates:)
@@ -42,6 +48,11 @@ module Cask
       else
         casks.select do |cask|
           raise CaskNotInstalledError, cask if !cask.installed? && !force
+
+          if cask.disabled?
+            opoo "Not upgrading #{cask.token}, it is #{DeprecateDisable.message(cask)}" unless quiet
+            next false
+          end
 
           if cask.outdated?(greedy: true)
             true

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -216,7 +216,10 @@ module Homebrew
           if formula_or_cask.is_a?(Formula)
             formula_or_cask.outdated?(fetch_head: args.fetch_HEAD?)
           else
-            formula_or_cask.outdated?(greedy:              upgrade_greedy_cask?(args.greedy?, formula_or_cask),
+            cask_greedy = upgrade_greedy_cask?(args.greedy?, formula_or_cask)
+            next false if formula_or_cask.auto_updates && !cask_greedy && !args.greedy_auto_updates?
+
+            formula_or_cask.outdated?(greedy:              cask_greedy,
                                       greedy_latest:       args.greedy_latest?,
                                       greedy_auto_updates: args.greedy_auto_updates?)
           end

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -440,7 +440,7 @@ module Homebrew
           casks,
           args:,
           force:               args.force?,
-          quiet:               args.quiet?,
+          quiet:               true,
           greedy:              args.greedy?,
           greedy_latest:       args.greedy_latest?,
           greedy_auto_updates: args.greedy_auto_updates?,

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -333,6 +333,18 @@ RSpec.describe Cask::Upgrade, :cask do
     end
   end
 
+  it "warns and skips disabled casks" do
+    cask = Cask::CaskLoader.load(cask_path("livecheck/livecheck-disabled"))
+    InstallHelper.stub_cask_installation(cask)
+    allow(cask).to receive(:outdated?).with(greedy: true).and_return(true)
+
+    expect(described_class).not_to receive(:upgrade_cask)
+
+    expect do
+      described_class.upgrade_casks!(cask, dry_run: true, args:)
+    end.to output(/Not upgrading livecheck-disabled, it is disabled/).to_stderr
+  end
+
   context "when an upgrade failed" do
     # These tests perform actual upgrades and test rollback behavior,
     # so they need full real installations.

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -7,6 +7,24 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Outdated do
   it_behaves_like "parseable arguments"
 
+  it "skips auto-updating casks without --greedy-auto-updates", :cask do
+    cask = Cask::CaskLoader.load(cask_path("auto-updates"))
+    cmd = described_class.new([])
+
+    expect(cask).not_to receive(:outdated?)
+    expect(cmd.send(:select_outdated, [cask])).to be_empty
+  end
+
+  it "checks auto-updating casks with --greedy-auto-updates", :cask do
+    cask = Cask::CaskLoader.load(cask_path("auto-updates"))
+    cmd = described_class.new(["--greedy-auto-updates"])
+
+    expect(cask).to receive(:outdated?)
+      .with(greedy: false, greedy_latest: false, greedy_auto_updates: true)
+      .and_return(true)
+    expect(cmd.send(:select_outdated, [cask])).to eq([cask])
+  end
+
   it "outputs JSON", :integration_test do
     setup_test_formula "testball"
     (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath


### PR DESCRIPTION
- keep `brew outdated` from treating `auto_updates true` casks as outdated unless `--greedy-auto-updates` is requested
- warn and skip disabled casks during `brew upgrade` so they stop failing the whole run
- suppress prefetch-time warnings so disabled casks only warn once during the real upgrade path

Fixes https://github.com/Homebrew/brew/pull/21882#issuecomment-4219832252
Fixes https://github.com/Homebrew/brew/issues/21972

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

OpenAI Codex with manual review and testing.

-----
