### PR TITLE
sorbet-runtime.rbi: use typed: strict

### DIFF
--- a/Library/Homebrew/sorbet/rbi/shims/sorbet-runtime.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/sorbet-runtime.rbi
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 
 # The classes below are reopened in `standalone/sorbet.rb` to override `valid?`.
 # We define their `build_type` method here to make the type checker happy, and


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

sorbet/rbi/shims/sorbet-runtime.rbi was recently added and since then `brew typecheck` has been surfacing an offense due to this file using `typed: true` instead of `typed: strict` ("Sorbet/StrictSigil: Sorbet sigil should be at least strict got true."). This updates the sigil to `typed: strict`, as `brew typecheck` seems to be fine with it and I didn't see any issues when running `brew tests`.

Of course, let me know if this isn't a good idea (e.g., if this uses `typed: true` because there are known issues when using `typed: strict`).