### PR TITLE
bump-cask-pr: handle `depends_on arch` scoped to `on_os` block

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -221,19 +221,15 @@ module Homebrew
         current_os_is_macos = MacOSVersion::SYMBOLS.include?(current_os)
         newest_macos = MacOSVersion.new(HOMEBREW_MACOS_NEWEST_SUPPORTED).to_sym
 
-        depends_on_archs = cask.depends_on.arch&.filter_map { |arch| arch[:type] }&.uniq
-
         # NOTE: We substitute the newest macOS (e.g. `:sequoia`) in place of
         # `:macos` values (when used), as a generic `:macos` value won't apply
         # to on_system blocks referencing macOS versions.
         os_values = []
 
+        arch_values = []
         if new_version.arm || new_version.intel
-          arch_values = []
           arch_values << :arm if new_version.arm
           arch_values << :intel if new_version.intel
-        else
-          arch_values = depends_on_archs.presence || []
         end
 
         if cask.on_system_blocks_exist?
@@ -245,13 +241,18 @@ module Homebrew
             end
           end
 
+          # `depends_on arch:` may be scoped to an `on_os` block, so arch
+          # filtering is deferred to `replace_version_and_checksum`.
           arch_values = OnSystem::ARCH_OPTIONS.dup if arch_values.empty?
         else
           # Architecture is only relevant if on_system blocks are present or
           # the cask uses `depends_on arch`, otherwise we default to ARM for
           # consistency.
           os_values << (current_os_is_macos ? current_os : newest_macos)
-          arch_values << :arm if arch_values.empty?
+          if arch_values.empty?
+            depends_on_archs = cask.depends_on.arch&.filter_map { |arch| arch[:type] }&.uniq
+            arch_values = depends_on_archs.presence || [:arm]
+          end
         end
 
         if arch_values.length > 1 && !new_version.general
@@ -292,6 +293,10 @@ module Homebrew
               raise unless cask.on_system_blocks_exist?
             end
             next if old_cask.nil?
+
+            # Skip archs excluded by the reloaded cask's `depends_on arch:`.
+            reloaded_archs = old_cask.depends_on.arch&.filter_map { |a| a[:type] }&.uniq
+            next if reloaded_archs.present? && reloaded_archs.exclude?(arch)
 
             old_version = old_cask.version
             next unless old_version

--- a/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
@@ -140,12 +140,14 @@ RSpec.describe Homebrew::DevCmd::BumpCaskPr do
     end
 
     context "when cask has on_system blocks/calls and `depends_on arch`" do
-      it "returns an array with combinations of `OnSystem::BASE_OS_OPTIONS` and `depends_on arch` value" do
+      it "returns an array with combinations of `OnSystem::BASE_OS_OPTIONS` and `OnSystem::ARCH_OPTIONS`" do
         Homebrew::SimulateSystem.with(os: :linux, arch: :arm) do
           expect(bump_cask_pr.send(:generate_system_options, c_on_system_depends_on_intel, new_version))
             .to eq([
               [newest_macos, :intel],
+              [newest_macos, :arm],
               [:linux, :intel],
+              [:linux, :arm],
             ])
         end
 
@@ -153,7 +155,39 @@ RSpec.describe Homebrew::DevCmd::BumpCaskPr do
           expect(bump_cask_pr.send(:generate_system_options, c_on_system_depends_on_intel, new_version))
             .to eq([
               [older_macos, :intel],
+              [older_macos, :arm],
               [:linux, :intel],
+              [:linux, :arm],
+            ])
+        end
+      end
+    end
+
+    context "when cask has `depends_on arch` scoped to an `on_os` block" do
+      it "returns all arch combinations for `OnSystem::BASE_OS_OPTIONS`" do
+        Homebrew::SimulateSystem.with(os: older_macos, arch: :arm) do
+          cask = Cask::Cask.new("test-on-macos-scoped-depends-on-arm") do
+            os macos: "darwin", linux: "linux"
+
+            version "0.0.1,2"
+
+            url "https://brew.sh/test-0.0.1.dmg"
+            name "Test"
+            desc "Test cask"
+            homepage "https://brew.sh"
+
+            on_macos do
+              depends_on arch: :arm64
+            end
+          end
+
+          expect(cask.depends_on.arch).to eq([{ type: :arm, bits: 64 }])
+          expect(bump_cask_pr.send(:generate_system_options, cask, new_version))
+            .to eq([
+              [older_macos, :intel],
+              [older_macos, :arm],
+              [:linux, :intel],
+              [:linux, :arm],
             ])
         end
       end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude iterated on the code with my feedback. Performed manual testing to verify accuracy.

-----
Noticed a cask in my personal tap wasn't getting its Linux x86_64 checksum refreshed by autobump. It's arm64-only on macOS (via`depends_on arch: :arm64` inside `on_macos`) but multi-arch on Linux, and `generate_system_options` was treating the scoped `depends_on arch:` as a global filter, dropping `(linux, intel)` from the system options.

Iterate all arches per OS when on_system blocks exist, and enforce restrictions per-combo inside `replace_version_and_checksum` by inspecting the cask as reloaded under `SimulateSystem`. The top-level optimization is preserved for casks without on_system blocks.