### PR TITLE
Warn for Nix-managed Homebrew

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -209,11 +209,13 @@ rescue Exception => e # rubocop:disable Lint/RescueException
     $stderr.puts "#{Tty.bold}You have disabled automatic updates and have not updated today.#{Tty.reset}"
     $stderr.puts "#{Tty.bold}Do not report this issue until you've run `brew update` and tried again.#{Tty.reset}"
   elsif (issues_url = (method_deprecated_error && e.issues_url) || Utils::Backtrace.tap_error_url(e))
-    $stderr.puts "If reporting this issue please do so at (not Homebrew/* repositories):"
-    $stderr.puts "  #{Formatter.url(issues_url)}"
+    $stderr.puts Utils::Output.issue_reporting_message(issues_url)
   elsif internal_cmd && !method_deprecated_error
-    $stderr.puts "#{Tty.bold}Please report this issue:#{Tty.reset}"
-    $stderr.puts "  #{Formatter.url(OS::ISSUES_URL)}"
+    if OS.nix_managed_homebrew?
+      $stderr.puts Utils::Output.issue_reporting_message(OS::ISSUES_URL)
+    else
+      $stderr.puts Utils::Output.issue_reporting_message(OS::ISSUES_URL, homebrew: true)
+    end
   end
 
   exit 1

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -612,6 +612,21 @@ module Homebrew
       end
 
       sig { returns(T.nilable(String)) }
+      def check_for_nix_homebrew
+        return unless OS.nix_managed_homebrew?
+
+        <<~EOS
+          Your Homebrew installation is managed by Nix.
+          Homebrew does not support Nix-managed installations.
+
+          This is a Tier 3 configuration:
+            #{Formatter.url("https://docs.brew.sh/Support-Tiers#tier-3")}
+          #{Formatter.bold("Report issues to the upstream Nix project, not Homebrew/* repositories:")}
+            #{Formatter.url(OS.nix_managed_homebrew_issues_url)}
+        EOS
+      end
+
+      sig { returns(T.nilable(String)) }
       def check_coretap_integrity
         core_tap = CoreTap.instance
         unless core_tap.installed?

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -683,12 +683,13 @@ class BuildError < RuntimeError
           Read the above document instead before opening any issues or PRs.
         EOS
       elsif formula_tap.official?
-        puts Formatter.error(Formatter.url(OS::ISSUES_URL), label: "READ THIS")
+        if OS.nix_managed_homebrew?
+          puts issue_reporting_message(OS::ISSUES_URL)
+        else
+          puts issue_reporting_message(OS::ISSUES_URL, read_this: true)
+        end
       elsif (issues_url = formula_tap.issues_url)
-        puts <<~EOS
-          If reporting this issue please do so at (not Homebrew/* repositories):
-            #{Formatter.url(issues_url)}
-        EOS
+        puts issue_reporting_message(issues_url)
       else
         puts <<~EOS
           If reporting this issue please do so to (not Homebrew/* repositories):

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -55,21 +55,65 @@ module OS
   LINUX_PREFERRED_GCC_COMPILER_FORMULA = T.let("gcc@#{LINUX_GCC_CI_VERSION}".freeze, String)
   LINUX_PREFERRED_GCC_RUNTIME_FORMULA = "gcc"
 
+  sig { returns(T::Boolean) }
+  def self.nix_managed_homebrew?
+    nix_homebrew? || nix_darwin?
+  end
+
+  sig { returns(String) }
+  def self.nix_managed_homebrew_issues_url
+    if nix_homebrew?
+      "https://github.com/zhaofengli/nix-homebrew/issues"
+    else
+      "https://github.com/nix-darwin/nix-darwin/issues"
+    end
+  end
+
+  sig { returns(T::Boolean) }
+  def self.nix_homebrew?
+    # nix-homebrew sets this repository name, creates this prefix marker and
+    # exports these update values.
+    # https://github.com/zhaofengli/nix-homebrew/blob/aeb2069920742d0d6570089e8b3b8620050bacf2/modules/default.nix#L29-L31
+    # https://github.com/zhaofengli/nix-homebrew/blob/aeb2069920742d0d6570089e8b3b8620050bacf2/modules/default.nix#L115-L125
+    HOMEBREW_REPOSITORY.basename.to_s == ".homebrew-is-managed-by-nix" ||
+      (HOMEBREW_PREFIX/".managed_by_nix_darwin").exist? ||
+      (ENV["HOMEBREW_UPDATE_BEFORE"] == "nix" && ENV["HOMEBREW_UPDATE_AFTER"] == "nix")
+  end
+  private_class_method :nix_homebrew?
+
+  sig { returns(T::Boolean) }
+  def self.nix_darwin?
+    # nix-darwin manages Homebrew through `brew bundle` during activation.
+    # https://github.com/nix-darwin/nix-darwin/blob/8c62fba0854ba15c8917aed18894dbccb48a3777/modules/homebrew.nix#L76-L129
+    ENV.fetch("HOMEBREW_BUNDLE_FILE", "").start_with?("/nix/store/") ||
+      ARGV.each_cons(2).any? { |arg, value| arg == "--file" && value.start_with?("/nix/store/") } ||
+      ARGV.any? { |arg| arg.start_with?("--file=/nix/store/") }
+  end
+  private_class_method :nix_darwin?
+
+  nix_managed_homebrew = T.let(OS.nix_managed_homebrew?, T::Boolean)
+
   if OS.mac?
     require "os/mac"
     require "hardware"
     # Don't tell people to report issues on non-Tier 1 configurations.
-    if !OS::Mac.version.prerelease? &&
-       !OS::Mac.version.outdated_release? &&
-       ARGV.none? { |v| v.start_with?("--cc=") } &&
-       (HOMEBREW_PREFIX.to_s == HOMEBREW_DEFAULT_PREFIX ||
-       (HOMEBREW_PREFIX.to_s == HOMEBREW_MACOS_ARM_DEFAULT_PREFIX && Hardware::CPU.arm?))
+    if nix_managed_homebrew
+      ISSUES_URL = OS.nix_managed_homebrew_issues_url.freeze
+    elsif !OS::Mac.version.prerelease? &&
+          !OS::Mac.version.outdated_release? &&
+          ARGV.none? { |v| v.start_with?("--cc=") } &&
+          (HOMEBREW_PREFIX.to_s == HOMEBREW_DEFAULT_PREFIX ||
+          (HOMEBREW_PREFIX.to_s == HOMEBREW_MACOS_ARM_DEFAULT_PREFIX && Hardware::CPU.arm?))
       ISSUES_URL = "https://docs.brew.sh/Troubleshooting"
     end
     PATH_OPEN = "/usr/bin/open"
   elsif OS.linux?
     require "os/linux"
-    ISSUES_URL = "https://docs.brew.sh/Troubleshooting"
+    ISSUES_URL = if nix_managed_homebrew
+      OS.nix_managed_homebrew_issues_url
+    else
+      "https://docs.brew.sh/Troubleshooting"
+    end.freeze
     PATH_OPEN = if OS::Linux.wsl? && (wslview = which("wslview").presence)
       wslview.to_s
     else

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -128,6 +128,13 @@ RSpec.describe Homebrew::Diagnostic::Checks do
     expect(checks.check_tmpdir).to match("doesn't exist")
   end
 
+  specify "#check_for_nix_homebrew" do
+    stub_const("HOMEBREW_REPOSITORY", HOMEBREW_PREFIX/"Library/.homebrew-is-managed-by-nix")
+
+    expect(checks.check_for_nix_homebrew)
+      .to include("This is a Tier 3 configuration", "https://github.com/zhaofengli/nix-homebrew/issues")
+  end
+
   specify "#check_for_external_cmd_name_conflict" do
     mktmpdir do |path1|
       mktmpdir do |path2|

--- a/Library/Homebrew/test/os_spec.rb
+++ b/Library/Homebrew/test/os_spec.rb
@@ -1,0 +1,53 @@
+# typed: false
+# frozen_string_literal: true
+
+require "os"
+
+RSpec.describe OS do
+  it "detects nix-homebrew from its repository" do
+    stub_const("HOMEBREW_REPOSITORY", HOMEBREW_PREFIX/"Library/.homebrew-is-managed-by-nix")
+
+    expect(described_class.nix_managed_homebrew?).to be(true)
+    expect(described_class.nix_managed_homebrew_issues_url)
+      .to eq("https://github.com/zhaofengli/nix-homebrew/issues")
+  end
+
+  it "detects nix-homebrew from its prefix marker" do
+    mktmpdir do |prefix|
+      stub_const("HOMEBREW_PREFIX", prefix)
+      stub_const("HOMEBREW_REPOSITORY", prefix/"Library/Homebrew")
+
+      (prefix/".managed_by_nix_darwin").write("")
+
+      expect(described_class.nix_managed_homebrew?).to be(true)
+    end
+  end
+
+  it "detects nix-homebrew from update environment values" do
+    old_update_before = ENV.fetch("HOMEBREW_UPDATE_BEFORE", nil)
+    old_update_after = ENV.fetch("HOMEBREW_UPDATE_AFTER", nil)
+    mktmpdir do |prefix|
+      stub_const("HOMEBREW_PREFIX", prefix)
+      stub_const("HOMEBREW_REPOSITORY", prefix/"Library/Homebrew")
+      ENV["HOMEBREW_UPDATE_BEFORE"] = "nix"
+      ENV["HOMEBREW_UPDATE_AFTER"] = "nix"
+
+      expect(described_class.nix_managed_homebrew?).to be(true)
+    end
+  ensure
+    ENV["HOMEBREW_UPDATE_BEFORE"] = old_update_before
+    ENV["HOMEBREW_UPDATE_AFTER"] = old_update_after
+  end
+
+  it "detects nix-darwin from a Nix store Brewfile" do
+    mktmpdir do |prefix|
+      stub_const("HOMEBREW_PREFIX", prefix)
+      stub_const("HOMEBREW_REPOSITORY", prefix/"Library/Homebrew")
+      stub_const("ARGV", ["bundle", "--file=/nix/store/example-Brewfile"])
+
+      expect(described_class.nix_managed_homebrew?).to be(true)
+      expect(described_class.nix_managed_homebrew_issues_url)
+        .to eq("https://github.com/nix-darwin/nix-darwin/issues")
+    end
+  end
+end

--- a/Library/Homebrew/utils/output.rb
+++ b/Library/Homebrew/utils/output.rb
@@ -109,6 +109,25 @@ module Utils
         Homebrew.failed = true
       end
 
+      sig { params(issues_url: String, homebrew: T::Boolean, read_this: T::Boolean).returns(String) }
+      def issue_reporting_message(issues_url, homebrew: false, read_this: false)
+        formatted_issues_url = Formatter.url(issues_url)
+
+        if read_this
+          Formatter.error(formatted_issues_url, label: "READ THIS")
+        elsif homebrew
+          <<~EOS
+            #{Tty.bold}Please report this issue:#{Tty.reset}
+              #{formatted_issues_url}
+          EOS
+        else
+          <<~EOS
+            If reporting this issue please do so at (not Homebrew/* repositories):
+              #{formatted_issues_url}
+          EOS
+        end
+      end
+
       # Print an error message and fail immediately.
       #
       # @api public

--- a/docs/Support-Tiers.md
+++ b/docs/Support-Tiers.md
@@ -95,7 +95,7 @@ Tier 3 configurations include:
 - macOS versions no longer covered by CI and no longer receiving regular Apple security updates
 - Systems that build official packages from source despite available bottles
 - Homebrew installed outside the default prefix (e.g. `/opt/homebrew`, `/usr/local`, or `/home/linuxbrew/.linuxbrew` used on mismatched architectures)
-- Homebrew installations managed by Nix e.g. nix-darwin or nix-homebrew
+- Homebrew installations managed by Nix (e.g. nix-darwin or nix-homebrew)
 - Installing formulae using `--HEAD`
 - Installing deprecated or disabled formulae
 - Macs using OpenCore Legacy Patcher with an Intel CPU older than Westmere

--- a/docs/Support-Tiers.md
+++ b/docs/Support-Tiers.md
@@ -95,6 +95,7 @@ Tier 3 configurations include:
 - macOS versions no longer covered by CI and no longer receiving regular Apple security updates
 - Systems that build official packages from source despite available bottles
 - Homebrew installed outside the default prefix (e.g. `/opt/homebrew`, `/usr/local`, or `/home/linuxbrew/.linuxbrew` used on mismatched architectures)
+- Homebrew installations managed by Nix e.g. nix-darwin or nix-homebrew
 - Installing formulae using `--HEAD`
 - Installing deprecated or disabled formulae
 - Macs using OpenCore Legacy Patcher with an Intel CPU older than Westmere


### PR DESCRIPTION
We've had a few issues in last wee while coming from Nix due to how they handle Homebrew in an unsupported fashion (e.g. https://github.com/Homebrew/brew/issues/22174). We have no desire to intentionally break things there but we should make clear that users Homebrew through Nix should file their issues with the upstream instead.

- Direct Nix-managed crash reports to upstream Nix projects.
- Treat `nix-homebrew` markers as Tier 3 for `brew doctor`.
- Document Nix-managed Homebrew in `Support-Tiers.md`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local tweaking.

-----
