### PR TITLE
services: install and manage systemd timer units alongside services

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -25,8 +25,8 @@ module Homebrew
     KEEP_ALIVE_KEYS = [:always, :successful_exit, :crashed, :path].freeze
     NICE_RANGE = T.let(-20..19, T::Range[Integer])
     SOCKET_STRING_REGEX = %r{^(?<type>[a-z]+)://(?<host>.+):(?<port>[0-9]+)$}i
-    # cron's integer weekdays (0..6, Sunday-indexed) mapped to the abbreviations systemd's
-    # `OnCalendar` accepts. Used by `to_systemd_timer`.
+    # Sunday-indexed weekday abbreviations accepted by systemd's `OnCalendar`. Indexed 0..6;
+    # cron's 0..7 (where both 0 and 7 are Sunday) is normalized via `% 7` in `to_systemd_timer`.
     SYSTEMD_WEEKDAYS = T.let(%w[Sun Mon Tue Wed Thu Fri Sat].freeze, T::Array[String])
 
     RunParam = T.type_alias { T.nilable(T.any(T::Array[T.any(String, Pathname)], String, Pathname)) }
@@ -534,7 +534,12 @@ module Homebrew
         options << if weekday == "*"
           "OnCalendar=#{date_and_time}"
         else
-          "OnCalendar=#{SYSTEMD_WEEKDAYS.fetch(T.cast(weekday, Integer) % 7)} #{date_and_time}"
+          weekday_int = T.cast(weekday, Integer)
+          unless (0..7).cover?(weekday_int)
+            raise ArgumentError,
+                  "Service#to_systemd_timer: Weekday must be 0..7, got #{weekday_int}"
+          end
+          "OnCalendar=#{SYSTEMD_WEEKDAYS.fetch(weekday_int % 7)} #{date_and_time}"
         end
       end
 

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -25,6 +25,9 @@ module Homebrew
     KEEP_ALIVE_KEYS = [:always, :successful_exit, :crashed, :path].freeze
     NICE_RANGE = T.let(-20..19, T::Range[Integer])
     SOCKET_STRING_REGEX = %r{^(?<type>[a-z]+)://(?<host>.+):(?<port>[0-9]+)$}i
+    # cron's integer weekdays (0..6, Sunday-indexed) mapped to the abbreviations systemd's
+    # `OnCalendar` accepts. Used by `to_systemd_timer`.
+    SYSTEMD_WEEKDAYS = T.let(%w[Sun Mon Tue Wed Thu Fri Sat].freeze, T::Array[String])
 
     RunParam = T.type_alias { T.nilable(T.any(T::Array[T.any(String, Pathname)], String, Pathname)) }
     Sockets = T.type_alias { T::Hash[Symbol, { host: String, port: String, type: String }] }
@@ -522,14 +525,16 @@ module Homebrew
       if @run_type == RUN_TYPE_CRON
         minutes = (@cron[:Minute] == "*") ? "*" : format("%02d", @cron[:Minute])
         hours   = (@cron[:Hour] == "*") ? "*" : format("%02d", @cron[:Hour])
-        # systemd's `OnCalendar` rejects a literal `*` in the day-of-week field; the field must be
-        # omitted entirely to mean "any day". A numeric (0-7) or named (Mon, ...) weekday is
-        # included with a space separator before the date.
+        # systemd's `OnCalendar` rejects a literal `*` in the day-of-week field — the field must
+        # be omitted entirely to mean "any day". When a weekday is set, systemd accepts only
+        # English abbreviations (Mon..Sun); cron's integer convention (0..7, where both 0 and 7
+        # are Sunday) is rejected, so we map it here.
         date_and_time = "*-#{@cron[:Month]}-#{@cron[:Day]} #{hours}:#{minutes}:00"
-        options << if @cron[:Weekday] == "*"
+        weekday = @cron[:Weekday]
+        options << if weekday == "*"
           "OnCalendar=#{date_and_time}"
         else
-          "OnCalendar=#{@cron[:Weekday]} #{date_and_time}"
+          "OnCalendar=#{SYSTEMD_WEEKDAYS.fetch(T.cast(weekday, Integer) % 7)} #{date_and_time}"
         end
       end
 

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -522,7 +522,15 @@ module Homebrew
       if @run_type == RUN_TYPE_CRON
         minutes = (@cron[:Minute] == "*") ? "*" : format("%02d", @cron[:Minute])
         hours   = (@cron[:Hour] == "*") ? "*" : format("%02d", @cron[:Hour])
-        options << "OnCalendar=#{@cron[:Weekday]}-*-#{@cron[:Month]}-#{@cron[:Day]} #{hours}:#{minutes}:00"
+        # systemd's `OnCalendar` rejects a literal `*` in the day-of-week field; the field must be
+        # omitted entirely to mean "any day". A numeric (0-7) or named (Mon, ...) weekday is
+        # included with a space separator before the date.
+        date_and_time = "*-#{@cron[:Month]}-#{@cron[:Day]} #{hours}:#{minutes}:00"
+        options << if @cron[:Weekday] == "*"
+          "OnCalendar=#{date_and_time}"
+        else
+          "OnCalendar=#{@cron[:Weekday]} #{date_and_time}"
+        end
       end
 
       <<~SYSTEMD
@@ -533,7 +541,7 @@ module Homebrew
         WantedBy=timers.target
 
         [Timer]
-        Unit=#{service_name}
+        Unit=#{service_name}.service
         #{options.join("\n")}
       SYSTEMD
     end

--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -172,6 +172,7 @@ module Homebrew
         targets.each do |service|
           unless service.loaded?
             rm service.dest if !keep && service.dest.exist? # get rid of installed service file anyway, dude
+            rm service.dest_timer if !keep && System.systemctl? && service.dest_timer.exist?
             if service.service_file_present?
               odie <<~EOS
                 Service `#{service.name}` is started as `#{service.owner}`. Try:
@@ -197,8 +198,10 @@ module Homebrew
           if System.systemctl?
             if keep
               System::Systemctl.quiet_run(*systemctl_args, "stop", service.service_name)
+              System::Systemctl.quiet_run(*systemctl_args, "stop", service.timer_name) if service.timed?
             else
               System::Systemctl.quiet_run(*systemctl_args, "disable", "--now", service.service_name)
+              System::Systemctl.quiet_run(*systemctl_args, "disable", "--now", service.timer_name) if service.timed?
             end
           elsif System.launchctl?
             dont_wait_statuses = [
@@ -230,6 +233,7 @@ module Homebrew
 
           unless keep
             rm service.dest if service.dest.exist?
+            rm service.dest_timer if System.systemctl? && service.dest_timer.exist?
             # Run daemon-reload on systemctl to finish unloading stopped and deleted service.
             System::Systemctl.run(*systemctl_args, "daemon-reload") if System.systemctl?
           end
@@ -355,6 +359,11 @@ module Homebrew
       def self.systemd_load(service, enable:)
         System::Systemctl.run("start", service.service_name)
         System::Systemctl.run("enable", service.service_name) if enable
+
+        return unless service.timed?
+
+        System::Systemctl.run("start", service.timer_name)
+        System::Systemctl.run("enable", service.timer_name) if enable
       end
 
       sig { params(service: Services::FormulaWrapper, file: T.nilable(Pathname), enable: T::Boolean).void }
@@ -415,7 +424,25 @@ module Homebrew
 
         chmod 0644, service.dest
 
+        install_timer_file(service) if System.systemctl? && service.timed?
+
         System::Systemctl.run("daemon-reload") if System.systemctl?
+      end
+
+      # Install the systemd `.timer` companion unit alongside the `.service`
+      # file so that scheduled (cron/interval) services actually fire.
+      sig { params(service: Services::FormulaWrapper).void }
+      def self.install_timer_file(service)
+        timer_source = service.timer_file
+        unless timer_source.exist?
+          opoo "Formula `#{service.name}` is timed but no `.timer` file was found at #{timer_source}."
+          return
+        end
+
+        timer_dest = service.dest_timer
+        rm timer_dest if timer_dest.exist?
+        cp timer_source, timer_dest
+        chmod 0644, timer_dest
       end
     end
   end

--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -78,7 +78,7 @@ module Homebrew
 
           puts "Removing unused service file: #{file}"
           rm file
-          cleaned << file
+          cleaned << file.to_s
         end
 
         cleaned

--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -73,8 +73,8 @@ module Homebrew
       sig { returns(T::Array[String]) }
       def self.remove_unused_service_files
         cleaned = []
-        System.path.glob("homebrew.*.{plist,service}").each do |file|
-          next if running.include?(File.basename(file).sub(/\.(plist|service)$/i, ""))
+        System.path.glob("homebrew.*.{plist,service,timer}").each do |file|
+          next if running.include?(File.basename(file).sub(/\.(plist|service|timer)$/i, ""))
 
           puts "Removing unused service file: #{file}"
           rm file
@@ -196,12 +196,14 @@ module Homebrew
           end
 
           if System.systemctl?
+            # Stop the timer before the service so a scheduled fire can't re-activate the
+            # service mid-stop.
             if keep
-              System::Systemctl.quiet_run(*systemctl_args, "stop", service.service_name)
               System::Systemctl.quiet_run(*systemctl_args, "stop", service.timer_name) if service.timed?
+              System::Systemctl.quiet_run(*systemctl_args, "stop", service.service_name)
             else
-              System::Systemctl.quiet_run(*systemctl_args, "disable", "--now", service.service_name)
               System::Systemctl.quiet_run(*systemctl_args, "disable", "--now", service.timer_name) if service.timed?
+              System::Systemctl.quiet_run(*systemctl_args, "disable", "--now", service.service_name)
             end
           elsif System.launchctl?
             dont_wait_statuses = [
@@ -430,13 +432,14 @@ module Homebrew
       end
 
       # Install the systemd `.timer` companion unit alongside the `.service`
-      # file so that scheduled (cron/interval) services actually fire.
+      # file so that scheduled (cron/interval) services actually fire. Callers
+      # must gate on `System.systemctl?` and `service.timed?`.
       sig { params(service: Services::FormulaWrapper).void }
       def self.install_timer_file(service)
         timer_source = service.timer_file
         unless timer_source.exist?
-          opoo "Formula `#{service.name}` is timed but no `.timer` file was found at #{timer_source}."
-          return
+          raise UsageError, "Formula `#{service.name}` is timed but no `.timer` file was found at " \
+                            "#{timer_source}. Try `brew reinstall #{service.name}`."
         end
 
         timer_dest = service.dest_timer

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -92,6 +92,24 @@ module Homebrew
         )
       end
 
+      # Path to the source systemd .timer file in the Cellar (systemd-only).
+      sig { returns(Pathname) }
+      def timer_file
+        @timer_file ||= T.let(formula.systemd_timer_path, T.nilable(Pathname))
+      end
+
+      # Name passed to `systemctl` for the timer unit (e.g. `homebrew.<formula>.timer`).
+      sig { returns(String) }
+      def timer_name
+        @timer_name ||= T.let("#{service_name}.timer", T.nilable(String))
+      end
+
+      # Path to the destination .timer file (boot_path or user_path).
+      sig { returns(Pathname) }
+      def dest_timer
+        dest_dir + timer_file.basename
+      end
+
       # Whether the service should be launched at startup
       sig { returns(T::Boolean) }
       def service_startup?

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -158,14 +158,18 @@ module Homebrew
         @status_output_success_type = nil
       end
 
-      # Returns `true` if the service is loaded, else false.
+      # Returns `true` if the service is loaded, else false. For systemd timers, the
+      # service unit is inactive between fires, so we also consider the timer's load
+      # state — otherwise `brew services stop` on an idle cron service takes the
+      # "not loaded" early-exit branch and leaves the timer registered with systemd.
       sig { params(cached: T::Boolean).returns(T::Boolean) }
       def loaded?(cached: false)
         if System.launchctl?
           reset_cache! unless cached
           status_success
         else # System.systemctl?
-          System::Systemctl.quiet_run("status", service_file.basename)
+          System::Systemctl.quiet_run("status", service_file.basename) ||
+            (timed? && System::Systemctl.quiet_run("status", timer_file.basename))
         end
       end
 

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -1119,11 +1119,11 @@ RSpec.describe Homebrew::Service do
       styles = {
         "@hourly":   "*-*-* *:00:00",
         "@daily":    "*-*-* 00:00:00",
-        "@weekly":   "0 *-*-* 00:00:00",
+        "@weekly":   "Sun *-*-* 00:00:00",
         "@monthly":  "*-*-1 00:00:00",
         "@yearly":   "*-1-1 00:00:00",
         "@annually": "*-1-1 00:00:00",
-        "5 5 5 5 5": "5 *-5-5 05:05:00",
+        "5 5 5 5 5": "Fri *-5-5 05:05:00",
       }
 
       styles.each do |cron, calendar|

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -1101,6 +1101,20 @@ RSpec.describe Homebrew::Service do
       expect(unit).to eq(unit_expect)
     end
 
+    it "raises on out-of-range cron weekday" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          run_type :cron
+          cron "0 0 * * 14"
+        end
+      end
+
+      expect do
+        f.service.to_systemd_timer
+      end.to raise_error(ArgumentError, /Weekday must be 0..7/)
+    end
+
     it "throws on incomplete cron" do
       f = stub_formula do
         service do
@@ -1124,6 +1138,7 @@ RSpec.describe Homebrew::Service do
         "@yearly":   "*-1-1 00:00:00",
         "@annually": "*-1-1 00:00:00",
         "5 5 5 5 5": "Fri *-5-5 05:05:00",
+        "5 5 5 5 7": "Sun *-5-5 05:05:00",
       }
 
       styles.each do |cron, calendar|

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -1072,7 +1072,7 @@ RSpec.describe Homebrew::Service do
         WantedBy=timers.target
 
         [Timer]
-        Unit=homebrew.formula_name
+        Unit=homebrew.formula_name.service
         OnUnitActiveSec=5
       SYSTEMD
       expect(unit).to eq(unit_expect)
@@ -1095,7 +1095,7 @@ RSpec.describe Homebrew::Service do
         WantedBy=timers.target
 
         [Timer]
-        Unit=homebrew.formula_name
+        Unit=homebrew.formula_name.service
 
       SYSTEMD
       expect(unit).to eq(unit_expect)
@@ -1117,13 +1117,13 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid cron timers" do
       styles = {
-        "@hourly":   "*-*-*-* *:00:00",
-        "@daily":    "*-*-*-* 00:00:00",
-        "@weekly":   "0-*-*-* 00:00:00",
-        "@monthly":  "*-*-*-1 00:00:00",
-        "@yearly":   "*-*-1-1 00:00:00",
-        "@annually": "*-*-1-1 00:00:00",
-        "5 5 5 5 5": "5-*-5-5 05:05:00",
+        "@hourly":   "*-*-* *:00:00",
+        "@daily":    "*-*-* 00:00:00",
+        "@weekly":   "0 *-*-* 00:00:00",
+        "@monthly":  "*-*-1 00:00:00",
+        "@yearly":   "*-1-1 00:00:00",
+        "@annually": "*-1-1 00:00:00",
+        "5 5 5 5 5": "5 *-5-5 05:05:00",
       }
 
       styles.each do |cron, calendar|
@@ -1144,7 +1144,7 @@ RSpec.describe Homebrew::Service do
           WantedBy=timers.target
 
           [Timer]
-          Unit=homebrew.formula_name
+          Unit=homebrew.formula_name.service
           Persistent=true
           OnCalendar=#{calendar}
         SYSTEMD

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe Homebrew::Services::Cli do
       expect(dest_timer.read).to eq("[Timer]\nOnCalendar=daily\n")
     end
 
-    it "warns and is a no-op when the source timer file is missing" do
+    it "raises UsageError when the source timer file is missing" do
       missing_timer = tmp_root/"missing.timer"
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
@@ -301,9 +301,23 @@ RSpec.describe Homebrew::Services::Cli do
 
       expect do
         services_cli.install_timer_file(service)
-      end.to output(/timed but no `\.timer` file was found/).to_stderr
+      end.to raise_error(UsageError, /timed but no `\.timer` file was found/)
 
       expect(dest_timer).not_to exist
+    end
+
+    it "overwrites a stale destination timer file with the new contents" do
+      dest_timer.write("[Timer]\nOnCalendar=hourly\n")
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:       "example_service",
+        timer_file: source_timer,
+        dest_timer: dest_timer,
+      )
+
+      services_cli.install_timer_file(service)
+
+      expect(dest_timer.read).to eq("[Timer]\nOnCalendar=daily\n")
     end
   end
 
@@ -326,7 +340,7 @@ RSpec.describe Homebrew::Services::Cli do
       dest_timer.write("tmr")
     end
 
-    it "disables --now both the service unit and the timer unit, and removes both files" do
+    it "disables --now the timer before the service and removes both files" do
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
         name:         "example_service",
@@ -343,13 +357,16 @@ RSpec.describe Homebrew::Services::Cli do
         services_cli.stop([service])
       end
 
-      expect(log.read).to include("--user disable --now homebrew.example_service\n")
-      expect(log.read).to include("--user disable --now homebrew.example_service.timer\n")
+      systemctl_lines = log.read.lines.grep(/disable/)
+      expect(systemctl_lines).to eq([
+        "--user disable --now homebrew.example_service.timer\n",
+        "--user disable --now homebrew.example_service\n",
+      ])
       expect(dest_service).not_to exist
       expect(dest_timer).not_to exist
     end
 
-    it "leaves the timer file in place when keep: true and only stops the units" do
+    it "leaves the timer file in place when keep: true and stops the timer before the service" do
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
         name:         "example_service",
@@ -366,11 +383,37 @@ RSpec.describe Homebrew::Services::Cli do
         services_cli.stop([service], keep: true)
       end
 
-      expect(log.read).to include("--user stop homebrew.example_service\n")
-      expect(log.read).to include("--user stop homebrew.example_service.timer\n")
+      systemctl_lines = log.read.lines.grep(/stop/)
+      expect(systemctl_lines).to eq([
+        "--user stop homebrew.example_service.timer\n",
+        "--user stop homebrew.example_service\n",
+      ])
       expect(log.read).not_to include("disable")
       expect(dest_service).to exist
       expect(dest_timer).to exist
+    end
+
+    it "removes a stale timer file when the service is no longer loaded" do
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:                  "example_service",
+        service_name:          "homebrew.example_service",
+        timer_name:            "homebrew.example_service.timer",
+        timed?:                true,
+        loaded?:               false,
+        owner:                 nil,
+        service_file_present?: false,
+        dest:                  dest_service,
+        dest_timer:            dest_timer,
+      )
+
+      with_env(PATH: bindir.to_s) do
+        expect { services_cli.stop([service]) }.to output(/not started/).to_stderr
+      end
+
+      expect(dest_service).not_to exist
+      expect(dest_timer).not_to exist
+      expect(log).not_to exist
     end
   end
 

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe Homebrew::Services::Cli do
     it "checks non-enabling run" do
       with_env(PATH: bindir.to_s) do
         services_cli.systemd_load(
-          instance_double(Homebrew::Services::FormulaWrapper, service_name: "name"),
+          instance_double(Homebrew::Services::FormulaWrapper, service_name: "name", timed?: false),
           enable: false,
         )
       end
@@ -214,7 +214,7 @@ RSpec.describe Homebrew::Services::Cli do
     it "checks enabling run" do
       with_env(PATH: bindir.to_s) do
         services_cli.systemd_load(
-          instance_double(Homebrew::Services::FormulaWrapper, service_name: "name"),
+          instance_double(Homebrew::Services::FormulaWrapper, service_name: "name", timed?: false),
           enable: true,
         )
       end
@@ -223,6 +223,154 @@ RSpec.describe Homebrew::Services::Cli do
         --user start name
         --user enable name
       EOS
+    end
+
+    it "also starts and enables the timer when the service is timed" do
+      with_env(PATH: bindir.to_s) do
+        services_cli.systemd_load(
+          instance_double(
+            Homebrew::Services::FormulaWrapper,
+            service_name: "name",
+            timed?:       true,
+            timer_name:   "name.timer",
+          ),
+          enable: true,
+        )
+      end
+
+      expect(log.read).to eq <<~EOS
+        --user start name
+        --user enable name
+        --user start name.timer
+        --user enable name.timer
+      EOS
+    end
+
+    it "starts but does not enable the timer when enable: false and the service is timed" do
+      with_env(PATH: bindir.to_s) do
+        services_cli.systemd_load(
+          instance_double(
+            Homebrew::Services::FormulaWrapper,
+            service_name: "name",
+            timed?:       true,
+            timer_name:   "name.timer",
+          ),
+          enable: false,
+        )
+      end
+
+      expect(log.read).to eq <<~EOS
+        --user start name
+        --user start name.timer
+      EOS
+    end
+  end
+
+  describe "#install_timer_file" do
+    let(:tmp_root) { mktmpdir }
+    let(:source_timer) { tmp_root/"homebrew.example_service.timer" }
+    let(:dest_timer) { tmp_root/"dest"/"homebrew.example_service.timer" }
+
+    before do
+      source_timer.write("[Timer]\nOnCalendar=daily\n")
+      dest_timer.parent.mkpath
+    end
+
+    it "copies the timer file from the Cellar to the dest_dir" do
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:       "example_service",
+        timer_file: source_timer,
+        dest_timer: dest_timer,
+      )
+
+      services_cli.install_timer_file(service)
+
+      expect(dest_timer).to be_file
+      expect(dest_timer.read).to eq("[Timer]\nOnCalendar=daily\n")
+    end
+
+    it "warns and is a no-op when the source timer file is missing" do
+      missing_timer = tmp_root/"missing.timer"
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:       "example_service",
+        timer_file: missing_timer,
+        dest_timer: dest_timer,
+      )
+
+      expect do
+        services_cli.install_timer_file(service)
+      end.to output(/timed but no `\.timer` file was found/).to_stderr
+
+      expect(dest_timer).not_to exist
+    end
+  end
+
+  describe "#stop with a timed service" do
+    let(:bindir) { mktmpdir }
+    let(:log) { bindir/"systemctl.log" }
+    let(:tmp_root) { mktmpdir }
+    let(:dest_service) { tmp_root/"homebrew.example_service.service" }
+    let(:dest_timer) { tmp_root/"homebrew.example_service.timer" }
+
+    before do
+      (bindir/"systemctl").write <<~SH
+        #!/bin/sh
+        printf '%s\\n' "$*" >> "#{log}"
+      SH
+      (bindir/"systemctl").chmod 0755
+      Homebrew::Services::System::Systemctl.reset_executable!
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      dest_service.write("svc")
+      dest_timer.write("tmr")
+    end
+
+    it "disables --now both the service unit and the timer unit, and removes both files" do
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:         "example_service",
+        service_name: "homebrew.example_service",
+        timer_name:   "homebrew.example_service.timer",
+        timed?:       true,
+        loaded?:      true,
+        pid?:         false,
+        dest:         dest_service,
+        dest_timer:   dest_timer,
+      )
+
+      with_env(PATH: bindir.to_s) do
+        services_cli.stop([service])
+      end
+
+      expect(log.read).to include("--user disable --now homebrew.example_service\n")
+      expect(log.read).to include("--user disable --now homebrew.example_service.timer\n")
+      expect(dest_service).not_to exist
+      expect(dest_timer).not_to exist
+    end
+
+    it "leaves the timer file in place when keep: true and only stops the units" do
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:         "example_service",
+        service_name: "homebrew.example_service",
+        timer_name:   "homebrew.example_service.timer",
+        timed?:       true,
+        loaded?:      true,
+        pid?:         false,
+        dest:         dest_service,
+        dest_timer:   dest_timer,
+      )
+
+      with_env(PATH: bindir.to_s) do
+        services_cli.stop([service], keep: true)
+      end
+
+      expect(log.read).to include("--user stop homebrew.example_service\n")
+      expect(log.read).to include("--user stop homebrew.example_service.timer\n")
+      expect(log.read).not_to include("disable")
+      expect(dest_service).to exist
+      expect(dest_timer).to exist
     end
   end
 
@@ -331,6 +479,7 @@ RSpec.describe Homebrew::Services::Cli do
             name:             "name",
             service_name:     "service.name",
             service_startup?: false,
+            timed?:           false,
             dest:             instance_double(Pathname, exist?: true),
           ),
           nil,
@@ -351,6 +500,7 @@ RSpec.describe Homebrew::Services::Cli do
             name:             "name",
             service_name:     "service.name",
             service_startup?: false,
+            timed?:           false,
             dest:             instance_double(Pathname, exist?: true),
           ),
           nil,

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -59,6 +59,30 @@ RSpec.describe Homebrew::Services::Cli do
     end
   end
 
+  describe "#remove_unused_service_files" do
+    let(:tmp_path) { mktmpdir }
+
+    before do
+      allow(Homebrew::Services::System).to receive(:path).and_return(tmp_path)
+    end
+
+    it "removes orphaned `.service` and `.timer` files but leaves matching ones running" do
+      (tmp_path/"homebrew.foo.service").write("svc")
+      (tmp_path/"homebrew.foo.timer").write("tmr")
+      (tmp_path/"homebrew.bar.service").write("svc")
+      (tmp_path/"homebrew.bar.timer").write("tmr")
+      allow(services_cli).to receive(:running).and_return(["homebrew.foo"])
+
+      expect { services_cli.remove_unused_service_files }
+        .to output(/homebrew\.bar\.service.*homebrew\.bar\.timer/m).to_stdout
+
+      expect(tmp_path/"homebrew.foo.service").to exist
+      expect(tmp_path/"homebrew.foo.timer").to exist
+      expect(tmp_path/"homebrew.bar.service").not_to exist
+      expect(tmp_path/"homebrew.bar.timer").not_to exist
+    end
+  end
+
   describe "#kill_orphaned_services" do
     it "skips unmanaged services" do
       allow(services_cli).to receive(:running).and_return(["example_service"])
@@ -184,6 +208,44 @@ RSpec.describe Homebrew::Services::Cli do
         UsageError,
         "Invalid usage: Formula `name` has not implemented #plist, #service or provided a locatable service file.",
       )
+    end
+
+    context "with a timed service under systemd" do
+      let(:tmp_root) { mktmpdir }
+      let(:source_service) { tmp_root/"src"/"homebrew.example_service.service" }
+      let(:source_timer) { tmp_root/"src"/"homebrew.example_service.timer" }
+      let(:dest_dir) { tmp_root/"dest" }
+      let(:dest_service) { dest_dir/"homebrew.example_service.service" }
+      let(:dest_timer) { dest_dir/"homebrew.example_service.timer" }
+
+      before do
+        source_service.parent.mkpath
+        source_service.write("[Service]\nExecStart=/bin/true\n")
+        source_timer.write("[Timer]\nOnCalendar=daily\n")
+        allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+        allow(Homebrew::Services::System::Systemctl).to receive(:run)
+      end
+
+      it "installs both the service file and the timer companion" do
+        service = instance_double(
+          Homebrew::Services::FormulaWrapper,
+          name:         "example_service",
+          service_name: "homebrew.example_service",
+          installed?:   true,
+          service_file: source_service,
+          timer_file:   source_timer,
+          timed?:       true,
+          dest_dir:     dest_dir,
+          dest:         dest_service,
+          dest_timer:   dest_timer,
+        )
+
+        services_cli.install_service_file(service, nil)
+
+        expect(dest_service).to be_file
+        expect(dest_timer).to be_file
+        expect(dest_timer.read).to eq("[Timer]\nOnCalendar=daily\n")
+      end
     end
   end
 

--- a/Library/Homebrew/test/services/formula_wrapper_spec.rb
+++ b/Library/Homebrew/test/services/formula_wrapper_spec.rb
@@ -183,6 +183,25 @@ RSpec.describe Homebrew::Services::FormulaWrapper do
       expect(service.loaded?).to be(false)
     end
 
+    it "systemD - returns true when only the timer unit is active for a timed service" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      allow(service).to receive(:timed?).and_return(true)
+      allow(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("status", service.service_file.basename).and_return(false)
+      allow(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("status", service.timer_file.basename).and_return(true)
+      expect(service.loaded?).to be(true)
+    end
+
+    it "systemD - does not consult the timer when service is not timed" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      allow(service).to receive(:timed?).and_return(false)
+      allow(Homebrew::Services::System::Systemctl).to receive(:quiet_run).and_return(false)
+      expect(Homebrew::Services::System::Systemctl).not_to receive(:quiet_run)
+        .with("status", service.timer_file.basename)
+      expect(service.loaded?).to be(false)
+    end
+
     it "Other - raises an error" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: false)
       expect do

--- a/Library/Homebrew/test/services/formula_wrapper_spec.rb
+++ b/Library/Homebrew/test/services/formula_wrapper_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper do
                     service_name:           "plist-mysql-test",
                     launchd_service_path:   Pathname.new("/usr/local/opt/mysql/homebrew.mysql.plist"),
                     systemd_service_path:   Pathname.new("/usr/local/opt/mysql/homebrew.mysql.service"),
+                    systemd_timer_path:     Pathname.new("/usr/local/opt/mysql/homebrew.mysql.timer"),
                     opt_prefix:             Pathname.new("/usr/local/opt/mysql"),
                     any_version_installed?: true,
                     service?:               false)
@@ -83,6 +84,37 @@ RSpec.describe Homebrew::Services::FormulaWrapper do
         service.service_name
       end.to raise_error(UsageError,
                          "Invalid usage: `brew services` is supported only on macOS or Linux (with systemd)!")
+    end
+  end
+
+  describe "#timer_file" do
+    it "returns the systemd timer path from the formula" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      expect(service.timer_file.to_s).to eq("/usr/local/opt/mysql/homebrew.mysql.timer")
+    end
+  end
+
+  describe "#timer_name" do
+    it "appends `.timer` to the service name" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      expect(service.timer_name).to eq("plist-mysql-test.timer")
+    end
+  end
+
+  describe "#dest_timer" do
+    before do
+      ENV["HOME"] = "/tmp_home"
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+    end
+
+    it "systemD - user - outputs the destination for the timer file" do
+      allow(Homebrew::Services::System).to receive(:root?).and_return(false)
+      expect(service.dest_timer.to_s).to eq("/tmp_home/.config/systemd/user/homebrew.mysql.timer")
+    end
+
+    it "systemD - root - outputs the destination for the timer file" do
+      allow(Homebrew::Services::System).to receive(:root?).and_return(true)
+      expect(service.dest_timer.to_s).to eq("/usr/lib/systemd/system/homebrew.mysql.timer")
     end
   end
 


### PR DESCRIPTION
Closes #22092.

`brew services start <formula>` on systemd never installed or started the `.timer` companion unit for cron- or interval-typed services. The formula installer writes the `.timer` to the Cellar (when `formula.service.timed?` is true), but `Homebrew/Services/Cli` had no references to "timer" — only the `.service` was being copied to `~/.config/systemd/user/`, started, and stopped. As a result, scheduled services never fired even though `brew services start` reported success.

Fixing the wiring alone surfaced two further bugs in `Service#to_systemd_timer` that prevented the timer file from being accepted by systemd, plus a stop-path bug in `FormulaWrapper#loaded?` that orphaned timers when stopping idle cron services. All four are addressed here.

### Services CLI wiring

- `FormulaWrapper` gains `timer_file`, `timer_name`, and `dest_timer` accessors that mirror the existing `service_file` / `service_name` / `dest` triplet.
- `Cli.install_service_file` now installs the `.timer` companion alongside the `.service` for timed services on systemd, via a new `Cli.install_timer_file` helper. The helper raises `UsageError` if the source `.timer` is missing, matching the behavior of `install_service_file` (a missing source means a corrupt Cellar install, not a soft warning).
- `Cli.systemd_load` starts (and `enable`s when requested) the timer after the service.
- `Cli.stop` stops/disables the timer **before** the service so a scheduled fire cannot re-activate the service mid-stop, then removes both files. The early-exit "service already unloaded" branch also cleans up a stale `.timer`.
- `Cli.remove_unused_service_files` now sweeps `.timer` files alongside `.plist` and `.service` so orphaned timers don't linger after `brew uninstall`.

### Generated `.timer` file correctness

- `Unit=` directive now includes the `.service` suffix; without it, systemd rejects the timer with `Unit type not valid`.
- `OnCalendar=` formatting fixed in three ways: the day-of-week field is omitted entirely when wildcard (systemd's calendar parser rejects a literal `*` for day-of-week); when a weekday is specified, it is mapped from cron's integer (0..7, where both 0 and 7 are Sunday) to the systemd-accepted English abbreviation (`Sun`..`Sat`) via a new `SYSTEMD_WEEKDAYS` constant; and the date and time fields are now correctly separated by a space (not a dash).
- Out-of-range cron weekdays now raise `ArgumentError` rather than silently mod-mapping onto a valid-but-wrong day.

### `FormulaWrapper#loaded?` for timed services

- `loaded?` previously checked only the `.service` unit. For an idle cron-typed service (the unit is inactive between fires), this returned false even when the timer was active, so `brew services stop` took the early-exit branch and left the timer registered with systemd. `loaded?` now also considers the timer when the service is timed.

### Verification

- `brew lgtm` passes locally — typecheck, style, and 165 changed-file tests.
- End-to-end verified on a Linux systemd container (Ubuntu with systemd 257) using a custom test formula. Verified both `run_type :interval` and `run_type :cron` (`@weekly`) variants:
  - `brew services start` correctly installs both unit files to `~/.config/systemd/user/` and enables/starts the timer.
  - `systemctl --user list-timers` shows the timer scheduled to fire at the next expected time (e.g. `Sun 2026-05-03 00:00:00 UTC` for `@weekly`).
  - The timer actually fires on schedule and the service runs (verified via a log-appending script).
  - `brew services stop` cleanly removes both unit files, deregisters the timer, and cleans out `timers.target.wants/`.

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

This PR was developed with Claude (Sonnet 4.6 and Opus 4.6) using a strict TDD workflow: failing tests were written first, the red phase was verified, then the implementation was added until tests passed green. After the initial wiring fix, end-to-end testing on a Linux systemd container surfaced the additional `Service#to_systemd_timer` bugs and the `loaded?` orphan; each was fixed with the same TDD discipline. Multiple review passes with separate code-review, test-coverage, error-handling, and comment-rot agents drove additional fixes — most notably the timer-before-service stop ordering to avoid a re-firing race, raising on missing-timer-source, sweeping `.timer` files in `remove_unused_service_files`, and validating cron weekdays against the documented 0..7 range. I ran `brew lgtm` after each change, repeatedly smoke-tested the full lifecycle on the systemd container with both `interval` and `cron` formulas, and reviewed every diff line before committing.

-----
