### PR TITLE
Track macOS support explicitly

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -209,10 +209,15 @@ module Cask
 
     sig { returns(T::Boolean) }
     def supports_linux?
-      return true if font?
+      return false if depends_on.requires_macos?
 
-      # Bare `depends_on :macos` explicitly marks a cask as macOS-only
-      return false if (macos_requirement = depends_on.macos) && !macos_requirement.version_specified?
+      if depends_on.macos_set_in_block?
+        return false if contains_os_specific_artifacts?
+
+        return true
+      end
+
+      return true if font?
 
       # Cache the os value before contains_os_specific_artifacts? refreshes the cask
       # (the refresh clears @dsl.os in generic/non-OS-specific contexts)
@@ -228,6 +233,11 @@ module Cask
         Artifact::MACOS_ONLY_ARTIFACTS.include?(a.class) ||
           (a.is_a?(Artifact::Installer) && a.manual_install)
       end
+    end
+
+    sig { returns(T::Boolean) }
+    def supports_macos?
+      true
     end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -579,6 +579,10 @@ module Cask
     def depends_on(arg = nil, **kwargs)
       @depends_on_set_in_block = true if @called_in_on_system_block
       if arg == :macos
+        if kwargs.key?(:macos)
+          raise CaskInvalidError.new(cask, "`depends_on :macos` cannot be combined with another macOS `depends_on`")
+        end
+
         kwargs[:macos] = :any
       elsif arg
         raise CaskInvalidError.new(cask, "invalid 'depends_on' value: #{arg.inspect}")
@@ -586,7 +590,7 @@ module Cask
       return @depends_on if kwargs.empty?
 
       begin
-        @depends_on.load(**kwargs)
+        @depends_on.load(kwargs, set_in_block: @called_in_on_system_block)
       rescue RuntimeError => e
         raise CaskInvalidError.new(cask, e)
       end
@@ -596,7 +600,7 @@ module Cask
     # @api private
     sig { void }
     def add_implicit_macos_dependency
-      return if (cask_depends_on = @depends_on).present? && cask_depends_on.macos.present?
+      return if @depends_on.os_support_specified?
       return if @cask.supports_linux?
 
       depends_on macos: ">= #{MacOSVersion.new(HOMEBREW_MACOS_OLDEST_ALLOWED).to_sym.inspect}"

--- a/Library/Homebrew/cask/dsl/depends_on.rb
+++ b/Library/Homebrew/cask/dsl/depends_on.rb
@@ -36,6 +36,9 @@ module Cask
         @cask = T.let(nil, T.nilable(T::Array[String]))
         @formula = T.let(nil, T.nilable(T::Array[String]))
         @macos = T.let(nil, T.nilable(MacOSRequirement))
+        @macos_set_in_block = T.let(false, T::Boolean)
+        @macos_bare_set_top_level = T.let(false, T::Boolean)
+        @macos_version_set_top_level = T.let(false, T::Boolean)
       end
 
       sig { returns(T::Array[String]) }
@@ -48,12 +51,18 @@ module Cask
         @formula ||= []
       end
 
-      sig { params(pairs: T::Hash[Symbol, T.any(String, Symbol, T::Array[T.any(String, Symbol)])]).void }
-      def load(pairs)
+      sig {
+        params(
+          pairs:        T::Hash[Symbol, T.any(String, Symbol, T::Array[T.any(String, Symbol)])],
+          set_in_block: T::Boolean,
+        ).void
+      }
+      def load(pairs, set_in_block: false)
         pairs.each do |key, value|
           raise "invalid depends_on key: '#{key.inspect}'" unless VALID_KEYS.include?(key)
 
           __getobj__[key] = send(:"#{key}=", *value)
+          record_os_requirement(key, set_in_block:)
         end
       end
 
@@ -95,6 +104,37 @@ module Cask
 
       sig { returns(T::Boolean) }
       def present? = !empty?
+
+      sig { returns(T::Boolean) }
+      def requires_macos?
+        @macos_bare_set_top_level || @macos_version_set_top_level
+      end
+
+      sig { returns(T::Boolean) }
+      def macos_set_in_block? = @macos_set_in_block
+
+      sig { returns(T::Boolean) }
+      def os_support_specified? = requires_macos? || macos_set_in_block?
+
+      sig { params(key: Symbol, set_in_block: T::Boolean).void }
+      def record_os_requirement(key, set_in_block:)
+        return if key != :macos
+
+        if set_in_block
+          @macos_set_in_block = true
+          return
+        end
+
+        if T.must(@macos).version_specified?
+          raise "`depends_on macos:` cannot be combined with `depends_on :macos`" if @macos_bare_set_top_level
+
+          @macos_version_set_top_level = true
+        else
+          raise "`depends_on :macos` cannot be combined with another macOS `depends_on`" if requires_macos?
+
+          @macos_bare_set_top_level = true
+        end
+      end
     end
   end
 end

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -19,6 +19,9 @@ module Cask
     extend ::Utils::Output::Mixin
     include ::Utils::Output::Mixin
 
+    sig { returns(::Cask::Cask) }
+    attr_reader :cask
+
     sig {
       params(
         cask: ::Cask::Cask, command: T.class_of(SystemCommand), force: T::Boolean, adopt: T::Boolean,

--- a/Library/Homebrew/extend/os/linux/cask/installer.rb
+++ b/Library/Homebrew/extend/os/linux/cask/installer.rb
@@ -11,7 +11,7 @@ module OS
 
         sig { void }
         def check_stanza_os_requirements
-          return if artifacts.all? { |artifact| supported_artifact?(artifact) }
+          return if !cask.depends_on.requires_macos? && artifacts.all? { |artifact| supported_artifact?(artifact) }
 
           raise ::Cask::CaskError, "macOS is required for this software."
         end

--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -48,7 +48,7 @@ module OS
 
       sig { returns(T::Boolean) }
       def valid_platform?
-        requirements.none? { |r| r.is_a?(MacOSRequirement) && !r.version_specified? }
+        supports_linux?
       end
     end
   end

--- a/Library/Homebrew/extend/os/mac/formula.rb
+++ b/Library/Homebrew/extend/os/mac/formula.rb
@@ -10,7 +10,7 @@ module OS
 
       sig { returns(T::Boolean) }
       def valid_platform?
-        requirements.none?(LinuxRequirement)
+        supports_macos?
       end
 
       sig {

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2619,7 +2619,19 @@ class Formula
   # Redefined in `extend/os`.
   sig { returns(T::Boolean) }
   def valid_platform?
-    requirements.none?(MacOSRequirement) && requirements.none?(LinuxRequirement)
+    supports_macos? && supports_linux?
+  end
+
+  sig { returns(T::Boolean) }
+  def supports_macos?
+    requirements.none?(LinuxRequirement)
+  end
+
+  sig { returns(T::Boolean) }
+  def supports_linux?
+    return false if active_spec.depends_on_macos_set_top_level?
+
+    requirements.none? { |r| r.is_a?(MacOSRequirement) && !r.version_specified? }
   end
 
   sig { params(options: T::Hash[Symbol, String]).void }
@@ -4334,7 +4346,8 @@ class Formula
     # @api public
     sig { params(dep: T.any(String, Symbol, T::Hash[T.any(String, Symbol, T::Class[Requirement]), T.untyped], T::Class[Requirement])).void }
     def depends_on(dep)
-      specs.each { |spec| spec.depends_on(dep) }
+      set_in_block = instance_variable_get(:@called_in_on_system_block) == true
+      specs.each { |spec| spec.depends_on(dep, set_in_block:) }
     end
 
     # Indicates use of dependencies provided by macOS.

--- a/Library/Homebrew/rubocops/cask/no_overrides.rb
+++ b/Library/Homebrew/rubocops/cask/no_overrides.rb
@@ -74,7 +74,8 @@ module RuboCop
                    send_node.arguments.first.pairs.any? { |a| a.key.value == :macos } &&
                    OnSystemConditionalsHelper::ON_SYSTEM_OPTIONS.map do |m|
                      :"on_#{m}"
-                   end.include?(T.cast(node, RuboCop::AST::BlockNode).method_name) && !allow_macos_depends_in_blocks
+                   end.include?(T.cast(node, RuboCop::AST::BlockNode).method_name) &&
+                   T.cast(node, RuboCop::AST::BlockNode).method_name != :on_macos && !allow_macos_depends_in_blocks
                   # Allow `depends_on macos:` in multiple `on_{system}` blocks for architecture-specific requirements
                   add_offense(send_node.source_range, message:)
                 end

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -56,6 +56,9 @@ class SoftwareSpec
   sig { returns(T::Array[CompilerFailure]) }
   attr_reader :compiler_failures
 
+  sig { returns(T::Boolean) }
+  attr_reader :depends_on_macos_set_in_block
+
   def_delegators :@resource, :stage, :fetch, :verify_download_integrity, :source_modified_time,
                  :cached_download, :clear_cache, :checksum, :mirrors, :specs, :using, :version, :mirror,
                  :downloader, :download_queue_name, :download_queue_type
@@ -82,6 +85,9 @@ class SoftwareSpec
     @deprecated_options = T.let([], T::Array[DeprecatedOption])
     @build = T.let(BuildOptions.new(Options.create(@flags), options), BuildOptions)
     @compiler_failures = T.let([], T::Array[CompilerFailure])
+    @depends_on_macos_bare_set_top_level = T.let(false, T::Boolean)
+    @depends_on_macos_version_set_top_level = T.let(false, T::Boolean)
+    @depends_on_macos_set_in_block = T.let(false, T::Boolean)
   end
 
   sig { override.params(other: T.any(SoftwareSpec, Downloadable)).void }
@@ -234,10 +240,53 @@ class SoftwareSpec
     @build = BuildOptions.new(Options.create(@flags), options)
   end
 
-  sig { params(spec: T.any(String, Symbol, T::Hash[T.any(String, Symbol, T::Class[Requirement]), T.untyped], T::Class[Requirement], Dependable)).void }
-  def depends_on(spec)
+  sig {
+    params(
+      spec:         T.nilable(T.any(String, Symbol,
+                                    T::Hash[T.any(String, Symbol, T::Class[Requirement]), T.untyped],
+                                    T::Class[Requirement], Dependable)),
+      set_in_block: T::Boolean,
+      spec_kwargs:  T.untyped,
+    ).void
+  }
+  def depends_on(spec = nil, set_in_block: false, **spec_kwargs)
+    spec = spec_kwargs if spec.nil? && spec_kwargs.present?
     dep = dependency_collector.add(spec)
+    record_os_requirement(dep, set_in_block:)
     add_dep_option(dep) if dep
+  end
+
+  sig { returns(T::Boolean) }
+  def depends_on_macos_set_top_level?
+    @depends_on_macos_bare_set_top_level || @depends_on_macos_version_set_top_level
+  end
+
+  sig { params(dep: T.untyped, set_in_block: T::Boolean).void }
+  def record_os_requirement(dep, set_in_block:)
+    return unless dep.is_a?(MacOSRequirement)
+
+    if set_in_block
+      @depends_on_macos_set_in_block = true
+      return
+    end
+
+    if dep.version_specified?
+      if @depends_on_macos_bare_set_top_level
+        # odeprecated "`depends_on :macos` with `depends_on macos:`"
+      end
+
+      @depends_on_macos_version_set_top_level = true
+    else
+      if @depends_on_macos_bare_set_top_level
+        raise ArgumentError, "`depends_on :macos` cannot be combined with another macOS `depends_on`"
+      end
+
+      if @depends_on_macos_version_set_top_level
+        # odeprecated "`depends_on :macos` with `depends_on macos:`"
+      end
+
+      @depends_on_macos_bare_set_top_level = true
+    end
   end
 
   sig {

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -581,8 +581,25 @@ RSpec.describe Cask::Cask, :cask do
   end
 
   describe "#supports_linux?" do
-    it "returns false for casks with bare depends_on :macos" do
+    it "uses explicit macOS dependencies before falling back to heuristics" do
       expect(Cask::CaskLoader.load("with-depends-on-macos-bare").supports_linux?).to be false
+      expect(Cask::CaskLoader.load("with-depends-on-macos-in-on-macos").supports_linux?).to be true
+
+      macos_artifact_cask = described_class.new("scoped-macos-dependency-with-app") do
+        version "1.0"
+        sha256 "bbbb"
+
+        url "https://brew.sh/test.zip"
+        homepage "https://brew.sh"
+
+        on_macos do
+          depends_on macos: :catalina
+        end
+
+        app "Test.app"
+      end
+
+      expect(macos_artifact_cask.supports_linux?).to be false
     end
 
     it "reflects whether the cask has only platform-agnostic artifacts" do

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -472,6 +472,14 @@ RSpec.describe Cask::DSL, :cask, :no_api do
         expect { cask }.to raise_error(Cask::CaskInvalidError)
       end
     end
+
+    context "when bare macOS and a macOS version are used" do
+      let(:token) { "invalid-depends-on-macos-bare-and-version" }
+
+      it "refuses to load" do
+        expect { cask }.to raise_error(Cask::CaskInvalidError)
+      end
+    end
   end
 
   describe "depends_on arch" do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -2092,6 +2092,51 @@ RSpec.describe Formula do
     end
   end
 
+  describe "OS support" do
+    it "returns false for Linux when macOS is required at the top level" do
+      f = formula do
+        url "foo"
+        version "1.0"
+        depends_on macos: :catalina
+      end
+
+      expect(f.supports_linux?).to be false
+    end
+
+    it "returns true for Linux when macOS is required in an on_macos block" do
+      f = formula do
+        url "foo"
+        version "1.0"
+        on_macos do
+          depends_on macos: :catalina
+        end
+      end
+
+      expect(f.supports_linux?).to be true
+    end
+
+    it "returns false for macOS when Linux is required at the top level" do
+      f = formula do
+        url "foo"
+        version "1.0"
+        depends_on :linux
+      end
+
+      expect(f.supports_macos?).to be false
+    end
+
+    it "allows bare and versioned macOS requirements for now" do
+      f = formula do
+        url "foo"
+        version "1.0"
+        depends_on :macos
+        depends_on macos: :catalina
+      end
+
+      expect(f.requirements.grep(MacOSRequirement).count).to eq(2)
+    end
+  end
+
   describe "#on_macos", :needs_macos do
     let(:f) do
       Class.new(Testball) do

--- a/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
@@ -25,6 +25,16 @@ RSpec.describe RuboCop::Cop::Cask::NoOverrides, :config do
     CASK
   end
 
+  it "accepts `depends_on macos:` in `on_macos` blocks" do
+    expect_no_offenses <<~CASK
+      cask 'foo' do
+        on_macos do
+          depends_on macos: :catalina
+        end
+      end
+    CASK
+  end
+
   it "accepts non-overridable stanzas in `on_*` blocks" do
     expect_no_offenses <<~CASK
       cask 'foo' do

--- a/Library/Homebrew/test/software_spec_spec.rb
+++ b/Library/Homebrew/test/software_spec_spec.rb
@@ -118,6 +118,11 @@ RSpec.describe SoftwareSpec do
       expect(spec.deps.first.name).to eq("foo")
     end
 
+    it "allows specifying requirements with keyword syntax" do
+      spec.depends_on macos: :sonoma
+      expect(spec.requirements.first).to eq(MacOSRequirement.new([:sonoma]))
+    end
+
     it "allows specifying optional dependencies" do
       spec.depends_on "foo" => :optional
       expect(spec).to have_defined_option("with-foo")

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-bare-and-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-bare-and-version.rb
@@ -1,0 +1,14 @@
+# typed: false
+
+cask "invalid-depends-on-macos-bare-and-version" do
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/invalid-depends-on-macos-bare-and-version"
+
+  depends_on :macos
+  depends_on macos: :monterey
+
+  app "Caffeine.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-in-on-macos.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-in-on-macos.rb
@@ -1,0 +1,15 @@
+# typed: false
+
+cask "with-depends-on-macos-in-on-macos" do
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/with-depends-on-macos-in-on-macos"
+
+  on_macos do
+    depends_on macos: :monterey
+  end
+
+  binary "caffeine"
+end

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -371,7 +371,7 @@ depends_on formula: "unar"
 
 ##### Setting a minimum macOS release
 
-The value for `depends_on macos:` may be a symbol listing the minimum compatible macOS release. The values for supported macOS releases can be found in the [`MacOSVersion` class](/rubydoc/MacOSVersion.html) documentation.
+Top-level `depends_on :macos` marks a cask as macOS-only. Top-level `depends_on macos:` marks a cask as macOS-only and declares the minimum compatible macOS release. The values for supported macOS releases can be found in the [`MacOSVersion` class](/rubydoc/MacOSVersion.html) documentation.
 
 Only major releases are covered (10.x numbers containing a single dot or whole numbers since macOS 11). The symbol form is used for readability:
 
@@ -392,6 +392,14 @@ depends_on macos: [
   :catalina,
   :big_sur,
 ]
+```
+
+For a cask that supports both macOS and Linux but needs a specific macOS version, put the macOS version requirement inside `on_macos`:
+
+```ruby
+on_macos do
+  depends_on macos: :big_sur
+end
 ```
 
 #### `depends_on` *arch*
@@ -1274,7 +1282,7 @@ cask "calibre" do
 end
 ```
 
-Such `on_<system>` blocks can be nested and contain other stanzas not listed here. However, they should not contain `depends_on macos:` stanzas, which should occur once below the `on_<system>` blocks and encompass all releases listed in the cask. Examples: [calhash.rb](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/c/calhash.rb), [r.rb](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/r/r.rb), [wireshark.rb](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/w/wireshark.rb)
+Such `on_<system>` blocks can be nested and contain other stanzas not listed here. However, version-specific macOS requirements should be placed in `on_macos` blocks rather than individual macOS release blocks. Examples: [calhash.rb](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/c/calhash.rb), [r.rb](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/r/r.rb), [wireshark.rb](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/w/wireshark.rb)
 
 ### Switch between languages or regions
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -152,6 +152,8 @@ A `String` (e.g. `"jpeg"`) specifies a formula dependency.
 
 A `Symbol` (e.g. `:xcode`) specifies a [`Requirement`](/rubydoc/Requirement.html) to restrict installation to systems meeting certain criteria, which can be fulfilled by one or more formulae, casks or other system-wide installed software (e.g. Xcode). Some [`Requirement`](/rubydoc/Requirement.html)s can also take a string or symbol specifying their minimum version that the formula depends on.
 
+Top-level `depends_on :macos` marks a formula as macOS-only. Top-level `depends_on macos: :sonoma` marks a formula as macOS-only and declares the minimum compatible macOS release. For a formula that supports both macOS and Linux but needs a specific macOS version, put the macOS version requirement inside `on_macos`.
+
 A `Hash` (e.g. `=>`) adds information to a dependency. Given a string or symbol, the value can be one or more of the following values:
 
 * `:build` means this is a build-time only dependency so it can be skipped when installing from a bottle or when listing missing dependencies using `brew missing`.


### PR DESCRIPTION
- Treat top-level macOS requirements as macOS-only.
- Preserve existing `:macos` plus `macos:` formulae for release safety.

----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local testing and review.

-----