### PR TITLE
info: add Binaries section listing executables

### DIFF
--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -192,6 +192,14 @@ class Bottle
     resource.installed_size
   end
 
+  sig { returns(T.nilable(T::Array[String])) }
+  def path_exec_files
+    resource = github_packages_manifest_resource
+    return unless resource&.downloaded?
+
+    resource.path_exec_files
+  end
+
   sig { returns(Filename) }
   def filename
     Filename.create(T.cast(resource.owner, Formula), @tag, @spec.rebuild)

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -53,6 +53,7 @@ module Homebrew
         switch "--github",
                description: "Open the GitHub source page for <formula> and <cask> in a browser. " \
                             "To view the history locally: `brew log -p` <formula> or <cask>"
+        # odeprecated replace this with --verbose on next release
         switch "--fetch-manifest",
                description: "Fetch GitHub Packages manifest for extra information when <formula> is not installed."
         flag   "--json",

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -596,6 +596,20 @@ module Homebrew
           Options.dump_for_formula formula
         end
 
+        binaries_keg = kegs.find(&:linked?) || kegs.last
+        binaries = if binaries_keg
+          binary_files = [binaries_keg/"bin", binaries_keg/"sbin"].select(&:directory?).flat_map do |dir|
+            dir.children.select { |child| child.file? && child.executable? }
+          end
+          binary_files.map { |path| path.basename.to_s }
+        elsif (path_exec_files = formula.bottle&.path_exec_files)
+          path_exec_files.map { |path| File.basename(path) }
+        end
+        if binaries.present?
+          binaries = binaries.sort.uniq
+          ohai "Binaries", Formatter.columns(binaries)
+        end
+
         caveats = Caveats.new(formula)
         if (caveats_string = caveats.to_s.presence)
           ohai "Caveats", caveats_string

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -70,7 +70,7 @@ module Homebrew
                depends_on:  "--json",
                description: "Include the variations hash in each formula's JSON output."
         switch "-v", "--verbose",
-               description: "Show more verbose analytics data for <formula>."
+               description: "Show more verbose data for <formula>."
         switch "--formula", "--formulae",
                description: "Treat all named arguments as formulae."
         switch "--cask", "--casks",
@@ -596,18 +596,20 @@ module Homebrew
           Options.dump_for_formula formula
         end
 
-        binaries_keg = kegs.find(&:linked?) || kegs.last
-        binaries = if binaries_keg
-          binary_files = [binaries_keg/"bin", binaries_keg/"sbin"].select(&:directory?).flat_map do |dir|
-            dir.children.select { |child| child.file? && child.executable? }
+        if args.verbose?
+          binaries_keg = kegs.find(&:linked?) || kegs.last
+          binaries = if binaries_keg
+            binary_files = [binaries_keg/"bin", binaries_keg/"sbin"].select(&:directory?).flat_map do |dir|
+              dir.children.select { |child| child.file? && child.executable? }
+            end
+            binary_files.map { |path| path.basename.to_s }
+          elsif (path_exec_files = formula.bottle&.path_exec_files)
+            path_exec_files.map { |path| File.basename(path) }
           end
-          binary_files.map { |path| path.basename.to_s }
-        elsif (path_exec_files = formula.bottle&.path_exec_files)
-          path_exec_files.map { |path| File.basename(path) }
-        end
-        if binaries.present?
-          binaries = binaries.sort.uniq
-          ohai "Binaries", Formatter.columns(binaries)
+          if binaries.present?
+            binaries = binaries.sort.uniq
+            ohai "Binaries", Formatter.columns(binaries)
+          end
         end
 
         caveats = Caveats.new(formula)

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -524,7 +524,7 @@ module Homebrew
           puts "Not installed"
           if (bottle = formula.bottle)
             begin
-              bottle.fetch_tab(quiet: !args.debug?) if args.fetch_manifest?
+              bottle.fetch_tab(quiet: !args.debug?) if args.fetch_manifest? || args.verbose?
               bottle_size = bottle.bottle_size
               installed_size = bottle.installed_size
               puts "Bottle Size: #{Formatter.disk_usage_readable(bottle_size)}" if bottle_size

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -411,6 +411,11 @@ class Resource
       manifest_annotations["sh.brew.bottle.installed_size"]&.to_i
     end
 
+    sig { returns(T.nilable(T::Array[String])) }
+    def path_exec_files
+      manifest_annotations["sh.brew.path_exec_files"]&.split(",")
+    end
+
     sig { override.returns(String) }
     def download_queue_type = "Bottle Manifest"
 

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -239,8 +239,8 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
-  it "prints a Binaries section listing executables in bin and sbin" do
-    info = described_class.new([])
+  it "prints a Binaries section listing executables in bin and sbin with --verbose" do
+    info = described_class.new(["--verbose"])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       homepage "https://brew.sh/testball"
@@ -267,8 +267,8 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
-  it "prints a Binaries section from the bottle manifest when the formula is not installed" do
-    info = described_class.new([])
+  it "prints a Binaries section from the bottle manifest when the formula is not installed with --verbose" do
+    info = described_class.new(["--verbose"])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       homepage "https://brew.sh/testball"
@@ -290,8 +290,33 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
-  it "omits the Binaries section when no executables are installed" do
+  it "omits the Binaries section without --verbose" do
     info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      homepage "https://brew.sh/testball"
+      desc "Some test"
+    end
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    (keg_path/"bin").mkpath
+    binary = keg_path/"bin/testball"
+    binary.write("#!/bin/sh\n")
+    binary.chmod(0755)
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.write
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to not_to_output(/==> Binaries/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "omits the Binaries section when no executables are installed" do
+    info = described_class.new(["--verbose"])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       homepage "https://brew.sh/testball"

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -239,6 +239,79 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
+  it "prints a Binaries section listing executables in bin and sbin" do
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      homepage "https://brew.sh/testball"
+      desc "Some test"
+    end
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    (keg_path/"bin").mkpath
+    (keg_path/"sbin").mkpath
+    ["bin/testball", "bin/another", "sbin/daemon"].each do |rel|
+      file = keg_path/rel
+      file.write("#!/bin/sh\n")
+      file.chmod(0755)
+    end
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.write
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(a_string_including("==> Binaries\nanother\ndaemon\ntestball\n")).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "prints a Binaries section from the bottle manifest when the formula is not installed" do
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      homepage "https://brew.sh/testball"
+      desc "Some test"
+    end
+
+    bottle = instance_double(
+      Bottle,
+      path_exec_files: ["bin/testball", "bin/another", "sbin/daemon"],
+      bottle_size:     nil,
+      installed_size:  nil,
+    )
+    allow(bottle).to receive(:fetch_tab)
+    allow(formula).to receive_messages(bottle:, core_formula?: false)
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+
+    expect { info.send(:info_formula, formula) }
+      .to output(a_string_including("==> Binaries\nanother\ndaemon\ntestball\n")).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "omits the Binaries section when no executables are installed" do
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      homepage "https://brew.sh/testball"
+      desc "Some test"
+    end
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    (keg_path/"lib").mkpath
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.write
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to not_to_output(/==> Binaries/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
   describe "::installation_status" do
     it "prints on-request installs explicitly" do
       expect(described_class.installation_status(instance_double(Tab, installed_on_request: true)))


### PR DESCRIPTION
List the formula's bin/ and sbin/ executables in a new `==> Binaries` section before `==> Caveats`.

For installed formulae the list is read from the linked keg; for not-installed formulae `--fetch-manifest` triggers a fallback that reads from the bottle manifest, mirroring how `Bottle Size` and `Installed Size` already behave:

```
❯ brew info coreutils --fetch-manifest
==> coreutils ↑: 9.6 → stable 9.11 (bottled), HEAD
GNU File, Shell, and Text utilities
https://www.gnu.org/software/coreutils/
Conflicts with:
  b2sum (because both install `b2sum` binaries)
  gfold (because both install `gfold` binaries)
  idutils (because both install `gid` and `gid.1`)
Installed (on request)
/opt/homebrew/Cellar/coreutils/9.6 (465 files, 12.3MB) *
  Poured from bottle using the formulae.brew.sh API on 2025-02-12 at 09:59:01
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/c/coreutils.rb
License: GPL-3.0-or-later
==> Dependencies
Required (1): gmp ✔
Recursive Runtime (1): all installed ✔
==> Options
--HEAD
	Install HEAD version
==> Binaries
b2sum       gchcon      gdf         gfold       gmd5sum     gpaste      gruncon     gstat       gtrue       gwho        tac
base32      gchgrp      gdir        ggroups     gmkdir      gpathchk    gseq        gstdbuf     gtruncate   gwhoami     timeout
basenc      gchmod      gdircolors  ghead       gmkfifo     gpinky      gsha1sum    gstty       gtsort      gyes
chcon       gchown      gdirname    ghostid     gmknod      gpr         gsha224sum  gsum        gtty        hostid
factor      gchroot     gdu         gid         gmktemp     gprintenv   gsha256sum  gsync       guname      nproc
g[          gcksum      gecho       ginstall    gmv         gprintf     gsha384sum  gtac        gunexpand   numfmt
gb2sum      gcomm       genv        gjoin       gnice       gptx        gsha512sum  gtail       guniq       pinky
gbase32     gcp         gexpand     gkill       gnl         gpwd        gshred      gtee        gunlink     ptx
gbase64     gcsplit     gexpr       glink       gnohup      greadlink   gshuf       gtest       guptime     runcon
gbasename   gcut        gfactor     gln         gnproc      grealpath   gsleep      gtimeout    gusers      shred
gbasenc     gdate       gfalse      glogname    gnumfmt     grm         gsort       gtouch      gvdir       shuf
gcat        gdd         gfmt        gls         god         grmdir      gsplit      gtr         gwc         stdbuf
==> Caveats
Commands also provided by macOS and the commands dir, dircolors, vdir have been installed with the prefix "g".
If you need to use these commands with their normal names, you can add a "gnubin" directory to your PATH with:
  PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"
==> Analytics
install: 114,135 (30 days), 310,879 (90 days), 1,010,611 (365 days)
install-on-request: 107,029 (30 days), 290,224 (90 days), 902,767 (365 days)
build-error: 39 (30 days)
```