### PR TITLE
upgrade: ignore failed shared prefetches

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -174,12 +174,13 @@ module Homebrew
 
         formulae = Homebrew::Attestation.sort_formulae_for_install(formulae) if Homebrew::Attestation.enabled?
 
+        formulae_prefetched = T.let(false, T::Boolean)
         prefetched_casks = T.let(false, T::Boolean)
         shared_download_queue = T.let(nil, T.nilable(Homebrew::DownloadQueue))
         if !args.dry_run? && !only_upgrade_formulae && !only_upgrade_casks
           shared_download_queue = Homebrew::DownloadQueue.new(pour: true)
           begin
-            upgrade_outdated_formulae!(
+            formulae_prefetched = upgrade_outdated_formulae!(
               formulae,
               prefetch_only:          true,
               download_queue:         shared_download_queue,
@@ -204,17 +205,28 @@ module Homebrew
               cask_names:    prefetched_cask_names,
             )
             shared_download_queue.fetch
+            if shared_download_queue.fetch_failed
+              formulae_prefetched = false
+              prefetched_casks = false
+            end
           ensure
             shared_download_queue.shutdown
           end
         end
 
-        upgrade_outdated_formulae!(formulae, use_prefetched: true) unless only_upgrade_casks
+        unless only_upgrade_casks
+          upgrade_outdated_formulae!(
+            formulae,
+            use_prefetched:       formulae_prefetched,
+            show_upgrade_summary: prefetched_formulae_upgrades.blank?,
+          )
+        end
         unless only_upgrade_formulae
           upgrade_outdated_casks!(
             casks,
-            skip_prefetch:  prefetched_casks,
-            download_queue: nil,
+            skip_prefetch:        prefetched_casks,
+            show_upgrade_summary: prefetched_cask_upgrades.blank?,
+            download_queue:       nil,
           )
         end
 
@@ -485,11 +497,11 @@ module Homebrew
       end
 
       sig {
-        params(casks: T::Array[Cask::Cask], skip_prefetch: T::Boolean,
+        params(casks: T::Array[Cask::Cask], skip_prefetch: T::Boolean, show_upgrade_summary: T::Boolean,
                download_queue: T.nilable(Homebrew::DownloadQueue))
           .returns(T::Boolean)
       }
-      def upgrade_outdated_casks!(casks, skip_prefetch: false,
+      def upgrade_outdated_casks!(casks, skip_prefetch: false, show_upgrade_summary: true,
                                   download_queue: nil)
         return false if args.formula?
 
@@ -509,7 +521,7 @@ module Homebrew
           verbose:              args.verbose?,
           quiet:                args.quiet?,
           skip_prefetch:,
-          show_upgrade_summary: !skip_prefetch,
+          show_upgrade_summary:,
           download_queue:,
           args:,
         )

--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -31,6 +31,7 @@ module Homebrew
       @symlink_targets = T.let({}, T::Hash[Pathname, T::Set[Downloadable]])
       @downloads_by_location = T.let({}, T::Hash[Pathname, Concurrent::Promises::Future])
       @cancelled = T.let(Concurrent::AtomicBoolean.new(false), Concurrent::AtomicBoolean)
+      @fetch_failed = T.let(false, T::Boolean)
     end
 
     sig {
@@ -68,6 +69,7 @@ module Homebrew
 
     sig { void }
     def fetch
+      @fetch_failed = false
       return if downloads.empty?
 
       context_before_fetch = Context.current
@@ -78,6 +80,7 @@ module Homebrew
         rescue CancelledDownloadError
           next
         rescue ChecksumMismatchError => e
+          @fetch_failed = true
           ofail "#{downloadable.download_queue_type} reports different checksum: #{e.expected}"
         rescue => e
           raise e unless bottle_manifest_error?(downloadable, e)
@@ -106,6 +109,7 @@ module Homebrew
 
             if future.rejected?
               if exception.is_a?(ChecksumMismatchError)
+                @fetch_failed = true
                 actual = Digest::SHA256.file(downloadable.cached_download).hexdigest
                 actual_message, expected_message = align_checksum_mismatch_message(downloadable.download_queue_type)
 
@@ -127,6 +131,7 @@ module Homebrew
                 else
                   future.reason.to_s
                 end
+                @fetch_failed = true
                 ofail message
                 next message.count("\n")
               end
@@ -192,6 +197,9 @@ module Homebrew
       @downloads_by_location.clear
       @symlink_targets.clear
     end
+
+    sig { returns(T::Boolean) }
+    attr_reader :fetch_failed
 
     sig { params(message: String).void }
     def stdout_print_and_flush_if_tty(message)

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
   it "prints a combined upgrade summary before fetching combined downloads" do
     cmd = described_class.new([])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, fetch_failed: false, shutdown: nil)
     cask = instance_double(
       Cask::Cask,
       artifacts:         [],
@@ -130,6 +130,51 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       codex 0.117.0 -> 0.118.0
       ==> Fetching downloads for: deno and codex
     EOS
+  end
+
+  it "does not trust failed shared prefetches" do
+    cmd = described_class.new([])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, fetch_failed: true, shutdown: nil)
+    cask = instance_double(
+      Cask::Cask,
+      artifacts:         [],
+      full_name:         "codex",
+      installed_version: "0.117.0",
+      version:           "0.118.0",
+    )
+    installer = instance_double(Cask::Installer, prelude: nil, enqueue_downloads: nil)
+
+    allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
+    allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, prefetch_only: false,
+                                                              use_prefetched: false,
+                                                              prefetch_names: nil,
+                                                              prefetch_upgrades: nil,
+                                                              show_upgrade_summary: true,
+                                                              **|
+      if prefetch_only
+        expect(show_upgrade_summary).to be(false)
+        prefetch_names&.replace(["deno"])
+        prefetch_upgrades&.replace(["deno 2.7.10 -> 2.7.11"])
+      else
+        expect(use_prefetched).to be(false)
+        expect(show_upgrade_summary).to be(false)
+      end
+
+      true
+    end
+    allow(Cask::Upgrade).to receive(:outdated_casks).and_return([cask])
+    allow(Cask::Installer).to receive(:new).and_return(installer)
+    allow(Cask::Upgrade).to receive(:upgrade_casks!) do |*_, **kwargs|
+      expect(kwargs[:skip_prefetch]).to be(false)
+      expect(kwargs[:show_upgrade_summary]).to be(false)
+
+      true
+    end
+    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
+    allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
+    allow(Homebrew.messages).to receive(:display_messages)
+
+    cmd.run
   end
 
   it "does not print removed caveats method errors for installed casks", :cask do

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -1,0 +1,40 @@
+# typed: false
+# frozen_string_literal: true
+
+require "download_queue"
+
+RSpec.describe Homebrew::DownloadQueue do
+  subject(:download_queue) { described_class.new }
+
+  let(:cached_download) { HOMEBREW_CACHE/"downloads/testball--0.1.tar.gz" }
+  let(:downloadable) do
+    instance_double(
+      Downloadable,
+      cached_download:,
+      download_queue_message: "Bottle testball",
+      download_queue_name:    "testball",
+      download_queue_type:    "Bottle",
+    )
+  end
+  let(:download_error) { DownloadError.new(downloadable, RuntimeError.new("network blew up")) }
+  let(:retryable_download) { instance_double(Homebrew::RetryableDownload) }
+
+  before do
+    allow(Homebrew::EnvConfig).to receive(:download_concurrency).and_return(2)
+    allow(retryable_download).to receive(:fetch).and_raise(download_error)
+    allow(Homebrew::RetryableDownload).to receive(:new).and_return(retryable_download)
+  end
+
+  after do
+    download_queue.shutdown
+  end
+
+  it "reports rejected download errors in parallel mode and marks the fetch as failed" do
+    download_queue.enqueue(downloadable)
+
+    expect { download_queue.fetch }.to output(/network blew up/).to_stderr
+
+    expect(download_queue.fetch_failed).to be(true)
+    expect(Homebrew).to have_failed
+  end
+end


### PR DESCRIPTION
- keep `DownloadQueue#fetch` output and failure handling unchanged while recording whether a shared fetch failed
- stop `brew upgrade` reusing prefetched downloads after a failed shared fetch so later retries download again
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex with several rounds of (mean) review and testing.

-----
