### PR TITLE
sorbet: remove redundant T.let in initialize methods

### DIFF
--- a/Library/Homebrew/cache_store.rb
+++ b/Library/Homebrew/cache_store.rb
@@ -52,7 +52,7 @@ class CacheStoreDatabase
   # @return [nil]
   sig { params(type: Symbol).void }
   def initialize(type)
-    @type = T.let(type, Symbol)
+    @type = type
     @dirty = T.let(false, T.nilable(T::Boolean))
   end
 
@@ -198,7 +198,7 @@ class CacheStore # rubocop:todo Style/OneClassPerFile
   # @return [nil]
   sig { params(database: CacheStoreDatabase).void }
   def initialize(database)
-    @database = T.let(database, CacheStoreDatabase)
+    @database = database
   end
 
   protected

--- a/Library/Homebrew/cask/artifact/generated_completion.rb
+++ b/Library/Homebrew/cask/artifact/generated_completion.rb
@@ -63,10 +63,10 @@ module Cask
       def initialize(cask, commands, base_name:, shell_parameter_format:, shells:)
         super(cask, *commands, base_name:, shell_parameter_format:, shells:)
 
-        @commands = T.let(commands, T::Array[T.any(Pathname, String)])
-        @base_name = T.let(base_name, T.nilable(String))
-        @shell_parameter_format = T.let(shell_parameter_format, T.nilable(T.any(Symbol, String)))
-        @shells = T.let(shells, T::Array[Symbol])
+        @commands = commands
+        @base_name = base_name
+        @shell_parameter_format = shell_parameter_format
+        @shells = shells
         @resolved_base_name = T.let(nil, T.nilable(String))
       end
 

--- a/Library/Homebrew/cask/artifact/manpage.rb
+++ b/Library/Homebrew/cask/artifact/manpage.rb
@@ -27,7 +27,7 @@ module Cask
 
       sig { params(cask: Cask, source: T.any(String, Pathname), section: String).void }
       def initialize(cask, source, section)
-        @section = T.let(section, String)
+        @section = section
 
         super(cask, source)
       end

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -180,7 +180,7 @@ module Cask
       @auto_updates_set_in_block = T.let(false, T::Boolean)
       @autobump = T.let(true, T::Boolean)
       @called_in_on_system_block = T.let(false, T::Boolean)
-      @cask = T.let(cask, Cask)
+      @cask = cask
       @caveats = T.let(DSL::Caveats.new(cask), DSL::Caveats)
       @conflicts_with = T.let(nil, T.nilable(DSL::ConflictsWith))
       @conflicts_with_set_in_block = T.let(false, T::Boolean)

--- a/Library/Homebrew/cask/dsl/base.rb
+++ b/Library/Homebrew/cask/dsl/base.rb
@@ -16,7 +16,7 @@ module Cask
       sig { params(cask: Cask, command: T.class_of(SystemCommand)).void }
       def initialize(cask, command = SystemCommand)
         @cask = cask
-        @command = T.let(command, T.class_of(SystemCommand))
+        @command = command
       end
 
       def_delegators :@cask, :token, :version, :caskroom_path, :staged_path, :appdir, :language, :arch

--- a/Library/Homebrew/cask/dsl/container.rb
+++ b/Library/Homebrew/cask/dsl/container.rb
@@ -15,8 +15,8 @@ module Cask
 
       sig { params(nested: T.nilable(String), type: T.nilable(Symbol)).void }
       def initialize(nested: nil, type: nil)
-        @nested = T.let(nested, T.nilable(String))
-        @type = T.let(type, T.nilable(Symbol))
+        @nested = nested
+        @type = type
 
         return if type.nil?
         return unless UnpackStrategy.from_type(type).nil?

--- a/Library/Homebrew/cask/exceptions.rb
+++ b/Library/Homebrew/cask/exceptions.rb
@@ -11,7 +11,7 @@ module Cask
     def initialize(errors)
       super()
 
-      @errors = T.let(errors, T::Array[StandardError])
+      @errors = errors
     end
 
     sig { returns(String) }

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -51,7 +51,7 @@ module Cask
       @verify_download_integrity = verify_download_integrity
       @quiet = quiet
       @download_queue = download_queue
-      @defer_fetch = T.let(defer_fetch, T::Boolean)
+      @defer_fetch = defer_fetch
       @ran_prelude = T.let(false, T::Boolean)
       @cask_and_formula_dependencies = T.let(nil, T.nilable(T::Array[T.any(Formula, ::Cask::Cask)]))
     end

--- a/Library/Homebrew/context.rb
+++ b/Library/Homebrew/context.rb
@@ -11,9 +11,9 @@ module Context
   class ContextStruct
     sig { params(debug: T.nilable(T::Boolean), quiet: T.nilable(T::Boolean), verbose: T.nilable(T::Boolean)).void }
     def initialize(debug: nil, quiet: nil, verbose: nil)
-      @debug = T.let(debug, T.nilable(T::Boolean))
-      @quiet = T.let(quiet, T.nilable(T::Boolean))
-      @verbose = T.let(verbose, T.nilable(T::Boolean))
+      @debug = debug
+      @quiet = quiet
+      @verbose = verbose
     end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -843,7 +843,7 @@ class LocalBottleDownloadStrategy < AbstractFileDownloadStrategy # rubocop:todo 
   # rubocop:disable Lint/MissingSuper
   sig { params(path: Pathname).void }
   def initialize(path)
-    @cached_location = T.let(path, Pathname)
+    @cached_location = path
   end
   # rubocop:enable Lint/MissingSuper
 
@@ -1266,7 +1266,7 @@ class GitHubGitDownloadStrategy < GitDownloadStrategy # rubocop:todo Style/OneCl
   sig { params(url: String, name: String, version: T.nilable(Version), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     super
-    @version = T.let(version, T.nilable(Version))
+    @version = version
 
     match_data = %r{^https?://github\.com/(?<user>[^/]+)/(?<repo>[^/]+)\.git$}.match(@url)
     return unless match_data

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -268,7 +268,7 @@ class Formula
 
     @force_bottle = force_bottle
 
-    @tap = T.let(tap, T.nilable(Tap))
+    @tap = tap
     @tap ||= if path == Formulary.core_path(name)
       CoreTap.instance
     else

--- a/Library/Homebrew/linkage_cache_store.rb
+++ b/Library/Homebrew/linkage_cache_store.rb
@@ -13,7 +13,7 @@ class LinkageCacheStore < CacheStore
   # @return [nil]
   sig { params(keg_path: String, database: CacheStoreDatabase).void }
   def initialize(keg_path, database)
-    @keg_path = T.let(keg_path, String)
+    @keg_path = keg_path
     super(database)
   end
 

--- a/Library/Homebrew/mcp_server.rb
+++ b/Library/Homebrew/mcp_server.rb
@@ -191,9 +191,9 @@ module Homebrew
     def initialize(stdin: $stdin, stdout: $stdout, stderr: $stderr)
       @debug_logging = T.let(ARGV.include?("--debug") || ARGV.include?("-d"), T::Boolean)
       @ping_switch = T.let(ARGV.include?("--ping"), T::Boolean)
-      @stdin = T.let(stdin, T.any(IO, StringIO))
-      @stdout = T.let(stdout, T.any(IO, StringIO))
-      @stderr = T.let(stderr, T.any(IO, StringIO))
+      @stdin = stdin
+      @stdout = stdout
+      @stderr = stderr
     end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -147,10 +147,10 @@ class Migrator
 
   sig { params(formula: Formula, oldname: String, force: T::Boolean).void }
   def initialize(formula, oldname, force: false)
-    @oldname = T.let(oldname, String)
+    @oldname = oldname
     @newname = T.let(formula.name, String)
 
-    @formula = T.let(formula, Formula)
+    @formula = formula
     @old_cellar = T.let(HOMEBREW_CELLAR/oldname, Pathname)
     raise MigratorNoOldpathError, oldname unless old_cellar.exist?
 

--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -50,7 +50,7 @@ class EmbeddedPatch # rubocop:todo Style/OneClassPerFile
 
   sig { params(strip: T.any(String, Symbol)).void }
   def initialize(strip)
-    @strip = T.let(strip, T.any(String, Symbol))
+    @strip = strip
     @owner = T.let(nil, T.nilable(Owner))
   end
 
@@ -114,7 +114,7 @@ class StringPatch < EmbeddedPatch # rubocop:todo Style/OneClassPerFile
   sig { params(strip: T.any(String, Symbol), str: String).void }
   def initialize(strip, str)
     super(strip)
-    @str = T.let(str, String)
+    @str = str
   end
 
   sig { override.returns(String) }
@@ -141,7 +141,7 @@ class ExternalPatch # rubocop:todo Style/OneClassPerFile
 
   sig { params(strip: T.any(String, Symbol), block: T.nilable(T.proc.bind(Resource::Patch).void)).void }
   def initialize(strip, &block)
-    @strip    = T.let(strip, T.any(String, Symbol))
+    @strip    = strip
     @resource = T.let(Resource::Patch.new(&block), Resource::Patch)
   end
 

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -130,8 +130,8 @@ module UnpackStrategy
   }
   def initialize(path, ref_type: nil, ref: nil, merge_xattrs: false)
     @path = T.let(Pathname(path).expand_path, Pathname)
-    @ref_type = T.let(ref_type, T.nilable(Symbol))
-    @ref = T.let(ref, T.nilable(String))
+    @ref_type = ref_type
+    @ref = ref
     @merge_xattrs = merge_xattrs
   end
 


### PR DESCRIPTION
Remove `T.let` calls in `initialize` methods where the ivar is assigned directly from a sig-typed parameter with an identical type. Sorbet already infers the ivar type from the sig, so the `T.let` is redundant.

16 files affected. Cases where `T.let` is still required were left untouched:
- Chain assignments (`specs[:x] = @x = T.let(...)`) in `cask/url.rb` — Sorbet requires explicit `T.let` for ivars in `typed: strict` here
- Conditionally-assigned ivars (`locale.rb`, `cmd/update-report.rb`) — `T.let` sets the nilable type
- Ivars where the local variable was mutated before assignment (`formula_installer.rb`)

Verified with `brew typecheck` and `brew style --fix --changed`.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] ~~Have you written new tests (excluding integration tests) for your changes?~~ (no behaviour change)
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

---

- [x] AI was used to generate or assist with generating this PR. Claude Code identified all instances of the pattern and applied the removals; changes were verified by running `brew typecheck` (which autocorrected one file where `T.let` is still required).
