### PR TITLE
Fixed the problem that brew services cleanup would not really remove …

### DIFF
--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -73,7 +73,7 @@ module Homebrew
       sig { returns(T::Array[String]) }
       def self.remove_unused_service_files
         cleaned = []
-        Dir["#{System.path}homebrew.*.{plist,service}"].each do |file|
+        Dir["#{System.path}/homebrew.*.{plist,service}"].each do |file|
           next if running.include?(File.basename(file).sub(/\.(plist|service)$/i, ""))
 
           puts "Removing unused service file: #{file}"

--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -73,7 +73,7 @@ module Homebrew
       sig { returns(T::Array[String]) }
       def self.remove_unused_service_files
         cleaned = []
-        Dir["#{System.path}/homebrew.*.{plist,service}"].each do |file|
+        System.path.glob("homebrew.*.{plist,service}").each do |file|
           next if running.include?(File.basename(file).sub(/\.(plist|service)$/i, ""))
 
           puts "Removing unused service file: #{file}"


### PR DESCRIPTION
…the unused service file.
remove_unused_service_files uses System.path in order to find the path of service file installation. But this path doesn't have the last /, so it won't be found. I made up this /, and now brew services cleanup can work normally.
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
