### PR TITLE
Add VCS revision as `scm_revision` in tab

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -145,6 +145,12 @@ class AbstractDownloadStrategy # rubocop:todo Style/OneClassPerFile
     Pathname.pwd.to_enum(:find).select(&:file?).map(&:mtime).max
   end
 
+  # Return the checked out source revision for version control downloads.
+  #
+  # @api public
+  sig { overridable.returns(T.nilable(String)) }
+  def source_revision; end
+
   # Remove {#cached_location} and any other files associated with the resource
   # from the cache.
   #
@@ -889,6 +895,9 @@ class SubversionDownloadStrategy < VCSDownloadStrategy # rubocop:todo Style/OneC
     Time.parse T.must(time)
   end
 
+  sig { override.returns(T.nilable(String)) }
+  def source_revision = last_commit
+
   # Return last commit's unique identifier for the repository.
   #
   # @api public
@@ -1002,6 +1011,9 @@ class GitDownloadStrategy < VCSDownloadStrategy # rubocop:todo Style/OneClassPer
   def source_modified_time
     Time.parse(silent_command("git", args: ["--git-dir", git_dir, "show", "-s", "--format=%cD"]).stdout)
   end
+
+  sig { override.returns(T.nilable(String)) }
+  def source_revision = current_revision.presence
 
   # Return last commit's unique identifier for the repository if fetched locally.
   #
@@ -1432,6 +1444,9 @@ class MercurialDownloadStrategy < VCSDownloadStrategy # rubocop:todo Style/OneCl
     Time.parse(silent_command("hg", args: ["tip", "--template", "{date|isodate}", "-R", cached_location]).stdout)
   end
 
+  sig { override.returns(T.nilable(String)) }
+  def source_revision = current_revision.presence
+
   # Return last commit's unique identifier for the repository.
   #
   # @api public
@@ -1523,6 +1538,9 @@ class BazaarDownloadStrategy < VCSDownloadStrategy # rubocop:todo Style/OneClass
     Time.parse(timestamp)
   end
 
+  sig { override.returns(T.nilable(String)) }
+  def source_revision = last_commit.presence
+
   # Return last commit's unique identifier for the repository.
   #
   # @api public
@@ -1586,6 +1604,9 @@ class FossilDownloadStrategy < VCSDownloadStrategy # rubocop:todo Style/OneClass
     out = silent_command("fossil", args: ["info", "tip", "-R", cached_location]).stdout
     Time.parse(T.must(out[/^(hash|uuid): +\h+ (.+)$/, 1]))
   end
+
+  sig { override.returns(T.nilable(String)) }
+  def source_revision = last_commit.presence
 
   # Return last commit's unique identifier for the repository.
   #

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -276,8 +276,18 @@ class Tab < AbstractTab # rubocop:todo Style/OneClassPerFile
     tab.stdlib = stdlib
     tab.aliases = formula.aliases
     tab.runtime_dependencies = Tab.runtime_deps_hash(formula, runtime_deps)
+    active_spec = if formula.active_spec_sym == :head
+      T.must(formula.head)
+    else
+      T.must(formula.stable)
+    end
+
     tab.source["spec"] = formula.active_spec_sym.to_s
     tab.source["path"] = formula.specified_path.to_s
+    if (downloader = active_spec.downloader).cached_location.exist? &&
+       (scm_revision = downloader.source_revision).present?
+      tab.source["scm_revision"] = scm_revision
+    end
     tab.source["versions"] = {
       "stable"                => formula.stable&.version&.to_s,
       "head"                  => formula.head&.version&.to_s,
@@ -579,10 +589,12 @@ class Tab < AbstractTab # rubocop:todo Style/OneClassPerFile
       "stdlib"               => stdlib&.to_s,
       "compiler"             => compiler.to_s,
       "runtime_dependencies" => runtime_dependencies,
+      "source"               => source.slice("scm_revision").compact.presence,
       "arch"                 => arch,
       "built_on"             => built_on,
     }
     attributes.delete("stdlib") if attributes["stdlib"].blank?
+    attributes.delete("source") if attributes["source"].blank?
     attributes
   end
 

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -59,10 +59,11 @@ RSpec.describe Tab do
       "stdlib"                  => "libcxx",
       "runtime_dependencies"    => [],
       "source"                  => {
-        "tap"      => CoreTap.instance.to_s,
-        "path"     => CoreTap.instance.path.to_s,
-        "spec"     => "stable",
-        "versions" => {
+        "tap"          => CoreTap.instance.to_s,
+        "path"         => CoreTap.instance.path.to_s,
+        "spec"         => "stable",
+        "scm_revision" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "versions"     => {
           "stable" => "0.10",
           "head"   => "HEAD-1111111",
         },
@@ -75,10 +76,30 @@ RSpec.describe Tab do
   let(:time) { Time.now.to_i }
   let(:unused_options) { Options.create(%w[--with-baz --without-qux]) }
   let(:used_options) { Options.create(%w[--with-foo --without-bar]) }
+  let(:git_repo) { HOMEBREW_CACHE/"tab-spec-git-repo" }
 
   let(:f) { formula { url "foo-1.0" } }
   let(:f_tab_path) { f.prefix/"INSTALL_RECEIPT.json" }
   let(:f_tab_content) { (TEST_FIXTURE_DIR/"receipt.json").read }
+
+  after do
+    FileUtils.rm_rf git_repo
+  end
+
+  def git_commit_all
+    system "git", "add", "--all"
+    system "git", "commit", "-m", "tab spec commit"
+  end
+
+  def setup_git_repo(path)
+    path.mkpath
+
+    path.cd do
+      system "git", "-c", "init.defaultBranch=master", "init"
+      FileUtils.touch "README"
+      git_commit_all
+    end
+  end
 
   specify "defaults" do
     # < 1.1.7 runtime_dependencies were wrong so are ignored
@@ -397,6 +418,7 @@ RSpec.describe Tab do
       expect(tab.runtime_dependencies).to eq(runtime_dependencies)
 
       expect(tab.source["path"]).to eq(f.path.to_s)
+      expect(tab.source["scm_revision"]).to be_nil
     end
 
     it "can create a formula Tab from an alias" do
@@ -407,6 +429,22 @@ RSpec.describe Tab do
       tab = described_class.create(f, compiler, stdlib)
 
       expect(tab.source["path"]).to eq(f.alias_path.to_s)
+    end
+
+    it "records the upstream source revision for VCS formulae" do
+      setup_git_repo(git_repo)
+
+      commit = git_repo.cd { Utils.popen_read("git", "rev-parse", "HEAD").chomp }
+      repo = git_repo
+      f = formula("tab-spec-git") do
+        url "file://#{repo}", using: :git, branch: "master"
+        version "1.0"
+      end
+      f.public_send(f.active_spec_sym).fetch
+
+      tab = described_class.create(f, DevelopmentTools.default_compiler, :libcxx)
+
+      expect(tab.source["scm_revision"]).to eq(commit)
     end
   end
 
@@ -501,6 +539,7 @@ RSpec.describe Tab do
     expect(json_tab.stable_version).to eq(tab.stable_version)
     expect(json_tab.head_version).to eq(tab.head_version)
     expect(json_tab.source["path"]).to eq(tab.source["path"])
+    expect(json_tab.source["scm_revision"]).to eq(tab.source["scm_revision"])
     expect(json_tab.arch).to eq(tab.arch.to_s)
     expect(json_tab.built_on["os"]).to eq(tab.built_on["os"])
   end
@@ -513,6 +552,7 @@ RSpec.describe Tab do
     expect(json_tab.stdlib).to eq(tab.stdlib)
     expect(json_tab.compiler).to eq(tab.compiler)
     expect(json_tab.runtime_dependencies).to eq(tab.runtime_dependencies)
+    expect(json_tab.source["scm_revision"]).to eq(tab.source["scm_revision"])
     expect(json_tab.arch).to eq(tab.arch.to_s)
     expect(json_tab.built_on["os"]).to eq(tab.built_on["os"])
   end


### PR DESCRIPTION
- record the source control commit hash in `INSTALL_RECEIPT.json` when a formula is built from a VCS download strategy (Git, SVN, Hg, Bazaar, Fossil)
- expose `source_revision` on download strategies so `Tab.create` can capture it from the active spec's downloader when the cached checkout exists
- propagate `scm_revision` through `to_bottle_hash` for bottle JSON metadata

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Built with Claude Code. Local review and editing.

-----
