### PR TITLE
info: show installed deps correctly

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -627,11 +627,10 @@ module Homebrew
                      (stable.present? ? stable.bottled? && formula.pour_bottle? : formula.head.blank?))))
 
           deps = formula.deps.send(type).uniq
-          decorate_tab_deps = tab_runtime_deps if kegs.any? && type != "build"
-          unless deps.empty?
-            "#{type.capitalize} (#{deps.count}): " \
-              "#{decorate_dependencies(deps, tab_runtime_deps: decorate_tab_deps)}"
-          end
+          next if deps.empty?
+
+          decorate_tab_deps = (kegs.any? && type != "build") ? tab_runtime_deps : nil
+          "#{type.capitalize} (#{deps.count}): #{decorate_dependencies(deps, tab_runtime_deps: decorate_tab_deps)}"
         end
         if dependency_lines.present? || tab_runtime_deps.present? || installed_dependents.any?
           ohai "Dependencies"
@@ -702,28 +701,21 @@ module Homebrew
                tab_runtime_deps: T.nilable(T::Array[T::Hash[String, T.untyped]])).returns(String)
       }
       def decorate_dependencies(dependencies, tab_runtime_deps: nil)
-        deps_status = dependencies.map do |dep|
-          if tab_runtime_deps ? dep_in_tab_and_installed?(dep, tab_runtime_deps) : dep.satisfied?
-            pretty_installed(dep_display_s(dep))
-          else
-            pretty_uninstalled(dep_display_s(dep))
+        dependencies.map do |dep|
+          display = dep_display_s(dep)
+          next dep.satisfied? ? pretty_installed(display) : pretty_uninstalled(display) unless tab_runtime_deps
+
+          tab_entry = tab_runtime_deps.find do |d|
+            name = d["full_name"]
+            name == dep.name || name&.split("/")&.last == dep.name
           end
-        end
-        deps_status.join(", ")
-      end
+          next pretty_uninstalled(display) unless tab_entry
 
-      sig {
-        params(dep: Dependency, tab_runtime_deps: T::Array[T::Hash[String, T.untyped]]).returns(T::Boolean)
-      }
-      def dep_in_tab_and_installed?(dep, tab_runtime_deps)
-        full_name = tab_runtime_deps.find do |d|
-          name = d["full_name"]
-          name == dep.name || name&.split("/")&.last == dep.name
-        end&.[]("full_name")
-        return false unless full_name
+          rack = HOMEBREW_CELLAR/tab_entry["full_name"].split("/").last
+          next pretty_uninstalled(display) if !rack.directory? || rack.subdirs.empty?
 
-        rack = HOMEBREW_CELLAR/full_name.split("/").last
-        rack.directory? && !rack.subdirs.empty?
+          dep.to_formula.outdated? ? pretty_upgradable(display) : pretty_installed(display)
+        end.join(", ")
       end
 
       sig { params(requirements: T::Array[Requirement]).returns(String) }

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -629,8 +629,8 @@ module Homebrew
           deps = formula.deps.send(type).uniq
           next if deps.empty?
 
-          decorate_tab_deps = (kegs.any? && type != "build") ? tab_runtime_deps : nil
-          "#{type.capitalize} (#{deps.count}): #{decorate_dependencies(deps, tab_runtime_deps: decorate_tab_deps)}"
+          tab_deps = (kegs.any? && type != "build") ? tab_runtime_deps : nil
+          "#{type.capitalize} (#{deps.count}): #{decorate_dependencies(deps, tab_runtime_deps: tab_deps)}"
         end
         if dependency_lines.present? || tab_runtime_deps.present? || installed_dependents.any?
           ohai "Dependencies"
@@ -703,16 +703,16 @@ module Homebrew
       def decorate_dependencies(dependencies, tab_runtime_deps: nil)
         dependencies.map do |dep|
           display = dep_display_s(dep)
-          next dep.satisfied? ? pretty_installed(display) : pretty_uninstalled(display) unless tab_runtime_deps
-
-          tab_entry = tab_runtime_deps.find do |d|
-            name = d["full_name"]
-            name == dep.name || name&.split("/")&.last == dep.name
+          full_name = if tab_runtime_deps
+            tab_runtime_deps.find do |d|
+              name = d["full_name"]
+              name == dep.name || name&.split("/")&.last == dep.name
+            end&.fetch("full_name")
+          else
+            dep.name
           end
-          next pretty_uninstalled(display) unless tab_entry
-
-          rack = HOMEBREW_CELLAR/tab_entry["full_name"].split("/").last
-          next pretty_uninstalled(display) if !rack.directory? || rack.subdirs.empty?
+          rack = HOMEBREW_CELLAR/full_name.split("/").last if full_name
+          next pretty_uninstalled(display) if rack.nil? || !rack.directory? || rack.subdirs.empty?
 
           dep.to_formula.outdated? ? pretty_upgradable(display) : pretty_installed(display)
         end.join(", ")

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -8,7 +8,6 @@ require "options"
 require "formula"
 require "formula_pin"
 require "keg"
-require "linkage_checker"
 require "tab"
 require "json"
 require "cask/cask_loader"
@@ -620,7 +619,6 @@ module Homebrew
         else
           [].freeze
         end
-        linkage = linkage_checker_for(kegs.last, formula) if kegs.any?
         dependency_lines = %w[build required recommended optional].filter_map do |type|
           next if type == "build" &&
                   (kegs.all? { |keg| keg.tab.poured_from_bottle } ||
@@ -629,7 +627,11 @@ module Homebrew
                      (stable.present? ? stable.bottled? && formula.pour_bottle? : formula.head.blank?))))
 
           deps = formula.deps.send(type).uniq
-          "#{type.capitalize} (#{deps.count}): #{decorate_dependencies(deps, linkage:)}" unless deps.empty?
+          decorate_tab_deps = tab_runtime_deps if kegs.any? && type != "build"
+          unless deps.empty?
+            "#{type.capitalize} (#{deps.count}): " \
+              "#{decorate_dependencies(deps, tab_runtime_deps: decorate_tab_deps)}"
+          end
         end
         if dependency_lines.present? || tab_runtime_deps.present? || installed_dependents.any?
           ohai "Dependencies"
@@ -695,24 +697,13 @@ module Homebrew
         Utils::Analytics.formula_output(formula, args:)
       end
 
-      sig { params(keg: T.nilable(Keg), formula: Formula).returns(T.nilable(LinkageChecker)) }
-      def linkage_checker_for(keg, formula)
-        return unless keg
-
-        CacheStoreDatabase.use(:linkage) do |db|
-          typed_db = T.cast(db, CacheStoreDatabase[String, T::Hash[T.any(String, Symbol), T.anything]])
-          LinkageChecker.new(keg, formula, cache_db: typed_db)
-        end
-      rescue
-        nil
-      end
-
       sig {
-        params(dependencies: T::Array[Dependency], linkage: T.nilable(LinkageChecker)).returns(String)
+        params(dependencies:     T::Array[Dependency],
+               tab_runtime_deps: T.nilable(T::Array[T::Hash[String, T.untyped]])).returns(String)
       }
-      def decorate_dependencies(dependencies, linkage: nil)
+      def decorate_dependencies(dependencies, tab_runtime_deps: nil)
         deps_status = dependencies.map do |dep|
-          if linkage ? dep_linkage_satisfied?(dep, linkage) : dep.satisfied?
+          if tab_runtime_deps ? dep_in_tab_and_installed?(dep, tab_runtime_deps) : dep.satisfied?
             pretty_installed(dep_display_s(dep))
           else
             pretty_uninstalled(dep_display_s(dep))
@@ -721,21 +712,18 @@ module Homebrew
         deps_status.join(", ")
       end
 
-      sig { params(dep: Dependency, linkage: LinkageChecker).returns(T::Boolean) }
-      def dep_linkage_satisfied?(dep, linkage)
-        dep_formula =
-          begin
-            dep.to_formula
-          rescue FormulaUnavailableError
-            nil
-          end
-        return false unless dep_formula
+      sig {
+        params(dep: Dependency, tab_runtime_deps: T::Array[T::Hash[String, T.untyped]]).returns(T::Boolean)
+      }
+      def dep_in_tab_and_installed?(dep, tab_runtime_deps)
+        full_name = tab_runtime_deps.find do |d|
+          name = d["full_name"]
+          name == dep.name || name&.split("/")&.last == dep.name
+        end&.[]("full_name")
+        return false unless full_name
 
-        names = [dep_formula.full_name, dep_formula.name, dep.name].compact.uniq
-        return false if names.any? { |n| linkage.broken_deps.key?(n) }
-        return true if names.any? { |n| linkage.brewed_dylibs.key?(n) }
-
-        dep_formula.any_installed_keg ? true : false
+        rack = HOMEBREW_CELLAR/full_name.split("/").last
+        rack.directory? && !rack.subdirs.empty?
       end
 
       sig { params(requirements: T::Array[Requirement]).returns(String) }

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -8,6 +8,7 @@ require "options"
 require "formula"
 require "formula_pin"
 require "keg"
+require "linkage_checker"
 require "tab"
 require "json"
 require "cask/cask_loader"
@@ -619,6 +620,7 @@ module Homebrew
         else
           [].freeze
         end
+        linkage = linkage_checker_for(kegs.last, formula) if kegs.any?
         dependency_lines = %w[build required recommended optional].filter_map do |type|
           next if type == "build" &&
                   (kegs.all? { |keg| keg.tab.poured_from_bottle } ||
@@ -627,7 +629,7 @@ module Homebrew
                      (stable.present? ? stable.bottled? && formula.pour_bottle? : formula.head.blank?))))
 
           deps = formula.deps.send(type).uniq
-          "#{type.capitalize} (#{deps.count}): #{decorate_dependencies deps}" unless deps.empty?
+          "#{type.capitalize} (#{deps.count}): #{decorate_dependencies(deps, linkage:)}" unless deps.empty?
         end
         if dependency_lines.present? || tab_runtime_deps.present? || installed_dependents.any?
           ohai "Dependencies"
@@ -693,16 +695,47 @@ module Homebrew
         Utils::Analytics.formula_output(formula, args:)
       end
 
-      sig { params(dependencies: T::Array[Dependency]).returns(String) }
-      def decorate_dependencies(dependencies)
+      sig { params(keg: T.nilable(Keg), formula: Formula).returns(T.nilable(LinkageChecker)) }
+      def linkage_checker_for(keg, formula)
+        return unless keg
+
+        CacheStoreDatabase.use(:linkage) do |db|
+          typed_db = T.cast(db, CacheStoreDatabase[String, T::Hash[T.any(String, Symbol), T.anything]])
+          LinkageChecker.new(keg, formula, cache_db: typed_db)
+        end
+      rescue
+        nil
+      end
+
+      sig {
+        params(dependencies: T::Array[Dependency], linkage: T.nilable(LinkageChecker)).returns(String)
+      }
+      def decorate_dependencies(dependencies, linkage: nil)
         deps_status = dependencies.map do |dep|
-          if dep.satisfied?
+          if linkage ? dep_linkage_satisfied?(dep, linkage) : dep.satisfied?
             pretty_installed(dep_display_s(dep))
           else
             pretty_uninstalled(dep_display_s(dep))
           end
         end
         deps_status.join(", ")
+      end
+
+      sig { params(dep: Dependency, linkage: LinkageChecker).returns(T::Boolean) }
+      def dep_linkage_satisfied?(dep, linkage)
+        dep_formula =
+          begin
+            dep.to_formula
+          rescue FormulaUnavailableError
+            nil
+          end
+        return false unless dep_formula
+
+        names = [dep_formula.full_name, dep_formula.name, dep.name].compact.uniq
+        return false if names.any? { |n| linkage.broken_deps.key?(n) }
+        return true if names.any? { |n| linkage.brewed_dylibs.key?(n) }
+
+        dep_formula.any_installed_keg ? true : false
       end
 
       sig { params(requirements: T::Array[Requirement]).returns(String) }

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -25,12 +25,6 @@ class LinkageChecker
   sig { returns(T::Set[String]) }
   attr_reader :system_dylibs
 
-  sig { returns(T::Hash[String, T::Set[String]]) }
-  attr_reader :brewed_dylibs
-
-  sig { returns(T::Hash[String, T::Array[String]]) }
-  attr_reader :broken_deps
-
   sig {
     params(
       keg: Keg, formula: T.nilable(Formula),

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -25,6 +25,12 @@ class LinkageChecker
   sig { returns(T::Set[String]) }
   attr_reader :system_dylibs
 
+  sig { returns(T::Hash[String, T::Set[String]]) }
+  attr_reader :brewed_dylibs
+
+  sig { returns(T::Hash[String, T::Array[String]]) }
+  attr_reader :broken_deps
+
   sig {
     params(
       keg: Keg, formula: T.nilable(Formula),

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -368,38 +368,6 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
-  it "marks a tab-listed dep with an installed rack as satisfied" do
-    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
-
-    info = described_class.new([])
-    formula = formula("testball") do
-      url "https://brew.sh/testball-0.1.tar.gz"
-      desc "Some test"
-
-      depends_on "bar"
-    end
-
-    keg_path = HOMEBREW_CELLAR/"testball/0.1"
-    keg_path.mkpath
-    tab = Tab.empty
-    tab.tabfile = keg_path/AbstractTab::FILENAME
-    tab.runtime_dependencies = [{ "full_name" => "bar", "version" => "1.0" }]
-    tab.write
-
-    bar_keg_path = HOMEBREW_CELLAR/"bar/1.0"
-    bar_keg_path.mkpath
-    bar_tab = Tab.empty
-    bar_tab.tabfile = bar_keg_path/AbstractTab::FILENAME
-    bar_tab.write
-
-    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
-    allow(formula).to receive(:core_formula?).and_return(false)
-
-    expect { info.send(:info_formula, formula) }
-      .to output(/Required \(1\): .*bar.*✔/).to_stdout
-      .and not_to_output.to_stderr
-  end
-
   it "marks a tab-listed dep with no installed rack as unsatisfied" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
@@ -415,7 +383,7 @@ RSpec.describe Homebrew::Cmd::Info do
     keg_path.mkpath
     tab = Tab.empty
     tab.tabfile = keg_path/AbstractTab::FILENAME
-    tab.runtime_dependencies = [{ "full_name" => "bar", "version" => "1.0" }]
+    tab.runtime_dependencies = [{ "full_name" => "bar", "version" => "1.0", "pkg_version" => "1.0" }]
     tab.write
 
     allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
@@ -423,6 +391,78 @@ RSpec.describe Homebrew::Cmd::Info do
 
     expect { info.send(:info_formula, formula) }
       .to output(/Required \(1\): .*bar.*✘/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "marks a tab-listed dep with an installed rack as satisfied when the dep formula is not outdated" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      desc "Some test"
+
+      depends_on "bar"
+    end
+    direct_dependency = formula.deps.required.first
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    keg_path.mkpath
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.runtime_dependencies = [{ "full_name" => "bar", "version" => "1.0", "pkg_version" => "1.0" }]
+    tab.write
+
+    bar_keg_path = HOMEBREW_CELLAR/"bar/1.0"
+    bar_keg_path.mkpath
+    bar_tab = Tab.empty
+    bar_tab.tabfile = bar_keg_path/AbstractTab::FILENAME
+    bar_tab.write
+
+    bar_formula = instance_double(Formula, outdated?: false)
+    allow(direct_dependency).to receive(:to_formula).and_return(bar_formula)
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/Required \(1\): .*bar.*✔/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "marks a tab-listed dep with an installed rack as outdated when the dep formula is outdated" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      desc "Some test"
+
+      depends_on "bar"
+    end
+    direct_dependency = formula.deps.required.first
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    keg_path.mkpath
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.runtime_dependencies = [{ "full_name" => "bar", "version" => "1.0", "pkg_version" => "1.0" }]
+    tab.write
+
+    bar_keg_path = HOMEBREW_CELLAR/"bar/1.0"
+    bar_keg_path.mkpath
+    bar_tab = Tab.empty
+    bar_tab.tabfile = bar_keg_path/AbstractTab::FILENAME
+    bar_tab.write
+
+    bar_formula = instance_double(Formula, outdated?: true)
+    allow(direct_dependency).to receive(:to_formula).and_return(bar_formula)
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/Required \(1\): .*bar.*↑/).to_stdout
       .and not_to_output.to_stderr
   end
 

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -368,6 +368,152 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
+  it "marks an installed dep as satisfied on the Required line" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      desc "Some test"
+
+      depends_on "bar"
+    end
+    bar = formula("bar") do
+      url "https://brew.sh/bar-1.0.tar.gz"
+    end
+    stub_formula_loader bar
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    keg_path.mkpath
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.write
+
+    bar_keg_path = HOMEBREW_CELLAR/"bar/1.0"
+    bar_keg_path.mkpath
+    bar_tab = Tab.empty
+    bar_tab.tabfile = bar_keg_path/AbstractTab::FILENAME
+    bar_tab.write
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/Required \(1\): .*bar.*✔/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "marks a missing dep as unsatisfied on the Required line" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      desc "Some test"
+
+      depends_on "bar"
+    end
+    bar = formula("bar") do
+      url "https://brew.sh/bar-1.0.tar.gz"
+    end
+    stub_formula_loader bar
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    keg_path.mkpath
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.write
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/Required \(1\): .*bar.*✘/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "marks a correctly-linked dep as satisfied even when newer dep version exists" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      desc "Some test"
+
+      depends_on "bar"
+    end
+    bar = formula("bar") do
+      url "https://brew.sh/bar-1.0.tar.gz"
+    end
+    stub_formula_loader bar
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    keg_path.mkpath
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.write
+
+    bar_keg_path = HOMEBREW_CELLAR/"bar/1.0"
+    bar_keg_path.mkpath
+    bar_tab = Tab.empty
+    bar_tab.tabfile = bar_keg_path/AbstractTab::FILENAME
+    bar_tab.write
+
+    fake_linkage = instance_double(
+      LinkageChecker,
+      brewed_dylibs: { "bar" => Set["/opt/homebrew/opt/bar/lib/libbar.1.dylib"] },
+      broken_deps:   {},
+    )
+    allow(info).to receive(:linkage_checker_for).and_return(fake_linkage)
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/Required \(1\): .*bar.*✔/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "marks a broken dep linkage as unsatisfied" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      desc "Some test"
+
+      depends_on "bar"
+    end
+    bar = formula("bar") do
+      url "https://brew.sh/bar-1.0.tar.gz"
+    end
+    stub_formula_loader bar
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    keg_path.mkpath
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.write
+
+    bar_keg_path = HOMEBREW_CELLAR/"bar/1.0"
+    bar_keg_path.mkpath
+    bar_tab = Tab.empty
+    bar_tab.tabfile = bar_keg_path/AbstractTab::FILENAME
+    bar_tab.write
+
+    fake_linkage = instance_double(
+      LinkageChecker,
+      brewed_dylibs: {},
+      broken_deps:   { "bar" => ["/opt/homebrew/opt/bar/lib/libbar.0.dylib"] },
+    )
+    allow(info).to receive(:linkage_checker_for).and_return(fake_linkage)
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/Required \(1\): .*bar.*✘/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
   it "omits build dependencies when a formula would pour from a bottle" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -466,6 +466,83 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
+  it "marks an installed dep on an uninstalled formula as satisfied" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      desc "Some test"
+
+      depends_on "bar"
+    end
+    direct_dependency = formula.deps.required.first
+
+    bar_keg_path = HOMEBREW_CELLAR/"bar/1.0"
+    bar_keg_path.mkpath
+    bar_tab = Tab.empty
+    bar_tab.tabfile = bar_keg_path/AbstractTab::FILENAME
+    bar_tab.write
+
+    bar_formula = instance_double(Formula, outdated?: false)
+    allow(direct_dependency).to receive(:to_formula).and_return(bar_formula)
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/Required \(1\): .*bar.*✔/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "marks an outdated installed dep on an uninstalled formula as upgradable" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      desc "Some test"
+
+      depends_on "bar"
+    end
+    direct_dependency = formula.deps.required.first
+
+    bar_keg_path = HOMEBREW_CELLAR/"bar/1.0"
+    bar_keg_path.mkpath
+    bar_tab = Tab.empty
+    bar_tab.tabfile = bar_keg_path/AbstractTab::FILENAME
+    bar_tab.write
+
+    bar_formula = instance_double(Formula, outdated?: true)
+    allow(direct_dependency).to receive(:to_formula).and_return(bar_formula)
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/Required \(1\): .*bar.*↑/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "marks a missing dep on an uninstalled formula as unsatisfied" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      desc "Some test"
+
+      depends_on "bar"
+    end
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/Required \(1\): .*bar.*✘/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
   it "marks a dep absent from the installed keg's tab as unsatisfied" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
-  it "marks an installed dep as satisfied on the Required line" do
+  it "marks a tab-listed dep with an installed rack as satisfied" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
     info = described_class.new([])
@@ -378,15 +378,12 @@ RSpec.describe Homebrew::Cmd::Info do
 
       depends_on "bar"
     end
-    bar = formula("bar") do
-      url "https://brew.sh/bar-1.0.tar.gz"
-    end
-    stub_formula_loader bar
 
     keg_path = HOMEBREW_CELLAR/"testball/0.1"
     keg_path.mkpath
     tab = Tab.empty
     tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.runtime_dependencies = [{ "full_name" => "bar", "version" => "1.0" }]
     tab.write
 
     bar_keg_path = HOMEBREW_CELLAR/"bar/1.0"
@@ -403,7 +400,7 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
-  it "marks a missing dep as unsatisfied on the Required line" do
+  it "marks a tab-listed dep with no installed rack as unsatisfied" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
     info = described_class.new([])
@@ -413,15 +410,12 @@ RSpec.describe Homebrew::Cmd::Info do
 
       depends_on "bar"
     end
-    bar = formula("bar") do
-      url "https://brew.sh/bar-1.0.tar.gz"
-    end
-    stub_formula_loader bar
 
     keg_path = HOMEBREW_CELLAR/"testball/0.1"
     keg_path.mkpath
     tab = Tab.empty
     tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.runtime_dependencies = [{ "full_name" => "bar", "version" => "1.0" }]
     tab.write
 
     allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
@@ -432,7 +426,7 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
-  it "marks a correctly-linked dep as satisfied even when newer dep version exists" do
+  it "marks a dep absent from the installed keg's tab as unsatisfied" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
     info = described_class.new([])
@@ -442,15 +436,12 @@ RSpec.describe Homebrew::Cmd::Info do
 
       depends_on "bar"
     end
-    bar = formula("bar") do
-      url "https://brew.sh/bar-1.0.tar.gz"
-    end
-    stub_formula_loader bar
 
     keg_path = HOMEBREW_CELLAR/"testball/0.1"
     keg_path.mkpath
     tab = Tab.empty
     tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.runtime_dependencies = []
     tab.write
 
     bar_keg_path = HOMEBREW_CELLAR/"bar/1.0"
@@ -459,53 +450,6 @@ RSpec.describe Homebrew::Cmd::Info do
     bar_tab.tabfile = bar_keg_path/AbstractTab::FILENAME
     bar_tab.write
 
-    fake_linkage = instance_double(
-      LinkageChecker,
-      brewed_dylibs: { "bar" => Set["/opt/homebrew/opt/bar/lib/libbar.1.dylib"] },
-      broken_deps:   {},
-    )
-    allow(info).to receive(:linkage_checker_for).and_return(fake_linkage)
-    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
-    allow(formula).to receive(:core_formula?).and_return(false)
-
-    expect { info.send(:info_formula, formula) }
-      .to output(/Required \(1\): .*bar.*✔/).to_stdout
-      .and not_to_output.to_stderr
-  end
-
-  it "marks a broken dep linkage as unsatisfied" do
-    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
-
-    info = described_class.new([])
-    formula = formula("testball") do
-      url "https://brew.sh/testball-0.1.tar.gz"
-      desc "Some test"
-
-      depends_on "bar"
-    end
-    bar = formula("bar") do
-      url "https://brew.sh/bar-1.0.tar.gz"
-    end
-    stub_formula_loader bar
-
-    keg_path = HOMEBREW_CELLAR/"testball/0.1"
-    keg_path.mkpath
-    tab = Tab.empty
-    tab.tabfile = keg_path/AbstractTab::FILENAME
-    tab.write
-
-    bar_keg_path = HOMEBREW_CELLAR/"bar/1.0"
-    bar_keg_path.mkpath
-    bar_tab = Tab.empty
-    bar_tab.tabfile = bar_keg_path/AbstractTab::FILENAME
-    bar_tab.write
-
-    fake_linkage = instance_double(
-      LinkageChecker,
-      brewed_dylibs: {},
-      broken_deps:   { "bar" => ["/opt/homebrew/opt/bar/lib/libbar.0.dylib"] },
-    )
-    allow(info).to receive(:linkage_checker_for).and_return(fake_linkage)
     allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
     allow(formula).to receive(:core_formula?).and_return(false)
 


### PR DESCRIPTION
It doesn't make sense to me that x264 is shown as not installed (`x264 ✘`), when it is installed:

```console
❯ brew info x264
==> x264 ↑: r3108 → stable r3222 (bottled), HEAD
...
==> Dependencies
Dependents (1): ffmpeg

❯ brew info ffmpeg
==> ffmpeg ↑: 7.1.1 → stable 8.1.1 (bottled), HEAD
...
==> Dependencies
Required (10): dav1d ✔, lame ✔, libvmaf ✘, libvpx ✘, openssl@3 ✔, opus ✘, sdl2 ✘, svt-av1 ✘, x264 ✘, x265 ✘
```

My theory is that since I'm not on latest ffmpeg version, that the dep version comparison check what would be needed for latest ffmpeg version.

This is counter-intuitive, since when I do eventually upgrade, I assume that I will then receive the latest dep version correctly, so there is not problem there. Thus, when not being on the latest version, the required deps should check if I have the correct version that is required for my current version, not any future versions.