### PR TITLE
Dockerfile: set `HOMEBREW_*` variables

### DIFF
--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -27,15 +27,10 @@ brew tap --force homebrew/core
 
 # install some useful development things
 sudo apt-get update
-
-apt_get_install() {
-  sudo apt-get install -y \
-    -o Dpkg::Options::=--force-confdef \
-    -o Dpkg::Options::=--force-confnew \
-    "$@"
-}
-
-apt_get_install \
+sudo apt-get install -y \
+  -o Dpkg::Options::=--force-confdef \
+  -o Dpkg::Options::=--force-confnew \
+  bash-completion \
   openssh-server \
   zsh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 USER linuxbrew
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}" \
+  HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew \
+  HOMEBREW_CELLAR=/home/linuxbrew/.linuxbrew/Cellar \
+  HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew \
   XDG_CACHE_HOME=/home/linuxbrew/.cache
 WORKDIR /home/linuxbrew
 


### PR DESCRIPTION
This matches what `brew shellenv` prints and make shell completions work in containers (and codespaces). Evaluating `brew shellenv` does not work because `brew shellenv` detects that `PATH` is already correctly set and thus exits without printing anything.

I don't think `MANPATH` and `INFOPATH` (which are also printed by `brew shellenv`) are needed in the Dockerfile because `man` and `info` are not installed in the image.

Also, while we're here, install bash-completion in codespaces, which gives codespace users a better shell completion experience.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
