### PR TITLE
Add user agent to HTMLProofer

### DIFF
--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -28,9 +28,16 @@ end
 desc "Run HTMLProofer to validate the HTML output."
 task test: :build do
   require "html-proofer"
+
+  HOMEBREW_USER_AGENT = ENV.fetch("HOMEBREW_USER_AGENT", nil).freeze
   HTMLProofer.check_directory(
     "./_site",
     parallel:            { in_threads: 4 },
+    typhoeus:            {
+      headers: {
+        "User-Agent" => "#{"#{HOMEBREW_USER_AGENT} " if HOMEBREW_USER_AGENT}HTMLProofer/#{HTMLProofer::VERSION}",
+      },
+    },
     favicon:             true,
     ignore_status_codes: [0, 403],
     check_favicon:       true,


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

The brew documentation tests use `HTMLProofer` to check for broken links in generated documentation HTML and this is causing all brew PRs to fail CI because one of the linked pages will return a JavaScript challenge page if the request uses a user agent that the server doesn't like (or no user agent at all). The default `HTMLProofer` user agent is "Mozilla/5.0 (compatible; HTML Proofer/5.2.1; +https://github.com/gjtorikian/html-proofer)" and, for whatever reason, the Mozilla user agent triggers the upstream server's scraper safeguards.

This updates docs/Rakefile to use a generic "HTMLProofer/5.2.1" user agent for these requests, which addresses this particular failure. I've set this up to conditionally prepend `HOMEBREW_USER_AGENT` if it's available in the environment, though it's not currently present in this context, so I can drop that if it's not wanted/needed.