### PR TITLE
info: clarify recursive runtime dependencies line

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -177,8 +177,11 @@ module Homebrew
 
       sig { params(installed_count: Integer, total_count: Integer).returns(String) }
       def self.dependency_status_counts(installed_count, total_count)
-        "#{installed_count} #{Formatter.success("✔")}, " \
-          "#{total_count - installed_count} #{Formatter.error("✘")}"
+        missing_count = total_count - installed_count
+        return "all installed #{Formatter.success("✔")}" if missing_count.zero?
+
+        "#{installed_count} installed #{Formatter.success("✔")}, " \
+          "#{missing_count} missing #{Formatter.error("✘")}"
       end
 
       sig { params(full_name: String, name: String).returns(Integer) }

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Cask::Info, :cask do
       From: #{Formatter.url("https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/w/with-depends-on-cask-multiple.rb")}
       #{ohai_title "Dependencies"}
       Required (2): #{uninstalled("local-caffeine (cask)")}, #{uninstalled("local-transmission-zip (cask)")}
-      Recursive Runtime (2): 0 #{Formatter.success("✔")}, 2 #{Formatter.error("✘")}
+      Recursive Runtime (2): 0 installed #{Formatter.success("✔")}, 2 missing #{Formatter.error("✘")}
       #{requirements_section(installed("macOS >= 10.15"))}
       #{ohai_title "Artifacts"}
       Caffeine.app (App)
@@ -100,11 +100,20 @@ RSpec.describe Cask::Info, :cask do
       From: #{Formatter.url("https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/w/with-depends-on-cask-multiple.rb")}
       #{ohai_title "Dependencies"}
       Required (2): #{uninstalled("local-caffeine (cask)")}, #{installed("local-transmission-zip (cask)")}
-      Recursive Runtime (2): 1 #{Formatter.success("✔")}, 1 #{Formatter.error("✘")}
+      Recursive Runtime (2): 1 installed #{Formatter.success("✔")}, 1 missing #{Formatter.error("✘")}
       #{requirements_section(installed("macOS >= 10.15"))}
       #{ohai_title "Artifacts"}
       Caffeine.app (App)
     EOS
+  end
+
+  it "summarises recursive runtime dependencies as all installed when none are missing" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+    mock_cask_installed("local-caffeine")
+    mock_cask_installed("local-transmission-zip")
+    expect do
+      described_class.info(Cask::CaskLoader.load("with-depends-on-cask-multiple"), args:)
+    end.to output(/Recursive Runtime \(2\): all installed #{Formatter.success("✔")}/).to_stdout
   end
 
   it "prints cask and formulas dependencies if the Cask has both" do
@@ -124,7 +133,7 @@ RSpec.describe Cask::Info, :cask do
       From: #{Formatter.url("https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/w/with-depends-on-everything.rb")}
       #{ohai_title "Dependencies"}
       Required (3): #{uninstalled("unar")}, #{uninstalled("local-caffeine (cask)")}, #{uninstalled("with-depends-on-cask (cask)")}
-      Recursive Runtime (4): 0 #{Formatter.success("✔")}, 4 #{Formatter.error("✘")}
+      Recursive Runtime (4): 0 installed #{Formatter.success("✔")}, 4 missing #{Formatter.error("✘")}
       #{requirements_section("#{arch_requirements}, #{installed("macOS >= 10.15")}")}
       #{ohai_title "Artifacts"}
       Caffeine.app (App)

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -100,11 +100,49 @@ RSpec.describe Homebrew::Cmd::Info do
     allow(formula).to receive(:core_formula?).and_return(false)
     allow(direct_dependency).to receive(:satisfied?).and_return(true)
 
+    expected_output = Regexp.new(
+      "==> Dependencies\nRequired \\(1\\): .*bar.*\n" \
+      "Recursive Runtime \\(2\\): 1 installed .*✔, 1 missing .*✘\nDependents: 1",
+    )
     expect { info.send(:info_formula, formula) }
-      .to output(
-        /==> Dependencies\nRequired \(1\): .*bar.*\nRecursive Runtime \(2\): 1 .*✔, 1 .*✘\nDependents: 1/,
-      ).to_stdout
+      .to output(expected_output).to_stdout
       .and not_to_output(/^Dependencies: /).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "summarises recursive runtime dependencies as all installed when none are missing" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      homepage "https://brew.sh/testball"
+      desc "Some test"
+
+      depends_on "bar"
+    end
+    direct_dependency = formula.deps.required.first
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    keg_path.mkpath
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.runtime_dependencies = [{ "full_name" => "installed-dep", "version" => "1.0" }]
+    tab.write
+
+    installed_dep_path = HOMEBREW_CELLAR/"installed-dep/1.0"
+    installed_dep_path.mkpath
+    installed_dep_tab = Tab.empty
+    installed_dep_tab.tabfile = installed_dep_path/AbstractTab::FILENAME
+    installed_dep_tab.write
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+    allow(direct_dependency).to receive(:satisfied?).and_return(true)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/Recursive Runtime \(1\): all installed .*✔/).to_stdout
+      .and not_to_output(/missing/).to_stdout
       .and not_to_output.to_stderr
   end
 


### PR DESCRIPTION
Make the "Recursive Runtime" line in `brew info` easier to read:

- Label the counts as "installed" / "missing" instead of bare numbers next to ✔/✘.
- When everything is installed it now just says "all installed ✔".

I found this recursive runtime info confusing, I didn't know what it meant:

```
❯ brew info git
==> git ✔: stable 2.54.0 (bottled), HEAD
Distributed revision control system
https://git-scm.com
Installed (on request)
/opt/homebrew/Cellar/git/2.53.0_1 (1,741 files, 62.0MB)
  Poured from bottle using the formulae.brew.sh API on 2026-04-11 at 19:30:15
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/g/git.rb
License: GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-3-Clause AND MIT
==> Dependencies
Required (2): pcre2 ✔, gettext ✔
Recursive Runtime (3): 3 ✔, 0 ✘
==> Options
--HEAD
	Install HEAD version
==> Caveats
The Tcl/Tk GUIs (e.g. gitk, git-gui) are now in the `git-gui` formula.
Subversion interoperability (git-svn) is now in the `git-svn` formula.
==> Analytics
install: 141,732 (30 days), 371,851 (90 days), 1,592,376 (365 days)
install-on-request: 139,588 (30 days), 365,853 (90 days), 1,538,521 (365 days)
build-error: 649 (30 days)
```