### PR TITLE
cli/parser: fix unwanted snippets of hidden args

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -213,12 +213,9 @@ module Homebrew
 
         description = option_description(description, *names, hidden:)
         env, counterpart = env
-        if env && @non_global_processed_options.any?
+        if env && @non_global_processed_options.any? && !hidden
           affix = counterpart ? " and `#{counterpart}` is passed." : "."
           description += " Enabled by default if `$HOMEBREW_#{env.upcase}` is set#{affix}"
-        end
-        if odeprecated || odisabled
-          description += " (#{odisabled ? "disabled" : "deprecated"}#{"; replaced by #{replacement}" if replacement})"
         end
         process_option(*names, description, type: :switch, hidden:) unless odisabled
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Hidden arguments use a placeholder of `@@HIDDEN@@` for description and the help text generation expects this to be a single line; however, the previous logic appended additional information that could exceed column width and cause partial snippets to output.

---

Example for prior logic would append quarantine message in an odd location:
```console
❯ brew install --help | rg -A4 'require-sha'
      --require-sha                Require all casks to have a checksum. Enabled
                                   by default if
                                   $HOMEBREW_CASK_OPTS_REQUIRE_SHA is set.
                                   $HOMEBREW_CASK_OPTS_QUARANTINE is set.
                                   (disabled)
```

With PR:
```console
❯ brew install --help | rg -A4 'require-sha'
      --require-sha                Require all casks to have a checksum. Enabled
                                   by default if
                                   $HOMEBREW_CASK_OPTS_REQUIRE_SHA is set.
      --adopt                      Adopt existing artifacts in the destination
                                   that are identical to those being installed.
```