### PR TITLE
Fix to not link keg_only if it doesn't installed by request

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -922,6 +922,7 @@ on_request: installed_on_request?, options:)
 
   sig { returns(T.nilable(String)) }
   def link_manual_command_warning
+    return unless installed_on_request?
     return unless formula.keg_only?
     return unless formula.keg_only_reason.versioned_formula?
     return if link_keg
@@ -1714,6 +1715,7 @@ on_request: installed_on_request?, options:)
 
   sig { returns(T::Boolean) }
   def auto_link_versioned_keg_only?
+    return false unless installed_on_request?
     return false unless formula.keg_only?
     return false unless formula.keg_only_reason.versioned_formula?
     return false if formula.any_version_installed?

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -157,8 +157,14 @@ RSpec.describe FormulaInstaller do
                                                   link_overwrite_formulae: [])
     end
 
-    it "links by default when no sibling variants are installed" do
+    it "does not link by default when it is not installed on request" do
       fi = described_class.new(keg_only_formula)
+
+      expect(fi.link_keg).to be false
+    end
+
+    it "links by default when no sibling variants are installed" do
+      fi = described_class.new(keg_only_formula, installed_on_request: true)
 
       expect(fi.link_keg).to be true
     end
@@ -314,7 +320,7 @@ RSpec.describe FormulaInstaller do
       allow(keg_only_formula).to receive_messages(any_version_installed?: false, linked?: false,
                                                   link_overwrite_formulae: [unversioned_formula])
 
-      installer = described_class.new(keg_only_formula)
+      installer = described_class.new(keg_only_formula, installed_on_request: true)
 
       expect(installer.send(:link_manual_command_warning)).to eq <<~EOS
         #{formula_name} was installed but not linked because #{base_name} is already linked.


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

From recent changes, `installed_as_dependency` value defaults to `false` and it is now changed to the reverse of `installed_on_request`. However, it's default value is also `false` and the test behavior is changed. I think the auto link guard should be kept and test should be fixed.