### PR TITLE
fix: 'generate_completions_from_executable' does not support shell(s)

### DIFF
--- a/Library/Homebrew/cask/artifact/generated_completion.rb
+++ b/Library/Homebrew/cask/artifact/generated_completion.rb
@@ -25,7 +25,7 @@ module Cask
           args:                   T.any(Pathname, String),
           base_name:              T.nilable(String),
           shell_parameter_format: T.nilable(T.any(Symbol, String)),
-          shells:                 T.nilable(T::Array[Symbol]),
+          shells:                 T.nilable(T::Array[T.any(Symbol, String)]),
         ).returns(T.attached_class)
       }
       def self.from_args(cask, *args, base_name: nil, shell_parameter_format: nil, shells: nil)
@@ -33,6 +33,7 @@ module Cask
 
         commands = args.to_a
         resolved_shells = shells || ::Utils::ShellCompletion.default_completion_shells(shell_parameter_format)
+        resolved_shells = resolved_shells.map(&:to_sym)
 
         unsupported_shells = resolved_shells - SUPPORTED_SHELLS
         unless unsupported_shells.empty?

--- a/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
@@ -84,6 +84,20 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
     end
   end
 
+  context "with string shell values (as loaded from cask.jws.json)" do
+    it "accepts and normalizes string shells to symbols" do
+      artifact = described_class.from_args(cask, "bin/foo", "completions", shells: ["zsh"])
+
+      expect(artifact.shells).to eq([:zsh])
+    end
+
+    it "raises CaskInvalidError for unsupported string shells" do
+      expect do
+        described_class.from_args(cask, "bin/foo", "completions", shells: ["nope"])
+      end.to raise_error(Cask::CaskInvalidError, /does not support shell\(s\): nope/)
+    end
+  end
+
   context "with specific shells and format" do
     let(:cask) do
       tmp_staged = staged_path


### PR DESCRIPTION
GeneratedCompletion is called with string values from `cask.jws.json` resulting in inadvertently incompatible operations on arrays strings and arrays of symbols.

This surfaces to the user as errors like:

```
Error: Cask '1password-cli' definition is invalid: 'generate_completions_from_executable' does not support shell(s): bash, zsh, fish, pwsh
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.
    @quad: I used AI to review the PR and write the unit test.

-----
