### PR TITLE
Don't compact `service_args` in `FormulaStruct#serialize`

### DIFF
--- a/Library/Homebrew/api/formula_struct.rb
+++ b/Library/Homebrew/api/formula_struct.rb
@@ -169,7 +169,14 @@ module Homebrew
         end
 
         hash = ::Utils.deep_stringify_symbols(hash)
-        ::Utils.deep_compact_blank(hash)
+
+        service_args = hash["service_args"]
+        hash = ::Utils.deep_compact_blank(hash)
+
+        # service_args may have falsey values that we don't want to remove, like `keep_alive successful_exit: false`
+        hash["service_args"] = service_args if service_args&.any?
+
+        hash
       end
 
       sig { params(hash: T::Hash[String, T.untyped], bottle_tag: ::Utils::Bottles::Tag).returns(FormulaStruct) }
@@ -205,10 +212,6 @@ module Homebrew
           hash["#{key}_uses_from_macos"] = uses_from_macos.map do |args|
             format_arg_pair(args, last: {})
           end
-        end
-
-        hash["service_args"] = if (service_args = hash["service_args"])
-          service_args.map { |service_arg| format_arg_pair(service_arg, last: nil) }
         end
 
         hash["conflicts"] = if (conflicts = hash["conflicts"])


### PR DESCRIPTION
Fixes the following issue:

```console
$ brew info nginx
==> nginx ✘: stable 1.29.8 (bottled), HEAD
HTTP(S) server and reverse proxy, and IMAP/POP3 proxy server
https://nginx.org/
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/n/nginx.rb
License: BSD-2-Clause
==> Dependencies
Required (2): openssl@3 ✔, pcre2 ✔
==> Options
--HEAD
 Install HEAD version
Defining service run_type with argument immediate
Defining service working_dir with argument /opt/homebrew
Defining service keep_alive with argument
Error: Parameter 'value': Expected type T.any(T::Boolean, T::Hash[Symbol, T.untyped]), got type NilClass
Caller: /opt/homebrew/Library/Homebrew/formulary.rb:315
Definition: /opt/homebrew/Library/Homebrew/service.rb:169 (Homebrew::Service#keep_alive)
...
```

Since `service_args` are defined by the `service` DSL and only include methods explicitly called, we shouldn't compact away falsey values. For example:

```ruby
keep_alive successful_exit: false
```

Internally, this sets `@keep_alive = { successful_exit: false }` which has a different effect from `@keep_alive = nil` which is what you get if you don't call `keep_alive` at all.

However, the current `FormulaStruct` serialization filters away all falsey values, reducing this to `keep_alive nil` which causes a type error. In reality, we need the falsey DSL values to be preserved.

The values passed to `service_args` are computed by `Homebrew::Service.from_hash` which only includes DSLs that were explicitly used, so this doesn't add any unnecessary information to the serialized files.

Please merge at the same time or after https://github.com/Homebrew/formulae.brew.sh/pull/2173

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
