### PR TITLE
sorbet: Add RSpec shims and typecheck some tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ When running Ruby directly (e.g. `ruby -e ...`, `gem`, profiling tools), never u
 
 ### Development Flow
 
-- Write new code (using Sorbet `sig` type signatures and `typed: strict` for new files.
+- Write new code (using Sorbet `sig` type signatures and `typed: strict` for new files).
 - Write new tests (avoid more than one `:integration_test` per file for speed). Try `typed: true` as a baseline but revert to `typed: false` if there are not easily fixable errors.
   Write fast tests by preferring a single `expect` per unit test and combine expectations in a single test when it is an integration test or has non-trivial `before` for test setup.
 - When adding or tightening tests, verify them with a red/green cycle using the exact `--only=file:line` target for the example you changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ When running Ruby directly (e.g. `ruby -e ...`, `gem`, profiling tools), never u
 
 ### Development Flow
 
-- Write new code (using Sorbet `sig` type signatures and `typed: strict` for new files, but never for RSpec/test/`*_spec.rb` files)
-- Write new tests (avoid more than one `:integration_test` per file for speed).
+- Write new code (using Sorbet `sig` type signatures and `typed: strict` for new files.
+- Write new tests (avoid more than one `:integration_test` per file for speed). Try `typed: true` as a baseline but revert to `typed: false` if there are not easily fixable errors.
   Write fast tests by preferring a single `expect` per unit test and combine expectations in a single test when it is an integration test or has non-trivial `before` for test setup.
 - When adding or tightening tests, verify them with a red/green cycle using the exact `--only=file:line` target for the example you changed.
 - Formula classes created in specs may be frozen; avoid stubbing class methods on them with RSpec mocks and prefer instance-level stubs or test setup that does not require class-method stubbing.

--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -186,6 +186,7 @@ module Homebrew
           RuboCop::Formatter::PathUtil
           RuboCop::Options
           RuboCop::ResultCache
+          RuboCop::RSpec::ExpectOffense
           RuboCop::Runner
           RuboCop::TargetFinder
           RuboCop::Version

--- a/Library/Homebrew/sorbet/rbi/gems/rubocop@1.86.1.rbi
+++ b/Library/Homebrew/sorbet/rbi/gems/rubocop@1.86.1.rbi
@@ -3998,9 +3998,9 @@ RuboCop::Formatter::PacmanFormatter::FALLBACK_TERMINAL_WIDTH = T.let(T.unsafe(ni
 
 RuboCop::Formatter::PacmanFormatter::GHOST = T.let(T.unsafe(nil), String)
 
-RuboCop::Formatter::PacmanFormatter::PACDOT = T.let(T.unsafe(nil), Rainbow::NullPresenter)
+RuboCop::Formatter::PacmanFormatter::PACDOT = T.let(T.unsafe(nil), Rainbow::Presenter)
 
-RuboCop::Formatter::PacmanFormatter::PACMAN = T.let(T.unsafe(nil), Rainbow::NullPresenter)
+RuboCop::Formatter::PacmanFormatter::PACMAN = T.let(T.unsafe(nil), Rainbow::Presenter)
 
 RuboCop::Formatter::ProgressFormatter::DOT = T.let(T.unsafe(nil), String)
 
@@ -4128,6 +4128,37 @@ RuboCop::Plugin::Loader::DEFAULT_PLUGIN_CONFIG = T.let(T.unsafe(nil), Hash)
 RuboCop::Plugin::OBSOLETE_INTERNAL_AFFAIRS_PLUGIN_NAME = T.let(T.unsafe(nil), String)
 
 RuboCop::ProcessedSource = RuboCop::AST::ProcessedSource
+
+module RuboCop::RSpec::ExpectOffense
+  def expect_correction(correction, loop: T.unsafe(nil), source: T.unsafe(nil)); end
+  def expect_no_corrections; end
+  def expect_no_offenses(source, file = T.unsafe(nil)); end
+  def expect_offense(source, file = T.unsafe(nil), severity: T.unsafe(nil), chomp: T.unsafe(nil), **replacements); end
+  def format_offense(source, **replacements); end
+  def parse_annotations(source, raise_error: T.unsafe(nil), **replacements); end
+  def parse_processed_source(source, file = T.unsafe(nil)); end
+  def set_formatter_options; end
+end
+
+class RuboCop::RSpec::ExpectOffense::AnnotatedSource
+  def initialize(lines, annotations); end
+
+  def ==(other); end
+  def inspect; end
+  def match_annotations?(other); end
+  def plain_source; end
+  def to_s; end
+  def with_offense_annotations(offenses); end
+
+  protected
+
+  def annotations; end
+  def lines; end
+
+  class << self
+    def parse(annotated_source); end
+  end
+end
 
 RuboCop::RSpec::ExpectOffense::AnnotatedSource::ABBREV = T.let(T.unsafe(nil), String)
 

--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -1,0 +1,7 @@
+# typed: strict
+
+class RSpec::Core::ExampleGroup
+  include RSpec::SharedContext
+  include RSpec::Matchers
+  include RSpec::Mocks::ExampleMethods
+end

--- a/Library/Homebrew/test/PATH_spec.rb
+++ b/Library/Homebrew/test/PATH_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "PATH"

--- a/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
+++ b/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/api/formula_struct_spec.rb
+++ b/Library/Homebrew/test/api/formula_struct_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/bottle_spec.rb
+++ b/Library/Homebrew/test/bottle_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "bottle_specification"

--- a/Library/Homebrew/test/bottle_specification_spec.rb
+++ b/Library/Homebrew/test/bottle_specification_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "bottle_specification"

--- a/Library/Homebrew/test/bundle/dumper_spec.rb
+++ b/Library/Homebrew/test/bundle/dumper_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/cask/artifact/abstract_artifact_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/abstract_artifact_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::AbstractArtifact, :cask do

--- a/Library/Homebrew/test/cask/artifact/relocated_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/relocated_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cask/artifact/relocated"

--- a/Library/Homebrew/test/cask/cask_loader/from_content_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_content_loader_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromContentLoader do

--- a/Library/Homebrew/test/cask/config_spec.rb
+++ b/Library/Homebrew/test/cask/config_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Cask::Config, :cask do

--- a/Library/Homebrew/test/cask/quarantine_spec.rb
+++ b/Library/Homebrew/test/cask/quarantine_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Cask::Quarantine do

--- a/Library/Homebrew/test/cmd/gist-logs_spec.rb
+++ b/Library/Homebrew/test/cmd/gist-logs_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/gist-logs"

--- a/Library/Homebrew/test/cxxstdlib_spec.rb
+++ b/Library/Homebrew/test/cxxstdlib_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/deprecate_disable_spec.rb
+++ b/Library/Homebrew/test/deprecate_disable_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "deprecate_disable"

--- a/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dev-cmd/pr-pull"

--- a/Library/Homebrew/test/dev-cmd/release_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/release_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/typecheck_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/typecheck_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/download_strategies/git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/git_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/github_git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/github_git_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/extend/blank_spec.rb
+++ b/Library/Homebrew/test/extend/blank_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "extend/blank"

--- a/Library/Homebrew/test/github_runner_spec.rb
+++ b/Library/Homebrew/test/github_runner_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "github_runner"

--- a/Library/Homebrew/test/hardware/cpu_spec.rb
+++ b/Library/Homebrew/test/hardware/cpu_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "hardware"

--- a/Library/Homebrew/test/head_software_spec_spec.rb
+++ b/Library/Homebrew/test/head_software_spec_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "head_software_spec"

--- a/Library/Homebrew/test/keg_only_reason_spec.rb
+++ b/Library/Homebrew/test/keg_only_reason_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "keg_only_reason"

--- a/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "keg_relocate"

--- a/Library/Homebrew/test/keg_relocate/relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/relocation_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "keg_relocate"

--- a/Library/Homebrew/test/language/python_spec.rb
+++ b/Library/Homebrew/test/language/python_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "language/python"

--- a/Library/Homebrew/test/linux_runner_spec_spec.rb
+++ b/Library/Homebrew/test/linux_runner_spec_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "linux_runner_spec"

--- a/Library/Homebrew/test/livecheck/livecheck_version_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_version_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/livecheck_version"

--- a/Library/Homebrew/test/livecheck/options_spec.rb
+++ b/Library/Homebrew/test/livecheck/options_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/options"

--- a/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/hackage_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/hackage_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/npm_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/npm_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/sourceforge_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sourceforge_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/macos_runner_spec_spec.rb
+++ b/Library/Homebrew/test/macos_runner_spec_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "macos_runner_spec"

--- a/Library/Homebrew/test/options/deprecated_option_spec.rb
+++ b/Library/Homebrew/test/options/deprecated_option_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "options"

--- a/Library/Homebrew/test/options_spec.rb
+++ b/Library/Homebrew/test/options_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "options"

--- a/Library/Homebrew/test/os/linux/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/linux/diagnostic_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/os/linux/elf_spec.rb
+++ b/Library/Homebrew/test/os/linux/elf_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 RSpec.describe OS::Linux::Elf do

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "requirements/codesign_requirement"

--- a/Library/Homebrew/test/requirements/linux_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/linux_requirement_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "requirements/linux_requirement"

--- a/Library/Homebrew/test/requirements_spec.rb
+++ b/Library/Homebrew/test/requirements_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "requirements"

--- a/Library/Homebrew/test/services/formulae_spec.rb
+++ b/Library/Homebrew/test/services/formulae_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "services/formulae"

--- a/Library/Homebrew/test/simulate_system_spec.rb
+++ b/Library/Homebrew/test/simulate_system_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "settings"

--- a/Library/Homebrew/test/test_bot/formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "test_bot"

--- a/Library/Homebrew/test/test_bot/junit_spec.rb
+++ b/Library/Homebrew/test/test_bot/junit_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "test_bot"

--- a/Library/Homebrew/test/test_bot/setup_spec.rb
+++ b/Library/Homebrew/test/test_bot/setup_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dev-cmd/test-bot"

--- a/Library/Homebrew/test/test_bot/step_spec.rb
+++ b/Library/Homebrew/test/test_bot/step_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_bot"

--- a/Library/Homebrew/test/test_bot/test_cleanup_spec.rb
+++ b/Library/Homebrew/test/test_bot/test_cleanup_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "dev-cmd/test-bot"

--- a/Library/Homebrew/test/test_bot/test_formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/test_formulae_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_bot"

--- a/Library/Homebrew/test/unlink_spec.rb
+++ b/Library/Homebrew/test/unlink_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "unlink"

--- a/Library/Homebrew/test/unpack_strategy/zstd_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/zstd_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/utils/ast/ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/ast_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/ast"

--- a/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/ast"

--- a/Library/Homebrew/test/utils/backtrace_spec.rb
+++ b/Library/Homebrew/test/utils/backtrace_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/backtrace"

--- a/Library/Homebrew/test/utils/bottles/collector_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/collector_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/bottles"

--- a/Library/Homebrew/test/utils/cpan_spec.rb
+++ b/Library/Homebrew/test/utils/cpan_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/cpan"

--- a/Library/Homebrew/test/utils/path_spec.rb
+++ b/Library/Homebrew/test/utils/path_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "utils/path"

--- a/Library/Homebrew/test/utils/service_spec.rb
+++ b/Library/Homebrew/test/utils/service_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "utils/service"

--- a/Library/Homebrew/test/utils/shared_audits_spec.rb
+++ b/Library/Homebrew/test/utils/shared_audits_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/shared_audits"

--- a/Library/Homebrew/test/utils/shell_completion_spec.rb
+++ b/Library/Homebrew/test/utils/shell_completion_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/shell_completion"

--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 RSpec.describe Tty do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

- Follow-up to https://github.com/Homebrew/brew/pull/21690. Cribbed the first commit's changes from the above PR.
- Then used Spoom to bump files that didn't have any errors after the shims and RBI re-generation.
- We can go further incrementally in future PRs, if we wish.