### PR TITLE
dev-cmd/extract: replace T.unsafe with instance_method/define_method

### DIFF
--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -119,7 +119,7 @@ module Homebrew
             result = Utils::Git.last_revision_of_file(repo, file)
           else
             file = files.fetch(0).realpath
-            rev = T.let("HEAD", T.nilable(String))
+            rev = "HEAD"
             version = Formulary.factory(file).version
             result = File.read(file)
           end
@@ -135,7 +135,7 @@ module Homebrew
                                 .gsub(/\D+/, ".")
 
         # Remove any existing version suffixes, as a new one will be added later.
-        name.sub!(/\b@(.*)\z\b/i, "")
+        name.sub!(/\b@(.*)\z/i, "")
         versioned_name = Formulary.class_s("#{name}@#{version_string}")
         result.sub!("class #{class_name} < Formula", "class #{versioned_name} < Formula")
 
@@ -172,68 +172,69 @@ module Homebrew
         with_monkey_patch { Formulary.from_contents(name, file, contents, ignore_errors: true) }
       end
 
-      sig { params(_block: T.proc.void).returns(T.untyped) }
+      sig { params(klass: T::Module[T.anything], method_name: Symbol).returns(T.nilable(Symbol)) }
+      def method_visibility(klass, method_name)
+        if klass.private_method_defined?(method_name, false)
+          :private
+        elsif klass.method_defined?(method_name, false)
+          klass.public_method_defined?(method_name) ? :public : :protected
+        end
+      end
+
+      sig { type_parameters(:U).params(_block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
       def with_monkey_patch(&_block)
-        # Since `method_defined?` is not a supported type guard, the use of `alias_method` below is not typesafe:
-        BottleSpecification.class_eval do
-          T.unsafe(self).alias_method :old_method_missing, :method_missing if method_defined?(:method_missing)
-          define_method(:method_missing) do |*_|
-            # do nothing
-          end
-        end
+        bs_vis = method_visibility(BottleSpecification, :method_missing)
+        mod_vis = method_visibility(Module, :method_missing)
+        res_vis = method_visibility(Resource, :method_missing)
+        dc_vis = method_visibility(DependencyCollector, :parse_symbol_spec)
 
-        Module.class_eval do
-          T.unsafe(self).alias_method :old_method_missing, :method_missing if method_defined?(:method_missing)
-          define_method(:method_missing) do |*_|
-            # do nothing
-          end
-        end
+        bs_mm = BottleSpecification.instance_method(:method_missing) if bs_vis
+        mod_mm = Module.instance_method(:method_missing) if mod_vis
+        res_mm = Resource.instance_method(:method_missing) if res_vis
+        dc_pss = DependencyCollector.instance_method(:parse_symbol_spec) if dc_vis
 
-        Resource.class_eval do
-          T.unsafe(self).alias_method :old_method_missing, :method_missing if method_defined?(:method_missing)
-          define_method(:method_missing) do |*_|
-            # do nothing
-          end
-        end
-
-        DependencyCollector.class_eval do
-          if method_defined?(:parse_symbol_spec)
-            T.unsafe(self).alias_method :old_parse_symbol_spec,
-                                        :parse_symbol_spec
-          end
-          define_method(:parse_symbol_spec) do |*_|
-            # do nothing
-          end
-        end
+        BottleSpecification.class_eval { private define_method(:method_missing) { |*_| nil } }
+        Module.class_eval { private define_method(:method_missing) { |*_| nil } }
+        Resource.class_eval { private define_method(:method_missing) { |*_| nil } }
+        DependencyCollector.class_eval { private define_method(:parse_symbol_spec) { |*_| nil } }
 
         yield
       ensure
-        BottleSpecification.class_eval do
-          if method_defined?(:old_method_missing)
-            T.unsafe(self).alias_method :method_missing, :old_method_missing
-            T.unsafe(self).undef :old_method_missing
+        if (mm = bs_mm) && (vis = bs_vis)
+          BottleSpecification.class_eval do
+            define_method(:method_missing, mm)
+            private(:method_missing) if vis == :private
+            protected(:method_missing) if vis == :protected
           end
+        else
+          BottleSpecification.class_eval { remove_method(:method_missing) }
         end
-
-        Module.class_eval do
-          if method_defined?(:old_method_missing)
-            T.unsafe(self).alias_method :method_missing, :old_method_missing
-            T.unsafe(self).undef :old_method_missing
+        if (mm = mod_mm) && (vis = mod_vis)
+          Module.class_eval do
+            define_method(:method_missing, mm)
+            private(:method_missing) if vis == :private
+            protected(:method_missing) if vis == :protected
           end
+        else
+          Module.class_eval { remove_method(:method_missing) }
         end
-
-        Resource.class_eval do
-          if method_defined?(:old_method_missing)
-            T.unsafe(self).alias_method :method_missing, :old_method_missing
-            T.unsafe(self).undef :old_method_missing
+        if (mm = res_mm) && (vis = res_vis)
+          Resource.class_eval do
+            define_method(:method_missing, mm)
+            private(:method_missing) if vis == :private
+            protected(:method_missing) if vis == :protected
           end
+        else
+          Resource.class_eval { remove_method(:method_missing) }
         end
-
-        DependencyCollector.class_eval do
-          if method_defined?(:old_parse_symbol_spec)
-            T.unsafe(self).alias_method :parse_symbol_spec, :old_parse_symbol_spec
-            T.unsafe(self).undef :old_parse_symbol_spec
+        if (pss = dc_pss) && (vis = dc_vis)
+          DependencyCollector.class_eval do
+            define_method(:parse_symbol_spec, pss)
+            private(:parse_symbol_spec) if vis == :private
+            protected(:parse_symbol_spec) if vis == :protected
           end
+        else
+          DependencyCollector.class_eval { remove_method(:parse_symbol_spec) }
         end
       end
     end

--- a/Library/Homebrew/test/dev-cmd/extract_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/extract_spec.rb
@@ -3,9 +3,80 @@
 
 require "cmd/shared_examples/args_parse"
 require "dev-cmd/extract"
+require "dependency_collector"
 
 RSpec.describe Homebrew::DevCmd::Extract do
   it_behaves_like "parseable arguments"
+
+  describe "#with_monkey_patch" do
+    subject(:extract) do
+      allow_any_instance_of(Homebrew::CLI::Parser).to receive(:check_named_args)
+      described_class.new([])
+    end
+
+    it "makes method_missing a noop on BottleSpecification during the block and restores it after" do
+      bs = BottleSpecification.new
+      expect { bs.no_such_method }.to raise_error(NoMethodError)
+      expect(BottleSpecification.private_instance_methods(false)).not_to include(:method_missing)
+      extract.send(:with_monkey_patch) do
+        expect { bs.no_such_method }.not_to raise_error
+      end
+      expect { bs.no_such_method }.to raise_error(NoMethodError)
+      expect(BottleSpecification.private_instance_methods(false)).not_to include(:method_missing)
+    end
+
+    it "makes method_missing a noop on Resource during the block and restores it after" do
+      resource = Resource.new
+      expect { resource.no_such_method }.to raise_error(NoMethodError)
+      expect(Resource.private_instance_methods(false)).not_to include(:method_missing)
+      extract.send(:with_monkey_patch) do
+        expect { resource.no_such_method }.not_to raise_error
+      end
+      expect { resource.no_such_method }.to raise_error(NoMethodError)
+      expect(Resource.private_instance_methods(false)).not_to include(:method_missing)
+    end
+
+    it "makes parse_symbol_spec a noop on DependencyCollector during the block and restores it after" do
+      dc = DependencyCollector.new
+      expect(dc.send(:parse_symbol_spec, :macos, [])).to be_a(MacOSRequirement)
+      extract.send(:with_monkey_patch) do
+        expect(dc.send(:parse_symbol_spec, :macos, [])).to be_nil
+      end
+      expect(dc.send(:parse_symbol_spec, :macos, [])).to be_a(MacOSRequirement)
+    end
+
+    it "restores all methods even when the block raises" do
+      dc = DependencyCollector.new
+      resource = Resource.new
+      expect { extract.send(:with_monkey_patch) { raise "oops" } }.to raise_error("oops")
+      expect(dc.send(:parse_symbol_spec, :macos, [])).to be_a(MacOSRequirement)
+      expect { resource.no_such_method }.to raise_error(NoMethodError)
+    end
+
+    it "restores a directly-defined method_missing on BottleSpecification if one exists" do
+      sentinel = Object.new
+      BottleSpecification.class_eval { private define_method(:method_missing) { |*_| sentinel } }
+      begin
+        extract.send(:with_monkey_patch) do
+          expect(BottleSpecification.new.no_such_method).to be_nil
+        end
+        expect(BottleSpecification.new.no_such_method).to be(sentinel)
+        expect(BottleSpecification.private_instance_methods(false)).to include(:method_missing)
+      ensure
+        BottleSpecification.remove_method(:method_missing)
+      end
+    end
+
+    it "restores correctly across multiple sequential invocations" do
+      dc = DependencyCollector.new
+      2.times do
+        extract.send(:with_monkey_patch) do
+          expect(dc.send(:parse_symbol_spec, :macos, [])).to be_nil
+        end
+        expect(dc.send(:parse_symbol_spec, :macos, [])).to be_a(MacOSRequirement)
+      end
+    end
+  end
 
   context "when extracting a formula" do
     let!(:target) do


### PR DESCRIPTION
-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Claude Code was used to implement and iterate on this change. The approach was reviewed carefully at each step, including catching a correctness bug (using `remove_method` instead of `define_method` when restoring an inherited method, so the class's method lookup chain is not permanently altered). All changes were verified with `brew lgtm` and new unit tests were written to cover the save/restore behaviour.

-----

Replace the `alias_method`/`undef` pattern in `with_monkey_patch` (which required `T.unsafe` to bypass Sorbet) with saving `UnboundMethod` objects via the public `instance_method` API and restoring them in `ensure` via `define_method` or `remove_method`.

The signature of `with_monkey_patch` is also improved from `returns(T.untyped)` to a generic `type_parameters(:U)` signature that correctly propagates the block's return type.

Key correctness detail: when the saved method's owner is not the patched class (i.e. it was inherited), use `remove_method` rather than `define_method` to restore, so that inheritance is properly reinstated rather than permanently shadowing the inherited method with a direct definition on the class.

Also drops the `method_defined?` guards, which were incorrect: `method_defined?` only checks public/protected methods, so it returns `false` for `method_missing` (which is private on `BasicObject`) even though `instance_method` can always find it. `parse_symbol_spec` is always defined directly on `DependencyCollector` so its guard was also unnecessary.

New unit tests verify that `method_missing` and `parse_symbol_spec` are correctly patched during the block and fully restored after — including when the block raises — and that no spurious direct definition is left on the class post-restoration.