### PR TITLE
Align cask macOS dependencies

### DIFF
--- a/Library/Homebrew/api/cask/cask_struct_generator.rb
+++ b/Library/Homebrew/api/cask/cask_struct_generator.rb
@@ -110,6 +110,8 @@ module Homebrew
             next [key, :any] if version_symbol.blank?
 
             version_symbol = MacOSVersion::SYMBOLS.key(version_symbol)
+            next [key, version_symbol] if dep_type.to_sym == :>= && version_symbol
+
             version_dep = "#{dep_type} :#{version_symbol}" if version_symbol
             [key, version_dep]
           end.compact

--- a/Library/Homebrew/cask/dsl/depends_on.rb
+++ b/Library/Homebrew/cask/dsl/depends_on.rb
@@ -71,27 +71,8 @@ module Cask
       def macos=(*args)
         raise "Only a single 'depends_on macos' is allowed." if @macos
 
-        # workaround for https://github.com/sorbet/sorbet/issues/6860
-        first_arg = args.first
-        first_arg_s = first_arg&.to_s
-
         begin
-          @macos = if first_arg == :any
-            MacOSRequirement.new
-          elsif args.count > 1
-            MacOSRequirement.new([args], comparator: "==")
-          elsif first_arg.is_a?(Symbol) && MacOSVersion::SYMBOLS.key?(first_arg)
-            MacOSRequirement.new([args.first], comparator: "==")
-          elsif (md = /^\s*(?<comparator><|>|[=<>]=)\s*:(?<version>\S+)\s*$/.match(first_arg_s))
-            # The named capture groups must exist, so we use T.must to assert that they do.
-            MacOSRequirement.new([T.must(md[:version]).to_sym], comparator: T.must(md[:comparator]))
-          elsif (md = /^\s*(?<comparator><|>|[=<>]=)\s*(?<version>\S+)\s*$/.match(first_arg_s))
-            # The named capture groups must exist, so we use T.must to assert that they do.
-            MacOSRequirement.new([md[:version]], comparator: T.must(md[:comparator]))
-          # This is not duplicate of the first case: see `args.first` and a different comparator.
-          else # rubocop:disable Lint/DuplicateBranch
-            MacOSRequirement.new([args.first], comparator: "==")
-          end
+          @macos = MacOSRequirement.parse(args, comparator: ">=")
         rescue MacOSVersion::Error, TypeError => e
           raise "invalid 'depends_on macos' value: #{e}"
         end

--- a/Library/Homebrew/requirements/macos_requirement.rb
+++ b/Library/Homebrew/requirements/macos_requirement.rb
@@ -28,6 +28,29 @@ class MacOSRequirement < Requirement
   ].freeze, T::Array[Symbol])
   DEPRECATED_MACOS_VERSIONS = T.let([].freeze, T::Array[Symbol])
 
+  sig { params(args: T::Array[T.any(String, Symbol)], comparator: String).returns(MacOSRequirement) }
+  def self.parse(args, comparator:)
+    first_arg = args.first
+    first_arg_s = first_arg&.to_s
+
+    if first_arg == :any
+      new
+    elsif args.count > 1
+      new([args], comparator: "==")
+    elsif first_arg.is_a?(Symbol) && MacOSVersion::SYMBOLS.key?(first_arg)
+      new([first_arg], comparator:)
+    elsif (md = /^\s*(?<comparator><|>|[=<>]=)\s*:(?<version>\S+)\s*$/.match(first_arg_s))
+      # odeprecated "string comparison format for `depends_on macos:`"
+      new([T.must(md[:version]).to_sym], comparator: T.must(md[:comparator]))
+    elsif (md = /^\s*(?<comparator><|>|[=<>]=)\s*(?<version>\S+)\s*$/.match(first_arg_s))
+      # odeprecated "string comparison format for `depends_on macos:`"
+      new([md[:version]], comparator: T.must(md[:comparator]))
+    else
+      # odeprecated "strict symbol format for `depends_on macos:`"
+      new([first_arg], comparator: "==")
+    end
+  end
+
   sig { params(tags: T.untyped, comparator: String).void }
   def initialize(tags = [], comparator: ">=")
     @version = T.let(begin

--- a/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
+++ b/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Homebrew::API::Cask::CaskStructGenerator do
     specify :aggregate_failures do
       expect(described_class.process_depends_on(depends_on_non_macos)).to eq({ arch: :intel, formula: ["foo"] })
       expect(described_class.process_depends_on(depends_on_macos_equals)).to eq({ macos: [:sequoia] })
-      expect(described_class.process_depends_on(depends_on_macos_greater)).to eq({ macos: ">= :sequoia" })
+      expect(described_class.process_depends_on(depends_on_macos_greater)).to eq({ macos: :sequoia })
       expect(described_class.process_depends_on(depends_on_macos_bare)).to eq({ macos: :any })
       expect(described_class.process_depends_on({ macos: {} })).to eq({ macos: :any })
     end

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -449,6 +449,14 @@ RSpec.describe Cask::DSL, :cask, :no_api do
       end
     end
 
+    context "when a symbol is used" do
+      let(:token) { "with-depends-on-macos-symbol" }
+
+      it "creates a minimum MacOSRequirement" do
+        expect(cask.depends_on.macos).to eq(MacOSRequirement.new([MacOS.version.to_sym], comparator: ">="))
+      end
+    end
+
     context "when the depends_on macos value is invalid" do
       let(:token) { "invalid-depends-on-macos-bad-release" }
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-failure.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-failure.rb
@@ -14,7 +14,7 @@ cask "with-depends-on-macos-failure" do
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
   homepage "https://brew.sh/with-depends-on-macos-failure"
 
-  depends_on macos: :monterey
+  depends_on macos: "== :monterey"
 
   app "Caffeine.app"
 end

--- a/docs/Adding-Software-to-Homebrew.md
+++ b/docs/Adding-Software-to-Homebrew.md
@@ -139,7 +139,7 @@ cask "fabfilter-one" do
     end
   end
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   pkg "FabFilter One #{version} Installer.pkg"
 

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -369,29 +369,30 @@ depends_on formula: "unar"
 
 #### `depends_on` *macos*
 
-##### Requiring an exact macOS release
+##### Setting a minimum macOS release
 
-The value for `depends_on macos:` may be a symbol or an array of symbols, listing the exact compatible macOS releases. The values for supported macOS releases can be found in the [`MacOSVersion` class](/rubydoc/MacOSVersion.html) documentation.
+The value for `depends_on macos:` may be a symbol listing the minimum compatible macOS release. The values for supported macOS releases can be found in the [`MacOSVersion` class](/rubydoc/MacOSVersion.html) documentation.
 
-Only major releases are covered (10.x numbers containing a single dot or whole numbers since macOS 11). The symbol form is used for readability. The following are all valid ways to enumerate the exact macOS release requirements for a cask:
+Only major releases are covered (10.x numbers containing a single dot or whole numbers since macOS 11). The symbol form is used for readability:
 
 ```ruby
 depends_on macos: :big_sur
-depends_on macos: [
-  :catalina,
-  :big_sur,
-]
 ```
 
-##### Setting a minimum macOS release
-
-`depends_on macos:` can also accept a string starting with a comparison operator such as `>=`, followed by a macOS release in the form above. The following is a valid expression meaning “at least macOS Big Sur (11.0)”:
+`depends_on macos:` still accepts a string starting with a comparison operator such as `>=`, followed by a macOS release in the form above. The following is a valid expression meaning “at least macOS Big Sur (11.0)”:
 
 ```ruby
 depends_on macos: ">= :big_sur"
 ```
 
-A comparison expression cannot be combined with any other form of `depends_on macos:`.
+Use `==` in the string form only when a cask must run on one exact macOS release. An array of symbols is also accepted when a cask must run on one of an exact set of macOS releases:
+
+```ruby
+depends_on macos: [
+  :catalina,
+  :big_sur,
+]
+```
 
 #### `depends_on` *arch*
 


### PR DESCRIPTION
- Use formula-style symbols for cask minimum macOS requirements.
- Keep comparison strings accepted during migration.
- Add style autocorrection and cookbook updates.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local testing and review.

-----
