### PR TITLE
upgrade: parallelize bottle tab fetching

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -335,6 +335,21 @@ class FormulaInstaller
   def prelude
     prelude_fetch unless @ran_prelude_fetch
 
+    determine_bottle_tab_attributes
+
+    verify_deps_exist unless ignore_deps?
+
+    forbidden_license_check
+    forbidden_tap_check
+    forbidden_formula_check
+
+    check_install_sanity
+
+    install_fetch_deps if !ignore_deps? && Homebrew::EnvConfig.download_concurrency <= 1
+  end
+
+  sig { void }
+  def determine_bottle_tab_attributes
     Tab.clear_cache
 
     # Setup bottle_tab_runtime_dependencies for compute_dependencies and
@@ -354,16 +369,6 @@ class FormulaInstaller
     rescue Resource::BottleManifest::Error
       # If we can't get the bottle manifest, assume a full dependencies install.
     end
-
-    verify_deps_exist unless ignore_deps?
-
-    forbidden_license_check
-    forbidden_tap_check
-    forbidden_formula_check
-
-    check_install_sanity
-
-    install_fetch_deps if !ignore_deps? && Homebrew::EnvConfig.download_concurrency <= 1
   end
 
   sig { void }

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -110,6 +110,8 @@ module Homebrew
         end
 
         installers.filter_map do |fi|
+          fi.determine_bottle_tab_attributes
+
           all_runtime_deps_installed = fi.bottle_tab_runtime_dependencies.presence&.all? do |dependency, hash|
             minimum_version = if (version = hash["version"])
               Version.new(version)

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -3,6 +3,7 @@
 
 require "reinstall"
 require "formula_installer"
+require "download_queue"
 require "development_tools"
 require "messages"
 require "cleanup"
@@ -69,46 +70,60 @@ module Homebrew
           end
         end
 
-        formulae_to_install.filter_map do |formula|
-          Migrator.migrate_if_needed(formula, force:, dry_run:)
-          begin
-            fi = create_formula_installer(
-              formula,
-              flags:,
-              force_bottle:,
-              build_from_source_formulae:,
-              interactive:,
-              keep_tmp:,
-              debug_symbols:,
-              force:,
-              overwrite:,
-              debug:,
-              quiet:,
-              verbose:,
-            )
-            fi.fetch_bottle_tab(quiet: !debug)
-
-            all_runtime_deps_installed = fi.bottle_tab_runtime_dependencies.presence&.all? do |dependency, hash|
-              minimum_version = if (version = hash["version"])
-                Version.new(version)
-              end
-              Dependency.new(dependency).installed?(minimum_version:, minimum_revision: hash["revision"].to_i)
+        # We need to fetch the bottle tabs ahead of the `Install.fetch_formulae`
+        # pipeline because we need to first filter out those formulae with all
+        # runtime dependencies already satisfied (see below).
+        download_queue = Homebrew::DownloadQueue.new
+        begin
+          installers = formulae_to_install.filter_map do |formula|
+            Migrator.migrate_if_needed(formula, force:, dry_run:)
+            begin
+              fi = create_formula_installer(
+                formula,
+                flags:,
+                force_bottle:,
+                build_from_source_formulae:,
+                interactive:,
+                keep_tmp:,
+                debug_symbols:,
+                force:,
+                overwrite:,
+                debug:,
+                quiet:,
+                verbose:,
+              )
+              fi.download_queue = download_queue
+              fi.fetch_bottle_tab(quiet: !debug, enqueue: true)
+              fi
+            rescue CannotInstallFormulaError => e
+              ofail e
+              nil
+            rescue UnsatisfiedRequirements, DownloadError => e
+              ofail "#{formula}: #{e}"
+              nil
             end
-
-            if !dry_run && dependents && all_runtime_deps_installed
-              # Don't need to install this bottle if all of the runtime
-              # dependencies have the same or newer version already installed.
-              next
-            end
-
-            fi
-          rescue CannotInstallFormulaError => e
-            ofail e
-            nil
-          rescue UnsatisfiedRequirements, DownloadError => e
-            ofail "#{formula}: #{e}"
-            nil
           end
+
+          download_queue.fetch
+        ensure
+          download_queue.shutdown
+        end
+
+        installers.filter_map do |fi|
+          all_runtime_deps_installed = fi.bottle_tab_runtime_dependencies.presence&.all? do |dependency, hash|
+            minimum_version = if (version = hash["version"])
+              Version.new(version)
+            end
+            Dependency.new(dependency).installed?(minimum_version:, minimum_revision: hash["revision"].to_i)
+          end
+
+          if !dry_run && dependents && all_runtime_deps_installed
+            # Don't need to install this bottle if all of the runtime
+            # dependencies have the same or newer version already installed.
+            next
+          end
+
+          fi
         end
       end
 


### PR DESCRIPTION
Currently, `FormulaInstaller#fetch_bottle_tab` is called sequentially and silently in the background for each formula to upgrade. When there is a large number of formulae to upgrade, this can lead to a significant delay before the any output is shown to the user.

Instead, let's parallelize the bottle tab fetching. This makes the upgrade progress much faster, and also visibly shows the user that something is happening.

A naive and rough benchmark involving 8 outdated formulae shows that this shortens `Upgrade#formula_installers` from ~4.7s to ~2.1s. With more outdated formulae, this difference should become even more significant.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
  - NB. I didn't benchmark this with Hyperfine due to the complexity of only timing the tab fetch logic. I did include a very basic comparison though.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
