### PR TITLE
Fix: sync  when changing 

### DIFF
--- a/Library/Homebrew/cmd/tab.rb
+++ b/Library/Homebrew/cmd/tab.rb
@@ -79,6 +79,7 @@ module Homebrew
         end
 
         tab.installed_on_request = installed_on_request
+        tab.installed_as_dependency = !installed_on_request
         tab.write
         ohai "#{name} is now marked as #{installed_on_request_str}."
       end


### PR DESCRIPTION
Fixes #21751

When running `brew tab --no-installed-on-request <formula>`, only `installed_on_request` was being updated in the tab. The `installed_as_dependency` field was left unchanged, causing `brew bundle dump` to still include the formula since its logic checks `installed_on_request? || !installed_as_dependency?`.

This patch ensures that when `installed_on_request` is set to `false`, `installed_as_dependency` is also set to `true`, and vice versa. This keeps the two fields in sync and makes `brew tab --no-installed-on-request` work as expected with `brew bundle dump`.