### PR TITLE
Re-enable `HOMEBREW_USE_INTERNAL_API`

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -751,10 +751,10 @@ module Homebrew
 
     sig { returns(T::Boolean) }
     def use_internal_api?
-      return true if ENV["HOMEBREW_REALLY_USE_INTERNAL_API"].present?
+      return false if Homebrew::EnvConfig.no_install_from_api?
 
-      # TODO: re-enable this when the internal API is ready again.
-      false
+      use_internal_api = ENV.fetch("HOMEBREW_USE_INTERNAL_API", nil)
+      use_internal_api.present? && FALSY_VALUES.exclude?(use_internal_api.downcase)
     end
   end
 end

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -165,4 +165,22 @@ RSpec.describe Homebrew::EnvConfig do
         .to raise_error(UsageError, /cannot both be set/i)
     end
   end
+
+  describe ".use_internal_api?" do
+    it "returns true if HOMEBREW_USE_INTERNAL_API is set" do
+      ENV["HOMEBREW_USE_INTERNAL_API"] = "1"
+      expect(env_config.use_internal_api?).to be(true)
+    end
+
+    it "returns false if HOMEBREW_USE_INTERNAL_API is not set" do
+      ENV["HOMEBREW_USE_INTERNAL_API"] = nil
+      expect(env_config.use_internal_api?).to be(false)
+    end
+
+    it "returns false if HOMEBREW_NO_INSTALL_FROM_API is set" do
+      ENV["HOMEBREW_USE_INTERNAL_API"] = "1"
+      ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
+      expect(env_config.use_internal_api?).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
This PR re-enables the `HOMEBREW_USE_INTERNAL_API` environment variable for opting into the new internal API installation process.

Previously, this was hidden behind a secret `HOMEBREW_REALLY_USE_INTERNAL_API` variable for testing. Now that all components have been implemented and things seem to be working, let's re-enable this for everyone who had opted in before.

No rush to merge this, we can do it whenever we're ready.
