### PR TITLE
Stabilize PyPI source spec

### DIFF
--- a/Library/Homebrew/test/cmd/source_spec.rb
+++ b/Library/Homebrew/test/cmd/source_spec.rb
@@ -99,8 +99,24 @@ RSpec.describe Homebrew::Cmd::Source do
     end
   end
 
-  describe "#pypi_repo_url", :needs_utils_curl do
+  describe "#pypi_repo_url" do
     it "finds repository for PyPI URL" do
+      expect(Utils::Curl).to receive(:curl_output)
+        .with(*Utils::Curl.curl_args(show_error: false, retries: 2), "https://pypi.org/pypi/numpy/json")
+        .and_return([
+          <<~JSON,
+            {
+              "info": {
+                "project_urls": {
+                  "Repository": "https://github.com/numpy/numpy"
+                }
+              }
+            }
+          JSON
+          "",
+          instance_double(Process::Status, success?: true),
+        ])
+
       expect(described_class.new([])
         .send(:pypi_repo_url,
               "https://files.pythonhosted.org/packages/24/62/ae72ff66c0f1fd959925b4c11f8c2dea61f47f6acaea75a08512cdfe3fed/numpy-2.4.1.tar.gz"))
@@ -108,6 +124,20 @@ RSpec.describe Homebrew::Cmd::Source do
     end
 
     it "returns nil for PyPI package without project information" do
+      expect(Utils::Curl).to receive(:curl_output)
+        .with(*Utils::Curl.curl_args(show_error: false, retries: 2), "https://pypi.org/pypi/foobar/json")
+        .and_return([
+          <<~JSON,
+            {
+              "info": {
+                "project_urls": {}
+              }
+            }
+          JSON
+          "",
+          instance_double(Process::Status, success?: true),
+        ])
+
       expect(described_class.new([])
         .send(:pypi_repo_url,
               "https://files.pythonhosted.org/packages/00/00/000000000000000000000000000000000000000000000000000000000000/foobar-0.0.1.tar.gz"))


### PR DESCRIPTION
- avoid live `pypi.org` lookups in `cmd/source` specs so the regression is deterministic
- keep coverage on `pypi_repo_url` package parsing by asserting the expected JSON API request

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Used OpenAI Codex xhigh with manual review.

-----
