### PR TITLE
cask: restrict no_autobump! usage to official Homebrew taps

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -464,7 +464,11 @@ module Cask
           raise CaskInvalidError.new(cask, "invalid 'version' value: #{arg.inspect}")
         end
 
-        no_autobump! because: :latest_version if arg == :latest
+        if arg == :latest
+          @no_autobump_defined = true
+          @no_autobump_message = :latest_version
+          @autobump = false
+        end
 
         DSL::Version.new(arg)
       end
@@ -672,7 +676,11 @@ module Cask
 
       @livecheck_defined = true
       @livecheck.instance_eval(&block)
-      no_autobump! because: :extract_plist if @livecheck.strategy == :extract_plist
+      if @livecheck.strategy == :extract_plist
+        @no_autobump_defined = true
+        @no_autobump_message = :extract_plist
+        @autobump = false
+      end
       @livecheck
     end
 
@@ -686,19 +694,7 @@ module Cask
         raise CaskInvalidError.new(cask, "'no_autobump!' can only be used in official Homebrew taps.")
       end
 
-      if because.is_a?(Symbol) && !NO_AUTOBUMP_REASONS_LIST.key?(because)
-        raise ArgumentError, "'because' argument should use valid symbol or a string!"
-      end
-
-      if !@cask.allow_reassignment && @no_autobump_defined
-        raise CaskInvalidError.new(cask, "'no_autobump_defined' stanza may only appear once.")
-      end
-
-      odeprecated "no_autobump! because: :requires_manual_review" if because == :requires_manual_review
-
-      @no_autobump_defined = true
-      @no_autobump_message = because
-      @autobump = false
+      set_no_autobump(because:)
     end
 
     # Is the cask in autobump list?
@@ -839,6 +835,25 @@ module Cask
       return HOMEBREW_CASK_APPDIR_PLACEHOLDER if Cask.generating_hash?
 
       cask.config.appdir
+    end
+
+    sig { params(because: T.any(String, Symbol)).void }
+    private
+
+    def set_no_autobump(because:)
+      if because.is_a?(Symbol) && !NO_AUTOBUMP_REASONS_LIST.key?(because)
+        raise ArgumentError, "'because' argument should use valid symbol or a string!"
+      end
+
+      if !@cask.allow_reassignment && @no_autobump_defined
+        raise CaskInvalidError.new(cask, "'no_autobump_defined' stanza may only appear once.")
+      end
+
+      odeprecated "no_autobump! because: :requires_manual_review" if because == :requires_manual_review
+
+      @no_autobump_defined = true
+      @no_autobump_message = because
+      @autobump = false
     end
   end
 end

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -464,7 +464,7 @@ module Cask
           raise CaskInvalidError.new(cask, "invalid 'version' value: #{arg.inspect}")
         end
 
-        set_no_autobump(because: :latest_version) if arg == :latest && !@no_autobump_defined
+        set_no_autobump(because: :latest_version) if arg == :latest && !no_autobump_defined?
 
         DSL::Version.new(arg)
       end
@@ -672,7 +672,7 @@ module Cask
 
       @livecheck_defined = true
       @livecheck.instance_eval(&block)
-      set_no_autobump(because: :extract_plist) if @livecheck.strategy == :extract_plist && !@no_autobump_defined
+      set_no_autobump(because: :extract_plist) if @livecheck.strategy == :extract_plist && !no_autobump_defined?
       @livecheck
     end
 
@@ -829,15 +829,20 @@ module Cask
       cask.config.appdir
     end
 
-    sig { params(because: T.any(String, Symbol)).void }
     private
 
+    sig { returns(T::Boolean) }
+    def no_autobump_defined?
+      @no_autobump_defined
+    end
+
+    sig { params(because: T.any(String, Symbol)).void }
     def set_no_autobump(because:)
       if because.is_a?(Symbol) && !NO_AUTOBUMP_REASONS_LIST.key?(because)
         raise ArgumentError, "'because' argument should use valid symbol or a string!"
       end
 
-      if !@cask.allow_reassignment && @no_autobump_defined
+      if !@cask.allow_reassignment && no_autobump_defined?
         raise CaskInvalidError.new(cask, "'no_autobump!' stanza may only appear once.")
       end
 

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -464,11 +464,7 @@ module Cask
           raise CaskInvalidError.new(cask, "invalid 'version' value: #{arg.inspect}")
         end
 
-        if arg == :latest
-          @no_autobump_defined = true
-          @no_autobump_message = :latest_version
-          @autobump = false
-        end
+        set_no_autobump(because: :latest_version) if arg == :latest && !@no_autobump_defined
 
         DSL::Version.new(arg)
       end
@@ -676,11 +672,7 @@ module Cask
 
       @livecheck_defined = true
       @livecheck.instance_eval(&block)
-      if @livecheck.strategy == :extract_plist
-        @no_autobump_defined = true
-        @no_autobump_message = :extract_plist
-        @autobump = false
-      end
+      set_no_autobump(because: :extract_plist) if @livecheck.strategy == :extract_plist && !@no_autobump_defined
       @livecheck
     end
 
@@ -846,7 +838,7 @@ module Cask
       end
 
       if !@cask.allow_reassignment && @no_autobump_defined
-        raise CaskInvalidError.new(cask, "'no_autobump_defined' stanza may only appear once.")
+        raise CaskInvalidError.new(cask, "'no_autobump!' stanza may only appear once.")
       end
 
       odeprecated "no_autobump! because: :requires_manual_review" if because == :requires_manual_review

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -678,12 +678,14 @@ module Cask
 
     # Excludes the cask from autobump list.
     #
-    # TODO: limit this method to the official taps only
-    #       (e.g. raise an error if `!tap.official?`)
-    #
     # @api public
     sig { params(because: T.any(String, Symbol)).void }
     def no_autobump!(because:)
+      tap = @cask.tap
+      if tap && !tap.official?
+        raise CaskInvalidError.new(cask, "'no_autobump!' can only be used in official Homebrew taps.")
+      end
+
       if because.is_a?(Symbol) && !NO_AUTOBUMP_REASONS_LIST.key?(because)
         raise ArgumentError, "'because' argument should use valid symbol or a string!"
       end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4675,12 +4675,15 @@ class Formula
 
     # Exclude the formula from the autobump list.
     #
-    # TODO: limit this method to the official taps only
-    #       (e.g. raise an error if `!tap.official?`)
-    #
     # @api public
     sig { params(because: T.any(String, Symbol)).void }
     def no_autobump!(because:)
+      caller_path = caller_locations(1, 1)&.first&.path
+      if caller_path
+        tap = Tap.from_path(caller_path)
+        raise "no_autobump! can only be used in official Homebrew taps." if tap && !tap.official?
+      end
+
       if because.is_a?(Symbol) && !NO_AUTOBUMP_REASONS_LIST.key?(because)
         raise ArgumentError, "'because' argument should use valid symbol or a string!"
       end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4681,7 +4681,7 @@ class Formula
       caller_path = caller_locations(1, 1)&.first&.path
       if caller_path
         tap = Tap.from_path(caller_path)
-        raise "no_autobump! can only be used in official Homebrew taps." if tap && !tap.official?
+        raise ArgumentError, "no_autobump! can only be used in official Homebrew taps." if tap && !tap.official?
       end
 
       if because.is_a?(Symbol) && !NO_AUTOBUMP_REASONS_LIST.key?(because)

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -159,6 +159,16 @@ RSpec.describe Cask::DSL, :cask, :no_api do
         expect(cask.no_autobump_message).to eq("some reason")
       end
     end
+
+    context "when used in an unofficial tap" do
+      it "raises an error" do
+        expect do
+          Cask::Cask.new("test-cask", tap: Tap.fetch("someone", "repo")) do
+            no_autobump! because: "some reason"
+          end
+        end.to raise_error(Cask::CaskInvalidError, /official Homebrew taps/)
+      end
+    end
   end
 
   describe "language stanza" do

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -168,6 +168,19 @@ RSpec.describe Cask::DSL, :cask, :no_api do
           end
         end.to raise_error(Cask::CaskInvalidError, /official Homebrew taps/)
       end
+
+      it "does not raise for internal no_autobump! usage from common DSL stanzas" do
+        expect do
+          Cask::Cask.new("test-cask", tap: Tap.fetch("someone", "repo")) do
+            version :latest
+            url "https://brew.sh/TestCask.dmg"
+            livecheck do
+              url "https://brew.sh/TestCask.plist"
+              strategy :extract_plist
+            end
+          end
+        end.not_to raise_error
+      end
     end
   end
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -2568,10 +2568,11 @@ RSpec.describe Formula do
     it "allows usage when tap is official" do
       allow(Tap).to receive(:from_path).and_return(nil)
 
-      klass = Class.new(Formula) do
-        no_autobump! because: "some reason"
-      end
-      expect(klass.no_autobump_defined?).to be(true)
+      expect do
+        Class.new(Formula) do
+          no_autobump! because: "some reason"
+        end
+      end.not_to raise_error
     end
   end
 end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -2552,4 +2552,26 @@ RSpec.describe Formula do
       expect(f.std_pip_args).to include("--uploaded-prior-to=2026-04-03T12:00:00Z")
     end
   end
+
+  describe ".no_autobump!" do
+    it "raises an error when used in an unofficial tap" do
+      unofficial_tap = Tap.fetch("someone", "repo")
+      allow(Tap).to receive(:from_path).and_return(unofficial_tap)
+
+      expect do
+        Class.new(Formula) do
+          no_autobump! because: "some reason"
+        end
+      end.to raise_error(RuntimeError, /official Homebrew taps/)
+    end
+
+    it "allows usage when tap is official" do
+      allow(Tap).to receive(:from_path).and_return(nil)
+
+      klass = Class.new(Formula) do
+        no_autobump! because: "some reason"
+      end
+      expect(klass.no_autobump_defined?).to be(true)
+    end
+  end
 end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -2562,17 +2562,17 @@ RSpec.describe Formula do
         Class.new(Formula) do
           no_autobump! because: "some reason"
         end
-      end.to raise_error(RuntimeError, /official Homebrew taps/)
+      end.to raise_error(ArgumentError, /official Homebrew taps/)
     end
 
     it "allows usage when tap is official" do
-      allow(Tap).to receive(:from_path).and_return(nil)
+      official_tap = Tap.fetch("Homebrew", "core")
+      allow(Tap).to receive(:from_path).and_return(official_tap)
 
-      expect do
-        Class.new(Formula) do
-          no_autobump! because: "some reason"
-        end
-      end.not_to raise_error
+      klass = Class.new(Formula) do
+        no_autobump! because: "some reason"
+      end
+      expect(klass.autobump?).to be(false)
     end
   end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
Resolve the TODO https://github.com/Homebrew/brew/blob/ac782bcd32ff3fb93fbac38ee5785dd2ccd95bad/Library/Homebrew/cask/dsl.rb#L593
 to limit `no_autobump!`  to official Homebrew taps only.