### PR TITLE
HeaderMatch: pass all headers into strategy block

### DIFF
--- a/Library/Homebrew/livecheck/strategy/header_match.rb
+++ b/Library/Homebrew/livecheck/strategy/header_match.rb
@@ -35,24 +35,37 @@ module Homebrew
 
         # Identify versions from HTTP headers.
         #
-        # @param headers [Hash] a hash of HTTP headers to check for versions
+        # @param headers [Array<Hash<String, String>>] an array of response HTTP
+        #   header hashes to check for versions
         # @param regex [Regexp, nil] a regex for matching versions in content
         # @return [Array]
         sig {
           params(
-            headers: T::Hash[String, String],
+            headers: T::Array[T::Hash[String, String]],
             regex:   T.nilable(Regexp),
             block:   T.nilable(Proc),
           ).returns(T::Array[String])
         }
         def self.versions_from_content(headers, regex = nil, &block)
+          # Merge the last value of each header from all responses into one hash
+          # for convenience
+          merged_headers = T.cast(headers.reduce(&:merge), T::Hash[String, String])
+
           if block
-            block_return_value = regex.present? ? yield(headers, regex) : yield(headers)
+            block_return_value = case block.parameters[0]
+            when [:opt, :headers], [:req, :headers], [:rest], [:req]
+              regex.present? ? yield(merged_headers, regex) : yield(merged_headers)
+            when [:opt, :all_headers], [:req, :all_headers]
+              regex.present? ? yield(headers, regex) : yield(headers)
+            else
+              raise ArgumentError,
+                    "First argument of #{Utils.demodulize(name)} `strategy` block must be `headers` or `all_headers`"
+            end
             return Strategy.handle_block_return(block_return_value)
           end
 
           DEFAULT_HEADERS_TO_CHECK.filter_map do |header_name|
-            header_value = headers[header_name]
+            header_value = merged_headers[header_name]
             next if header_value.blank?
 
             if regex
@@ -93,11 +106,7 @@ module Homebrew
           end
           return match_data if content.blank?
 
-          # Merge the headers from all responses into one hash
-          merged_headers = content.reduce(&:merge)
-          return match_data if merged_headers.blank?
-
-          versions_from_content(merged_headers, regex, &block).each do |version_text|
+          versions_from_content(content, regex, &block).each do |version_text|
             match_data[:matches][version_text] = Version.new(version_text)
           end
 

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -214,12 +214,12 @@ module Homebrew
 
           if block
             block_return_value = case block.parameters[0]
-            when [:opt, :item], [:rest], [:req]
+            when [:opt, :item], [:req, :item], [:rest], [:req]
               regex.present? ? yield(item, regex) : yield(item)
-            when [:opt, :items]
+            when [:opt, :items], [:req, :items]
               regex.present? ? yield(items, regex) : yield(items)
             else
-              raise "First argument of Sparkle `strategy` block must be `item` or `items`"
+              raise ArgumentError, "First argument of Sparkle `strategy` block must be `item` or `items`"
             end
             return Strategy.handle_block_return(block_return_value)
           end

--- a/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
@@ -63,39 +63,54 @@ RSpec.describe Homebrew::Livecheck::Strategy::HeaderMatch do
 
   describe "::versions_from_content" do
     it "returns an empty array if headers hash is empty" do
-      expect(header_match.versions_from_content({})).to eq([])
+      expect(header_match.versions_from_content([{}])).to eq([])
     end
 
     it "returns an empty array if checked headers do not contain versions" do
-      expect(header_match.versions_from_content(headers[:no_version])).to eq([])
+      expect(header_match.versions_from_content([headers[:no_version]])).to eq([])
     end
 
     it "returns an array of version strings when given headers" do
-      expect(header_match.versions_from_content(headers[:content_disposition])).to eq(matches[:content_disposition])
-      expect(header_match.versions_from_content(headers[:location])).to eq(matches[:location])
-      expect(header_match.versions_from_content(headers[:content_disposition_and_location]))
+      expect(header_match.versions_from_content([headers[:content_disposition]])).to eq(matches[:content_disposition])
+      expect(header_match.versions_from_content([headers[:location]])).to eq(matches[:location])
+      expect(header_match.versions_from_content([headers[:content_disposition_and_location]]))
         .to eq(matches[:content_disposition_and_location])
 
-      expect(header_match.versions_from_content(headers[:content_disposition], regexes[:archive]))
+      expect(header_match.versions_from_content([headers[:content_disposition]], regexes[:archive]))
         .to eq(matches[:content_disposition])
-      expect(header_match.versions_from_content(headers[:location], regexes[:latest])).to eq(matches[:location])
-      expect(header_match.versions_from_content(headers[:content_disposition_and_location], regexes[:latest]))
+      expect(header_match.versions_from_content([headers[:location]], regexes[:latest])).to eq(matches[:location])
+      expect(header_match.versions_from_content([headers[:content_disposition_and_location]], regexes[:latest]))
         .to eq(matches[:location])
     end
 
     it "returns an array of version strings when given headers and a block" do
       # Returning a string from block, no regex.
       expect(
-        header_match.versions_from_content(headers[:location]) do |headers|
+        header_match.versions_from_content([headers[:location]]) do |headers|
           v = Version.parse(headers["location"], detected_from_url: true)
+          v.null? ? nil : v.to_s
+        end,
+      ).to eq(matches[:location])
+      expect(
+        header_match.versions_from_content([headers[:location]]) do |all_headers|
+          location = all_headers[0]&.[]("location")
+          next unless location
+
+          v = Version.parse(location, detected_from_url: true)
           v.null? ? nil : v.to_s
         end,
       ).to eq(matches[:location])
 
       # Returning a string from block, explicit regex.
       expect(
-        header_match.versions_from_content(headers[:location], regexes[:latest]) do |headers, regex|
+        header_match.versions_from_content([headers[:location]], regexes[:latest]) do |headers, regex|
           headers["location"] ? headers["location"][regex, 1] : nil
+        end,
+      ).to eq(matches[:location])
+      expect(
+        header_match.versions_from_content([headers[:location]], regexes[:latest]) do |all_headers, regex|
+          location = all_headers[0]&.[]("location")
+          location ? location[regex, 1] : nil
         end,
       ).to eq(matches[:location])
 
@@ -105,21 +120,46 @@ RSpec.describe Homebrew::Livecheck::Strategy::HeaderMatch do
       #       are filtered out without needing to use `#compact` in the block.
       expect(
         header_match.versions_from_content(
-          headers[:content_disposition_and_location],
+          [headers[:content_disposition_and_location]],
           regexes[:loose],
         ) do |headers, regex|
           headers.transform_values { |header| header[regex, 1] }.values
         end,
       ).to eq(matches[:content_disposition_and_location])
+      expect(
+        header_match.versions_from_content(
+          [headers[:content_disposition_and_location]],
+          regexes[:loose],
+        ) do |all_headers, regex|
+          all_headers.map do |headers|
+            headers.transform_values { |header| header[regex, 1] }.values
+          end.flatten
+        end,
+      ).to eq(matches[:content_disposition_and_location])
     end
 
     it "allows a nil return from a block" do
-      expect(header_match.versions_from_content(headers[:location]) { next }).to eq([])
+      expect(header_match.versions_from_content([headers[:location]]) do |headers|
+        _ = headers # To appease `brew style` without modifying arg name
+        next
+      end).to eq([])
     end
 
     it "errors on an invalid return type from a block" do
-      expect { header_match.versions_from_content(headers[:location]) { 123 } }
-        .to raise_error(TypeError, Homebrew::Livecheck::Strategy::INVALID_BLOCK_RETURN_VALUE_MSG)
+      expect do
+        header_match.versions_from_content([headers[:location]]) do |headers|
+          _ = headers # To appease `brew style` without modifying arg name
+          123
+        end
+      end.to raise_error(TypeError, Homebrew::Livecheck::Strategy::INVALID_BLOCK_RETURN_VALUE_MSG)
+    end
+
+    it "errors if the first block argument uses an unhandled name" do
+      expect { header_match.versions_from_content([headers[:location]]) { |something| something } }
+        .to raise_error(
+          ArgumentError,
+          "First argument of HeaderMatch `strategy` block must be `headers` or `all_headers`",
+        )
     end
   end
 

--- a/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe Homebrew::Livecheck::Strategy::Sparkle do
 
     it "errors if the first block argument uses an unhandled name" do
       expect { sparkle.versions_from_content(xml[:appcast]) { |something| something } }
-        .to raise_error("First argument of Sparkle `strategy` block must be `item` or `items`")
+        .to raise_error(ArgumentError, "First argument of Sparkle `strategy` block must be `item` or `items`")
     end
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

This modifies livecheck's `HeaderMatch` strategy to allow `strategy` blocks to use an `all_headers` argument to receive the original array of response headers rather than a merged hash that only includes the last instance of a given header. Over the years, we've encountered a few checks where a server makes multiple redirections (i.e., there are multiple responses with a `Location` header) but we need to target a `Location` header that isn't the last occurrence. This hasn't been possible due to the `merged_headers` setup, so we've simply worked around it.

We recently ran into this shortcoming again in homebrew-cask but there isn't a way to work around it this time, so this is now strictly necessary. This implementation borrows from my prior art in the `Sparkle` strategy, where the name of the first argument to a `strategy` block is strictly enforced and the name dictates what value is provided. I've ensured that all `HeaderMatch` strategy blocks in core/cask use a `headers` argument, so they will continue working as expected.