### PR TITLE
cask: implement Linux freedesktop trash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,4 @@ When running commands in this repository, use `./bin/brew` (not a system `brew` 
 7. Keep diffs as minimal as possible.
 8. Prefer shelling out via `HOMEBREW_BREW_FILE` instead of requiring `cmd/` or `dev-cmd` when composing brew commands.
 9. Inline new or existing methods as methods or local variables unless they are reused 2+ times or needed for unit tests.
+10. Keep `extend/os/*` prepends as thin as possible; put the `prepend` in the OS-specific `linux` or `macos` file rather than the shared `extend/os/*` loader with an inline `if`, and prefer putting substantive logic in shared code outside `extend/` when practical so it can be tested on all platforms instead of relying on `:needs_linux` or `:needs_macos` specs.

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -6,6 +6,7 @@ require "timeout"
 require "utils/user"
 require "cask/artifact/abstract_artifact"
 require "cask/pkg"
+require "cask/utils/trash"
 require "extend/hash/keys"
 require "system_command"
 
@@ -521,27 +522,7 @@ module Cask
       def trash_paths(*paths, command: nil, **_kwargs)
         return if paths.empty?
 
-        stdout = system_command(HOMEBREW_LIBRARY_PATH/"cask/utils/trash.swift",
-                                args:         paths,
-                                print_stderr: Homebrew::EnvConfig.developer?).stdout
-
-        trashed, _, untrashable = stdout.partition("\n")
-        trashed = trashed.split(":")
-        untrashable = untrashable.split(":")
-
-        trashed_with_permissions, untrashable = untrashable.partition do |path|
-          Utils.gain_permissions(Pathname(path), ["-R"], SystemCommand) do
-            system_command! HOMEBREW_LIBRARY_PATH/"cask/utils/trash.swift",
-                            args:         [path],
-                            print_stderr: Homebrew::EnvConfig.developer?
-          end
-
-          true
-        rescue
-          false
-        end
-
-        trashed += trashed_with_permissions
+        trashed, untrashable = ::Cask::Utils::Trash.trash(*paths, command:)
 
         return trashed, untrashable if untrashable.empty?
 

--- a/Library/Homebrew/cask/utils/trash.rb
+++ b/Library/Homebrew/cask/utils/trash.rb
@@ -1,0 +1,122 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "cask/utils"
+require "fileutils"
+require "system_command"
+require "uri"
+
+module Cask
+  module Utils
+    module Trash
+      extend SystemCommand::Mixin
+
+      sig {
+        params(paths: Pathname, command: T.nilable(T.class_of(SystemCommand)))
+          .returns([T::Array[String], T::Array[String]])
+      }
+      def self.trash(*paths, command: nil)
+        swift_trash(*paths, command:)
+      end
+
+      sig {
+        params(paths: Pathname, command: T.nilable(T.class_of(SystemCommand)))
+          .returns([T::Array[String], T::Array[String]])
+      }
+      def self.swift_trash(*paths, command: nil)
+        return [[], []] if paths.empty?
+
+        stdout = system_command(HOMEBREW_LIBRARY_PATH/"cask/utils/trash.swift",
+                                args:         paths,
+                                print_stderr: Homebrew::EnvConfig.developer?).stdout
+
+        trashed, _, untrashable = stdout.partition("\n")
+        trashed = trashed.split(":")
+        untrashable = untrashable.split(":")
+
+        trashed_with_permissions, untrashable = untrashable.partition do |path|
+          Utils.gain_permissions(Pathname(path), ["-R"], SystemCommand) do
+            system_command! HOMEBREW_LIBRARY_PATH/"cask/utils/trash.swift",
+                            args:         [path],
+                            print_stderr: Homebrew::EnvConfig.developer?
+          end
+
+          true
+        rescue
+          false
+        end
+
+        [trashed + trashed_with_permissions, untrashable]
+      end
+
+      sig { params(paths: Pathname).returns([T::Array[String], T::Array[String]]) }
+      def self.freedesktop_trash(*paths)
+        return [[], []] if paths.empty?
+
+        files_path = home_trash_path/"files"
+        info_path = home_trash_path/"info"
+
+        files_path.mkpath
+        info_path.mkpath
+
+        trashed, untrashable = paths.partition do |path|
+          trash_path(path, files_path:, info_path:)
+          true
+        rescue
+          false
+        end
+
+        [trashed.map(&:to_s), untrashable.map(&:to_s)]
+      end
+
+      sig { returns(Pathname) }
+      def self.home_trash_path
+        Pathname.new(ENV["XDG_DATA_HOME"].presence || "#{Dir.home}/.local/share")/"Trash"
+      end
+      private_class_method :home_trash_path
+
+      sig { params(path: Pathname, files_path: Pathname, info_path: Pathname).void }
+      def self.trash_path(path, files_path:, info_path:)
+        basename = path.basename.to_s
+        deletion_date = Time.now.strftime("%Y-%m-%dT%H:%M:%S")
+        suffix = 0
+
+        Kernel.loop do
+          candidate = suffix.zero? ? basename : "#{basename}.#{suffix}"
+          target_path = files_path/candidate
+          target_info_path = info_path/"#{candidate}.trashinfo"
+
+          if target_path.exist? || target_path.symlink?
+            suffix += 1
+            next
+          end
+
+          begin
+            File.open(target_info_path, File::WRONLY | File::CREAT | File::EXCL, 0600) do |file|
+              file.write <<~EOS
+                [Trash Info]
+                Path=#{URI::DEFAULT_PARSER.escape(path.to_s)}
+                DeletionDate=#{deletion_date}
+              EOS
+            end
+          rescue Errno::EEXIST
+            suffix += 1
+            next
+          end
+
+          begin
+            FileUtils.mv(path, target_path)
+          rescue
+            target_info_path.delete if target_info_path.exist?
+            Kernel.raise
+          end
+
+          return
+        end
+      end
+      private_class_method :swift_trash, :freedesktop_trash, :trash_path
+    end
+  end
+end
+
+require "extend/os/cask/utils/trash"

--- a/Library/Homebrew/extend/os/cask/utils/trash.rb
+++ b/Library/Homebrew/extend/os/cask/utils/trash.rb
@@ -1,0 +1,4 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "extend/os/linux/cask/utils/trash" if OS.linux?

--- a/Library/Homebrew/extend/os/linux/cask/utils/trash.rb
+++ b/Library/Homebrew/extend/os/linux/cask/utils/trash.rb
@@ -1,0 +1,24 @@
+# typed: strict
+# frozen_string_literal: true
+
+module OS
+  module Linux
+    module Cask
+      module Utils
+        module Trash
+          module ClassMethods
+            sig {
+              params(paths: Pathname, command: T.nilable(T.class_of(SystemCommand)))
+                .returns([T::Array[String], T::Array[String]])
+            }
+            def trash(*paths, command: nil)
+              freedesktop_trash(*paths)
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+Cask::Utils::Trash.singleton_class.prepend(OS::Linux::Cask::Utils::Trash::ClassMethods)

--- a/Library/Homebrew/test/cask/utils/trash_spec.rb
+++ b/Library/Homebrew/test/cask/utils/trash_spec.rb
@@ -1,0 +1,68 @@
+# typed: false
+# frozen_string_literal: true
+
+require "cask/utils/trash"
+
+RSpec.describe Cask::Utils::Trash do
+  describe "::trash" do
+    let(:path) { Pathname("/tmp/example") }
+
+    it "uses the Swift trash implementation on macOS" do
+      expect(described_class).to receive(:swift_trash)
+        .with(path, command: nil)
+        .and_return([[path.to_s], []])
+
+      expect(described_class.trash(path)).to eq([[path.to_s], []])
+    end
+  end
+
+  describe "::swift_trash" do
+    let(:path) { Pathname("/tmp/example") }
+    let(:system_command_result) { instance_double(SystemCommand::Result, stdout: "#{path}\n") }
+
+    it "uses the Swift helper on macOS" do
+      expect(described_class).to receive(:system_command)
+        .with(HOMEBREW_LIBRARY_PATH/"cask/utils/trash.swift",
+              args:         [path],
+              print_stderr: Homebrew::EnvConfig.developer?)
+        .and_return(system_command_result)
+
+      expect(described_class.send(:swift_trash, path)).to eq([[path.to_s], []])
+    end
+  end
+
+  describe "::freedesktop_trash" do
+    let(:deletion_time) { Time.local(2026, 4, 25, 13, 14, 15) }
+    let(:xdg_data_home) { mktmpdir/"xdg-data" }
+    let(:trash_path) { xdg_data_home/"Trash" }
+    let(:files_path) { trash_path/"files" }
+    let(:info_path) { trash_path/"info" }
+    let(:path) { mktmpdir/"folder with spaces"/"example file.txt" }
+
+    around do |example|
+      old_xdg_data_home = ENV.fetch("XDG_DATA_HOME", nil)
+      ENV["XDG_DATA_HOME"] = xdg_data_home.to_s
+      example.run
+    ensure
+      ENV["XDG_DATA_HOME"] = old_xdg_data_home
+    end
+
+    it "moves files into the XDG trash and writes a trashinfo file" do
+      path.dirname.mkpath
+      path.write("example")
+      allow(Time).to receive(:now).and_return(deletion_time)
+
+      trashed, untrashable = described_class.send(:freedesktop_trash, path)
+
+      expect(path).not_to exist
+      expect(trashed).to eq([path.to_s])
+      expect(untrashable).to be_empty
+      expect((files_path/"example file.txt").read).to eq("example")
+      expect((info_path/"example file.txt.trashinfo").read).to eq(<<~EOS)
+        [Trash Info]
+        Path=#{URI::DEFAULT_PARSER.escape(path.to_s)}
+        DeletionDate=2026-04-25T13:14:15
+      EOS
+    end
+  end
+end


### PR DESCRIPTION
- keep `trash` behind a shared helper so OS-specific behaviour stays in one place
- use the existing Swift helper on macOS and the freedesktop home trash layout on Linux so `zap trash:` actually trashes files

Fixes https://github.com/Homebrew/brew/issues/22082

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Used OpenAI Codex with multiple local tweaks.

-----
