### PR TITLE
Reject unsupported API casks earlier

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -114,8 +114,8 @@ module Cask
     def fetch(quiet: nil, timeout: nil)
       odebug "Cask::Installer#fetch"
 
-      load_cask_from_source_api! if cask_from_source_api?
       check_requirements
+      load_cask_from_source_api! if cask_from_source_api?
 
       forbidden_tap_check
       forbidden_cask_and_formula_check
@@ -919,6 +919,7 @@ on_request: true)
     sig { void }
     def enqueue_downloads
       download_queue = @download_queue
+      check_requirements
 
       # FIXME: We need to load Cask source before enqueuing to support
       # language-specific URLs, but this will block the main process.

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -247,6 +247,34 @@ RSpec.describe Cask::Installer, :cask do
       end
     end
 
+    context "when loaded from the api with unsupported requirements" do
+      let(:cask) { Cask::CaskLoader.load(cask_path("with-preflight")) }
+      let(:download_queue) { instance_double(Homebrew::DownloadQueue, enqueue: nil) }
+      let(:macos_requirement) { cask.depends_on.macos }
+
+      before do
+        allow(macos_requirement).to receive(:satisfied?).and_return(false)
+        allow(macos_requirement).to receive(:message).with(type: :cask).and_return("macOS is required")
+        allow(cask).to receive(:loaded_from_api?).and_return(true)
+      end
+
+      it "checks requirements before enqueueing downloads" do
+        expect(Homebrew::API::Cask).not_to receive(:source_download)
+
+        expect do
+          described_class.new(cask, download_queue:).enqueue_downloads
+        end.to raise_error(Cask::CaskError, "macOS is required")
+      end
+
+      it "checks requirements before loading the source cask during fetch" do
+        expect(Homebrew::API::Cask).not_to receive(:source_download_cask)
+
+        expect do
+          described_class.new(cask).fetch
+        end.to raise_error(Cask::CaskError, "macOS is required")
+      end
+    end
+
     it "zap method reinstall cask" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
       described_class.new(caffeine).install


### PR DESCRIPTION
- stop `gimp` on Linux before source reloads fail
- avoid queued downloads for unsupported API-backed casks
- cover `fetch` and `enqueue_downloads` with regression tests

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Used OpenAI Codex xhigh with local review.

-----
