### PR TITLE
test: disable `return false` handling

### DIFF
--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -49,14 +49,12 @@ begin
   ENV.setup_build_environment(formula:, testing_formula: true)
   Pathname.activate_extensions!
 
-  # tests can also return false to indicate failure
   run_test = proc do |_|
     # TODO: Replace proc usage with direct `formula.run_test` when removing this.
     # Also update formula.rb 'TODO: replace `returns(BasicObject)` with `void`'
     if formula.run_test(keep_tmp: args.keep_tmp?) == false
       require "utils/output"
       Utils::Output.odisabled "`return false` in test", "`raise \"<reason for failure>\"`"
-      raise "test returned false"
     end
   end
   if args.debug? # --debug is interactive

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -55,7 +55,7 @@ begin
     # Also update formula.rb 'TODO: replace `returns(BasicObject)` with `void`'
     if formula.run_test(keep_tmp: args.keep_tmp?) == false
       require "utils/output"
-      Utils::Output.odeprecated "`return false` in test", "`raise \"<reason for failure>\"`"
+      Utils::Output.odisabled "`return false` in test", "`raise \"<reason for failure>\"`"
       raise "test returned false"
     end
   end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
Upgrade `odeprecated` to `odisabled` for `return false` in formula test blocks. `return false` was deprecated in #21296 (merged 2025-12-21). The deprecation has been live for ~4.5 months.