### PR TITLE
Use joint packages JSON file in `Homebrew::API::Internal`

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -182,8 +182,7 @@ module Homebrew
       end
 
       if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.fetch_formula_api!(download_queue:, stale_seconds:, enqueue: true)
-        Homebrew::API::Internal.fetch_cask_api!(download_queue:, stale_seconds:, enqueue: true)
+        Homebrew::API::Internal.fetch_packages_api!(download_queue:, stale_seconds:, enqueue: true)
       else
         Homebrew::API::Formula.fetch_api!(download_queue:, stale_seconds:, enqueue: true)
         Homebrew::API::Formula.fetch_tap_migrations!(download_queue:, stale_seconds: DEFAULT_API_STALE_SECONDS,
@@ -320,7 +319,7 @@ module Homebrew
     sig { returns(Pathname) }
     def self.cached_formula_json_file_path
       if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.cached_formula_json_file_path
+        Homebrew::API::Internal.cached_packages_json_file_path
       else
         Homebrew::API::Formula.cached_json_file_path
       end
@@ -356,7 +355,7 @@ module Homebrew
     sig { returns(Pathname) }
     def self.cached_cask_json_file_path
       if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.cached_cask_json_file_path
+        Homebrew::API::Internal.cached_packages_json_file_path
       else
         Homebrew::API::Cask.cached_json_file_path
       end

--- a/Library/Homebrew/api/internal.rb
+++ b/Library/Homebrew/api/internal.rb
@@ -15,13 +15,8 @@ module Homebrew
       private_class_method :cache
 
       sig { returns(String) }
-      def self.formula_endpoint
-        "internal/formula.#{SimulateSystem.current_tag}.jws.json"
-      end
-
-      sig { returns(String) }
-      def self.cask_endpoint
-        "internal/cask.#{SimulateSystem.current_tag}.jws.json"
+      def self.packages_endpoint
+        "internal/packages.#{SimulateSystem.current_tag}.jws.json"
       end
 
       sig { params(name: String).returns(Homebrew::API::FormulaStruct) }
@@ -55,67 +50,43 @@ module Homebrew
       end
 
       sig { returns(Pathname) }
-      def self.cached_formula_json_file_path
-        HOMEBREW_CACHE_API/formula_endpoint
-      end
-
-      sig { returns(Pathname) }
-      def self.cached_cask_json_file_path
-        HOMEBREW_CACHE_API/cask_endpoint
+      def self.cached_packages_json_file_path
+        HOMEBREW_CACHE_API/packages_endpoint
       end
 
       sig {
         params(download_queue: Homebrew::DownloadQueue, stale_seconds: T.nilable(Integer), enqueue: T::Boolean)
           .returns([T::Hash[String, T.untyped], T::Boolean])
       }
-      def self.fetch_formula_api!(download_queue: Homebrew.default_download_queue, stale_seconds: nil,
-                                  enqueue: false)
-        json_contents, updated = Homebrew::API.fetch_json_api_file(formula_endpoint, stale_seconds:, download_queue:,
-                                                                   enqueue:)
-        [T.cast(json_contents, T::Hash[String, T.untyped]), updated]
-      end
-
-      sig {
-        params(download_queue: Homebrew::DownloadQueue, stale_seconds: T.nilable(Integer), enqueue: T::Boolean)
-          .returns([T::Hash[String, T.untyped], T::Boolean])
-      }
-      def self.fetch_cask_api!(download_queue: Homebrew.default_download_queue, stale_seconds: nil,
-                               enqueue: false)
-        json_contents, updated = Homebrew::API.fetch_json_api_file(cask_endpoint, stale_seconds:, download_queue:,
+      def self.fetch_packages_api!(download_queue: Homebrew.default_download_queue, stale_seconds: nil,
+                                   enqueue: false)
+        json_contents, updated = Homebrew::API.fetch_json_api_file(packages_endpoint, stale_seconds:, download_queue:,
                                                                    enqueue:)
         [T.cast(json_contents, T::Hash[String, T.untyped]), updated]
       end
 
       sig { returns(T::Boolean) }
-      def self.download_and_cache_formula_data!
-        json_contents, updated = fetch_formula_api!
+      def self.download_and_cache_data!
+        json_contents, updated = fetch_packages_api!
         cache["formula_structs"] = {}
-        cache["formula_aliases"] = json_contents["aliases"]
-        cache["formula_renames"] = json_contents["renames"]
-        cache["formula_tap_git_head"] = json_contents["tap_git_head"]
-        cache["formula_tap_migrations"] = json_contents["tap_migrations"]
-        cache["formula_hashes"] = json_contents["formulae"]
-
-        updated
-      end
-      private_class_method :download_and_cache_formula_data!
-
-      sig { returns(T::Boolean) }
-      def self.download_and_cache_cask_data!
-        json_contents, updated = fetch_cask_api!
         cache["cask_structs"] = {}
-        cache["cask_renames"] = json_contents["renames"]
-        cache["cask_tap_git_head"] = json_contents["tap_git_head"]
-        cache["cask_tap_migrations"] = json_contents["tap_migrations"]
+        cache["formula_aliases"] = json_contents["formula_aliases"]
+        cache["formula_renames"] = json_contents["formula_renames"]
+        cache["cask_renames"] = json_contents["cask_renames"]
+        cache["formula_tap_git_head"] = json_contents["formula_tap_git_head"]
+        cache["cask_tap_git_head"] = json_contents["cask_tap_git_head"]
+        cache["formula_tap_migrations"] = json_contents["formula_tap_migrations"]
+        cache["cask_tap_migrations"] = json_contents["cask_tap_migrations"]
+        cache["formula_hashes"] = json_contents["formulae"]
         cache["cask_hashes"] = json_contents["casks"]
 
         updated
       end
-      private_class_method :download_and_cache_cask_data!
+      private_class_method :download_and_cache_data!
 
       sig { params(regenerate: T::Boolean).void }
       def self.write_formula_names_and_aliases(regenerate: false)
-        download_and_cache_formula_data! unless cache.key?("formula_hashes")
+        download_and_cache_data! unless cache.key?("formula_hashes")
 
         Homebrew::API.write_names_file!(formula_hashes.keys, "formula", regenerate:)
         Homebrew::API.write_aliases_file!(formula_aliases, "formula", regenerate:)
@@ -123,7 +94,7 @@ module Homebrew
 
       sig { params(regenerate: T::Boolean).void }
       def self.write_cask_names(regenerate: false)
-        download_and_cache_cask_data! unless cache.key?("cask_hashes")
+        download_and_cache_data! unless cache.key?("cask_hashes")
 
         Homebrew::API.write_names_file!(cask_hashes.keys, "cask", regenerate:)
       end
@@ -131,7 +102,7 @@ module Homebrew
       sig { returns(T::Hash[String, T::Hash[String, T.untyped]]) }
       def self.formula_hashes
         unless cache.key?("formula_hashes")
-          updated = download_and_cache_formula_data!
+          updated = download_and_cache_data!
           write_formula_names_and_aliases(regenerate: updated)
         end
 
@@ -141,7 +112,7 @@ module Homebrew
       sig { returns(T::Hash[String, String]) }
       def self.formula_aliases
         unless cache.key?("formula_aliases")
-          updated = download_and_cache_formula_data!
+          updated = download_and_cache_data!
           write_formula_names_and_aliases(regenerate: updated)
         end
 
@@ -151,7 +122,7 @@ module Homebrew
       sig { returns(T::Hash[String, String]) }
       def self.formula_renames
         unless cache.key?("formula_renames")
-          updated = download_and_cache_formula_data!
+          updated = download_and_cache_data!
           write_formula_names_and_aliases(regenerate: updated)
         end
 
@@ -161,7 +132,7 @@ module Homebrew
       sig { returns(T::Hash[String, String]) }
       def self.formula_tap_migrations
         unless cache.key?("formula_tap_migrations")
-          updated = download_and_cache_formula_data!
+          updated = download_and_cache_data!
           write_formula_names_and_aliases(regenerate: updated)
         end
 
@@ -171,7 +142,7 @@ module Homebrew
       sig { returns(String) }
       def self.formula_tap_git_head
         unless cache.key?("formula_tap_git_head")
-          updated = download_and_cache_formula_data!
+          updated = download_and_cache_data!
           write_formula_names_and_aliases(regenerate: updated)
         end
 
@@ -181,7 +152,7 @@ module Homebrew
       sig { returns(T::Hash[String, T::Hash[String, T.untyped]]) }
       def self.cask_hashes
         unless cache.key?("cask_hashes")
-          updated = download_and_cache_cask_data!
+          updated = download_and_cache_data!
           write_cask_names(regenerate: updated)
         end
 
@@ -191,7 +162,7 @@ module Homebrew
       sig { returns(T::Hash[String, String]) }
       def self.cask_renames
         unless cache.key?("cask_renames")
-          updated = download_and_cache_cask_data!
+          updated = download_and_cache_data!
           write_cask_names(regenerate: updated)
         end
 
@@ -201,7 +172,7 @@ module Homebrew
       sig { returns(T::Hash[String, String]) }
       def self.cask_tap_migrations
         unless cache.key?("cask_tap_migrations")
-          updated = download_and_cache_cask_data!
+          updated = download_and_cache_data!
           write_cask_names(regenerate: updated)
         end
 
@@ -211,7 +182,7 @@ module Homebrew
       sig { returns(String) }
       def self.cask_tap_git_head
         unless cache.key?("cask_tap_git_head")
-          updated = download_and_cache_cask_data!
+          updated = download_and_cache_data!
           write_cask_names(regenerate: updated)
         end
 

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -401,7 +401,7 @@ module Cask
           if path
             path
           elsif from_json
-            from_internal_json ? Homebrew::API::Internal.cached_cask_json_file_path : Homebrew::API::Cask.cached_json_file_path
+            from_internal_json ? Homebrew::API::Internal.cached_packages_json_file_path : Homebrew::API::Cask.cached_json_file_path
           else
             Homebrew::API.cached_cask_json_file_path
           end,

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -464,7 +464,7 @@ class Formula
   # The path that was specified to find this formula.
   sig { returns(T.nilable(Pathname)) }
   def specified_path
-    return Homebrew::API::Internal.cached_formula_json_file_path if loaded_from_internal_api?
+    return Homebrew::API::Internal.cached_packages_json_file_path if loaded_from_internal_api?
     return Homebrew::API::Formula.cached_json_file_path if loaded_from_api?
     return alias_path if alias_path&.exist?
 

--- a/Library/Homebrew/test/api/internal_spec.rb
+++ b/Library/Homebrew/test/api/internal_spec.rb
@@ -5,223 +5,248 @@ require "api/internal"
 
 RSpec.describe Homebrew::API::Internal do
   let(:cache_dir) { mktmpdir }
+  let(:packages_json) do
+    <<~JSON
+      {
+        "formulae": {
+          "foo": {
+            "desc": "Foo formula",
+            "homepage": "https://example.com/foo",
+            "license": "MIT",
+            "ruby_source_checksum": "09f88b61e36045188ddb1b1ba8e402b9f3debee1770cc4ca91355eeccb5f4a38",
+            "stable_version": "1.0.0"
+          },
+          "bar": {
+            "desc": "Bar formula",
+            "homepage": "https://example.com/bar",
+            "license": "Apache-2.0",
+            "ruby_source_checksum": "bb6e3408f39a404770529cfce548dc2666e861077acd173825cb3138c27c205a",
+            "stable_version": "0.4.0",
+            "revision": 5,
+            "version_scheme": 1
+          },
+          "baz": {
+            "desc": "Baz formula",
+            "homepage": "https://example.com/baz",
+            "license": "GPL-3.0-or-later",
+            "ruby_source_checksum": "404c97537d65ca0b75c389e7d439dcefb9b56f34d3b98017669eda0d0501add7",
+            "stable_version": "10.4.5",
+            "revision": 2,
+            "bottle_rebuild": 2
+          }
+        },
+        "casks": {
+          "foo": {
+            "desc": "Foo cask",
+            "homepage": "https://example.com/foo",
+            "sha256": "09f88b61e36045188ddb1b1ba8e402b9f3debee1770cc4ca91355eeccb5f4a38",
+            "version": "1.0.0"
+          },
+          "bar": {
+            "desc": "Bar cask",
+            "homepage": "https://example.com/bar",
+            "sha256": "bb6e3408f39a404770529cfce548dc2666e861077acd173825cb3138c27c205a",
+            "version": "0.4.0"
+          },
+          "baz": {
+            "desc": "Baz cask",
+            "homepage": "https://example.com/baz",
+            "sha256": "404c97537d65ca0b75c389e7d439dcefb9b56f34d3b98017669eda0d0501add7",
+            "version": "10.4.5"
+          }
+        },
+        "formula_aliases": {
+          "foo-alias1": "foo",
+          "foo-alias2": "foo",
+          "bar-alias": "bar"
+        },
+        "formula_renames": {
+          "foo-old": "foo",
+          "bar-old": "bar",
+          "baz-old": "baz"
+        },
+        "cask_renames": {
+          "foo-old": "foo",
+          "bar-old": "bar",
+          "baz-old": "baz"
+        },
+        "formula_tap_git_head": "b871900717ccbb3508ca93fa56e128940b9bd371",
+        "cask_tap_git_head": "030eea17b14b437b0a7b96f4dbc9473cce4be31c",
+        "formula_tap_migrations": {
+          "abc": "some/tap",
+          "def": "another/tap"
+        },
+        "cask_tap_migrations": {
+          "abc": "some/tap",
+          "def": "another/tap"
+        }
+      }
+    JSON
+  end
+  let(:formula_hashes) do
+    {
+      "foo" => {
+        "desc"                 => "Foo formula",
+        "homepage"             => "https://example.com/foo",
+        "license"              => "MIT",
+        "ruby_source_checksum" => "09f88b61e36045188ddb1b1ba8e402b9f3debee1770cc4ca91355eeccb5f4a38",
+        "stable_version"       => "1.0.0",
+      },
+      "bar" => {
+        "desc"                 => "Bar formula",
+        "homepage"             => "https://example.com/bar",
+        "license"              => "Apache-2.0",
+        "ruby_source_checksum" => "bb6e3408f39a404770529cfce548dc2666e861077acd173825cb3138c27c205a",
+        "stable_version"       => "0.4.0",
+        "revision"             => 5,
+        "version_scheme"       => 1,
+      },
+      "baz" => {
+        "desc"                 => "Baz formula",
+        "homepage"             => "https://example.com/baz",
+        "license"              => "GPL-3.0-or-later",
+        "ruby_source_checksum" => "404c97537d65ca0b75c389e7d439dcefb9b56f34d3b98017669eda0d0501add7",
+        "stable_version"       => "10.4.5",
+        "revision"             => 2,
+        "bottle_rebuild"       => 2,
+      },
+    }
+  end
+  let(:cask_hashes) do
+    {
+      "foo" => {
+        "desc"     => "Foo cask",
+        "homepage" => "https://example.com/foo",
+        "sha256"   => "09f88b61e36045188ddb1b1ba8e402b9f3debee1770cc4ca91355eeccb5f4a38",
+        "version"  => "1.0.0",
+      },
+      "bar" => {
+        "desc"     => "Bar cask",
+        "homepage" => "https://example.com/bar",
+        "sha256"   => "bb6e3408f39a404770529cfce548dc2666e861077acd173825cb3138c27c205a",
+        "version"  => "0.4.0",
+      },
+      "baz" => {
+        "desc"     => "Baz cask",
+        "homepage" => "https://example.com/baz",
+        "sha256"   => "404c97537d65ca0b75c389e7d439dcefb9b56f34d3b98017669eda0d0501add7",
+        "version"  => "10.4.5",
+      },
+    }
+  end
+  let(:formula_structs) do
+    formula_hashes.to_h do |name, hash|
+      struct = Homebrew::API::FormulaStruct.new(**hash.transform_keys(&:to_sym))
+      [name, struct]
+    end
+  end
+  let(:cask_structs) do
+    cask_hashes.to_h do |name, hash|
+      struct = Homebrew::API::CaskStruct.new(**hash.transform_keys(&:to_sym))
+      [name, struct]
+    end
+  end
+  let(:formulae_aliases) do
+    {
+      "foo-alias1" => "foo",
+      "foo-alias2" => "foo",
+      "bar-alias"  => "bar",
+    }
+  end
+  let(:formulae_renames) do
+    {
+      "foo-old" => "foo",
+      "bar-old" => "bar",
+      "baz-old" => "baz",
+    }
+  end
+  let(:cask_renames) do
+    {
+      "foo-old" => "foo",
+      "bar-old" => "bar",
+      "baz-old" => "baz",
+    }
+  end
+  let(:formula_tap_git_head) { "b871900717ccbb3508ca93fa56e128940b9bd371" }
+  let(:cask_tap_git_head) { "030eea17b14b437b0a7b96f4dbc9473cce4be31c" }
+  let(:formula_tap_migrations) do
+    {
+      "abc" => "some/tap",
+      "def" => "another/tap",
+    }
+  end
+  let(:cask_tap_migrations) do
+    {
+      "abc" => "some/tap",
+      "def" => "another/tap",
+    }
+  end
 
   before do
     FileUtils.mkdir_p(cache_dir/"internal")
     stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
-  end
-
-  def mock_curl_download(stdout:)
     allow(Utils::Curl).to receive(:curl_download) do |*_args, **kwargs|
-      kwargs[:to].write stdout
+      kwargs[:to].write packages_json
     end
     allow(Homebrew::API).to receive(:verify_and_parse_jws) do |json_data|
       [true, json_data]
     end
   end
 
-  context "for formulae" do
-    let(:formula_json) do
-      <<~JSON
-        {
-          "formulae": {
-            "foo": {
-              "desc": "Foo formula",
-              "homepage": "https://example.com/foo",
-              "license": "MIT",
-              "ruby_source_checksum": "09f88b61e36045188ddb1b1ba8e402b9f3debee1770cc4ca91355eeccb5f4a38",
-              "stable_version": "1.0.0"
-            },
-            "bar": {
-              "desc": "Bar formula",
-              "homepage": "https://example.com/bar",
-              "license": "Apache-2.0",
-              "ruby_source_checksum": "bb6e3408f39a404770529cfce548dc2666e861077acd173825cb3138c27c205a",
-              "stable_version": "0.4.0",
-              "revision": 5,
-              "version_scheme": 1
-            },
-            "baz": {
-              "desc": "Baz formula",
-              "homepage": "https://example.com/baz",
-              "license": "GPL-3.0-or-later",
-              "ruby_source_checksum": "404c97537d65ca0b75c389e7d439dcefb9b56f34d3b98017669eda0d0501add7",
-              "stable_version": "10.4.5",
-              "revision": 2,
-              "bottle_rebuild": 2
-            }
-          },
-          "aliases": {
-            "foo-alias1": "foo",
-            "foo-alias2": "foo",
-            "bar-alias": "bar"
-          },
-          "renames": {
-            "foo-old": "foo",
-            "bar-old": "bar",
-            "baz-old": "baz"
-          },
-          "tap_git_head": "b871900717ccbb3508ca93fa56e128940b9bd371",
-          "tap_migrations": {
-            "abc": "some/tap",
-            "def": "another/tap"
-          }
-        }
-      JSON
-    end
-    let(:formula_hashes) do
-      {
-        "foo" => {
-          "desc"                 => "Foo formula",
-          "homepage"             => "https://example.com/foo",
-          "license"              => "MIT",
-          "ruby_source_checksum" => "09f88b61e36045188ddb1b1ba8e402b9f3debee1770cc4ca91355eeccb5f4a38",
-          "stable_version"       => "1.0.0",
-        },
-        "bar" => {
-          "desc"                 => "Bar formula",
-          "homepage"             => "https://example.com/bar",
-          "license"              => "Apache-2.0",
-          "ruby_source_checksum" => "bb6e3408f39a404770529cfce548dc2666e861077acd173825cb3138c27c205a",
-          "stable_version"       => "0.4.0",
-          "revision"             => 5,
-          "version_scheme"       => 1,
-        },
-        "baz" => {
-          "desc"                 => "Baz formula",
-          "homepage"             => "https://example.com/baz",
-          "license"              => "GPL-3.0-or-later",
-          "ruby_source_checksum" => "404c97537d65ca0b75c389e7d439dcefb9b56f34d3b98017669eda0d0501add7",
-          "stable_version"       => "10.4.5",
-          "revision"             => 2,
-          "bottle_rebuild"       => 2,
-        },
-      }
-    end
-    let(:formula_structs) do
-      formula_hashes.to_h do |name, hash|
-        struct = Homebrew::API::FormulaStruct.new(**hash.transform_keys(&:to_sym))
-        [name, struct]
-      end
-    end
-    let(:formulae_aliases) do
-      {
-        "foo-alias1" => "foo",
-        "foo-alias2" => "foo",
-        "bar-alias"  => "bar",
-      }
-    end
-    let(:formulae_renames) do
-      {
-        "foo-old" => "foo",
-        "bar-old" => "bar",
-        "baz-old" => "baz",
-      }
-    end
-    let(:formula_tap_git_head) { "b871900717ccbb3508ca93fa56e128940b9bd371" }
-    let(:formula_tap_migrations) do
-      {
-        "abc" => "some/tap",
-        "def" => "another/tap",
-      }
-    end
-
-    it "returns the expected formula structs" do
-      mock_curl_download stdout: formula_json
-      formula_structs.each do |name, struct|
-        expect(described_class.formula_struct(name)).to eq struct
-      end
-    end
-
-    it "returns the expected formula hashes" do
-      mock_curl_download stdout: formula_json
-      formula_hashes_output = described_class.formula_hashes
-      expect(formula_hashes_output).to eq formula_hashes
-    end
-
-    it "returns the expected formula alias list" do
-      mock_curl_download stdout: formula_json
-      formula_aliases_output = described_class.formula_aliases
-      expect(formula_aliases_output).to eq formulae_aliases
-    end
-
-    it "returns the expected formula rename list" do
-      mock_curl_download stdout: formula_json
-      formula_renames_output = described_class.formula_renames
-      expect(formula_renames_output).to eq formulae_renames
-    end
-
-    it "returns the expected formula tap git head" do
-      mock_curl_download stdout: formula_json
-      formula_tap_git_head_output = described_class.formula_tap_git_head
-      expect(formula_tap_git_head_output).to eq formula_tap_git_head
-    end
-
-    it "returns the expected formula tap migrations list" do
-      mock_curl_download stdout: formula_json
-      formula_tap_migrations_output = described_class.formula_tap_migrations
-      expect(formula_tap_migrations_output).to eq formula_tap_migrations
+  it "returns the expected formula structs" do
+    formula_structs.each do |name, struct|
+      expect(described_class.formula_struct(name)).to eq struct
     end
   end
 
-  context "for casks" do
-    let(:cask_json) do
-      <<~JSON
-        {
-          "casks": {
-            "foo": { "version": "1.0.0" },
-            "bar": { "version": "0.4.0" },
-            "baz": { "version": "10.4.5" }
-          },
-          "renames": {
-            "foo-old": "foo",
-            "bar-old": "bar",
-            "baz-old": "baz"
-          },
-          "tap_migrations": {
-            "abc": "some/tap",
-            "def": "another/tap"
-          }
-        }
-      JSON
+  it "returns the expected cask structs" do
+    cask_structs.each do |name, struct|
+      expect(described_class.cask_struct(name)).to eq struct
     end
-    let(:cask_hashes) do
-      {
-        "foo" => { "version" => "1.0.0" },
-        "bar" => { "version" => "0.4.0" },
-        "baz" => { "version" => "10.4.5" },
-      }
-    end
-    let(:cask_renames) do
-      {
-        "foo-old" => "foo",
-        "bar-old" => "bar",
-        "baz-old" => "baz",
-      }
-    end
-    let(:cask_tap_migrations) do
-      {
-        "abc" => "some/tap",
-        "def" => "another/tap",
-      }
-    end
+  end
 
-    it "returns the expected cask hashes" do
-      mock_curl_download stdout: cask_json
-      cask_hashes_output = described_class.cask_hashes
-      expect(cask_hashes_output).to eq cask_hashes
-    end
+  it "returns the expected formula hashes" do
+    formula_hashes_output = described_class.formula_hashes
+    expect(formula_hashes_output).to eq formula_hashes
+  end
 
-    it "returns the expected cask rename list" do
-      mock_curl_download stdout: cask_json
-      cask_renames_output = described_class.cask_renames
-      expect(cask_renames_output).to eq cask_renames
-    end
+  it "returns the expected cask hashes" do
+    cask_hashes_output = described_class.cask_hashes
+    expect(cask_hashes_output).to eq cask_hashes
+  end
 
-    it "returns the expected cask tap migrations list" do
-      mock_curl_download stdout: cask_json
-      cask_tap_migrations_output = described_class.cask_tap_migrations
-      expect(cask_tap_migrations_output).to eq cask_tap_migrations
-    end
+  it "returns the expected formula alias list" do
+    formula_aliases_output = described_class.formula_aliases
+    expect(formula_aliases_output).to eq formulae_aliases
+  end
+
+  it "returns the expected formula rename list" do
+    formula_renames_output = described_class.formula_renames
+    expect(formula_renames_output).to eq formulae_renames
+  end
+
+  it "returns the expected cask rename list" do
+    cask_renames_output = described_class.cask_renames
+    expect(cask_renames_output).to eq cask_renames
+  end
+
+  it "returns the expected formula tap git head" do
+    formula_tap_git_head_output = described_class.formula_tap_git_head
+    expect(formula_tap_git_head_output).to eq formula_tap_git_head
+  end
+
+  it "returns the expected cask tap git head" do
+    cask_tap_git_head_output = described_class.cask_tap_git_head
+    expect(cask_tap_git_head_output).to eq cask_tap_git_head
+  end
+
+  it "returns the expected formula tap migrations list" do
+    formula_tap_migrations_output = described_class.formula_tap_migrations
+    expect(formula_tap_migrations_output).to eq formula_tap_migrations
+  end
+
+  it "returns the expected cask tap migrations list" do
+    cask_tap_migrations_output = described_class.cask_tap_migrations
+    expect(cask_tap_migrations_output).to eq cask_tap_migrations
   end
 end

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
         expect(cask_from_internal_api.loaded_from_api?).to be(true)
         expect(cask_from_internal_api.loaded_from_internal_api?).to be(true)
         expect(cask_from_internal_api.caskfile_only?).to be(caskfile_only)
-        expect(cask_from_internal_api.sourcefile_path).to eq(Homebrew::API::Internal.cached_cask_json_file_path)
+        expect(cask_from_internal_api.sourcefile_path).to eq(Homebrew::API::Internal.cached_packages_json_file_path)
       end
     end
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -2393,7 +2393,7 @@ RSpec.describe Formula do
       end
 
       it "returns the internal API path" do
-        expect(f.specified_path).to eq(Homebrew::API::Internal.cached_formula_json_file_path)
+        expect(f.specified_path).to eq(Homebrew::API::Internal.cached_packages_json_file_path)
       end
     end
   end


### PR DESCRIPTION
This PR switches `Homebrew::API::Internal` to use the single `packages.TAG.json` file when using the internal API rather than the separate formula and cask files

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
