### PR TITLE
pr-pull: broaden trailer detection in separate_commit_message

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -188,12 +188,24 @@ module Homebrew
         first_line = message.lines.first
         return ["", "", ""] unless first_line
 
-        # Skip the subject and separate lines that look like trailers (e.g. "Co-authored-by")
-        # from lines that look like regular body text.
-        trailers, body = message.lines.drop(1).partition { |s| s.match?(/^[a-z-]+-by:/i) }
+        remaining = message.lines.drop(1)
 
-        trailers = trailers.uniq.join.strip
-        body = body.join.strip.gsub(/\n{3,}/, "\n\n")
+        # Detect trailers as a contiguous block at the end of the message.
+        trailer_start = remaining.length
+        remaining.reverse_each.with_index do |line, i|
+          pos = remaining.length - 1 - i
+          if line.match?(/^[A-Za-z][A-Za-z0-9-]*:\s/)
+            trailer_start = pos
+          elsif line.strip.empty?
+            # Allow blank lines between trailer lines
+            next
+          else
+            break
+          end
+        end
+
+        body = remaining[0...trailer_start].to_a.join.strip.gsub(/\n{3,}/, "\n\n")
+        trailers = remaining[trailer_start..].to_a.grep(/^[A-Za-z][A-Za-z0-9-]*:\s/).uniq.join.strip
 
         [first_line.strip, body, trailers]
       end

--- a/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
@@ -163,6 +163,52 @@ RSpec.describe Homebrew::DevCmd::PrPull do
     end
   end
 
+  describe "#separate_commit_message" do
+    it "separates standard -by: trailers" do
+      message = "Update foo\n\nSome body text.\n\nCo-authored-by: Alice <a@b.com>\nSigned-off-by: Bob <b@b.com>\n"
+      subject, body, trailers = pr_pull.separate_commit_message(message)
+      expect(subject).to eq("Update foo")
+      expect(body).to eq("Some body text.")
+      expect(trailers).to include("Co-authored-by: Alice <a@b.com>")
+      expect(trailers).to include("Signed-off-by: Bob <b@b.com>")
+    end
+
+    it "separates non-by trailers like Closes: and Fixes:" do
+      message = "Fix bug\n\nBody here.\n\nCloses: #123\nFixes: #456\nReviewed-by: Carol <c@c.com>\n"
+      subject, body, trailers = pr_pull.separate_commit_message(message)
+      expect(subject).to eq("Fix bug")
+      expect(body).to eq("Body here.")
+      expect(trailers).to include("Closes: #123")
+      expect(trailers).to include("Fixes: #456")
+      expect(trailers).to include("Reviewed-by: Carol <c@c.com>")
+    end
+
+    it "does not extract trailer-like text from mid-body" do
+      message = "Subject\n\nSome text.\nCloses: #99\nMore text.\n\nCo-authored-by: D <d@d.com>\n"
+      subject, body, trailers = pr_pull.separate_commit_message(message)
+      expect(subject).to eq("Subject")
+      expect(body).to include("Closes: #99")
+      expect(body).to include("More text.")
+      expect(trailers).to eq("Co-authored-by: D <d@d.com>")
+    end
+
+    it "returns empty trailers when there are none" do
+      message = "Subject\n\nJust a body with no trailers.\n"
+      subject, body, trailers = pr_pull.separate_commit_message(message)
+      expect(subject).to eq("Subject")
+      expect(body).to eq("Just a body with no trailers.")
+      expect(trailers).to eq("")
+    end
+
+    it "handles empty and blank messages" do
+      expect(pr_pull.separate_commit_message("")).to eq(["", "", ""])
+      subject, body, trailers = pr_pull.separate_commit_message("Subject only\n")
+      expect(subject).to eq("Subject only")
+      expect(body).to eq("")
+      expect(trailers).to eq("")
+    end
+  end
+
   describe "#determine_bump_subject" do
     it "correctly bumps a new formula" do
       expect(pr_pull.determine_bump_subject("", formula, formula_file)).to eq("foo 1.0 (new formula)")


### PR DESCRIPTION
## Summary
- Broadens the trailer regex in `separate_commit_message` from `^[a-z-]+-by:/i` to `^[A-Za-z][A-Za-z0-9-]*:\s` to recognize all standard Git trailers (Fixes:, Closes:, Change-Id:, etc.), not just `*-by:` patterns
- Detects trailers as a contiguous block at the end of the message instead of using `partition`, which incorrectly extracted trailer-like lines from the middle of commit bodies
- Adds unit tests covering: standard `-by:` trailers, non-by trailers, mid-body trailer-like text (should not be extracted), no trailers, and empty/blank messages

## Test plan
- [x] `brew style --fix` passes
- [x] `brew typecheck` passes
- [x] `brew tests --only=dev-cmd/pr-pull` passes (21 examples, 0 failures)

Nightshift-Task: commit-normalize
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)