### PR TITLE
cask: avoid repeat upgrade alerts

### DIFF
--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -12,7 +12,13 @@ module Cask
     extend SystemCommand::Mixin
     extend ::Utils::Output::Mixin
 
+    class SigningIdentity < T::Struct
+      const :identifier, T.nilable(String)
+      const :team_identifier, T.nilable(String)
+    end
+
     QUARANTINE_ATTRIBUTE = "com.apple.quarantine"
+    USER_APPROVED_FLAG = 0x0040
 
     QUARANTINE_SCRIPT = T.let((HOMEBREW_LIBRARY_PATH/"cask/utils/quarantine.swift").freeze, Pathname)
     COPY_XATTRS_SCRIPT = T.let((HOMEBREW_LIBRARY_PATH/"cask/utils/copy-xattrs.swift").freeze, Pathname)
@@ -124,6 +130,37 @@ module Cask
       system_command(T.must(xattr),
                      args:         ["-p", QUARANTINE_ATTRIBUTE, file],
                      print_stderr: false).stdout.rstrip
+    end
+
+    sig { params(file: T.any(String, Pathname)).returns(T::Boolean) }
+    def self.user_approved?(file)
+      return false if xattr.nil?
+
+      quarantine_status = status(file)
+      return false if quarantine_status.empty?
+
+      quarantine_status.split(";").fetch(0).to_i(16).anybits?(USER_APPROVED_FLAG)
+    end
+
+    sig { params(file: T.any(String, Pathname)).returns(T.nilable(SigningIdentity)) }
+    def self.signing_identity(file)
+      result = system_command("codesign", args: ["-dvvv", file], print_stderr: false)
+      return unless result.success?
+
+      identifier = T.let(nil, T.nilable(String))
+      team_identifier = T.let(nil, T.nilable(String))
+
+      result.merged_output.to_s.each_line do |line|
+        case line.chomp
+        when /\AIdentifier=(.+)\z/
+          identifier = Regexp.last_match(1)
+        when /\ATeamIdentifier=(.+)\z/
+          team_identifier = Regexp.last_match(1)
+          team_identifier = nil if team_identifier == "not set"
+        end
+      end
+
+      SigningIdentity.new(identifier:, team_identifier:)
     end
 
     sig { params(attribute: String).returns(String) }

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -3,6 +3,7 @@
 
 require "env_config"
 require "cask/config"
+require "cask/quarantine"
 require "deprecate_disable"
 require "utils/output"
 
@@ -201,9 +202,9 @@ module Cask
             # This is significantly easier given the weird difference in Sorbet signatures here.
             # rubocop:disable Style/DoubleNegation
             Installer.new(cask, binaries: !!binaries, verbose: !!verbose, force: !!force,
-                                                 skip_cask_deps: !!skip_cask_deps, require_sha: !!require_sha,
-                                                 upgrade: true, quarantine:, download_queue: prefetch_download_queue,
-                                                 defer_fetch: true)
+                                    skip_cask_deps: !!skip_cask_deps, require_sha: !!require_sha,
+                                    upgrade: true, quarantine: quarantine != false,
+                                    download_queue: prefetch_download_queue, defer_fetch: true)
             # rubocop:enable Style/DoubleNegation
           end
 
@@ -243,6 +244,36 @@ module Cask
       raise MultipleCaskErrors, caught_exceptions if caught_exceptions.count > 1
       raise caught_exceptions.fetch(0) if caught_exceptions.one?
 
+      false
+    end
+
+    sig {
+      params(
+        old_cask:               Cask,
+        new_cask:               Cask,
+        old_signing_identities: T::Hash[String, T.nilable(Quarantine::SigningIdentity)],
+        old_user_approved:      T::Hash[String, T::Boolean],
+      ).returns(T::Boolean)
+    }
+    def self.release_app_upgrade_quarantine?(old_cask, new_cask, old_signing_identities, old_user_approved)
+      old_app_artifacts = old_cask.artifacts.grep(Artifact::App)
+      new_app_artifacts = new_cask.artifacts.grep(Artifact::App)
+      return false if old_app_artifacts.empty? || old_app_artifacts.length != new_app_artifacts.length
+
+      old_app_artifacts.each_with_index.all? do |artifact, index|
+        next false unless old_user_approved.fetch(artifact.target.to_s, false)
+
+        old_identity = old_signing_identities[artifact.target.to_s]
+        new_identity = Quarantine.signing_identity(new_app_artifacts.fetch(index).target)
+
+        [
+          [old_identity&.identifier, new_identity&.identifier],
+          [old_identity&.team_identifier, new_identity&.team_identifier],
+        ].none? do |old_value, new_value|
+          !old_value.nil? && !new_value.nil? && old_value != new_value
+        end
+      end
+    rescue
       false
     end
 
@@ -288,16 +319,16 @@ module Cask
         skip_cask_deps:,
         require_sha:,
         upgrade:        true,
-        quarantine:,
         download_queue:,
-        defer_fetch:    true,
       }.compact
 
       new_cask_installer =
-        Installer.new(new_cask, **new_options)
+        Installer.new(new_cask, **new_options, quarantine: quarantine != false, defer_fetch: true)
 
       started_upgrade = false
       new_artifacts_installed = false
+      old_signing_identities = T.let({}, T::Hash[String, T.nilable(Quarantine::SigningIdentity)])
+      old_user_approved = T.let({}, T::Hash[String, T::Boolean])
 
       begin
         oh1 "Upgrading #{Formatter.identifier(old_cask)}"
@@ -312,6 +343,18 @@ module Cask
 
         new_cask_installer.fetch
 
+        if quarantine.nil?
+          old_cask.artifacts.grep(Artifact::App).each do |artifact|
+            old_user_approved[artifact.target.to_s] =
+              if artifact.target.exist?
+                Quarantine.user_approved?(artifact.target)
+              else
+                false
+              end
+            old_signing_identities[artifact.target.to_s] = Quarantine.signing_identity(artifact.target)
+          end
+        end
+
         # Move the old cask's artifacts back to staging
         old_cask_installer.start_upgrade(successor: new_cask)
         # And flag it so in case of error
@@ -322,6 +365,14 @@ module Cask
 
         new_cask_installer.install_artifacts(predecessor: old_cask)
         new_artifacts_installed = true
+
+        if quarantine.nil? &&
+           Quarantine.available? &&
+           release_app_upgrade_quarantine?(old_cask, new_cask, old_signing_identities, old_user_approved)
+          new_cask.artifacts.grep(Artifact::App).each do |artifact|
+            Quarantine.release!(download_path: artifact.target)
+          end
+        end
 
         # If successful, wipe the old cask from staging.
         old_cask_installer.finalize_upgrade

--- a/Library/Homebrew/test/cask/quarantine_spec.rb
+++ b/Library/Homebrew/test/cask/quarantine_spec.rb
@@ -1,0 +1,69 @@
+# typed: false
+# frozen_string_literal: true
+
+RSpec.describe Cask::Quarantine do
+  describe ".user_approved?" do
+    let(:file) { Pathname("/tmp/Test.app") }
+
+    before do
+      allow(described_class).to receive(:xattr).and_return(Pathname("/usr/bin/xattr"))
+    end
+
+    it "returns true when the user approval flag is set" do
+      allow(described_class).to receive(:status).with(file).and_return("01c3;6723b9fa;Safari;event-id")
+
+      expect(described_class.user_approved?(file)).to be(true)
+    end
+
+    it "returns false when the user approval flag is not set" do
+      allow(described_class).to receive(:status).with(file).and_return("0183;6723b9fa;Safari;event-id")
+
+      expect(described_class.user_approved?(file)).to be(false)
+    end
+  end
+
+  describe ".signing_identity" do
+    let(:file) { Pathname("/tmp/Test.app") }
+
+    it "returns the signed identifier and Team ID" do
+      result = instance_double(
+        SystemCommand::Result,
+        success?:      true,
+        merged_output: <<~EOS,
+          Identifier=sh.brew.test-app
+          TeamIdentifier=ABCDE12345
+          Authority=Developer ID Application: Brew Test (ABCDE12345)
+        EOS
+      )
+      allow(described_class).to receive(:system_command).with("codesign", args: ["-dvvv", file], print_stderr: false)
+                                                        .and_return(result)
+
+      identity = described_class.signing_identity(file)
+
+      expect(identity).to have_attributes(identifier: "sh.brew.test-app", team_identifier: "ABCDE12345")
+    end
+
+    it "returns the signed identifier when the Team ID is missing" do
+      result = instance_double(SystemCommand::Result, success?: true, merged_output: "Identifier=sh.brew.test-app\n")
+      allow(described_class).to receive(:system_command).with("codesign", args: ["-dvvv", file], print_stderr: false)
+                                                        .and_return(result)
+
+      expect(described_class.signing_identity(file)).to have_attributes(identifier:      "sh.brew.test-app",
+                                                                        team_identifier: nil)
+    end
+
+    it 'returns nil for the Team ID when it is "not set"' do
+      result = instance_double(
+        SystemCommand::Result,
+        success?:      true,
+        merged_output: "Identifier=com.apple.calculator\n" \
+                       "TeamIdentifier=not set\n",
+      )
+      allow(described_class).to receive(:system_command).with("codesign", args: ["-dvvv", file], print_stderr: false)
+                                                        .and_return(result)
+
+      expect(described_class.signing_identity(file)).to have_attributes(identifier:      "com.apple.calculator",
+                                                                        team_identifier: nil)
+    end
+  end
+end

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -349,6 +349,129 @@ RSpec.describe Cask::Upgrade, :cask do
     end
   end
 
+  context "when releasing quarantine during upgrade" do
+    let(:outdated_auto_updates) { Cask::CaskLoader.load(cask_path("outdated/auto-updates")) }
+    let(:outdated_local_caffeine) { Cask::CaskLoader.load(cask_path("outdated/local-caffeine")) }
+    let(:auto_updates_identity) do
+      Cask::Quarantine::SigningIdentity.new(identifier: "sh.brew.auto-updates", team_identifier: "ABCDE12345")
+    end
+    let(:auto_updates_changed_team_identity) do
+      Cask::Quarantine::SigningIdentity.new(identifier: "sh.brew.auto-updates", team_identifier: "VWXYZ98765")
+    end
+    let(:auto_updates_changed_identifier_identity) do
+      Cask::Quarantine::SigningIdentity.new(identifier: "sh.brew.auto-updates-renamed", team_identifier: "ABCDE12345")
+    end
+    let(:local_caffeine_identity) do
+      Cask::Quarantine::SigningIdentity.new(identifier: "sh.brew.local-caffeine", team_identifier: "ABCDE12345")
+    end
+
+    before do
+      [
+        "outdated/local-caffeine",
+        "outdated/auto-updates",
+      ].each do |cask_name|
+        InstallHelper.stub_cask_installation(Cask::CaskLoader.load(cask_path(cask_name)))
+      end
+    end
+
+    it 'prefetches "auto_updates true" casks with quarantine until signed identity is checked' do
+      installer = instance_double(Cask::Installer, prelude: nil, enqueue_downloads: nil)
+
+      expect(Cask::Installer).to receive(:new) do |cask, **options|
+        expect(cask).to eq(auto_updates)
+        expect(options[:quarantine]).to be(true)
+        installer
+      end
+      expect(described_class).to receive(:upgrade_cask)
+
+      described_class.upgrade_casks!(auto_updates, show_upgrade_summary: false, args:)
+    end
+
+    it "releases quarantine when Gatekeeper was already approved and identity matches" do
+      allow(Cask::Quarantine).to receive(:signing_identity).with(auto_updates_path).and_return(auto_updates_identity)
+
+      expect(described_class.release_app_upgrade_quarantine?(
+               outdated_auto_updates,
+               auto_updates,
+               { auto_updates_path.to_s => auto_updates_identity },
+               { auto_updates_path.to_s => true },
+             )).to be(true)
+    end
+
+    it "still keeps quarantine when the Team ID changes" do
+      allow(Cask::Quarantine).to receive(:signing_identity).with(auto_updates_path)
+                                                           .and_return(auto_updates_changed_team_identity)
+
+      expect(described_class.release_app_upgrade_quarantine?(
+               outdated_auto_updates,
+               auto_updates,
+               { auto_updates_path.to_s => auto_updates_identity },
+               { auto_updates_path.to_s => true },
+             )).to be(false)
+    end
+
+    it "still keeps quarantine when the signed identifier changes" do
+      allow(Cask::Quarantine).to receive(:signing_identity).with(auto_updates_path)
+                                                           .and_return(auto_updates_changed_identifier_identity)
+
+      expect(described_class.release_app_upgrade_quarantine?(
+               outdated_auto_updates,
+               auto_updates,
+               { auto_updates_path.to_s => auto_updates_identity },
+               { auto_updates_path.to_s => true },
+             )).to be(false)
+    end
+
+    it "releases quarantine when signed fields are unset before or after the upgrade" do
+      allow(Cask::Quarantine).to receive(:signing_identity).with(auto_updates_path)
+                                                           .and_return(auto_updates_identity)
+
+      expect(described_class.release_app_upgrade_quarantine?(
+               outdated_auto_updates,
+               auto_updates,
+               { auto_updates_path.to_s => Cask::Quarantine::SigningIdentity.new(identifier:      nil,
+                                                                                 team_identifier: nil) },
+               { auto_updates_path.to_s => true },
+             )).to be(true)
+    end
+
+    it "still keeps quarantine when Gatekeeper was not approved" do
+      allow(Cask::Quarantine).to receive(:signing_identity).with(auto_updates_path).and_return(auto_updates_identity)
+
+      expect(described_class.release_app_upgrade_quarantine?(
+               outdated_auto_updates,
+               auto_updates,
+               { auto_updates_path.to_s => auto_updates_identity },
+               { auto_updates_path.to_s => false },
+             )).to be(false)
+    end
+
+    it "releases quarantine for casks without auto_updates when Gatekeeper was already approved " \
+       "and identity matches" do
+      allow(Cask::Quarantine).to receive(:signing_identity).with(local_caffeine_path)
+                                                           .and_return(local_caffeine_identity)
+
+      expect(described_class.release_app_upgrade_quarantine?(
+               outdated_local_caffeine,
+               local_caffeine,
+               { local_caffeine_path.to_s => local_caffeine_identity },
+               { local_caffeine_path.to_s => true },
+             )).to be(true)
+    end
+
+    it "still keeps quarantine for casks without auto_updates when Gatekeeper was not approved" do
+      allow(Cask::Quarantine).to receive(:signing_identity).with(local_caffeine_path)
+                                                           .and_return(local_caffeine_identity)
+
+      expect(described_class.release_app_upgrade_quarantine?(
+               outdated_local_caffeine,
+               local_caffeine,
+               { local_caffeine_path.to_s => local_caffeine_identity },
+               { local_caffeine_path.to_s => false },
+             )).to be(false)
+    end
+  end
+
   it "warns and skips disabled casks" do
     cask = Cask::CaskLoader.load(cask_path("livecheck/livecheck-disabled"))
     InstallHelper.stub_cask_installation(cask)


### PR DESCRIPTION
- avoid showing repeated quarantine alerts on `brew upgrade` when the app's own updater would usually not prompt again
- keep quarantine in place through download and install so Gatekeeper still checks upgraded apps before first launch
- only clear quarantine after install when the previous app was already accepted and signed `Identifier` or `TeamIdentifier` values do not change
- keep quarantine when approval is missing or signing changes, so upgrades do not silently trust different code or malware
- add upgrade and quarantine specs covering approval, signing changes, and partially unset signing metadata

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Used OpenAI Codex with manual review, editing and testing.

-----
