### PR TITLE
deps: skip recursive_req_includes when --include-requirements not passed

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -274,7 +274,7 @@ module Homebrew
 
         if recursive
           deps ||= recursive_dep_includes(dependency, includes, ignores)
-          reqs   = recursive_req_includes(dependency, includes, ignores)
+          reqs = args.include_requirements? ? recursive_req_includes(dependency, includes, ignores) : Requirements.new
         else
           deps ||= select_includes(dependency.deps, ignores, includes)
           reqs   = select_includes(dependency.requirements, ignores, includes)

--- a/Library/Homebrew/dependencies_helpers.rb
+++ b/Library/Homebrew/dependencies_helpers.rb
@@ -24,9 +24,7 @@ module DependenciesHelpers
       .returns(T::Array[Dependency])
   }
   def recursive_dep_includes(root_dependent, includes, ignores)
-    # The use of T.unsafe is recommended by the Sorbet docs:
-    #   https://sorbet.org/docs/overloads#multiple-methods-but-sharing-a-common-implementation
-    T.unsafe(recursive_includes(Dependency, root_dependent, includes, ignores))
+    T.cast(recursive_includes(Dependency, root_dependent, includes, ignores), T::Array[Dependency])
   end
 
   sig {
@@ -34,9 +32,7 @@ module DependenciesHelpers
       .returns(Requirements)
   }
   def recursive_req_includes(root_dependent, includes, ignores)
-    # The use of T.unsafe is recommended by the Sorbet docs:
-    #   https://sorbet.org/docs/overloads#multiple-methods-but-sharing-a-common-implementation
-    T.unsafe(recursive_includes(Requirement, root_dependent, includes, ignores))
+    T.cast(recursive_includes(Requirement, root_dependent, includes, ignores), Requirements)
   end
 
   sig {


### PR DESCRIPTION
`deps_for_dependent` always called `recursive_req_includes` in the recursive branch, even though `condense_requirements` immediately discards any `Requirement` objects unless `--include-requirements` is explicitly passed. Skipping the expansion avoids traversing the static dependency tree and loading formula objects for transitive dependencies of every installed formula.

This mirrors the existing pattern in `dependables` (line 377), which already guards `select_includes(formula.requirements, ...)` behind `args.include_requirements?`.

Also replaces `T.unsafe` with `T.cast` in `dependencies_helpers.rb` since the return type is known.

**Benchmark** (`brew deps --installed`, 235 installed formulae, 10 runs each):

| | Mean ± σ | User time |
|---|---|---|
| Before | 2644 ms ± 153 ms | 1854 ms |
| After | 2362 ms ± 148 ms | 1492 ms |
| Improvement | **~282 ms (~10.7%)** | **~362 ms (~19.5%)** |

```
hyperfine --warmup 3 --runs 10 './bin/brew deps --installed'
```

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Claude Code was used to profile `brew deps --installed`, identify the bottleneck (`recursive_req_includes` being called unconditionally), and implement the fix. I manually verified that `brew deps --installed` and `brew deps --installed --include-requirements` produce identical output before and after the change, and that all existing tests pass.*

-----