### PR TITLE
Harden cask uninstall path checks

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -453,22 +453,26 @@ module Cask
         return enum_for(:each_resolved_path, action, paths) unless block_given?
 
         paths.each do |path|
-          resolved_path = Pathname.new(path)
+          resolved_path = Pathname.new(path.to_s.sub(%r{^~(?=(/|$))}, Dir.home))
 
-          resolved_path = resolved_path.expand_path if path.to_s.start_with?("~")
-
-          if resolved_path.relative? || resolved_path.split.any? { |part| part.to_s == ".." }
+          if resolved_path.relative?
             opoo "Skipping #{Formatter.identifier(action)} for relative path '#{path}'."
             next
           end
 
-          if undeletable?(resolved_path)
-            opoo "Skipping #{Formatter.identifier(action)} for undeletable path '#{path}'."
+          if resolved_path.each_filename.any? { |part| [".", ".."].include?(part) }
+            opoo "Skipping #{Formatter.identifier(action)} for path with relative segments '#{path}'."
             next
           end
 
           begin
-            yield path, Pathname.glob(resolved_path)
+            resolved_paths = Pathname.glob(resolved_path).reject do |target|
+              next false unless undeletable?(target)
+
+              opoo "Skipping #{Formatter.identifier(action)} for undeletable path '#{target}'."
+              true
+            end
+            yield path, resolved_paths
           rescue Errno::EPERM
             raise if File.readable?(File.expand_path("~/Library/Application Support/com.apple.TCC"))
 

--- a/Library/Homebrew/test/cask/artifact/abstract_uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/abstract_uninstall_spec.rb
@@ -1,0 +1,103 @@
+# typed: false
+# frozen_string_literal: true
+
+RSpec.describe Cask::Artifact::AbstractUninstall, :cask do
+  [
+    [Cask::Artifact::Uninstall, :uninstall],
+    [Cask::Artifact::Zap, :zap],
+  ].each do |artifact_class, artifact_dsl_key|
+    describe "#each_resolved_path for #{artifact_dsl_key.inspect}" do
+      subject(:artifact) { cask.artifacts.find { |candidate| candidate.is_a?(artifact_class) } }
+
+      let(:cask) { Cask::CaskLoader.load(cask_path("with-#{artifact_dsl_key}-delete")) }
+
+      around do |example|
+        old_home = Dir.home
+        ENV["HOME"] = TEST_TMPDIR
+        example.run
+      ensure
+        ENV["HOME"] = old_home
+      end
+
+      it "skips relative paths" do
+        result = nil
+        expect do
+          result = artifact.send(:each_resolved_path, :delete, ["relative/path"]).to_a
+        end.to output(%r{Skipping delete for relative path 'relative/path'\.}).to_stderr
+
+        expect(result).to be_empty
+      end
+
+      it "skips absolute paths containing relative segments" do
+        tmpdir = Pathname.new(TEST_TMPDIR)
+        valid_path = tmpdir/"each_resolved_path_#{artifact_dsl_key}"
+
+        FileUtils.touch valid_path
+
+        [
+          tmpdir/"nested/../#{valid_path.basename}",
+          tmpdir/"nested/./#{valid_path.basename}",
+        ].each do |invalid_path|
+          result = nil
+          expect do
+            result = artifact.send(:each_resolved_path, :delete, [invalid_path.to_s]).to_a
+          end.to output(
+            /Skipping delete for path with relative segments '#{Regexp.escape(invalid_path.to_s)}'\./,
+          ).to_stderr
+
+          expect(result).to be_empty
+        end
+      ensure
+        FileUtils.rm_f valid_path
+      end
+
+      it "skips tilde paths containing relative segments" do
+        invalid_path = "~/../each_resolved_path_#{artifact_dsl_key}"
+
+        result = nil
+        expect do
+          result = artifact.send(:each_resolved_path, :delete, [invalid_path]).to_a
+        end.to output(
+          /Skipping delete for path with relative segments '#{Regexp.escape(invalid_path)}'\./,
+        ).to_stderr
+
+        expect(result).to be_empty
+      end
+
+      it "skips undeletable glob matches after expansion" do
+        glob_dir = Pathname.new(TEST_TMPDIR)/"each_resolved_path_glob_#{artifact_dsl_key}"
+        safe_path = glob_dir/"safe.plist"
+        undeletable_path = glob_dir/"undeletable.plist"
+
+        FileUtils.mkdir_p glob_dir
+        FileUtils.touch [safe_path, undeletable_path]
+
+        allow(artifact).to receive(:undeletable?) { |target| target == undeletable_path }
+
+        result = nil
+        expect do
+          result = artifact.send(:each_resolved_path, :delete, ["#{glob_dir}/*.plist"]).to_a
+        end.to output(
+          /Skipping delete for undeletable path '#{Regexp.escape(undeletable_path.to_s)}'\./,
+        ).to_stderr
+
+        expect(result).to eq([["#{glob_dir}/*.plist", [safe_path]]])
+      ensure
+        FileUtils.rm_rf glob_dir
+      end
+
+      it "surfaces Full Disk Access guidance when globbing raises EPERM" do
+        allow(Pathname).to receive(:glob).and_raise(Errno::EPERM)
+        allow(File).to receive(:readable?).and_call_original
+        allow(File).to receive(:readable?).with(File.expand_path("~/Library/Application Support/com.apple.TCC"))
+                                          .and_return(false)
+        allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:ventura))
+
+        expect do
+          artifact.send(:each_resolved_path, :delete, ["/tmp/each_resolved_path_#{artifact_dsl_key}"]).to_a
+        end.to raise_error(SystemExit)
+          .and output(/Full Disk Access/).to_stderr
+      end
+    end
+  end
+end


### PR DESCRIPTION
- stop `each_resolved_path` from accepting `.` or `..` segments that can escape intended delete targets
- re-check glob matches after expansion so undeletable paths are filtered before `rm -rf` runs
- add regressions in `abstract_uninstall_spec.rb` so traversal and glob bypasses stay covered

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Used OpenAI Codex xhigh and manually reviewed all changes.

-----
