### PR TITLE
workflows/vendor-gems: fail PRs with out-of-sync vendored gems

### DIFF
--- a/.github/workflows/vendor-gems.yml
+++ b/.github/workflows/vendor-gems.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Check out pull request
         id: checkout
-        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot')
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]')
         run: |
           gh pr checkout "${PR}"
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Vendor Gems
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" || ("${GITHUB_EVENT_NAME}" == "pull_request" && "${GITHUB_ACTOR}" == "dependabot") ]]
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" || ("${GITHUB_EVENT_NAME}" == "pull_request" && "${GITHUB_ACTOR}" == "dependabot[bot]") ]]
           then
             brew vendor-gems --non-bundler-gems
           else
@@ -78,7 +78,7 @@ jobs:
         run: brew typecheck --update
 
       - name: Commit RBI changes
-        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot')
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]')
         env:
           GEM_NAME: ${{ steps.checkout.outputs.gem_name }}
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
@@ -99,10 +99,26 @@ jobs:
           private-key: ${{ secrets.BREW_COMMIT_APP_KEY }}
 
       - name: Push to pull request
-        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot')
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]')
         uses: Homebrew/actions/git-try-push@main
         with:
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
           branch: ${{ steps.checkout.outputs.branch }}
           force: true
+
+      - name: Check vendored gems are in sync
+        if: github.event_name == 'pull_request'
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        run: |
+          status="$(git status --porcelain -- Library/Homebrew/vendor/bundle Library/Homebrew/sorbet)"
+          if [ -n "${status}" ]
+          then
+            {
+              echo "::error::Vendored gems are out of sync with Gemfile.lock."
+              echo "Run 'brew vendor-gems' and 'brew typecheck --update' and commit the changes."
+              echo
+              echo "${status}"
+            } >&2
+            exit 1
+          fi


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

Follow-up to #22065: #22059 merged with its `Gemfile.lock` ahead of the vendored tree because the `vendor-gems.yml` workflow silently no-oped. Root cause: `github.event.pull_request.user.login` is `dependabot[bot]`, not `dependabot`, so the "Check out pull request", "Commit RBI changes" and "Push to pull request" steps added in aaefb351b4 have been skipped on every dependabot PR since. Fix the conditional so the workflow again pushes the regenerated vendor tree back, and add a final `git diff --exit-code` step that fails the check when the vendored tree / RBIs drift from `Gemfile.lock` — so a repeat of #22059 can't merge even if the auto-push ever fails.

Workflow-only change: ran `actionlint .github/workflows/vendor-gems.yml` and `brew style --changed` (both clean); skipped the full `brew lgtm` since there's no Ruby touched. AI (Claude Code) drafted the workflow diff from my description of the bug; I verified `dependabot[bot]` was the actual `user.login` against the GitHub API for PR #22059 before accepting the fix.