### PR TITLE
exceptions: hint when a download is HTML, not a binary

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -951,6 +951,7 @@ class ChecksumMismatchError < RuntimeError
 
     <<~EOS
 
+
       Note: the downloaded file looks like HTML, not the expected binary.
       The server may have returned a bot-protection challenge (e.g. Anubis,
       Cloudflare), a rate-limit page or an error page instead of the artifact.

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -927,7 +927,37 @@ class ChecksumMismatchError < RuntimeError
       Expected: #{Formatter.success(expected.to_s)}
         Actual: #{Formatter.error(actual.to_s)}
           File: #{path}
-      To retry an incomplete download, remove the file above.
+      To retry an incomplete download, remove the file above.#{ChecksumMismatchError.html_hint(path)}
+    EOS
+  end
+
+  # Detect downloads that are HTML pages (bot-protection challenges, rate-limit
+  # or error pages served as `text/html`) rather than the expected binary
+  # artifact. Returns an extra hint for the error message, or an empty string.
+  sig { params(path: T.any(Pathname, String)).returns(String) }
+  def self.html_hint(path)
+    return "" unless path.is_a?(Pathname)
+    return "" unless path.file?
+
+    head = path.binread(512).to_s
+    return "" unless head.match?(/\A\s*(?:<!doctype\s+html|<html|<\?xml[^>]*\?>\s*<html)/i)
+
+    rm_command = if path.to_s.start_with?("#{HOMEBREW_CACHE}/")
+      relative = path.relative_path_from(HOMEBREW_CACHE)
+      %Q(rm "$(brew --cache)/#{relative}")
+    else
+      %Q(rm "#{path}")
+    end
+
+    <<~EOS
+
+      Note: the downloaded file looks like HTML, not the expected binary.
+      The server may have returned a bot-protection challenge (e.g. Anubis,
+      Cloudflare), a rate-limit page or an error page instead of the artifact.
+      Delete the cached file and re-run the same command to retry:
+        #{rm_command}
+      If it keeps happening, try later or from a different network — the
+      upstream URL or mirror may be broken.
     EOS
   end
 end

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -956,6 +956,8 @@ class ChecksumMismatchError < RuntimeError
       error page instead. Delete the file and retry:
         #{rm_command}
     EOS
+  rescue SystemCallError
+    ""
   end
 end
 

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -951,14 +951,10 @@ class ChecksumMismatchError < RuntimeError
 
     <<~EOS
 
-
-      Note: the downloaded file looks like HTML, not the expected binary.
-      The server may have returned a bot-protection challenge (e.g. Anubis,
-      Cloudflare), a rate-limit page or an error page instead of the artifact.
-      Delete the cached file and re-run the same command to retry:
+      The start of the downloaded file is HTML/XML, not a binary.
+      The server may have returned a bot-protection, rate-limit or
+      error page instead. Delete the file and retry:
         #{rm_command}
-      If it keeps happening, try later or from a different network — the
-      upstream URL or mirror may be broken.
     EOS
   end
 end

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe "Exception" do
         file.write("PK\x03\x04binary-content")
         file.flush
         message = described_class.new(Pathname(file.path), expected_checksum, actual_checksum).to_s
-        expect(message).not_to match(/looks like HTML/)
+        expect(message).not_to match(%r{HTML/XML})
       end
     end
 
@@ -250,7 +250,7 @@ RSpec.describe "Exception" do
         file.write('<!doctype html><html lang="en"><head><title>Oh noes!</title>')
         file.flush
         message = described_class.new(Pathname(file.path), expected_checksum, actual_checksum).to_s
-        expect(message).to match(/looks like HTML/)
+        expect(message).to match(%r{HTML/XML, not a binary})
       end
     end
   end

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -233,6 +233,26 @@ RSpec.describe "Exception" do
     let(:actual_checksum) { instance_double(Checksum, to_s: "deadcafe") }
 
     it(:to_s) { expect(error.to_s).to match(/SHA-256 mismatch/) }
+
+    it "does not add an HTML hint for non-HTML downloads" do
+      Tempfile.create("brew-checksum-test") do |file|
+        file.binmode
+        file.write("PK\x03\x04binary-content")
+        file.flush
+        message = described_class.new(Pathname(file.path), expected_checksum, actual_checksum).to_s
+        expect(message).not_to match(/looks like HTML/)
+      end
+    end
+
+    it "adds an HTML hint when the download is an HTML page" do
+      Tempfile.create("brew-checksum-test") do |file|
+        file.binmode
+        file.write('<!doctype html><html lang="en"><head><title>Oh noes!</title>')
+        file.flush
+        message = described_class.new(Pathname(file.path), expected_checksum, actual_checksum).to_s
+        expect(message).to match(/looks like HTML/)
+      end
+    end
   end
 
   describe ResourceMissingError do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change? *(searched open + closed PRs for "checksum HTML"; none found.)*
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? *(see Summary below; motivated by [discussion #6837](https://github.com/orgs/Homebrew/discussions/6837).)*
- [x] Have you written new tests (excluding integration tests) for your changes? *(two new specs in `Library/Homebrew/test/exceptions_spec.rb`: one verifying the hint appears for an HTML download, one verifying it does **not** appear for a non-HTML download. Additionally, I rendered the message manually via `./bin/brew ruby` against both an HTML and a binary tempfile to verify the formatting.)*
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally? *(`./bin/brew lgtm`: typecheck clean, RuboCop clean, all changed-file specs pass.)*

-----

- [x] AI was used to generate or assist with generating this PR.

  Claude (Anthropic, Opus 4.7) was used as a coding assistant to:
  - locate the existing `ChecksumMismatchError` and `Pathname#verify_checksum` code paths,
  - draft the HTML-detection helper, the message wording, and the new specs,
  - iterate on the wording and run `brew lgtm`.

  Manual review and verification I performed:
  - Read the modified `Library/Homebrew/exceptions.rb` and `Library/Homebrew/test/exceptions_spec.rb` end-to-end.
  - Adjusted the message text and chose the `rm "$(brew --cache)/..."` form so the user gets a copy-pasteable command instead of a long absolute path with their home directory.
  - Verified the magic-byte regex matches the real-world failure shape from #6837 (`<!doctype html`, `<html`, and the `<?xml ... ?><html` shape) and ran the error class manually through `./bin/brew ruby` to inspect the rendered message for both an HTML and a non-HTML cached file.
  - Confirmed the original `ChecksumMismatchError` message is unchanged for non-HTML downloads — the hint is appended only when the magic-byte check matches — so existing behaviour and existing assertions are preserved.
  - Ran `./bin/brew lgtm` after every change.

  No other AI-assisted PRs from me are open.

-----

## Summary

When a download URL silently returns an HTML page (a bot-protection challenge such as Anubis or Cloudflare, a rate-limit page, or an error page served as `text/html`) instead of the expected binary artifact, `ChecksumMismatchError` is raised with no clue that no real download happened. This points users toward investigating cask version drift or filing a stale-checksum PR — when in fact no real download happened at all.

This change detects HTML in the first 512 bytes of the downloaded file and appends a dedicated hint to the existing checksum-mismatch message, including a copy-pasteable `rm "$(brew --cache)/..."` command for retrying. The original error path is unchanged for non-HTML downloads.

The same code path (`Pathname#verify_checksum` → `ChecksumMismatchError`) is shared by cask, formula, bottle and resource downloads, so all of them benefit.

Discussion / motivation: https://github.com/orgs/Homebrew/discussions/6837 (real-world `mactex` example with a CTAN mirror serving an Anubis challenge page).

## Example output

Before:
```
Error: SHA-256 mismatch
Expected: e30af0640f51979a95b9f54084456d1e16749b79e12e65bdebd630fb2795ff1e
  Actual: 5df46a658a5c780eba5f7dd908284c974500e0ea3266708451f24803c6ceee4f
    File: /Users/you/Library/Caches/Homebrew/downloads/abc--mactex.pkg
To retry an incomplete download, remove the file above.
```

After (only when the file content looks like HTML):
```
Error: SHA-256 mismatch
Expected: e30af0640f51979a95b9f54084456d1e16749b79e12e65bdebd630fb2795ff1e
  Actual: 5df46a658a5c780eba5f7dd908284c974500e0ea3266708451f24803c6ceee4f
    File: /Users/you/Library/Caches/Homebrew/downloads/abc--mactex.pkg
To retry an incomplete download, remove the file above.

Note: the downloaded file looks like HTML, not the expected binary.
The server may have returned a bot-protection challenge (e.g. Anubis,
Cloudflare), a rate-limit page or an error page instead of the artifact.
Delete the cached file and re-run the same command to retry:
  rm "$(brew --cache)/downloads/abc--mactex.pkg"
If it keeps happening, try later or from a different network — the
upstream URL or mirror may be broken.
```