### PR TITLE
api: don't refresh cache mtime after failed JSON download

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -99,6 +99,7 @@ module Homebrew
       end
 
       json_data = begin
+        download_succeeded = T.let(false, T::Boolean)
         begin
           args = curl_args.dup
           args.prepend("--time-cond", target.to_s) if target.exist? && !target.empty?
@@ -110,6 +111,7 @@ module Homebrew
             ohai "Downloading #{url}" if $stdout.tty? && !Context.current.quiet?
             # Disable retries here, we handle them ourselves below.
             Utils::Curl.curl_download(*args, url, to: target, retries: 0, show_error: false)
+            download_succeeded = true
           end
         rescue ErrorDuringExecution
           if url == default_url
@@ -128,8 +130,13 @@ module Homebrew
           opoo "#{target.basename}: update failed, falling back to cached version."
         end
 
-        mtime = insecure_download ? Time.new(1970, 1, 1) : Time.now
-        FileUtils.touch(target, mtime:) unless skip_download
+        # Only refresh the cache mtime after a successful curl revalidation/download.
+        # Touching after a failed download would mark a stale cache as fresh and
+        # cause `skip_download?` to short-circuit subsequent retries until cleanup.
+        if download_succeeded
+          mtime = insecure_download ? Time.new(1970, 1, 1) : Time.now
+          FileUtils.touch(target, mtime:)
+        end
         # Can use `target.read` again when/if https://github.com/sorbet/sorbet/pull/8999 is merged/released.
         JSON.parse(File.read(target, encoding: Encoding::UTF_8), freeze: true)
       rescue JSON::ParserError

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -63,6 +63,54 @@ RSpec.describe Homebrew::API do
         described_class.fetch_json_api_file("baz.json", target: cache_dir/"baz.json")
       end.to raise_error(SystemExit)
     end
+
+    it "does not refresh the cache mtime when the download fails" do
+      target = cache_dir/"bar.json"
+      target.write json
+      stale_mtime = Time.now - 7200
+      FileUtils.touch(target, mtime: stale_mtime)
+
+      allow(Utils::Curl).to receive(:curl_download).and_raise(ErrorDuringExecution.new(["curl"], status: 1))
+
+      expect do
+        described_class.fetch_json_api_file(
+          "bar.json",
+          target:        target,
+          stale_seconds: 3600,
+        )
+      end.to output(/update failed, falling back to cached version/).to_stderr
+
+      expect(target.mtime.to_i).to eq stale_mtime.to_i
+    end
+
+    it "refreshes the cache mtime when a fallback to the default API domain succeeds" do
+      target = cache_dir/"bar.json"
+      target.write json
+      stale_mtime = Time.now - 7200
+      FileUtils.touch(target, mtime: stale_mtime)
+
+      allow(Homebrew::EnvConfig).to receive(:api_domain).and_return("https://example.invalid/api")
+
+      requested_urls = []
+      allow(Utils::Curl).to receive(:curl_download) do |*args, **kwargs|
+        requested_urls << args.last
+        raise ErrorDuringExecution.new(["curl"], status: 1) if requested_urls.length == 1
+
+        kwargs[:to].write json
+      end
+
+      described_class.fetch_json_api_file(
+        "bar.json",
+        target:        target,
+        stale_seconds: 3600,
+      )
+
+      expect(requested_urls).to eq([
+        "https://example.invalid/api/bar.json",
+        "#{HOMEBREW_API_DEFAULT_DOMAIN}/bar.json",
+      ])
+      expect(target.mtime.to_i).to be > stale_mtime.to_i
+    end
   end
 
   describe "::tap_from_source_download" do


### PR DESCRIPTION
When fetch_json_api_file's curl_download raised ErrorDuringExecution and fell back to the cached version, the code unconditionally touched the cache file with the current mtime. On the next `brew upgrade`, `skip_download?` saw a 'fresh' mtime and short-circuited the download entirely, so brew kept reusing the stale formula.jws.json / cask.jws.json until `brew cleanup` removed it.

Track `download_succeeded` and only refresh the cache mtime after a successful curl revalidation/download. Reset the flag at the top of the retried outer `begin` so a JSON::ParserError-triggered retry cannot inherit a stale `true` from the previous attempt.

Closes #22089

Many thanks to @MikeMcQuaid for #22091 — my original report in #22089 was unclear about which layer was failing, and that PR addresses a real (but separate) DownloadQueue / use_prefetched issue. Digging into it more carefully, I found the symptoms I actually hit come from the JSON API layer, which this PR fixes.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

Claude Opus 4.7 via amp and then multiple rounds of reviews using GPT 5.4 via amp.