### PR TITLE
Support bare `depends_on :macos` in casks

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -209,6 +209,9 @@ module Cask
     def supports_linux?
       return true if font?
 
+      # Bare `depends_on :macos` explicitly marks a cask as macOS-only
+      return false if (macos_requirement = depends_on.macos) && !macos_requirement.version_specified?
+
       # Cache the os value before contains_os_specific_artifacts? refreshes the cask
       # (the refresh clears @dsl.os in generic/non-OS-specific contexts)
       os_value = dsl!.os

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -572,9 +572,14 @@ module Cask
     # NOTE: Multiple dependencies can be specified.
     #
     # @api public
-    sig { params(kwargs: T.untyped).returns(DSL::DependsOn) }
-    def depends_on(**kwargs)
+    sig { params(arg: T.nilable(Symbol), kwargs: T.untyped).returns(DSL::DependsOn) }
+    def depends_on(arg = nil, **kwargs)
       @depends_on_set_in_block = true if @called_in_on_system_block
+      if arg == :macos
+        kwargs[:macos] = :any
+      elsif arg
+        raise CaskInvalidError.new(cask, "invalid 'depends_on' value: #{arg.inspect}")
+      end
       return @depends_on if kwargs.empty?
 
       begin

--- a/Library/Homebrew/cask/dsl/depends_on.rb
+++ b/Library/Homebrew/cask/dsl/depends_on.rb
@@ -76,7 +76,9 @@ module Cask
         first_arg_s = first_arg&.to_s
 
         begin
-          @macos = if args.count > 1
+          @macos = if first_arg == :any
+            MacOSRequirement.new
+          elsif args.count > 1
             MacOSRequirement.new([args], comparator: "==")
           elsif first_arg.is_a?(Symbol) && MacOSVersion::SYMBOLS.key?(first_arg)
             MacOSRequirement.new([args.first], comparator: "==")

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -572,6 +572,10 @@ RSpec.describe Cask::Cask, :cask do
   end
 
   describe "#supports_linux?" do
+    it "returns false for casks with bare depends_on :macos" do
+      expect(Cask::CaskLoader.load("with-depends-on-macos-bare").supports_linux?).to be false
+    end
+
     it "reflects whether the cask has only platform-agnostic artifacts" do
       expect(Cask::CaskLoader.load("with-non-executable-binary").supports_linux?).to be true
       expect(Cask::CaskLoader.load("basic-cask").supports_linux?).to be false

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -415,6 +415,16 @@ RSpec.describe Cask::DSL, :cask, :no_api do
   end
 
   describe "depends_on macos" do
+    context "when bare :macos is used without a version" do
+      let(:token) { "with-depends-on-macos-bare" }
+
+      it "creates a MacOSRequirement without a version" do
+        macos_requirement = cask.depends_on.macos
+        expect(macos_requirement).to be_a(MacOSRequirement)
+        expect(macos_requirement.version_specified?).to be false
+      end
+    end
+
     context "when the depends_on macos value is invalid" do
       let(:token) { "invalid-depends-on-macos-bad-release" }
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-bare.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-bare.rb
@@ -1,0 +1,14 @@
+# typed: false
+# frozen_string_literal: true
+
+cask "with-depends-on-macos-bare" do
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/with-depends-on-macos-bare"
+
+  depends_on :macos
+
+  binary "#{appdir}/Caffeine.app/Contents/MacOS/caffeine"
+end


### PR DESCRIPTION
- Allow casks to use `depends_on :macos` without a version to explicitly mark them as macOS-only
- This mirrors the formula behaviour and lets `brew bundle` and search filtering detect macOS-only casks via `supports_linux?` returning false
- On Linux the bare requirement is unsatisfied, blocking install; on macOS any version satisfies it

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Build with Claude Code with manual review and testing.

-----
