### PR TITLE
bundle/checker: enable `typed: strict`

### DIFF
--- a/Library/Homebrew/bundle/checker.rb
+++ b/Library/Homebrew/bundle/checker.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "bundle/dsl"
@@ -20,11 +20,21 @@ module Homebrew
         :formulae_to_start,
       ].freeze, T::Array[CheckStep])
 
+      sig {
+        params(
+          global:              T::Boolean,
+          file:                T.nilable(String),
+          exit_on_first_error: T::Boolean,
+          no_upgrade:          T::Boolean,
+          verbose:             T::Boolean,
+        ).returns(CheckResult)
+      }
       def self.check(global: false, file: nil, exit_on_first_error: false, no_upgrade: false, verbose: false)
         require "bundle/brewfile"
+        @dsl = T.let(@dsl, T.nilable(Homebrew::Bundle::Dsl))
         @dsl ||= Brewfile.read(global:, file:)
 
-        errors = []
+        errors = T.let([], T::Array[Object])
         enumerator = exit_on_first_error ? :find : :map
 
         work_to_be_done = CORE_CHECKS.public_send(enumerator) do |check_step|
@@ -39,29 +49,73 @@ module Homebrew
         CheckResult.new work_to_be_done, errors
       end
 
+      sig {
+        params(
+          exit_on_first_error: T::Boolean,
+          no_upgrade:          T::Boolean,
+          verbose:             T::Boolean,
+        ).returns(T::Array[Object])
+      }
       def self.apps_to_install(exit_on_first_error: false, no_upgrade: false, verbose: false)
         extension_errors(:apps_to_install, exit_on_first_error:, no_upgrade:, verbose:)
       end
 
+      sig {
+        params(
+          exit_on_first_error: T::Boolean,
+          no_upgrade:          T::Boolean,
+          verbose:             T::Boolean,
+        ).returns(T::Array[Object])
+      }
       def self.formulae_to_start(exit_on_first_error: false, no_upgrade: false, verbose: false)
+        raise ArgumentError, "dsl is unset!" unless @dsl
+
         Homebrew::Bundle::Brew::Services.new.find_actionable(
           @dsl.entries,
           exit_on_first_error:, no_upgrade:, verbose:,
         )
       end
 
+      sig {
+        params(
+          exit_on_first_error: T::Boolean,
+          no_upgrade:          T::Boolean,
+          verbose:             T::Boolean,
+        ).returns(T::Array[Object])
+      }
       def self.taps_to_tap(exit_on_first_error: false, no_upgrade: false, verbose: false)
         package_type_errors(:tap, exit_on_first_error:, no_upgrade:, verbose:)
       end
 
+      sig {
+        params(
+          exit_on_first_error: T::Boolean,
+          no_upgrade:          T::Boolean,
+          verbose:             T::Boolean,
+        ).returns(T::Array[Object])
+      }
       def self.casks_to_install(exit_on_first_error: false, no_upgrade: false, verbose: false)
         package_type_errors(:cask, exit_on_first_error:, no_upgrade:, verbose:)
       end
 
+      sig {
+        params(
+          exit_on_first_error: T::Boolean,
+          no_upgrade:          T::Boolean,
+          verbose:             T::Boolean,
+        ).returns(T::Array[Object])
+      }
       def self.formulae_to_install(exit_on_first_error: false, no_upgrade: false, verbose: false)
         package_type_errors(:brew, exit_on_first_error:, no_upgrade:, verbose:)
       end
 
+      sig {
+        params(
+          exit_on_first_error: T::Boolean,
+          no_upgrade:          T::Boolean,
+          verbose:             T::Boolean,
+        ).returns(T::Array[Object])
+      }
       def self.registered_extensions_to_install(exit_on_first_error: false, no_upgrade: false, verbose: false)
         extension_errors(:registered_extensions_to_install, exit_on_first_error:, no_upgrade:, verbose:)
       end
@@ -75,6 +129,8 @@ module Homebrew
         ).returns(T::Array[Object])
       }
       def self.extension_errors(step, exit_on_first_error:, no_upgrade:, verbose:)
+        raise ArgumentError, "dsl is unset!" unless @dsl
+
         matching_extensions = Homebrew::Bundle.extensions.select { |extension| extension.legacy_check_step == step }
         errors = T.let([], T::Array[Object])
 
@@ -93,8 +149,9 @@ module Homebrew
         errors
       end
 
+      sig { void }
       def self.reset!
-        @dsl = nil
+        @dsl = T.let(nil, T.nilable(Homebrew::Bundle::Dsl))
         Homebrew::Bundle.package_types.each(&:reset!)
         Homebrew::Bundle.extensions.each(&:reset!)
       end
@@ -108,6 +165,8 @@ module Homebrew
         ).returns(T::Array[Object])
       }
       def self.package_type_errors(type, exit_on_first_error:, no_upgrade:, verbose:)
+        raise ArgumentError, "dsl is unset!" unless @dsl
+
         package_type = Homebrew::Bundle.package_type(type)
         return [] if package_type.nil?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes?
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Bumps `Library/Homebrew/bundle/checker.rb` from `# typed: true` to `# typed: strict`. This finishes the directory-wide migration started in #21935, which left `checker.rb` and `commands/exec.rb` as the only two `typed: true` files remaining under `Library/Homebrew/bundle/`.

To satisfy strict mode the change also:

- adds `sig` blocks to the eight previously unsigned `def self.*` methods (`check`, `apps_to_install`, `formulae_to_start`, `taps_to_tap`, `casks_to_install`, `formulae_to_install`, `registered_extensions_to_install`, `reset!`);
- declares the module-level `@dsl` instance variable as `T.nilable(Homebrew::Bundle::Dsl)` in `reset!`; and
- adds `raise ArgumentError, "dsl is unset!" unless @dsl` before the three `@dsl.entries` accesses, mirroring the pattern already used in `Library/Homebrew/bundle/commands/cleanup.rb`.

No new tests: there is no behaviour change on the happy path. The new guard converts one specific misuse (calling a private check method without first invoking `.check`) from an opaque `NoMethodError` on `nil` into an explicit `ArgumentError`, matching the message used by `cleanup.rb`. The existing `test/bundle/commands/check_spec.rb` covers the public surface and continues to pass.

Verified locally:
- `./bin/brew typecheck` : No errors
- `./bin/brew style --fix --changed` : no offenses
- `./bin/brew tests --only=bundle/commands/check` : 20 examples, 0 failures

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
