### PR TITLE
Stop relying on transitive `uri` loads

### DIFF
--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "uri"
 require "source_location"
 
 module Cask

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "digest/sha2"
+require "uri"
 require "cachable"
 require "tab"
 require "utils"

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -195,7 +195,7 @@ class GitHubPackages
     end
   end
 
-  sig { params(uri: URI::Generic).returns(T.nilable(T::Hash[String, T.untyped])) }
+  T::Sig::WithoutRuntime.sig { params(uri: URI::Generic).returns(T.nilable(T::Hash[String, T.untyped])) }
   def schema_resolver(uri)
     @schema_json&.fetch(uri.to_s.gsub(/#.*/, ""))
   end

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -268,7 +268,7 @@ module GitHub
       end, T.nilable(String))
     end
 
-    sig {
+    T::Sig::WithoutRuntime.sig {
       params(
         url:              T.any(String, URI::Generic),
         data:             T::Hash[Symbol, T.untyped],
@@ -353,7 +353,7 @@ module GitHub
       end
     end
 
-    sig {
+    T::Sig::WithoutRuntime.sig {
       params(
         url:                     T.any(String, URI::Generic),
         additional_query_params: String,


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Claude Code grepped for the same `URI::Generic`-without-`require "uri"` shape across the tree, classified each site (sig-only vs runtime use), and applied the matching fix. I reviewed the diff and ensured a clean `brew lgtm`.

-----

Companion to https://github.com/Homebrew/brew/pull/22160. Fixes the remaining instances of this issue.