### PR TITLE
Add maximum macOS cask deps

### DIFF
--- a/Library/Homebrew/api/cask/cask_struct_generator.rb
+++ b/Library/Homebrew/api/cask/cask_struct_generator.rb
@@ -94,7 +94,7 @@ module Homebrew
             end
             next [key, :any] if key == :linux
 
-            next [key, value] if key != :macos
+            next [key, value] unless [:macos, :maximum_macos].include?(key)
 
             value = value.to_h if value.is_a?(MacOSRequirement)
             dep_type = value.keys.first
@@ -111,7 +111,7 @@ module Homebrew
             next [key, :any] if version_symbol.blank?
 
             version_symbol = MacOSVersion::SYMBOLS.key(version_symbol)
-            next [key, version_symbol] if dep_type.to_sym == :>= && version_symbol
+            next [key, version_symbol] if [:>=, :<=].include?(dep_type.to_sym) && version_symbol
 
             version_dep = "#{dep_type} :#{version_symbol}" if version_symbol
             [key, version_dep]

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -590,10 +590,12 @@ module Cask
         begin
           OnSystem::VALID_OS_ARCH_TAGS.each do |bottle_tag|
             next if bottle_tag.linux? && dsl!.os.nil?
+
+            macos_requirements = [depends_on.macos, depends_on.maximum_macos].compact
             next if bottle_tag.macos? &&
-                    depends_on.macos &&
+                    macos_requirements.present? &&
                     !dsl!.depends_on_set_in_block? &&
-                    !depends_on.macos.allows?(bottle_tag.to_macos_version)
+                    macos_requirements.any? { |requirement| !requirement.allows?(bottle_tag.to_macos_version) }
 
             Homebrew::SimulateSystem.with_tag(bottle_tag) do
               refresh

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -579,7 +579,7 @@ module Cask
     def depends_on(arg = nil, **kwargs)
       @depends_on_set_in_block = true if @called_in_on_system_block
       if arg == :macos
-        if kwargs.key?(:macos)
+        if kwargs.key?(:macos) || kwargs.key?(:maximum_macos)
           raise CaskInvalidError.new(cask, "`depends_on :macos` cannot be combined with another macOS `depends_on`")
         end
 

--- a/Library/Homebrew/cask/dsl/depends_on.rb
+++ b/Library/Homebrew/cask/dsl/depends_on.rb
@@ -14,6 +14,7 @@ module Cask
         :formula,
         :cask,
         :macos,
+        :maximum_macos,
         :linux,
         :arch,
       ]).freeze, T::Set[Symbol])
@@ -31,6 +32,9 @@ module Cask
       sig { returns(T.nilable(MacOSRequirement)) }
       attr_reader :macos
 
+      sig { returns(T.nilable(MacOSRequirement)) }
+      attr_reader :maximum_macos
+
       sig { returns(T.nilable(LinuxRequirement)) }
       attr_reader :linux
 
@@ -41,10 +45,13 @@ module Cask
         @cask = T.let(nil, T.nilable(T::Array[String]))
         @formula = T.let(nil, T.nilable(T::Array[String]))
         @macos = T.let(nil, T.nilable(MacOSRequirement))
+        @maximum_macos = T.let(nil, T.nilable(MacOSRequirement))
         @linux = T.let(nil, T.nilable(LinuxRequirement))
         @macos_set_in_block = T.let(false, T::Boolean)
+        @maximum_macos_set_in_block = T.let(false, T::Boolean)
         @macos_bare_set_top_level = T.let(false, T::Boolean)
         @macos_version_set_top_level = T.let(false, T::Boolean)
+        @maximum_macos_set_top_level = T.let(false, T::Boolean)
         @linux_set_top_level = T.let(false, T::Boolean)
       end
 
@@ -94,6 +101,23 @@ module Cask
         end
       end
 
+      sig { params(args: T.any(String, Symbol)).returns(T.nilable(MacOSRequirement)) }
+      def maximum_macos=(*args)
+        raise "Only a single 'depends_on maximum_macos' is allowed." if @maximum_macos
+        raise "invalid 'depends_on maximum_macos' value: only a single macOS version is allowed" if args.count != 1
+
+        maximum_macos = begin
+          MacOSRequirement.parse(args, comparator: "<=")
+        rescue MacOSVersion::Error, TypeError => e
+          raise "invalid 'depends_on maximum_macos' value: #{e}"
+        end
+        if maximum_macos.comparator != "<="
+          raise "invalid 'depends_on maximum_macos' value: must use the '<=' comparator"
+        end
+
+        @maximum_macos = maximum_macos
+      end
+
       sig { params(args: T.any(String, Symbol)).returns(T.nilable(LinuxRequirement)) }
       def linux=(*args)
         raise "Only a single 'depends_on linux' is allowed." if @linux
@@ -122,14 +146,14 @@ module Cask
 
       sig { returns(T::Boolean) }
       def requires_macos?
-        @macos_bare_set_top_level || @macos_version_set_top_level
+        @macos_bare_set_top_level || @macos_version_set_top_level || @maximum_macos_set_top_level
       end
 
       sig { returns(T::Boolean) }
       def requires_linux? = @linux_set_top_level
 
       sig { returns(T::Boolean) }
-      def macos_set_in_block? = @macos_set_in_block
+      def macos_set_in_block? = @macos_set_in_block || @maximum_macos_set_in_block
 
       sig { returns(T::Boolean) }
       def os_support_specified? = requires_macos? || requires_linux? || macos_set_in_block?
@@ -138,7 +162,15 @@ module Cask
       def record_os_requirement(key, set_in_block:)
         case key
         when :macos
-          record_macos_requirement(set_in_block:)
+          macos = @macos
+          raise "invalid 'depends_on macos' value" unless macos
+
+          record_macos_requirement(macos, set_in_block:)
+        when :maximum_macos
+          maximum_macos = @maximum_macos
+          raise "invalid 'depends_on maximum_macos' value" unless maximum_macos
+
+          record_macos_requirement(maximum_macos, set_in_block:)
         when :linux
           return if set_in_block
           raise "`depends_on :linux` cannot be combined with `depends_on macos:`" if requires_macos?
@@ -147,23 +179,31 @@ module Cask
         end
       end
 
-      sig { params(set_in_block: T::Boolean).void }
-      def record_macos_requirement(set_in_block:)
+      sig { params(requirement: MacOSRequirement, set_in_block: T::Boolean).void }
+      def record_macos_requirement(requirement, set_in_block:)
         if set_in_block
-          @macos_set_in_block = true
+          if requirement.comparator == "<="
+            @maximum_macos_set_in_block = true
+          else
+            @macos_set_in_block = true
+          end
           return
         end
 
         raise "`depends_on :linux` cannot be combined with `depends_on macos:`" if requires_linux?
 
-        if T.must(@macos).version_specified?
-          raise "`depends_on macos:` cannot be combined with `depends_on :macos`" if @macos_bare_set_top_level
-
-          @macos_version_set_top_level = true
-        else
+        if !requirement.version_specified?
           raise "`depends_on :macos` cannot be combined with another macOS `depends_on`" if requires_macos?
 
           @macos_bare_set_top_level = true
+        elsif requirement.comparator == "<="
+          raise "`depends_on maximum_macos:` cannot be combined with `depends_on :macos`" if @macos_bare_set_top_level
+
+          @maximum_macos_set_top_level = true
+        else
+          raise "`depends_on macos:` cannot be combined with `depends_on :macos`" if @macos_bare_set_top_level
+
+          @macos_version_set_top_level = true
         end
       end
     end

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -386,10 +386,11 @@ on_request: true)
 
     sig { void }
     def check_macos_requirements
-      return unless @cask.depends_on.macos
-      return if @cask.depends_on.macos.satisfied?
+      macos_requirements = [@cask.depends_on.macos, @cask.depends_on.maximum_macos].compact
+      return if macos_requirements.empty?
+      return if macos_requirements.all?(&:satisfied?)
 
-      raise CaskError, @cask.depends_on.macos.message(type: :cask)
+      raise CaskError, macos_requirements.find { |requirement| !requirement.satisfied? }&.message(type: :cask)
     end
 
     sig { void }

--- a/Library/Homebrew/cask_dependent.rb
+++ b/Library/Homebrew/cask_dependent.rb
@@ -79,6 +79,7 @@ class CaskDependent
         end
         requirements << dsl_reqs.linux if dsl_reqs.linux
         requirements << dsl_reqs.macos if dsl_reqs.macos
+        requirements << dsl_reqs.maximum_macos if dsl_reqs.maximum_macos
 
         requirements
       end,

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -254,14 +254,14 @@ module Homebrew
 
       sig { params(cask: T.untyped).returns(T::Array[String]) }
       def self.cask_requirements_lines(cask)
-        requirement = if (macos = cask.depends_on.macos)
-          requirement = macos.display_s
-          if cask.supports_linux?
-            requirement.sub(" (or Linux)",
-                            " or Linux")
-          else
-            requirement.delete_suffix(" (or Linux)")
+        macos_requirements = [cask.depends_on.macos, cask.depends_on.maximum_macos].compact
+        requirement = if macos_requirements.present?
+          requirement = macos_requirements.filter_map do |macos_requirement|
+            macos_requirement.display_s.delete_suffix(" (or Linux)").delete_prefix("macOS").strip.presence
           end
+          requirement = requirement.present? ? "macOS #{requirement.join(", ")}" : "macOS"
+          requirement += " or Linux" if cask.supports_linux?
+          requirement
         elsif cask.supports_macos? && cask.supports_linux?
           "macOS or Linux"
         elsif cask.supports_macos?

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -90,6 +90,7 @@ class SoftwareSpec
     @compiler_failures = T.let([], T::Array[CompilerFailure])
     @depends_on_macos_bare_set_top_level = T.let(false, T::Boolean)
     @depends_on_macos_version_set_top_level = T.let(false, T::Boolean)
+    @depends_on_maximum_macos_set_top_level = T.let(false, T::Boolean)
     @depends_on_macos_set_in_block = T.let(false, T::Boolean)
     @depends_on_linux_set_top_level = T.let(false, T::Boolean)
   end
@@ -262,7 +263,9 @@ class SoftwareSpec
 
   sig { returns(T::Boolean) }
   def depends_on_macos_set_top_level?
-    @depends_on_macos_bare_set_top_level || @depends_on_macos_version_set_top_level
+    @depends_on_macos_bare_set_top_level ||
+      @depends_on_macos_version_set_top_level ||
+      @depends_on_maximum_macos_set_top_level
   end
 
   sig { params(dep: T.untyped, set_in_block: T::Boolean).void }
@@ -279,22 +282,36 @@ class SoftwareSpec
               "`depends_on :linux` cannot be combined with `depends_on macos:`"
       end
 
-      if dep.version_specified?
-        if @depends_on_macos_bare_set_top_level
-          # odeprecated "`depends_on :macos` with `depends_on macos:`"
-        end
-
-        @depends_on_macos_version_set_top_level = true
-      else
+      if !dep.version_specified?
         if @depends_on_macos_bare_set_top_level
           raise ArgumentError, "`depends_on :macos` cannot be combined with another macOS `depends_on`"
         end
 
-        if @depends_on_macos_version_set_top_level
+        if @depends_on_macos_version_set_top_level || @depends_on_maximum_macos_set_top_level
           # odeprecated "`depends_on :macos` with `depends_on macos:`"
         end
 
         @depends_on_macos_bare_set_top_level = true
+      elsif dep.comparator == "<="
+        if @depends_on_macos_bare_set_top_level
+          # odeprecated "`depends_on :macos` with `depends_on maximum_macos:`"
+        end
+
+        if @depends_on_maximum_macos_set_top_level
+          raise ArgumentError, "`depends_on maximum_macos:` cannot be combined with another macOS `depends_on`"
+        end
+
+        @depends_on_maximum_macos_set_top_level = true
+      else
+        if @depends_on_macos_bare_set_top_level
+          # odeprecated "`depends_on :macos` with `depends_on macos:`"
+        end
+
+        if @depends_on_macos_version_set_top_level
+          raise ArgumentError, "`depends_on macos:` cannot be combined with another macOS `depends_on`"
+        end
+
+        @depends_on_macos_version_set_top_level = true
       end
     when LinuxRequirement
       return if set_in_block

--- a/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
+++ b/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Homebrew::API::Cask::CaskStructGenerator do
     let(:depends_on_macos_equals) { { macos: { :== => ["15"] } } }
     let(:depends_on_macos_greater) { { macos: MacOSRequirement.new([:sequoia], comparator: ">=") } }
     let(:depends_on_macos_bare) { { macos: MacOSRequirement.new([]) } }
+    let(:depends_on_maximum_macos) { { maximum_macos: MacOSRequirement.new([:sequoia], comparator: "<=") } }
 
     specify :aggregate_failures do
       expect(described_class.process_depends_on(depends_on_non_macos)).to eq({ arch: :intel, formula: ["foo"] })
@@ -23,6 +24,7 @@ RSpec.describe Homebrew::API::Cask::CaskStructGenerator do
       expect(described_class.process_depends_on(depends_on_macos_greater)).to eq({ macos: :sequoia })
       expect(described_class.process_depends_on(depends_on_macos_bare)).to eq({ macos: :any })
       expect(described_class.process_depends_on({ macos: {} })).to eq({ macos: :any })
+      expect(described_class.process_depends_on(depends_on_maximum_macos)).to eq({ maximum_macos: :sequoia })
     end
   end
 

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -583,6 +583,7 @@ RSpec.describe Cask::Cask, :cask do
   describe "#supports_linux?" do
     it "uses explicit macOS dependencies before falling back to heuristics" do
       expect(Cask::CaskLoader.load("with-depends-on-macos-bare").supports_linux?).to be false
+      expect(Cask::CaskLoader.load("with-depends-on-maximum-macos").supports_linux?).to be false
       expect(Cask::CaskLoader.load("with-depends-on-macos-in-on-macos").supports_linux?).to be true
       expect(Cask::CaskLoader.load("with-depends-on-linux-bare").supports_linux?).to be true
 

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -500,6 +500,32 @@ RSpec.describe Cask::DSL, :cask, :no_api do
     end
   end
 
+  describe "depends_on maximum_macos" do
+    context "when a symbol is used" do
+      let(:token) { "with-depends-on-maximum-macos" }
+
+      it "creates a maximum MacOSRequirement" do
+        expect(cask.depends_on.maximum_macos).to eq(MacOSRequirement.new([:tahoe], comparator: "<="))
+      end
+    end
+
+    context "when the comparator is not an upper bound" do
+      let(:token) { "invalid-depends-on-maximum-macos-comparator" }
+
+      it "refuses to load" do
+        expect { cask }.to raise_error(Cask::CaskInvalidError)
+      end
+    end
+
+    context "when multiple values are used" do
+      let(:token) { "invalid-depends-on-maximum-macos-array" }
+
+      it "refuses to load" do
+        expect { cask }.to raise_error(Cask::CaskInvalidError)
+      end
+    end
+  end
+
   describe "depends_on arch" do
     context "when valid" do
       let(:token) { "with-depends-on-arch" }

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -2148,14 +2148,23 @@ RSpec.describe Formula do
       end.to raise_error(ArgumentError, "`depends_on :macos` cannot be combined with another macOS `depends_on`")
     end
 
+    it "returns false for Linux when maximum macOS is required at the top level" do
+      f = formula do
+        url "foo"
+        version "1.0"
+        depends_on maximum_macos: :tahoe
+      end
+
+      expect(f.supports_linux?).to be false
+    end
+
     it "does not allow Linux then macOS requirements" do
       expect do
         formula do
           url "foo"
           version "1.0"
-          depends_on_method = :depends_on
-          public_send(depends_on_method, :linux)
-          public_send(depends_on_method, macos: :catalina)
+          depends_on :linux
+          depends_on macos: :catalina
         end
       end.to raise_error(ArgumentError, "`depends_on :linux` cannot be combined with `depends_on macos:`")
     end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-maximum-macos-array.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-maximum-macos-array.rb
@@ -1,0 +1,13 @@
+# typed: false
+
+cask "invalid-depends-on-maximum-macos-array" do
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/invalid-depends-on-maximum-macos-array"
+
+  depends_on maximum_macos: [:ventura, :sonoma]
+
+  app "Caffeine.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-maximum-macos-comparator.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-maximum-macos-comparator.rb
@@ -1,0 +1,13 @@
+# typed: false
+
+cask "invalid-depends-on-maximum-macos-comparator" do
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/invalid-depends-on-maximum-macos-comparator"
+
+  depends_on maximum_macos: ">= :sonoma"
+
+  app "Caffeine.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-maximum-macos.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-maximum-macos.rb
@@ -1,0 +1,13 @@
+# typed: false
+
+cask "with-depends-on-maximum-macos" do
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/with-depends-on-maximum-macos"
+
+  depends_on maximum_macos: :tahoe
+
+  app "Caffeine.app"
+end

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -394,6 +394,12 @@ depends_on macos: [
 ]
 ```
 
+Top-level `depends_on maximum_macos:` marks a cask as macOS-only and declares the newest compatible macOS release:
+
+```ruby
+depends_on maximum_macos: :ventura
+```
+
 For a cask that supports both macOS and Linux but needs a specific macOS version, put the macOS version requirement inside `on_macos`:
 
 ```ruby

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -152,7 +152,7 @@ A `String` (e.g. `"jpeg"`) specifies a formula dependency.
 
 A `Symbol` (e.g. `:xcode`) specifies a [`Requirement`](/rubydoc/Requirement.html) to restrict installation to systems meeting certain criteria, which can be fulfilled by one or more formulae, casks or other system-wide installed software (e.g. Xcode). Some [`Requirement`](/rubydoc/Requirement.html)s can also take a string or symbol specifying their minimum version that the formula depends on.
 
-Top-level `depends_on :macos` marks a formula as macOS-only. Top-level `depends_on macos: :sonoma` marks a formula as macOS-only and declares the minimum compatible macOS release. Top-level `depends_on :linux` marks a formula as Linux-only. For a formula that supports both macOS and Linux but needs a specific macOS version, put the macOS version requirement inside `on_macos`.
+Top-level `depends_on :macos` marks a formula as macOS-only. Top-level `depends_on macos: :sonoma` marks a formula as macOS-only and declares the minimum compatible macOS release. Top-level `depends_on maximum_macos: :ventura` marks a formula as macOS-only and declares the newest compatible macOS release. Top-level `depends_on :linux` marks a formula as Linux-only. For a formula that supports both macOS and Linux but needs a specific macOS version, put the macOS version requirement inside `on_macos`.
 
 A `Hash` (e.g. `=>`) adds information to a dependency. Given a string or symbol, the value can be one or more of the following values:
 


### PR DESCRIPTION
- Support `depends_on maximum_macos:` in casks.
- Treat maximum macOS requirements as macOS-only.
- Document matching formula and cask OS semantics.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with manual testing and review.

-----
