### PR TITLE
info: list installed dependents with --verbose

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -185,28 +185,29 @@ module Homebrew
           "#{missing_count} missing #{Formatter.error("✘")}"
       end
 
-      sig { params(full_name: String, name: String).returns(Integer) }
-      def self.count_installed_dependents(full_name, name)
-        Formula.racks.count do |rack|
+      sig { params(full_name: String, name: String).returns(T::Array[String]) }
+      def self.installed_dependent_names(full_name, name)
+        Formula.racks.filter_map do |rack|
           keg = Keg.from_rack(rack)
-          next false unless keg
+          next unless keg
 
           tab_path = keg/AbstractTab::FILENAME
-          next false unless tab_path.file?
+          next unless tab_path.file?
 
           # Fast path: skip JSON parsing when the formula name
           # does not appear anywhere in the raw receipt.
           content = File.read(tab_path)
-          next false unless content.include?(name)
+          next unless content.include?(name)
 
           tab_deps = Tab.from_file_content(content, tab_path).runtime_dependencies
-          next false unless tab_deps
+          next unless tab_deps
 
-          tab_deps.any? do |dep|
+          dependent = tab_deps.any? do |dep|
             dep_full_name = T.cast(dep, T::Hash[String, T.untyped])["full_name"]
             dep_full_name == full_name || dep_full_name&.split("/")&.last == name
           end
-        end
+          keg.name if dependent
+        end.sort.uniq
       end
 
       sig { params(formula: T.untyped).returns(T::Array[String]) }
@@ -551,9 +552,9 @@ module Homebrew
 
         tab_runtime_deps = kegs.last&.runtime_dependencies
         installed_dependents = if $stdout.tty? && kegs.any?
-          self.class.count_installed_dependents(formula.full_name, formula.name)
+          self.class.installed_dependent_names(formula.full_name, formula.name)
         else
-          0
+          [].freeze
         end
         dependency_lines = %w[build required recommended optional].filter_map do |type|
           next if type == "build" &&
@@ -565,7 +566,7 @@ module Homebrew
           deps = formula.deps.send(type).uniq
           "#{type.capitalize} (#{deps.count}): #{decorate_dependencies deps}" unless deps.empty?
         end
-        if dependency_lines.present? || tab_runtime_deps.present? || installed_dependents.positive?
+        if dependency_lines.present? || tab_runtime_deps.present? || installed_dependents.any?
           ohai "Dependencies"
           puts dependency_lines
           if tab_runtime_deps.present?
@@ -579,7 +580,13 @@ module Homebrew
             puts "Recursive Runtime (#{tab_runtime_deps.count}): " \
                  "#{self.class.dependency_status_counts(installed_count, tab_runtime_deps.count)}"
           end
-          puts "Dependents: #{installed_dependents}" if installed_dependents.positive?
+          if installed_dependents.any?
+            if args.verbose?
+              ohai "Dependents (#{installed_dependents.count})", Formatter.columns(installed_dependents)
+            else
+              puts "Dependents: #{installed_dependents.count}"
+            end
+          end
         end
 
         unless formula.requirements.to_a.empty?

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -582,7 +582,7 @@ module Homebrew
           end
           if installed_dependents.any?
             if args.verbose?
-              ohai "Dependents (#{installed_dependents.count})", Formatter.columns(installed_dependents)
+              puts "Dependents (#{installed_dependents.count}): #{installed_dependents.join(", ")}"
             else
               puts "Dependents: #{installed_dependents.count}"
             end

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -110,6 +110,42 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
+  it "lists installed dependents in a tabular section with --verbose" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new(["--verbose"])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      homepage "https://brew.sh/testball"
+      desc "Some test"
+    end
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    keg_path.mkpath
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.write
+
+    %w[some-dependent another-dependent].each do |dependent_name|
+      dependent_keg_path = HOMEBREW_CELLAR/"#{dependent_name}/1.0"
+      dependent_keg_path.mkpath
+      dependent_tab = Tab.empty
+      dependent_tab.tabfile = dependent_keg_path/AbstractTab::FILENAME
+      dependent_tab.runtime_dependencies = [
+        { "full_name" => "testball", "version" => "0.1" },
+      ]
+      dependent_tab.write
+    end
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/==> Dependents \(2\)\n.*another-dependent.*some-dependent/).to_stdout
+      .and not_to_output(/^Dependents: /).to_stdout
+      .and not_to_output.to_stderr
+  end
+
   it "summarises recursive runtime dependencies as all installed when none are missing" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
-  it "lists installed dependents in a tabular section with --verbose" do
+  it "lists installed dependents inline under Dependencies with --verbose" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
     info = described_class.new(["--verbose"])
@@ -141,7 +141,7 @@ RSpec.describe Homebrew::Cmd::Info do
     allow(formula).to receive(:core_formula?).and_return(false)
 
     expect { info.send(:info_formula, formula) }
-      .to output(/==> Dependents \(2\)\n.*another-dependent.*some-dependent/).to_stdout
+      .to output(/^Dependents \(2\): another-dependent, some-dependent$/).to_stdout
       .and not_to_output(/^Dependents: /).to_stdout
       .and not_to_output.to_stderr
   end


### PR DESCRIPTION
Show which are the dependents:

```
❯ brew info -v x265
==> x265 ↑: 4.1 → stable 4.2 (bottled), HEAD
H.265/HEVC encoder
https://bitbucket.org/multicoreware/x265_git
Installed (as dependency)
/opt/homebrew/Cellar/x265/4.1 (12 files, 11.8MB) *
  Poured from bottle using the formulae.brew.sh API on 2024-12-29 at 18:21:32
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/x/x265.rb
License: GPL-2.0-or-later
==> Dependencies
Dependents (3): ffmpeg, imagemagick, libheif
==> Options
--HEAD
	Install HEAD version
==> Binaries
x265
```