### PR TITLE
Fix bundle tap cask handling

### DIFF
--- a/Library/Homebrew/bundle/brew.rb
+++ b/Library/Homebrew/bundle/brew.rb
@@ -238,8 +238,6 @@ module Homebrew
         def fetchable_name(name, options = {}, no_upgrade: false)
           _ = options
 
-          return if (tap_name = Utils.tap_from_full_name(name)) &&
-                    Homebrew::Bundle::Tap.installed_taps.exclude?(tap_name)
           return if formula_installed_and_up_to_date?(name, no_upgrade:)
 
           name

--- a/Library/Homebrew/bundle/cask.rb
+++ b/Library/Homebrew/bundle/cask.rb
@@ -144,8 +144,6 @@ module Homebrew
         sig { params(name: String, options: Homebrew::Bundle::EntryOptions, no_upgrade: T::Boolean).returns(T.nilable(String)) }
         def fetchable_name(name, options = {}, no_upgrade: false)
           full_name = T.cast(options.fetch(:full_name, name), String)
-          return if (tap_name = Utils.tap_from_full_name(full_name)) &&
-                    Homebrew::Bundle::Tap.installed_taps.exclude?(tap_name)
           return unless installable_or_upgradable?(name, no_upgrade:, **options)
 
           full_name

--- a/Library/Homebrew/bundle/commands/cleanup.rb
+++ b/Library/Homebrew/bundle/commands/cleanup.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "utils/formatter"
+require "utils"
 require "bundle/dsl"
 require "bundle/extensions"
 
@@ -243,6 +244,14 @@ module Homebrew
 
           kept_formulae = self.kept_formulae(global:, file:).filter_map { lookup_formula(it) }
           kept_taps = @dsl.entries.select { |e| e.type == :tap }.map(&:name)
+          kept_taps += @dsl.entries.filter_map do |entry|
+            case entry.type
+            when :brew
+              Utils.tap_from_full_name(entry.name)
+            when :cask
+              Utils.tap_from_full_name(T.cast(entry.options.fetch(:full_name, entry.name), String))
+            end
+          end
           kept_taps += kept_formulae.filter_map(&:tap).map(&:name)
           current_taps = Homebrew::Bundle::Tap.tap_names
           current_taps - kept_taps - IGNORED_TAPS

--- a/Library/Homebrew/bundle/installer.rb
+++ b/Library/Homebrew/bundle/installer.rb
@@ -4,15 +4,28 @@
 require "bundle/dsl"
 require "bundle/package_types"
 require "bundle/skipper"
+require "utils/output"
 
 module Homebrew
   module Bundle
     module Installer
+      extend ::Utils::Output::Mixin
+
       class InstallableEntry < T::Struct
         const :name, String
         const :options, Homebrew::Bundle::EntryOptions
         const :verb, String
         const :cls, T.class_of(Homebrew::Bundle::PackageType)
+
+        sig { returns(String) }
+        def full_name
+          T.cast(options.fetch(:full_name, name), String)
+        end
+
+        sig { returns(T.nilable(String)) }
+        def tap_name
+          ::Utils.tap_from_full_name(full_name)
+        end
       end
 
       sig { void }
@@ -103,10 +116,59 @@ module Homebrew
         ).returns(T::Array[String])
       }
       def self.fetchable_formulae_and_casks(entries, no_upgrade:)
+        installed_taps = Tap.installed_taps
+
         entries.filter_map do |entry|
+          next if tap_dependencies(entry, entries:, installed_taps:).present?
+
           entry.cls.fetchable_name(entry.name, entry.options, no_upgrade:)
         end
       end
+
+      sig {
+        params(
+          entry:          InstallableEntry,
+          entries:        T::Array[InstallableEntry],
+          installed_taps: T::Array[String],
+        ).returns(T::Array[String])
+      }
+      def self.tap_dependencies(entry, entries:, installed_taps:)
+        return [] unless [Brew, Cask].include?(entry.cls)
+
+        if (tap_name = entry.tap_name)
+          return installed_taps.exclude?(tap_name) ? [tap_name] : []
+        end
+
+        tap_names = entries.filter_map do |tap_entry|
+          tap_entry.name if tap_entry.cls == Tap && installed_taps.exclude?(tap_entry.name)
+        end
+        return [] if tap_names.empty?
+        return [] unless unavailable_without_tap?(entry)
+
+        tap_names
+      end
+
+      sig { params(entry: InstallableEntry).returns(T::Boolean) }
+      def self.unavailable_without_tap?(entry)
+        require "api"
+
+        case entry.cls.name
+        when "Homebrew::Bundle::Brew"
+          Homebrew::API.formula_names.exclude?(entry.name) &&
+            Homebrew::API.formula_aliases.exclude?(entry.name) &&
+            Homebrew::API.formula_renames.exclude?(entry.name)
+        when "Homebrew::Bundle::Cask"
+          Homebrew::API.cask_tokens.exclude?(entry.name) &&
+            Homebrew::API.cask_renames.exclude?(entry.name)
+        else
+          false
+        end
+      rescue => e
+        opoo "Treating `#{entry.name}` as dependent on Brewfile taps because Homebrew could not " \
+             "check API metadata: #{e}"
+        true
+      end
+      private_class_method :unavailable_without_tap?
 
       sig {
         params(

--- a/Library/Homebrew/bundle/parallel_installer.rb
+++ b/Library/Homebrew/bundle/parallel_installer.rb
@@ -97,6 +97,8 @@ module Homebrew
 
       sig { returns(T::Hash[String, T::Set[String]]) }
       def build_dependency_map
+        installed_taps = Homebrew::Bundle::Tap.installed_taps
+
         # Phase 1: Map both full and short names so dep lookups work either way.
         entry_name_map = @entries.each_with_object({}) do |entry, map|
           map[entry.name] = entry.name
@@ -117,11 +119,7 @@ module Homebrew
           end
 
           # Entries from non-default taps depend on the tap being installed first.
-          tap_prefix = entry.name.split("/").first(2).join("/") if entry.name.include?("/")
-          if tap_prefix && entry.cls != Homebrew::Bundle::Tap
-            deps = deps.dup
-            deps << tap_prefix
-          end
+          deps += Homebrew::Bundle::Installer.tap_dependencies(entry, entries: @entries, installed_taps:)
 
           brewfile_deps[entry.name] = deps
         end

--- a/Library/Homebrew/test/bundle/commands/cleanup_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/cleanup_spec.rb
@@ -102,7 +102,46 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
       expect(described_class.taps_to_untap).to eql(%w[z])
     end
 
+    it "keeps taps referenced by fully qualified formulae" do
+      allow_any_instance_of(Pathname).to receive(:read).and_return <<~EOS
+        brew "homebrew/tap/foo"
+      EOS
+      described_class.read_dsl_from_brewfile!
+
+      allow(Homebrew::Bundle::Brew).to receive(:formulae).and_return([
+        { name: "foo", full_name: "homebrew/tap/foo", dependencies: [], build_dependencies: [] },
+      ])
+      stub_formula_loader formula("foo", tap: Tap.fetch("homebrew/tap")) { url "foo-1.0" }, "homebrew/tap/foo"
+      allow(Homebrew::Bundle::Tap).to \
+        receive(:tap_names).and_return(%w[homebrew/core homebrew/tap])
+
+      expect(described_class.formulae_to_uninstall).to be_empty
+      expect(described_class.taps_to_untap).to be_empty
+    end
+
+    it "keeps taps referenced by fully qualified casks" do
+      allow_any_instance_of(Pathname).to receive(:read).and_return <<~EOS
+        cask "homebrew/tap/foo"
+      EOS
+      described_class.read_dsl_from_brewfile!
+
+      allow(Homebrew::Bundle::Cask).to receive(:casks).and_return([
+        instance_double(Cask::Cask, to_s: "foo", old_tokens: [], depends_on: {}),
+      ])
+      allow(Homebrew::Bundle::Brew).to receive(:formulae).and_return([])
+      allow(Homebrew::Bundle::Tap).to \
+        receive(:tap_names).and_return(%w[homebrew/core homebrew/tap])
+
+      expect(described_class.casks_to_uninstall).to be_empty
+      expect(described_class.taps_to_untap).to be_empty
+    end
+
     it "ignores unavailable formulae when computing which taps to keep" do
+      allow_any_instance_of(Pathname).to receive(:read).and_return <<~EOS
+        brew "foo"
+      EOS
+      described_class.read_dsl_from_brewfile!
+
       allow(Formulary).to \
         receive(:factory).and_raise(TapFormulaUnavailableError.new(Tap.fetch("homebrew/tap"), "foo"))
       allow(Homebrew::Bundle::Tap).to \

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -79,6 +79,90 @@ RSpec.describe Homebrew::Bundle::Installer do
     described_class.install!([tap_entry, tapped_formula_entry], quiet: true)
   end
 
+  it "skips fetching formulae from fully qualified untapped taps" do
+    tapped_formula_entry = Homebrew::Bundle::Dsl::Entry.new(:brew, "homebrew/foo/bar")
+
+    allow(Homebrew::Bundle::Brew).to receive(:formula_installed_and_up_to_date?)
+      .with("homebrew/foo/bar", no_upgrade: false).and_return(false)
+
+    expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
+
+    described_class.install!([tapped_formula_entry], quiet: true)
+  end
+
+  it "skips fetching unqualified formulae when Brewfile taps are untapped" do
+    tap_entry = Homebrew::Bundle::Dsl::Entry.new(:tap, "homebrew/foo")
+    untapped_formula_entry = Homebrew::Bundle::Dsl::Entry.new(:brew, "bar")
+
+    allow(Homebrew::API).to receive_messages(formula_names: [], formula_aliases: {}, formula_renames: {})
+
+    expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
+
+    described_class.install!([tap_entry, untapped_formula_entry], quiet: true)
+  end
+
+  it "warns and skips fetching unqualified formulae when API metadata is unavailable" do
+    tap_entry = Homebrew::Bundle::Dsl::Entry.new(:tap, "homebrew/foo")
+    untapped_formula_entry = Homebrew::Bundle::Dsl::Entry.new(:brew, "bar")
+
+    allow(Homebrew::API).to receive(:formula_names).and_raise("API unavailable")
+
+    expect(described_class).to receive(:opoo).with(/could not check API metadata: API unavailable/)
+    expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
+
+    described_class.install!([tap_entry, untapped_formula_entry], quiet: true)
+  end
+
+  it "prefetches unqualified formulae available without untapped Brewfile taps" do
+    tap_entry = Homebrew::Bundle::Dsl::Entry.new(:tap, "homebrew/foo")
+    formula_entry = Homebrew::Bundle::Dsl::Entry.new(:brew, "mysql")
+
+    allow(Homebrew::API).to receive_messages(formula_names: ["mysql"], formula_aliases: {}, formula_renames: {})
+    allow(Homebrew::Bundle::Brew).to receive(:formula_installed_and_up_to_date?)
+      .with("mysql", no_upgrade: false).and_return(false)
+
+    expect(Homebrew::Bundle).to receive(:brew)
+      .with("fetch", "mysql", verbose: false)
+      .and_return(true)
+
+    described_class.install!([tap_entry, formula_entry], quiet: true)
+  end
+
+  it "skips fetching fully qualified casks from untapped taps" do
+    tapped_cask_entry = Homebrew::Bundle::Dsl::Entry.new(:cask, "bar", args: {}, full_name: "homebrew/foo/bar")
+
+    expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
+
+    described_class.install!([tapped_cask_entry], quiet: true)
+  end
+
+  it "skips fetching unqualified casks when Brewfile taps are untapped" do
+    tap_entry = Homebrew::Bundle::Dsl::Entry.new(:tap, "xykong/tap")
+    untapped_cask_entry = Homebrew::Bundle::Dsl::Entry.new(:cask, "flux-markdown",
+                                                           args: {}, full_name: "flux-markdown")
+
+    allow(Homebrew::API).to receive_messages(cask_tokens: [], cask_renames: {})
+
+    expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
+
+    described_class.install!([tap_entry, untapped_cask_entry], quiet: true)
+  end
+
+  it "prefetches unqualified casks available without untapped Brewfile taps" do
+    tap_entry = Homebrew::Bundle::Dsl::Entry.new(:tap, "xykong/tap")
+    cask_entry = Homebrew::Bundle::Dsl::Entry.new(:cask, "google-chrome", args: {}, full_name: "google-chrome")
+
+    allow(Homebrew::API).to receive_messages(cask_tokens: ["google-chrome"], cask_renames: {})
+    allow(Homebrew::Bundle::Cask).to receive(:installable_or_upgradable?)
+      .with("google-chrome", no_upgrade: false, args: {}, full_name: "google-chrome").and_return(true)
+
+    expect(Homebrew::Bundle).to receive(:brew)
+      .with("fetch", "google-chrome", verbose: false)
+      .and_return(true)
+
+    described_class.install!([tap_entry, cask_entry], quiet: true)
+  end
+
   describe "parallel installation" do
     let(:alpha_entry) do
       Homebrew::Bundle::Installer::InstallableEntry.new(
@@ -145,6 +229,80 @@ RSpec.describe Homebrew::Bundle::Installer do
       expect(success).to eq(2)
       expect(failure).to eq(0)
       expect(install_order).to eq(["beta", "alpha"])
+    end
+
+    it "installs unqualified formulae after Brewfile taps" do
+      tap_entry = Homebrew::Bundle::Installer::InstallableEntry.new(
+        name:    "homebrew/foo",
+        options: {},
+        verb:    "Tapping",
+        cls:     Homebrew::Bundle::Tap,
+      )
+      tapped_formula_entry = Homebrew::Bundle::Installer::InstallableEntry.new(
+        name:    "bar",
+        options: {},
+        verb:    "Installing",
+        cls:     Homebrew::Bundle::Brew,
+      )
+      install_order = []
+
+      allow(Homebrew::API).to receive_messages(formula_names: [], formula_aliases: {}, formula_renames: {})
+      allow(Homebrew::Bundle::Brew).to receive_messages(formula_bottled?: true, formula_dep_names: [],
+                                                        recursive_dep_names: Set.new)
+      allow(Homebrew::Bundle::Tap).to receive(:install!) do |name, **_options|
+        install_order << name
+        true
+      end
+      allow(Homebrew::Bundle::Brew).to receive(:install!) do |name, **_options|
+        install_order << name
+        true
+      end
+
+      success, failure = Homebrew::Bundle::ParallelInstaller.new(
+        [tap_entry, tapped_formula_entry],
+        jobs: 2, no_upgrade: false, verbose: false, force: false, quiet: true,
+      ).run!
+
+      expect(success).to eq(2)
+      expect(failure).to eq(0)
+      expect(install_order).to eq(["homebrew/foo", "bar"])
+    end
+
+    it "installs unqualified casks after Brewfile taps" do
+      tap_entry = Homebrew::Bundle::Installer::InstallableEntry.new(
+        name:    "xykong/tap",
+        options: {},
+        verb:    "Tapping",
+        cls:     Homebrew::Bundle::Tap,
+      )
+      tapped_cask_entry = Homebrew::Bundle::Installer::InstallableEntry.new(
+        name:    "flux-markdown",
+        options: { args: {}, full_name: "flux-markdown" },
+        verb:    "Installing",
+        cls:     Homebrew::Bundle::Cask,
+      )
+      install_order = []
+
+      allow(Homebrew::API).to receive_messages(cask_tokens: [], cask_renames: {})
+      allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(false)
+      allow(Homebrew::Bundle::Cask).to receive(:formula_dependencies).with(["flux-markdown"]).and_return([])
+      allow(Homebrew::Bundle::Tap).to receive(:install!) do |name, **_options|
+        install_order << name
+        true
+      end
+      allow(Homebrew::Bundle::Cask).to receive(:install!) do |name, **_options|
+        install_order << name
+        true
+      end
+
+      success, failure = Homebrew::Bundle::ParallelInstaller.new(
+        [tap_entry, tapped_cask_entry],
+        jobs: 2, no_upgrade: false, verbose: false, force: false, quiet: true,
+      ).run!
+
+      expect(success).to eq(2)
+      expect(failure).to eq(0)
+      expect(install_order).to eq(["xykong/tap", "flux-markdown"])
     end
 
     it "falls back to sequential with jobs=1" do


### PR DESCRIPTION
- Avoid prefetching Brewfile entries from taps before those taps exist.
- Keep taps referenced by fully qualified `brew` and `cask` entries during `brew bundle cleanup`.

Fixes https://github.com/Homebrew/brew/issues/22129

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex with local review, testing and several approach changes.

-----
