### PR TITLE
Use the internal API for developers/devcmdrun

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -763,6 +763,7 @@ module Homebrew
     sig { returns(T::Boolean) }
     def use_internal_api?
       return false if Homebrew::EnvConfig.no_install_from_api?
+      return true if Homebrew::EnvConfig.developer? || Homebrew::EnvConfig.devcmdrun?
 
       use_internal_api = ENV.fetch("HOMEBREW_USE_INTERNAL_API", nil)
       use_internal_api.present? && FALSY_VALUES.exclude?(use_internal_api.downcase)


### PR DESCRIPTION
Let's switch all developers and devcmdrun folks to use the internal API

Disabling the API with `HOMEBREW_NO_INSTALL_FROM_API` still works for these people. Non-developers can opt-in still with `HOMEBREW_USE_INTERNAL_API`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
