### PR TITLE
cachable: add Sorbet generics for key and value types

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -16,7 +16,13 @@ module Homebrew
   module API
     extend Utils::Output::Mixin
 
+    extend T::Generic
     extend Cachable
+
+    # Sorbet type members are mutable by design and cannot be frozen.
+    # rubocop:disable Style/MutableConstant
+    Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
+    # rubocop:enable Style/MutableConstant
 
     HOMEBREW_CACHE_API = T.let((HOMEBREW_CACHE/"api").freeze, Pathname)
     HOMEBREW_CACHE_API_SOURCE = T.let((HOMEBREW_CACHE/"api-source").freeze, Pathname)

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -11,7 +11,13 @@ module Homebrew
   module API
     # Helper functions for using the cask JSON API.
     module Cask
+      extend T::Generic
       extend Cachable
+
+      # Sorbet type members are mutable by design and cannot be frozen.
+      # rubocop:disable Style/MutableConstant
+      Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
+      # rubocop:enable Style/MutableConstant
 
       DEFAULT_API_FILENAME = "cask.jws.json"
 

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -11,7 +11,13 @@ module Homebrew
   module API
     # Helper functions for using the formula JSON API.
     module Formula
+      extend T::Generic
       extend Cachable
+
+      # Sorbet type members are mutable by design and cannot be frozen.
+      # rubocop:disable Style/MutableConstant
+      Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
+      # rubocop:enable Style/MutableConstant
 
       DEFAULT_API_FILENAME = "formula.jws.json"
 

--- a/Library/Homebrew/api/internal.rb
+++ b/Library/Homebrew/api/internal.rb
@@ -10,7 +10,13 @@ module Homebrew
   module API
     # Helper functions for using the JSON internal API.
     module Internal
+      extend T::Generic
       extend Cachable
+
+      # Sorbet type members are mutable by design and cannot be frozen.
+      # rubocop:disable Style/MutableConstant
+      Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
+      # rubocop:enable Style/MutableConstant
 
       private_class_method :cache
 

--- a/Library/Homebrew/cachable.rb
+++ b/Library/Homebrew/cachable.rb
@@ -2,9 +2,13 @@
 # frozen_string_literal: true
 
 module Cachable
-  sig { returns(T::Hash[T.untyped, T.untyped]) }
+  extend T::Generic
+
+  # Sorbet type members are mutable by design and cannot be frozen.
+  Cache = type_member { { upper: T::Hash[T.anything, T.anything] } }
+  sig { returns(Cache) }
   def cache
-    @cache ||= T.let({}, T.nilable(T::Hash[T.untyped, T.untyped]))
+    @cache ||= T.let(T.cast({}, Cache), T.nilable(Cache))
   end
 
   sig { void }

--- a/Library/Homebrew/cask/tab.rb
+++ b/Library/Homebrew/cask/tab.rb
@@ -5,6 +5,11 @@ require "tab"
 
 module Cask
   class Tab < ::AbstractTab
+    # Sorbet type members are mutable by design and cannot be frozen.
+    # rubocop:disable Style/MutableConstant
+    Cache = type_template { { fixed: T::Hash[T.any(Pathname, String), T.untyped] } }
+    # rubocop:enable Style/MutableConstant
+
     sig { returns(T.nilable(T::Boolean)) }
     attr_accessor :uninstall_flight_blocks
 

--- a/Library/Homebrew/cask_dependent.rb
+++ b/Library/Homebrew/cask_dependent.rb
@@ -7,6 +7,11 @@ require "requirement"
 class CaskDependent
   # Defines a dependency on another cask
   class Requirement < ::Requirement
+    # Sorbet type members are mutable by design and cannot be frozen.
+    # rubocop:disable Style/MutableConstant
+    Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
+    # rubocop:enable Style/MutableConstant
+
     satisfy(build_env: false) do
       cask_token = cask
       raise "unexpected nil cask" unless cask_token

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -18,7 +18,13 @@ require "cachable"
 # This class is used by `depends_on` in the formula DSL to turn dependency
 # specifications into the proper kinds of dependencies and requirements.
 class DependencyCollector
+  extend T::Generic
   extend Cachable
+
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[T.untyped, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
 
   sig { returns(Dependencies) }
   attr_reader :deps

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -84,10 +84,16 @@ class Formula
   include OnSystem::MacOSAndLinux
   include Homebrew::Livecheck::Constants
   extend Forwardable
+  extend T::Generic
   extend Cachable
   extend APIHashable
   extend T::Helpers
   extend Utils::Output::Mixin
+
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[Symbol, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
 
   abstract!
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -18,9 +18,15 @@ require "tap"
 # It is not meant to be used directly from formulae.
 module Formulary
   extend Context
+  extend T::Generic
   extend Cachable
   extend Utils::Output::Mixin
   include Utils::Output::Mixin
+
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
 
   ALLOWED_URL_SCHEMES = %w[file].freeze
   private_constant :ALLOWED_URL_SCHEMES

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -10,8 +10,14 @@ require "utils/output"
 
 # Installation prefix of a formula.
 class Keg
+  extend T::Generic
   extend Cachable
   include Utils::Output::Mixin
+
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[Symbol, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
 
   # Error for when a keg is already linked.
   class AlreadyLinkedError < RuntimeError

--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -8,10 +8,15 @@ require "utils/output"
 
 # Helper module for validating syntax in taps.
 module Readall
+  extend T::Generic
   extend Cachable
   extend SystemCommand::Mixin
   extend Utils::Output::Mixin
 
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[Symbol, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
   # TODO: remove this once the `MacOS` module is undefined on Linux
   MACOS_MODULE_REGEX = /\b(MacOS|OS::Mac)(\.|::)\b/
   private_constant :MACOS_MODULE_REGEX

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -13,8 +13,14 @@ require "utils/output"
 class Requirement
   include Dependable
   include Utils::Output::Mixin
+  extend T::Generic
   extend Cachable
   extend T::Helpers
+
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
 
   # This base class enforces no constraints on its own.
   # Individual subclasses use the `satisfy` DSL to define those constraints.

--- a/Library/Homebrew/requirements/arch_requirement.rb
+++ b/Library/Homebrew/requirements/arch_requirement.rb
@@ -5,6 +5,11 @@ require "requirement"
 
 # A requirement on a specific architecture.
 class ArchRequirement < Requirement
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
+
   fatal true
 
   @arch = T.let(nil, T.nilable(Symbol))

--- a/Library/Homebrew/requirements/codesign_requirement.rb
+++ b/Library/Homebrew/requirements/codesign_requirement.rb
@@ -3,6 +3,11 @@
 
 # A requirement on a code-signing identity.
 class CodesignRequirement < Requirement
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
+
   fatal true
 
   sig { returns(String) }

--- a/Library/Homebrew/requirements/linux_requirement.rb
+++ b/Library/Homebrew/requirements/linux_requirement.rb
@@ -3,6 +3,11 @@
 
 # A requirement on Linux.
 class LinuxRequirement < Requirement
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
+
   fatal true
 
   satisfy(build_env: false) { OS.linux? }

--- a/Library/Homebrew/requirements/macos_requirement.rb
+++ b/Library/Homebrew/requirements/macos_requirement.rb
@@ -5,6 +5,11 @@ require "requirement"
 
 # A requirement on macOS.
 class MacOSRequirement < Requirement
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
+
   fatal true
 
   sig { returns(String) }

--- a/Library/Homebrew/requirements/xcode_requirement.rb
+++ b/Library/Homebrew/requirements/xcode_requirement.rb
@@ -5,6 +5,11 @@ require "requirement"
 
 # A requirement on Xcode.
 class XcodeRequirement < Requirement
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
+
   fatal true
 
   sig { returns(T.nilable(String)) }

--- a/Library/Homebrew/sorbet/rbi/shims/portable_formula.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/portable_formula.rbi
@@ -1,0 +1,14 @@
+# typed: strict
+
+# Not a real formula, just a Sorbet shim for external taps.
+# rubocop:disable FormulaAudit/Desc,FormulaAudit/Homepage
+class PortableFormula < Formula
+  extend T::Generic
+
+  # This is required for type checking on official taps to initially succeed
+  # This could also be added to homebrew-core/Abstract/portable-formula.rb and subsequently removed here
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[Symbol, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
+end
+# rubocop:enable FormulaAudit/Desc,FormulaAudit/Homepage

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -9,8 +9,14 @@ require "cachable"
 
 # Rather than calling `new` directly, use one of the class methods like {Tab.create}.
 class AbstractTab
+  extend T::Generic
   extend Cachable
   extend T::Helpers
+
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[T.any(Pathname, String), T.untyped] } }
+  # rubocop:enable Style/MutableConstant
 
   abstract!
 
@@ -199,12 +205,20 @@ class AbstractTab
 
   sig { void }
   def write
-    self.class.cache[tabfile] = self
-    T.must(tabfile).atomic_write(to_json)
+    tfile = tabfile
+    raise "No tabfile to write to" unless tfile
+
+    self.class.cache[tfile] = self
+    tfile.atomic_write(to_json)
   end
 end
 
 class Tab < AbstractTab # rubocop:todo Style/OneClassPerFile
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[T.any(Pathname, String), T.untyped] } }
+  # rubocop:enable Style/MutableConstant
+
   # Check whether the formula was poured from a bottle.
   #
   # @api internal

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -13,9 +13,15 @@ require "utils/output"
 # {#user} represents the GitHub username and {#repository} represents the
 # repository name without the leading `homebrew-`.
 class Tap
+  extend T::Generic
   extend Cachable
   extend Utils::Output::Mixin
   include Utils::Output::Mixin
+
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[T.any(String, Symbol), T.untyped] } }
+  # rubocop:enable Style/MutableConstant
 
   HOMEBREW_TAP_CASK_RENAMES_FILE = "cask_renames.json"
   private_constant :HOMEBREW_TAP_CASK_RENAMES_FILE
@@ -1249,6 +1255,7 @@ class AbstractCoreTap < Tap # rubocop:todo Style/OneClassPerFile
   abstract!
 
   class << self
+    Cache = type_member { { fixed: T::Hash[T.any(String, Symbol), T.untyped] } }
     Elem = type_member(:out) { { fixed: Tap } }
   end
 
@@ -1286,6 +1293,7 @@ end
 # A specialized {Tap} class for the core formulae.
 class CoreTap < AbstractCoreTap # rubocop:todo Style/OneClassPerFile
   class << self
+    Cache = type_member { { fixed: T::Hash[T.any(String, Symbol), T.untyped] } }
     Elem = type_member(:out) { { fixed: Tap } }
   end
 
@@ -1491,6 +1499,7 @@ end
 # A specialized {Tap} class for homebrew-cask.
 class CoreCaskTap < AbstractCoreTap # rubocop:todo Style/OneClassPerFile
   class << self
+    Cache = type_member { { fixed: T::Hash[T.any(String, Symbol), T.untyped] } }
     Elem = type_member(:out) { { fixed: Tap } }
   end
 

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -105,9 +105,19 @@ RSpec.describe "Exception" do
       Module.new do
         # These are defined within an anonymous module to avoid polluting the global namespace.
         # rubocop:disable RSpec/LeakyConstantDeclaration,Lint/ConstantDefinitionInBlock
-        class Bar < Requirement; end
+        class Bar < Requirement
+          # Sorbet type members are mutable by design and cannot be frozen.
+          # rubocop:disable Style/MutableConstant
+          Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
+          # rubocop:enable Style/MutableConstant
+        end
 
-        class Baz < Formula; end
+        class Baz < Formula
+          # Sorbet type members are mutable by design and cannot be frozen.
+          # rubocop:disable Style/MutableConstant
+          Cache = type_template { { fixed: T::Hash[Symbol, T.untyped] } }
+          # rubocop:enable Style/MutableConstant
+        end
         # rubocop:enable RSpec/LeakyConstantDeclaration,Lint/ConstantDefinitionInBlock
       end
     end

--- a/Library/Homebrew/test/support/fixtures/failball.rb
+++ b/Library/Homebrew/test/support/fixtures/failball.rb
@@ -2,6 +2,11 @@
 # frozen_string_literal: true
 
 class Failball < Formula
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[Symbol, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
+
   def initialize(name = "failball", path = Pathname.new(__FILE__).expand_path, spec = :stable,
                  alias_path: nil, tap: nil, force_bottle: false)
     super

--- a/Library/Homebrew/test/support/fixtures/failball_offline_install.rb
+++ b/Library/Homebrew/test/support/fixtures/failball_offline_install.rb
@@ -2,6 +2,11 @@
 # frozen_string_literal: true
 
 class FailballOfflineInstall < Formula
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[Symbol, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
+
   def initialize(name = "failball_offline_install", path = Pathname.new(__FILE__).expand_path, spec = :stable,
                  alias_path: nil, tap: nil, force_bottle: false)
     super

--- a/Library/Homebrew/test/support/fixtures/testball.rb
+++ b/Library/Homebrew/test/support/fixtures/testball.rb
@@ -2,6 +2,11 @@
 # frozen_string_literal: true
 
 class Testball < Formula
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[Symbol, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
+
   def initialize(name = "testball", path = Pathname.new(__FILE__).expand_path, spec = :stable,
                  alias_path: nil, tap: nil, force_bottle: false)
     super

--- a/Library/Homebrew/test/support/fixtures/testball_bottle.rb
+++ b/Library/Homebrew/test/support/fixtures/testball_bottle.rb
@@ -2,6 +2,11 @@
 # frozen_string_literal: true
 
 class TestballBottle < Formula
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[Symbol, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
+
   def initialize(name = "testball_bottle", path = Pathname.new(__FILE__).expand_path, spec = :stable,
                  alias_path: nil, tap: nil, force_bottle: false)
     super

--- a/Library/Homebrew/test/support/fixtures/testball_bottle_cellar.rb
+++ b/Library/Homebrew/test/support/fixtures/testball_bottle_cellar.rb
@@ -2,6 +2,11 @@
 # frozen_string_literal: true
 
 class TestballBottleCellar < Formula
+  # Sorbet type members are mutable by design and cannot be frozen.
+  # rubocop:disable Style/MutableConstant
+  Cache = type_template { { fixed: T::Hash[Symbol, T.untyped] } }
+  # rubocop:enable Style/MutableConstant
+
   def initialize(name = "testball_bottle", path = Pathname.new(__FILE__).expand_path, spec = :stable,
                  alias_path: nil, tap: nil, force_bottle: false)
     super

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -16,7 +16,13 @@ module Utils
     INFLUX_ORG = "d81a3e6d582d485f"
 
     extend Utils::Output::Mixin
+    extend T::Generic
     extend Cachable
+
+    # Sorbet type members are mutable by design and cannot be frozen.
+    # rubocop:disable Style/MutableConstant
+    Cache = type_template { { fixed: T::Hash[Symbol, T.untyped] } }
+    # rubocop:enable Style/MutableConstant
 
     class << self
       include Context


### PR DESCRIPTION
## What does this do?

Makes the `Cachable` module generic over a `Cache` hash type using Sorbet `type_member`, so each consumer can declare the concrete type their cache operates on rather than using `T::Hash[T.untyped, T.untyped]`.

`Cachable` now looks like:

```ruby
module Cachable
  extend T::Generic

  Cache = type_member { { upper: T::Hash[T.untyped, T.untyped] } }

  sig { returns(Cache) }
  def cache ...
end
```

Each consumer re-declares `Cache` as a `type_template` with `fixed` bounds. Using a single `Cache` type (rather than separate `CacheKey` and `CacheValue` members) permits consumers to fix the cache to a [shape type](https://sorbet.org/docs/shapes) if desired, enabling a statically-checked enumeration of valid cache keys.

As a side effect, a latent nil-safety issue in `AbstractTab#write` is now visible and fixed: `tabfile` is captured into a local variable and guarded with a raise before use.

## Checklist

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Claude Code (`claude-sonnet-4-6`) was used to implement this change under developer direction and review. All changes were manually verified via `brew lgtm` (typecheck, style, tests).*
