### PR TITLE
update-portable-ruby: skip vendor-gems if lockfile already matches

### DIFF
--- a/Library/Homebrew/dev-cmd/update-portable-ruby.rb
+++ b/Library/Homebrew/dev-cmd/update-portable-ruby.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "abstract_command"
+require "bundler"
 require "formula"
 require "utils/bottles"
 
@@ -21,6 +22,13 @@ module Homebrew
                             "`Gemfile.lock` updates."
 
         named_args :none
+      end
+
+      sig { params(contents: String, ruby_version: String, bundler_version: String).returns(T::Boolean) }
+      def self.lockfile_in_sync?(contents, ruby_version, bundler_version)
+        parsed = Bundler::LockfileParser.new(contents)
+        parsed.ruby_version == "ruby #{ruby_version}" &&
+          parsed.bundler_version&.to_s == bundler_version
       end
 
       sig { override.void }
@@ -65,6 +73,9 @@ module Homebrew
           ohai "Writing #{ruby_sh}"
           ruby_sh.atomic_write(updated)
         end
+
+        gemfile_lock = (HOMEBREW_LIBRARY_PATH/"Gemfile.lock").read
+        return if self.class.lockfile_in_sync?(gemfile_lock, version, bundler_version)
 
         ohai "brew vendor-gems --no-commit --update=--ruby,--bundler=#{bundler_version}"
         safe_system HOMEBREW_BREW_FILE, "vendor-gems", "--no-commit", "--update=--ruby,--bundler=#{bundler_version}"

--- a/Library/Homebrew/test/dev-cmd/update-portable-ruby_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-portable-ruby_spec.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: false
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"
@@ -6,4 +6,28 @@ require "dev-cmd/update-portable-ruby"
 
 RSpec.describe Homebrew::DevCmd::UpdatePortableRuby do
   it_behaves_like "parseable arguments"
+
+  describe ".lockfile_in_sync?" do
+    let(:lockfile) do
+      <<~LOCK
+        RUBY VERSION
+          ruby 4.0.3
+
+        BUNDLED WITH
+          4.0.6
+      LOCK
+    end
+
+    it "returns true when both versions match" do
+      expect(described_class.lockfile_in_sync?(lockfile, "4.0.3", "4.0.6")).to be true
+    end
+
+    it "returns false when the Ruby version differs" do
+      expect(described_class.lockfile_in_sync?(lockfile, "4.0.2", "4.0.6")).to be false
+    end
+
+    it "returns false when the bundler version differs" do
+      expect(described_class.lockfile_in_sync?(lockfile, "4.0.3", "4.0.10")).to be false
+    end
+  end
 end

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -5,7 +5,7 @@
 # shellcheck disable=SC2154
 export HOMEBREW_REQUIRED_RUBY_VERSION="4.0"
 HOMEBREW_PORTABLE_RUBY_VERSION="$(cat "${HOMEBREW_LIBRARY}/Homebrew/vendor/portable-ruby-version")"
-export HOMEBREW_BUNDLER_VERSION="4.0.3"
+export HOMEBREW_BUNDLER_VERSION="4.0.6"
 
 # Disable Ruby options we don't need.
 export HOMEBREW_RUBY_DISABLE_OPTIONS="--disable=gems,rubyopt"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
Follow-up to #22058. `brew update-portable-ruby` always called `brew vendor-gems`, which regenerates `vendor/bundle/bundler/setup.rb` off the currently vendored gems and pulled in unrelated version bumps as noise. Skip the shell-out when `Gemfile.lock` already has the target `RUBY VERSION` / `BUNDLED WITH`.

Also fixes the bundler version in ruby.sh (will be handled by the command going forward).