### PR TITLE
OS::Linux: fix Pathname type signature issues

### DIFF
--- a/Library/Homebrew/extend/os/linux/cask/utils/trash.rb
+++ b/Library/Homebrew/extend/os/linux/cask/utils/trash.rb
@@ -8,7 +8,7 @@ module OS
         module Trash
           module ClassMethods
             sig {
-              params(paths: Pathname, command: T.nilable(T.class_of(SystemCommand)))
+              params(paths: ::Pathname, command: T.nilable(T.class_of(SystemCommand)))
                 .returns([T::Array[String], T::Array[String]])
             }
             def trash(*paths, command: nil)

--- a/Library/Homebrew/extend/os/linux/development_tools.rb
+++ b/Library/Homebrew/extend/os/linux/development_tools.rb
@@ -11,7 +11,7 @@ module OS
 
         sig { params(tool: T.any(String, Symbol)).returns(T.nilable(::Pathname)) }
         def locate(tool)
-          @locate ||= T.let({}, T.nilable(T::Hash[T.any(String, Symbol), Pathname]))
+          @locate ||= T.let({}, T.nilable(T::Hash[T.any(String, Symbol), ::Pathname]))
           @locate.fetch(tool) do |key|
             @locate[key] = if ::DevelopmentTools.needs_build_formulae? &&
                               (binutils_path = HOMEBREW_PREFIX/"opt/binutils/bin/#{tool}").executable?


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

A recent homebrew-cask PR (https://github.com/Homebrew/homebrew-cask/pull/261663) surfaced the following type error in `OS::Linux::Cask::Utils::Trash::ClassMethods#trash`: `Parameter 'paths': Expected type OS::Linux::Pathname, got type Pathname with value #<Pathname:/home/linuxbrew/...ew/Caskroom/gcloud-cli/latest>`.

This addresses the error by updating the type signature for `trash` to use `::Pathname` instead of `Pathname` (which is `OS::Linux::Pathname` instead).

While searching for `Pathname` usage in `extend/os/linux` as part of fixing the `trash` type error, I noticed that `DevelopmentTools` references `::Pathname` in the `locate` method signature but the type signature for the `@locate` hash uses `Pathname` instead. This may eventually error in a similar fashion, so this preemptively updates the `@locate` type signature to use `::Pathname`.