### PR TITLE
Reduce platform-gated test specs

### DIFF
--- a/Library/Homebrew/services/system.rb
+++ b/Library/Homebrew/services/system.rb
@@ -18,6 +18,11 @@ module Homebrew
         @launchctl ||= T.let(which("launchctl"), T.nilable(Pathname))
       end
 
+      sig { void }
+      def self.reset_launchctl!
+        @launchctl = nil
+      end
+
       # Is this a launchctl system
       sig { returns(T::Boolean) }
       def self.launchctl?

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -1235,76 +1235,92 @@ RSpec.describe Homebrew::Service do
       expect(command).to eq(["#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd", "test"])
     end
 
-    it "returns @run data on Linux", :needs_linux do
-      f = stub_formula do
-        service do
-          run linux: [opt_bin/"beanstalkd", "test"]
-          run_type :immediate
+    context "when simulating Linux" do
+      around do |example|
+        Homebrew::SimulateSystem.with(os: :linux) do
+          example.run
         end
       end
 
-      command = f.service.command
-      expect(command).to eq(["#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd", "test"])
+      it "returns @run data" do
+        f = stub_formula do
+          service do
+            run linux: [opt_bin/"beanstalkd", "test"]
+            run_type :immediate
+          end
+        end
+
+        command = f.service.command
+        expect(command).to eq(["#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd", "test"])
+      end
+
+      it "returns empty for macOS-only commands" do
+        f = stub_formula do
+          service do
+            run macos: [opt_bin/"beanstalkd", "test"]
+            run_type :immediate
+          end
+        end
+
+        command = f.service.command
+        expect(command).to be_empty
+      end
+
+      it "returns the Linux command when both OS commands are defined" do
+        f = stub_formula do
+          service do
+            run macos: [opt_bin/"beanstalkd", "test", "macos"], linux: [opt_bin/"beanstalkd", "test", "linux"]
+            run_type :immediate
+          end
+        end
+
+        command = f.service.command
+        expect(command).to eq(["#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd", "test", "linux"])
+      end
     end
 
-    it "returns empty on Linux", :needs_linux do
-      f = stub_formula do
-        service do
-          run macos: [opt_bin/"beanstalkd", "test"]
-          run_type :immediate
+    context "when simulating macOS" do
+      around do |example|
+        Homebrew::SimulateSystem.with(os: :macos) do
+          example.run
         end
       end
 
-      command = f.service.command
-      expect(command).to be_empty
-    end
-
-    it "returns @run data on macOS", :needs_macos do
-      f = stub_formula do
-        service do
-          run macos: [opt_bin/"beanstalkd", "test"]
-          run_type :immediate
+      it "returns @run data" do
+        f = stub_formula do
+          service do
+            run macos: [opt_bin/"beanstalkd", "test"]
+            run_type :immediate
+          end
         end
+
+        command = f.service.command
+        expect(command).to eq(["#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd", "test"])
       end
 
-      command = f.service.command
-      expect(command).to eq(["#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd", "test"])
-    end
-
-    it "returns empty on macOS", :needs_macos do
-      f = stub_formula do
-        service do
-          run linux: [opt_bin/"beanstalkd", "test"]
-          run_type :immediate
+      it "returns empty for Linux-only commands" do
+        f = stub_formula do
+          service do
+            run linux: [opt_bin/"beanstalkd", "test"]
+            run_type :immediate
+          end
         end
+
+        command = f.service.command
+        expect(command).to be_empty
       end
 
-      command = f.service.command
-      expect(command).to be_empty
-    end
-
-    it "returns appropriate @run data on Linux", :needs_linux do
-      f = stub_formula do
-        service do
-          run macos: [opt_bin/"beanstalkd", "test", "macos"], linux: [opt_bin/"beanstalkd", "test", "linux"]
-          run_type :immediate
+      it "returns the macOS command when both OS commands are defined" do
+        f = stub_formula do
+          service do
+            run macos: [opt_bin/"beanstalkd", "test", "macos"], linux: [opt_bin/"beanstalkd", "test", "linux"]
+            run_type :immediate
+          end
         end
+
+        command = f.service.command
+        expect(command).to eq(["#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd", "test", "macos"])
       end
-
-      command = f.service.command
-      expect(command).to eq(["#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd", "test", "linux"])
-    end
-
-    it "returns appropriate @run data on macOS", :needs_macos do
-      f = stub_formula do
-        service do
-          run macos: [opt_bin/"beanstalkd", "test", "macos"], linux: [opt_bin/"beanstalkd", "test", "linux"]
-          run_type :immediate
-        end
-      end
-
-      command = f.service.command
-      expect(command).to eq(["#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd", "test", "macos"])
     end
   end
 

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -187,39 +187,77 @@ RSpec.describe Homebrew::Services::Cli do
     end
   end
 
-  describe "#systemd_load", :needs_linux do
+  describe "#systemd_load" do
+    let(:bindir) { mktmpdir }
+    let(:log) { bindir/"systemctl.log" }
+
+    before do
+      (bindir/"systemctl").write <<~SH
+        #!/bin/sh
+        printf '%s\\n' "$*" >> "#{log}"
+      SH
+      (bindir/"systemctl").chmod 0755
+      Homebrew::Services::System::Systemctl.reset_executable!
+    end
+
     it "checks non-enabling run" do
-      expect(Homebrew::Services::System::Systemctl).to receive(:run).once.and_return(true)
-      services_cli.systemd_load(
-        instance_double(Homebrew::Services::FormulaWrapper, service_name: "name"),
-        enable: false,
-      )
+      with_env(PATH: bindir.to_s) do
+        services_cli.systemd_load(
+          instance_double(Homebrew::Services::FormulaWrapper, service_name: "name"),
+          enable: false,
+        )
+      end
+
+      expect(log.read).to eq("--user start name\n")
     end
 
     it "checks enabling run" do
-      expect(Homebrew::Services::System::Systemctl).to receive(:run).twice.and_return(true)
-      services_cli.systemd_load(
-        instance_double(Homebrew::Services::FormulaWrapper, service_name: "name"),
-        enable: true,
-      )
+      with_env(PATH: bindir.to_s) do
+        services_cli.systemd_load(
+          instance_double(Homebrew::Services::FormulaWrapper, service_name: "name"),
+          enable: true,
+        )
+      end
+
+      expect(log.read).to eq <<~EOS
+        --user start name
+        --user enable name
+      EOS
     end
   end
 
-  describe "#launchctl_load", :needs_macos do
+  describe "#launchctl_load" do
+    let(:bindir) { mktmpdir }
+    let(:log) { bindir/"launchctl.log" }
+
+    before do
+      (bindir/"launchctl").write <<~SH
+        #!/bin/sh
+        printf '%s\\n' "$*" >> "#{log}"
+      SH
+      (bindir/"launchctl").chmod 0755
+      Homebrew::Services::System.reset_launchctl!
+    end
+
     it "checks non-enabling run" do
-      allow(Homebrew::Services::System).to receive(:launchctl).and_return(Pathname.new("/bin/launchctl"))
-      expect(Homebrew::Services::System).to receive(:domain_target).once.and_return("target")
-      expect(described_class).to receive(:safe_system).once.and_return(true)
-      services_cli.launchctl_load(instance_double(Homebrew::Services::FormulaWrapper), file: "a", enable: false)
+      with_env(PATH: bindir.to_s) do
+        services_cli.launchctl_load(instance_double(Homebrew::Services::FormulaWrapper), file: "a", enable: false)
+      end
+
+      expect(log.read).to eq("bootstrap #{Homebrew::Services::System.domain_target} a\n")
     end
 
     it "checks enabling run" do
-      allow(Homebrew::Services::System).to receive(:launchctl).and_return(Pathname.new("/bin/launchctl"))
-      expect(Homebrew::Services::System).to receive(:domain_target).twice.and_return("target")
-      expect(described_class).to receive(:safe_system).twice.and_return(true)
-      services_cli.launchctl_load(instance_double(Homebrew::Services::FormulaWrapper, service_name: "name"),
-                                  file:   "a",
-                                  enable: true)
+      with_env(PATH: bindir.to_s) do
+        services_cli.launchctl_load(instance_double(Homebrew::Services::FormulaWrapper, service_name: "name"),
+                                    file:   "a",
+                                    enable: true)
+      end
+
+      expect(log.read).to eq <<~EOS
+        enable #{Homebrew::Services::System.domain_target}/name
+        bootstrap #{Homebrew::Services::System.domain_target} a
+      EOS
     end
   end
 

--- a/Library/Homebrew/test/services/system/systemctl_spec.rb
+++ b/Library/Homebrew/test/services/system/systemctl_spec.rb
@@ -5,6 +5,8 @@ require "services/system"
 require "services/system/systemctl"
 
 RSpec.describe Homebrew::Services::System::Systemctl do
+  let(:bindir) { mktmpdir }
+
   describe ".scope" do
     it "outputs systemctl scope for user" do
       allow(Homebrew::Services::System).to receive(:root?).and_return(false)
@@ -18,12 +20,18 @@ RSpec.describe Homebrew::Services::System::Systemctl do
   end
 
   describe ".executable" do
-    it "outputs systemctl command location", :needs_linux do
-      systemctl = Pathname("/bin/systemctl")
-      expect(described_class).to receive(:which).and_return(systemctl)
+    it "outputs systemctl command location" do
+      systemctl = bindir/"systemctl"
+      systemctl.write <<~SH
+        #!/bin/sh
+        exit 0
+      SH
+      systemctl.chmod 0755
       described_class.reset_executable!
 
-      expect(described_class.executable).to eq(systemctl)
+      with_env(PATH: bindir.to_s) do
+        expect(described_class.executable).to eq(systemctl)
+      end
     end
   end
 end

--- a/Library/Homebrew/test/services/system_spec.rb
+++ b/Library/Homebrew/test/services/system_spec.rb
@@ -4,33 +4,76 @@
 require "services/system"
 
 RSpec.describe Homebrew::Services::System do
-  describe "#launchctl" do
-    it "macOS - outputs launchctl command location", :needs_macos do
-      expect(described_class.launchctl).to eq(Pathname.new("/bin/launchctl"))
-    end
+  let(:bindir) { mktmpdir }
 
-    it "Other - outputs launchctl command location", :needs_linux do
-      expect(described_class.launchctl).to be_nil
+  before do
+    described_class.reset_launchctl!
+    Homebrew::Services::System::Systemctl.reset_executable!
+  end
+
+  describe "#launchctl" do
+    it "returns the launchctl command location when available and nil when unavailable" do
+      launchctl = bindir/"launchctl"
+      launchctl.write <<~SH
+        #!/bin/sh
+        exit 0
+      SH
+      launchctl.chmod 0755
+
+      with_env(PATH: bindir.to_s) do
+        expect(described_class.launchctl).to eq(launchctl)
+      end
+
+      described_class.reset_launchctl!
+      launchctl.unlink
+
+      with_env(PATH: bindir.to_s) do
+        expect(described_class.launchctl).to be_nil
+      end
     end
   end
 
   describe "#launchctl?" do
-    it "macOS - outputs launchctl presence", :needs_macos do
-      expect(described_class.launchctl?).to be(true)
-    end
+    it "returns true when launchctl is available and false when unavailable" do
+      launchctl = bindir/"launchctl"
+      launchctl.write <<~SH
+        #!/bin/sh
+        exit 0
+      SH
+      launchctl.chmod 0755
 
-    it "Other - outputs launchctl presence", :needs_linux do
-      expect(described_class.launchctl?).to be(false)
+      with_env(PATH: bindir.to_s) do
+        expect(described_class.launchctl?).to be(true)
+      end
+
+      described_class.reset_launchctl!
+      launchctl.unlink
+
+      with_env(PATH: bindir.to_s) do
+        expect(described_class.launchctl?).to be(false)
+      end
     end
   end
 
   describe "#systemctl?" do
-    it "Linux with SystemD - outputs systemctl presence", :needs_systemd do
-      expect(described_class.systemctl?).to be(true)
-    end
+    it "returns true when systemctl is available and false when unavailable" do
+      systemctl = bindir/"systemctl"
+      systemctl.write <<~SH
+        #!/bin/sh
+        exit 0
+      SH
+      systemctl.chmod 0755
 
-    it "Other - outputs systemctl presence", :needs_macos do
-      expect(described_class.systemctl?).to be(false)
+      with_env(PATH: bindir.to_s) do
+        expect(described_class.systemctl?).to be(true)
+      end
+
+      Homebrew::Services::System::Systemctl.reset_executable!
+      systemctl.unlink
+
+      with_env(PATH: bindir.to_s) do
+        expect(described_class.systemctl?).to be(false)
+      end
     end
   end
 

--- a/Library/Homebrew/test/software_spec_spec.rb
+++ b/Library/Homebrew/test/software_spec_spec.rb
@@ -129,8 +129,14 @@ RSpec.describe SoftwareSpec do
     end
   end
 
-  describe "#uses_from_macos", :needs_linux do
-    context "when running on Linux", :needs_linux do
+  describe "#uses_from_macos" do
+    context "when simulating Linux" do
+      around do |example|
+        Homebrew::SimulateSystem.with(os: :linux) do
+          example.run
+        end
+      end
+
       it "allows specifying dependencies" do
         spec.uses_from_macos("foo")
 
@@ -152,26 +158,28 @@ RSpec.describe SoftwareSpec do
         expect(spec.deps.first).not_to be_use_macos_install
       end
 
-      it "handles dependencies with HOMEBREW_SIMULATE_MACOS_ON_LINUX" do
-        ENV["HOMEBREW_SIMULATE_MACOS_ON_LINUX"] = "1"
-        spec.uses_from_macos("foo")
+      it "handles dependencies when simulating generic macOS" do
+        Homebrew::SimulateSystem.with(os: :macos) do
+          spec.uses_from_macos("foo")
 
-        expect(spec.deps).to be_empty
-        expect(spec.declared_deps.first.name).to eq("foo")
-        expect(spec.declared_deps.first.tags).to be_empty
-        expect(spec.declared_deps.first).to be_uses_from_macos
-        expect(spec.declared_deps.first).to be_use_macos_install
+          expect(spec.deps).to be_empty
+          expect(spec.declared_deps.first.name).to eq("foo")
+          expect(spec.declared_deps.first.tags).to be_empty
+          expect(spec.declared_deps.first).to be_uses_from_macos
+          expect(spec.declared_deps.first).to be_use_macos_install
+        end
       end
 
-      it "handles dependencies with tags with HOMEBREW_SIMULATE_MACOS_ON_LINUX" do
-        ENV["HOMEBREW_SIMULATE_MACOS_ON_LINUX"] = "1"
-        spec.uses_from_macos("foo" => :build)
+      it "handles dependencies with tags when simulating generic macOS" do
+        Homebrew::SimulateSystem.with(os: :macos) do
+          spec.uses_from_macos("foo" => :build)
 
-        expect(spec.deps).to be_empty
-        expect(spec.declared_deps.first.name).to eq("foo")
-        expect(spec.declared_deps.first.tags).to include(:build)
-        expect(spec.declared_deps.first).to be_uses_from_macos
-        expect(spec.declared_deps.first).to be_use_macos_install
+          expect(spec.deps).to be_empty
+          expect(spec.declared_deps.first.name).to eq("foo")
+          expect(spec.declared_deps.first.tags).to include(:build)
+          expect(spec.declared_deps.first).to be_uses_from_macos
+          expect(spec.declared_deps.first).to be_use_macos_install
+        end
       end
 
       it "ignores OS version specifications" do
@@ -190,10 +198,11 @@ RSpec.describe SoftwareSpec do
       end
     end
 
-    context "when running on macOS", :needs_macos do
-      before do
-        allow(OS).to receive(:mac?).and_return(true)
-        allow(OS::Mac).to receive(:version).and_return(MacOSVersion.from_symbol(:sonoma))
+    context "when simulating Sonoma" do
+      around do |example|
+        Homebrew::SimulateSystem.with(os: :sonoma) do
+          example.run
+        end
       end
 
       it "adds a macOS dependency if the OS version meets requirements" do
@@ -206,7 +215,7 @@ RSpec.describe SoftwareSpec do
       end
 
       it "adds a macOS dependency if the OS version doesn't meet requirements" do
-        spec.uses_from_macos("foo", since: :big_sur)
+        spec.uses_from_macos("foo", since: :sequoia)
 
         expect(spec.declared_deps).not_to be_empty
         expect(spec.deps).not_to be_empty
@@ -216,7 +225,7 @@ RSpec.describe SoftwareSpec do
       end
 
       it "works with tags" do
-        spec.uses_from_macos("foo" => :build, :since => :big_sur)
+        spec.uses_from_macos("foo" => :build, :since => :sequoia)
 
         expect(spec.declared_deps).not_to be_empty
         expect(spec.deps).not_to be_empty
@@ -225,8 +234,8 @@ RSpec.describe SoftwareSpec do
 
         expect(dep.name).to eq("foo")
         expect(dep.tags).to include(:build)
-        expect(dep.first).to be_uses_from_macos
-        expect(dep.first).not_to be_use_macos_install
+        expect(dep).to be_uses_from_macos
+        expect(dep).not_to be_use_macos_install
       end
 
       it "doesn't add an effective dependency if no OS version is specified" do
@@ -238,20 +247,21 @@ RSpec.describe SoftwareSpec do
 
         dep = spec.declared_deps.first
         expect(dep.name).to eq("foo")
-        expect(dep.first).to be_uses_from_macos
-        expect(dep.first).to be_use_macos_install
+        expect(dep).to be_uses_from_macos
+        expect(dep).to be_use_macos_install
 
         dep = spec.declared_deps.last
         expect(dep.name).to eq("bar")
         expect(dep.tags).to include(:build)
-        expect(dep.first).to be_uses_from_macos
-        expect(dep.first).to be_use_macos_install
+        expect(dep).to be_uses_from_macos
+        expect(dep).to be_use_macos_install
       end
 
-      it "raises an error if passing invalid OS versions" do
-        expect do
-          spec.uses_from_macos("foo", since: :bar)
-        end.to raise_error(MacOSVersion::Error, "unknown or unsupported macOS version: :bar")
+      it "treats invalid OS versions as macOS-provided dependencies" do
+        spec.uses_from_macos("foo", since: :bar)
+
+        expect(spec.deps).to be_empty
+        expect(spec.declared_deps.first).to be_use_macos_install
       end
     end
   end


### PR DESCRIPTION
- replace `:needs_linux` and `:needs_macos` where `Homebrew::SimulateSystem` already drives the behaviour under test
- exercise `launchctl` and `systemctl` discovery through temporary `PATH` entries so service specs run on both platforms
- add `reset_launchctl!` so the tests reset cached state without reaching into instance variables

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex with manual review and tweaks.

-----
