### PR TITLE
info: avoid broken GitHub URL for removed formulae

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -437,6 +437,10 @@ module Homebrew
           formula = formula_or_cask
           tap = formula.tap
           return formula.path.to_s if tap.blank? || tap.remote.blank?
+          # The formula file may live outside the tap (e.g. loaded from a keg's
+          # `.brew/` directory after the formula was removed from its tap), in
+          # which case there is no meaningful upstream URL to link to.
+          return formula.path.to_s unless formula.path.to_s.start_with?("#{tap.path}/")
 
           formula.path.relative_path_from(tap.path)
         when Cask::Cask

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -234,4 +234,31 @@ RSpec.describe Homebrew::Cmd::Info do
         .to eq("https://mywebsite.com/foo/bar.rb")
     end
   end
+
+  describe "#github_info" do
+    let(:tap) { CoreTap.instance }
+
+    it "returns the local path for a formula whose file lives outside its tap" do
+      # Simulates a formula that was removed from its tap but is still installed,
+      # so it gets loaded from the keg's `.brew/` directory by `FromKegLoader`.
+      keg_formula_path = HOMEBREW_CELLAR/"testball/0.1/.brew/testball.rb"
+      formula_instance = formula("testball", path: keg_formula_path, tap:) do
+        url "https://brew.sh/testball-0.1.tar.gz"
+      end
+
+      expect(described_class.new([]).send(:github_info, formula_instance))
+        .to eq(keg_formula_path.to_s)
+    end
+
+    it "returns a GitHub URL for a formula whose file lives inside its tap" do
+      formula_path = tap.new_formula_path("testball")
+      formula_instance = formula("testball", path: formula_path, tap:) do
+        url "https://brew.sh/testball-0.1.tar.gz"
+      end
+
+      expect(described_class.new([]).send(:github_info, formula_instance))
+        .to eq("https://github.com/Homebrew/homebrew-core/blob/HEAD/" \
+               "#{formula_path.relative_path_from(tap.path)}")
+    end
+  end
 end


### PR DESCRIPTION
When a formula has been removed from its tap but is still installed (e.g. `terraform`, which was disabled on 2025-04-04 and later removed from `homebrew-core`), `FromKegLoader` loads it from the keg's `.brew/<name>.rb` with the tap still set from the install receipt. `github_info` then built a "From:" URL by joining the tap's GitHub remote with `formula.path.relative_path_from(tap.path)`, producing a path full of `../` components:

Before:

```
$ brew info terraform
...
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/../../../../opt/terraform/.brew/terraform.rb
```

After:

```
$ brew info terraform
...
From: /opt/homebrew/opt/terraform/.brew/terraform.rb
```

The fix falls back to the formula's local path when its file is not inside its tap's directory, matching the existing behaviour for formulae with no tap (or no remote). The `"#{tap.path}/"` (with trailing `/`) containment check is the same idiom already used in `dev-cmd/pr-pull.rb` and `cask/artifact/symlinked.rb`.

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Cursor (Claude Opus 4.7) was used to investigate the root cause, propose the fix, and draft the tests under my direction and review. I verified end-to-end that `brew info terraform` now prints the local path (and that `brew info git` still prints the correct GitHub URL for a formula present in its tap), and ran `brew style`, `brew typecheck`, and `brew tests --only=cmd/info` locally.