### PR TITLE
bundle: split missing service manager handling

### DIFF
--- a/Library/Homebrew/bundle/brew_services.rb
+++ b/Library/Homebrew/bundle/brew_services.rb
@@ -69,12 +69,16 @@ module Homebrew
           end
 
           sig { returns(T::Array[String]) }
+          def started_services_without_daemon_manager
+            odie Homebrew::Services::System::MISSING_DAEMON_MANAGER_EXCEPTION_MESSAGE
+          end
+
+          sig { returns(T::Array[String]) }
           def started_services
             @started_services ||= T.let(
-              begin
-                if !Homebrew::Services::System.launchctl? && !Homebrew::Services::System.systemctl?
-                  odie Homebrew::Services::System::MISSING_DAEMON_MANAGER_EXCEPTION_MESSAGE
-                end
+              if !Homebrew::Services::System.launchctl? && !Homebrew::Services::System.systemctl?
+                started_services_without_daemon_manager
+              else
                 states_to_skip = %w[stopped none]
 
                 services_list = JSON.parse(Utils.safe_popen_read(HOMEBREW_BREW_FILE, "services", "list", "--json"))
@@ -159,3 +163,5 @@ module Homebrew
     end
   end
 end
+
+require "extend/os/bundle/brew_services"

--- a/Library/Homebrew/extend/os/bundle/brew_services.rb
+++ b/Library/Homebrew/extend/os/bundle/brew_services.rb
@@ -1,0 +1,4 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "extend/os/linux/bundle/brew_services" if OS.linux?

--- a/Library/Homebrew/extend/os/linux/bundle/brew_services.rb
+++ b/Library/Homebrew/extend/os/linux/bundle/brew_services.rb
@@ -1,0 +1,20 @@
+# typed: strict
+# frozen_string_literal: true
+
+module OS
+  module Linux
+    module Bundle
+      module BrewServices
+        module ClassMethods
+          sig { returns(T::Array[String]) }
+          def started_services_without_daemon_manager
+            Homebrew::Bundle::Brew::Services.opoo "Skipping `brew services list` due to missing systemctl"
+            []
+          end
+        end
+      end
+    end
+  end
+end
+
+Homebrew::Bundle::Brew::Services.singleton_class.prepend(OS::Linux::Bundle::BrewServices::ClassMethods)

--- a/Library/Homebrew/test/bundle/brew_services_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_services_spec.rb
@@ -35,12 +35,27 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
       expect(described_class.started_services).to eq([])
     end
 
-    it "exits with error when no daemon manager is available" do
+    it "returns the missing daemon manager fallback when no daemon manager is available" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: false)
+      allow(described_class).to receive(:started_services_without_daemon_manager).and_return([])
+
+      expect(described_class.started_services).to eq([])
+    end
+
+    it "exits with error on macOS when no daemon manager is available", :needs_macos do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: false)
       expect do
         described_class.started_services
       end.to raise_error(SystemExit)
         .and output(/supported only on macOS or Linux/).to_stderr
+    end
+  end
+
+  describe ".started_services_without_daemon_manager" do
+    it "warns and returns an empty array on Linux", :needs_linux do
+      expect do
+        expect(described_class.started_services_without_daemon_manager).to eq([])
+      end.to output(/Skipping `brew services list` due to missing systemctl/).to_stderr
     end
   end
 


### PR DESCRIPTION
- warn and continue when Linux lacks `systemctl`, which is common in containers and other non-systemd environments
- keep macOS failing fast because a missing `launchctl` indicates a broken setup rather than an expected configuration
- cover the shared fallback plus macOS and Linux specific behaviour

Closes https://github.com/Homebrew/brew/pull/21828 (replaces and implements feedback and fixes merge conflicts)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Used OpenAI Codex with manual review and tweaks.

-----
