### PR TITLE
bump: require "tap.rb"

### DIFF
--- a/Library/Homebrew/bump.rb
+++ b/Library/Homebrew/bump.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "system_command"
+require "tap"
 require "utils/git"
 require "utils/github"
 require "utils/output"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
Now this code fails with `uninitialized constant` error, see https://github.com/Homebrew/brew/pull/22014#issuecomment-4244012844