### PR TITLE
Fix requirement which override

### DIFF
--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -200,10 +200,11 @@ class Requirement
     ""
   end
 
-  sig { params(cmd: String).returns(T.nilable(Pathname)) }
-  def which(cmd)
-    super(cmd, PATH.new(ORIGINAL_PATHS))
+  sig { override.params(cmd: String, path: PATH::Elements).returns(T.nilable(Pathname)) }
+  def which(cmd, path = PATH.new(ORIGINAL_PATHS))
+    super
   end
+  public :which
 
   class << self
     include BuildEnvironment::DSL

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -154,6 +154,20 @@ RSpec.describe Requirement do
         requirement.modify_build_environment
       end
     end
+
+    describe "#satisfy with block calling #which and :build_env set to false" do
+      let(:klass) do
+        Class.new(described_class) do
+          satisfy(build_env: false) do
+            which("sh")
+          end
+        end
+      end
+
+      it "does not raise an error" do
+        expect { requirement.satisfied? }.not_to raise_error
+      end
+    end
   end
 
   describe "#build?" do


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22036

- preserve `Requirement#which` defaulting to `ORIGINAL_PATHS`
- match `Kernel#which` arity and visibility for Sorbet
- cover `which` inside `satisfy(build_env: false)` regression

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Used OpenAI Codex xhigh with manual review and testing.

-----
