### PR TITLE
Fix flaky `conflicts_with` brew spec

### DIFF
--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -444,11 +444,10 @@ RSpec.describe Homebrew::Bundle::Brew do
 
       context "when the conflicts_with option is provided" do
         before do
-          allow(described_class).to receive(:formulae_by_full_name).and_call_original
-          allow(described_class).to receive(:formulae_by_full_name).with("mysql").and_return(
-            name:           "mysql",
-            conflicts_with: ["mysql55"],
-          )
+          stub_formula_loader formula(formula_name) {
+            url "mysql-1.0"
+            conflicts_with "mysql55"
+          }
           allow(described_class).to receive(:formula_installed?).and_return(true)
           allow_any_instance_of(described_class).to receive(:install_formula!).and_return(true)
           allow_any_instance_of(described_class).to receive(:upgrade_formula!).and_return(true)


### PR DESCRIPTION
Sorbet's runtime `validate_call` uses `bind_call` to invoke the original `formulae_by_full_name` method, bypassing RSpec mocks. Replace the mock with a real formula that declares `conflicts_with "mysql55"` via `stub_formula_loader`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude Code with manual verification and testing.

-----
