### PR TITLE
Use PyPI mtimes for source dates

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -444,6 +444,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy # rubocop:todo Style/O
     @try_partial = T.let(true, T::Boolean)
     @mirrors = T.let(meta.fetch(:mirrors, []), T::Array[String])
     @file_size = T.let(nil, T.nilable(Integer))
+    @last_modified = T.let(nil, T.nilable(Time))
 
     # Merge `:header` with `:headers`.
     if (header = meta.delete(:header))
@@ -497,6 +498,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy # rubocop:todo Style/O
         rescue ErrorDuringExecution
           raise unless cached_location_valid
         end
+        @last_modified = last_modified
 
         # Authorization is no longer valid after redirects
         meta[:headers]&.delete_if { |header| header.start_with?("Authorization") } if is_redirection
@@ -708,6 +710,20 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy # rubocop:todo Style/O
   def curl(*args, print_stdout: true, **options)
     options[:connect_timeout] = 15 unless mirrors.empty?
     super(*_curl_args, *args, **_curl_opts, **command_output_options, **options)
+  end
+end
+
+# Strategy for downloading files from PyPI.
+#
+# @api public
+class PyPIDownloadStrategy < CurlDownloadStrategy # rubocop:todo Style/OneClassPerFile
+  sig { override.returns(Time) }
+  def source_modified_time
+    last_modified = @last_modified
+    source_modified_time = super
+    return source_modified_time if last_modified.nil? || source_modified_time > last_modified
+
+    last_modified
   end
 end
 
@@ -1693,6 +1709,8 @@ class DownloadStrategyDetector # rubocop:todo Style/OneClassPerFile
     when %r{^https?://www\.apache\.org/dyn/closer\.cgi},
          %r{^https?://www\.apache\.org/dyn/closer\.lua}
       CurlApacheMirrorDownloadStrategy
+    when %r{^https?://files\.pythonhosted\.org/packages/}
+      PyPIDownloadStrategy
     when %r{^https?://([A-Za-z0-9\-.]+\.)?googlecode\.com/svn},
          %r{^https?://svn\.},
          %r{^svn://},

--- a/Library/Homebrew/test/download_strategies/detector_spec.rb
+++ b/Library/Homebrew/test/download_strategies/detector_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe DownloadStrategyDetector do
       it { is_expected.to eq(GitHubGitDownloadStrategy) }
     end
 
+    context "when given a PyPI URL" do
+      let(:url) do
+        "https://files.pythonhosted.org/packages/ab/cd/efg/example-package-1.2.3.tar.gz"
+      end
+
+      it { is_expected.to eq(PyPIDownloadStrategy) }
+    end
+
     it "defaults to curl" do
       expect(strategy_detector).to eq(CurlDownloadStrategy)
     end

--- a/Library/Homebrew/test/download_strategies/pypi_spec.rb
+++ b/Library/Homebrew/test/download_strategies/pypi_spec.rb
@@ -1,0 +1,33 @@
+# typed: false
+# frozen_string_literal: true
+
+require "download_strategy"
+
+RSpec.describe PyPIDownloadStrategy do
+  subject(:strategy) { described_class.new(url, "foo", "1.2.3") }
+
+  let(:url) { "https://files.pythonhosted.org/packages/ab/cd/efg/foo-1.2.3.tar.gz" }
+  let(:last_modified) { Time.utc(2026, 5, 6, 13, 43, 5) }
+
+  before do
+    allow(Homebrew::EnvConfig).to receive(:artifact_domain).and_return(nil)
+    allow(strategy).to receive(:resolve_url_basename_time_file_size)
+      .and_return([url, "foo-1.2.3.tar.gz", last_modified, 1024, "application/gzip", false])
+    allow(strategy).to receive(:_fetch)
+    strategy.clear_cache
+    strategy.temporary_path.dirname.mkpath
+    FileUtils.touch strategy.temporary_path
+  end
+
+  describe "#source_modified_time" do
+    it "uses the PyPI last modified time when archive contents are older" do
+      strategy.fetch
+
+      mktmpdir("mtime").cd do
+        FileUtils.touch "foo.py", mtime: Time.utc(2020, 2, 2)
+
+        expect(strategy.source_modified_time).to eq(last_modified)
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -152,6 +152,31 @@ RSpec.describe Resource do
     end
   end
 
+  describe "#stage" do
+    let(:last_modified) { Time.utc(2026, 5, 6, 13, 43, 5) }
+    let(:tarball) { TEST_FIXTURE_DIR/"tarballs/testball-0.1.tbz" }
+    let(:url) { "https://files.pythonhosted.org/packages/ab/cd/efg/testball-0.1.tbz" }
+
+    before do
+      resource.url(url)
+      resource.sha256(tarball.sha256)
+      allow(resource.downloader).to receive(:resolve_url_basename_time_file_size)
+        .and_return([url, tarball.basename.to_s, last_modified, tarball.size, "application/x-bzip2", false])
+      allow(resource.downloader).to receive(:_fetch) do
+        resource.downloader.temporary_path.dirname.mkpath
+        FileUtils.cp tarball, resource.downloader.temporary_path
+      end
+    end
+
+    after { resource.clear_cache }
+
+    it "records the PyPI last modified time when staged files are older" do
+      resource.stage(mktmpdir)
+
+      expect(resource.source_modified_time).to eq(last_modified)
+    end
+  end
+
   describe "#owner" do
     let(:owner) { described_class.new("test-owner") }
 


### PR DESCRIPTION
- PyPI sdists can reuse reproducible archive mtimes across releases.
- That left Python bytecode caches looking fresh after dependency bumps.
- Use PyPI `Last-Modified` metadata for newer bottle source times.

Fixes https://github.com/Homebrew/brew/issues/22152

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local tweaking and testing.

-----
