### PR TITLE
fix(cask): require URI scheme in FromURILoader

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -244,6 +244,7 @@ module Cask
 
         uri = URI(uri)
         return unless uri.path
+        return unless uri.scheme.present?
 
         new(uri)
       end

--- a/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe Cask::CaskLoader::FromURILoader do
         end
       RUBY
     end
+
+    it "returns nil when given a scheme-less absolute path string" do
+      expect(described_class.try_new("#{TEST_FIXTURE_DIR}/cask/Casks/local-caffeine.rb")).to be_nil
+    end
   end
 
   describe "::load" do

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe Cask::CaskLoader, :cask do
   describe "::for" do
     let(:tap) { CoreCaskTap.instance }
 
+    it "uses FromPathLoader for scheme-less absolute path strings", :no_api do
+      path = "#{TEST_FIXTURE_DIR}/cask/Casks/local-caffeine.rb"
+
+      expect(described_class.for(path)).to be_a(Cask::CaskLoader::FromPathLoader)
+    end
+
     context "when a cask is renamed" do
       let(:old_token) { "version-newest" }
       let(:new_token) { "version-latest" }


### PR DESCRIPTION
## What problem does this PR solve?

`Cask::CaskLoader::FromURILoader` accepted URI-like strings without requiring a scheme, and this loader is evaluated before `FromPathLoader`.
As a result, scheme-less local cask paths (e.g. `brew install --cask /path/to/cask.rb`) could be misclassified as URI installs and fail with `UnsupportedInstallationMethod` instead of loading from disk.

This is a regression candidate in a core workflow used for local testing, tap development, CI scripts, and incident recovery.

## How does this PR fix the problem?

- Require a URI scheme in `Cask::CaskLoader::FromURILoader.try_new` by adding:
  - `return unless uri.scheme.present?`
- Keep scheme-less filesystem paths out of URI loading so they fall through to `FromPathLoader` as intended.

## What tests were added/updated?

- Added `FromURILoader` regression coverage:
  - verifies `try_new` returns `nil` for a scheme-less absolute path string.
- Added `CaskLoader.for` regression coverage:
  - verifies a scheme-less absolute path selects `FromPathLoader`.

## Checklist

- [x] Fix is minimal and targeted.
- [x] Includes regression tests.
- [ ] Ran `./bin/brew lgtm --online` locally.

## AI/LLM Disclosure

This pull request was prepared with AI assistance (Cursor/Codex). I have reviewed the generated changes before requesting review.
