### PR TITLE
Explain upgrade metadata fetch

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -393,6 +393,13 @@ module Homebrew
 
         if prefetch_only
           prefetch_download_queue = download_queue || Homebrew.default_download_queue
+          if context.formulae_installer.any? do |fi|
+            fi.pour_bottle? && fi.formula.local_bottle_path.blank? &&
+            fi.formula.bottle&.github_packages_manifest_resource
+          end
+            oh1 "Fetching dependencies metadata"
+          end
+
           valid_formula_installers = Install.enqueue_formulae(context.formulae_installer,
                                                               download_queue: prefetch_download_queue)
           if show_downloads_heading

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -132,6 +132,36 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     EOS
   end
 
+  it "prints a dependencies metadata heading before formula prefetches" do
+    cmd = described_class.new([])
+    formula = formula("deno") do
+      url "https://brew.sh/deno-2.7.11.tar.gz"
+
+      bottle do
+        root_url HOMEBREW_BOTTLE_DEFAULT_DOMAIN
+        sha256 cellar: :any_skip_relocation,
+               Utils::Bottles.tag.to_sym => "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97"
+      end
+    end
+    formula_installer = FormulaInstaller.new(formula)
+    download_queue = instance_double(Homebrew::DownloadQueue)
+
+    allow(cmd).to receive(:formulae_upgrade_context).and_return(
+      described_class::FormulaeUpgradeContext.new(
+        formulae_to_install: [formula],
+        formulae_installer:  [formula_installer],
+        dependants:          Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: []),
+      ),
+    )
+    allow(Homebrew::Install).to receive(:enqueue_formulae)
+      .with([formula_installer], download_queue:)
+      .and_return([formula_installer])
+
+    expect do
+      cmd.send(:upgrade_outdated_formulae!, [], prefetch_only: true, download_queue:, show_downloads_heading: false)
+    end.to output("==> Fetching dependencies metadata\n").to_stdout
+  end
+
   it "does not trust failed shared prefetches" do
     cmd = described_class.new([])
     download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, fetch_failed: true, shutdown: nil)


### PR DESCRIPTION
- Print a short heading before `brew upgrade` prefetches bottle manifests, so early downloads are not detached from their purpose.
- Cover the shared prefetch path with a focused `cmd/upgrade` regression.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex with manual review and testing.

-----
