### PR TITLE
audit: respect `livecheck` throttle days

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -806,8 +806,13 @@ module Cask
       )
       if result
         throttle = cask.livecheck.throttle
-        throttle ||= referenced_cask.livecheck.throttle if referenced_cask
-        latest_version = throttle ? result[:latest_throttled] : result[:latest]
+        throttle_days = cask.livecheck.throttle_days
+        if referenced_cask
+          throttle ||= referenced_cask.livecheck.throttle
+          throttle_days ||= referenced_cask.livecheck.throttle_days
+        end
+
+        latest_version = (throttle || throttle_days) ? result[:latest_throttled] : result[:latest]
       end
 
       if latest_version && (cask.version.to_s == latest_version.to_s)

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -1193,10 +1193,18 @@ module Homebrew
       end
       return if sourcefile.nil?
 
+      default_branch = Utils.popen_read(
+        Utils::Git.git,
+        "symbolic-ref",
+        "refs/remotes/origin/HEAD",
+        "--short",
+      ).chomp.delete_prefix("origin/").presence || "main"
+
       relative_sourcefile = sourcefile.relative_path_from(tap.path).to_s
       timestamp = Utils.popen_read(
         Utils::Git.git,
         "log",
+        default_branch,
         "-1",
         "--format=%ct",
         "--",

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -637,6 +637,37 @@ RSpec.describe Cask::Audit, :cask do
         end
       end
 
+      context "when the Cask has a `livecheck` block using `throttle days:`" do
+        let(:cask_token) { "livecheck-throttle-days" }
+        let(:cask) do
+          tmp_cask cask_token.to_s, <<~RUBY
+            cask "#{cask_token}" do
+              version "1.2.5"
+              sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+              url "https://brew.sh/#{cask_token}-1.2.5.dmg"
+              name "Throttle Days"
+              homepage "https://brew.sh/#{cask_token}"
+
+              livecheck do
+                url :homepage
+                throttle days: 7
+              end
+
+              app "#{cask_token}.app"
+            end
+          RUBY
+        end
+
+        it do
+          allow(Homebrew::Livecheck).to receive(:latest_version).and_return({
+            latest:           Version.new("1.2.6"),
+            latest_throttled: Version.new("1.2.5"),
+          })
+          expect(run).not_to error_with(message)
+        end
+      end
+
       context "when the Cask has a `livecheck` block referencing a Cask that uses `throttle`" do
         let(:cask_token) { "livecheck-throttle-reference" }
 
@@ -645,6 +676,58 @@ RSpec.describe Cask::Audit, :cask do
             latest:           Version.new("1.2.6"),
             latest_throttled: Version.new("1.2.5"),
           })
+          expect(run).not_to error_with(message)
+        end
+      end
+
+      context "when the Cask has a `livecheck` block referencing a Cask that uses `throttle days:`" do
+        let(:cask_token) { "livecheck-throttle-days-reference" }
+        let(:referenced_cask) do
+          tmp_cask "livecheck-throttle-days-source", <<~RUBY
+            cask "livecheck-throttle-days-source" do
+              version "1.2.5"
+              sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+              url "https://brew.sh/livecheck-throttle-days-source-1.2.5.dmg"
+              name "Throttle Days Source"
+              homepage "https://brew.sh/livecheck-throttle-days-source"
+
+              livecheck do
+                url :homepage
+                throttle days: 7
+              end
+
+              app "livecheck-throttle-days-source.app"
+            end
+          RUBY
+        end
+        let(:cask) do
+          tmp_cask cask_token.to_s, <<~RUBY
+            cask "#{cask_token}" do
+              version "1.2.5"
+              sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+              url "https://brew.sh/#{cask_token}-1.2.5.dmg"
+              name "Throttle Days Reference"
+              homepage "https://brew.sh/#{cask_token}"
+
+              livecheck do
+                cask "livecheck-throttle-days-source"
+              end
+
+              app "#{cask_token}.app"
+            end
+          RUBY
+        end
+
+        it do
+          allow(Homebrew::Livecheck).to receive_messages(
+            resolve_livecheck_reference: [referenced_cask, nil],
+            latest_version:              {
+              latest:           Version.new("1.2.6"),
+              latest_throttled: Version.new("1.2.5"),
+            },
+          )
           expect(run).not_to error_with(message)
         end
       end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

I used Codex to help find the discrepancy between the `brew livecheck` and `brew audit` behaviour.

-----

With the recent introduction of the `days` parameter to `livecheck throttle`, the behaviour has been updated to be correctly reflected across `brew bump` and `brew livecheck` - however `brew audit` was not receiving the change, as discovered in https://github.com/Homebrew/homebrew-cask/pull/260573