### PR TITLE
How-To-Open-a-Homebrew-Pull-Request: clarify `brew audit --new` for new formulae

### DIFF
--- a/docs/How-To-Open-a-Homebrew-Pull-Request.md
+++ b/docs/How-To-Open-a-Homebrew-Pull-Request.md
@@ -123,6 +123,7 @@ To make changes on a new branch and submit it for review, create a GitHub pull r
    ```
 
    For new formulae, use `--new` instead (which implies `--strict`, `--online` and additional new-formula eligibility checks):
+
    ```sh
    HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <NEW_FORMULA>
    brew test <NEW_FORMULA>

--- a/docs/How-To-Open-a-Homebrew-Pull-Request.md
+++ b/docs/How-To-Open-a-Homebrew-Pull-Request.md
@@ -112,7 +112,7 @@ To make changes on a new branch and submit it for review, create a GitHub pull r
 
 4. Make your changes. For formulae or casks, use `brew edit` or your favourite text editor, using the guidelines in the [Formula Cookbook](Formula-Cookbook.md) or [Cask Cookbook](Cask-Cookbook.md) for reference.
    * If there's a `bottle do` block in the formula, don't remove or change it; we'll update it when we merge your PR.
-5. For changed formulae and casks, make sure you do the brew audit step after your changed formula/cask has been installed.
+5. For changed formulae and casks, make sure you do the `brew audit` step after your changed formula/cask has been installed.
 
    For formulae:
 

--- a/docs/How-To-Open-a-Homebrew-Pull-Request.md
+++ b/docs/How-To-Open-a-Homebrew-Pull-Request.md
@@ -112,32 +112,28 @@ To make changes on a new branch and submit it for review, create a GitHub pull r
 
 4. Make your changes. For formulae or casks, use `brew edit` or your favourite text editor, using the guidelines in the [Formula Cookbook](Formula-Cookbook.md) or [Cask Cookbook](Cask-Cookbook.md) for reference.
    * If there's a `bottle do` block in the formula, don't remove or change it; we'll update it when we merge your PR.
-5. For changed formulae and casks, make sure you do the `brew audit` step after your changed formula/cask has been installed.
+5. For changed formulae and casks, make sure you do the `brew lgtm` step after your changed formula/cask has been installed.
 
    For formulae:
 
    ```sh
    HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <CHANGED_FORMULA>
    brew test <CHANGED_FORMULA>
-   brew audit --strict --online <CHANGED_FORMULA>
+brew lgtm
    ```
 
    For new formulae, use `--new` instead (which implies `--strict`, `--online` and additional new-formula eligibility checks):
 
    ```sh
    HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <NEW_FORMULA>
-   brew test <NEW_FORMULA>
-   brew audit --new <NEW_FORMULA>
+   brew lgtm
    ```
-
-   You can also run `brew lgtm` to run style, typecheck and tests on your changes in one go.
-
    For casks:
 
    ```sh
    HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <CHANGED_CASK>
    brew uninstall --cask <CHANGED_CASK>
-   brew audit --strict --online --cask <CHANGED_CASK>
+   brew lgtm
    ```
 
 6. [Make a separate commit](Formula-Cookbook.md#commit) for each changed formula with `git add` and `git commit`. Each formula's commits must be squashed.

--- a/docs/How-To-Open-a-Homebrew-Pull-Request.md
+++ b/docs/How-To-Open-a-Homebrew-Pull-Request.md
@@ -112,7 +112,7 @@ To make changes on a new branch and submit it for review, create a GitHub pull r
 
 4. Make your changes. For formulae or casks, use `brew edit` or your favourite text editor, using the guidelines in the [Formula Cookbook](Formula-Cookbook.md) or [Cask Cookbook](Cask-Cookbook.md) for reference.
    * If there's a `bottle do` block in the formula, don't remove or change it; we'll update it when we merge your PR.
-5. Test your changes by running the following, and ensure they all pass without issue. For changed formulae and casks, make sure you do the `brew audit` step after your changed formula/cask has been installed.
+5. Test your changes by running the following, and ensure they all pass without issue. For changed formulae and casks, make sure you do the brew audit step after your changed formula/cask has been installed. If you are adding a new formula or cask, use `brew audit --new` instead, which implies `--strict` and `--online` and runs additional checks for new submissions.
 
    For formulae:
 

--- a/docs/How-To-Open-a-Homebrew-Pull-Request.md
+++ b/docs/How-To-Open-a-Homebrew-Pull-Request.md
@@ -112,7 +112,7 @@ To make changes on a new branch and submit it for review, create a GitHub pull r
 
 4. Make your changes. For formulae or casks, use `brew edit` or your favourite text editor, using the guidelines in the [Formula Cookbook](Formula-Cookbook.md) or [Cask Cookbook](Cask-Cookbook.md) for reference.
    * If there's a `bottle do` block in the formula, don't remove or change it; we'll update it when we merge your PR.
-5. Test your changes by running the following, and ensure they all pass without issue. For changed formulae and casks, make sure you do the brew audit step after your changed formula/cask has been installed. If you are adding a new formula or cask, use `brew audit --new` instead, which implies `--strict` and `--online` and runs additional checks for new submissions.
+5. For changed formulae and casks, make sure you do the brew audit step after your changed formula/cask has been installed.
 
    For formulae:
 
@@ -121,6 +121,15 @@ To make changes on a new branch and submit it for review, create a GitHub pull r
    brew test <CHANGED_FORMULA>
    brew audit --strict --online <CHANGED_FORMULA>
    ```
+
+   For new formulae, use `--new` instead (which implies `--strict`, `--online` and additional new-formula eligibility checks):
+   ```sh
+   HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <NEW_FORMULA>
+   brew test <NEW_FORMULA>
+   brew audit --new <NEW_FORMULA>
+   ```
+
+   You can also run `brew lgtm` to run style, typecheck and tests on your changes in one go.
 
    For casks:
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes?
- [ ] Have you successfully run `brew lgtm` with your changes locally?

---

- [x] AI was used to generate or assist with generating this PR. Claude Sonnet 4.6 (claude.ai) was used to identify the inconsistency between this page and `Adding-Software-to-Homebrew.md`. The one-line change was written and reviewed manually.

---

The guide currently shows `brew audit --strict --online` for changed formulae, which is correct. However, it doesn't distinguish this from the new formula case. A contributor adding a new formula following this guide would not know to use `brew audit --new`, which runs additional new-formula eligibility checks (and implies `--strict` and `--online`). This is already documented correctly in `Adding-Software-to-Homebrew.md` but the cross-reference is missing here.
