### PR TITLE
tap_auditor: check rename files in local tap

### DIFF
--- a/Library/Homebrew/tap_auditor.rb
+++ b/Library/Homebrew/tap_auditor.rb
@@ -51,13 +51,15 @@ module Homebrew
       @problems                                       = T.let([], T::Array[T::Hash[Symbol, T.untyped]])
       @cask_tokens                                    = T.let([], T::Array[String])
       @formula_aliases                                = T.let([], T::Array[String])
-      @formula_renames                                = T.let(tap.formula_renames, T::Hash[String, String])
-      @cask_renames                                   = T.let(tap.cask_renames, T::Hash[String, String])
+      @formula_renames                                = T.let({}, T::Hash[String, String])
+      @cask_renames                                   = T.let({}, T::Hash[String, String])
       @formula_names                                  = T.let([], T::Array[String])
 
       Homebrew.with_no_api_env do
         tap.clear_cache if Homebrew::EnvConfig.automatically_set_no_install_from_api?
 
+        @formula_renames = tap.formula_renames
+        @cask_renames    = tap.cask_renames
         @cask_tokens = tap.cask_tokens.map do |cask_token|
           Utils.name_from_full_name(cask_token)
         end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

I used `claude-code` to help find and debug the issue as discovered in https://github.com/Homebrew/homebrew-cask/pull/259504

-----

When running `TapAuditor` the `@cask_tokens` and `@formula_names` were loaded inside of a `Homebrew.with_no_api_env` block. However, `@cask_renames` and `@formula_renames` were loaded outside of it. This cause the tokens/names to reflect the on-disk tap files, but the renames list is representing what is currently available via the API.

It makes sense to me for this audit to check the status of the repository based on the currently open PR. But if I'm missing something to do with API timing, and these changes breaking tap readability, I'm all ears.