### PR TITLE
perf: replace inject("+") with sum and use filter_map in utils

### DIFF
--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -274,7 +274,7 @@ module Utils
 
               table_output(category, days.to_s, results)
             else
-              total_count = results.values.inject("+")
+              total_count = results.values.sum
               analytics << "#{Formatter.number_readable(total_count)} (#{days} days)"
             end
           end
@@ -417,7 +417,7 @@ module Utils
       }
       def table_output(category, days, results, os_version: false, cask_install: false)
         oh1 "#{category} (#{days} days)"
-        total_count = results.values.inject("+")
+        total_count = results.values.sum
         formatted_total_count = format_count(total_count)
         formatted_total_percent = format_percent(100)
 

--- a/Library/Homebrew/utils/topological_hash.rb
+++ b/Library/Homebrew/utils/topological_hash.rb
@@ -37,9 +37,7 @@ module Utils
                                      .map { |c| Cask::CaskLoader.load(c, config: nil) }
         when Formula
           formula_deps = cask_or_formula.deps
-                                        .reject(&:build?)
-                                        .reject(&:test?)
-                                        .map(&:to_formula)
+                                        .filter_map { |d| d.to_formula if !d.build? && !d.test? }
           cask_deps = cask_or_formula.requirements
                                      .filter_map(&:cask)
                                      .map { |c| Cask::CaskLoader.load(c, config: nil) }


### PR DESCRIPTION
-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

AI (Claude) identified optimization candidates, wrote micro-benchmarks and Hyperfine benchmarks to validate each one, and discarded candidates where the proposed change was slower (e.g. `filter_map` on low-rejection-rate `select+map` chains was ~20% slower; nested `flat_map` was ~15–24% slower than chained). Only changes confirmed faster by benchmarking were applied. All changes were manually reviewed.

-----

## What

Two small performance improvements in `Library/Homebrew/utils/`:

**`analytics.rb`** — replace `inject("+")` with `sum` at two call sites (`Utils::Analytics#output_analytics` and `#table_output`).

**`topological_hash.rb`** — replace chained `.reject(&:build?).reject(&:test?).map(&:to_formula)` with a single `.filter_map { |d| d.to_formula if !d.build? && !d.test? }` in `graph_package_dependencies`.

## Why

- `inject("+")` on a numeric array dispatches through `send` on every element; `Array#sum` is a C-level optimised implementation.
- The chained `reject` calls each allocate an intermediate array and make a full pass over `deps`. `filter_map` does both the filtering and the transform in one pass with one allocation.
- Several other candidates were evaluated and benchmarked (chained `flat_map`, `select+map` in `github.rb` and `pypi.rb`) but discarded because the "optimisation" was measurably slower.

## Benchmarks

Benchmarks run with [Hyperfine](https://github.com/sharkdp/hyperfine) 1.20.0 on macOS (Darwin 25.4.0), warmed up with 5 runs.

### `inject("+")` → `sum` (`analytics.rb`)

```
hyperfine --warmup 5 \
  'ruby -e "v = Array.new(50){rand(10_000)}; 100_000.times { v.inject(:+) }"' \
  'ruby -e "v = Array.new(50){rand(10_000)}; 100_000.times { v.sum }"'
```

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `inject(:+)` | 55.2 ± 5.5 | 50.8 | 78.9 | 1.10 ± 0.12 |
| `sum` | 50.3 ± 1.7 | 47.8 | 59.4 | **1.00** |

~10% faster.

### chained `reject+reject+map` → `filter_map` (`topological_hash.rb`)

Ruby `Benchmark` (1 M iterations, 60 deps, ~15% build / ~10% test):

| Method | Time |
|:---|---:|
| `.reject(&:build?).reject(&:test?).map(&:to_formula)` | 3295 ms |
| `.filter_map { \|d\| d.to_formula if !d.build? && !d.test? }` | **2503 ms** |

~24% faster — one pass, one array allocation instead of three.