### PR TITLE
Prepare for opt-in HOMEBREW_SBOM

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -482,6 +482,12 @@ module Homebrew
         description: "If set, use Pry for the `brew irb` command.",
         boolean:     true,
       },
+      HOMEBREW_SBOM:                             {
+        # odeprecated: edit in 5.2.0
+        description: "If set, Homebrew will write SBOM files and run SBOM-related installation logic. " \
+                     "This is a no-op until Homebrew 5.2.0, when it will become required for that behaviour.",
+        boolean:     true,
+      },
       HOMEBREW_SIMULATE_MACOS_ON_LINUX:          {
         description: "If set, running Homebrew on Linux will simulate certain macOS code paths. This is useful " \
                      "when auditing macOS formulae while on Linux.",

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -22,6 +22,7 @@ require "deprecate_disable"
 require "unlink"
 require "service"
 require "attestation"
+# odeprecated: load lazily in 5.2.0 when `HOMEBREW_SBOM` is required
 require "sbom"
 require "utils/fork"
 require "utils/output"
@@ -1004,6 +1005,7 @@ on_request: installed_on_request?, options:)
     tab.runtime_dependencies = Tab.runtime_deps_hash(formula, f_runtime_deps)
     tab.write
 
+    # odeprecated: require `HOMEBREW_SBOM` in 5.2.0
     # write/update a SBOM file (if we aren't bottling)
     unless build_bottle?
       sbom = SBOM.create(formula, tab)

--- a/Library/Homebrew/test_bot.rb
+++ b/Library/Homebrew/test_bot.rb
@@ -73,6 +73,7 @@ module Homebrew
       ENV["HOMEBREW_GIT"] = ENV["HOMEBREW_GIT_PATH"] = GIT
       ENV["HOMEBREW_DISALLOW_LIBNSL1"] = "1"
       ENV["HOMEBREW_NO_ENV_HINTS"] = "1"
+      ENV["HOMEBREW_SBOM"] = "1"
       ENV["HOMEBREW_PATH"] = ENV["PATH"] =
         "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV.fetch("PATH")}"
 


### PR DESCRIPTION
This functionality is not widely used and it's relatively slow. Let's make it an opt-in for those who need it in 5.2.0.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex with several rounds of local tweaking and review.

-----
