### PR TITLE
info: show installed version and upgrade hint on headline

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -484,9 +484,11 @@ module Homebrew
         name_with_status = if kegs.empty?
           pretty_uninstalled(formula.full_name)
         elsif formula.outdated?
-          installed_version = formula.linked_version ||
-                              kegs.max_by(&:scheme_and_version)&.version
-          specs[0] = "#{installed_version} → #{specs.first}" if specs.first
+          if (upgrade_version = specs.first.presence)
+            installed_version = formula.linked_version ||
+                                kegs.max_by(&:scheme_and_version)&.version
+            specs[0] = "#{installed_version} → #{upgrade_version}"
+          end
           pretty_upgradable(formula.full_name)
         else
           pretty_installed(formula.full_name)

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -467,7 +467,7 @@ module Homebrew
 
       sig { params(formula: Formula).void }
       def info_formula(formula)
-        specs = []
+        specs = T.let([], T::Array[String])
 
         if (stable = formula.stable)
           string = "stable #{stable.version}"
@@ -483,6 +483,11 @@ module Homebrew
         kegs = formula.installed_kegs
         name_with_status = if kegs.empty?
           pretty_uninstalled(formula.full_name)
+        elsif formula.outdated?
+          installed_version = formula.linked_version ||
+                              kegs.max_by(&:scheme_and_version)&.version
+          specs[0] = "#{installed_version} → #{specs.first}" if specs.first
+          pretty_upgradable(formula.full_name)
         else
           pretty_installed(formula.full_name)
         end

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -175,6 +175,27 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
+  it "shows the installed and stable versions in the headline when outdated" do
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      homepage "https://brew.sh/testball"
+      desc "Some test"
+    end
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive_messages(core_formula?: false, outdated?: true)
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.0.1"
+    keg_path.mkpath
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.write
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/\A==> testball: 0\.0\.1 → stable 0\.1\n/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
   it "prints Linux requirements through the requirements section" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 

--- a/Library/Homebrew/utils/output.rb
+++ b/Library/Homebrew/utils/output.rb
@@ -237,6 +237,17 @@ module Utils
       end
 
       sig { params(string: String).returns(String) }
+      def pretty_upgradable(string)
+        if !$stdout.tty?
+          string
+        elsif Homebrew::EnvConfig.no_emoji?
+          "#{Tty.bold}#{string} (upgradable)#{Tty.reset}"
+        else
+          "#{Tty.bold}#{string} #{Formatter.success("↑")}#{Tty.reset}"
+        end
+      end
+
+      sig { params(string: String).returns(String) }
       def pretty_deprecated(string)
         if $stdout.tty?
           "#{string} #{Formatter.warning("(deprecated)")}"


### PR DESCRIPTION
Today `brew info` on an outdated formula shows the latest version on the headline with a checkmark, which makes it look like you're up to date even when you aren't. This change shows the installed version on the headline alongside an upgrade hint, so it's obvious at a glance.

Before:
```
==> mole ✔: stable 1.36.3 (bottled), HEAD
```


After:
```
==> mole ↑: 1.34.0 → stable 1.36.3 (bottled), HEAD
```

