### PR TITLE
Start systemd timers for services

### DIFF
--- a/Library/Homebrew/cask/artifact/generated_completion.rb
+++ b/Library/Homebrew/cask/artifact/generated_completion.rb
@@ -25,14 +25,15 @@ module Cask
           args:                   T.any(Pathname, String),
           base_name:              T.nilable(String),
           shell_parameter_format: T.nilable(T.any(Symbol, String)),
-          shells:                 T.nilable(T::Array[Symbol]),
+          shells:                 T.nilable(T::Array[T.any(Symbol, String)]),
         ).returns(T.attached_class)
       }
       def self.from_args(cask, *args, base_name: nil, shell_parameter_format: nil, shells: nil)
         raise CaskInvalidError.new(cask.token, "'#{dsl_key}' requires at least one command") if args.empty?
 
         commands = args.to_a
-        resolved_shells = shells || ::Utils::ShellCompletion.default_completion_shells(shell_parameter_format)
+        resolved_shells = (shells || ::Utils::ShellCompletion.default_completion_shells(shell_parameter_format))
+                          .map(&:to_sym)
 
         unsupported_shells = resolved_shells - SUPPORTED_SHELLS
         unless unsupported_shells.empty?

--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -73,12 +73,12 @@ module Homebrew
       sig { returns(T::Array[String]) }
       def self.remove_unused_service_files
         cleaned = []
-        System.path.glob("homebrew.*.{plist,service}").each do |file|
-          next if running.include?(File.basename(file).sub(/\.(plist|service)$/i, ""))
+        System.path.glob("homebrew.*.{plist,service,timer}").each do |file|
+          next if running.include?(File.basename(file).sub(/\.(plist|service|timer)$/i, ""))
 
           puts "Removing unused service file: #{file}"
           rm file
-          cleaned << file
+          cleaned << file.to_s
         end
 
         cleaned
@@ -171,7 +171,10 @@ module Homebrew
       def self.stop(targets, verbose: false, no_wait: false, max_wait: 0, keep: false)
         targets.each do |service|
           unless service.loaded?
-            rm service.dest if !keep && service.dest.exist? # get rid of installed service file anyway, dude
+            unless keep
+              rm service.dest if service.dest.exist? # get rid of installed service file anyway, dude
+              rm service.timer_dest if System.systemctl? && service.timed? && service.timer_dest.exist?
+            end
             if service.service_file_present?
               odie <<~EOS
                 Service `#{service.name}` is started as `#{service.owner}`. Try:
@@ -196,7 +199,11 @@ module Homebrew
 
           if System.systemctl?
             if keep
+              System::Systemctl.quiet_run(*systemctl_args, "stop", service.timer_name) if service.timed?
               System::Systemctl.quiet_run(*systemctl_args, "stop", service.service_name)
+            elsif service.timed?
+              System::Systemctl.quiet_run(*systemctl_args, "disable", "--now", service.timer_name)
+              System::Systemctl.quiet_run(*systemctl_args, "disable", "--now", service.service_name)
             else
               System::Systemctl.quiet_run(*systemctl_args, "disable", "--now", service.service_name)
             end
@@ -230,6 +237,7 @@ module Homebrew
 
           unless keep
             rm service.dest if service.dest.exist?
+            rm service.timer_dest if System.systemctl? && service.timed? && service.timer_dest.exist?
             # Run daemon-reload on systemctl to finish unloading stopped and deleted service.
             System::Systemctl.run(*systemctl_args, "daemon-reload") if System.systemctl?
           end
@@ -354,7 +362,12 @@ module Homebrew
       sig { params(service: Services::FormulaWrapper, enable: T::Boolean).void }
       def self.systemd_load(service, enable:)
         System::Systemctl.run("start", service.service_name)
-        System::Systemctl.run("enable", service.service_name) if enable
+        if service.timed?
+          System::Systemctl.run("start", service.timer_name)
+          System::Systemctl.run("enable", service.timer_name) if enable
+        elsif enable
+          System::Systemctl.run("enable", service.service_name)
+        end
       end
 
       sig { params(service: Services::FormulaWrapper, file: T.nilable(Pathname), enable: T::Boolean).void }
@@ -414,6 +427,11 @@ module Homebrew
         temp.close
 
         chmod 0644, service.dest
+        if System.systemctl? && service.timed?
+          rm service.timer_dest if service.timer_dest.exist?
+          cp service.timer_file, service.timer_dest
+          chmod 0644, service.timer_dest
+        end
 
         System::Systemctl.run("daemon-reload") if System.systemctl?
       end

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -92,6 +92,21 @@ module Homebrew
         )
       end
 
+      sig { returns(Pathname) }
+      def timer_file
+        @timer_file ||= T.let(formula.systemd_timer_path, T.nilable(Pathname))
+      end
+
+      sig { returns(String) }
+      def timer_name
+        @timer_name ||= T.let(timer_file.basename.to_s, T.nilable(String))
+      end
+
+      sig { returns(Pathname) }
+      def timer_dest
+        dest_dir + timer_file.basename
+      end
+
       # Whether the service should be launched at startup
       sig { returns(T::Boolean) }
       def service_startup?
@@ -147,7 +162,7 @@ module Homebrew
           reset_cache! unless cached
           status_success
         else # System.systemctl?
-          System::Systemctl.quiet_run("status", service_file.basename)
+          System::Systemctl.quiet_run("status", timed? ? timer_name : service_file.basename)
         end
       end
 

--- a/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
@@ -114,4 +114,24 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
       expect(fish_dir/"bar.fish").not_to exist
     end
   end
+
+  context "with string shells" do
+    let(:cask) do
+      tmp_staged = staged_path
+      Cask::Cask.new("test-generated-completion") do
+        version "1.0"
+        sha256 :no_check
+        url "file:///dev/null"
+        generate_completions_from_executable "bin/foo", "completions",
+                                             shells: %w[bash zsh fish pwsh]
+        instance_variable_set(:@staged_path, tmp_staged)
+      end
+    end
+
+    it "normalizes shells to symbols" do
+      artifact = cask.artifacts.grep(described_class).first
+
+      expect(artifact.shells).to eq([:bash, :zsh, :fish, :pwsh])
+    end
+  end
 end

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -85,6 +85,24 @@ RSpec.describe Homebrew::Services::Cli do
     end
   end
 
+  describe "#remove_unused_service_files" do
+    it "removes unused timer files" do
+      path = mktmpdir
+      active_timer = path/"homebrew.name.timer"
+      stale_timer = path/"homebrew.stale.timer"
+      active_timer.write("timer")
+      stale_timer.write("timer")
+      allow(Homebrew::Services::System).to receive(:path).and_return(path)
+      allow(services_cli).to receive(:running).and_return(["homebrew.name"])
+
+      expect do
+        expect(services_cli.remove_unused_service_files).to eq([stale_timer.to_s])
+      end.to output("Removing unused service file: #{stale_timer}\n").to_stdout
+      expect(active_timer).to exist
+      expect(stale_timer).not_to exist
+    end
+  end
+
   describe "#run" do
     it "checks missing file causes error" do
       expect(Homebrew::Services::System).not_to receive(:root?)
@@ -138,6 +156,64 @@ RSpec.describe Homebrew::Services::Cli do
       expect(Homebrew::Services::System).not_to receive(:root?)
       services_cli.stop([])
     end
+
+    it "stops timed systemd timers before services when kept" do
+      allow(Homebrew::Services::System).to receive(:systemctl?).and_return(true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("stop", "homebrew.name.timer")
+        .ordered
+        .and_return(true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("stop", "homebrew.name")
+        .ordered
+        .and_return(true)
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:         "name",
+        service_name: "homebrew.name",
+        timed?:       true,
+        timer_name:   "homebrew.name.timer",
+        pid?:         false,
+      )
+      allow(service).to receive(:loaded?).and_return(true, false)
+
+      expect do
+        services_cli.stop([service], keep: true)
+      end.to output(/Successfully stopped `name`/).to_stdout
+    end
+
+    it "stops and removes timed systemd timer files" do
+      allow(Homebrew::Services::System).to receive(:systemctl?).and_return(true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("disable", "--now", "homebrew.name.timer")
+        .and_return(true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("disable", "--now", "homebrew.name")
+        .and_return(true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:run).with("daemon-reload")
+
+      dest_dir = mktmpdir
+      service_dest = dest_dir/"homebrew.name.service"
+      timer_dest = dest_dir/"homebrew.name.timer"
+      service_dest.write("service")
+      timer_dest.write("timer")
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:         "name",
+        service_name: "homebrew.name",
+        dest:         service_dest,
+        timed?:       true,
+        timer_name:   "homebrew.name.timer",
+        timer_dest:,
+        pid?:         false,
+      )
+      allow(service).to receive(:loaded?).and_return(true, false)
+
+      expect do
+        services_cli.stop([service])
+      end.to output(/Successfully stopped `name`/).to_stdout
+      expect(timer_dest).not_to exist
+    end
   end
 
   describe "#kill" do
@@ -185,6 +261,34 @@ RSpec.describe Homebrew::Services::Cli do
         "Invalid usage: Formula `name` has not implemented #plist, #service or provided a locatable service file.",
       )
     end
+
+    it "installs timed systemd timer files" do
+      allow(Homebrew::Services::System).to receive(:systemctl?).and_return(true)
+      allow(Homebrew::Services::System::Systemctl).to receive(:run).with("daemon-reload")
+
+      source_dir = mktmpdir
+      dest_dir = mktmpdir
+      service_file = source_dir/"homebrew.name.service"
+      timer_file = source_dir/"homebrew.name.timer"
+      service_file.write("service")
+      timer_file.write("timer")
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:         "name",
+        service_name: "homebrew.name",
+        installed?:   true,
+        service_file:,
+        dest:         dest_dir/service_file.basename,
+        dest_dir:,
+        timed?:       true,
+        timer_file:,
+        timer_dest:   dest_dir/timer_file.basename,
+      )
+
+      services_cli.install_service_file(service, nil)
+
+      expect(service.timer_dest.read).to eq("timer")
+    end
   end
 
   describe "#systemd_load" do
@@ -203,7 +307,7 @@ RSpec.describe Homebrew::Services::Cli do
     it "checks non-enabling run" do
       with_env(PATH: bindir.to_s) do
         services_cli.systemd_load(
-          instance_double(Homebrew::Services::FormulaWrapper, service_name: "name"),
+          instance_double(Homebrew::Services::FormulaWrapper, service_name: "name", timed?: false),
           enable: false,
         )
       end
@@ -214,7 +318,7 @@ RSpec.describe Homebrew::Services::Cli do
     it "checks enabling run" do
       with_env(PATH: bindir.to_s) do
         services_cli.systemd_load(
-          instance_double(Homebrew::Services::FormulaWrapper, service_name: "name"),
+          instance_double(Homebrew::Services::FormulaWrapper, service_name: "name", timed?: false),
           enable: true,
         )
       end
@@ -222,6 +326,26 @@ RSpec.describe Homebrew::Services::Cli do
       expect(log.read).to eq <<~EOS
         --user start name
         --user enable name
+      EOS
+    end
+
+    it "checks enabling timed run" do
+      with_env(PATH: bindir.to_s) do
+        services_cli.systemd_load(
+          instance_double(
+            Homebrew::Services::FormulaWrapper,
+            service_name: "name",
+            timed?:       true,
+            timer_name:   "name.timer",
+          ),
+          enable: true,
+        )
+      end
+
+      expect(log.read).to eq <<~EOS
+        --user start name
+        --user start name.timer
+        --user enable name.timer
       EOS
     end
   end
@@ -332,6 +456,7 @@ RSpec.describe Homebrew::Services::Cli do
             service_name:     "service.name",
             service_startup?: false,
             dest:             instance_double(Pathname, exist?: true),
+            timed?:           false,
           ),
           nil,
           enable: false,
@@ -352,6 +477,7 @@ RSpec.describe Homebrew::Services::Cli do
             service_name:     "service.name",
             service_startup?: false,
             dest:             instance_double(Pathname, exist?: true),
+            timed?:           false,
           ),
           nil,
           enable: true,

--- a/Library/Homebrew/test/services/formula_wrapper_spec.rb
+++ b/Library/Homebrew/test/services/formula_wrapper_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper do
                     service_name:           "plist-mysql-test",
                     launchd_service_path:   Pathname.new("/usr/local/opt/mysql/homebrew.mysql.plist"),
                     systemd_service_path:   Pathname.new("/usr/local/opt/mysql/homebrew.mysql.service"),
+                    systemd_timer_path:     Pathname.new("/usr/local/opt/mysql/homebrew.mysql.timer"),
                     opt_prefix:             Pathname.new("/usr/local/opt/mysql"),
                     any_version_installed?: true,
                     service?:               false)
@@ -149,6 +150,16 @@ RSpec.describe Homebrew::Services::FormulaWrapper do
       allow(Homebrew::Services::System::Systemctl).to receive(:quiet_run).and_return(false)
       allow(Utils).to receive(:safe_popen_read)
       expect(service.loaded?).to be(false)
+    end
+
+    it "systemD - checks timer status for timed services" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      allow(service).to receive(:timed?).and_return(true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("status", "homebrew.mysql.timer")
+        .and_return(true)
+
+      expect(service.loaded?).to be(true)
     end
 
     it "Other - raises an error" do


### PR DESCRIPTION
- Schedule cron and interval services by loading generated `.timer` units, not only their `.service` units.
- Keep status and stop paths timer-aware so registered timers are removed with the matching service.

Fixes https://github.com/Homebrew/brew/issues/22092
Closes https://github.com/Homebrew/brew/pull/22106

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex xhigh with local testing and review.

-----
