### PR TITLE
Test bare cask macOS dependencies

### DIFF
--- a/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
+++ b/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Homebrew::API::Cask::CaskStructGenerator do
       expect(described_class.process_depends_on(depends_on_macos_equals)).to eq({ macos: [:sequoia] })
       expect(described_class.process_depends_on(depends_on_macos_greater)).to eq({ macos: ">= :sequoia" })
       expect(described_class.process_depends_on(depends_on_macos_bare)).to eq({ macos: :any })
+      expect(described_class.process_depends_on({ macos: {} })).to eq({ macos: :any })
     end
   end
 


### PR DESCRIPTION
- Guard against regressions in API cask loading for `depends_on`.
- The JSON API can encode bare `depends_on :macos` as `{}`.

Doesn't fix https://github.com/Homebrew/brew/issues/22165 but should avoid regressions.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with some manual review and editing.

-----
