### PR TITLE
Fix `brew update` with `HOMEBREW_USE_INTERNAL_API`

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -1021,8 +1021,17 @@ EOS
 
     # Not a typo, these are the files we used to download that no longer need so should cleanup.
     rm -f "${HOMEBREW_CACHE}/api/formula.json" "${HOMEBREW_CACHE}/api/cask.json"
-    rm -f "${HOMEBREW_CACHE}/api/internal/formula.$(bottle_tag).jws.json"
-    rm -f "${HOMEBREW_CACHE}/api/internal/cask.$(bottle_tag).jws.json"
+    rm -f "${HOMEBREW_CACHE}"/api/internal/formula.*.jws.json
+    rm -f "${HOMEBREW_CACHE}"/api/internal/cask.*.jws.json
+
+    # Remove API files from previous OS versions.
+    for f in "${HOMEBREW_CACHE}"/api/internal/packages.*.jws.json
+    do
+      case "${f}" in
+        "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json") ;;
+        *) rm -f "${f}" ;;
+      esac
+    done
   else
     if [[ -n "${HOMEBREW_VERBOSE}" ]]
     then

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -399,12 +399,12 @@ fetch_api_file() {
   local cache_path="${api_cache}/${filename}"
   mkdir -p "$(dirname "${cache_path}")"
 
-  if [[ "${filename}" == "formula.jws.json" ]] || [[ "${filename}" == "internal/formula.$(bottle_tag).jws.json" ]]
+  if [[ "${filename}" == "formula.jws.json" ]] || [[ "${filename}" == "internal/packages.$(bottle_tag).jws.json" ]]
   then
     local is_formula_file=1
   fi
 
-  if [[ "${filename}" == "cask.jws.json" ]] || [[ "${filename}" == "internal/cask.$(bottle_tag).jws.json" ]]
+  if [[ "${filename}" == "cask.jws.json" ]] || [[ "${filename}" == "internal/packages.$(bottle_tag).jws.json" ]]
   then
     local is_cask_file=1
   fi
@@ -448,7 +448,8 @@ fetch_api_file() {
   if [[ -n ${is_formula_file} ]] && [[ -f "${api_cache}/formula_names.txt" ]]
   then
     mv -f "${api_cache}/formula_names.txt" "${api_cache}/formula_names.before.txt"
-  elif [[ -n ${is_cask_file} ]] && [[ -f "${api_cache}/cask_names.txt" ]]
+  fi
+  if [[ -n ${is_cask_file} ]] && [[ -f "${api_cache}/cask_names.txt" ]]
   then
     mv -f "${api_cache}/cask_names.txt" "${api_cache}/cask_names.before.txt"
   fi
@@ -997,7 +998,7 @@ EOS
   then
     if [[ -n "${HOMEBREW_USE_INTERNAL_API}" ]]
     then
-      api_files=("internal/formula.$(bottle_tag)" "internal/cask.$(bottle_tag)")
+      api_files=("internal/packages.$(bottle_tag)")
     else
       api_files=(formula cask formula_tap_migrations cask_tap_migrations)
     fi
@@ -1015,12 +1016,13 @@ EOS
       rm -f "${HOMEBREW_CACHE}/api/formula_tap_migrations.jws.json" "${HOMEBREW_CACHE}/api/cask_tap_migrations.jws.json"
     else
       # Remove files only downloaded by the internal API
-      rm -f "${HOMEBREW_CACHE}/api/internal/formula.$(bottle_tag).jws.json"
-      rm -f "${HOMEBREW_CACHE}/api/internal/cask.$(bottle_tag).jws.json"
+      rm -f "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json"
     fi
 
     # Not a typo, these are the files we used to download that no longer need so should cleanup.
     rm -f "${HOMEBREW_CACHE}/api/formula.json" "${HOMEBREW_CACHE}/api/cask.json"
+    rm -f "${HOMEBREW_CACHE}/api/internal/formula.$(bottle_tag).jws.json"
+    rm -f "${HOMEBREW_CACHE}/api/internal/cask.$(bottle_tag).jws.json"
   else
     if [[ -n "${HOMEBREW_VERBOSE}" ]]
     then


### PR DESCRIPTION
When I switched `HOMEBREW_USE_INTERNAL_API` to use the new `/api/packages.$(bottle_tag).jws.json` files, I forgot to also make the change in `update.sh`. As a result, `brew update` would update the old files, and the new ones would never be updated (outside of Ruby code). This would trick `brew` into thinking that everything was up to date with the old files.

If you have `HOMEBREW_NO_AUTO_UPDATE` set, this means you'd never end up getting new files.

I noticed this when wondering why `brew update` hadn't shown me any new package updates in several days... 😅

This PR fixes this and also adjusts the cleanup to remove old `formula.*.jws.json` and `cask.*.jws.json` files, as well as all old `packages.*.jws.json` files (i.e. where the bottle tag is not current).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
