### PR TITLE
fix: invalidate git cache when formula branch changes

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1103,7 +1103,21 @@ class GitDownloadStrategy < VCSDownloadStrategy # rubocop:todo Style/OneClassPer
 
   sig { override.returns(T::Boolean) }
   def repo_valid?
-    silent_command("git", args: ["-C", cached_location, "status", "-s"]).success?
+    return false unless silent_command("git", args: ["-C", cached_location, "status", "-s"]).success?
+    return true if @ref.blank?
+
+    refs_to_check = case @ref_type
+    when :branch
+      ["origin/#{@ref}", @ref]
+    else
+      [@ref]
+    end
+
+    refs_to_check.any? do |ref|
+      silent_command("git",
+                     args: ["--git-dir", git_dir, "rev-parse", "-q", "--verify", "#{ref}^{commit}"])
+        .success?
+    end
   end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/test/download_strategies/git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/git_spec.rb
@@ -50,6 +50,23 @@ RSpec.describe GitDownloadStrategy do
     expect(strategy.last_commit).to eq("f68266e")
   end
 
+  describe "#repo_valid?" do
+    it "returns true when the ref exists" do
+      cached_location.cd do
+        setup_git_repo
+      end
+      expect(strategy.send(:repo_valid?)).to be true
+    end
+
+    it "returns false when the ref does not exist" do
+      cached_location.cd do
+        setup_git_repo
+      end
+      strategy_with_branch = described_class.new(url, name, version, branch: "nonexistent")
+      expect(strategy_with_branch.send(:repo_valid?)).to be false
+    end
+  end
+
   describe "#fetch_last_commit" do
     let(:url) { "file://#{remote_repo}" }
     let(:version) { Version.new("HEAD") }


### PR DESCRIPTION
Fixes #22203

## Problem

When a formula's `head` directive changes its `branch:` attribute, existing cached git repositories at `~/Library/Caches/Homebrew/<name>--git` are considered "valid" by `GitDownloadStrategy#repo_valid?` even though they don't contain the requested branch. This causes `brew install --HEAD` to fail with:

```
fatal: invalid reference: <branch-name>
```

`brew cleanup -s` does not remove these VCS caches (they live outside the `downloads/` directory), so the stale repo persists indefinitely.

## Solution

Extend `GitDownloadStrategy#repo_valid?` to also verify that the requested `@ref` exists in the cached repository:

- For **branches**: check both `origin/<branch>` (remote-tracking ref) and `<branch>` (local branch)
- For **tags** and **revisions**: check the ref directly

If the ref is not found, `repo_valid?` returns `false`, which triggers `fetch` to call `clear_cache` and perform a fresh clone with the correct `--branch` flag.

## Changes

- `Library/Homebrew/download_strategy.rb`: Updated `GitDownloadStrategy#repo_valid?`
- `Library/Homebrew/test/download_strategies/git_spec.rb`: Added tests for the new behavior

## Verification

- [x] `./bin/brew typecheck` passes
- [x] `./bin/brew style --fix` passes
- [x] `./bin/brew tests --only=download_strategies/git` passes (5 examples, 0 failures)
- [x] `./bin/brew tests --only=download_strategies/github_git` passes (1 example, 0 failures)