### PR TITLE
cask/caskroom: use the user's primary group on Linux

### DIFF
--- a/Library/Homebrew/extend/os/linux/cask/caskroom.rb
+++ b/Library/Homebrew/extend/os/linux/cask/caskroom.rb
@@ -6,13 +6,20 @@ module OS
     module Cask
       module Caskroom
         module ClassMethods
-          # Unlike macOS (which uses the shared `admin` group for multi-admin support),
-          # Homebrew on Linux is conventionally a single-user install, so it is OK to use
-          # the current user's primary group as the group of the `Caskroom` directory.
-          # This also avoids a `sudo` prompt to `chgrp` the directory after creation.
+          # Unlike macOS (which uses the `admin` group), Homebrew on Linux is run
+          # in a variety of distributions, so use the current user's primary group
+          # as the group of the `Caskroom` directory.
+          # This avoids a `sudo` prompt to `chgrp` the directory after creation.
           sig { returns(String) }
           def expected_caskroom_group
-            Etc.getgrgid(Process.egid)&.name || "root"
+            @expected_caskroom_group ||= T.let(
+              begin
+                Etc.getgrgid(Process.egid)&.name || "root"
+              rescue ArgumentError
+                "root"
+              end,
+              T.nilable(String),
+            )
           end
         end
       end

--- a/Library/Homebrew/extend/os/linux/cask/caskroom.rb
+++ b/Library/Homebrew/extend/os/linux/cask/caskroom.rb
@@ -6,14 +6,13 @@ module OS
     module Cask
       module Caskroom
         module ClassMethods
-          sig { params(path: ::Pathname, _sudo: T::Boolean).void }
-          def chgrp_path(path, _sudo)
-            SystemCommand.run("chgrp", args: [expected_caskroom_group, path], sudo: true)
-          end
-
+          # Unlike macOS (which uses the shared `admin` group for multi-admin support),
+          # Homebrew on Linux is conventionally a single-user install, so it is OK to use
+          # the current user's primary group as the group of the `Caskroom` directory.
+          # This also avoids a `sudo` prompt to `chgrp` the directory after creation.
           sig { returns(String) }
           def expected_caskroom_group
-            "root"
+            Etc.getgrgid(Process.egid)&.name || "root"
           end
         end
       end

--- a/Library/Homebrew/test/cask/caskroom_spec.rb
+++ b/Library/Homebrew/test/cask/caskroom_spec.rb
@@ -4,6 +4,8 @@
 require "cask/caskroom"
 
 RSpec.describe Cask::Caskroom do
+  before { described_class.instance_variable_set(:@expected_caskroom_group, nil) }
+
   describe ".ensure_caskroom_exists" do
     it "changes the group when sudo is unnecessary and the group is wrong" do
       Dir.mktmpdir do |dir|
@@ -82,9 +84,10 @@ RSpec.describe Cask::Caskroom do
     end
 
     it "checks the current user's primary group on Linux", :needs_linux do
-      group_name = Etc.getgrgid(Process.egid).name
+      group_name = "primary-group"
       path = Pathname("/tmp/Caskroom")
       allow(path).to receive(:stat).and_return(instance_double(File::Stat, gid: 1))
+      allow(Etc).to receive(:getgrgid).with(Process.egid).and_return(instance_double(Etc::Group, name: group_name))
       allow(Etc).to receive(:getgrnam).with(group_name).and_return(instance_double(Etc::Group, gid: 1))
 
       expect(described_class.caskroom_group_correct?(path)).to be true

--- a/Library/Homebrew/test/cask/caskroom_spec.rb
+++ b/Library/Homebrew/test/cask/caskroom_spec.rb
@@ -26,6 +26,50 @@ RSpec.describe Cask::Caskroom do
         described_class.ensure_caskroom_exists
       end
     end
+
+    it "changes the group with sudo when the parent is not writable and the group is wrong" do
+      Dir.mktmpdir do |dir|
+        path = Pathname(dir)/"sub"/"Caskroom"
+        parent = path.parent
+        allow(described_class).to receive_messages(path:, caskroom_group_correct?: false)
+        allow(path).to receive(:parent).and_return(parent)
+        allow(parent).to receive(:writable?).and_return(false)
+        allow(SystemCommand).to receive(:run)
+
+        expect(described_class).to receive(:chgrp_path).with(path, true)
+
+        described_class.ensure_caskroom_exists
+      end
+    end
+
+    it "skips changing the group when it is already correct and the parent is not writable" do
+      Dir.mktmpdir do |dir|
+        path = Pathname(dir)/"sub"/"Caskroom"
+        parent = path.parent
+        allow(described_class).to receive_messages(path:, caskroom_group_correct?: true)
+        allow(path).to receive(:parent).and_return(parent)
+        allow(parent).to receive(:writable?).and_return(false)
+        allow(SystemCommand).to receive(:run)
+
+        expect(described_class).not_to receive(:chgrp_path)
+
+        described_class.ensure_caskroom_exists
+      end
+    end
+
+    it "skips sudo on Linux when the parent is user-writable", :needs_linux do
+      Dir.mktmpdir do |dir|
+        path = Pathname(dir)/"Caskroom"
+        allow(described_class).to receive(:path).and_return(path)
+        expect(SystemCommand).not_to receive(:run).with(anything, hash_including(sudo: true))
+        allow(SystemCommand).to receive(:run).and_call_original
+
+        described_class.ensure_caskroom_exists
+
+        expect(path).to be_directory
+        expect(path.stat.gid).to eq(Process.egid)
+      end
+    end
   end
 
   describe ".caskroom_group_correct?" do
@@ -37,10 +81,11 @@ RSpec.describe Cask::Caskroom do
       expect(described_class.caskroom_group_correct?(path)).to be true
     end
 
-    it "checks the root group on Linux", :needs_linux do
+    it "checks the current user's primary group on Linux", :needs_linux do
+      group_name = Etc.getgrgid(Process.egid).name
       path = Pathname("/tmp/Caskroom")
       allow(path).to receive(:stat).and_return(instance_double(File::Stat, gid: 1))
-      allow(Etc).to receive(:getgrnam).with("root").and_return(instance_double(Etc::Group, gid: 1))
+      allow(Etc).to receive(:getgrnam).with(group_name).and_return(instance_double(Etc::Group, gid: 1))
 
       expect(described_class.caskroom_group_correct?(path)).to be true
     end


### PR DESCRIPTION
- Use the current user's primary group as the `Caskroom` group on Linux, matching the group `mkdir` already assigns on a single-user prefix.
- Drop the `chgrp_path` override that forced `sudo: true` regardless of whether the parent prefix was user-writable, so the inherited base method honors its computed `sudo` flag.
- Cover the `chgrp_path` branch matrix and add a Linux integration spec asserting `ensure_caskroom_exists` performs no `sudo` invocation when the prefix is user-writable.

Fixes #22120

Addressing https://github.com/Homebrew/brew/issues/22120#issuecomment-4412397993

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [X] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
