### PR TITLE
list.sh: only show headings when there are items to show

### DIFF
--- a/Library/Homebrew/list.sh
+++ b/Library/Homebrew/list.sh
@@ -51,35 +51,35 @@ homebrew-list() {
 
   if [[ -z "${cask}" && -d "${HOMEBREW_CELLAR}" ]]
   then
-    if [[ -n "${tty}" && -z "${formula}" ]]
-    then
-      ohai "Formulae"
-    fi
-
     local formula_output
     formula_output="$(/usr/bin/env "${ls_env[@]}" ls "${ls_args[@]}" "${HOMEBREW_CELLAR}")" || exit 1
     if [[ -n "${formula_output}" ]]
     then
-      echo "${formula_output}"
-    fi
+      if [[ -n "${tty}" && -z "${formula}" ]]
+      then
+        ohai "Formulae"
+      fi
 
-    if [[ -n "${tty}" && -z "${formula}" ]]
-    then
-      echo
+      echo "${formula_output}"
+
+      if [[ -n "${tty}" && -z "${formula}" ]]
+      then
+        echo
+      fi
     fi
   fi
 
   if [[ -z "${formula}" && -d "${HOMEBREW_CASKROOM}" ]]
   then
-    if [[ -n "${tty}" && -z "${cask}" ]]
-    then
-      ohai "Casks"
-    fi
-
     local cask_output
     cask_output="$(/usr/bin/env "${ls_env[@]}" ls "${ls_args[@]}" "${HOMEBREW_CASKROOM}")" || exit 1
     if [[ -n "${cask_output}" ]]
     then
+      if [[ -n "${tty}" && -z "${cask}" ]]
+      then
+        ohai "Casks"
+      fi
+
       echo "${cask_output}"
     fi
 


### PR DESCRIPTION
If there are no formulae or casks to show, then don't show the "Formulae" or "Casks" headings. This used to be the case when there was only the Ruby implementation, and continues to be the case when the Ruby implementation is used [^1], so we should maintain the consistency.

[^1]: https://github.com/Homebrew/brew/blob/4a95077682ae5f342cf60ff181ebbcfb03d49117/Library/Homebrew/cmd/list.rb#L162-L170

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
