### PR TITLE
bundle/commands/exec: enable `typed: strict`

### DIFF
--- a/Library/Homebrew/bundle/commands/exec.rb
+++ b/Library/Homebrew/bundle/commands/exec.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "English"
@@ -53,6 +53,7 @@ module Homebrew
           raise UsageError, "No command to execute was specified!" if command.blank?
 
           require "bundle/brewfile"
+          @dsl ||= T.let(nil, T.nilable(Homebrew::Bundle::Dsl))
           @dsl = Brewfile.read(global:, file:)
 
           require "formula"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes?
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Bumps `Library/Homebrew/bundle/commands/exec.rb` from `# typed: true` to `# typed: strict`.

All four `def self.*` methods (`run`, `map_service_info`, `run_services`, `stop_services`) already carried Sorbet `sig` blocks. The only change required by strict mode is a single `T.let(nil, T.nilable(Homebrew::Bundle::Dsl))` declaration for the `@dsl` class instance variable, mirroring the pattern already used in the sibling `Library/Homebrew/bundle/commands/install.rb`.

No new tests: there is no behaviour change. Existing `test/bundle/commands/exec_spec.rb` covers the public surface and continues to pass.

Verified locally:
- `./bin/brew typecheck` : No errors
- `./bin/brew style --fix --changed` : no offenses
- `./bin/brew tests --only=bundle/commands/exec` : 17 examples, 0 failures

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----