### PR TITLE
dev-cmd/tests: remove obsolete `HOMEBREW_REALLY_USE_INTERNAL_API` cleanup

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -265,9 +265,6 @@ module Homebrew
           ENV.delete(env)
         end
 
-        # TODO: remove this once we kill `HOMEBREW_REALLY_USE_INTERNAL_API`.
-        ENV.delete("HOMEBREW_REALLY_USE_INTERNAL_API")
-
         # Fetch JSON API files if needed.
         require "api"
         Homebrew::API.fetch_api_files!


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes?
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Removes the dead `ENV.delete("HOMEBREW_REALLY_USE_INTERNAL_API")` line and its TODO comment from `Library/Homebrew/dev-cmd/tests.rb`.

The lines were added in #21663 with a TODO to remove them once `HOMEBREW_REALLY_USE_INTERNAL_API` was killed. The variable's only runtime read site was removed in #22042 on 2026-04-22, so the test-env cleanup is now actionable.

Verified the var is no longer referenced anywhere in the tree:

