### PR TITLE
Supports in repository patch files

### DIFF
--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -4,6 +4,7 @@
 require "cachable"
 require "api"
 require "api/source_download"
+require "local_patch"
 require "download_queue"
 require "api/formula/formula_struct_generator"
 
@@ -44,19 +45,27 @@ module Homebrew
       sig {
         params(
           formula:        ::Formula,
+          path:           String,
+          checksum:       T.nilable(Checksum),
           download_queue: Homebrew::DownloadQueue,
           enqueue:        T::Boolean,
         ).returns(Homebrew::API::SourceDownload)
       }
-      def self.source_download(formula, download_queue: Homebrew.default_download_queue, enqueue: false)
-        path = formula.ruby_source_path || "Formula/#{formula.name}.rb"
+      def self.source_download_path(formula, path, checksum: nil, download_queue: Homebrew.default_download_queue,
+                                    enqueue: false)
+        unless LocalPatch.valid_path?(path)
+          raise ArgumentError, "API source path must be a relative path within the repository."
+        end
+
+        path = Pathname(path).cleanpath
+
         git_head = formula.tap_git_head || "HEAD"
         tap = formula.tap&.full_name || "Homebrew/homebrew-core"
 
         download = Homebrew::API::SourceDownload.new(
           "https://raw.githubusercontent.com/#{tap}/#{git_head}/#{path}",
-          formula.ruby_source_checksum,
-          cache: HOMEBREW_CACHE_API_SOURCE/"#{tap}/#{git_head}/Formula",
+          checksum,
+          cache: HOMEBREW_CACHE_API_SOURCE/"#{tap}/#{git_head}"/path.dirname,
         )
 
         if enqueue
@@ -66,6 +75,18 @@ module Homebrew
         end
 
         download
+      end
+
+      sig {
+        params(
+          formula:        ::Formula,
+          download_queue: Homebrew::DownloadQueue,
+          enqueue:        T::Boolean,
+        ).returns(Homebrew::API::SourceDownload)
+      }
+      def self.source_download(formula, download_queue: Homebrew.default_download_queue, enqueue: false)
+        path = formula.ruby_source_path || "Formula/#{formula.name}.rb"
+        source_download_path(formula, path, checksum: formula.ruby_source_checksum, download_queue:, enqueue:)
       end
 
       sig { params(formula: ::Formula).returns(::Formula) }
@@ -78,12 +99,23 @@ module Homebrew
                 "Try `rm -rf $(brew --cache)/api-source` and retrying."
         end
 
-        with_env(HOMEBREW_INTERNAL_ALLOW_PACKAGES_FROM_PATHS: "1") do
+        source_formula = with_env(HOMEBREW_INTERNAL_ALLOW_PACKAGES_FROM_PATHS: "1") do
           Formulary.factory(download.symlink_location,
                             formula.active_spec_sym,
                             alias_path: formula.alias_path,
                             flags:      formula.class.build_flags)
         end
+
+        source_formula.resources.each do |resource|
+          resource.patches.grep(LocalPatch) do |patch|
+            source_download_path(formula, patch.file.to_s)
+          end
+        end
+        source_formula.patchlist.grep(LocalPatch) do |patch|
+          source_download_path(formula, patch.file.to_s)
+        end
+
+        source_formula
       end
 
       sig { returns(Pathname) }

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -83,22 +83,36 @@ module Homebrew
       def stale_api_source?(pathname, scrub)
         return true if scrub
 
-        org, repo, git_head, type, basename = pathname.each_filename.to_a.last(5)
+        path_parts = pathname.each_filename.to_a
+        api_source_index = path_parts.rindex("api-source")
+        return false if api_source_index.nil?
 
-        name = "#{org}/#{repo}/#{File.basename(T.must(basename), ".rb")}"
-        package = if type == "Cask"
+        relative_path_parts = path_parts.drop(api_source_index + 1)
+        return false if relative_path_parts.length < 4
+
+        org = relative_path_parts.fetch(0)
+        repo = relative_path_parts.fetch(1)
+        git_head = relative_path_parts.fetch(2)
+        type = relative_path_parts.fetch(3)
+        basename = relative_path_parts.fetch(-1)
+        return false unless basename.end_with?(".rb")
+
+        name = "#{org}/#{repo}/#{File.basename(basename, ".rb")}"
+        package = case type
+        when "Cask"
           begin
             Cask::CaskLoader.load(name)
           rescue Cask::CaskError
             nil
           end
-        else
+        when "Formula"
           begin
             Formulary.factory(name)
           rescue FormulaUnavailableError
             nil
           end
         end
+        return false if package.nil? && %w[Cask Formula].exclude?(type)
         return true if package.nil?
 
         package.tap_git_head != git_head
@@ -450,7 +464,7 @@ module Homebrew
     def cache_files
       files = cache.directory? ? cache.children : []
       cask_files = (cache/"Cask").directory? ? (cache/"Cask").children : []
-      api_source_files = (cache/"api-source").glob("*/*/*/*/*") # `<org>/<repo>/<git_head>/<type>/<token>.rb`
+      api_source_files = (cache/"api-source").glob("*/*/*/**/*").select { |path| path.file? || path.symlink? }
       gh_actions_artifacts = (cache/"gh-actions-artifact").directory? ? (cache/"gh-actions-artifact").children : []
 
       files.map { |path| { path:, type: nil } } +

--- a/Library/Homebrew/local_patch.rb
+++ b/Library/Homebrew/local_patch.rb
@@ -1,0 +1,84 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "embedded_patch"
+
+# A patch file stored locally within a formula repository.
+class LocalPatch < EmbeddedPatch
+  sig { returns(T.any(String, Pathname)) }
+  attr_reader :file
+
+  sig { returns(T.nilable(Resource::Owner)) }
+  attr_reader :owner
+
+  sig { params(path_string: String).returns(T::Boolean) }
+  def self.valid_path?(path_string)
+    path = Pathname(path_string).cleanpath
+    path_string.present? &&
+      !path_string.end_with?("/") &&
+      !path.absolute? &&
+      %w[. ..].exclude?(path.to_s) &&
+      !path.to_s.start_with?("../")
+  end
+
+  sig { params(strip: T.any(String, Symbol), file: T.any(String, Pathname)).void }
+  def initialize(strip, file)
+    super(strip)
+    @file = file
+  end
+
+  sig { override.returns(String) }
+  def contents
+    owner = self.owner
+    raise ArgumentError, "LocalPatch#contents called before owner was set!" unless owner
+
+    formula = T.cast(owner, SoftwareSpec).owner
+    raise ArgumentError, "LocalPatch#contents requires a formula owner!" unless formula.is_a?(::Formula)
+
+    repository_path = repository_path(formula)
+    file_path = repository_path/Pathname(file)
+    repository_realpath = repository_path.realpath
+    file_realpath = begin
+      file_path.realpath
+    rescue Errno::ENOENT
+      raise ArgumentError, "Patch file does not exist: #{file}"
+    end
+    if file_realpath.ascend.none?(repository_realpath)
+      raise ArgumentError, "Patch file must be within the formula repository."
+    end
+    raise ArgumentError, "Patch file must be a file: #{file}" unless file_realpath.file?
+
+    file_realpath.read
+  end
+
+  sig { override.returns(String) }
+  def inspect
+    "#<#{self.class.name}: #{strip.inspect} #{file.inspect}>"
+  end
+
+  private
+
+  sig { params(formula: ::Formula).returns(Pathname) }
+  def repository_path(formula)
+    formula_path = formula.specified_path || formula.path
+    api_source_repository_path(formula_path) || formula.tap&.path || formula_path.dirname
+  end
+
+  sig { params(path: Pathname).returns(T.nilable(Pathname)) }
+  def api_source_repository_path(path)
+    source_root = if defined?(Homebrew::API::HOMEBREW_CACHE_API_SOURCE)
+      Homebrew::API::HOMEBREW_CACHE_API_SOURCE
+    else
+      HOMEBREW_CACHE/"api-source"
+    end.expand_path
+    relative_path = path.expand_path.relative_path_from(source_root)
+    return if relative_path.to_s.start_with?("../")
+
+    path_parts = relative_path.each_filename.to_a.first(3)
+    return if path_parts.length < 3
+
+    source_root/path_parts.fetch(0)/path_parts.fetch(1)/path_parts.fetch(2)
+  rescue ArgumentError
+    nil
+  end
+end

--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -5,6 +5,7 @@ require "embedded_patch"
 require "data_patch"
 require "external_patch"
 require "string_patch"
+require "local_patch"
 
 # Helper module for creating patches.
 module Patch
@@ -28,7 +29,18 @@ module Patch
       when String
         StringPatch.new(strip, src)
       else
-        ExternalPatch.new(strip, &block)
+        external_patch = ExternalPatch.new(strip, &block)
+        resource = external_patch.resource
+        if (file = resource.file)
+          raise ArgumentError, "Patch cannot have both `file` and `url`." if resource.url.present?
+          raise ArgumentError, "Patch cannot use `sha256` with `file`." if resource.checksum
+          raise ArgumentError, "Patch cannot use `directory` with `file`." if resource.directory.present?
+          raise ArgumentError, "Patch cannot use `apply` with `file`." if resource.patch_files.present?
+
+          LocalPatch.new(strip, file)
+        else
+          external_patch
+        end
       end
     end
   end

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -470,6 +470,7 @@ class Resource
     def initialize(&block)
       @patch_files = T.let([], T::Array[T.any(String, Pathname)])
       @directory = T.let(nil, T.nilable(T.any(String, Pathname)))
+      @file = T.let(nil, T.nilable(T.any(String, Pathname)))
       super "patch", &block
     end
 
@@ -484,6 +485,18 @@ class Resource
       return @directory if val.nil?
 
       @directory = val
+    end
+
+    sig { params(val: T.nilable(T.any(String, Pathname))).returns(T.nilable(T.any(String, Pathname))) }
+    def file(val = nil)
+      return @file if val.nil?
+
+      path_string = val.to_s
+      unless LocalPatch.valid_path?(path_string)
+        raise ArgumentError, "Patch file must be a relative path within the repository."
+      end
+
+      @file = val
     end
 
     sig { override.returns(String) }

--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -19,11 +19,12 @@ module RuboCop
 
           external_patches = find_all_blocks(body_node, :patch)
           external_patches.each do |patch_block|
-            url_node = find_every_method_call_by_name(patch_block, :url).fetch(0)
-            url_string = parameters(url_node).fetch(0)
-            sha256_node = find_every_method_call_by_name(patch_block, :sha256).first
-            sha256_string = parameters(sha256_node).first if sha256_node
-            patch_problems(url_string, sha256_string)
+            find_every_method_call_by_name(patch_block, :url).each do |url_node|
+              url_string = parameters(url_node).fetch(0)
+              sha256_node = find_every_method_call_by_name(patch_block, :sha256).first
+              sha256_string = parameters(sha256_node).first if sha256_node
+              patch_problems(url_string, sha256_string)
+            end
           end
 
           inline_patches = find_every_method_call_by_name(body_node, :patch)

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -6,9 +6,11 @@ require "test/support/fixtures/testball"
 
 RSpec.describe Homebrew::API::Formula do
   let(:cache_dir) { mktmpdir }
+  let(:source_cache_dir) { mktmpdir }
 
   before do
     stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
+    stub_const("Homebrew::API::HOMEBREW_CACHE_API_SOURCE", source_cache_dir)
   end
 
   def mock_curl_download(stdout:)
@@ -134,6 +136,31 @@ RSpec.describe Homebrew::API::Formula do
       result = described_class.source_download_formula(f)
       expect(result).to be_a(Formula)
       expect(result.name).to eq("testball")
+    end
+
+    it "loads local patch files from API source cache" do
+      source_path = source_cache_dir/"Homebrew/homebrew-core/abc123/Formula/testball.rb"
+      source_path.dirname.mkpath
+      source_path.write <<~RUBY
+        class Testball < Formula
+          url "https://brew.sh/testball-0.1.tar.gz"
+
+          patch do
+            file "patches/noop-a.diff"
+          end
+        end
+      RUBY
+
+      allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:fetch) do |download|
+        next if download.symlink_location.basename.to_s != "noop-a.diff"
+
+        download.symlink_location.dirname.mkpath
+        download.symlink_location.write("patch contents")
+      end
+
+      result = described_class.source_download_formula(f)
+
+      expect(result.patchlist.fetch(0).contents).to eq("patch contents")
     end
   end
 end

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -435,6 +435,57 @@ RSpec.describe Homebrew::Cleanup do
       expect(foo).to exist
     end
 
+    it "cleans up API source files and symlinks at any depth without cleaning directories" do
+      root_file = HOMEBREW_CACHE/"api-source/Homebrew/homebrew-core/abc123/README.md"
+      nested_file = HOMEBREW_CACHE/"api-source/Homebrew/homebrew-core/abc123/Formula/a/testball.rb"
+      nested_symlink = HOMEBREW_CACHE/"api-source/Homebrew/homebrew-core/abc123/patches/subdir/noop-a.diff"
+      nested_directory = HOMEBREW_CACHE/"api-source/Homebrew/homebrew-core/abc123/patches/keep"
+      symlink_target = mktmpdir/"noop-a.diff"
+
+      root_file.dirname.mkpath
+      nested_file.dirname.mkpath
+      nested_symlink.dirname.mkpath
+      nested_directory.mkpath
+      FileUtils.touch root_file
+      FileUtils.touch nested_file
+      FileUtils.touch symlink_target
+      FileUtils.ln_s symlink_target, nested_symlink
+
+      described_class.new(days: 0).cleanup_cache
+
+      expect([root_file.exist?, nested_file.exist?, nested_symlink.exist?, nested_directory.exist?])
+        .to eq([false, false, false, true])
+    end
+
+    it "does not remove recent API source local patches as stale" do
+      patch_file = HOMEBREW_CACHE/"api-source/Homebrew/homebrew-core/abc123/patches/noop-a.diff"
+      nested_patch_file = HOMEBREW_CACHE/"api-source/Homebrew/homebrew-core/abc123/patches/subdir/noop-b.diff"
+      patch_file.dirname.mkpath
+      nested_patch_file.dirname.mkpath
+      FileUtils.touch patch_file
+      FileUtils.touch nested_patch_file
+
+      cleanup.cleanup_cache
+
+      expect([patch_file.exist?, nested_patch_file.exist?]).to eq([true, true])
+    end
+
+    it "keeps current API formula source paths when tap git head matches" do
+      source_file = HOMEBREW_CACHE/"api-source/Homebrew/homebrew-core/abc123/Formula/testball.rb"
+      nested_source_file = HOMEBREW_CACHE/"api-source/Homebrew/homebrew-core/abc123/Formula/a/testball.rb"
+      package = instance_double(Formula, tap_git_head: "abc123")
+      source_file.dirname.mkpath
+      nested_source_file.dirname.mkpath
+      FileUtils.touch source_file
+      FileUtils.touch nested_source_file
+      expect(Formulary).to receive(:factory).with("Homebrew/homebrew-core/testball").twice.and_return(package)
+
+      cleanup.cleanup_cache([{ path: source_file, type: :api_source },
+                             { path: nested_source_file, type: :api_source }])
+
+      expect([source_file.exist?, nested_source_file.exist?]).to eq([true, true])
+    end
+
     context "when cleaning old files in HOMEBREW_CACHE" do
       let(:bottle) { HOMEBREW_CACHE/"testball--0.0.1.tag.bottle.tar.gz" }
       let(:testball) { HOMEBREW_CACHE/"testball--0.0.1" }

--- a/Library/Homebrew/test/patch_spec.rb
+++ b/Library/Homebrew/test/patch_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Patch do
       subject(:patch) { described_class.create(:p2, nil) }
 
       specify(:aggregate_failures) do
-        expect(subject).to be_a ExternalPatch # rubocop:todo RSpec/NamedSubject
-        expect(subject).to be_external # rubocop:todo RSpec/NamedSubject
+        expect(patch).to be_a ExternalPatch
+        expect(patch).to be_external
       end
 
       it(:strip) { expect(patch.strip).to eq(:p2) }
@@ -42,6 +42,90 @@ RSpec.describe Patch do
 
       it { is_expected.to be_a DATAPatch }
       it(:strip) { expect(patch.strip).to eq(:p1) }
+    end
+
+    context "with a local file patch" do
+      subject(:patch) { described_class.create(:p0, nil) { file "Patches/foo.diff" } }
+
+      specify(:aggregate_failures) do
+        expect(patch).to be_a LocalPatch
+        expect(patch).not_to be_external
+      end
+
+      it(:strip) { expect(patch.strip).to eq(:p0) }
+      it(:inspect) { expect(patch.inspect).to eq('#<LocalPatch: :p0 "Patches/foo.diff">') }
+    end
+
+    it "rejects blank local file patch paths" do
+      expect do
+        described_class.create(:p1, nil) { file "" }
+      end.to raise_error(ArgumentError, "Patch file must be a relative path within the repository.")
+    end
+
+    it "rejects current directory local file patch paths" do
+      expect do
+        described_class.create(:p1, nil) { file "." }
+      end.to raise_error(ArgumentError, "Patch file must be a relative path within the repository.")
+    end
+
+    it "rejects parent directory local file patch paths" do
+      expect do
+        described_class.create(:p1, nil) { file ".." }
+      end.to raise_error(ArgumentError, "Patch file must be a relative path within the repository.")
+    end
+
+    it "rejects local file patch paths ending in a slash" do
+      expect do
+        described_class.create(:p1, nil) { file "Patches/" }
+      end.to raise_error(ArgumentError, "Patch file must be a relative path within the repository.")
+    end
+
+    it "rejects local file patches outside the repository" do
+      expect do
+        described_class.create(:p1, nil) { file "../foo.diff" }
+      end.to raise_error(ArgumentError, "Patch file must be a relative path within the repository.")
+    end
+
+    it "rejects absolute local file patches" do
+      expect do
+        described_class.create(:p1, nil) { file "/tmp/foo.diff" }
+      end.to raise_error(ArgumentError, "Patch file must be a relative path within the repository.")
+    end
+
+    it "rejects local file patches with URLs" do
+      expect do
+        described_class.create(:p1, nil) do
+          file "Patches/foo.diff"
+          url "https://brew.sh/foo.diff"
+        end
+      end.to raise_error(ArgumentError, "Patch cannot have both `file` and `url`.")
+    end
+
+    it "rejects local file patches with sha256" do
+      expect do
+        described_class.create(:p1, nil) do
+          file "Patches/foo.diff"
+          sha256 "63376b8fdd6613a91976106d9376069274191860cd58f039b29ff16de1925621"
+        end
+      end.to raise_error(ArgumentError, "Patch cannot use `sha256` with `file`.")
+    end
+
+    it "rejects local file patches with directory" do
+      expect do
+        described_class.create(:p1, nil) do
+          file "Patches/foo.diff"
+          directory "subdir"
+        end
+      end.to raise_error(ArgumentError, "Patch cannot use `directory` with `file`.")
+    end
+
+    it "rejects local file patches with apply" do
+      expect do
+        described_class.create(:p1, nil) do
+          file "Patches/foo.diff"
+          apply "foo.diff"
+        end
+      end.to raise_error(ArgumentError, "Patch cannot use `apply` with `file`.")
     end
   end
 

--- a/Library/Homebrew/test/patching_spec.rb
+++ b/Library/Homebrew/test/patching_spec.rb
@@ -26,9 +26,10 @@ RSpec.describe "patching", type: :system do
     end
   end
 
-  def formula(name = "formula_name", path: Formulary.core_path(name), spec: :stable, alias_path: nil, &block)
+  def formula(name = "formula_name", path: Formulary.core_path(name), spec: :stable, alias_path: nil, tap: nil,
+              &block)
     formula_subclass.class_eval(&block)
-    formula_subclass.new(name, path, spec, alias_path:)
+    formula_subclass.new(name, path, spec, alias_path:, tap:)
   end
 
   matcher :be_patched do
@@ -96,6 +97,93 @@ RSpec.describe "patching", type: :system do
         end
       end,
     ).to be_patched
+  end
+
+  specify "local_patch_dsl_resolves_path_loaded_formulae_from_formula_directory" do
+    expect(
+      formula(path: TEST_FIXTURE_DIR/"testball.rb") do
+        patch do
+          file "patches/noop-a.diff"
+        end
+      end,
+    ).to be_patched
+  end
+
+  specify "local_patch_dsl_with_strip" do
+    expect(
+      formula(path: TEST_FIXTURE_DIR/"testball.rb") do
+        patch :p0 do
+          file "patches/noop-b.diff"
+        end
+      end,
+    ).to be_patched
+  end
+
+  specify "local_patch_dsl_with_homebrew_prefix" do
+    expect(
+      formula(path: TEST_FIXTURE_DIR/"testball.rb") do
+        patch do
+          file "patches/noop-d.diff"
+        end
+      end,
+    ).to be_patched_with_homebrew_prefix
+  end
+
+  specify "local_patch_dsl_resolves_tapped_formulae_from_tap_root" do
+    tap = Tap.fetch("homebrew", "local-patch-test")
+    (tap.path/"Formula").mkpath
+    (tap.path/"patches").mkpath
+    FileUtils.cp TEST_FIXTURE_DIR/"patches/noop-a.diff", tap.path/"patches/noop-a.diff"
+
+    expect(
+      formula(path: tap.path/"Formula/testball.rb", tap:) do
+        patch do
+          file "patches/noop-a.diff"
+        end
+      end,
+    ).to be_patched
+  ensure
+    FileUtils.rm_rf tap.path if tap
+  end
+
+  specify "local_patch_dsl_missing_file_fail" do
+    f = formula(path: TEST_FIXTURE_DIR/"testball.rb") do
+      patch do
+        file "patches/missing.diff"
+      end
+    end
+
+    expect { f.stable.patches.last.contents }
+      .to raise_error(ArgumentError, "Patch file does not exist: patches/missing.diff")
+  end
+
+  specify "local_patch_dsl_directory_fail" do
+    f = formula(path: TEST_FIXTURE_DIR/"testball.rb") do
+      patch do
+        file "patches"
+      end
+    end
+
+    expect { f.stable.patches.last.contents }
+      .to raise_error(ArgumentError, "Patch file must be a file: patches")
+  end
+
+  specify "local_patch_dsl_rejects_symlink_escape" do
+    mktmpdir do |tmpdir|
+      repository = tmpdir/"repository"
+      repository.mkpath
+      FileUtils.cp TEST_FIXTURE_DIR/"patches/noop-a.diff", tmpdir/"outside.diff"
+      FileUtils.ln_s tmpdir/"outside.diff", repository/"escape.diff"
+
+      f = formula(path: repository/"testball.rb") do
+        patch do
+          file "escape.diff"
+        end
+      end
+
+      expect { f.stable.patches.last.contents }
+        .to raise_error(ArgumentError, "Patch file must be within the formula repository.")
+    end
   end
 
   specify "single_patch_dsl_for_resource" do

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -229,6 +229,19 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Patches do
     end
   end
 
+  context "when auditing local file patches" do
+    it "reports no offenses for local file patches" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          patch do
+            file "Patches/foo.diff"
+          end
+        end
+      RUBY
+    end
+  end
+
   context "when auditing external patches with corrector" do
     it "corrects Bitbucket patch URLs to use API format" do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
   ## What does this PR do?

   This recreates the local patch file support from closed PR #22136 on top of current `main`.

   It allows formula patches to reference patch files stored in the repository, while keeping the implementation
 scoped to the patch-file feature itself. I intentionally left the earlier class-extraction refactor out of this PR
 to keep the diff focused and easier to review.

   ## Why is this useful?

   This makes larger or reusable patches easier to maintain than embedding them directly in formula files, while
 preserving existing patch behavior and test coverage.

   -----

   - [x] Have you followed the guidelines in our
 [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
   - [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls)
 for the same change?
   - [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance
 claims must include Hyperfine benchmarks.
   - [x] Have you written new tests, excluding integration tests, for your changes?
   - [x] Have you successfully run `brew lgtm` with your changes locally? (not really needed)

   -----

   - [x] AI was used to generate or assist with generating this PR.

   I used GPT 5.5 via the oh-my-pi coding agent to recreate the local patch file feature from the old closed PR #22136 on top
 of current `main`, while accounting for maintainer feedback. I manually reviewed the resulting diff, kept the
 class-extraction refactor out of this PR, and verified the feature with targeted tests.

   Verified with:

   - `./bin/brew tests --only=patch`
   - `./bin/brew tests --only=patching`
   - `./bin/brew tests --only=api/formula`
   - `./bin/brew typecheck`
   - `./bin/brew style --fix --changed`