### PR TITLE
formula: dedupe link_overwrite_formulae across aliases

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -779,7 +779,7 @@ class Formula
       Formula[formula_name]
     rescue FormulaUnavailableError
       nil
-    end
+    end.uniq(&:full_name)
   end
 
   sig { params(path: Pathname).returns(T.nilable(T.any(String, Symbol))) }

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -319,6 +319,22 @@ RSpec.describe Formula do
     end
   end
 
+  describe "#link_overwrite_formulae" do
+    it "deduplicates formulae shared by an alias and canonical name" do
+      f = formula "foo@2.0" do
+        url "foo-2.0"
+      end
+      other_formula = formula "foo@1.0" do
+        url "foo-1.0"
+      end
+      allow(f).to receive(:link_overwrite_formulae_names).and_return(["foo", "foo@1.0"])
+      allow(Formulary).to receive(:factory).with("foo").and_return(other_formula)
+      allow(Formulary).to receive(:factory).with("foo@1.0").and_return(other_formula)
+
+      expect(f.link_overwrite_formulae).to eq([other_formula])
+    end
+  end
+
   describe "#link_overwrite_formulae_names" do
     let(:f) do
       formula "foo" do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Claude Code Opus 4.7 was used to create the test.

-----

When I installed `openssl@4` today, I was presented with this warning:

> Warning: openssl@4 was installed but not linked because openssl@3 and openssl@3 are already linked.

After this change:

> Warning: openssl@4 was installed but not linked because openssl@3 is already linked.

`Formula#link_overwrite_formulae_names` can include both an alias (`openssl`) and its canonical name (`openssl@3`) as distinct strings that resolve to the same `Formula` via `Formula[]`, so the sentence ends up listing it twice. Dedupe by `full_name` after resolving names to formulae.