### PR TITLE
diagnostic: cap OCLP tier when macOS is outdated

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -168,7 +168,11 @@ module OS
             return
           end
 
-          oclp_support_tier = ::Hardware::CPU.features.include?(:pclmulqdq) ? 2 : 3
+          oclp_support_tier = if ::Hardware::CPU.features.include?(:pclmulqdq) && !OS::Mac.version.outdated_release?
+            2
+          else
+            3
+          end
 
           <<~EOS
             You have booted macOS using OpenCore Legacy Patcher.

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -17,6 +17,42 @@ RSpec.describe Homebrew::Diagnostic::Checks do
       .to match("We do not provide support for this pre-release version.")
   end
 
+  describe "#check_for_opencore" do
+    let(:macos_version) { MacOSVersion.new("13") }
+
+    before do
+      allow(OS::Mac).to receive_messages(version: macos_version, full_version: macos_version)
+      allow(Hardware::CPU).to receive(:physical_cpu_arm64?).and_return(false)
+      allow(Utils).to receive(:safe_popen_read)
+        .with("/usr/sbin/nvram", "4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:opencore-version")
+        .and_return("opencore-version\t1.0.0")
+      allow(Utils).to receive(:safe_popen_read)
+        .with("/usr/sbin/nvram", "4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:OCLP-Version")
+        .and_return("OCLP-Version\t2.0.0")
+    end
+
+    it "reports Tier 2 on a modern CPU running a supported macOS" do
+      allow(Hardware::CPU).to receive(:features).and_return([:pclmulqdq])
+      allow(macos_version).to receive(:outdated_release?).and_return(false)
+
+      expect(checks.check_for_opencore).to include("This is a Tier 2 configuration")
+    end
+
+    it "reports Tier 3 on an old CPU" do
+      allow(Hardware::CPU).to receive(:features).and_return([])
+      allow(macos_version).to receive(:outdated_release?).and_return(false)
+
+      expect(checks.check_for_opencore).to include("This is a Tier 3 configuration")
+    end
+
+    it "reports Tier 3 on a modern CPU running an outdated macOS" do
+      allow(Hardware::CPU).to receive(:features).and_return([:pclmulqdq])
+      allow(macos_version).to receive(:outdated_release?).and_return(true)
+
+      expect(checks.check_for_opencore).to include("This is a Tier 3 configuration")
+    end
+  end
+
   specify "#check_if_xcode_needs_clt_installed" do
     macos_version = MacOSVersion.new("11")
     allow(OS::Mac).to receive_messages(version: macos_version, full_version: macos_version)


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Claude Code with local review and verification.

-----
Fixes https://github.com/orgs/Homebrew/discussions/6835.