### PR TITLE
cask/artifact/qlplugin: fix type override

### DIFF
--- a/Library/Homebrew/cask/artifact/qlplugin.rb
+++ b/Library/Homebrew/cask/artifact/qlplugin.rb
@@ -19,27 +19,33 @@ module Cask
           force:        T::Boolean,
           verbose:      T::Boolean,
           predecessor:  T.nilable(Cask),
+          successor:    T.nilable(Cask),
           reinstall:    T::Boolean,
           command:      T.class_of(SystemCommand),
           options:      T.anything,
         ).void
       }
       def install_phase(adopt: false, auto_updates: false, force: false, verbose: false, predecessor: nil,
-                        reinstall: false, command: SystemCommand, **options)
+                        successor: nil, reinstall: false, command: SystemCommand, **options)
         super
         reload_quicklook(command:)
       end
 
       sig {
         override.params(
-          skip:    T::Boolean,
-          force:   T::Boolean,
-          adopt:   T::Boolean,
-          command: T.class_of(SystemCommand),
-          options: T.anything,
+          skip:      T::Boolean,
+          force:     T::Boolean,
+          adopt:     T::Boolean,
+          verbose:   T::Boolean,
+          successor: T.nilable(Cask),
+          upgrade:   T::Boolean,
+          reinstall: T::Boolean,
+          command:   T.class_of(SystemCommand),
+          options:   T.anything,
         ).void
       }
-      def uninstall_phase(skip: false, force: false, adopt: false, command: SystemCommand, **options)
+      def uninstall_phase(skip: false, force: false, adopt: false, verbose: false, successor: nil, upgrade: false,
+                          reinstall: false, command: SystemCommand, **options)
         super
         reload_quicklook(command:)
       end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude was used to help add the correct type override to match the parent.

-----

This PR adds missing `sig` parameters from the parent `Moved` that is inherited by `qlplugin` but was missing from the override.

Resolves: https://github.com/orgs/Homebrew/discussions/6797