### PR TITLE
caveats: sort shadowed executables alphabetically

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -133,7 +133,7 @@ class Caveats
     shadowed = shadowed_executables
     return if shadowed.empty?
 
-    lines = shadowed.map { |name, shadower| "  #{name} (shadowed by #{shadower})" }
+    lines = shadowed.sort_by(&:first).map { |name, shadower| "  #{name} (shadowed by #{shadower})" }
     s = <<~EOS
       The following #{formula.name} executables are shadowed by other commands earlier in your PATH:
       #{lines.join("\n")}

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -253,12 +253,21 @@ RSpec.describe Caveats do
         allow_any_instance_of(Object).to receive(:which).and_call_original
       end
 
-      it "warns when an executable is shadowed by another on PATH" do
-        shadower = Pathname.new("/usr/local/bin/foo")
-        allow_any_instance_of(Object).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(shadower)
-        allow(shadower).to receive(:realpath).and_return(shadower)
+      it "warns about shadowed executables on PATH in alphabetical order" do
+        FileUtils.touch(f.opt_bin/"bar")
+        FileUtils.chmod(0755, f.opt_bin/"bar")
 
-        expect(described_class.new(f).caveats).to include("foo (shadowed by #{shadower})")
+        foo_shadower = Pathname.new("/usr/local/bin/foo")
+        bar_shadower = Pathname.new("/usr/local/bin/bar")
+        allow_any_instance_of(Object).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(foo_shadower)
+        allow_any_instance_of(Object).to receive(:which).with("bar", ORIGINAL_PATHS).and_return(bar_shadower)
+        allow(foo_shadower).to receive(:realpath).and_return(foo_shadower)
+        allow(bar_shadower).to receive(:realpath).and_return(bar_shadower)
+        allow(f.opt_bin).to receive(:children).and_return([f.opt_bin/"foo", f.opt_bin/"bar"])
+
+        caveats = described_class.new(f).caveats
+        expect(caveats).to include("foo (shadowed by #{foo_shadower})")
+        expect(caveats.index("bar (shadowed by")).to be < caveats.index("foo (shadowed by")
       end
 
       it "does not warn when PATH resolves to the formula's own executable" do


### PR DESCRIPTION
Sort the shadowed-executables list alphabetically so the caveat output has a stable, predictable order. Currently:

```
The following git executables are shadowed by other commands earlier in your PATH:
  git-receive-pack (shadowed by /usr/local/bin/git-receive-pack)
  git-upload-archive (shadowed by /usr/local/bin/git-upload-archive)
  git-cvsserver (shadowed by /usr/local/bin/git-cvsserver)
  git-shell (shadowed by /usr/local/bin/git-shell)
  git-upload-pack (shadowed by /usr/local/bin/git-upload-pack)
  scalar (shadowed by /usr/local/bin/scalar)
  git (shadowed by /usr/local/bin/git)
```