### PR TITLE
language: add `detected_<language>_shebang` to public API

### DIFF
--- a/Library/Homebrew/language/perl.rb
+++ b/Library/Homebrew/language/perl.rb
@@ -30,6 +30,7 @@ module Language
         )
       end
 
+      # @api public
       sig { params(formula: Formula).returns(Utils::Shebang::RewriteInfo) }
       def detected_perl_shebang(formula = T.cast(self, Formula))
         perl_deps = formula.declared_deps.select { |dep| dep.required? && dep.name == "perl" }

--- a/Library/Homebrew/language/php.rb
+++ b/Library/Homebrew/language/php.rb
@@ -30,6 +30,7 @@ module Language
         )
       end
 
+      # @api public
       sig { params(formula: Formula).returns(Utils::Shebang::RewriteInfo) }
       def detected_php_shebang(formula = T.cast(self, Formula))
         php_deps = formula.deps.select(&:required?).map(&:name).grep(/^php(@.+)?$/)

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -132,6 +132,7 @@ module Language
         )
       end
 
+      # @api public
       sig { params(formula: Formula, use_python_from_path: T::Boolean).returns(Utils::Shebang::RewriteInfo) }
       def detected_python_shebang(formula = T.cast(self, Formula), use_python_from_path: false)
         python_path = if use_python_from_path


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

These are used in Homebrew/core formulae, particularly Python method. Perl has a couple. PHP was added specifically to use in formulae.

I had thought these were transitively public API via module, e.g.
https://github.com/Homebrew/brew/blob/3aae2a34408a7f8ca0bfeb1ebb8604f8dcc2b228/Library/Homebrew/language/perl.rb#L7-L8

However, YARD output shows it as private
- https://docs.brew.sh/rubydoc/Language/Perl/Shebang.html#detected_perl_shebang-class_method
