### PR TITLE
rubocops/resource_requires_dependencies: add bcrypt

### DIFF
--- a/Library/Homebrew/rubocops/resource_requires_dependencies.rb
+++ b/Library/Homebrew/rubocops/resource_requires_dependencies.rb
@@ -17,7 +17,7 @@ module RuboCop
           resource_nodes = find_every_method_call_by_name(body_node, :resource)
           return if resource_nodes.empty?
 
-          %w[lxml pynacl pyyaml].each do |resource_name|
+          %w[bcrypt lxml pynacl pyyaml].each do |resource_name|
             found = resource_nodes.find { |node| node.arguments&.first&.str_content == resource_name }
             next unless found
 
@@ -34,6 +34,9 @@ module RuboCop
             end
 
             required_deps = case resource_name
+            when "bcrypt"
+              kind = "depends_on"
+              ["pkgconf", "rust"]
             when "lxml"
               kind = depends_on?(:linux) ? "depends_on" : "uses_from_macos"
               ["libxml2", "libxslt"]

--- a/Library/Homebrew/test/rubocops/resource_requires_dependencies_spec.rb
+++ b/Library/Homebrew/test/rubocops/resource_requires_dependencies_spec.rb
@@ -19,6 +19,60 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ResourceRequiresDependencies do
     end
   end
 
+  context "when a formula does not have the bcrypt resource" do
+    it "does not report offenses" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
+
+          uses_from_macos "libxml2"
+
+          resource "not-bcrypt" do
+            url "blah"
+            sha256 "blah"
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when a formula has the bcrypt resource" do
+    it "does not report offenses if the dependencies are present" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
+
+          depends_on "pkgconf" => :build
+          depends_on "rust" => :build
+
+          resource "bcrypt" do
+            url "blah"
+            sha256 "blah"
+          end
+        end
+      RUBY
+    end
+
+    it "reports offenses if missing a dependency" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
+
+          depends_on "pkgconf" => :build
+
+          resource "bcrypt" do
+          ^^^^^^^^^^^^^^^^^ FormulaAudit/ResourceRequiresDependencies: Add `depends_on` lines above for `"pkgconf"` and `"rust"`.
+            url "blah"
+            sha256 "blah"
+          end
+        end
+      RUBY
+    end
+  end
+
   context "when a formula does not have the lxml resource" do
     it "does not report offenses" do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Claude Code was used to locate the existing `ResourceRequiresDependencies` cop, add the `bcrypt` entry and corresponding specs, and run `brew lgtm` locally. I reviewed the diff and verified the specs match the pattern used by the existing `lxml`/`pynacl`/`pyyaml` checks.

-----

Flags Python formulae that include the `bcrypt` resource but don't declare the `pkgconf` and `rust` build dependencies it needs to build from source. Follow-up to the standardization in Homebrew/homebrew-core#278702.