### PR TITLE
utils/github: use WithoutRuntime sig for create_bump_pr

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -724,7 +724,13 @@ module GitHub
     [remote_url, username]
   end
 
-  sig { params(info: T::Hash[Symbol, T.untyped], args: T.any(Homebrew::DevCmd::BumpFormulaPr::Args, Homebrew::DevCmd::BumpCaskPr::Args)).void }
+  # The sig requires specific commands to be loaded, so we use WithoutRuntime
+  T::Sig::WithoutRuntime.sig {
+    params(
+      info: T::Hash[Symbol, T.untyped],
+      args: T.any(Homebrew::DevCmd::BumpFormulaPr::Args, Homebrew::DevCmd::BumpCaskPr::Args)
+    ).void
+  }
   def self.create_bump_pr(info, args:)
     # --write-only without --commit means don't take any git actions at all.
     return if args.write_only? && !args.commit?

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -728,7 +728,7 @@ module GitHub
   T::Sig::WithoutRuntime.sig {
     params(
       info: T::Hash[Symbol, T.untyped],
-      args: T.any(Homebrew::DevCmd::BumpFormulaPr::Args, Homebrew::DevCmd::BumpCaskPr::Args)
+      args: T.any(Homebrew::DevCmd::BumpFormulaPr::Args, Homebrew::DevCmd::BumpCaskPr::Args),
     ).void
   }
   def self.create_bump_pr(info, args:)


### PR DESCRIPTION
Fix `uninitialized constant Homebrew::DevCmd::BumpCaskPr` errors in
homebrew-core CI autobump jobs by switching the `create_bump_pr` sig
to `T::Sig::WithoutRuntime.sig`, which resolves the type lazily
instead of at class load time.

See: https://github.com/Homebrew/homebrew-core/actions/runs/24371330931/job/71175423834#step:6:1307

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Claude Code was used to commit and open the PR. The fix itself was authored by the developer.*

-----