### PR TITLE
Cask::DSL::DependsOn: allow :macos and version

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -212,10 +212,10 @@ module Cask
       return true if font?
 
       # Bare `depends_on :macos` explicitly marks a cask as macOS-only
-      return false if (macos_requirement = depends_on.macos) && !macos_requirement.version_specified?
+      return false if depends_on.macos?
 
-      # Cache the os value before contains_os_specific_artifacts? refreshes the cask
-      # (the refresh clears @dsl.os in generic/non-OS-specific contexts)
+      # Cache the os value before contains_os_specific_artifacts? refreshes the
+      # cask (the refresh clears @dsl.os in generic/non-OS-specific contexts)
       os_value = dsl!.os
 
       return false if contains_os_specific_artifacts?

--- a/Library/Homebrew/cask/dsl/depends_on.rb
+++ b/Library/Homebrew/cask/dsl/depends_on.rb
@@ -36,6 +36,7 @@ module Cask
         @cask = T.let(nil, T.nilable(T::Array[String]))
         @formula = T.let(nil, T.nilable(T::Array[String]))
         @macos = T.let(nil, T.nilable(MacOSRequirement))
+        @requires_macos = T.let(false, T::Boolean)
       end
 
       sig { returns(T::Array[String]) }
@@ -69,15 +70,20 @@ module Cask
 
       sig { params(args: T.any(String, Symbol)).returns(T.nilable(MacOSRequirement)) }
       def macos=(*args)
-        raise "Only a single 'depends_on macos' is allowed." if @macos
-
         # workaround for https://github.com/sorbet/sorbet/issues/6860
         first_arg = args.first
         first_arg_s = first_arg&.to_s
 
+        if first_arg && first_arg != :any && @macos&.version_specified?
+          raise "Only a single 'depends_on macos:' is allowed."
+        end
+
         begin
           @macos = if first_arg == :any
-            MacOSRequirement.new
+            @requires_macos ||= true
+
+            # Don't override an existing `@macos` value with a blank requirement
+            @macos || MacOSRequirement.new
           elsif args.count > 1
             MacOSRequirement.new([args], comparator: "==")
           elsif first_arg.is_a?(Symbol) && MacOSVersion::SYMBOLS.key?(first_arg)
@@ -108,6 +114,9 @@ module Cask
 
         @arch.concat(arches.map { |arch| VALID_ARCHES.fetch(arch) })
       end
+
+      sig { returns(T::Boolean) }
+      def macos? = @requires_macos
 
       sig { returns(T::Boolean) }
       def empty? = T.let(__getobj__, T::Hash[Symbol, T.untyped]).empty?

--- a/Library/Homebrew/test/cask/depends_on_spec.rb
+++ b/Library/Homebrew/test/cask/depends_on_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe "Satisfy Dependencies and Requirements", :cask do
   end
 
   describe "depends_on macos" do
+    context "with :macos" do
+      let(:cask) { Cask::CaskLoader.load(cask_path("with-depends-on-macos-bare")) }
+
+      it "does not raise an error" do
+        expect { install }.not_to raise_error
+      end
+    end
+
     context "with an array" do
       let(:cask) { Cask::CaskLoader.load(cask_path("with-depends-on-macos-array")) }
 
@@ -50,7 +58,15 @@ RSpec.describe "Satisfy Dependencies and Requirements", :cask do
       end
     end
 
-    context "with a symbol" do
+    context "with :macos and a comparison" do
+      let(:cask) { Cask::CaskLoader.load(cask_path("with-depends-on-macos-bare-and-comparison")) }
+
+      it "does not raise an error" do
+        expect { install }.not_to raise_error
+      end
+    end
+
+    context "with a macOS version symbol" do
       let(:cask) { Cask::CaskLoader.load(cask_path("with-depends-on-macos-symbol")) }
 
       it "does not raise an error" do

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -442,9 +442,28 @@ RSpec.describe Cask::DSL, :cask, :no_api do
       let(:token) { "with-depends-on-macos-bare" }
 
       it "creates a MacOSRequirement without a version" do
-        macos_requirement = cask.depends_on.macos
-        expect(macos_requirement).to be_a(MacOSRequirement)
-        expect(macos_requirement.version_specified?).to be false
+        depends_on_macos = cask.depends_on.macos
+        expect(depends_on_macos).to eq(MacOSRequirement.new)
+        expect(depends_on_macos.version_specified?).to be false
+      end
+    end
+
+    context "when bare :macos is used alongside a version" do
+      let(:token) { "with-depends-on-macos-bare-and-comparison" }
+
+      it "creates a MacOSRequirement with the version" do
+        macos_requirement = MacOSRequirement.new([:catalina], comparator: ">=")
+
+        depends_on_macos = cask.depends_on.macos
+        expect(depends_on_macos).to eq(macos_requirement)
+        expect(depends_on_macos.version_specified?).to be true
+        expect(cask.depends_on.macos?).to be true
+
+        # Call `depends_on :macos` again (after `depends_on macos: "..." has
+        # been called) to confirm it doesn't override the specific macOS
+        # requirement with a blank one.
+        cask.depends_on :macos
+        expect(cask.depends_on.macos).to eq(macos_requirement)
       end
     end
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-bare-and-comparison.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-bare-and-comparison.rb
@@ -1,0 +1,15 @@
+# typed: false
+# frozen_string_literal: true
+
+cask "with-depends-on-macos-bare-and-comparison" do
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/with-depends-on-macos-bare-and-comparison"
+
+  depends_on :macos
+  depends_on macos: ">= :catalina"
+
+  app "Caffeine.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-bare.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-bare.rb
@@ -10,5 +10,5 @@ cask "with-depends-on-macos-bare" do
 
   depends_on :macos
 
-  binary "#{appdir}/Caffeine.app/Contents/MacOS/caffeine"
+  binary "#{staged_path}/Caffeine.app/Contents/MacOS/Caffeine"
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

Currently `Cask::DSL::DependsOn.macos=` will raise an "Only a single 'depends_on macos' is allowed" error if a cask uses `depends_on :macos` and specifies a macOS requirement like `depends_on macos: ">= :catalina"`. These shouldn't be mutually exclusive, as the former is used to specify that a cask is macOS-only and the latter is used to specify a macOS version requirement and that can be used in casks that also support Linux (i.e., it implies macOS support but not macOS exclusivity). Since `depends_on macos:` can be used in casks that support both macOS and Linux, we also need to add `depends_on :macos` to casks that are macOS-only, like we recently did for casks that don't use `depends_on macos:`.

To make that possible, this updates `Cask::DSL::DependsOn.macos=` to only raise this error if `depends_on macos:` is called with a version and a version has already been specified. I've set this up so that calling `depends_on :macos` won't overwrite an existing `@macos` value. Similarly, calling `depends_on macos:` with a version requirement will overwrite a blank `MacOSRequirement`, so `depends_on.macos` will reflect the macOS version requirement. This should work regardless of whether `depends_on :macos` comes before or after `depends_on macos:`.

However, `Cask::Cask.supports_linux?` uses a false `version_specified?` value as the indicator that a cask uses `depends_on :macos` and this won't be true if a cask also uses `depends_on macos:`. To address this issue, this also modifies `Cask::DSL::DependsOn.macos=` to set a `@requires_macos` variable to true when `depends_on :macos` is used, so we have a stable indicator that we can rely on. I've also added a `macos?` method that simply returns the `@requires_macos` value and I've updated `supports_linux?` to use that in the related condition instead.