### PR TITLE
docs: clean up generated pages

### DIFF
--- a/docs/Taps.md
+++ b/docs/Taps.md
@@ -18,7 +18,7 @@ but the command isn't limited to any one location.
   petere/postgresql
   ```
 
-* It should be noted: `brew tap` will not output anything if no taps were added yet. That is the case after a fresh install of homebrew.
+* It should be noted: `brew tap` will not output anything if no taps were added yet. That is the case after a fresh install of Homebrew.
 
 * `brew tap <user>/<repo>` makes a clone of the repository at
   `https://github.com/<user>/homebrew-<repo>` into `$(brew --repository)/Library/Taps`.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,6 +11,7 @@ exclude:
   - docs_rubocop_style.yml
   - Gemfile*
   - Rakefile
+  - README.md
   - vale-styles
   - vendor
 include:
@@ -23,6 +24,8 @@ plugins:
   - jekyll-seo-tag
   - jekyll-sitemap
   - jekyll-titles-from-headings
+optional_front_matter:
+  remove_originals: true
 
 permalink: :title
 


### PR DESCRIPTION
Remove the docs README from the generated site, because https://docs.brew.sh/README doesn't make sense.

Also remove the original markdown files for pages generated by the jekyll-optional-front-matter plugin, like https://docs.brew.sh/Manpage.md .

Finally, while we're here, fix an incorrect casing of "Homebrew".

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
