### PR TITLE
utils/formatter: avoid loading URI library for `Formatter.url`

### DIFF
--- a/Library/Homebrew/utils/formatter.rb
+++ b/Library/Homebrew/utils/formatter.rb
@@ -99,7 +99,7 @@ module Formatter
           .gsub(/(.{1,#{width}})( +|$)(?!-)\n?/, "\\1\n")
   end
 
-  sig { params(string: T.nilable(T.any(String, URI::Generic))).returns(String) }
+  T::Sig::WithoutRuntime.sig { params(string: T.nilable(T.any(String, URI::Generic))).returns(String) }
   def self.url(string)
     "#{Tty.underline}#{string}#{Tty.no_underline}"
   end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Claude Code traced the stack and drafted the fix. I reproduced the crash on unmodified `main`, confirmed the patch resolves it with a clean `brew lgtm`.

-----

`Formatter.url`'s sig references `URI::Generic` but `utils/formatter.rb` never requires `"uri"`. This worked transitively until 2677aedea8 dropped `require "uri"` from `system_command.rb`.

Failing CI: https://github.com/Homebrew/homebrew-core/actions/runs/25470842332/job/74734261080

Switch to `T::Sig::WithoutRuntime.sig` so the sig isn't evaluated at runtime, which is the same pattern in `cask_loader`.