### PR TITLE
cask: further `auto_updates` refinement

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -550,7 +550,7 @@ module Cask
     HASH_KEYS_TO_SKIP = T.let(%w[outdated installed versions].freeze, T::Array[String])
     private_constant :HASH_KEYS_TO_SKIP
 
-    AUTO_UPDATES_BAD_BUNDLE_VERSIONS = %w[0.0].freeze
+    AUTO_UPDATES_BAD_BUNDLE_VERSIONS = %w[0 0.0].freeze
     private_constant :AUTO_UPDATES_BAD_BUNDLE_VERSIONS
 
     sig { returns(T::Hash[String, T.untyped]) }
@@ -671,6 +671,7 @@ module Cask
     sig { params(first: T.nilable(String), second: T.nilable(String)).returns(T.nilable(Integer)) }
     def compare_version_strings(first, second)
       return if first.blank? || second.blank?
+      return if first.split(".").size != second.split(".").size
 
       Version.new(first) <=> Version.new(second)
     rescue
@@ -692,6 +693,8 @@ module Cask
         return false
       end
       installed_bundle_version = nil if AUTO_UPDATES_BAD_BUNDLE_VERSIONS.include?(installed_bundle_version)
+      installed_short_version = nil if AUTO_UPDATES_BAD_BUNDLE_VERSIONS.include?(installed_short_version)
+      return false if installed_short_version.nil? && installed_bundle_version.nil?
 
       return false if [installed_short_version, installed_bundle_version].any? do |installed_plist_version|
         compare_version_strings(installed_plist_version, tap_short_version)&.zero?

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -318,6 +318,15 @@ RSpec.describe Cask::Cask, :cask do
 
         expect(cask.outdated_version).to be_nil
       end
+
+      it "is not outdated when plist version segment counts differ from the tap version" do
+        tap_version = "1.0"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("0.9")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "1", bundle_version: "200")
+
+        expect(cask.outdated_version).to be_nil
+      end
     end
 
     describe ":latest casks" do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This PR further refines the behaviour of comparing an application's `bundle_version` with the `version` in the Caskfile.

1. Include version `0` to the `AUTO_UPDATES_BAD_BUNDLE_VERSIONS` constant.
2. Compare the `AUTO_UPDATES_BAD_BUNDLE_VERSIONS` constant with both `installed_bundle_version` and `installed_short_version`
3. Only compare version numbers with the same length of `major.minor.patch.etc`. The downside here is that we may miss some genuine updates, but it ensures we don't compare versions when a less granular version number is provided in the `info.plist` (for example: `info.plist` only shows `2.4` when the actual version is `2.4.5`).