### PR TITLE
Remove aggregate examples todos

### DIFF
--- a/Library/Homebrew/test/build_options_spec.rb
+++ b/Library/Homebrew/test/build_options_spec.rb
@@ -15,23 +15,14 @@ RSpec.describe BuildOptions do
   let(:opts) { Options.create(%w[--with-foo --with-bar --without-baz --without-qux]) }
   let(:bad_args) { Options.create(%w[--with-foo --with-bar --without-bas --without-qux --without-abc]) }
 
-  specify "#with?" do
+  specify do
     expect(build_options).to be_built_with("foo")
     expect(build_options).to be_built_with("bar")
     expect(build_options).to be_built_with("baz")
-  end
-
-  specify "#without?" do # rubocop:todo RSpec/AggregateExamples
     expect(build_options).to be_built_without("qux")
     expect(build_options).to be_built_without("xyz")
-  end
-
-  specify "#used_options" do # rubocop:todo RSpec/AggregateExamples
     expect(build_options.used_options).to include("--with-foo")
     expect(build_options.used_options).to include("--with-bar")
-  end
-
-  specify "#unused_options" do # rubocop:todo RSpec/AggregateExamples
     expect(build_options.unused_options).to include("--without-baz")
   end
 end

--- a/Library/Homebrew/test/bump_version_parser_spec.rb
+++ b/Library/Homebrew/test/bump_version_parser_spec.rb
@@ -52,17 +52,11 @@ RSpec.describe Homebrew::BumpVersionParser do
       )
     end
 
-    it "correctly parses general version" do
+    specify do
       expect(new_version.general).to eq(Cask::DSL::Version.new(general_version.to_s))
       expect(new_version_version.general).to eq(Cask::DSL::Version.new(general_version.to_s))
-    end
-
-    it "correctly parses arm version" do # rubocop:todo RSpec/AggregateExamples
       expect(new_version.arm).to eq(Cask::DSL::Version.new(arm_version.to_s))
       expect(new_version_version.arm).to eq(Cask::DSL::Version.new(arm_version.to_s))
-    end
-
-    it "correctly parses intel version" do # rubocop:todo RSpec/AggregateExamples
       expect(new_version.intel).to eq(Cask::DSL::Version.new(intel_version.to_s))
       expect(new_version_version.intel).to eq(Cask::DSL::Version.new(intel_version.to_s))
     end

--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -744,23 +744,11 @@ RSpec.describe Homebrew::Bundle::Brew do
           allow(Homebrew::Bundle::Brew::Services).to receive(:started?).with(formula_name).and_return(true)
         end
 
-        it "is false by default" do
+        specify do
           expect(described_class.new(formula_name).start_service_needed?).to be(false)
-        end
-
-        it "is false with {start_service: true}" do # rubocop:todo RSpec/AggregateExamples
           expect(described_class.new(formula_name, start_service: true).start_service_needed?).to be(false)
-        end
-
-        it "is false with {restart_service: true}" do # rubocop:todo RSpec/AggregateExamples
           expect(described_class.new(formula_name, restart_service: true).start_service_needed?).to be(false)
-        end
-
-        it "is false with {restart_service: :changed}" do # rubocop:todo RSpec/AggregateExamples
           expect(described_class.new(formula_name, restart_service: :changed).start_service_needed?).to be(false)
-        end
-
-        it "is false with {restart_service: :always}" do # rubocop:todo RSpec/AggregateExamples
           expect(described_class.new(formula_name, restart_service: :always).start_service_needed?).to be(false)
         end
       end
@@ -770,23 +758,11 @@ RSpec.describe Homebrew::Bundle::Brew do
           allow(Homebrew::Bundle::Brew::Services).to receive(:started?).with(formula_name).and_return(false)
         end
 
-        it "is false by default" do
+        specify do
           expect(described_class.new(formula_name).start_service_needed?).to be(false)
-        end
-
-        it "is true if {start_service: true}" do # rubocop:todo RSpec/AggregateExamples
           expect(described_class.new(formula_name, start_service: true).start_service_needed?).to be(true)
-        end
-
-        it "is true if {restart_service: true}" do # rubocop:todo RSpec/AggregateExamples
           expect(described_class.new(formula_name, restart_service: true).start_service_needed?).to be(true)
-        end
-
-        it "is true if {restart_service: :changed}" do # rubocop:todo RSpec/AggregateExamples
           expect(described_class.new(formula_name, restart_service: :changed).start_service_needed?).to be(true)
-        end
-
-        it "is true if {restart_service: :always}" do # rubocop:todo RSpec/AggregateExamples
           expect(described_class.new(formula_name, restart_service: :always).start_service_needed?).to be(true)
         end
       end
@@ -826,15 +802,9 @@ RSpec.describe Homebrew::Bundle::Brew do
           allow_any_instance_of(described_class).to receive(:changed?).and_return(false)
         end
 
-        it "is false with {restart_service: true}" do
+        specify do
           expect(described_class.new(formula_name, restart_service: true).restart_service_needed?).to be(false)
-        end
-
-        it "is true with {restart_service: :always}" do # rubocop:todo RSpec/AggregateExamples
           expect(described_class.new(formula_name, restart_service: :always).restart_service_needed?).to be(true)
-        end
-
-        it "is false if {restart_service: :changed}" do # rubocop:todo RSpec/AggregateExamples
           expect(described_class.new(formula_name, restart_service: :changed).restart_service_needed?).to be(false)
         end
       end
@@ -844,15 +814,9 @@ RSpec.describe Homebrew::Bundle::Brew do
           allow_any_instance_of(described_class).to receive(:changed?).and_return(true)
         end
 
-        it "is true with {restart_service: true}" do
+        specify do
           expect(described_class.new(formula_name, restart_service: true).restart_service_needed?).to be(true)
-        end
-
-        it "is true with {restart_service: :always}" do # rubocop:todo RSpec/AggregateExamples
           expect(described_class.new(formula_name, restart_service: :always).restart_service_needed?).to be(true)
-        end
-
-        it "is true if {restart_service: :changed}" do # rubocop:todo RSpec/AggregateExamples
           expect(described_class.new(formula_name, restart_service: :changed).restart_service_needed?).to be(true)
         end
       end

--- a/Library/Homebrew/test/bundle/cargo_spec.rb
+++ b/Library/Homebrew/test/bundle/cargo_spec.rb
@@ -28,11 +28,8 @@ RSpec.describe Homebrew::Bundle::Cargo do
         allow(described_class).to receive(:package_manager_executable).and_return(nil)
       end
 
-      it "returns an empty list" do
+      specify do
         expect(dumper.packages).to be_empty
-      end
-
-      it "dumps an empty string" do # rubocop:todo RSpec/AggregateExamples
         expect(dumper.dump).to eql("")
       end
     end

--- a/Library/Homebrew/test/bundle/cask_spec.rb
+++ b/Library/Homebrew/test/bundle/cask_spec.rb
@@ -15,11 +15,8 @@ RSpec.describe Homebrew::Bundle::Cask do
         allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(false)
       end
 
-      it "returns empty list" do
+      specify do
         expect(dumper.cask_names).to be_empty
-      end
-
-      it "dumps as empty string" do # rubocop:todo RSpec/AggregateExamples
         expect(dumper.dump).to eql("")
       end
     end
@@ -31,11 +28,8 @@ RSpec.describe Homebrew::Bundle::Cask do
         allow(Cask::Caskroom).to receive(:casks).and_return([])
       end
 
-      it "returns empty list" do
+      specify do
         expect(dumper.cask_names).to be_empty
-      end
-
-      it "dumps as empty string" do # rubocop:todo RSpec/AggregateExamples
         expect(dumper.dump).to eql("")
       end
 

--- a/Library/Homebrew/test/bundle/go_spec.rb
+++ b/Library/Homebrew/test/bundle/go_spec.rb
@@ -15,11 +15,8 @@ RSpec.describe Homebrew::Bundle::Go do
         allow(described_class).to receive(:package_manager_executable).and_return(nil)
       end
 
-      it "returns an empty list" do
+      specify do
         expect(dumper.packages).to be_empty
-      end
-
-      it "dumps an empty string" do # rubocop:todo RSpec/AggregateExamples
         expect(dumper.dump).to eql("")
       end
     end

--- a/Library/Homebrew/test/bundle/mac_app_store_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_spec.rb
@@ -15,11 +15,8 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
         allow(described_class).to receive(:package_manager_executable).and_return(nil)
       end
 
-      it "returns empty list" do
+      specify do
         expect(dumper.apps).to be_empty
-      end
-
-      it "dumps as empty string" do # rubocop:todo RSpec/AggregateExamples
         expect(dumper.dump).to eql("")
       end
     end
@@ -30,11 +27,8 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
         allow(described_class).to receive_messages(package_manager_executable: Pathname.new("mas"), "`": "")
       end
 
-      it "returns empty list" do
+      specify do
         expect(dumper.apps).to be_empty
-      end
-
-      it "dumps as empty string" do # rubocop:todo RSpec/AggregateExamples
         expect(dumper.dump).to eql("")
       end
     end
@@ -147,11 +141,8 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
                                                    "`":                        invalid_mas_output)
       end
 
-      it "returns only valid apps" do
+      specify do
         expect(dumper.apps).to eql(expected_app_details_array)
-      end
-
-      it "dumps excluding invalid apps" do # rubocop:todo RSpec/AggregateExamples
         expect(dumper.dump).to eq(expected_mas_dumped_output.strip)
       end
     end

--- a/Library/Homebrew/test/bundle/npm_spec.rb
+++ b/Library/Homebrew/test/bundle/npm_spec.rb
@@ -15,11 +15,8 @@ RSpec.describe Homebrew::Bundle::Npm do
         allow(described_class).to receive(:package_manager_executable).and_return(nil)
       end
 
-      it "returns an empty list" do
+      specify do
         expect(dumper.packages).to be_empty
-      end
-
-      it "dumps an empty string" do # rubocop:todo RSpec/AggregateExamples
         expect(dumper.dump).to eql("")
       end
     end

--- a/Library/Homebrew/test/bundle/tap_spec.rb
+++ b/Library/Homebrew/test/bundle/tap_spec.rb
@@ -15,11 +15,8 @@ RSpec.describe Homebrew::Bundle::Tap do
         allow(Tap).to receive(:select).and_return []
       end
 
-      it "returns empty list" do
+      specify do
         expect(dumper.tap_names).to be_empty
-      end
-
-      it "dumps as empty string" do # rubocop:todo RSpec/AggregateExamples
         expect(dumper.dump).to eql("")
       end
     end

--- a/Library/Homebrew/test/bundle/vscode_extension_spec.rb
+++ b/Library/Homebrew/test/bundle/vscode_extension_spec.rb
@@ -16,11 +16,8 @@ RSpec.describe Homebrew::Bundle::VscodeExtension do
         allow(described_class).to receive_messages(package_manager_executable: nil, "`": "")
       end
 
-      it "returns an empty list" do
+      specify do
         expect(dumper.extensions).to be_empty
-      end
-
-      it "dumps an empty string" do # rubocop:todo RSpec/AggregateExamples
         expect(dumper.dump).to eql("")
       end
     end

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -64,11 +64,8 @@ RSpec.describe Cask::Audit, :cask do
     context "when `new_cask` is specified" do
       let(:new_cask) { true }
 
-      it "implies `online`" do
+      specify do
         expect(audit).to be_online
-      end
-
-      it "implies `strict`" do # rubocop:todo RSpec/AggregateExamples
         expect(audit).to be_strict
       end
     end
@@ -1190,14 +1187,18 @@ RSpec.describe Cask::Audit, :cask do
         allow(UnpackStrategy).to receive(:detect).and_return(nil)
       end
 
-      it "when download and verification succeed it does not fail" do
-        expect(download_double).to receive(:fetch).and_return(Pathname.new("/tmp/test.zip"))
-        expect(run).to pass
+      context "when the download succeeds" do
+        it "passes" do
+          expect(download_double).to receive(:fetch).and_return(Pathname.new("/tmp/test.zip"))
+          expect(run).to pass
+        end
       end
 
-      it "when download fails it fails" do # rubocop:todo RSpec/AggregateExamples
-        expect(download_double).to receive(:fetch).and_raise(StandardError.new(message))
-        expect(run).to error_with(/#{message}/)
+      context "when the download fails" do
+        it "fails" do
+          expect(download_double).to receive(:fetch).and_raise(StandardError.new(message))
+          expect(run).to error_with(/#{message}/)
+        end
       end
     end
 

--- a/Library/Homebrew/test/cask/macos_spec.rb
+++ b/Library/Homebrew/test/cask/macos_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 RSpec.describe MacOS, :cask do
-  it "says '/' is undeletable" do
+  specify do
     expect(described_class).to be_undeletable(
       "/",
     )
@@ -12,9 +12,6 @@ RSpec.describe MacOS, :cask do
     expect(described_class).to be_undeletable(
       "/usr/local/Library/Taps/../../../..",
     )
-  end
-
-  it "says '/Applications' is undeletable" do # rubocop:todo RSpec/AggregateExamples
     expect(described_class).to be_undeletable(
       "/Applications",
     )
@@ -27,9 +24,6 @@ RSpec.describe MacOS, :cask do
     expect(described_class).to be_undeletable(
       "/Applications/Mail.app/..",
     )
-  end
-
-  it "says the home directory is undeletable" do # rubocop:todo RSpec/AggregateExamples
     expect(described_class).to be_undeletable(
       Dir.home,
     )
@@ -39,9 +33,6 @@ RSpec.describe MacOS, :cask do
     expect(described_class).to be_undeletable(
       "#{Dir.home}/Documents/..",
     )
-  end
-
-  it "says the user library directory is undeletable" do # rubocop:todo RSpec/AggregateExamples
     expect(described_class).to be_undeletable(
       "#{Dir.home}/Library",
     )
@@ -54,15 +45,9 @@ RSpec.describe MacOS, :cask do
     expect(described_class).to be_undeletable(
       "#{Dir.home}/Library/Preferences/..",
     )
-  end
-
-  it "says '/Applications/.app' is deletable" do # rubocop:todo RSpec/AggregateExamples
     expect(described_class).not_to be_undeletable(
       "/Applications/.app",
     )
-  end
-
-  it "says '/Applications/SnakeOil Professional.app' is deletable" do # rubocop:todo RSpec/AggregateExamples
     expect(described_class).not_to be_undeletable(
       "/Applications/SnakeOil Professional.app",
     )

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -211,11 +211,8 @@ RSpec.describe Homebrew::CLI::NamedArgs do
       expect(described_class.new("foo", "bar").to_kegs.map(&:name)).to eq ["foo", "foo", "bar"]
     end
 
-    it "resolves kegs with multiple versions with #resolve_keg" do
+    specify do
       expect(described_class.new("foo").to_kegs.map { |k| k.version.version.to_s }.sort).to eq ["1.0", "2.0"]
-    end
-
-    it "when there are no matching kegs returns an empty array" do # rubocop:todo RSpec/AggregateExamples
       expect(described_class.new.to_kegs).to be_empty
     end
 
@@ -310,12 +307,9 @@ RSpec.describe Homebrew::CLI::NamedArgs do
   end
 
   describe "#homebrew_tap_cask_names" do
-    it "returns an array of casks from homebrew-cask" do
+    specify do
       expect(described_class.new("foo", "homebrew/cask/local-caffeine").homebrew_tap_cask_names)
         .to eq ["homebrew/cask/local-caffeine"]
-    end
-
-    it "returns an empty array when there are no matching casks" do # rubocop:todo RSpec/AggregateExamples
       expect(described_class.new("foo").homebrew_tap_cask_names).to be_empty
     end
   end

--- a/Library/Homebrew/test/dependable_spec.rb
+++ b/Library/Homebrew/test/dependable_spec.rb
@@ -16,23 +16,11 @@ RSpec.describe Dependable do
     end.new
   end
 
-  specify "#options" do
+  specify do
     expect(dependable.options.as_flags.sort).to eq(%w[--foo --bar].sort)
-  end
-
-  specify "#build?" do # rubocop:todo RSpec/AggregateExamples
     expect(dependable).to be_a_build_dependency
-  end
-
-  specify "#optional?" do # rubocop:todo RSpec/AggregateExamples
     expect(dependable).not_to be_optional
-  end
-
-  specify "#recommended?" do # rubocop:todo RSpec/AggregateExamples
     expect(dependable).not_to be_recommended
-  end
-
-  specify "#no_linkage?" do # rubocop:todo RSpec/AggregateExamples
     expect(dependable).not_to be_no_linkage
   end
 
@@ -47,11 +35,8 @@ RSpec.describe Dependable do
       end.new
     end
 
-    specify "#no_linkage?" do
+    specify do
       expect(dependable_no_linkage).to be_no_linkage
-    end
-
-    specify "#required?" do # rubocop:todo RSpec/AggregateExamples
       expect(dependable_no_linkage).to be_required
     end
   end

--- a/Library/Homebrew/test/extend/array_spec.rb
+++ b/Library/Homebrew/test/extend/array_spec.rb
@@ -5,11 +5,17 @@ require "extend/array"
 
 RSpec.describe Array do
   describe ".to_sentence" do
-    it "converts a plain array to a sentence" do
+    specify do
       expect([].to_sentence).to eq("")
       expect(["one"].to_sentence).to eq("one")
       expect(["one", "two"].to_sentence).to eq("one and two")
       expect(["one", "two", "three"].to_sentence).to eq("one, two and three")
+      expect([1].to_sentence).to eq("1")
+      expect([nil, "one", "", "two", "three"].to_sentence).to eq(", one, , two and three")
+      expect([""].to_sentence).not_to be_frozen
+      expect(["one"].to_sentence).not_to be_frozen
+      expect(["one", "two"].to_sentence).not_to be_frozen
+      expect(["one", "two", "three"].to_sentence).not_to be_frozen
     end
 
     it "converts an array to a sentence with a custom connector" do
@@ -31,21 +37,6 @@ RSpec.describe Array do
     it "creates a new string" do
       elements = ["one"]
       expect(elements.to_sentence.object_id).not_to eq(elements[0].object_id)
-    end
-
-    it "converts a non-String to a sentence" do # rubocop:todo RSpec/AggregateExamples
-      expect([1].to_sentence).to eq("1")
-    end
-
-    it "converts an array with blank elements to a sentence" do # rubocop:todo RSpec/AggregateExamples
-      expect([nil, "one", "", "two", "three"].to_sentence).to eq(", one, , two and three")
-    end
-
-    it "does not return a frozen string" do # rubocop:todo RSpec/AggregateExamples
-      expect([""].to_sentence).not_to be_frozen
-      expect(["one"].to_sentence).not_to be_frozen
-      expect(["one", "two"].to_sentence).not_to be_frozen
-      expect(["one", "two", "three"].to_sentence).not_to be_frozen
     end
   end
 end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -138,11 +138,8 @@ RSpec.describe Formula do
       end
     end
 
-    it "returns true for @-versioned formulae" do
+    specify do
       expect(f2.versioned_formula?).to be true
-    end
-
-    it "returns false for non-@-versioned formulae" do # rubocop:todo RSpec/AggregateExamples
       expect(f.versioned_formula?).to be false
     end
   end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -5,7 +5,6 @@ require "formula"
 require "formula_installer"
 require "utils/bottles"
 
-# rubocop:todo RSpec/AggregateExamples
 RSpec.describe Formulary do
   let(:formula_name) { "testball_bottle" }
   let(:formula_path) { CoreTap.instance.new_formula_path(formula_name) }
@@ -168,11 +167,8 @@ RSpec.describe Formulary do
       context "when given a bottle" do
         subject(:formula) { described_class.factory(bottle) }
 
-        it "returns a Formula" do
+        specify do
           expect(formula).to be_a(Formula)
-        end
-
-        it "calling #local_bottle_path on the returned Formula returns the bottle path" do
           expect(formula.local_bottle_path).to eq(bottle.realpath)
         end
       end
@@ -188,11 +184,8 @@ RSpec.describe Formulary do
           FileUtils.ln_s formula_path, alias_path
         end
 
-        it "returns a Formula" do
+        specify do
           expect(formula).to be_a(Formula)
-        end
-
-        it "calling #alias_path on the returned Formula returns the alias path" do
           expect(formula.alias_path).to eq(alias_path)
         end
       end
@@ -915,4 +908,3 @@ RSpec.describe Formulary do
     end
   end
 end
-# rubocop:enable RSpec/AggregateExamples

--- a/Library/Homebrew/test/livecheck/options_spec.rb
+++ b/Library/Homebrew/test/livecheck/options_spec.rb
@@ -140,21 +140,15 @@ RSpec.describe Homebrew::Livecheck::Options do
   end
 
   describe "#empty?" do
-    it "returns true if object has only default values" do
+    specify do
       expect(options.new.empty?).to be true
-    end
-
-    it "returns false if object has any non-default values" do # rubocop:todo RSpec/AggregateExamples
       expect(options.new(**args).empty?).to be false
     end
   end
 
   describe "#present?" do
-    it "returns false if object has only default values" do
+    specify do
       expect(options.new.present?).to be false
-    end
-
-    it "returns true if object has any non-default values" do # rubocop:todo RSpec/AggregateExamples
       expect(options.new(**args).present?).to be true
     end
   end

--- a/Library/Homebrew/test/macos_version_spec.rb
+++ b/Library/Homebrew/test/macos_version_spec.rb
@@ -62,25 +62,25 @@ RSpec.describe MacOSVersion do
     expect(frozen_version.instance_variable_get(:@comparison_cache)).to eq({})
   end
 
-  specify "comparison with Integer" do
+  specify do
     expect(version).to be > 10
     expect(version).to be < 11
-  end
-
-  specify "comparison with String" do # rubocop:todo RSpec/AggregateExamples
     expect(version).to be > "10.3"
     expect(version).to eq "10.15"
     # We're explicitly testing the `===` operator results here.
     expect(version).to be === "10.15" # rubocop:disable Style/CaseEquality
     expect(version).to be < "11"
-  end
-
-  specify "comparison with Version" do # rubocop:todo RSpec/AggregateExamples
     expect(version).to be > Version.new("10.3")
     expect(version).to eq Version.new("10.15")
     # We're explicitly testing the `===` operator results here.
     expect(version).to be === Version.new("10.15") # rubocop:disable Style/CaseEquality
     expect(version).to be < Version.new("11")
+    expect(described_class.new("11").inspect).to eq("#<MacOSVersion: \"11\">")
+    expect(described_class.new(described_class::SYMBOLS.values.first).outdated_release?).to be false
+    expect(described_class.new("10.0").outdated_release?).to be true
+    expect(described_class.new("1000").prerelease?).to be true
+    expect(described_class.new("10.0").unsupported_release?).to be true
+    expect(described_class.new("1000").unsupported_release?).to be true
   end
 
   describe "after Big Sur" do
@@ -102,12 +102,9 @@ RSpec.describe MacOSVersion do
   describe "#strip_patch" do
     let(:catalina_update) { described_class.new("10.15.1") }
 
-    it "returns the version without the patch" do
+    specify do
       expect(big_sur_update.strip_patch).to eq(described_class.new("11"))
       expect(catalina_update.strip_patch).to eq(described_class.new("10.15"))
-    end
-
-    it "returns self if version is null" do # rubocop:todo RSpec/AggregateExamples
       expect(described_class::NULL.strip_patch).to be described_class::NULL
     end
   end
@@ -140,24 +137,6 @@ RSpec.describe MacOSVersion do
     # the `@pretty_name` instance variable because the object is frozen.
     expect(frozen_version.pretty_name).to eq(version_pretty_name)
     expect(frozen_version.instance_variable_get(:@pretty_name)).to be_nil
-  end
-
-  specify "#inspect" do # rubocop:todo RSpec/AggregateExamples
-    expect(described_class.new("11").inspect).to eq("#<MacOSVersion: \"11\">")
-  end
-
-  specify "#outdated_release?" do # rubocop:todo RSpec/AggregateExamples
-    expect(described_class.new(described_class::SYMBOLS.values.first).outdated_release?).to be false
-    expect(described_class.new("10.0").outdated_release?).to be true
-  end
-
-  specify "#prerelease?" do # rubocop:todo RSpec/AggregateExamples
-    expect(described_class.new("1000").prerelease?).to be true
-  end
-
-  specify "#unsupported_release?" do # rubocop:todo RSpec/AggregateExamples
-    expect(described_class.new("10.0").unsupported_release?).to be true
-    expect(described_class.new("1000").prerelease?).to be true
   end
 
   describe "#requires_nehalem_cpu?", :needs_macos do

--- a/Library/Homebrew/test/options/deprecated_option_spec.rb
+++ b/Library/Homebrew/test/options/deprecated_option_spec.rb
@@ -6,19 +6,10 @@ require "options"
 RSpec.describe DeprecatedOption do
   subject(:option) { described_class.new("foo", "bar") }
 
-  specify "#old" do
+  specify do
     expect(option.old).to eq("foo")
-  end
-
-  specify "#old_flag" do # rubocop:todo RSpec/AggregateExamples
     expect(option.old_flag).to eq("--foo")
-  end
-
-  specify "#current" do # rubocop:todo RSpec/AggregateExamples
     expect(option.current).to eq("bar")
-  end
-
-  specify "#current_flag" do # rubocop:todo RSpec/AggregateExamples
     expect(option.current_flag).to eq("--bar")
   end
 

--- a/Library/Homebrew/test/options/option_spec.rb
+++ b/Library/Homebrew/test/options/option_spec.rb
@@ -6,8 +6,11 @@ require "options"
 RSpec.describe Option do
   subject(:option) { described_class.new("foo") }
 
-  specify "#to_s" do
+  specify do
     expect(option.to_s).to eq("--foo")
+    expect(option.description).to be_empty
+    expect(described_class.new("foo", "foo").description).to eq("foo")
+    expect(option.inspect).to eq("#<Option: \"--foo\">")
   end
 
   specify "equality" do
@@ -17,14 +20,5 @@ RSpec.describe Option do
     expect(option).not_to eq(bar)
     expect(option).to eql(foo)
     expect(option).not_to eql(bar)
-  end
-
-  specify "#description" do # rubocop:todo RSpec/AggregateExamples
-    expect(option.description).to be_empty
-    expect(described_class.new("foo", "foo").description).to eq("foo")
-  end
-
-  specify "#inspect" do # rubocop:todo RSpec/AggregateExamples
-    expect(option.inspect).to eq("#<Option: \"--foo\">")
   end
 end

--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -122,18 +122,12 @@ RSpec.describe Pathname do
   end
 
   describe "#extname" do
-    it "supports common multi-level archives" do
+    specify do
       expect(described_class.new("foo-0.1.tar.gz").extname).to eq(".tar.gz")
       expect(described_class.new("foo-0.1.cpio.gz").extname).to eq(".cpio.gz")
-    end
-
-    it "does not treat version numbers as extensions" do # rubocop:todo RSpec/AggregateExamples
       expect(described_class.new("foo-0.1").extname).to eq("")
       expect(described_class.new("foo-1.0-rc1").extname).to eq("")
       expect(described_class.new("foo-1.2.3").extname).to eq ""
-    end
-
-    it "supports `.7z` with version numbers" do # rubocop:todo RSpec/AggregateExamples
       expect(described_class.new("snap7-full-1.4.2.7z").extname).to eq ".7z"
     end
   end

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -73,11 +73,8 @@ RSpec.describe Resource do
   end
 
   describe "#livecheck_defined?" do
-    it "returns false if `livecheck` block is not set in resource" do
+    specify do
       expect(resource.livecheck_defined?).to be false
-    end
-
-    specify "`livecheck` block defined in resources" do # rubocop:todo RSpec/AggregateExamples
       expect(livecheck_resource.livecheck_defined?).to be true
     end
   end

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -121,16 +121,22 @@ RSpec.describe Tab do
     expect(tab.source["path"]).to be_nil
   end
 
-  specify "#include?" do
+  specify do
     expect(tab).to include("with-foo")
     expect(tab).to include("without-bar")
-  end
-
-  specify "#with?" do # rubocop:todo RSpec/AggregateExamples
     expect(tab).to be_built_with("foo")
     expect(tab).to be_built_with("qux")
     expect(tab).not_to be_built_with("bar")
     expect(tab).not_to be_built_with("baz")
+    expect(tab.cxxstdlib.compiler).to eq(:clang)
+    expect(tab.cxxstdlib.type).to eq(:libcxx)
+    expect(tab.tap.name).to eq("homebrew/core")
+    expect(tab.time).to eq(time)
+    expect(tab).not_to be_built_as_bottle
+    expect(tab).to be_poured_from_bottle
+    expect(tab).to be_installed_on_request
+    expect(tab).not_to be_loaded_from_api
+    expect(tab).not_to be_loaded_from_internal_api
   end
 
   specify "#parsed_homebrew_version" do
@@ -263,21 +269,6 @@ RSpec.describe Tab do
       ]
       expect(described_class.runtime_deps_hash(formula, formula_recursive_deps)).to eq(expected_output)
     end
-  end
-
-  specify "#cxxstdlib" do # rubocop:todo RSpec/AggregateExamples
-    expect(tab.cxxstdlib.compiler).to eq(:clang)
-    expect(tab.cxxstdlib.type).to eq(:libcxx)
-  end
-
-  specify "other attributes" do # rubocop:todo RSpec/AggregateExamples
-    expect(tab.tap.name).to eq("homebrew/core")
-    expect(tab.time).to eq(time)
-    expect(tab).not_to be_built_as_bottle
-    expect(tab).to be_poured_from_bottle
-    expect(tab).to be_installed_on_request
-    expect(tab).not_to be_loaded_from_api
-    expect(tab).not_to be_loaded_from_internal_api
   end
 
   describe "::from_file" do

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -775,11 +775,8 @@ RSpec.describe Tap do
   end
 
   describe "#repository_var_suffix" do
-    it "converts the repo directory to an environment variable suffix" do
+    specify do
       expect(CoreTap.instance.repository_var_suffix).to eq "_HOMEBREW_HOMEBREW_CORE"
-    end
-
-    it "converts non-alphanumeric characters to underscores" do # rubocop:todo RSpec/AggregateExamples
       expect(described_class.fetch("my",
                                    "tap-with-dashes").repository_var_suffix).to eq "_MY_HOMEBREW_TAP_WITH_DASHES"
       expect(described_class.fetch("my",

--- a/Library/Homebrew/test/test_runner_formula_spec.rb
+++ b/Library/Homebrew/test/test_runner_formula_spec.rb
@@ -26,11 +26,8 @@ RSpec.describe TestRunnerFormula do
   end
 
   describe "#eval_all" do
-    it "is false by default" do
+    specify do
       expect(described_class.new(testball).eval_all).to be(false)
-    end
-
-    it "can be instantiated to be `true`" do # rubocop:todo RSpec/AggregateExamples
       expect(described_class.new(testball, eval_all: true).eval_all).to be(true)
     end
 

--- a/Library/Homebrew/test/utils/bottles/tag_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/tag_spec.rb
@@ -47,11 +47,8 @@ RSpec.describe Utils::Bottles::Tag do
   end
 
   describe "#standardized_arch" do
-    it "returns :x86_64 for :intel" do
+    specify do
       expect(described_class.new(system: :all, arch: :intel).standardized_arch).to eq(:x86_64)
-    end
-
-    it "returns :arm64 for :arm" do # rubocop:todo RSpec/AggregateExamples
       expect(described_class.new(system: :all, arch: :arm).standardized_arch).to eq(:arm64)
     end
   end

--- a/Library/Homebrew/test/utils/cpan_spec.rb
+++ b/Library/Homebrew/test/utils/cpan_spec.rb
@@ -20,25 +20,16 @@ RSpec.describe CPAN do
     let(:package_from_non_cpan_url) { described_class.new("SomePackage", non_cpan_package_url) }
 
     describe "initialize" do
-      it "initializes resource name" do
+      specify do
         expect(package_from_cpan_url.name).to eq "Scalar::Util"
-      end
-
-      it "extracts version from CPAN url" do # rubocop:todo RSpec/AggregateExamples
         expect(package_from_cpan_url.current_version).to eq "1.68"
-      end
-
-      it "handles .tgz extensions" do # rubocop:todo RSpec/AggregateExamples
         expect(package_from_tgz_url.current_version).to eq "1.23"
       end
     end
 
     describe ".valid_cpan_package?" do
-      it "is true for CPAN URLs" do
+      specify do
         expect(package_from_cpan_url.valid_cpan_package?).to be true
-      end
-
-      it "is false for non-CPAN URLs" do # rubocop:todo RSpec/AggregateExamples
         expect(package_from_non_cpan_url.valid_cpan_package?).to be false
       end
     end

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -31,51 +31,18 @@ RSpec.describe PyPI do
     let(:other_package) { described_class.new("virtualenv==20.2.0") }
 
     describe "initialize" do
-      it "initializes name" do
+      specify do
         expect(described_class.new("foo").name).to eq "foo"
-      end
-
-      it "initializes name with extra" do # rubocop:todo RSpec/AggregateExamples
         expect(described_class.new("foo[bar]").name).to eq "foo"
-      end
-
-      it "initializes extra" do # rubocop:todo RSpec/AggregateExamples
         expect(described_class.new("foo[bar]").extras).to eq ["bar"]
-      end
-
-      it "initializes multiple extras" do # rubocop:todo RSpec/AggregateExamples
         expect(described_class.new("foo[bar,baz]").extras).to eq ["bar", "baz"]
-      end
-
-      it "initializes name with version" do # rubocop:todo RSpec/AggregateExamples
         expect(described_class.new("foo==1.2.3").name).to eq "foo"
-      end
-
-      it "initializes version" do # rubocop:todo RSpec/AggregateExamples
         expect(described_class.new("foo==1.2.3").version).to eq "1.2.3"
-      end
-
-      it "initializes extra with version" do # rubocop:todo RSpec/AggregateExamples
         expect(described_class.new("foo[bar]==1.2.3").extras).to eq ["bar"]
-      end
-
-      it "initializes multiple extras with version" do # rubocop:todo RSpec/AggregateExamples
         expect(described_class.new("foo[bar,baz]==1.2.3").extras).to eq ["bar", "baz"]
-      end
-
-      it "initializes version with extra" do # rubocop:todo RSpec/AggregateExamples
         expect(described_class.new("foo[bar]==1.2.3").version).to eq "1.2.3"
-      end
-
-      it "initializes version with multiple extras" do # rubocop:todo RSpec/AggregateExamples
         expect(described_class.new("foo[bar,baz]==1.2.3").version).to eq "1.2.3"
-      end
-
-      it "initializes name from PyPI url" do # rubocop:todo RSpec/AggregateExamples
         expect(described_class.new(pypi_package_url, is_url: true).name).to eq "snakemake"
-      end
-
-      it "initializes version from PyPI url" do # rubocop:todo RSpec/AggregateExamples
         expect(described_class.new(pypi_package_url, is_url: true).version).to eq "5.29.0"
       end
     end
@@ -105,36 +72,25 @@ RSpec.describe PyPI do
     end
 
     describe ".valid_pypi_package?" do
-      it "is true for package names" do
+      specify do
         expect(package.valid_pypi_package?).to be true
-      end
-
-      it "is true for PyPI URLs" do # rubocop:todo RSpec/AggregateExamples
         expect(package_from_pypi_url.valid_pypi_package?).to be true
-      end
-
-      it "is false for non-PyPI URLs" do # rubocop:todo RSpec/AggregateExamples
         expect(package_from_non_pypi_url.valid_pypi_package?).to be false
       end
     end
 
     describe ".pypi_info", :needs_network do
-      it "gets pypi info from a package name" do
+      specify do
         expect(package.pypi_info.first).to eq "snakemake"
+        expect(package_with_extra.pypi_info.first).to eq "snakemake"
+        expect(package_with_version.pypi_info).to eq ["snakemake", old_pypi_package_url, old_package_checksum,
+                                                      "5.28.0"]
+        expect(package_from_pypi_url.pypi_info).to eq ["snakemake", pypi_package_url, package_checksum, "5.29.0"]
       end
 
       it "gets pypi info from a package name and specified version" do
         expect(package.pypi_info(new_version: "5.29.0")).to eq ["snakemake", pypi_package_url, package_checksum,
                                                                 "5.29.0"]
-      end
-
-      it "gets pypi info from a package name with extra" do # rubocop:todo RSpec/AggregateExamples
-        expect(package_with_extra.pypi_info.first).to eq "snakemake"
-      end
-
-      it "gets pypi info from a package name and version" do # rubocop:todo RSpec/AggregateExamples
-        expect(package_with_version.pypi_info).to eq ["snakemake", old_pypi_package_url, old_package_checksum,
-                                                      "5.28.0"]
       end
 
       it "gets pypi info from a package name with overridden version" do
@@ -147,10 +103,6 @@ RSpec.describe PyPI do
         expect(package_with_extra_and_version.pypi_info).to eq expected_result
       end
 
-      it "gets pypi info from a url" do # rubocop:todo RSpec/AggregateExamples
-        expect(package_from_pypi_url.pypi_info).to eq ["snakemake", pypi_package_url, package_checksum, "5.29.0"]
-      end
-
       it "gets pypi info from a url with overridden version" do
         expected_result = ["snakemake", old_pypi_package_url, old_package_checksum, "5.28.0"]
         expect(package_from_pypi_url.pypi_info(new_version: "5.28.0")).to eq expected_result
@@ -158,23 +110,11 @@ RSpec.describe PyPI do
     end
 
     describe ".to_s" do
-      it "returns string representation of package name" do
+      specify do
         expect(package.to_s).to eq "snakemake"
-      end
-
-      it "returns string representation of package with version" do # rubocop:todo RSpec/AggregateExamples
         expect(package_with_version.to_s).to eq "snakemake==5.28.0"
-      end
-
-      it "returns string representation of package with extra" do # rubocop:todo RSpec/AggregateExamples
         expect(package_with_extra.to_s).to eq "snakemake[foo]"
-      end
-
-      it "returns string representation of package with extra and version" do # rubocop:todo RSpec/AggregateExamples
         expect(package_with_extra_and_version.to_s).to eq "snakemake[foo]==5.28.0"
-      end
-
-      it "returns string representation of package from url" do # rubocop:todo RSpec/AggregateExamples
         expect(package_from_pypi_url.to_s).to eq "snakemake==5.29.0"
       end
     end

--- a/Library/Homebrew/test/utils/spdx_spec.rb
+++ b/Library/Homebrew/test/utils/spdx_spec.rb
@@ -43,28 +43,15 @@ RSpec.describe SPDX do
   end
 
   describe ".parse_license_expression" do
-    it "returns a single license" do
+    specify do
       expect(described_class.parse_license_expression("MIT").first).to eq ["MIT"]
-    end
-
-    it "returns a single license with plus" do # rubocop:todo RSpec/AggregateExamples
       expect(described_class.parse_license_expression("Apache-2.0+").first).to eq ["Apache-2.0+"]
-    end
-
-    it "returns multiple licenses with :any" do # rubocop:todo RSpec/AggregateExamples
       expect(described_class.parse_license_expression(any_of: ["MIT", "0BSD"]).first).to eq ["MIT", "0BSD"]
-    end
-
-    it "returns multiple licenses with :all" do # rubocop:todo RSpec/AggregateExamples
       expect(described_class.parse_license_expression(all_of: ["MIT", "0BSD"]).first).to eq ["MIT", "0BSD"]
-    end
-
-    it "returns multiple licenses with plus" do # rubocop:todo RSpec/AggregateExamples
       expect(described_class.parse_license_expression(any_of: ["MIT", "EPL-1.0+"]).first).to eq ["MIT", "EPL-1.0+"]
-    end
-
-    it "returns multiple licenses with array" do # rubocop:todo RSpec/AggregateExamples
       expect(described_class.parse_license_expression(["MIT", "EPL-1.0+"]).first).to eq ["MIT", "EPL-1.0+"]
+      expect(described_class.parse_license_expression(:public_domain).first).to eq [:public_domain]
+      expect(described_class.parse_license_expression(:cannot_represent).first).to eq [:cannot_represent]
     end
 
     it "returns license and exception" do
@@ -82,14 +69,6 @@ RSpec.describe SPDX do
       ] }
       result = [["MIT", :public_domain, "curl", "0BSD", "Zlib"], ["LLVM-exception"]]
       expect(described_class.parse_license_expression(license_expression)).to eq result
-    end
-
-    it "returns :public_domain" do # rubocop:todo RSpec/AggregateExamples
-      expect(described_class.parse_license_expression(:public_domain).first).to eq [:public_domain]
-    end
-
-    it "returns :cannot_represent" do # rubocop:todo RSpec/AggregateExamples
-      expect(described_class.parse_license_expression(:cannot_represent).first).to eq [:cannot_represent]
     end
   end
 

--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -9,11 +9,8 @@ RSpec.describe Tty do
   end
 
   describe "::width" do
-    it "returns an Integer" do
+    specify do
       expect(described_class.width).to be_a(Integer)
-    end
-
-    it "cannot be negative" do # rubocop:todo RSpec/AggregateExamples
       expect(described_class.width).to be >= 0
     end
   end

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -11,11 +11,8 @@ RSpec.describe Version do
   end
 
   describe Version::Token do
-    specify "#inspect" do
+    specify do
       expect(described_class.create("foo").inspect).to eq('#<Version::StringToken "foo">')
-    end
-
-    specify "#to_s" do # rubocop:todo RSpec/AggregateExamples
       expect(described_class.create("foo").to_s).to eq("foo")
     end
 
@@ -79,15 +76,9 @@ RSpec.describe Version do
   describe "when the version is `NULL`" do
     subject(:null_version) { Version::NULL }
 
-    it "is always smaller" do
+    specify do
       expect(null_version).to be < described_class.new("1")
-    end
-
-    it "is never greater" do # rubocop:todo RSpec/AggregateExamples
       expect(null_version).not_to be > described_class.new("0")
-    end
-
-    it "isn't equal to itself" do # rubocop:todo RSpec/AggregateExamples
       expect(null_version).not_to eql(null_version)
     end
 
@@ -129,11 +120,8 @@ RSpec.describe Version do
   describe "::NULL_TOKEN" do
     subject(:null_version) { described_class::NULL_TOKEN }
 
-    specify "#inspect" do
+    specify do
       expect(null_version.inspect).to eq("#<Version::NullToken>")
-    end
-
-    it "is equal to itself" do # rubocop:todo RSpec/AggregateExamples
       expect(null_version).to eq described_class::NULL_TOKEN
     end
   end


### PR DESCRIPTION
- `RSpec/AggregateExamples` todos hid spec groups that RuboCop can now aggregate directly.
- Aggregating adjacent examples keeps the tests aligned with the active style rule without carrying stale suppressions.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Codex 5.5 xhigh with local review and testing.

-----
