### PR TITLE
fix: allow absolute `--path`/`--dir` for `typecheck`ing

### DIFF
--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -112,13 +112,19 @@ module Homebrew
           srb_exec += ["--ignore", args.ignore] if args.ignore.present?
           if args.file.present? || args.dir.present? || (tap_dirs = args.named.to_paths(only: :tap)).present?
             cd("sorbet") do
-              if args.file
-                path = Pathname args.file.to_s
-                srb_exec += ["--file", path.absolute? ? path.to_path : "../#{path}"]
+              path = if (file = args.file.presence)
+                srb_exec << "--file"
+                Pathname(file)
+              elsif (dir = args.dir.presence)
+                srb_exec << "--dir"
+                Pathname(dir)
               end
-              if args.dir
-                path = Pathname args.dir.to_s
-                srb_exec += ["--dir", path.absolute? ? path.to_path : "../#{path}"]
+              if path
+                srb_exec << if path.absolute?
+                  path.to_path
+                else
+                  "../#{path}"
+                end
               end
               tap_dirs&.each do |tap_dir|
                 srb_exec += ["--dir", tap_dir.to_s]

--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -112,8 +112,14 @@ module Homebrew
           srb_exec += ["--ignore", args.ignore] if args.ignore.present?
           if args.file.present? || args.dir.present? || (tap_dirs = args.named.to_paths(only: :tap)).present?
             cd("sorbet") do
-              srb_exec += ["--file", "../#{args.file}"] if args.file
-              srb_exec += ["--dir", "../#{args.dir}"] if args.dir
+              if args.file
+                path = Pathname args.file.to_s
+                srb_exec += ["--file", path.absolute? ? path.to_path : "../#{path}"]
+              end
+              if args.dir
+                path = Pathname args.dir.to_s
+                srb_exec += ["--dir", path.absolute? ? path.to_path : "../#{path}"]
+              end
               tap_dirs&.each do |tap_dir|
                 srb_exec += ["--dir", tap_dir.to_s]
               end


### PR DESCRIPTION
Currently, any `--path`/`--dir` given to `brew typecheck` is forcibly prefixed with `../`, which breaks this functionality under most circumstances. This PR enables passing an absolute `--path`, or `--dir` to `typecheck`, with the goal being that we can make use of it with 3rd party taps…

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
