### PR TITLE
tap-info: list formulae and casks

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -546,18 +546,14 @@ module Homebrew
         attrs << "keg-only" if formula.keg_only?
 
         kegs = formula.installed_kegs
-        name_with_status = if kegs.empty?
-          pretty_uninstalled(formula.full_name)
-        elsif formula.outdated?
-          if (upgrade_version = specs.first.presence)
-            installed_version = formula.linked_version ||
-                                kegs.max_by(&:scheme_and_version)&.version
-            specs[0] = "#{installed_version} → #{upgrade_version}"
-          end
-          pretty_upgradable(formula.full_name)
-        else
-          pretty_installed(formula.full_name)
+        installed = kegs.any?
+        outdated = installed && formula.outdated?
+        if outdated && (upgrade_version = specs.first.presence)
+          installed_version = formula.linked_version ||
+                              kegs.max_by(&:scheme_and_version)&.version
+          specs[0] = "#{installed_version} → #{upgrade_version}"
         end
+        name_with_status = pretty_install_status(formula.full_name, installed:, outdated:)
 
         puts "#{oh1_title(name_with_status)}: #{specs * ", "}#{" [#{attrs * ", "}]" unless attrs.empty?}"
         puts formula.desc if formula.desc
@@ -712,9 +708,9 @@ module Homebrew
             dep.name
           end
           rack = HOMEBREW_CELLAR/Utils.name_from_full_name(full_name) if full_name
-          next pretty_uninstalled(display) if rack.nil? || !rack.directory? || rack.subdirs.empty?
-
-          dep.to_formula.outdated? ? pretty_upgradable(display) : pretty_installed(display)
+          installed = !rack.nil? && rack.directory? && !rack.subdirs.empty?
+          outdated = installed ? dep.to_formula.outdated? : false
+          pretty_install_status(display, installed:, outdated:)
         end.join(", ")
       end
 

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -82,13 +82,84 @@ module Homebrew
               info += "\nHEAD: #{tap.git_head || "(none)"}"
               info += "\nlast commit: #{tap.git_last_commit || "never"}"
               info += "\nbranch: #{tap.git_branch || "(none)"}" if default_branches.exclude?(tap.git_branch)
+              puts info
+              print_tap_listings(tap)
             else
               info += "Not installed"
               Homebrew.failed = true
+              puts info
             end
-            puts info
           end
         end
+      end
+
+      LISTING_LIMIT = 30
+      private_constant :LISTING_LIMIT
+
+      sig { params(tap: Tap).void }
+      def print_tap_listings(tap)
+        commands = tap.command_files
+                      .map { |path| path.basename(path.extname).to_s.delete_prefix("brew-") }
+                      .sort
+        installed_formula_names = Formula.installed_formula_names.to_set
+        installed_cask_tokens = Cask::Caskroom.tokens.to_set
+        formula_names = tap.formula_names.map { |name| Utils.name_from_full_name(name) }.sort
+        cask_tokens = tap.cask_tokens.map { |token| Utils.name_from_full_name(token) }.sort
+        installed_formulae = formula_names.select { |name| installed_formula_names.include?(name) }
+        installed_casks = cask_tokens.select { |token| installed_cask_tokens.include?(token) }
+
+        if commands.any?
+          ohai "Commands"
+          puts commands.join(", ")
+        end
+
+        print_section(tap, "Formulae", formula_names, installed_formulae) do |name|
+          decorate_formula(tap, name, installed: installed_formula_names.include?(name))
+        end
+        print_section(tap, "Casks", cask_tokens, installed_casks) do |token|
+          decorate_cask(tap, token, installed: installed_cask_tokens.include?(token))
+        end
+      end
+
+      sig {
+        params(
+          tap:       Tap,
+          label:     String,
+          all:       T::Array[String],
+          installed: T::Array[String],
+          block:     T.proc.params(name: String).returns(String),
+        ).void
+      }
+      def print_section(tap, label, all, installed, &block)
+        return if all.none?
+
+        if all.size <= LISTING_LIMIT
+          ohai label, Formatter.columns(all.map(&block))
+        elsif installed.any?
+          ohai label
+          opoo "Tap has more than #{LISTING_LIMIT} #{label.downcase}; showing only installed entries."
+          puts Formatter.columns(installed.map(&block))
+        else
+          ohai label
+          opoo "Tap has more than #{LISTING_LIMIT} #{label.downcase} and none are installed."
+          puts "See: #{tap.remote}" if tap.remote.present?
+        end
+      end
+
+      sig { params(tap: Tap, name: String, installed: T::Boolean).returns(String) }
+      def decorate_formula(tap, name, installed:)
+        outdated = installed && Formulary.factory("#{tap.name}/#{name}").outdated?
+        pretty_install_status(name, installed:, outdated:)
+      rescue
+        pretty_installed(name)
+      end
+
+      sig { params(tap: Tap, token: String, installed: T::Boolean).returns(String) }
+      def decorate_cask(tap, token, installed:)
+        outdated = installed && Cask::CaskLoader.load("#{tap.name}/#{token}").outdated?
+        pretty_install_status(token, installed:, outdated:)
+      rescue
+        pretty_installed(token)
       end
 
       sig { params(taps: T::Array[Tap]).void }

--- a/Library/Homebrew/test/cmd/tap-info_spec.rb
+++ b/Library/Homebrew/test/cmd/tap-info_spec.rb
@@ -22,4 +22,177 @@ RSpec.describe Homebrew::Cmd::TapInfo do
       .and not_to_output.to_stderr
       .and be_a_success
   end
+
+  describe "#decorate_formula" do
+    let(:tap_info) { described_class.new([]) }
+    let(:tap) { instance_double(Tap, name: "homebrew/foo") }
+
+    before do
+      allow($stdout).to receive(:tty?).and_return(true)
+      allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+    end
+
+    it "marks an uninstalled formula as unsatisfied" do
+      expect(tap_info.send(:decorate_formula, tap, "missing", installed: false)).to match(/missing.*✘/)
+    end
+
+    it "marks an installed formula as satisfied" do
+      formula = instance_double(Formula, outdated?: false)
+      allow(Formulary).to receive(:factory).with("homebrew/foo/installed").and_return(formula)
+
+      expect(tap_info.send(:decorate_formula, tap, "installed", installed: true)).to match(/installed.*✔/)
+    end
+
+    it "marks an outdated installed formula as upgradable" do
+      formula = instance_double(Formula, outdated?: true)
+      allow(Formulary).to receive(:factory).with("homebrew/foo/outdated").and_return(formula)
+
+      expect(tap_info.send(:decorate_formula, tap, "outdated", installed: true)).to match(/outdated.*↑/)
+    end
+  end
+
+  describe "#decorate_cask" do
+    let(:tap_info) { described_class.new([]) }
+    let(:tap) { instance_double(Tap, name: "homebrew/foo") }
+
+    before do
+      allow($stdout).to receive(:tty?).and_return(true)
+      allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+    end
+
+    it "marks an uninstalled cask as unsatisfied" do
+      expect(tap_info.send(:decorate_cask, tap, "missing", installed: false)).to match(/missing.*✘/)
+    end
+
+    it "marks an installed cask as satisfied" do
+      cask = instance_double(Cask::Cask, outdated?: false)
+      allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/installed").and_return(cask)
+
+      expect(tap_info.send(:decorate_cask, tap, "installed", installed: true)).to match(/installed.*✔/)
+    end
+
+    it "marks an outdated installed cask as upgradable" do
+      cask = instance_double(Cask::Cask, outdated?: true)
+      allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/outdated").and_return(cask)
+
+      expect(tap_info.send(:decorate_cask, tap, "outdated", installed: true)).to match(/outdated.*↑/)
+    end
+  end
+
+  describe "#print_tap_listings" do
+    let(:tap_info) { described_class.new([]) }
+
+    before do
+      allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+    end
+
+    context "with a small tap and a mix of installed and uninstalled entries" do
+      let(:tap) do
+        instance_double(
+          Tap,
+          name:          "homebrew/foo",
+          remote:        "https://github.com/homebrew/homebrew-foo",
+          command_files: [Pathname("/some/tap/cmd/brew-mycmd.rb")],
+          formula_names: ["homebrew/foo/foo", "homebrew/foo/uninstalled-formula"],
+          cask_tokens:   ["homebrew/foo/bar", "homebrew/foo/uninstalled-cask"],
+        )
+      end
+
+      before do
+        allow(Formula).to receive(:installed_formula_names).and_return(["foo"])
+        allow(Cask::Caskroom).to receive(:tokens).and_return(["bar"])
+        allow(Formulary).to receive(:factory).with("homebrew/foo/foo")
+                                             .and_return(instance_double(Formula, outdated?: false))
+        allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/bar")
+                                                 .and_return(instance_double(Cask::Cask, outdated?: false))
+      end
+
+      it "lists every formula and cask with mixed install markers under their headers" do
+        expect { tap_info.send(:print_tap_listings, tap) }
+          .to output(
+            /Commands.*mycmd.*==> Formulae.*foo.*✔.*uninstalled-formula.*✘.*==> Casks.*bar.*✔.*uninstalled-cask.*✘/m,
+          ).to_stdout
+      end
+    end
+
+    context "with a large tap and some installed entries" do
+      let(:formula_names) { (1..40).map { |i| "homebrew/foo/formula#{i}" } }
+      let(:tap) do
+        instance_double(
+          Tap,
+          name:          "homebrew/foo",
+          remote:        "https://github.com/homebrew/homebrew-foo",
+          command_files: [],
+          formula_names: formula_names,
+          cask_tokens:   [],
+        )
+      end
+
+      before do
+        allow(Formula).to receive(:installed_formula_names).and_return(["formula7"])
+        allow(Cask::Caskroom).to receive(:tokens).and_return([])
+        allow(Formulary).to receive(:factory).with("homebrew/foo/formula7")
+                                             .and_return(instance_double(Formula, outdated?: false))
+      end
+
+      it "warns about truncation and shows only installed entries under the standard header" do
+        expect { tap_info.send(:print_tap_listings, tap) }
+          .to output(/==> Formulae.*formula7.*✔/m).to_stdout
+          .and output(/Tap has more than 30 formulae; showing only installed entries\./).to_stderr
+      end
+    end
+
+    context "with a small tap and nothing installed" do
+      let(:tap) do
+        instance_double(
+          Tap,
+          name:          "homebrew/foo",
+          remote:        "https://github.com/homebrew/homebrew-foo",
+          command_files: [],
+          formula_names: ["homebrew/foo/foo", "homebrew/foo/baz"],
+          cask_tokens:   ["homebrew/foo/bar"],
+        )
+      end
+
+      before do
+        allow(Formula).to receive(:installed_formula_names).and_return([])
+        allow(Cask::Caskroom).to receive(:tokens).and_return([])
+      end
+
+      it "lists every formula and cask with uninstalled markers" do
+        expect { tap_info.send(:print_tap_listings, tap) }
+          .to output(/==> Formulae.*baz.*✘.*foo.*✘.*==> Casks.*bar.*✘/m).to_stdout
+      end
+    end
+
+    context "with a large tap and nothing installed" do
+      let(:formula_names) { (1..40).map { |i| "homebrew/foo/formula#{i}" } }
+      let(:tap) do
+        instance_double(
+          Tap,
+          name:          "homebrew/foo",
+          remote:        "https://github.com/homebrew/homebrew-foo",
+          command_files: [],
+          formula_names: formula_names,
+          cask_tokens:   [],
+        )
+      end
+
+      before do
+        allow(Formula).to receive(:installed_formula_names).and_return([])
+        allow(Cask::Caskroom).to receive(:tokens).and_return([])
+      end
+
+      it "shows a link to the tap remote and warns when nothing is installed" do
+        expect { tap_info.send(:print_tap_listings, tap) }
+          .to output(%r{See: https://github.com/homebrew/homebrew-foo}).to_stdout
+          .and output(/Tap has more than 30 formulae and none are installed\./).to_stderr
+      end
+
+      it "does not list individual formula names" do
+        expect { tap_info.send(:print_tap_listings, tap) }
+          .not_to output(/formula1\b/).to_stdout
+      end
+    end
+  end
 end

--- a/Library/Homebrew/utils/output.rb
+++ b/Library/Homebrew/utils/output.rb
@@ -295,6 +295,13 @@ module Utils
         end
       end
 
+      sig { params(string: String, installed: T::Boolean, outdated: T::Boolean).returns(String) }
+      def pretty_install_status(string, installed:, outdated: false)
+        return pretty_uninstalled(string) unless installed
+
+        outdated ? pretty_upgradable(string) : pretty_installed(string)
+      end
+
       sig { params(seconds: T.nilable(T.any(Integer, Float))).returns(String) }
       def pretty_duration(seconds)
         seconds = seconds.to_i


### PR DESCRIPTION
Show the actual formulas when listing a tap:

```
❯ brew tap-info facebook/fb
facebook/fb: Installed
6 formulae
/opt/homebrew/Library/Taps/facebook/homebrew-fb (23 files, 5.8MB)
From: https://github.com/facebook/homebrew-fb
HEAD: c0386793f59da10c619787f2aa18d938ef1d69c9
last commit: 3 years, 9 months ago
==> Formulae
buck ✘, fbsimctl ✘, fbthrift-compiler ✘, idb-companion ✔, watchman ✘, xar ✘
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code, Extra High Effort

-----

