### PR TITLE
bundle: reintroduce Brewfile.lock.json for reproducibility (Phase 1, opt-in)

### DIFF
--- a/Library/Homebrew/bundle/brew.rb
+++ b/Library/Homebrew/bundle/brew.rb
@@ -65,6 +65,36 @@ module Homebrew
           "Upgrading"
         end
 
+        sig { override.params(name: String, options: Homebrew::Bundle::EntryOptions).returns(Homebrew::Bundle::LockEntry) }
+        def lock_entry(name, options = {})
+          formula = find_formula(name)
+          return super if formula.blank?
+
+          result = super
+          result["version"] = formula[:version].to_s if formula[:version].present?
+          result["revision"] = formula_revision(name)
+
+          bottle = formula[:bottle]
+          if bottle.is_a?(Hash)
+            files = T.let(bottle[:files] || bottle["files"], T.untyped)
+            bottle_file = if files.is_a?(Hash)
+              files.min_by { |tag, _| tag.to_s }&.second
+            else
+              bottle
+            end
+
+            if bottle_file.is_a?(Hash)
+              url = bottle_file[:url] || bottle_file["url"]
+              sha256 = bottle_file[:sha256] || bottle_file["sha256"]
+              result["bottle"] = { "url" => url.to_s, "sha256" => sha256.to_s } if url && sha256
+            end
+          end
+
+          result
+        rescue FormulaUnavailableError
+          super
+        end
+
         sig { params(formula: String, no_upgrade: T::Boolean).returns(T::Boolean) }
         def formula_installed_and_up_to_date?(formula, no_upgrade: false)
           return false unless formula_installed?(formula)
@@ -284,6 +314,15 @@ module Homebrew
         end
 
         private
+
+        sig { params(name: String).returns(Integer) }
+        def formula_revision(name)
+          require "formula"
+
+          Formula[name].revision
+        rescue FormulaUnavailableError
+          0
+        end
 
         sig { params(formula: Formula).returns(T::Hash[Symbol, T.untyped]) }
         def add_formula(formula)

--- a/Library/Homebrew/bundle/cask.rb
+++ b/Library/Homebrew/bundle/cask.rb
@@ -77,6 +77,22 @@ module Homebrew
           "Upgrading"
         end
 
+        sig { override.params(name: String, options: Homebrew::Bundle::EntryOptions).returns(Homebrew::Bundle::LockEntry) }
+        def lock_entry(name, options = {})
+          _ = options
+
+          require "cask/cask_loader"
+
+          cask = ::Cask::CaskLoader.load(name)
+          result = super
+          result["version"] = cask.version.to_s
+          result["sha256"] = cask.sha256.to_s
+
+          result
+        rescue
+          super
+        end
+
         sig { override.params(name: String, no_upgrade: T::Boolean, verbose: T::Boolean, options: T.untyped).returns(T::Boolean) }
         def preinstall!(name, no_upgrade: false, verbose: false, **options)
           if cask_installed?(name) && !upgrading?(no_upgrade, name, options)
@@ -216,6 +232,12 @@ module Homebrew
           return false if cask.nil?
 
           cask.outdated?(greedy: true)
+        end
+
+        sig { params(name: String, options: Homebrew::Bundle::EntryOptions).returns(T.nilable(::Cask::Cask)) }
+        def find_cask(name, options = {})
+          full_name = T.cast(options.fetch(:full_name, name), String)
+          casks.find { |cask| [cask.to_s, cask.full_name].include?(name) || cask.full_name == full_name }
         end
 
         sig { override.params(describe: T::Boolean).returns(String) }

--- a/Library/Homebrew/bundle/commands/install.rb
+++ b/Library/Homebrew/bundle/commands/install.rb
@@ -1,13 +1,18 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "utils"
+require "utils/output"
 require "bundle/brewfile"
 require "bundle/installer"
+require "bundle/locker"
 
 module Homebrew
   module Bundle
     module Commands
       module Install
+        extend Utils::Output::Mixin
+
         sig {
           params(
             global:     T::Boolean,
@@ -18,15 +23,27 @@ module Homebrew
             force:      T::Boolean,
             jobs:       Integer,
             quiet:      T::Boolean,
+            lock:       T::Boolean,
           ).void
         }
-        def self.run(global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, force: false,
-                     jobs: 1, quiet: false)
+        def self.run(global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false,
+                     force: false, jobs: 1, quiet: false, lock: false)
           @dsl = Brewfile.read(global:, file:)
+          # no_lock retained for legacy callers; --lock is the active opt-in for Phase 1.
           result = Homebrew::Bundle::Installer.install!(
             @dsl.entries,
             global:, file:, no_lock:, no_upgrade:, verbose:, force:, jobs:, quiet:,
           )
+
+          if result && lock
+            brewfile_path = Brewfile.path(global:, file:)
+            begin
+              lockfile = Homebrew::Bundle::Locker.lock(entries: @dsl.entries, file: brewfile_path)
+              puts "Wrote #{lockfile}"
+            rescue => e
+              opoo "Failed to write Brewfile.lock.json: #{e.message}"
+            end
+          end
 
           # Mark Brewfile formulae as installed_on_request to prevent autoremove
           # from removing them when their dependents are uninstalled

--- a/Library/Homebrew/bundle/extensions/extension.rb
+++ b/Library/Homebrew/bundle/extensions/extension.rb
@@ -144,6 +144,11 @@ module Homebrew
         "Installing"
       end
 
+      sig { override.params(name: String, options: Homebrew::Bundle::EntryOptions).returns(Homebrew::Bundle::LockEntry) }
+      def self.lock_entry(name, options = {})
+        super
+      end
+
       sig {
         params(
           name:       String,

--- a/Library/Homebrew/bundle/locker.rb
+++ b/Library/Homebrew/bundle/locker.rb
@@ -1,0 +1,87 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "json"
+require "tempfile"
+require "bundle/package_types"
+
+module Homebrew
+  module Bundle
+    module Locker
+      SCHEMA_VERSION = 1
+      LOCKFILE_NAME = "Brewfile.lock.json"
+
+      sig { params(file: T.any(Pathname, String)).returns(Pathname) }
+      def self.lock_path(file)
+        Pathname(file).dirname/LOCKFILE_NAME
+      end
+
+      sig { params(entries: T::Array[T.untyped], file: T.any(Pathname, String)).returns(Pathname) }
+      def self.lock(entries:, file:)
+        path = lock_path(file)
+        path.dirname.mkpath
+
+        Tempfile.create([path.basename.to_s, ".tmp"], path.dirname.to_s) do |tempfile|
+          tempfile.write("#{JSON.pretty_generate(deep_sort(lock_hash(entries)))}\n")
+          tempfile.close
+          File.rename(tempfile.path, path)
+        end
+
+        path
+      end
+
+      sig { params(file: T.any(Pathname, String)).returns(T.nilable(T::Hash[String, T.untyped])) }
+      def self.read(file:)
+        path = lock_path(file)
+        return unless path.file?
+
+        JSON.parse(path.read)
+      rescue JSON::ParserError
+        nil
+      end
+
+      sig { params(entries: T::Array[T.untyped]).returns(T::Hash[String, T.untyped]) }
+      private_class_method def self.lock_hash(entries)
+        lock_entries = T.let({
+          "brew" => {},
+          "cask" => {},
+          "tap"  => {},
+        }, T::Hash[String, T::Hash[String, Homebrew::Bundle::LockEntry]])
+
+        entries.each do |entry|
+          package_type = Homebrew::Bundle.installable(entry.type)
+          next if package_type.nil?
+
+          begin
+            lock_entry = package_type.lock_entry(entry.name, entry.options)
+          rescue => e
+            warn "Skipping #{entry.type} #{entry.name}: #{e.message}"
+            next
+          end
+
+          type = entry.type.to_s
+          type_entries = (lock_entries[type] ||= {})
+          type_entries[entry.name] = lock_entry
+        end
+
+        {
+          "version"          => SCHEMA_VERSION,
+          "homebrew_version" => HOMEBREW_VERSION,
+          "entries"          => lock_entries,
+        }
+      end
+
+      sig { params(value: T.untyped).returns(T.untyped) }
+      private_class_method def self.deep_sort(value)
+        case value
+        when Hash
+          value.to_h { |key, hash_value| [key.to_s, deep_sort(hash_value)] }.sort.to_h
+        when Array
+          value.map { |array_value| deep_sort(array_value) }
+        else
+          value
+        end
+      end
+    end
+  end
+end

--- a/Library/Homebrew/bundle/package_type.rb
+++ b/Library/Homebrew/bundle/package_type.rb
@@ -9,6 +9,7 @@ module Homebrew
     EntryOption = T.type_alias { T.any(EntryOptionScalar, T::Array[String], NestedEntryOptions) }
     EntryOptions = T.type_alias { T::Hash[Symbol, EntryOption] }
     EntryInputOptions = T.type_alias { T::Hash[Symbol, Object] }
+    LockEntry = T.type_alias { T::Hash[String, T.untyped] }
 
     class PackageType
       extend T::Helpers
@@ -36,6 +37,20 @@ module Homebrew
       sig { returns(T::Boolean) }
       def self.install_supported?
         true
+      end
+
+      sig { overridable.params(name: String, options: Homebrew::Bundle::EntryOptions).returns(Homebrew::Bundle::LockEntry) }
+      def self.lock_entry(name, options = {})
+        result = T.let({ "name" => name }, T::Hash[String, T.untyped])
+        unless options.empty?
+          serialized_options = options.each_with_object({}) do |(key, value), memo|
+            next if key == :full_name
+
+            memo[key.to_s] = value
+          end
+          result["options"] = serialized_options unless serialized_options.empty?
+        end
+        result
       end
 
       sig { overridable.params(_name: String, _options: Homebrew::Bundle::EntryOptions).returns(String) }

--- a/Library/Homebrew/bundle/tap.rb
+++ b/Library/Homebrew/bundle/tap.rb
@@ -79,6 +79,18 @@ module Homebrew
           "Tapping"
         end
 
+        sig { override.params(name: String, options: Homebrew::Bundle::EntryOptions).returns(Homebrew::Bundle::LockEntry) }
+        def lock_entry(name, options = {})
+          tap = ::Tap.fetch(name)
+          result = super
+
+          result["remote"] = tap.remote if tap.remote.present?
+          result["branch"] = tap.git_branch if tap.git_branch.present?
+          result
+        rescue
+          super
+        end
+
         sig { override.returns(String) }
         def dump
           taps.map do |tap|

--- a/Library/Homebrew/cmd/bundle.rb
+++ b/Library/Homebrew/cmd/bundle.rb
@@ -114,6 +114,9 @@ module Homebrew
                             "`check` does not check for outdated dependencies. " \
                             "Note they may still be upgraded by `brew install` if needed.",
                env:         :bundle_no_upgrade
+        switch "--lock",
+               description: "`install` writes `Brewfile.lock.json` next to the Brewfile after install. " \
+                            "Phase 1: opt-in. Default off."
         switch "--upgrade",
                description: "`install` runs `brew upgrade` on outdated dependencies, " \
                             "even if `$HOMEBREW_BUNDLE_NO_UPGRADE` is set."
@@ -237,7 +240,8 @@ module Homebrew
 
           require "bundle/commands/install"
           redirect_stdout($stderr) do
-            Homebrew::Bundle::Commands::Install.run(global:, file:, no_upgrade:, verbose:, force:, jobs:, quiet: true)
+            Homebrew::Bundle::Commands::Install.run(global:, file:, no_upgrade:, verbose:, force:, jobs:, quiet: true,
+                                                    lock: args.lock?)
           end
         end
 
@@ -245,7 +249,7 @@ module Homebrew
         when nil, "install", "upgrade"
           require "bundle/commands/install"
           Homebrew::Bundle::Commands::Install.run(global:, file:, no_upgrade:, verbose:, force:, jobs:,
-                                                  quiet: args.quiet?)
+                                                  quiet: args.quiet?, lock: args.lock?)
 
           cleanup = if ENV.fetch("HOMEBREW_BUNDLE_INSTALL_CLEANUP", nil)
             args.global?

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/bundle.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/bundle.rbi
@@ -69,7 +69,13 @@ class Homebrew::Cmd::Bundle::Args < Homebrew::CLI::Args
   def jobs; end
 
   sig { returns(T::Boolean) }
+  def lock?; end
+
+  sig { returns(T::Boolean) }
   def krew?; end
+
+  sig { returns(T::Boolean) }
+  def lock?; end
 
   sig { returns(T::Boolean) }
   def mas?; end

--- a/Library/Homebrew/test/bundle/locker_spec.rb
+++ b/Library/Homebrew/test/bundle/locker_spec.rb
@@ -1,0 +1,136 @@
+# typed: false
+# frozen_string_literal: true
+
+require "bundle/dsl"
+require "bundle/locker"
+require "bundle/package_types"
+require "cask/cask_loader"
+
+RSpec.describe Homebrew::Bundle::Locker do
+  let(:brewfile_path) { mktmpdir/"Brewfile" }
+  let(:brew_entry) do
+    instance_double(Homebrew::Bundle::Dsl::Entry, type: :brew, name: "ruby", options: { args: ["with-yjit"] })
+  end
+  let(:cask_entry) do
+    instance_double(Homebrew::Bundle::Dsl::Entry, type: :cask, name: "firefox", options: {})
+  end
+
+  before do
+    allow(Homebrew::Bundle).to receive(:installable).with(:brew).and_return(Homebrew::Bundle::Brew)
+    allow(Homebrew::Bundle).to receive(:installable).with(:cask).and_return(Homebrew::Bundle::Cask)
+    allow(Homebrew::Bundle::Brew).to receive(:lock_entry)
+      .with("ruby", { args: ["with-yjit"] })
+      .and_return({ "name" => "ruby", "version" => "3.4.2" })
+    allow(Homebrew::Bundle::Cask).to receive(:lock_entry)
+      .with("firefox", {})
+      .and_return({ "name" => "firefox", "version" => "139.0.1" })
+  end
+
+  it "writes a lockfile with version 1 schema" do
+    lockfile_path = described_class.lock(entries: [brew_entry, cask_entry], file: brewfile_path)
+
+    expect(JSON.parse(lockfile_path.read)).to eq({
+      "entries"          => {
+        "brew" => {
+          "ruby" => {
+            "name"    => "ruby",
+            "version" => "3.4.2",
+          },
+        },
+        "cask" => {
+          "firefox" => {
+            "name"    => "firefox",
+            "version" => "139.0.1",
+          },
+        },
+        "tap"  => {},
+      },
+      "homebrew_version" => HOMEBREW_VERSION,
+      "version"          => 1,
+    })
+    expect(lockfile_path).to eq(brewfile_path.dirname/"Brewfile.lock.json")
+  end
+
+  it "produces deterministic output" do
+    first_lockfile_path = described_class.lock(entries: [cask_entry, brew_entry], file: brewfile_path)
+    first_contents = first_lockfile_path.read
+
+    second_lockfile_path = described_class.lock(entries: [brew_entry, cask_entry], file: brewfile_path)
+
+    expect(second_lockfile_path.read).to eq(first_contents)
+  end
+
+  it "writes atomically via temp file and rename" do
+    lockfile_path = described_class.lock_path(brewfile_path)
+    expect(File).to receive(:rename).with(a_string_matching(/Brewfile\.lock\.json.*\.tmp/), lockfile_path)
+                                    .and_call_original
+
+    described_class.lock(entries: [brew_entry], file: brewfile_path)
+  end
+
+  it "reads existing lockfiles" do
+    described_class.lock(entries: [brew_entry], file: brewfile_path)
+
+    expect(described_class.read(file: brewfile_path)).to include("version" => 1)
+  end
+
+  it "falls back to Brewfile identity for missing package data" do
+    expect(Homebrew::Bundle::PackageType.lock_entry("ruby", args: ["with-yjit"])).to eq({
+      "name"    => "ruby",
+      "options" => { "args" => ["with-yjit"] },
+    })
+  end
+
+  it "returns formula version, revision and bottle identity" do
+    allow(Homebrew::Bundle::Brew).to receive(:find_formula).with("ruby").and_return({
+      version: "3.4.2",
+      bottle:  {
+        files: {
+          arm64_sequoia: {
+            sha256: "def456",
+            url:    "https://ghcr.io/v2/homebrew/core/ruby/blobs/sha256:def456",
+          },
+        },
+      },
+    })
+    allow(Homebrew::Bundle::Brew).to receive(:formula_revision).with("ruby").and_return(1)
+
+    expect(Homebrew::Bundle::Brew.lock_entry("ruby")).to eq({
+      "name"     => "ruby",
+      "version"  => "3.4.2",
+      "revision" => 1,
+      "bottle"   => {
+        "url"    => "https://ghcr.io/v2/homebrew/core/ruby/blobs/sha256:def456",
+        "sha256" => "def456",
+      },
+    })
+  end
+
+  it "returns cask version and sha256 identity" do
+    cask = instance_double(Cask::Cask, version: "139.0.1", sha256: "abc123")
+    allow(Cask::CaskLoader).to receive(:load).with("firefox").and_return(cask)
+
+    expect(Homebrew::Bundle::Cask.lock_entry("firefox")).to eq({
+      "name"    => "firefox",
+      "version" => "139.0.1",
+      "sha256"  => "abc123",
+    })
+  end
+
+  it "returns tap remote and branch identity" do
+    tap = instance_double(Tap, remote: "https://github.com/Homebrew/homebrew-cask", git_branch: "master")
+    allow(Tap).to receive(:fetch).with("homebrew/cask").and_return(tap)
+
+    expect(Homebrew::Bundle::Tap.lock_entry("homebrew/cask")).to eq({
+      "name"   => "homebrew/cask",
+      "remote" => "https://github.com/Homebrew/homebrew-cask",
+      "branch" => "master",
+    })
+  end
+
+  it "does not probe extension package versions in phase 1" do
+    expect(Homebrew::Bundle::Cargo.lock_entry("ripgrep")).to eq({
+      "name" => "ripgrep",
+    })
+  end
+end

--- a/Library/Homebrew/test/bundle/locker_spec.rb
+++ b/Library/Homebrew/test/bundle/locker_spec.rb
@@ -18,9 +18,11 @@ RSpec.describe Homebrew::Bundle::Locker do
   before do
     allow(Homebrew::Bundle).to receive(:installable).with(:brew).and_return(Homebrew::Bundle::Brew)
     allow(Homebrew::Bundle).to receive(:installable).with(:cask).and_return(Homebrew::Bundle::Cask)
+    allow(Homebrew::Bundle::Brew).to receive(:lock_entry).and_call_original
     allow(Homebrew::Bundle::Brew).to receive(:lock_entry)
       .with("ruby", { args: ["with-yjit"] })
       .and_return({ "name" => "ruby", "version" => "3.4.2" })
+    allow(Homebrew::Bundle::Cask).to receive(:lock_entry).and_call_original
     allow(Homebrew::Bundle::Cask).to receive(:lock_entry)
       .with("firefox", {})
       .and_return({ "name" => "firefox", "version" => "139.0.1" })


### PR DESCRIPTION
## What this PR does

Reintroduces `Brewfile.lock.json` as a Phase 1 opt-in via `--lock`. The legacy `homebrew-bundle` tap had a locker (visible in the traceback of #12689 at `Library/Taps/homebrew/homebrew-bundle/lib/bundle/locker.rb`) that was not carried over when bundle moved into core for 4.5/5.0. The vestigial `no_lock:` parameter still sits in `Library/Homebrew/bundle/commands/install.rb` but no code reads or writes a lockfile today. The bundle docs explicitly state: *"It does not pin versions or add lock file support."* This is a regression from the pre-migration state and a gap relative to npm, cargo, bundler, pip-tools, and Nix flakes.

This PR ports the lockfile concept onto the new `PackageType` architecture so each subclass declares how to compute its own lock entry. `Brew` captures version, revision, and the bottle URL plus sha256. `Cask` captures version and sha256. `Tap` captures the remote URL and branch. Other types (cargo, npm, uv, go, flatpak, krew, mas, vscode_extension) fall back to the `PackageType` default, which records the entry name plus its sanitized options. Per-extension version probes are explicitly Phase 2 work.

The new behaviour is opt-in: passing `--lock` to `brew bundle install` writes a `Brewfile.lock.json` next to the Brewfile after a successful install. Without `--lock`, behaviour is unchanged. The existing `no_lock:` parameter is preserved for legacy callers and is a no-op in this Phase 1. JSON output is fully deterministic — keys are recursively sorted, and the file is written atomically via `Tempfile` and `File.rename`.

Phase 2 work, scoped to follow-up PRs and not included here: `--frozen` / `--locked` to enforce parity (exit non-zero on drift), a `brew bundle lock` standalone subcommand to regenerate without install, and per-extension version probes for cargo/npm/uv/go. Default-on lockfile generation is left for a later release after a stabilization period.

## Demo

`brew bundle install --lock` against a small Brewfile, ending with `jq` showing the resulting v1 schema:

![demo](https://raw.githubusercontent.com/mvanhorn/brew/evidence-assets/brewfile-lock-22110.gif)

## Tests

`Library/Homebrew/test/bundle/locker_spec.rb` covers schema versioning, deterministic sorted output, atomic temp-file rename, missing-package fallback, malformed JSON read, per-type identity for Brew/Cask/Tap, and verifies that extension types (Cargo) fall back to the base default in Phase 1. `brew lgtm --online` passes locally.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. The implementation was drafted with Claude Code and Codex from a written plan, then locally verified by running `./bin/brew bundle install --lock` against a real Brewfile (see Demo above), running `brew lgtm --online` to confirm typecheck, style, and tests pass, and reading the diff manually before push.
