### PR TITLE
test/dev-cmd/unbottled_spec: add usage test

### DIFF
--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -316,6 +316,8 @@ class Requirement
   private_constant :Satisfier
 
   class << self
+    require "cask_dependent"
+
     # Expand the requirements of dependent recursively, optionally yielding
     # `[dependent, req]` pairs to allow callers to apply arbitrary filters to
     # the list.

--- a/Library/Homebrew/test/dev-cmd/unbottled_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/unbottled_spec.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"
@@ -6,4 +6,13 @@ require "dev-cmd/unbottled"
 
 RSpec.describe Homebrew::DevCmd::Unbottled do
   it_behaves_like "parseable arguments"
+
+  it "prints that an unbottled formula with no dependencies is ready to bottle", :integration_test do
+    setup_test_formula "testball"
+
+    expect { brew "unbottled", "testball" }
+      .to output(/testball: ready to bottle/).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

I recently noticed that `brew unbottled` is broken. To demonstrate this, I added a simple integration test to `test/dev-cmd/unbottled_spec.rb` that expects that `brew unbottled testball` succeeds, prints "testball: ready to bottle" to stdout and nothing to stderr. This test passes locally for me with 5.1.6 but fails on 5.1.7 and current `main` (481b5783bbfb86f1a562ec3bca900c0b28efa9a7). I ran a `git bisect` which said that 5dc7064da611075782ca23438c125d3690a64037 is the first bad commit, though the backtrace is slightly different between that first bad commit and 5.1.7.

~~~
$ git checkout 5.1.6
...
$ brew unbottled wget
==> Populating dependency tree...
==> :arm64_sequoia bottle status
wget: already bottled
~~~

~~~
$ git checkout 5dc7064da611075782ca23438c125d3690a64037
...
$ brew unbottled wget
==> Populating dependency tree...
Error: uninitialized constant #<Class:Dependency>::CaskDependent
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
/opt/homebrew/Library/Homebrew/dependency.rb:233:in 'block in singleton class'
/opt/homebrew/Library/Homebrew/dependency.rb:202:in 'block in Dependency.expand'
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/4.0.2_1/lib/ruby/4.0.0/delegate.rb:88:in 'Array#each'
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/4.0.2_1/lib/ruby/4.0.0/delegate.rb:88:in 'Delegator#method_missing'
/opt/homebrew/Library/Homebrew/dependency.rb:199:in 'Dependency.expand'
/opt/homebrew/Library/Homebrew/dev-cmd/unbottled.rb:187:in 'block in Homebrew::DevCmd::Unbottled#deps_uses_from_formulae'
/opt/homebrew/Library/Homebrew/dev-cmd/unbottled.rb:186:in 'Array#each'
/opt/homebrew/Library/Homebrew/dev-cmd/unbottled.rb:186:in 'Homebrew::DevCmd::Unbottled#deps_uses_from_formulae'
/opt/homebrew/Library/Homebrew/dev-cmd/unbottled.rb:90:in 'block in Homebrew::DevCmd::Unbottled#run'
/opt/homebrew/Library/Homebrew/simulate_system.rb:39:in 'Homebrew::SimulateSystem.with'
/opt/homebrew/Library/Homebrew/dev-cmd/unbottled.rb:76:in 'Homebrew::DevCmd::Unbottled#run'
/opt/homebrew/Library/Homebrew/brew.rb:114:in '<main>'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
~~~

~~~
$ git checkout 5.1.7
...
$ brew unbottled wget
==> Populating dependency tree...
==> :arm64_sequoia bottle status
Error: uninitialized constant #<Class:Requirement>::CaskDependent
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
/opt/homebrew/Library/Homebrew/requirement.rb:320:in 'block in singleton class'
/opt/homebrew/Library/Homebrew/formula.rb:2685:in 'Formula#recursive_requirements'
/opt/homebrew/Library/Homebrew/dev-cmd/unbottled.rb:232:in 'block in Homebrew::DevCmd::Unbottled#output_unbottled'
/opt/homebrew/Library/Homebrew/dev-cmd/unbottled.rb:224:in 'Array#each'
/opt/homebrew/Library/Homebrew/dev-cmd/unbottled.rb:224:in 'Homebrew::DevCmd::Unbottled#output_unbottled'
/opt/homebrew/Library/Homebrew/dev-cmd/unbottled.rb:113:in 'block in Homebrew::DevCmd::Unbottled#run'
/opt/homebrew/Library/Homebrew/simulate_system.rb:39:in 'Homebrew::SimulateSystem.with'
/opt/homebrew/Library/Homebrew/dev-cmd/unbottled.rb:76:in 'Homebrew::DevCmd::Unbottled#run'
/opt/homebrew/Library/Homebrew/brew.rb:114:in '<main>'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
~~~

