### PR TITLE
docs: fix link to "C++ Standard Libraries" page

### DIFF
--- a/docs/C++-Standard-Libraries.md
+++ b/docs/C++-Standard-Libraries.md
@@ -1,7 +1,5 @@
 ---
 last_review_date: "1970-01-01"
-redirect_from:
-  - /C++-Standard-Libraries.md
 ---
 
 # C++ Standard Libraries

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ last_review_date: "2026-04-25"
 - [Anonymous Analytics](Analytics.md)
 
 - [Querying `brew`](Querying-Brew.md)
-- [C++ Standard Libraries](C++-Standard-Libraries.md)
+- [C++ Standard Libraries](C%2B%2B-Standard-Libraries.md)
 - [MD5 and SHA-1 Deprecation](Checksum_Deprecation.md)
 - [Custom GCC and Cross Compilers](Custom-GCC-and-cross-compilers.md)
 - [External Commands](External-Commands.md)


### PR DESCRIPTION
The jekyll-relative-links plugin converts .md links to clean URLs (e.g., `FAQ.md` to `/FAQ`), which works for all links in `index.md` except `C++-Standard-Libraries.md`. The issue is that the plugin assumes that the link is escaped with `CGI.escape`, and calls `CGI.unescape` to try to reverse the escaping. The plus signs `+` are unescaped to space characters, so the unescaped link matches nothing, and the link is left unconverted.

Fix that by escaping the plus signs in the link, which allows the plugin to convert the link as expected.

Fixes #22102.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
