### PR TITLE
Fixed the format problem of the generated .timer file.

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -512,6 +512,17 @@ module Homebrew
       SYSTEMD
     end
 
+    sig { params(cron_weekday: T.nilable(T.any(Integer, String))).returns(String) }
+    def cron_weekday_to_systemd_weekday(cron_weekday)
+      if cron_weekday != "*" &&
+         (weekday_number = cron_weekday&.to_i) &&
+         (0..7).cover?(weekday_number)
+        "#{Date::ABBR_DAYNAMES[weekday_number % 7]} "
+      else
+        ""
+      end
+    end
+
     # Returns a `String` systemd unit timer.
     sig { returns(String) }
     def to_systemd_timer
@@ -522,7 +533,8 @@ module Homebrew
       if @run_type == RUN_TYPE_CRON
         minutes = (@cron[:Minute] == "*") ? "*" : format("%02d", @cron[:Minute])
         hours   = (@cron[:Hour] == "*") ? "*" : format("%02d", @cron[:Hour])
-        options << "OnCalendar=#{@cron[:Weekday]}-*-#{@cron[:Month]}-#{@cron[:Day]} #{hours}:#{minutes}:00"
+        options << "OnCalendar=#{cron_weekday_to_systemd_weekday(@cron[:Weekday])}" \
+                   "*-#{@cron[:Month]}-#{@cron[:Day]} #{hours}:#{minutes}:00"
       end
 
       <<~SYSTEMD
@@ -533,7 +545,7 @@ module Homebrew
         WantedBy=timers.target
 
         [Timer]
-        Unit=#{service_name}
+        Unit=#{service_name}.service
         #{options.join("\n")}
       SYSTEMD
     end

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -1072,7 +1072,7 @@ RSpec.describe Homebrew::Service do
         WantedBy=timers.target
 
         [Timer]
-        Unit=homebrew.formula_name
+        Unit=homebrew.formula_name.service
         OnUnitActiveSec=5
       SYSTEMD
       expect(unit).to eq(unit_expect)
@@ -1095,7 +1095,7 @@ RSpec.describe Homebrew::Service do
         WantedBy=timers.target
 
         [Timer]
-        Unit=homebrew.formula_name
+        Unit=homebrew.formula_name.service
 
       SYSTEMD
       expect(unit).to eq(unit_expect)
@@ -1117,13 +1117,13 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid cron timers" do
       styles = {
-        "@hourly":   "*-*-*-* *:00:00",
-        "@daily":    "*-*-*-* 00:00:00",
-        "@weekly":   "0-*-*-* 00:00:00",
-        "@monthly":  "*-*-*-1 00:00:00",
-        "@yearly":   "*-*-1-1 00:00:00",
-        "@annually": "*-*-1-1 00:00:00",
-        "5 5 5 5 5": "5-*-5-5 05:05:00",
+        "@hourly":   "*-*-* *:00:00",
+        "@daily":    "*-*-* 00:00:00",
+        "@weekly":   "Sun *-*-* 00:00:00",
+        "@monthly":  "*-*-1 00:00:00",
+        "@yearly":   "*-1-1 00:00:00",
+        "@annually": "*-1-1 00:00:00",
+        "5 5 5 5 5": "Fri *-5-5 05:05:00",
       }
 
       styles.each do |cron, calendar|
@@ -1144,7 +1144,7 @@ RSpec.describe Homebrew::Service do
           WantedBy=timers.target
 
           [Timer]
-          Unit=homebrew.formula_name
+          Unit=homebrew.formula_name.service
           Persistent=true
           OnCalendar=#{calendar}
         SYSTEMD


### PR DESCRIPTION
I noticed two problems. 
First, the format of OnCalendar. According to the manual page of systemd.time(7), it should be like this.
￼<img width="1243" height="954" alt="585036896-88add5ce-5e8d-45bf-8f5d-b32d118ca5cb" src="https://github.com/user-attachments/assets/b4335ee2-c20c-40a6-b313-a8e3e3692459" /> 
And this is the current format: "OnCalendar=#{@Cron[:Weekday]}-*-#{@Cron[:Month]}-#{@Cron[:Day]} #{hours}:#{minutes}:00" 
The second problem is the "Unit=" field under [Timer]. It should contain the service suffix, that is, .service, otherwise you will get message like this: /home/choems/.config/systemd/user/homebrew.logrotate.timer:8: Unit type not valid, ignoring: homebrew.logrotate
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
