### PR TITLE
Stop cleaning corrupt cask dirs

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -348,7 +348,6 @@ module Homebrew
         end
         Cleanup.autoremove(dry_run: dry_run?) unless Homebrew::EnvConfig.no_autoremove?
 
-        cleanup_corrupt_cask_dirs
         cleanup_cache
         cleanup_empty_api_source_directories
         cleanup_bootsnap
@@ -410,19 +409,6 @@ module Homebrew
       rm_ds_store([formula.rack]) if ds_store
       cleanup_cache_db(formula.rack) if cache_db
       cleanup_lockfiles(FormulaLock.new(formula.name).path)
-    end
-
-    sig { void }
-    def cleanup_corrupt_cask_dirs
-      Cask::Caskroom.corrupt_cask_dirs.each do |token|
-        corrupt_path = Cask::Caskroom.path/token
-        if dry_run?
-          puts "Would remove corrupt cask directory: #{corrupt_path}"
-        else
-          ohai "Removing corrupt cask directory: #{corrupt_path}"
-          FileUtils.rm_rf corrupt_path
-        end
-      end
     end
 
     sig { params(cask: Cask::Cask, ds_store: T::Boolean).void }

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1053,13 +1053,12 @@ module Homebrew
         corrupt = Cask::Caskroom.corrupt_cask_dirs
         return if corrupt.empty?
 
-        corrupt_dirs = corrupt.map { |t| "#{Cask::Caskroom.path}/#{t}" }
-
         <<~EOS
           Some directories in the Caskroom do not have valid metadata.
-          They may be left over from a manual or incomplete uninstall:
-            #{corrupt_dirs.join("\n  ")}
-          Run `brew cleanup` to remove them.
+            #{corrupt.map { |token| "#{Cask::Caskroom.path}/#{token}" }.join("\n  ")}
+          The following #{Utils.pluralize("cask", corrupt.count)} cannot be upgraded as-is.
+          To fix this, run:
+            #{corrupt.map { |token| "brew reinstall --cask --force #{token}" }.join("\n  ")}
         EOS
       end
 

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -131,4 +131,18 @@ RSpec.describe Homebrew::Diagnostic::Checks do
 
     expect(checks.check_for_unnecessary_cask_tap).to match("unnecessary local Cask tap")
   end
+
+  specify "#check_cask_corrupt_dirs" do
+    allow(Cask::Caskroom).to receive(:corrupt_cask_dirs).and_return(["google-chrome", "docker-desktop"])
+
+    expect(checks.check_cask_corrupt_dirs).to eq <<~EOS
+      Some directories in the Caskroom do not have valid metadata.
+        #{Cask::Caskroom.path}/google-chrome
+        #{Cask::Caskroom.path}/docker-desktop
+      The following casks cannot be upgraded as-is.
+      To fix this, run:
+        brew reinstall --cask --force google-chrome
+        brew reinstall --cask --force docker-desktop
+    EOS
+  end
 end


### PR DESCRIPTION
- stop deleting corrupt cask directories from `brew cleanup` so missing metadata does not silently erase user state
- update `brew doctor` to recommend `brew reinstall --cask --force <token>` for those casks
- cover the new `check_cask_corrupt_dirs` guidance in `Library/Homebrew/test/diagnostic_checks_spec.rb`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

OpenAI Codex used with multiple local review and testing passes.

-----
