### PR TITLE
Route update-report to Rust

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -301,7 +301,7 @@ rust-frontend-enabled() {
   fi
 
   case "${HOMEBREW_COMMAND}" in
-    fetch | search | info | list | install | reinstall | update | upgrade | uninstall) ;;
+    fetch | search | info | list | install | reinstall | update-report | upgrade | uninstall) ;;
     *) return 1 ;;
   esac
 

--- a/Library/Homebrew/test/cmd/update_spec.rb
+++ b/Library/Homebrew/test/cmd/update_spec.rb
@@ -97,4 +97,51 @@ RSpec.describe Homebrew::Cmd::Update do
     expect(stderr).to be_empty
     expect(args_file.read).to eq("update-report\n--auto-update\n")
   end
+
+  it "preserves `update-report` arguments and exit status with the Rust frontend enabled" do
+    args_file = test_root/"brew-args.txt"
+    brew_wrapper = test_root/"brew-wrapper"
+    (test_root/"Library/Homebrew/utils").mkpath
+    FileUtils.ln_s repository_root/"Library/Homebrew/utils/lock.sh", test_root/"Library/Homebrew/utils/lock.sh"
+    (test_root/"cache").mkpath
+    (test_root/"repository").mkpath
+    brew_wrapper.write <<~SH
+      #!/bin/bash
+      printf '%s\n' "$@" > "#{args_file}"
+      exit 42
+    SH
+    brew_wrapper.chmod 0755
+
+    _stdout, stderr, status = run_update_shell(
+      <<~SH,
+        source "#{repository_root}/Library/Homebrew/utils/helpers.sh"
+        source "#{update_script}"
+        fetch_api_file() { :; }
+        git() {
+          [[ "$1" == "--version" ]] && return 0
+          return 1
+        }
+        git_init_if_necessary() { :; }
+        lock() { :; }
+        setup_ca_certificates() { :; }
+        setup_curl() { :; }
+        setup_git() { :; }
+        homebrew-update --auto-update
+      SH
+      {
+        "HOMEBREW_BREW_FILE"                  => brew_wrapper.to_s,
+        "HOMEBREW_CACHE"                      => (test_root/"cache").to_s,
+        "HOMEBREW_CELLAR"                     => (test_root/"cellar").to_s,
+        "HOMEBREW_EXPERIMENTAL_RUST_FRONTEND" => "1",
+        "HOMEBREW_LIBRARY"                    => (test_root/"Library").to_s,
+        "HOMEBREW_NO_INSTALL_FROM_API"        => "1",
+        "HOMEBREW_PREFIX"                     => (test_root/"prefix").to_s,
+        "HOMEBREW_REPOSITORY"                 => (test_root/"repository").to_s,
+      },
+    )
+
+    expect(status.exitstatus).to eq 42
+    expect(stderr).to be_empty
+    expect(args_file.read).to eq("update-report\n--auto-update\n")
+  end
 end


### PR DESCRIPTION
- Keep `brew update` on `update.sh` to preserve the update flow.
- Only re-enter `brew` for `update-report` when the Rust frontend is set.
- Leave the existing Ruby report call unchanged for normal update runs.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex with manual review and tweaks.

-----
