### PR TITLE
download_queue: kill curl on cancellation

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -6,6 +6,7 @@ require "concurrent/promises"
 require "concurrent/executors"
 require "concurrent/atomic/atomic_boolean"
 require "retryable_download"
+require "concurrent/set"
 require "resource"
 require "utils/output"
 
@@ -31,6 +32,7 @@ module Homebrew
       @symlink_targets = T.let({}, T::Hash[Pathname, T::Set[Downloadable]])
       @downloads_by_location = T.let({}, T::Hash[Pathname, Concurrent::Promises::Future])
       @cancelled = T.let(Concurrent::AtomicBoolean.new(false), Concurrent::AtomicBoolean)
+      @download_threads = T.let(Concurrent::Set.new, Concurrent::Set)
       @fetch_failed = T.let(false, T::Boolean)
     end
 
@@ -54,14 +56,25 @@ module Homebrew
       ) do |download, cancelled, force, quiet, check_attestation|
         raise CancelledDownloadError if cancelled.true?
 
-        download.clear_cache if force
-        download.fetch(quiet:)
-        raise CancelledDownloadError if cancelled.true?
+        @download_threads.add(Thread.current)
+        begin
+          download.clear_cache if force
+          download.fetch(quiet:)
+          if cancelled.true?
+            download.clear_cache
+            raise CancelledDownloadError
+          end
 
-        if check_attestation && downloadable.is_a?(Bottle)
-          Utils::Attestation.check_attestation(downloadable, quiet: true)
+          if check_attestation && downloadable.is_a?(Bottle)
+            Utils::Attestation.check_attestation(downloadable, quiet: true)
+          end
+          create_symlinks_for_shared_download(cached_location)
+        rescue Interrupt
+          download.clear_cache
+          raise CancelledDownloadError
+        ensure
+          @download_threads.delete(Thread.current)
         end
-        create_symlinks_for_shared_download(cached_location)
       end
 
       downloads[downloadable] = @downloads_by_location.fetch(cached_location)
@@ -243,10 +256,11 @@ module Homebrew
 
     sig { void }
     def cancel
-      # Signal cooperative cancellation to all running downloads.
-      # Downloads check the cancelled flag at key points and will raise
-      # CancelledDownloadError when cancelled.
+      # Signal cooperative cancellation and interrupt any active download threads.
+      # Raising Interrupt on the thread triggers the existing rescue Interrupt in
+      # system_command.rb which sends SIGINT to the curl subprocess directly.
       @cancelled.make_true
+      @download_threads.each { |thread| thread.raise(Interrupt) }
     end
 
     sig { returns(Concurrent::FixedThreadPool) }

--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -60,17 +60,13 @@ module Homebrew
         begin
           download.clear_cache if force
           download.fetch(quiet:)
-          if cancelled.true?
-            download.clear_cache
-            raise CancelledDownloadError
-          end
+          raise CancelledDownloadError if cancelled.true?
 
           if check_attestation && downloadable.is_a?(Bottle)
             Utils::Attestation.check_attestation(downloadable, quiet: true)
           end
           create_symlinks_for_shared_download(cached_location)
         rescue Interrupt
-          download.clear_cache
           raise CancelledDownloadError
         ensure
           @download_threads.delete(Thread.current)


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
### **Why include these changes?**
This PR fixes a bug where cancelling a download with `Ctrl+C` leaves orphaned `curl` processes running in the background. By tracking active download threads and explicitly raising an `Interrupt` exception on them during cancellation, we ensure the signal propagates to the subprocesses. This triggers the existing cleanup logic in `system_command.rb`, which kills the `curl` PID and removes partial files from the cache. This is a follow-up to #21526 to complete the cooperative cancellation model.
