### PR TITLE
Avoid redundant Caskroom chgrp

### DIFF
--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -63,12 +63,25 @@ module Cask
       SystemCommand.run("chmod", args: ["g+rwx", path], sudo:)
       SystemCommand.run("chown", args: [User.current.to_s, path], sudo:)
 
-      chgrp_path(path, sudo)
+      chgrp_path(path, sudo) unless caskroom_group_correct?(path)
     end
 
     sig { params(path: Pathname, sudo: T::Boolean).void }
     def self.chgrp_path(path, sudo)
-      SystemCommand.run("chgrp", args: ["admin", path], sudo:)
+      SystemCommand.run("chgrp", args: [expected_caskroom_group, path], sudo:)
+    end
+
+    sig { params(path: Pathname).returns(T::Boolean) }
+    def self.caskroom_group_correct?(path)
+      group = Etc.getgrnam(expected_caskroom_group)
+      return false if group.nil?
+
+      path.stat.gid == group.gid
+    end
+
+    sig { returns(String) }
+    def self.expected_caskroom_group
+      "admin"
     end
 
     # Get all installed casks.

--- a/Library/Homebrew/extend/os/linux/cask/caskroom.rb
+++ b/Library/Homebrew/extend/os/linux/cask/caskroom.rb
@@ -8,7 +8,12 @@ module OS
         module ClassMethods
           sig { params(path: ::Pathname, _sudo: T::Boolean).void }
           def chgrp_path(path, _sudo)
-            SystemCommand.run("chgrp", args: ["root", path], sudo: true)
+            SystemCommand.run("chgrp", args: [expected_caskroom_group, path], sudo: true)
+          end
+
+          sig { returns(String) }
+          def expected_caskroom_group
+            "root"
           end
         end
       end

--- a/Library/Homebrew/test/cask/caskroom_spec.rb
+++ b/Library/Homebrew/test/cask/caskroom_spec.rb
@@ -4,6 +4,55 @@
 require "cask/caskroom"
 
 RSpec.describe Cask::Caskroom do
+  describe ".ensure_caskroom_exists" do
+    it "changes the group when sudo is unnecessary and the group is wrong" do
+      Dir.mktmpdir do |dir|
+        path = Pathname(dir)/"Caskroom"
+        allow(described_class).to receive(:path).and_return(path)
+        allow(described_class).to receive(:caskroom_group_correct?).with(path).and_return(false)
+        expect(described_class).to receive(:chgrp_path).with(path, false)
+
+        described_class.ensure_caskroom_exists
+      end
+    end
+
+    it "skips changing the group when it is already correct" do
+      Dir.mktmpdir do |dir|
+        path = Pathname(dir)/"Caskroom"
+        allow(described_class).to receive(:path).and_return(path)
+        allow(described_class).to receive(:caskroom_group_correct?).with(path).and_return(true)
+        expect(described_class).not_to receive(:chgrp_path)
+
+        described_class.ensure_caskroom_exists
+      end
+    end
+  end
+
+  describe ".caskroom_group_correct?" do
+    it "checks the admin group on macOS", :needs_macos do
+      path = Pathname("/tmp/Caskroom")
+      allow(path).to receive(:stat).and_return(instance_double(File::Stat, gid: 1))
+      allow(Etc).to receive(:getgrnam).with("admin").and_return(instance_double(Etc::Group, gid: 1))
+
+      expect(described_class.caskroom_group_correct?(path)).to be true
+    end
+
+    it "checks the root group on Linux", :needs_linux do
+      path = Pathname("/tmp/Caskroom")
+      allow(path).to receive(:stat).and_return(instance_double(File::Stat, gid: 1))
+      allow(Etc).to receive(:getgrnam).with("root").and_return(instance_double(Etc::Group, gid: 1))
+
+      expect(described_class.caskroom_group_correct?(path)).to be true
+    end
+
+    it "returns false when the expected group is unavailable" do
+      allow(described_class).to receive(:expected_caskroom_group).and_return("missing")
+      allow(Etc).to receive(:getgrnam).with("missing").and_return(nil)
+
+      expect(described_class.caskroom_group_correct?(Pathname("/tmp/Caskroom"))).to be false
+    end
+  end
+
   describe ".corrupt_cask_dirs" do
     it "returns tokens for directories without valid caskfiles" do
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
- Check the `Caskroom` group before running `chgrp`.
- Share the expected group name between checks and fixes.
- Keep Linux using `sudo` when the group must change.

Fixes https://github.com/Homebrew/brew/issues/22120

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Used OpenAI Codex with substantial local refactoring.

-----
