### PR TITLE
Dockerfile: retry add-apt-repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN touch /var/mail/ubuntu && chown ubuntu /var/mail/ubuntu && userdel -r ubuntu
 # shellcheck disable=SC1091,SC2154,SC2292
 RUN bash -c "for i in {1..5}; do apt-get update && break || sleep \$((i)); done" \
   && apt-get install -y --no-install-recommends software-properties-common gnupg-agent \
-  && if [ "$(uname -m)" != aarch64 ]; then add-apt-repository -y ppa:git-core/ppa; fi \
+  && if [ "$(uname -m)" != aarch64 ]; then bash -c "for i in {1..5}; do add-apt-repository -y ppa:git-core/ppa && break || sleep \$((i)); done"; fi \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
   acl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ RUN touch /var/mail/ubuntu && chown ubuntu /var/mail/ubuntu && userdel -r ubuntu
 # We need `[` instead of `[[` because the shell is `/bin/sh`.
 # shellcheck disable=SC1091,SC2154,SC2292
 RUN retry() { bash -c 'for i in {1..5}; do "$@" && exit 0; [[ $((i)) -lt 5 ]] && sleep $((i)); done; exit 1' -- "$@"; } \
-  && retry apt-get update \
+  && retry apt-get update --error-on=any \
   && apt-get install -y --no-install-recommends software-properties-common gnupg-agent \
   && if [ "$(uname -m)" != aarch64 ]; then retry add-apt-repository -y ppa:git-core/ppa; fi \
-  && apt-get update \
+  && retry apt-get update --error-on=any \
   && apt-get install -y --no-install-recommends \
   acl \
   bzip2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,10 @@ RUN touch /var/mail/ubuntu && chown ubuntu /var/mail/ubuntu && userdel -r ubuntu
 # `gh` installation taken from https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt
 # /etc/lsb-release is checked inside the container and sets DISTRIB_RELEASE.
 # We need `[` instead of `[[` because the shell is `/bin/sh`.
+# `:` below is a no-op that works around a ShellCheck parsing error.
 # shellcheck disable=SC1091,SC2154,SC2292
-RUN retry() { bash -c 'for i in {1..5}; do "$@" && exit 0; [[ $((i)) -lt 5 ]] && sleep $((i)); done; exit 1' -- "$@"; } \
+RUN : \
+  && retry() { bash -c 'for i in {1..5}; do "$@" && exit 0; [[ $((i)) -lt 5 ]] && sleep $((i)); done; exit 1' -- "$@"; } \
   && retry apt-get update --error-on=any \
   && apt-get install -y --no-install-recommends software-properties-common gnupg-agent \
   && if [ "$(uname -m)" != aarch64 ]; then retry add-apt-repository -y ppa:git-core/ppa; fi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,10 @@ RUN touch /var/mail/ubuntu && chown ubuntu /var/mail/ubuntu && userdel -r ubuntu
 # /etc/lsb-release is checked inside the container and sets DISTRIB_RELEASE.
 # We need `[` instead of `[[` because the shell is `/bin/sh`.
 # shellcheck disable=SC1091,SC2154,SC2292
-RUN bash -c "for i in {1..5}; do apt-get update && break || sleep \$((i)); done" \
+RUN retry() { bash -c 'for i in {1..5}; do "$@" && exit 0; [[ $((i)) -lt 5 ]] && sleep $((i)); done; exit 1' -- "$@"; } \
+  && retry apt-get update \
   && apt-get install -y --no-install-recommends software-properties-common gnupg-agent \
-  && if [ "$(uname -m)" != aarch64 ]; then bash -c "for i in {1..5}; do add-apt-repository -y ppa:git-core/ppa && break || sleep \$((i)); done"; fi \
+  && if [ "$(uname -m)" != aarch64 ]; then retry add-apt-repository -y ppa:git-core/ppa; fi \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
   acl \


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
Retry `add-apt-repository` to work around intermittent 504s from Launchpad's API during the ongoing Canonical infrastructure DDoS (https://www.theregister.com/2026/05/01/canonical_confirms_ubuntu_infrastructure_under/).

Mirrors the existing `apt-get update` retry on the line above.