### PR TITLE
Fix `build.rb` receiving `formula.jws.json` instead of `.rb` source path

### DIFF
--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -55,7 +55,7 @@ module Homebrew
 
         if enqueue
           download_queue.enqueue(download)
-        elsif !download.symlink_location.exist?
+        elsif !download.symlink_location.exist? || !download.symlink_location.symlink?
           download.fetch
         end
 
@@ -65,6 +65,12 @@ module Homebrew
       sig { params(formula: ::Formula).returns(::Formula) }
       def self.source_download_formula(formula)
         download = source_download(formula)
+
+        unless download.symlink_location.exist?
+          raise CannotInstallFormulaError,
+                "#{formula.full_name} source code not found at #{download.symlink_location}. " \
+                "Try `rm -rf $(brew --cache)/api-source` and retrying."
+        end
 
         with_env(HOMEBREW_INTERNAL_ALLOW_PACKAGES_FROM_PATHS: "1") do
           Formulary.factory(download.symlink_location,

--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -268,6 +268,13 @@ begin
 
   trap("INT", old_trap)
 
+  formula_path = ARGV.first
+  if formula_path&.end_with?(".json")
+    raise "build.rb received an API JSON file as the formula path: #{formula_path}. " \
+          "This usually means the formula source was not downloaded from the API. " \
+          "Try clearing the cache: rm -rf $(brew --cache)/api-source"
+  end
+
   formula = args.named.to_formulae.fetch(0)
   options = Options.create(args.flags_only)
   build   = Build.new(formula, options, args:)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1093,6 +1093,12 @@ on_request: installed_on_request?, options:)
 
     @start_time = Time.now
 
+    # If the formula is still loaded from the API (i.e. the source .rb was never
+    # fetched), attempt to download the source now. Without this, specified_path
+    # would point at a JSON file (e.g. formula.jws.json) which build.rb cannot
+    # load. See: https://github.com/orgs/Homebrew/discussions/6455
+    @formula = Homebrew::API::Formula.source_download_formula(formula) if formula.loaded_from_api?
+
     # 1. formulae can modify ENV, so we must ensure that each
     #    installation has a pristine ENV when it starts, forking now is
     #    the easiest way to do this

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "api"
+require "test/support/fixtures/testball"
 
 RSpec.describe Homebrew::API::Formula do
   let(:cache_dir) { mktmpdir }
@@ -62,6 +63,77 @@ RSpec.describe Homebrew::API::Formula do
       mock_curl_download stdout: formulae_json
       aliases_output = described_class.all_aliases
       expect(aliases_output).to eq formulae_aliases
+    end
+  end
+
+  describe "::source_download" do
+    let(:f) { Testball.new }
+
+    before do
+      allow(Homebrew::API).to receive(:formula_names).and_return([])
+      allow(f).to receive_messages(ruby_source_path: "Formula/testball.rb", tap_git_head: "abc123",
+                                   ruby_source_checksum: nil)
+      allow(f).to receive(:tap).and_return(CoreTap.instance)
+    end
+
+    it "forces re-download when symlink_location exists but is not a symlink" do
+      regular_file = mktmpdir/"testball.rb"
+      regular_file.write("not a symlink")
+
+      allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:symlink_location).and_return(regular_file)
+      expect_any_instance_of(Homebrew::API::SourceDownload).to receive(:fetch)
+
+      described_class.source_download(f)
+    end
+
+    it "skips download when symlink_location is a valid symlink" do
+      target = mktmpdir/"testball_target.rb"
+      target.write("content")
+      symlink = mktmpdir/"testball.rb"
+      FileUtils.ln_s(target, symlink)
+
+      allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:symlink_location).and_return(symlink)
+      expect_any_instance_of(Homebrew::API::SourceDownload).not_to receive(:fetch)
+
+      described_class.source_download(f)
+    end
+  end
+
+  describe "::source_download_formula" do
+    let(:f) { Testball.new }
+
+    before do
+      allow(Homebrew::API).to receive(:formula_names).and_return([])
+      allow(f).to receive_messages(ruby_source_path: "Formula/testball.rb", tap_git_head: "abc123",
+                                   ruby_source_checksum: nil)
+      allow(f).to receive(:tap).and_return(CoreTap.instance)
+    end
+
+    it "raises CannotInstallFormulaError when source file is missing" do
+      allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:fetch)
+      allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:symlink_location).and_return(
+        Pathname("/nonexistent/path/testball.rb"),
+      )
+
+      expect do
+        described_class.source_download_formula(f)
+      end.to raise_error(CannotInstallFormulaError, /source code not found/)
+    end
+
+    it "loads formula from symlink_location when source file exists" do
+      source_path = (mktmpdir/"testball.rb")
+      source_path.write <<~RUBY
+        class Testball < Formula
+          url "https://brew.sh/testball-0.1.tar.gz"
+        end
+      RUBY
+
+      allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:fetch)
+      allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:symlink_location).and_return(source_path)
+
+      result = described_class.source_download_formula(f)
+      expect(result).to be_a(Formula)
+      expect(result.name).to eq("testball")
     end
   end
 end

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -786,4 +786,46 @@ RSpec.describe FormulaInstaller do
       expect(path).not_to exist
     end
   end
+
+  describe "#build" do
+    it "attempts source download when formula is loaded from API" do
+      formula = Testball.new
+      allow(formula).to receive(:loaded_from_api?).and_return(true)
+
+      source_formula = Testball.new
+      allow(source_formula).to receive(:loaded_from_api?).and_return(false)
+
+      expect(Homebrew::API::Formula).to receive(:source_download_formula)
+        .with(formula)
+        .and_return(source_formula)
+
+      installer = described_class.new(formula)
+
+      # Stub out the actual build subprocess since we only care about the guard
+      allow(installer).to receive(:build_argv).and_return([])
+      allow(Utils).to receive(:safe_fork)
+      allow(source_formula).to receive_messages(logs: mktmpdir, update_head_version: nil, prefix: mktmpdir,
+                                                network_access_allowed?: true)
+      allow(Keg).to receive(:new).and_return(instance_double(Keg, empty_installation?: false))
+
+      installer.build
+
+      expect(installer.formula).to eq(source_formula)
+    end
+
+    it "raises when formula is loaded from API and source download fails" do
+      formula = Testball.new
+      allow(formula).to receive(:loaded_from_api?).and_return(true)
+
+      expect(Homebrew::API::Formula).to receive(:source_download_formula)
+        .with(formula)
+        .and_raise(CannotInstallFormulaError, "source code not found")
+
+      installer = described_class.new(formula)
+
+      expect do
+        installer.build
+      end.to raise_error(CannotInstallFormulaError, /source code not found/)
+    end
+  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Debugged with Claude Opus 4.7. Verified locally.

-----

Fixes https://github.com/orgs/Homebrew/discussions/6455

On Tier-3 systems (no bottles available), `FormulaInstaller#build` passes `formula.specified_path` to `build.rb`. If the async API to source formula swap failed silently, `specified_path` still points at `formula.jws.json`, producing `FormulaUnavailableError: formula.jws.json`.

Adds defense-in-depth guards at `source_download_formula`, `FormulaInstaller#build`, and `build.rb`, each with actionable error messages so users aren't left with a cryptic failure.