### PR TITLE
bundle: fix flaky installer spec

### DIFF
--- a/Library/Homebrew/bundle/installer.rb
+++ b/Library/Homebrew/bundle/installer.rb
@@ -15,6 +15,13 @@ module Homebrew
         const :cls, T.class_of(Homebrew::Bundle::PackageType)
       end
 
+      sig { void }
+      def self.reset!
+        Homebrew::Bundle.reset!
+        Homebrew::Bundle::Cask.reset!
+        Homebrew::Bundle::Tap.reset!
+      end
+
       sig {
         params(
           entries:    T::Array[Dsl::Entry],

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Homebrew::Bundle::Installer do
   let(:cask_entry) { Homebrew::Bundle::Dsl::Entry.new(:cask, "google-chrome", cask_options) }
 
   before do
+    described_class.reset!
     allow(Homebrew::Bundle::Skipper).to receive(:skip?).and_return(false)
     allow(Homebrew::Bundle::Brew).to receive_messages(formula_upgradable?: false, install!: true)
     allow(Homebrew::Bundle::Brew).to receive_messages(formula_installed_and_up_to_date?: false,
@@ -20,6 +21,18 @@ RSpec.describe Homebrew::Bundle::Installer do
     allow(Homebrew::Bundle::Cask).to receive_messages(cask_upgradable?: false, install!: true)
     allow(Homebrew::Bundle::Cask).to receive_messages(installable_or_upgradable?: true, preinstall!: true)
     allow(Homebrew::Bundle::Tap).to receive_messages(preinstall!: true, install!: true, installed_taps: [])
+  end
+
+  it "resets cached package state before installing" do
+    expect(Homebrew::Bundle::Cask).to receive(:casks).twice.and_return(
+      [double(to_s: "stale")],
+      [double(to_s: "google-chrome")],
+    )
+
+    expect(Homebrew::Bundle::Cask.cask_names).to eq(["stale"])
+
+    described_class.reset!
+    described_class.install!([cask_entry], verbose: false, force: false, quiet: true)
   end
 
   it "prefetches installable formulae and casks before installing" do
@@ -85,8 +98,13 @@ RSpec.describe Homebrew::Bundle::Installer do
     end
 
     it "installs independent formulae in parallel with jobs > 1" do
+      allow(Homebrew::Bundle::Brew).to receive(:formula_bottled?).and_return(true)
       allow(Homebrew::Bundle::Brew).to receive(:formulae_by_full_name).with("alpha").and_return({ dependencies: [] })
       allow(Homebrew::Bundle::Brew).to receive(:formulae_by_full_name).with("beta").and_return({ dependencies: [] })
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("alpha",
+                                                                          include_build: false).and_return(Set.new)
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("beta",
+                                                                          include_build: false).and_return(Set.new)
       expect(Homebrew::Bundle::Brew).to receive(:install!)
         .with("alpha", preinstall: true, no_upgrade: false, verbose: false, force: false)
         .and_return(true)
@@ -110,9 +128,14 @@ RSpec.describe Homebrew::Bundle::Installer do
         true
       end
 
+      allow(Homebrew::Bundle::Brew).to receive(:formula_bottled?).and_return(true)
       allow(Homebrew::Bundle::Brew).to receive(:formulae_by_full_name).with("alpha")
                                                                       .and_return({ dependencies: ["beta"] })
       allow(Homebrew::Bundle::Brew).to receive(:formulae_by_full_name).with("beta").and_return({ dependencies: [] })
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("alpha",
+                                                                          include_build: false).and_return(Set.new)
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("beta",
+                                                                          include_build: false).and_return(Set.new)
 
       success, failure = Homebrew::Bundle::ParallelInstaller.new(
         [alpha_entry, beta_entry],


### PR DESCRIPTION
- keep cached `Cask` and tap state from leaking between examples
- exercise `Installer.reset!` instead of poking cached internals
- stub parallel formula metadata in `installer_spec.rb`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Built with OpenAI Codex with manual review and approach changes.

-----
