### PR TITLE
test/dev-cmd/developer_spec: add usage test

### DIFF
--- a/Library/Homebrew/test/cmd/developer_spec.rb
+++ b/Library/Homebrew/test/cmd/developer_spec.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/developer"
@@ -6,4 +6,11 @@ require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::Developer do
   it_behaves_like "parseable arguments"
+
+  it "prints that Developer mode is disabled by default", :integration_test do
+    expect { brew "developer" }
+      .to output(/Developer mode is disabled/).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

After adding a test for `brew unbottled` in #22050, I noticed that it would be straightforward to also add a test for `brew developer`, expecting that `brew developer` succeeds and prints
"Developer mode is disabled" by default.
