### PR TITLE
formula_auditor: align throttle checks with livecheck

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -4,6 +4,7 @@
 require "deprecate_disable"
 require "formula_versions"
 require "formula_name_cask_token_auditor"
+require "livecheck/livecheck"
 require "resource_auditor"
 require "utils"
 require "utils/shared_audits"
@@ -880,10 +881,15 @@ module Homebrew
       stable_url_version = Version.parse(url)
       stable_url_minor_version = stable_url_version.minor.to_i
 
-      formula_suffix = stable.version.patch.to_i
-      throttled_rate = formula.livecheck.throttle
-      if throttled_rate && formula_suffix.modulo(throttled_rate).nonzero?
-        problem "Should only be updated every #{throttled_rate} releases on multiples of #{throttled_rate}"
+      throttle_rate = formula.livecheck.throttle
+      throttle_days = formula.livecheck.throttle_days
+      if (!throttle_rate.nil? || !throttle_days.nil?) &&
+         !Livecheck.throttle_allows_bump?(formula, stable.version, throttle_rate:, throttle_days:)
+        throttle_items = []
+        throttle_items << "#{throttle_rate} releases on multiples of #{throttle_rate}" if throttle_rate
+        throttle_items << "#{throttle_days} #{Utils.pluralize("day", throttle_days)}" if throttle_days
+
+        problem "Should only be updated every #{throttle_items.join(" or ")}"
       end
 
       case url

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -755,6 +755,8 @@ RSpec.describe Homebrew::FormulaAuditor do
 
   describe "#audit_specs" do
     let(:livecheck_throttle) { "livecheck do\n    throttle 10\n  end" }
+    let(:livecheck_throttle_days) { "livecheck do\n    throttle days: 1\n  end" }
+    let(:livecheck_throttle_rate_days) { "livecheck do\n    throttle 10, days: 1\n  end" }
     let(:versioned_head_spec_list) { { versioned_head_spec_allowlist: ["foo"] } }
 
     it "doesn't allow to miss a checksum" do
@@ -913,6 +915,67 @@ RSpec.describe Homebrew::FormulaAuditor do
 
       fa.audit_specs
       expect(fa.problems.first[:message]).to match "Should only be updated every 10 releases on multiples of 10"
+    end
+
+    it "allows patch versions that aren't multiples of the throttle rate when throttle interval has elapsed" do
+      fa = formula_auditor "foo", <<~RUBY, core_tap: true
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.1.tgz"
+          sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
+          #{livecheck_throttle_rate_days}
+        end
+      RUBY
+
+      allow(Homebrew::Livecheck).to receive(:throttle_interval_elapsed?).and_return(true)
+
+      fa.audit_specs
+      expect(fa.problems).to be_empty
+    end
+
+    it "doesn't allow patch versions that aren't multiples when throttle interval has not elapsed" do
+      fa = formula_auditor "foo", <<~RUBY, core_tap: true
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.1.tgz"
+          sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
+          #{livecheck_throttle_rate_days}
+        end
+      RUBY
+
+      allow(Homebrew::Livecheck).to receive(:throttle_interval_elapsed?).and_return(false)
+
+      fa.audit_specs
+      expect(fa.problems.first[:message])
+        .to match "Should only be updated every 10 releases on multiples of 10 or 1 day"
+    end
+
+    it "allows throttle with only days when throttle interval has elapsed" do
+      fa = formula_auditor "foo", <<~RUBY, core_tap: true
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.1.tgz"
+          sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
+          #{livecheck_throttle_days}
+        end
+      RUBY
+
+      allow(Homebrew::Livecheck).to receive(:throttle_interval_elapsed?).and_return(true)
+
+      fa.audit_specs
+      expect(fa.problems).to be_empty
+    end
+
+    it "doesn't allow throttle with only days when throttle interval has not elapsed" do
+      fa = formula_auditor "foo", <<~RUBY, core_tap: true
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.1.tgz"
+          sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
+          #{livecheck_throttle_days}
+        end
+      RUBY
+
+      allow(Homebrew::Livecheck).to receive(:throttle_interval_elapsed?).and_return(false)
+
+      fa.audit_specs
+      expect(fa.problems.first[:message]).to match "Should only be updated every 1 day"
     end
 
     it "allows non-versioned formulae to have a `HEAD` spec" do


### PR DESCRIPTION
Follow-up for https://github.com/Homebrew/brew/pull/21853 and https://github.com/Homebrew/brew/pull/22043.

There's another duplication of throttling logic which I aligned with common one, this time in formula_auditor used during PR checks.

@samford , feel free to rewrite everything you think should be rewritten :)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

AI (OpenAI Codex 5.3) was used to write Ruby code under my control and code-review.
