### PR TITLE
Add Linux OS dependencies

### DIFF
--- a/Library/Homebrew/api/cask/cask_struct_generator.rb
+++ b/Library/Homebrew/api/cask/cask_struct_generator.rb
@@ -92,6 +92,7 @@ module Homebrew
 
               next [:arch, :arm64]
             end
+            next [key, :any] if key == :linux
 
             next [key, value] if key != :macos
 

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -209,6 +209,7 @@ module Cask
 
     sig { returns(T::Boolean) }
     def supports_linux?
+      return true if depends_on.requires_linux?
       return false if depends_on.requires_macos?
 
       if depends_on.macos_set_in_block?
@@ -237,6 +238,8 @@ module Cask
 
     sig { returns(T::Boolean) }
     def supports_macos?
+      return false if depends_on.requires_linux?
+
       true
     end
 

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -584,6 +584,8 @@ module Cask
         end
 
         kwargs[:macos] = :any
+      elsif arg == :linux
+        kwargs[:linux] = :any
       elsif arg
         raise CaskInvalidError.new(cask, "invalid 'depends_on' value: #{arg.inspect}")
       end

--- a/Library/Homebrew/cask/dsl/depends_on.rb
+++ b/Library/Homebrew/cask/dsl/depends_on.rb
@@ -4,6 +4,7 @@
 require "delegate"
 
 require "requirements/macos_requirement"
+require "requirements/linux_requirement"
 
 module Cask
   class DSL
@@ -13,6 +14,7 @@ module Cask
         :formula,
         :cask,
         :macos,
+        :linux,
         :arch,
       ]).freeze, T::Set[Symbol])
 
@@ -29,6 +31,9 @@ module Cask
       sig { returns(T.nilable(MacOSRequirement)) }
       attr_reader :macos
 
+      sig { returns(T.nilable(LinuxRequirement)) }
+      attr_reader :linux
+
       sig { void }
       def initialize
         super({})
@@ -36,9 +41,11 @@ module Cask
         @cask = T.let(nil, T.nilable(T::Array[String]))
         @formula = T.let(nil, T.nilable(T::Array[String]))
         @macos = T.let(nil, T.nilable(MacOSRequirement))
+        @linux = T.let(nil, T.nilable(LinuxRequirement))
         @macos_set_in_block = T.let(false, T::Boolean)
         @macos_bare_set_top_level = T.let(false, T::Boolean)
         @macos_version_set_top_level = T.let(false, T::Boolean)
+        @linux_set_top_level = T.let(false, T::Boolean)
       end
 
       sig { returns(T::Array[String]) }
@@ -87,6 +94,14 @@ module Cask
         end
       end
 
+      sig { params(args: T.any(String, Symbol)).returns(T.nilable(LinuxRequirement)) }
+      def linux=(*args)
+        raise "Only a single 'depends_on linux' is allowed." if @linux
+        raise "invalid 'depends_on linux' value: #{args.first.inspect}" if args.first != :any
+
+        @linux = LinuxRequirement.new
+      end
+
       sig { params(args: Symbol).returns(T::Array[T::Hash[Symbol, T.any(Symbol, Integer)]]) }
       def arch=(*args)
         @arch ||= []
@@ -111,19 +126,35 @@ module Cask
       end
 
       sig { returns(T::Boolean) }
+      def requires_linux? = @linux_set_top_level
+
+      sig { returns(T::Boolean) }
       def macos_set_in_block? = @macos_set_in_block
 
       sig { returns(T::Boolean) }
-      def os_support_specified? = requires_macos? || macos_set_in_block?
+      def os_support_specified? = requires_macos? || requires_linux? || macos_set_in_block?
 
       sig { params(key: Symbol, set_in_block: T::Boolean).void }
       def record_os_requirement(key, set_in_block:)
-        return if key != :macos
+        case key
+        when :macos
+          record_macos_requirement(set_in_block:)
+        when :linux
+          return if set_in_block
+          raise "`depends_on :linux` cannot be combined with `depends_on macos:`" if requires_macos?
 
+          @linux_set_top_level = true
+        end
+      end
+
+      sig { params(set_in_block: T::Boolean).void }
+      def record_macos_requirement(set_in_block:)
         if set_in_block
           @macos_set_in_block = true
           return
         end
+
+        raise "`depends_on :linux` cannot be combined with `depends_on macos:`" if requires_linux?
 
         if T.must(@macos).version_specified?
           raise "`depends_on macos:` cannot be combined with `depends_on :macos`" if @macos_bare_set_top_level

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -379,7 +379,9 @@ on_request: true)
 
     sig { void }
     def check_stanza_os_requirements
-      nil
+      return if @cask.supports_macos?
+
+      raise CaskError, "Linux is required for this software."
     end
 
     sig { void }

--- a/Library/Homebrew/cask_dependent.rb
+++ b/Library/Homebrew/cask_dependent.rb
@@ -77,6 +77,7 @@ class CaskDependent
         dsl_reqs.cask.each do |cask_ref|
           requirements << CaskDependent::Requirement.new([{ cask: cask_ref }])
         end
+        requirements << dsl_reqs.linux if dsl_reqs.linux
         requirements << dsl_reqs.macos if dsl_reqs.macos
 
         requirements

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2624,11 +2624,14 @@ class Formula
 
   sig { returns(T::Boolean) }
   def supports_macos?
+    return false if active_spec.depends_on_linux_set_top_level
+
     requirements.none?(LinuxRequirement)
   end
 
   sig { returns(T::Boolean) }
   def supports_linux?
+    return true if active_spec.depends_on_linux_set_top_level
     return false if active_spec.depends_on_macos_set_top_level?
 
     requirements.none? { |r| r.is_a?(MacOSRequirement) && !r.version_specified? }

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -59,6 +59,9 @@ class SoftwareSpec
   sig { returns(T::Boolean) }
   attr_reader :depends_on_macos_set_in_block
 
+  sig { returns(T::Boolean) }
+  attr_reader :depends_on_linux_set_top_level
+
   def_delegators :@resource, :stage, :fetch, :verify_download_integrity, :source_modified_time,
                  :cached_download, :clear_cache, :checksum, :mirrors, :specs, :using, :version, :mirror,
                  :downloader, :download_queue_name, :download_queue_type
@@ -88,6 +91,7 @@ class SoftwareSpec
     @depends_on_macos_bare_set_top_level = T.let(false, T::Boolean)
     @depends_on_macos_version_set_top_level = T.let(false, T::Boolean)
     @depends_on_macos_set_in_block = T.let(false, T::Boolean)
+    @depends_on_linux_set_top_level = T.let(false, T::Boolean)
   end
 
   sig { override.params(other: T.any(SoftwareSpec, Downloadable)).void }
@@ -263,29 +267,44 @@ class SoftwareSpec
 
   sig { params(dep: T.untyped, set_in_block: T::Boolean).void }
   def record_os_requirement(dep, set_in_block:)
-    return unless dep.is_a?(MacOSRequirement)
-
-    if set_in_block
-      @depends_on_macos_set_in_block = true
-      return
-    end
-
-    if dep.version_specified?
-      if @depends_on_macos_bare_set_top_level
-        # odeprecated "`depends_on :macos` with `depends_on macos:`"
+    case dep
+    when MacOSRequirement
+      if set_in_block
+        @depends_on_macos_set_in_block = true
+        return
       end
 
-      @depends_on_macos_version_set_top_level = true
-    else
-      if @depends_on_macos_bare_set_top_level
-        raise ArgumentError, "`depends_on :macos` cannot be combined with another macOS `depends_on`"
+      if @depends_on_linux_set_top_level
+        raise ArgumentError,
+              "`depends_on :linux` cannot be combined with `depends_on macos:`"
       end
 
-      if @depends_on_macos_version_set_top_level
-        # odeprecated "`depends_on :macos` with `depends_on macos:`"
+      if dep.version_specified?
+        if @depends_on_macos_bare_set_top_level
+          # odeprecated "`depends_on :macos` with `depends_on macos:`"
+        end
+
+        @depends_on_macos_version_set_top_level = true
+      else
+        if @depends_on_macos_bare_set_top_level
+          raise ArgumentError, "`depends_on :macos` cannot be combined with another macOS `depends_on`"
+        end
+
+        if @depends_on_macos_version_set_top_level
+          # odeprecated "`depends_on :macos` with `depends_on macos:`"
+        end
+
+        @depends_on_macos_bare_set_top_level = true
+      end
+    when LinuxRequirement
+      return if set_in_block
+
+      if depends_on_macos_set_top_level?
+        raise ArgumentError,
+              "`depends_on :linux` cannot be combined with `depends_on macos:`"
       end
 
-      @depends_on_macos_bare_set_top_level = true
+      @depends_on_linux_set_top_level = true
     end
   end
 

--- a/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
+++ b/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
@@ -11,12 +11,14 @@ RSpec.describe Homebrew::API::Cask::CaskStructGenerator do
         formula: ["foo"],
       }
     end
+    let(:depends_on_linux) { { linux: LinuxRequirement.new } }
     let(:depends_on_macos_equals) { { macos: { :== => ["15"] } } }
     let(:depends_on_macos_greater) { { macos: MacOSRequirement.new([:sequoia], comparator: ">=") } }
     let(:depends_on_macos_bare) { { macos: MacOSRequirement.new([]) } }
 
     specify :aggregate_failures do
       expect(described_class.process_depends_on(depends_on_non_macos)).to eq({ arch: :intel, formula: ["foo"] })
+      expect(described_class.process_depends_on(depends_on_linux)).to eq({ linux: :any })
       expect(described_class.process_depends_on(depends_on_macos_equals)).to eq({ macos: [:sequoia] })
       expect(described_class.process_depends_on(depends_on_macos_greater)).to eq({ macos: :sequoia })
       expect(described_class.process_depends_on(depends_on_macos_bare)).to eq({ macos: :any })

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -584,6 +584,7 @@ RSpec.describe Cask::Cask, :cask do
     it "uses explicit macOS dependencies before falling back to heuristics" do
       expect(Cask::CaskLoader.load("with-depends-on-macos-bare").supports_linux?).to be false
       expect(Cask::CaskLoader.load("with-depends-on-macos-in-on-macos").supports_linux?).to be true
+      expect(Cask::CaskLoader.load("with-depends-on-linux-bare").supports_linux?).to be true
 
       macos_artifact_cask = described_class.new("scoped-macos-dependency-with-app") do
         version "1.0"
@@ -620,6 +621,12 @@ RSpec.describe Cask::Cask, :cask do
       end
 
       expect(arch_only_cask.supports_linux?).to be true
+    end
+  end
+
+  describe "#supports_macos?" do
+    it "returns false for casks with bare depends_on :linux" do
+      expect(Cask::CaskLoader.load("with-depends-on-linux-bare").supports_macos?).to be false
     end
   end
 

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -482,6 +482,24 @@ RSpec.describe Cask::DSL, :cask, :no_api do
     end
   end
 
+  describe "depends_on linux" do
+    context "when bare :linux is used" do
+      let(:token) { "with-depends-on-linux-bare" }
+
+      it "creates a LinuxRequirement" do
+        expect(cask.depends_on.linux).to be_a(LinuxRequirement)
+      end
+    end
+
+    context "when macOS and Linux are both required" do
+      let(:token) { "invalid-depends-on-macos-and-linux" }
+
+      it "refuses to load" do
+        expect { cask }.to raise_error(Cask::CaskInvalidError)
+      end
+    end
+  end
+
   describe "depends_on arch" do
     context "when valid" do
       let(:token) { "with-depends-on-arch" }

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -86,6 +86,13 @@ RSpec.describe Cask::Installer, :cask do
       end.to raise_error(/--require-sha/)
     end
 
+    it "fails to install if Linux is required" do
+      linux_cask = Cask::CaskLoader.load("with-depends-on-linux-bare")
+      expect do
+        described_class.new(linux_cask).check_stanza_os_requirements
+      end.to raise_error(Cask::CaskError, "Linux is required for this software.")
+    end
+
     it "installs fine if sha256 :no_check is used with --require-sha and --force" do
       no_checksum = Cask::CaskLoader.load(cask_path("no-checksum"))
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -2123,6 +2123,7 @@ RSpec.describe Formula do
       end
 
       expect(f.supports_macos?).to be false
+      expect(f.supports_linux?).to be true
     end
 
     it "allows bare and versioned macOS requirements for now" do
@@ -2134,6 +2135,40 @@ RSpec.describe Formula do
       end
 
       expect(f.requirements.grep(MacOSRequirement).count).to eq(2)
+    end
+
+    it "does not allow duplicate bare macOS requirements" do
+      expect do
+        formula do
+          url "foo"
+          version "1.0"
+          depends_on :macos
+          depends_on :macos
+        end
+      end.to raise_error(ArgumentError, "`depends_on :macos` cannot be combined with another macOS `depends_on`")
+    end
+
+    it "does not allow Linux then macOS requirements" do
+      expect do
+        formula do
+          url "foo"
+          version "1.0"
+          depends_on_method = :depends_on
+          public_send(depends_on_method, :linux)
+          public_send(depends_on_method, macos: :catalina)
+        end
+      end.to raise_error(ArgumentError, "`depends_on :linux` cannot be combined with `depends_on macos:`")
+    end
+
+    it "does not allow macOS then Linux requirements" do
+      expect do
+        formula do
+          url "foo"
+          version "1.0"
+          depends_on macos: :catalina
+          depends_on :linux
+        end
+      end.to raise_error(ArgumentError, "`depends_on :linux` cannot be combined with `depends_on macos:`")
     end
   end
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-and-linux.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-and-linux.rb
@@ -1,15 +1,15 @@
 # typed: false
 
-cask "invalid-depends-on-macos-bare-and-version" do
+cask "invalid-depends-on-macos-and-linux" do
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage "https://brew.sh/invalid-depends-on-macos-bare-and-version"
+  homepage "https://brew.sh/invalid-depends-on-macos-and-linux"
 
-  depends_on_arg = :macos
-  depends_on depends_on_arg
   depends_on macos: :monterey
+  depends_on_arg = :linux
+  depends_on depends_on_arg
 
   app "Caffeine.app"
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-linux-bare.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-linux-bare.rb
@@ -1,0 +1,13 @@
+# typed: false
+
+cask "with-depends-on-linux-bare" do
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/with-depends-on-linux-bare"
+
+  depends_on :linux
+
+  binary "caffeine"
+end

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -402,6 +402,10 @@ on_macos do
 end
 ```
 
+#### `depends_on` *linux*
+
+Top-level `depends_on :linux` marks a cask as Linux-only.
+
 #### `depends_on` *arch*
 
 The value for `depends_on arch:` may be a symbol or an array of symbols, listing the hardware compatibility requirements for a cask. The requirement is satisfied at install time if any one of the provided `arch:` values matches the user’s hardware.

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -152,7 +152,7 @@ A `String` (e.g. `"jpeg"`) specifies a formula dependency.
 
 A `Symbol` (e.g. `:xcode`) specifies a [`Requirement`](/rubydoc/Requirement.html) to restrict installation to systems meeting certain criteria, which can be fulfilled by one or more formulae, casks or other system-wide installed software (e.g. Xcode). Some [`Requirement`](/rubydoc/Requirement.html)s can also take a string or symbol specifying their minimum version that the formula depends on.
 
-Top-level `depends_on :macos` marks a formula as macOS-only. Top-level `depends_on macos: :sonoma` marks a formula as macOS-only and declares the minimum compatible macOS release. For a formula that supports both macOS and Linux but needs a specific macOS version, put the macOS version requirement inside `on_macos`.
+Top-level `depends_on :macos` marks a formula as macOS-only. Top-level `depends_on macos: :sonoma` marks a formula as macOS-only and declares the minimum compatible macOS release. Top-level `depends_on :linux` marks a formula as Linux-only. For a formula that supports both macOS and Linux but needs a specific macOS version, put the macOS version requirement inside `on_macos`.
 
 A `Hash` (e.g. `=>`) adds information to a dependency. Given a string or symbol, the value can be one or more of the following values:
 


### PR DESCRIPTION
- Support `depends_on :linux` for casks and formulae.
- Fast-path support checks for Linux-only software.
- Document the Linux-only dependency semantics.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local testing and review.

-----