### PR TITLE
Fix cask tab marking with missing tab file

### DIFF
--- a/Library/Homebrew/cask/tab.rb
+++ b/Library/Homebrew/cask/tab.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "tab"
+require "utils/topological_hash"
 
 module Cask
   class Tab < ::AbstractTab

--- a/Library/Homebrew/cmd/tab.rb
+++ b/Library/Homebrew/cmd/tab.rb
@@ -59,14 +59,21 @@ module Homebrew
 
       sig { params(formula_or_cask: T.any(Formula, Cask::Cask), installed_on_request: T::Boolean).void }
       def update_tab(formula_or_cask, installed_on_request:)
-        name, tab = if formula_or_cask.is_a?(Formula)
-          [formula_or_cask.name, Tab.for_formula(formula_or_cask)]
+        name, tab, created_tab = if formula_or_cask.is_a?(Formula)
+          [formula_or_cask.name, Tab.for_formula(formula_or_cask), false]
         else
-          [formula_or_cask.token, formula_or_cask.tab]
+          cask = formula_or_cask
+          cask_tab = cask.tab
+          cask_tabfile = cask_tab.tabfile
+          if cask_tabfile.blank? || !cask_tabfile.exist?
+            [cask.token, Cask::Tab.create(cask), true]
+          else
+            [cask.token, cask_tab, false]
+          end
         end
 
         tabfile = tab.tabfile
-        if tabfile.blank? || !tabfile.exist?
+        if !created_tab && (tabfile.blank? || !tabfile.exist?)
           raise ArgumentError,
                 "Tab file for #{name} does not exist."
         end
@@ -74,6 +81,7 @@ module Homebrew
         installed_on_request_str = "#{"not " unless installed_on_request}installed on request"
         if (tab.installed_on_request && installed_on_request) ||
            (!tab.installed_on_request && !installed_on_request)
+          tab.write if created_tab
           ohai "#{name} is already marked as #{installed_on_request_str}."
           return
         end

--- a/Library/Homebrew/test/cmd/tab_spec.rb
+++ b/Library/Homebrew/test/cmd/tab_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe Homebrew::Cmd::TabCmd do
     Tab.for_formula(formula).installed_on_request
   end
 
+  def cask_installed_on_request?(cask)
+    # `brew` subprocesses can change the tab, invalidating the cached values.
+    Cask::Tab.clear_cache
+    cask.tab.installed_on_request
+  end
+
   it_behaves_like "parseable arguments"
 
   it "marks or unmarks a formula as installed on request", :integration_test do
@@ -30,5 +36,32 @@ RSpec.describe Homebrew::Cmd::TabCmd do
       .and output(/foo is now marked as not installed on request/).to_stdout
       .and not_to_output.to_stderr
     expect(installed_on_request?(foo)).to be false
+  end
+
+  it "marks or unmarks a cask as installed on request with a missing tab", :cask do
+    cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+    InstallHelper.install_with_caskfile(cask)
+    tab_path = cask.metadata_main_container_path/AbstractTab::FILENAME
+
+    expect(tab_path).not_to exist
+
+    cmd = described_class.new(["--installed-on-request", "--cask", cask.token])
+    allow(cmd.args.named).to receive(:to_formulae_to_casks).and_return([[], [cask]])
+    expect { cmd.run }
+      .to output(/local-caffeine is now marked as installed on request/).to_stdout
+      .and not_to_output.to_stderr
+    expect(tab_path).to exist
+    expect(cask_installed_on_request?(cask)).to be true
+
+    tab_path.delete
+    Cask::Tab.clear_cache
+
+    cmd = described_class.new(["--no-installed-on-request", "--cask", cask.token])
+    allow(cmd.args.named).to receive(:to_formulae_to_casks).and_return([[], [cask]])
+    expect { cmd.run }
+      .to output(/local-caffeine is already marked as not installed on request/).to_stdout
+      .and not_to_output.to_stderr
+    expect(tab_path).to exist
+    expect(cask_installed_on_request?(cask)).to be false
   end
 end


### PR DESCRIPTION
## What does this PR do?

This fixes `brew tab --installed-on-request --cask <cask>` when an installed cask does not already have an `INSTALL_RECEIPT.json` tab file.

Previously, `brew tab` raised `Tab file for <cask> does not exist.` For casks with a missing tab file, this PR creates a writable cask tab before updating `installed_on_request`.

Fixes Homebrew/brew#22206.

## Why is this useful?

This makes `brew tab` behave correctly for installed casks whose tab file is missing, including casks reported as installed as a dependency. It avoids an unnecessary error and lets users mark those casks as installed on request or not installed on request.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims must include Hyperfine benchmarks.
- [x] Have you written new tests, excluding integration tests, for your changes?
- [x] Have you successfully run `brew lgtm` with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

I used GPT-5.5 via a coding agent to implement the fix for missing cask tab files in `brew tab`. I manually reviewed the resulting diff and kept the change focused on cask tab handling and the related test coverage.

Verified with:

- `bundle exec rspec Library/Homebrew/test/cmd/tab_spec.rb`
- `brew style --fix Library/Homebrew/cask/tab.rb Library/Homebrew/cmd/tab.rb Library/Homebrew/test/cmd/tab_spec.rb`
- `brew lgtm`