### PR TITLE
Move test-bot OS logic to extend/os

### DIFF
--- a/Library/Homebrew/extend/os/linux/test_bot.rb
+++ b/Library/Homebrew/extend/os/linux/test_bot.rb
@@ -1,0 +1,71 @@
+# typed: strict
+# frozen_string_literal: true
+
+module OS
+  module Linux
+    module TestBot
+      module ClassMethods
+        extend T::Helpers
+
+        requires_ancestor { T.class_of(::Homebrew::TestBot) }
+
+        sig { returns(String) }
+        def runner_os_title
+          OS.kernel_name
+        end
+
+        sig { returns(String) }
+        def runner_os_title_with_arch
+          "#{runner_os_title} #{::Hardware::CPU.arch}"
+        end
+      end
+
+      module TestFormulae
+        extend T::Helpers
+
+        requires_ancestor { ::Homebrew::TestBot::TestFormulae }
+
+        sig { returns(String) }
+        def previous_run_artifact_specifier
+          "{linux,ubuntu}"
+        end
+      end
+
+      module FormulaeDependents
+        extend T::Helpers
+
+        requires_ancestor { ::Homebrew::TestBot::FormulaeDependents }
+
+        sig { params(formula: Formula, args: ::Homebrew::Cmd::TestBotCmd::Args).returns(T::Boolean) }
+        def skip_recursive_dependents?(formula, args:)
+          super || formula.requirements.exclude?(LinuxRequirement.new)
+        end
+
+        sig { params(dependent: Formula).returns(T::Boolean) }
+        def build_dependent_from_source?(dependent)
+          dependent.requirements.include?(LinuxRequirement.new)
+        end
+      end
+
+      module CleanupBefore
+        extend T::Helpers
+
+        requires_ancestor { ::Homebrew::TestBot::CleanupBefore }
+
+        sig { void }
+        def cleanup_github_actions_hosted_runner
+          # brew doctor complains
+          delete_or_move %w[
+            /usr/local/include/node/
+            /opt/pipx_bin/ansible-config
+          ].map { |path| ::Pathname.new(path) }, sudo: true
+        end
+      end
+    end
+  end
+end
+
+Homebrew::TestBot.singleton_class.prepend(OS::Linux::TestBot::ClassMethods)
+Homebrew::TestBot::TestFormulae.prepend(OS::Linux::TestBot::TestFormulae)
+Homebrew::TestBot::FormulaeDependents.prepend(OS::Linux::TestBot::FormulaeDependents)
+Homebrew::TestBot::CleanupBefore.prepend(OS::Linux::TestBot::CleanupBefore)

--- a/Library/Homebrew/extend/os/mac/test_bot.rb
+++ b/Library/Homebrew/extend/os/mac/test_bot.rb
@@ -1,0 +1,85 @@
+# typed: strict
+# frozen_string_literal: true
+
+module OS
+  module Mac
+    module TestBot
+      module ClassMethods
+        extend T::Helpers
+
+        requires_ancestor { T.class_of(::Homebrew::TestBot) }
+
+        sig { returns(String) }
+        def runner_os_title
+          title = "macOS #{MacOS.version.pretty_name} (#{MacOS.version})"
+          title << " on Apple Silicon" if ::Hardware::CPU.arm?
+
+          title
+        end
+      end
+
+      module TestFormulae
+        extend T::Helpers
+
+        requires_ancestor { ::Homebrew::TestBot::TestFormulae }
+
+        sig { returns(String) }
+        def previous_run_artifact_specifier
+          "{macos-#{MacOS.version},#{MacOS.version}-#{::Hardware::CPU.arch}}"
+        end
+      end
+
+      module Formulae
+        extend T::Helpers
+
+        requires_ancestor { ::Homebrew::TestBot::Formulae }
+
+        sig { params(args: ::Homebrew::Cmd::TestBotCmd::Args).void }
+        def setup_bottle_sudo_purge!(args:)
+          # This is needed where sparse files may be handled (bsdtar >=3.0).
+          # We use gnu-tar with sparse files disabled when --only-json-tab is passed.
+          ENV["HOMEBREW_BOTTLE_SUDO_PURGE"] = "1" if MacOS.version >= :catalina && !args.only_json_tab?
+        end
+      end
+
+      module FormulaeDependents
+        extend T::Helpers
+
+        requires_ancestor { ::Homebrew::TestBot::FormulaeDependents }
+
+        sig { params(_formula: Formula, args: ::Homebrew::Cmd::TestBotCmd::Args).returns(T::Boolean) }
+        def skip_recursive_dependents?(_formula, args:)
+          super || ::Hardware::CPU.intel?
+        end
+      end
+
+      module CleanupBefore
+        extend T::Helpers
+
+        requires_ancestor { ::Homebrew::TestBot::CleanupBefore }
+
+        sig { void }
+        def cleanup_github_actions_hosted_runner
+          delete_or_move HOMEBREW_CELLAR.glob("*")
+          delete_or_move HOMEBREW_CASKROOM.glob("session-manager-plugin")
+
+          delete_or_move %w[
+            Mono.framework
+            PluginManager.framework
+            Python.framework
+            R.framework
+            Xamarin.Android.framework
+            Xamarin.Mac.framework
+            Xamarin.iOS.framework
+          ].map { |framework| ::Pathname.new("/Library/Frameworks")/framework }, sudo: true
+        end
+      end
+    end
+  end
+end
+
+Homebrew::TestBot.singleton_class.prepend(OS::Mac::TestBot::ClassMethods)
+Homebrew::TestBot::TestFormulae.prepend(OS::Mac::TestBot::TestFormulae)
+Homebrew::TestBot::Formulae.prepend(OS::Mac::TestBot::Formulae)
+Homebrew::TestBot::FormulaeDependents.prepend(OS::Mac::TestBot::FormulaeDependents)
+Homebrew::TestBot::CleanupBefore.prepend(OS::Mac::TestBot::CleanupBefore)

--- a/Library/Homebrew/extend/os/test_bot.rb
+++ b/Library/Homebrew/extend/os/test_bot.rb
@@ -1,0 +1,5 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "extend/os/linux/test_bot" if OS.linux?
+require "extend/os/mac/test_bot" if OS.mac?

--- a/Library/Homebrew/test_bot.rb
+++ b/Library/Homebrew/test_bot.rb
@@ -142,3 +142,5 @@ module Homebrew
     end
   end
 end
+
+require "extend/os/test_bot"

--- a/Library/Homebrew/test_bot/cleanup_before.rb
+++ b/Library/Homebrew/test_bot/cleanup_before.rb
@@ -16,42 +16,17 @@ module Homebrew
 
         if ENV["HOMEBREW_GITHUB_ACTIONS"] && !ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"]
           # minimally fix brew doctor failures (a full clean takes ~5m)
-          # TODO: move to extend/os
-          # rubocop:todo Homebrew/MoveToExtendOS
-          if OS.linux?
-            # brew doctor complains
-            bad_paths = %w[
-              /usr/local/include/node/
-              /opt/pipx_bin/ansible-config
-            ].map { |path| Pathname.new(path) }
-
-            delete_or_move bad_paths, sudo: true
-          elsif OS.mac?
-            delete_or_move HOMEBREW_CELLAR.glob("*")
-            delete_or_move HOMEBREW_CASKROOM.glob("session-manager-plugin")
-
-            frameworks_dir = Pathname("/Library/Frameworks")
-            frameworks = %w[
-              Mono.framework
-              PluginManager.framework
-              Python.framework
-              R.framework
-              Xamarin.Android.framework
-              Xamarin.Mac.framework
-              Xamarin.iOS.framework
-            ].map { |framework| frameworks_dir/framework }
-
-            delete_or_move frameworks, sudo: true
-          end
-
+          cleanup_github_actions_hosted_runner
           test "brew", "cleanup", "--prune-prefix"
         end
-        # rubocop:enable Homebrew/MoveToExtendOS
 
         # Keep all "brew" invocations after cleanup_shared
         # (which cleans up Homebrew/brew)
         cleanup_shared
       end
+
+      sig { void }
+      def cleanup_github_actions_hosted_runner; end
     end
   end
 end

--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -52,15 +52,8 @@ module Homebrew
           # Portable Ruby bottles are handled differently.
           next if testing_portable_ruby?
 
-          # TODO: move to extend/os
-          # rubocop:todo Homebrew/MoveToExtendOS
-          bottle_specifier = if OS.linux?
-            "{linux,ubuntu}"
-          else
-            "{macos-#{MacOS.version},#{MacOS.version}-#{Hardware::CPU.arch}}"
-          end
-          # rubocop:enable Homebrew/MoveToExtendOS
-          download_artifacts_from_previous_run!("bottles{,_#{bottle_specifier}*}", dry_run: args.dry_run?)
+          download_artifacts_from_previous_run!("bottles{,_#{previous_run_artifact_specifier}*}",
+                                                dry_run: args.dry_run?)
         end
         @bottle_checksums.merge!(
           bottle_glob("*", artifact_cache, ".{json,tar.gz}", bottle_tag: "*").to_h do |bottle_file|
@@ -291,13 +284,7 @@ module Homebrew
           "#{T.must(tap).default_remote}/releases/download/#{formula.name}-#{formula.pkg_version}"
         end
 
-        # This is needed where sparse files may be handled (bsdtar >=3.0).
-        # We use gnu-tar with sparse files disabled when --only-json-tab is passed.
-        #
-        # TODO: move to extend/os
-        # rubocop:todo Homebrew/MoveToExtendOS
-        ENV["HOMEBREW_BOTTLE_SUDO_PURGE"] = "1" if OS.mac? && MacOS.version >= :catalina && !args.only_json_tab?
-        # rubocop:enable Homebrew/MoveToExtendOS
+        setup_bottle_sudo_purge!(args:)
 
         bottle_args = ["--verbose", "--json", formula.full_name]
         bottle_args << "--keep-old" if args.keep_old? && !new_formula
@@ -367,6 +354,9 @@ module Homebrew
 
         !args.build_from_source?
       end
+
+      sig { params(args: Homebrew::Cmd::TestBotCmd::Args).void }
+      def setup_bottle_sudo_purge!(args:); end
 
       sig { params(formula: Formula).void }
       def livecheck(formula)

--- a/Library/Homebrew/test_bot/formulae_dependents.rb
+++ b/Library/Homebrew/test_bot/formulae_dependents.rb
@@ -44,16 +44,8 @@ module Homebrew
 
         install_formulae_if_needed_from_bottles!(installable_bottles, args:)
 
-        # TODO: move to extend/os
-        # rubocop:todo Homebrew/MoveToExtendOS
-        artifact_specifier = if OS.linux?
-          "{linux,ubuntu}"
-        else
-          "{macos-#{MacOS.version},#{MacOS.version}-#{Hardware::CPU.arch}}"
-        end
-        # rubocop:enable Homebrew/MoveToExtendOS
-
-        download_artifacts_from_previous_run!("dependents{,_#{artifact_specifier}*}", dry_run: args.dry_run?)
+        download_artifacts_from_previous_run!("dependents{,_#{previous_run_artifact_specifier}*}",
+                                              dry_run: args.dry_run?)
         @skip_candidates = T.let(
           if (tested_dependents_cache = artifact_cache/@tested_dependents_list).exist?
             tested_dependents_cache.read.split("\n")
@@ -157,12 +149,7 @@ module Homebrew
         # Always skip recursive dependents on Intel. It's really slow.
         # Also skip recursive dependents on Linux unless it's a Linux-only formula.
         #
-        # TODO: move to extend/os
-        # rubocop:todo Homebrew/MoveToExtendOS
-        skip_recursive_dependents = args.skip_recursive_dependents? ||
-                                    (OS.mac? && Hardware::CPU.intel?) ||
-                                    (OS.linux? && formula.requirements.exclude?(LinuxRequirement.new))
-        # rubocop:enable Homebrew/MoveToExtendOS
+        skip_recursive_dependents = skip_recursive_dependents?(formula, args:)
 
         uses_args = %w[--formula --eval-all]
         uses_include_test_args = [*uses_args, "--include-test"]
@@ -219,10 +206,7 @@ module Homebrew
         # either the `--build-dependents-from-source` flag was passed or a dependent has no
         # bottle on the current OS.
         source_dependents, dependents = dependents.partition do |dependent, deps|
-          # TODO: move to extend/os
-          # rubocop:todo Homebrew/MoveToExtendOS
-          next false if OS.linux? && dependent.requirements.exclude?(LinuxRequirement.new)
-          # rubocop:enable Homebrew/MoveToExtendOS
+          next false unless build_dependent_from_source?(dependent)
 
           all_deps_bottled_or_built = deps.all? do |d|
             bottled_or_built?(d.to_formula, @dependent_testing_formulae)
@@ -407,25 +391,23 @@ module Homebrew
            !dependent_was_previously_installed &&
            all_tests_passed &&
            dependent.deps.all? { |d| bottled?(d.to_formula, no_older_versions: true) }
-          # TODO: move to extend/os
-          # rubocop:todo Homebrew/MoveToExtendOS
-          os_string = if OS.mac?
-            str = "macOS #{MacOS.version.pretty_name} (#{MacOS.version})"
-            str << " on Apple Silicon" if Hardware::CPU.arm?
-
-            str
-          else
-            OS.kernel_name
-          end
-          # rubocop:enable Homebrew/MoveToExtendOS
-
           puts GitHub::Actions::Annotation.new(
             :notice,
             "All tests passed.",
             file:  dependent.path.to_s.delete_prefix("#{repository}/"),
-            title: "#{dependent} should be bottled for #{os_string}!",
+            title: "#{dependent} should be bottled for #{Homebrew::TestBot.runner_os_title}!",
           )
         end
+      end
+
+      sig { params(_formula: Formula, args: Homebrew::Cmd::TestBotCmd::Args).returns(T::Boolean) }
+      def skip_recursive_dependents?(_formula, args:)
+        args.skip_recursive_dependents?
+      end
+
+      sig { params(_dependent: Formula).returns(T::Boolean) }
+      def build_dependent_from_source?(_dependent)
+        true
       end
 
       sig { params(formula: Formula).void }

--- a/Library/Homebrew/test_bot/step.rb
+++ b/Library/Homebrew/test_bot/step.rb
@@ -6,6 +6,16 @@ require "utils/github/actions"
 
 module Homebrew
   module TestBot
+    sig { returns(String) }
+    def self.runner_os_title
+      raise NotImplementedError, "Homebrew::TestBot.runner_os_title must be implemented in extend/os."
+    end
+
+    sig { returns(String) }
+    def self.runner_os_title_with_arch
+      runner_os_title
+    end
+
     # Wraps command invocations. Instantiated by Test#test.
     # Handles logging and pretty-printing.
     class Step
@@ -253,18 +263,6 @@ module Homebrew
           return
         end
 
-        # TODO: move to extend/os
-        # rubocop:todo Homebrew/MoveToExtendOS
-        os_string = if OS.mac?
-          str = "macOS #{MacOS.version.pretty_name} (#{MacOS.version})"
-          str << " on Apple Silicon" if Hardware::CPU.arm?
-
-          str
-        else
-          "#{OS.kernel_name} #{Hardware::CPU.arch}"
-        end
-        # rubocop:enable Homebrew/MoveToExtendOS
-
         @named_args.each do |name|
           next if name.blank?
 
@@ -274,7 +272,7 @@ module Homebrew
           # GitHub Actions has a 4KB maximum for annotations.
           annotation_output = truncate_output(@output, max_kb: 4, context_lines: 5)
 
-          annotation_title = "`#{command_trimmed}` failed on #{os_string}!"
+          annotation_title = "`#{command_trimmed}` failed on #{Homebrew::TestBot.runner_os_title_with_arch}!"
           file = path.delete_prefix("#{@repository}/")
           puts_in_github_actions_group("Truncated #{command_short} output") do
             puts_github_actions_annotation(annotation_output, annotation_title, file, line)

--- a/Library/Homebrew/test_bot/test_formulae.rb
+++ b/Library/Homebrew/test_bot/test_formulae.rb
@@ -420,6 +420,11 @@ module Homebrew
         unsatisfied_requirements.values.flatten.map(&:message).join("\n").presence
       end
 
+      sig { returns(String) }
+      def previous_run_artifact_specifier
+        raise NotImplementedError, "#{self.class} must implement previous_run_artifact_specifier in extend/os."
+      end
+
       sig { params(keep_formulae: T::Array[String], args: Homebrew::Cmd::TestBotCmd::Args).void }
       def cleanup_during!(keep_formulae = [], args:)
         return unless cleanup?(args)


### PR DESCRIPTION
- Avoids `Homebrew/MoveToExtendOS` suppressions in `test_bot`.
- Keeps runner labels and hosted cleanup defined by each OS extension.
- Shares bottle artifact matching through `TestFormulae`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
