### PR TITLE
formatter: require uri

### DIFF
--- a/Library/Homebrew/utils/formatter.rb
+++ b/Library/Homebrew/utils/formatter.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "uri"
 require "utils/tty"
 
 # Helper module for formatting output.


### PR DESCRIPTION
`brew help analytics` crashes like this:

```
❯ brew help analytics
Error: uninitialized constant Formatter::URI
Warning: Removed Sorbet lines from backtrace!
/opt/homebrew/Library/Homebrew/utils/formatter.rb:102:in 'block in <module:Formatter>'
/opt/homebrew/Library/Homebrew/cli/parser.rb:452:in 'block in Homebrew::CLI::Parser#generate_help_text'
/opt/homebrew/Library/Homebrew/cli/parser.rb:452:in 'String#gsub'
/opt/homebrew/Library/Homebrew/cli/parser.rb:452:in 'Homebrew::CLI::Parser#generate_help_text'
/opt/homebrew/Library/Homebrew/help.rb:92:in 'Homebrew::Help.parser_help'
/opt/homebrew/Library/Homebrew/help.rb:65:in 'Homebrew::Help.command_help'
/opt/homebrew/Library/Homebrew/help.rb:49:in 'Homebrew::Help.help'
/opt/homebrew/Library/Homebrew/brew.rb:92:in '<main>'
Please report this issue:
/opt/homebrew/Library/Homebrew/utils/formatter.rb:102:in 'block in <module:Formatter>': uninitialized constant Formatter::URI (NameError)
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.13164/lib/types/private/methods/_methods.rb:340:in 'BasicObject#instance_exec'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.13164/lib/types/private/methods/_methods.rb:340:in 'T::Private::Methods.run_builder'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.13164/lib/types/private/methods/_methods.rb:318:in 'T::Private::Methods.run_sig'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.13164/lib/types/private/methods/_methods.rb:230:in 'block in T::Private::Methods._on_method_added'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.13164/lib/types/private/methods/_methods.rb:455:in 'T::Private::Methods.run_sig_block_for_key'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.13164/lib/types/private/methods/_methods.rb:422:in 'T::Private::Methods.maybe_run_sig_block_for_key'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.13164/lib/types/private/methods/_methods.rb:240:in 'block in Formatter._on_method_added'
	from /opt/homebrew/Library/Homebrew/brew.rb:216:in '<main>'
```