### PR TITLE
Silence short name core/cask migration warning

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -301,6 +301,14 @@ module Cask
 
         return unless (token_tap_type = CaskLoader.tap_cask_token_type(ref, warn:))
 
+        loader_from_token_tap_type(token_tap_type)
+      end
+
+      sig {
+        params(token_tap_type: [String, Tap, T.nilable(Symbol)])
+          .returns(T.nilable(T.any(T.attached_class, FromAPILoader)))
+      }
+      def self.loader_from_token_tap_type(token_tap_type)
         token, tap, type = token_tap_type
 
         if type == :migration && tap.core_cask_tap? && (loader = FromAPILoader.try_new(token))
@@ -550,6 +558,8 @@ module Cask
     # Loader which tries loading casks from tap paths, failing
     # if the same token exists in multiple taps.
     class FromNameLoader < FromTapLoader
+      extend ::Utils::Output::Mixin
+
       sig {
         override.params(ref: T.any(String, Pathname, Cask, URI::Generic), warn: T::Boolean)
                 .returns(T.nilable(T.any(T.attached_class, FromAPILoader)))
@@ -558,12 +568,23 @@ module Cask
         return unless ref.is_a?(String)
         return unless ref.match?(/\A#{HOMEBREW_TAP_CASK_TOKEN_REGEX}\Z/o)
 
-        token = ref
+        token = ref.downcase
 
         # If it exists in the default tap, never treat it as ambiguous with another tap.
-        if (core_cask_tap = CoreCaskTap.instance).installed? &&
-           (core_cask_loader = super("#{core_cask_tap}/#{token}", warn:))&.path&.exist?
-          return core_cask_loader
+        if (core_cask_tap = CoreCaskTap.instance).installed? && (token_tap_type = CaskLoader.tap_cask_token_type(
+          "#{core_cask_tap}/#{token}", warn: false
+        ))
+          migrated_token, migrated_tap, type = token_tap_type
+
+          if warn && [:rename, :migration].include?(type) &&
+             !(type == :migration && migrated_tap.core_tap?)
+            opoo "Cask #{token} was renamed to " \
+                 "#{migrated_tap.core_cask_tap? ? migrated_token : "#{migrated_tap}/#{migrated_token}"}."
+          end
+
+          if (core_cask_loader = loader_from_token_tap_type(token_tap_type))&.path&.exist?
+            return core_cask_loader
+          end
         end
 
         loaders = Tap.select { |tap| tap.installed? && !tap.core_cask_tap? }

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -678,6 +678,13 @@ module Formulary
 
       return unless (name_tap_type = Formulary.tap_formula_name_type(ref, warn:))
 
+      loader_from_name_tap_type(ref, name_tap_type)
+    end
+
+    sig {
+      params(ref: String, name_tap_type: [String, Tap, T.nilable(Symbol)]).returns(T.nilable(T.attached_class))
+    }
+    def self.loader_from_name_tap_type(ref, name_tap_type)
       name, tap, type = name_tap_type
       path = Formulary.find_formula_in_tap(name, tap)
 
@@ -731,6 +738,8 @@ module Formulary
 
   # Loads a formula from a name, as long as it exists only in a single tap.
   class FromNameLoader < FromTapLoader
+    extend ::Utils::Output::Mixin
+
     sig {
       override.params(ref: T.any(String, Pathname, URI::Generic), from: T.nilable(Symbol), warn: T::Boolean)
               .returns(T.nilable(T.attached_class))
@@ -739,12 +748,23 @@ module Formulary
       return unless ref.is_a?(String)
       return unless ref.match?(/\A#{HOMEBREW_TAP_FORMULA_NAME_REGEX}\Z/o)
 
-      name = ref
+      name = ref.downcase
 
       # If it exists in the default tap, never treat it as ambiguous with another tap.
-      if (core_tap = CoreTap.instance).installed? &&
-         (core_loader = super("#{core_tap}/#{name}", warn:))&.path&.exist?
-        return core_loader
+      if (core_tap = CoreTap.instance).installed? && (name_tap_type = Formulary.tap_formula_name_type(
+        "#{core_tap}/#{name}", warn: false
+      ))
+        migrated_name, migrated_tap, type = name_tap_type
+
+        if warn && [:rename, :migration].include?(type) &&
+           !(type == :migration && migrated_tap.core_cask_tap?)
+          opoo "Formula #{name} was renamed to " \
+               "#{migrated_tap.core_tap? ? migrated_name : "#{migrated_tap}/#{migrated_name}"}."
+        end
+
+        if (core_loader = loader_from_name_tap_type("#{core_tap}/#{name}", name_tap_type))&.path&.exist?
+          return core_loader
+        end
       end
 
       loaders = Tap.select { |tap| tap.installed? && !tap.core_tap? }

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -101,6 +101,12 @@ RSpec.describe Cask::CaskLoader, :cask do
             end.to output(%r{Cask #{old_tap}/#{token} was renamed to #{new_tap}/#{token}\.}).to_stderr
           end
 
+          it "warns with the canonical token when loading an uppercase short token" do
+            expect do
+              described_class.for(token.upcase)
+            end.to output(%r{Cask #{old_tap}/#{token} was renamed to #{new_tap}/#{token}\.}).to_stderr
+          end
+
           it "does not warn when loading the full token in the new tap" do
             expect do
               described_class.for("#{new_tap}/#{token}")
@@ -134,12 +140,10 @@ RSpec.describe Cask::CaskLoader, :cask do
             FileUtils.touch formula_file
           end
 
-          it "warn only once" do
+          it "does not warn when loading the short token" do
             expect do
               described_class.for(token)
-            end.to output(
-              a_string_including("Warning: Cask #{token} was renamed to #{new_tap}/#{token}.").once,
-            ).to_stderr
+            end.not_to output.to_stderr
           end
         end
 

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -811,12 +811,10 @@ RSpec.describe Formulary do
             FileUtils.touch cask_file
           end
 
-          it "warn only once" do
+          it "does not warn when loading the short token" do
             expect do
               described_class.loader_for(token)
-            end.to output(
-              a_string_including("Warning: Formula #{token} was renamed to #{new_tap}/#{token}.").once,
-            ).to_stderr
+            end.not_to output.to_stderr
           end
         end
 
@@ -886,6 +884,14 @@ RSpec.describe Formulary do
           it "warns when loading the short token" do
             expect do
               described_class.loader_for(token)
+            end.to output(
+              a_string_including("Formula #{old_tap}/#{token} was renamed to #{new_tap}/#{token}.").once,
+            ).to_stderr
+          end
+
+          it "warns with the canonical token when loading an uppercase short token" do
+            expect do
+              described_class.loader_for(token.upcase)
             end.to output(
               a_string_including("Formula #{old_tap}/#{token} was renamed to #{new_tap}/#{token}.").once,
             ).to_stderr


### PR DESCRIPTION
- avoid warning on short-token moves between `homebrew/core` and `homebrew/cask`
- keep rename warnings for other migrations so explicit tap changes still stay visible

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Used OpenAI Codex with local review and testing.

-----
