### PR TITLE
fix(bundle): don't skip tap-qualified casks on Linux before tap is installed

### DIFF
--- a/Library/Homebrew/extend/os/linux/bundle/skipper.rb
+++ b/Library/Homebrew/extend/os/linux/bundle/skipper.rb
@@ -18,6 +18,12 @@ module OS
               false
             end
           rescue ::Cask::CaskError
+            # If the cask can't be loaded, it may be from a tap that hasn't been
+            # tapped yet. Don't assume macOS-only in that case — let the normal
+            # install flow handle it after the tap is processed.
+            full_name = T.cast(entry.options[:full_name], T.nilable(String))
+            return false if full_name&.include?("/")
+
             true
           end
 

--- a/Library/Homebrew/test/bundle/skipper_spec.rb
+++ b/Library/Homebrew/test/bundle/skipper_spec.rb
@@ -95,6 +95,17 @@ RSpec.describe Homebrew::Bundle::Skipper do
       end
     end
 
+    context "with a cask from an untapped tap on Linux", :needs_linux do
+      let(:entry) do
+        Homebrew::Bundle::Dsl::Entry.new(:cask, "vscodium-linux", full_name: "ublue-os/tap/vscodium-linux")
+      end
+
+      it "does not skip when cask can't be loaded" do
+        allow(Cask::CaskLoader).to receive(:load).with("vscodium-linux").and_raise(Cask::CaskUnavailableError.new("vscodium-linux"))
+        expect(skipper.skip?(entry)).to be false
+      end
+    end
+
     context "with a listed formula in a failed tap" do
       let(:entry) { Homebrew::Bundle::Dsl::Entry.new(:brew, "org/repo/formula") }
 


### PR DESCRIPTION
When a Brewfile cask comes from a tap (e.g., `ublue-os/tap/vscodium-linux`),
the Linux skipper's `macos_only_cask?` check tries to load the cask before
its tap is installed. The `CaskError` rescue assumed macOS-only, causing the
cask to be skipped on the first run but installed correctly on the second.

This checks if the cask has a tap-qualified `full_name` in the rescue block.
If so, it doesn't assume macOS-only, letting the normal install flow handle
it after the tap is processed.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. Claude Code was used to assist with investigating the root cause and drafting the fix. All changes were reviewed and verified manually. The fix is a small logic change in the rescue block of `macos_only_cask?` in the Linux bundle skipper.

-----

Fixes #21992