### PR TITLE
Support `HOMEBREW_CASK_OPTS_REQUIRE_SHA`

### DIFF
--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -16,12 +16,19 @@ module Cask
     sig { returns(::Cask::Cask) }
     attr_reader :cask
 
-    sig { params(cask: ::Cask::Cask, quarantine: T.nilable(T::Boolean)).void }
-    def initialize(cask, quarantine: nil)
+    sig {
+      params(
+        cask:        ::Cask::Cask,
+        quarantine:  T.nilable(T::Boolean),
+        require_sha: T::Boolean,
+      ).void
+    }
+    def initialize(cask, quarantine: nil, require_sha: false)
       super()
 
       @cask = cask
       @quarantine = quarantine
+      @require_sha = require_sha
     end
 
     sig { override.returns(T.nilable(::URL)) }
@@ -51,6 +58,7 @@ module Cask
         .returns(Pathname)
     }
     def fetch(quiet: nil, verify_download_integrity: true, timeout: nil)
+      verify_has_sha if @require_sha
       downloader.quiet! if quiet
 
       begin
@@ -96,6 +104,16 @@ module Cask
     def download_queue_type = "Cask"
 
     private
+
+    sig { void }
+    def verify_has_sha
+      return if @cask.sha256 != :no_check
+
+      raise CaskError, <<~EOS
+        Cask '#{@cask}' does not have a sha256 checksum defined.
+        This means you have the #{Formatter.identifier("--require-sha")} option set, perhaps in your `$HOMEBREW_CASK_OPTS`.
+      EOS
+    end
 
     sig { params(path: Pathname).void }
     def quarantine(path)

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -115,7 +115,6 @@ module Cask
       odebug "Cask::Installer#fetch"
 
       load_cask_from_source_api! if cask_from_source_api?
-      verify_has_sha if require_sha? && !force?
       check_requirements
 
       forbidden_tap_check
@@ -244,7 +243,10 @@ on_request: true)
 
     sig { returns(Download) }
     def downloader
-      @downloader ||= T.let(Download.new(@cask, quarantine: quarantine?), T.nilable(Download))
+      @downloader ||= T.let(
+        Download.new(@cask, quarantine: quarantine?, require_sha: require_sha? && !force?),
+        T.nilable(Download),
+      )
     end
 
     sig { params(quiet: T.nilable(T::Boolean), timeout: T.nilable(T.any(Integer, Float))).returns(Pathname) }
@@ -252,17 +254,6 @@ on_request: true)
       # Store cask download path in cask to prevent multiple downloads in a row when checking if it's outdated
       @cask.download ||= downloader.fetch(quiet:, verify_download_integrity: @verify_download_integrity,
                                           timeout:)
-    end
-
-    sig { void }
-    def verify_has_sha
-      odebug "Checking cask has checksum"
-      return if @cask.sha256 != :no_check
-
-      raise CaskError, <<~EOS
-        Cask '#{@cask}' does not have a sha256 checksum defined and was not installed.
-        This means you have the #{Formatter.identifier("--require-sha")} option set, perhaps in your `$HOMEBREW_CASK_OPTS`.
-      EOS
     end
 
     sig { returns(UnpackStrategy) }

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -169,7 +169,11 @@ module Homebrew
                 quarantine = args.quarantine?
                 quarantine = true if quarantine.nil?
 
-                download = Cask::Download.new(cask, quarantine:)
+                download = Cask::Download.new(
+                  cask,
+                  quarantine:,
+                  require_sha: Homebrew::EnvConfig.cask_opts_require_sha?,
+                )
                 download_queue.enqueue(download)
               end
             end

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -112,6 +112,12 @@ module Homebrew
                      "`~/.profile`, `~/.bash_profile`, or `~/.zshenv`:" \
                      "\n\n    `export HOMEBREW_CASK_OPTS=\"--appdir=${HOME}/Applications --fontdir=/Library/Fonts\"`",
       },
+      HOMEBREW_CASK_OPTS_BINARIES:               {
+        description: "Enable linking of helper executables for casks.",
+      },
+      HOMEBREW_CASK_OPTS_REQUIRE_SHA:            {
+        description: "Require all casks to have a checksum.",
+      },
       HOMEBREW_CLEANUP_MAX_AGE_DAYS:             {
         description: "Cleanup all cached files older than this many days.",
         default:     120,
@@ -592,6 +598,8 @@ module Homebrew
     CUSTOM_IMPLEMENTATIONS = T.let(Set.new([
       :HOMEBREW_MAKE_JOBS,
       :HOMEBREW_CASK_OPTS,
+      :HOMEBREW_CASK_OPTS_BINARIES,
+      :HOMEBREW_CASK_OPTS_REQUIRE_SHA,
       :HOMEBREW_FORBID_PACKAGES_FROM_PATHS,
       :HOMEBREW_DOWNLOAD_CONCURRENCY,
       :HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS,
@@ -640,11 +648,20 @@ module Homebrew
       Shellwords.shellsplit(ENV.fetch("HOMEBREW_CASK_OPTS", ""))
     end
 
+    sig { returns(T.nilable(String)) }
+    def cask_opts_binaries
+      ENV["HOMEBREW_CASK_OPTS_BINARIES"].presence
+    end
+
     sig { returns(T::Boolean) }
     def cask_opts_binaries?
       cask_opts.reverse_each do |opt|
         return true if opt == "--binaries"
         return false if opt == "--no-binaries"
+      end
+
+      if (env_value = ENV.fetch("HOMEBREW_CASK_OPTS_BINARIES", nil)).present?
+        return FALSY_VALUES.exclude?(env_value.downcase)
       end
 
       true
@@ -660,9 +677,18 @@ module Homebrew
       true
     end
 
+    sig { returns(T.nilable(String)) }
+    def cask_opts_require_sha
+      ENV["HOMEBREW_CASK_OPTS_REQUIRE_SHA"].presence
+    end
+
     sig { returns(T::Boolean) }
     def cask_opts_require_sha?
-      cask_opts.include?("--require-sha")
+      cask_opts.include?("--require-sha") ||
+        begin
+          env_value = ENV.fetch("HOMEBREW_CASK_OPTS_REQUIRE_SHA", nil)
+          env_value.present? && FALSY_VALUES.exclude?(env_value.downcase)
+        end
     end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/test/cask/download_spec.rb
+++ b/Library/Homebrew/test/cask/download_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe Cask::Download, :cask do
     end
   end
 
+  describe "#fetch" do
+    it "fails before downloading if sha256 :no_check is used with --require-sha" do
+      no_checksum = Cask::CaskLoader.load(cask_path("no-checksum"))
+      download = described_class.new(no_checksum, require_sha: true)
+
+      expect(download).not_to receive(:downloader)
+      expect { download.fetch }.to raise_error(/--require-sha/)
+    end
+  end
+
   describe "#verify_download_integrity" do
     subject(:verification) { described_class.new(cask).verify_download_integrity(downloaded_path) }
 

--- a/Library/Homebrew/test/cmd/config_spec.rb
+++ b/Library/Homebrew/test/cmd/config_spec.rb
@@ -13,4 +13,13 @@ RSpec.describe Homebrew::Cmd::Config do
       .and not_to_output.to_stderr
       .and be_a_success
   end
+
+  it "prints HOMEBREW_CASK_OPTS_REQUIRE_SHA in env config output when set" do
+    ENV["HOMEBREW_CASK_OPTS_REQUIRE_SHA"] = "1"
+    output = StringIO.new
+
+    SystemConfig.homebrew_env_config(output)
+
+    expect(output.string).to include("HOMEBREW_CASK_OPTS_REQUIRE_SHA: 1")
+  end
 end

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -71,6 +71,30 @@ RSpec.describe Homebrew::EnvConfig do
     end
   end
 
+  describe ".cask_opts_binaries?" do
+    before do
+      ENV["HOMEBREW_CASK_OPTS"] = nil
+      ENV["HOMEBREW_CASK_OPTS_BINARIES"] = nil
+    end
+
+    it "returns false if HOMEBREW_CASK_OPTS_BINARIES is set to a falsey value" do
+      ENV["HOMEBREW_CASK_OPTS_BINARIES"] = "0"
+      expect(env_config.cask_opts_binaries?).to be(false)
+    end
+  end
+
+  describe ".cask_opts_require_sha?" do
+    before do
+      ENV["HOMEBREW_CASK_OPTS"] = nil
+      ENV["HOMEBREW_CASK_OPTS_REQUIRE_SHA"] = nil
+    end
+
+    it "returns true if HOMEBREW_CASK_OPTS_REQUIRE_SHA is set" do
+      ENV["HOMEBREW_CASK_OPTS_REQUIRE_SHA"] = "1"
+      expect(env_config.cask_opts_require_sha?).to be(true)
+    end
+  end
+
   describe ".forbid_packages_from_paths?" do
     before do
       ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = nil


### PR DESCRIPTION
- keep documented cask opt env vars visible in `brew config`
- stop `:no_check` cask fetches before any download starts when `--require-sha` is in effect
- keep `brew fetch --cask` aligned with install-time SHA enforcement

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Build using OpenAI Codex xhigh with manual review/testing.

-----
