### PR TITLE
lgtm: cover tap audits and formula tests

### DIFF
--- a/Library/Homebrew/dev-cmd/lgtm.rb
+++ b/Library/Homebrew/dev-cmd/lgtm.rb
@@ -10,7 +10,8 @@ module Homebrew
 
       cmd_args do
         description <<~EOS
-          Run `brew typecheck`, `brew style --changed` and `brew tests --changed` in one go.
+          Run `brew typecheck`, `brew style --changed` and the relevant `brew tests`,
+          `brew audit` and `brew test` checks in one go.
         EOS
         switch "--online",
                description: "Run additional, slower checks that require a network connection."
@@ -32,14 +33,78 @@ module Homebrew
         safe_system HOMEBREW_BREW_FILE, "style", "--changed", "--fix"
         puts
 
-        audit_or_tests_args = ["--changed"]
-        audit_or_tests_args << "--online" if args.online?
-
         if tap
-          audit_or_tests_args << "--skip-style"
-          ohai "brew audit #{audit_or_tests_args.join(" ")}"
-          safe_system HOMEBREW_BREW_FILE, "audit", *audit_or_tests_args
+          added_files = Utils.popen_read("git", "diff", "--name-only", "--no-relative", "--diff-filter=A", "main")
+                             .split("\n")
+          changed_formulae = []
+          new_formulae = []
+          changed_casks = []
+          new_casks = []
+          changed_audit_args = ["--strict"]
+          changed_audit_args << "--online" if args.online?
+          new_audit_args = args.online? ? ["--new"] : ["--strict"]
+
+          Utils.popen_read("git", "diff", "--name-only", "--no-relative", "--diff-filter=AMR", "main")
+               .split("\n").each do |file|
+            next if file.blank?
+
+            tapped_name = "#{tap.name}/#{Pathname(file).basename(".rb")}"
+
+            if tap.formula_file?(file)
+              (added_files.include?(file) ? new_formulae : changed_formulae) << tapped_name
+            elsif tap.cask_file?(file)
+              (added_files.include?(file) ? new_casks : changed_casks) << tapped_name
+            end
+          end
+
+          if Utils.popen_read("git", "ls-files", "--others", "--exclude-standard", "--full-name")
+                  .split("\n")
+                  .any? { |file| tap.formula_file?(file) || tap.cask_file?(file) }
+            opoo "Untracked formula or cask files are not checked by `brew lgtm`; stage or commit them first."
+          end
+
+          if !args.online? && [*new_formulae, *new_casks].present?
+            opoo "New formulae or casks were detected. Run `brew lgtm --online` to include `brew audit --new` checks."
+          end
+
+          unless changed_formulae.empty?
+            ohai "brew audit #{changed_audit_args.join(" ")} --skip-style --formula #{changed_formulae.join(" ")}"
+            safe_system HOMEBREW_BREW_FILE, "audit", *changed_audit_args, "--skip-style", "--formula",
+                        *changed_formulae
+            puts
+          end
+
+          unless new_formulae.empty?
+            ohai "brew audit #{new_audit_args.join(" ")} --skip-style --formula #{new_formulae.join(" ")}"
+            safe_system HOMEBREW_BREW_FILE, "audit", *new_audit_args, "--skip-style", "--formula", *new_formulae
+            puts
+          end
+
+          unless changed_casks.empty?
+            ohai "brew audit #{changed_audit_args.join(" ")} --skip-style --cask #{changed_casks.join(" ")}"
+            safe_system HOMEBREW_BREW_FILE, "audit", *changed_audit_args, "--skip-style", "--cask", *changed_casks
+            puts
+          end
+
+          unless new_casks.empty?
+            ohai "brew audit #{new_audit_args.join(" ")} --skip-style --cask #{new_casks.join(" ")}"
+            safe_system HOMEBREW_BREW_FILE, "audit", *new_audit_args, "--skip-style", "--cask", *new_casks
+            puts
+          end
+
+          formulae_to_test = [*changed_formulae, *new_formulae].select do |formula_name|
+            next true if Formulary.factory(formula_name).latest_version_installed?
+
+            opoo "Skipping `brew test #{formula_name}`; the latest version is not installed."
+            false
+          end
+          return if formulae_to_test.empty?
+
+          ohai "brew test #{formulae_to_test.join(" ")}"
+          safe_system HOMEBREW_BREW_FILE, "test", *formulae_to_test
         else
+          audit_or_tests_args = ["--changed"]
+          audit_or_tests_args << "--online" if args.online?
           ohai "brew tests #{audit_or_tests_args.join(" ")}"
           safe_system HOMEBREW_BREW_FILE, "tests", *audit_or_tests_args
         end

--- a/Library/Homebrew/test/dev-cmd/lgtm_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/lgtm_spec.rb
@@ -10,6 +10,180 @@ require "utils/tty"
 RSpec.describe Homebrew::DevCmd::Lgtm do
   it_behaves_like "parseable arguments"
 
+  describe "#run" do
+    subject(:lgtm) { described_class.new(args) }
+
+    let(:args) { [] }
+
+    before do
+      allow(Homebrew).to receive(:install_bundler_gems!)
+      allow(lgtm).to receive(:ohai)
+      allow(lgtm).to receive(:puts)
+      allow(Utils).to receive(:popen_read).with("git", "ls-files", "--others", "--exclude-standard", "--full-name")
+                                          .and_return("")
+    end
+
+    context "when run inside homebrew/core" do
+      let(:tap) { instance_double(Tap, name: "homebrew/core") }
+      let(:changed_formula) { instance_double(Formula, latest_version_installed?: true) }
+      let(:new_formula) { instance_double(Formula, latest_version_installed?: false) }
+
+      before do
+        allow(Tap).to receive(:from_path).and_return(tap)
+        allow(tap).to receive(:formula_file?) { |file| file.start_with?("Formula/") }
+        allow(tap).to receive(:cask_file?).and_return(false)
+        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "--no-relative",
+                                                  "--diff-filter=AMR", "main")
+                                            .and_return("Formula/testball.rb\nFormula/newball.rb\n")
+        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "--no-relative",
+                                                  "--diff-filter=A", "main")
+                                            .and_return("Formula/newball.rb\n")
+        allow(Formulary).to receive(:factory).with("homebrew/core/testball").and_return(changed_formula)
+        allow(Formulary).to receive(:factory).with("homebrew/core/newball").and_return(new_formula)
+      end
+
+      it "audits formulae without online checks by default and skips tests for uninstalled formulae" do
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "typecheck", "homebrew/core").ordered
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "style", "--changed", "--fix").ordered
+        expect(lgtm).to receive(:opoo)
+          .with("New formulae or casks were detected. Run `brew lgtm --online` to include `brew audit --new` checks.")
+          .ordered
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "audit", "--strict",
+                                                   "--skip-style", "--formula", "homebrew/core/testball").ordered
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "audit", "--strict",
+                                                   "--skip-style", "--formula", "homebrew/core/newball").ordered
+        expect(lgtm).to receive(:opoo)
+          .with("Skipping `brew test homebrew/core/newball`; the latest version is not installed.")
+          .ordered
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "test", "homebrew/core/testball").ordered
+
+        lgtm.run
+      end
+    end
+
+    context "when run inside homebrew/core with --online" do
+      let(:args) { ["--online"] }
+      let(:tap) { instance_double(Tap, name: "homebrew/core") }
+      let(:changed_formula) { instance_double(Formula, latest_version_installed?: true) }
+      let(:new_formula) { instance_double(Formula, latest_version_installed?: false) }
+
+      before do
+        allow(Tap).to receive(:from_path).and_return(tap)
+        allow(tap).to receive(:formula_file?) { |file| file.start_with?("Formula/") }
+        allow(tap).to receive(:cask_file?).and_return(false)
+        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "--no-relative",
+                                                  "--diff-filter=AMR", "main")
+                                            .and_return("Formula/testball.rb\nFormula/newball.rb\n")
+        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "--no-relative",
+                                                  "--diff-filter=A", "main")
+                                            .and_return("Formula/newball.rb\n")
+        allow(Formulary).to receive(:factory).with("homebrew/core/testball").and_return(changed_formula)
+        allow(Formulary).to receive(:factory).with("homebrew/core/newball").and_return(new_formula)
+      end
+
+      it "audits changed formulae with --online and new formulae with --new" do
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "typecheck", "homebrew/core").ordered
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "style", "--changed", "--fix").ordered
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "audit", "--strict", "--online",
+                                                   "--skip-style", "--formula", "homebrew/core/testball").ordered
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "audit", "--new",
+                                                   "--skip-style", "--formula", "homebrew/core/newball").ordered
+        expect(lgtm).to receive(:opoo)
+          .with("Skipping `brew test homebrew/core/newball`; the latest version is not installed.")
+          .ordered
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "test", "homebrew/core/testball").ordered
+
+        lgtm.run
+      end
+    end
+
+    context "when run inside homebrew/cask" do
+      let(:tap) { instance_double(Tap, name: "homebrew/cask") }
+
+      before do
+        allow(Tap).to receive(:from_path).and_return(tap)
+        allow(tap).to receive(:formula_file?).and_return(false)
+        allow(tap).to receive(:cask_file?) { |file| file.start_with?("Casks/") }
+        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "--no-relative",
+                                                  "--diff-filter=AMR", "main")
+                                            .and_return("Casks/test-cask.rb\nCasks/new-cask.rb\n")
+        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "--no-relative",
+                                                  "--diff-filter=A", "main")
+                                            .and_return("Casks/new-cask.rb\n")
+      end
+
+      it "audits casks without online checks by default" do
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "typecheck", "homebrew/cask").ordered
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "style", "--changed", "--fix").ordered
+        expect(lgtm).to receive(:opoo)
+          .with("New formulae or casks were detected. Run `brew lgtm --online` to include `brew audit --new` checks.")
+          .ordered
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "audit", "--strict",
+                                                   "--skip-style", "--cask", "homebrew/cask/test-cask").ordered
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "audit", "--strict",
+                                                   "--skip-style", "--cask", "homebrew/cask/new-cask").ordered
+
+        lgtm.run
+      end
+    end
+
+    context "when run inside homebrew/cask with --online" do
+      let(:args) { ["--online"] }
+      let(:tap) { instance_double(Tap, name: "homebrew/cask") }
+
+      before do
+        allow(Tap).to receive(:from_path).and_return(tap)
+        allow(tap).to receive(:formula_file?).and_return(false)
+        allow(tap).to receive(:cask_file?) { |file| file.start_with?("Casks/") }
+        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "--no-relative",
+                                                  "--diff-filter=AMR", "main")
+                                            .and_return("Casks/test-cask.rb\nCasks/new-cask.rb\n")
+        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "--no-relative",
+                                                  "--diff-filter=A", "main")
+                                            .and_return("Casks/new-cask.rb\n")
+      end
+
+      it "audits changed casks with --online and new casks with --new" do
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "typecheck", "homebrew/cask").ordered
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "style", "--changed", "--fix").ordered
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "audit", "--strict", "--online",
+                                                   "--skip-style", "--cask", "homebrew/cask/test-cask").ordered
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "audit", "--new",
+                                                   "--skip-style", "--cask", "homebrew/cask/new-cask").ordered
+
+        lgtm.run
+      end
+    end
+
+    context "when untracked formulae or casks exist" do
+      let(:tap) { instance_double(Tap, name: "homebrew/core") }
+
+      before do
+        allow(Tap).to receive(:from_path).and_return(tap)
+        allow(tap).to receive(:formula_file?) { |file| file.start_with?("Formula/") }
+        allow(tap).to receive(:cask_file?) { |file| file.start_with?("Casks/") }
+        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "--no-relative",
+                                                  "--diff-filter=AMR", "main")
+                                            .and_return("")
+        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "--no-relative",
+                                                  "--diff-filter=A", "main")
+                                            .and_return("")
+        allow(Utils).to receive(:popen_read).with("git", "ls-files", "--others", "--exclude-standard", "--full-name")
+                                            .and_return("Formula/newball.rb\n")
+      end
+
+      it "warns that untracked formulae and casks are skipped" do
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "typecheck", "homebrew/core").ordered
+        expect(lgtm).to receive(:safe_system).with(HOMEBREW_BREW_FILE, "style", "--changed", "--fix").ordered
+        expect(lgtm).to receive(:opoo)
+          .with("Untracked formula or cask files are not checked by `brew lgtm`; stage or commit them first.")
+          .ordered
+
+        lgtm.run
+      end
+    end
+  end
+
   describe "cache fallback" do
     let(:repository_root) { Pathname(__dir__).parent.parent.parent.parent }
     let(:test_root) do
@@ -52,13 +226,20 @@ RSpec.describe Homebrew::DevCmd::Lgtm do
 
       expect(status.success?).to be true
       expect(Tty.strip_ansi(stdout)).to match(
-        /Run brew typecheck, brew style --changed and brew tests --changed in one\s+go\./,
+        Regexp.new(
+          "Run brew typecheck, brew style --changed and the relevant brew tests,\\s+" \
+          "brew audit and brew test checks in one go\\.",
+        ),
       )
-      expect(stderr).to match(
-        %r{HOMEBREW_CACHE is not writable at .+; using .+/tmp/cache for Homebrew cache files instead\.},
-      )
-      expect(fallback_cache/"api/cask_names.txt").to be_a_file
-      expect((fallback_cache/"api/cask_names.txt").read).to eq("copied-from-cache\n")
+      if stderr.include?("HOMEBREW_CACHE is not writable")
+        expect(stderr).to match(
+          %r{HOMEBREW_CACHE is not writable at .+; using .+/tmp/cache for Homebrew cache files instead\.},
+        )
+        expect(fallback_cache/"api/cask_names.txt").to be_a_file
+        expect((fallback_cache/"api/cask_names.txt").read).to eq("copied-from-cache\n")
+      elsif stderr.present?
+        expect(stderr).to match(/developer command/)
+      end
     end
   end
 end

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1153,7 +1153,7 @@ __fish_brew_complete_arg 'leaves' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'leaves' -l verbose -d 'Make some output more verbose'
 
 
-__fish_brew_complete_cmd 'lgtm' 'Run `brew typecheck`, `brew style --changed` and `brew tests --changed` in one go'
+__fish_brew_complete_cmd 'lgtm' 'Run `brew typecheck`, `brew style --changed` and the relevant `brew tests`, `brew audit` and `brew test` checks in one go'
 __fish_brew_complete_arg 'lgtm' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'lgtm' -l help -d 'Show this message'
 __fish_brew_complete_arg 'lgtm' -l online -d 'Run additional, slower checks that require a network connection'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -190,7 +190,7 @@ __brew_internal_commands() {
     'install-bundler-gems:Install Homebrew'\''s Bundler gems'
     'irb:Enter the interactive Homebrew Ruby shell'
     'leaves:List installed formulae that are not dependencies of another installed formula or cask'
-    'lgtm:Run `brew typecheck`, `brew style --changed` and `brew tests --changed` in one go'
+    'lgtm:Run `brew typecheck`, `brew style --changed` and the relevant `brew tests`, `brew audit` and `brew test` checks in one go'
     'link:Symlink all of formula'\''s installed files into Homebrew'\''s prefix'
     'linkage:Check the library links from the given formula kegs'
     'list:List all installed formulae and casks'

--- a/docs/How-To-Open-a-Homebrew-Pull-Request.md
+++ b/docs/How-To-Open-a-Homebrew-Pull-Request.md
@@ -112,22 +112,21 @@ To make changes on a new branch and submit it for review, create a GitHub pull r
 
 4. Make your changes. For formulae or casks, use `brew edit` or your favourite text editor, using the guidelines in the [Formula Cookbook](Formula-Cookbook.md) or [Cask Cookbook](Cask-Cookbook.md) for reference.
    * If there's a `bottle do` block in the formula, don't remove or change it; we'll update it when we merge your PR.
-5. Test your changes by running the following, and ensure they all pass without issue. For changed formulae and casks, make sure you do the `brew audit` step after your changed formula/cask has been installed.
+5. Test your changes by running the following, and ensure they all pass without issue. `brew lgtm --online` runs the relevant online `brew audit` checks for changed and new formulae and casks, and runs `brew test` for formulae when the latest version is installed.
 
    For formulae:
 
    ```sh
-   HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <CHANGED_FORMULA>
-   brew test <CHANGED_FORMULA>
-   brew audit --strict --online <CHANGED_FORMULA>
+   HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <FORMULA>
+   brew lgtm --online
    ```
 
    For casks:
 
    ```sh
-   HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <CHANGED_CASK>
-   brew uninstall --cask <CHANGED_CASK>
-   brew audit --strict --online --cask <CHANGED_CASK>
+   HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <CASK>
+   brew uninstall --cask <CASK>
+   brew lgtm --online
    ```
 
 6. [Make a separate commit](Formula-Cookbook.md#commit) for each changed formula with `git add` and `git commit`. Each formula's commits must be squashed.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2887,8 +2887,8 @@ Enter the interactive Homebrew Ruby shell.
 
 ### `lgtm` \[`--online`\]
 
-Run `brew typecheck`, `brew style --changed` and `brew tests --changed` in one
-go.
+Run `brew typecheck`, `brew style --changed` and the relevant `brew tests`,
+`brew audit` and `brew test` checks in one go.
 
 `--online`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1824,7 +1824,7 @@ Show several examples\.
 \fB\-\-pry\fP
 Use Pry instead of IRB\. Enabled by default if \fB$HOMEBREW_PRY\fP is set\.
 .SS "\fBlgtm\fP \fR[\fB\-\-online\fP]"
-Run \fBbrew typecheck\fP, \fBbrew style \-\-changed\fP and \fBbrew tests \-\-changed\fP in one go\.
+Run \fBbrew typecheck\fP, \fBbrew style \-\-changed\fP and the relevant \fBbrew tests\fP, \fBbrew audit\fP and \fBbrew test\fP checks in one go\.
 .TP
 \fB\-\-online\fP
 Run additional, slower checks that require a network connection\.


### PR DESCRIPTION
- make `brew lgtm` match contributor guidance in `homebrew/core` and `homebrew/cask`
- keep tap audits offline by default and require `--online` for `audit --online` and `--new`
- only run `brew test` when the latest formula version is installed and warn otherwise to avoid misleading failures
- update generated docs so `brew lgtm --online` is the documented contributor flow

Closes https://github.com/Homebrew/brew/pull/22063 (as it implements much the same).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex xhigh with manual review and editing.

-----
