### PR TITLE
docs: bump yard to 0.9.39

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -17,8 +17,7 @@ group :jekyll_plugins do
 end
 
 gem "redcarpet"
-# Ruby 4.0 support: https://github.com/lsegal/yard/pull/1649
-gem "yard", github: "Bo98/yard", ref: "62a50d2fd54f2d23365b14553323c1f90b946d1f"
+gem "yard"
 gem "yard-sorbet"
 
 group :development do

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/Bo98/yard.git
-  revision: 62a50d2fd54f2d23365b14553323c1f90b946d1f
-  ref: 62a50d2fd54f2d23365b14553323c1f90b946d1f
-  specs:
-    yard (0.9.38)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -214,6 +207,7 @@ GEM
       ethon (>= 0.18.0)
     unicode-display_width (2.6.0)
     webrick (1.9.2)
+    yard (0.9.39)
     yard-sorbet (0.9.0)
       sorbet-runtime
       yard
@@ -246,7 +240,7 @@ DEPENDENCIES
   rake
   redcarpet
   webrick
-  yard!
+  yard
   yard-sorbet
 
 CHECKSUMS
@@ -349,7 +343,7 @@ CHECKSUMS
   typhoeus (1.6.0) sha256=bacc41c23e379547e29801dc235cd1699b70b955a1ba3d32b2b877aa844c331d
   unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
-  yard (0.9.38)
+  yard (0.9.39) sha256=0bbbcd87ffd132824c3f89bbd39deef1ffb3877259090849bd49e48daeaf7b56
   yard-sorbet (0.9.0) sha256=03d1aa461b9e9c82b886919a13aa3e09fcf4d1852239d2967ed97e92723ffe21
   yell (2.2.2) sha256=1d166f3cc3b6dc49a59778ea7156ed6d8de794c15106d48ffd6cbb061b9b26bc
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

In #21999 I forgot to also bump yard (to 0.9.39)  in `docs/Gemfile.lock`, since that is used to publish the docs. I only updated `Library/Homebrew/Gemfile.lock` in the previous pr.

I also removed the yard fork from the .lock and Gemfile as 0.9.39 supports ruby 4.