### PR TITLE
Remove stale RuboCop disables

### DIFF
--- a/Library/Homebrew/bundle/tap.rb
+++ b/Library/Homebrew/bundle/tap.rb
@@ -85,11 +85,8 @@ module Homebrew
             remote = if tap.custom_remote? && (tap_remote = tap.remote)
               if (api_token = ENV.fetch("HOMEBREW_GITHUB_API_TOKEN", false).presence)
                 # Replace the API token in the remote URL with interpolation.
-                # Rubocop's warning here is wrong; we intentionally want to not
-                # evaluate this string until the Brewfile is evaluated.
-                # rubocop:disable Lint/InterpolationCheck
-                tap_remote = tap_remote.gsub api_token, '#{ENV.fetch("HOMEBREW_GITHUB_API_TOKEN")}'
-                # rubocop:enable Lint/InterpolationCheck
+                # Keep the interpolation unevaluated until the Brewfile is evaluated.
+                tap_remote = tap_remote.gsub api_token, "\#{ENV.fetch(\"HOMEBREW_GITHUB_API_TOKEN\")}"
               end
               ", \"#{tap_remote}\""
             end

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -546,7 +546,7 @@ module Cask
           if cask_struct.caveats_rosetta
             caveats do
               # Dynamically defined via `caveat :requires_rosetta` — Sorbet can't resolve it.
-              public_send(:requires_rosetta) # rubocop:disable Style/SendWithLiteralMethodName
+              T.unsafe(self).requires_rosetta
             end
           end
         end

--- a/Library/Homebrew/extend/object/duplicable.rb
+++ b/Library/Homebrew/extend/object/duplicable.rb
@@ -21,10 +21,6 @@
 #
 # That's why we hardcode the following cases and check duplicable? instead of
 # using that rescue idiom.
-# rubocop:disable Layout/EmptyLines
-
-
-# rubocop:enable Layout/EmptyLines
 class Object
   # Can you safely dup this object?
   #

--- a/Library/Homebrew/test/cmd/mcp-server_spec.rb
+++ b/Library/Homebrew/test/cmd/mcp-server_spec.rb
@@ -3,12 +3,9 @@
 
 RSpec.describe "brew mcp-server", type: :system do
   it "starts the MCP server", :integration_test do
-    # This is the easiest way to handle a newline here.
-    # rubocop:disable Style/StringConcatenation
     expect { brew_sh "mcp-server", "--ping" }
       .to output("==> Started Homebrew MCP server...\n").to_stderr
-      .and output('{"jsonrpc":"2.0","id":1,"result":{}}' + "\n").to_stdout
+      .and output("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n").to_stdout
       .and be_a_success
-    # rubocop:enable Style/StringConcatenation
   end
 end

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -270,8 +270,6 @@ RSpec.describe Keg do
       expect(lib.children.length).to eq(2)
     end
 
-    # This is a legacy violation that would benefit from a clear expectation.
-    # rubocop:disable RSpec/NoExpectationExample
     it "removes broken symlinks that conflict with directories" do
       a = HOMEBREW_CELLAR/"a"/"1.0"
       (a/"lib"/"foo").mkpath
@@ -283,8 +281,9 @@ RSpec.describe Keg do
       link.make_symlink(nonexistent)
 
       keg.link
+
+      expect(link).to be_a_directory
     end
-    # rubocop:enable RSpec/NoExpectationExample
   end
 
   describe "#optlink" do

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -59,10 +59,9 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Patches do
           expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source:)
             FormulaAudit/Patches: MacPorts patches should specify a revision instead of trunk: #{patch_url}
           EOS
-        # GitHub patch diff regexps can't be any shorter.
-        # rubocop:disable Layout/LineLength
-        elsif patch_url.match?(%r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)})
-          # rubocop:enable Layout/LineLength
+        elsif patch_url.match?(%r{
+          https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)
+        }x)
           expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source:)
             FormulaAudit/Patches: Use a commit hash URL rather than patch-diff: #{patch_url}
           EOS
@@ -211,10 +210,9 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Patches do
           expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source:)
             FormulaAudit/Patches: Use a commit hash URL rather than an unstable merge request URL: #{patch_url}
           EOS
-        # GitHub patch diff regexps can't be any shorter.
-        # rubocop:disable Layout/LineLength
-        elsif patch_url.match?(%r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)})
-          # rubocop:enable Layout/LineLength
+        elsif patch_url.match?(%r{
+          https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)
+        }x)
           expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source:)
             FormulaAudit/Patches: Use a commit hash URL rather than patch-diff: #{patch_url}
           EOS

--- a/Library/Homebrew/test/utils/spdx_spec.rb
+++ b/Library/Homebrew/test/utils/spdx_spec.rb
@@ -77,8 +77,10 @@ RSpec.describe SPDX do
         "MIT",
         :public_domain,
         # The final array item is legitimately a hash in the case of license expressions.
-        all_of: ["0BSD", "Zlib"], # rubocop:disable Style/HashAsLastArrayItem
-        "curl" => { with: "LLVM-exception" },
+        {
+          all_of: ["0BSD", "Zlib"],
+          "curl" => { with: "LLVM-exception" },
+        },
       ] }
       result = [["MIT", :public_domain, "curl", "0BSD", "Zlib"], ["LLVM-exception"]]
       expect(described_class.parse_license_expression(license_expression)).to eq result
@@ -198,8 +200,10 @@ RSpec.describe SPDX do
         "MIT",
         :public_domain,
         # The final array item is legitimately a hash in the case of license expressions.
-        all_of: ["0BSD", "Zlib"], # rubocop:disable Style/HashAsLastArrayItem
-        "curl" => { with: "LLVM-exception" },
+        {
+          all_of: ["0BSD", "Zlib"],
+          "curl" => { with: "LLVM-exception" },
+        },
       ] }
       result = "MIT OR LicenseRef-Homebrew-public-domain OR (0BSD AND Zlib) OR (curl WITH LLVM-exception)"
       expect(described_class.license_expression_to_string(license_expression)).to eq result
@@ -239,19 +243,17 @@ RSpec.describe SPDX do
     end
 
     # The final array item is legitimately a hash in the case of license expressions.
-    # rubocop:disable Style/HashAsLastArrayItem
     it "handles nested brackets" do
       expect(described_class.string_to_license_expression("A AND (B OR (C AND D))")).to eq({
         all_of: [
           "A",
-          any_of: [
+          { any_of: [
             "B",
-            all_of: ["C", "D"],
-          ],
+            { all_of: ["C", "D"] },
+          ] },
         ],
       })
     end
-    # rubocop:enable Style/HashAsLastArrayItem
 
     it "returns :public_domain" do
       expect(described_class.string_to_license_expression("LicenseRef-Homebrew-public-domain")).to eq :public_domain

--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -134,7 +134,7 @@ module Utils
 
       str = str.dup
       # Anything that isn't a known safe character is padded.
-      str.gsub!(UNSAFE_SHELL_CHAR, "\\\\" + "\\1") # rubocop:disable Style/StringConcatenation
+      str.gsub!(UNSAFE_SHELL_CHAR, '\\\\\\1')
       # Newlines have to be specially quoted in `csh`.
       str.gsub!("\n", "'\\\n'")
       str
@@ -148,7 +148,7 @@ module Utils
 
       str = str.dup
       # Anything that isn't a known safe character is padded.
-      str.gsub!(UNSAFE_SHELL_CHAR, "\\\\" + "\\1") # rubocop:disable Style/StringConcatenation
+      str.gsub!(UNSAFE_SHELL_CHAR, '\\\\\\1')
       str.gsub!("\n", "'\n'")
       str
     end


### PR DESCRIPTION
- Reduce local lint noise where ordinary Ruby expresses the intent.
- Keep intentional `rubocop:disable` sites that document required choices.
- Add a direct keg expectation so the spec no longer needs suppression.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
