### PR TITLE
Fix RSpec named subjects

### DIFF
--- a/Library/Homebrew/test/cask/denylist_spec.rb
+++ b/Library/Homebrew/test/cask/denylist_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Cask::Denylist, :cask do
     end
 
     specify(:aggregate_failures) do
-      expect(subject).not_to disallow("adobe-air") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("adobe-after-effects") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("adobe-illustrator") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("adobe-indesign") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("adobe-photoshop") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("adobe-premiere") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("pharo") # rubocop:todo RSpec/NamedSubject
-      expect(subject).not_to disallow("allowed-cask") # rubocop:todo RSpec/NamedSubject
+      expect(described_class).not_to disallow("adobe-air")
+      expect(described_class).to disallow("adobe-after-effects")
+      expect(described_class).to disallow("adobe-illustrator")
+      expect(described_class).to disallow("adobe-indesign")
+      expect(described_class).to disallow("adobe-photoshop")
+      expect(described_class).to disallow("adobe-premiere")
+      expect(described_class).to disallow("pharo")
+      expect(described_class).not_to disallow("allowed-cask")
     end
   end
 end

--- a/Library/Homebrew/test/checksum_spec.rb
+++ b/Library/Homebrew/test/checksum_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe Checksum do
   end
 
   describe "#==" do
-    subject { described_class.new(TEST_SHA256) }
+    subject(:checksum) { described_class.new(TEST_SHA256) }
 
     let(:other) { described_class.new(TEST_SHA256) }
     let(:other_reversed) { described_class.new(TEST_SHA256.reverse) }
 
     specify(:aggregate_failures) do
-      expect(subject).to eq(other) # rubocop:todo RSpec/NamedSubject
-      expect(subject).not_to eq(other_reversed) # rubocop:todo RSpec/NamedSubject
-      expect(subject).not_to be_nil # rubocop:todo RSpec/NamedSubject
+      expect(checksum).to eq(other)
+      expect(checksum).not_to eq(other_reversed)
+      expect(checksum).not_to be_nil
     end
   end
 end

--- a/Library/Homebrew/test/locale_spec.rb
+++ b/Library/Homebrew/test/locale_spec.rb
@@ -48,15 +48,15 @@ RSpec.describe Locale do
   end
 
   describe "#include?" do
-    subject { described_class.new("zh", "Hans", "CN") }
+    subject(:locale) { described_class.new("zh", "Hans", "CN") }
 
     specify(:aggregate_failures) do
-      expect(subject).to include("zh") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to include("zh-CN") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to include("CN") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to include("Hans-CN") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to include("Hans") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to include("zh-Hans-CN") # rubocop:todo RSpec/NamedSubject
+      expect(locale).to include("zh")
+      expect(locale).to include("zh-CN")
+      expect(locale).to include("CN")
+      expect(locale).to include("Hans-CN")
+      expect(locale).to include("Hans")
+      expect(locale).to include("zh-Hans-CN")
     end
   end
 
@@ -65,18 +65,18 @@ RSpec.describe Locale do
 
     context "when all parts match" do
       specify(:aggregate_failures) do
-        expect(subject).to eql("zh-Hans-CN") # rubocop:todo RSpec/NamedSubject
-        expect(subject).to eql(locale) # rubocop:todo RSpec/NamedSubject
+        expect(locale).to eql("zh-Hans-CN")
+        expect(locale).to eql(described_class.new("zh", "Hans", "CN"))
       end
     end
 
     context "when only some parts match" do
       specify(:aggregate_failures) do
-        expect(subject).not_to eql("zh") # rubocop:todo RSpec/NamedSubject
-        expect(subject).not_to eql("zh-CN") # rubocop:todo RSpec/NamedSubject
-        expect(subject).not_to eql("CN") # rubocop:todo RSpec/NamedSubject
-        expect(subject).not_to eql("Hans-CN") # rubocop:todo RSpec/NamedSubject
-        expect(subject).not_to eql("Hans") # rubocop:todo RSpec/NamedSubject
+        expect(locale).not_to eql("zh")
+        expect(locale).not_to eql("zh-CN")
+        expect(locale).not_to eql("CN")
+        expect(locale).not_to eql("Hans-CN")
+        expect(locale).not_to eql("Hans")
       end
     end
 

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -18,17 +18,17 @@ RSpec.describe Homebrew::MissingFormula do
     end
 
     specify(:aggregate_failures) do
-      expect(subject).to disallow("gem") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("pip") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("pil") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("macruby") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("lzma") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("gsutil") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("gfortran") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("play") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("haskell-platform") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("mysqldump-secure") # rubocop:todo RSpec/NamedSubject
-      expect(subject).to disallow("ngrok") # rubocop:todo RSpec/NamedSubject
+      expect(described_class).to disallow("gem")
+      expect(described_class).to disallow("pip")
+      expect(described_class).to disallow("pil")
+      expect(described_class).to disallow("macruby")
+      expect(described_class).to disallow("lzma")
+      expect(described_class).to disallow("gsutil")
+      expect(described_class).to disallow("gfortran")
+      expect(described_class).to disallow("play")
+      expect(described_class).to disallow("haskell-platform")
+      expect(described_class).to disallow("mysqldump-secure")
+      expect(described_class).to disallow("ngrok")
     end
 
     it("disallows Xcode", :needs_macos) { is_expected.to disallow("xcode") }
@@ -115,15 +115,15 @@ RSpec.describe Homebrew::MissingFormula do
   end
 
   describe "::cask_reason", :cask do
-    subject { described_class.cask_reason(formula, show_info:) }
+    subject(:reason) { described_class.cask_reason(formula, show_info:) }
 
     context "with a formula name that is a cask and show_info: false" do
       let(:formula) { "local-caffeine" }
       let(:show_info) { false }
 
       specify(:aggregate_failures) do
-        expect(subject).to match(/Found a cask named "local-caffeine" instead./) # rubocop:todo RSpec/NamedSubject
-        expect(subject).to match(/Try\n  brew install --cask local-caffeine/) # rubocop:todo RSpec/NamedSubject
+        expect(reason).to match(/Found a cask named "local-caffeine" instead./)
+        expect(reason).to match(/Try\n  brew install --cask local-caffeine/)
       end
     end
 
@@ -143,15 +143,15 @@ RSpec.describe Homebrew::MissingFormula do
   end
 
   describe "::suggest_command", :cask do
-    subject { described_class.suggest_command(name, command) }
+    subject(:reason) { described_class.suggest_command(name, command) }
 
     context "when installing" do
       let(:name) { "local-caffeine" }
       let(:command) { "install" }
 
       specify(:aggregate_failures) do
-        expect(subject).to match(/Found a cask named "local-caffeine" instead./) # rubocop:todo RSpec/NamedSubject
-        expect(subject).to match(/Try\n  brew install --cask local-caffeine/) # rubocop:todo RSpec/NamedSubject
+        expect(reason).to match(/Found a cask named "local-caffeine" instead./)
+        expect(reason).to match(/Try\n  brew install --cask local-caffeine/)
       end
     end
 
@@ -167,8 +167,8 @@ RSpec.describe Homebrew::MissingFormula do
         end
 
         specify(:aggregate_failures) do
-          expect(subject).to match(/Found a cask named "local-caffeine" instead./) # rubocop:todo RSpec/NamedSubject
-          expect(subject).to match(/Try\n  brew uninstall --cask local-caffeine/) # rubocop:todo RSpec/NamedSubject
+          expect(reason).to match(/Found a cask named "local-caffeine" instead./)
+          expect(reason).to match(/Try\n  brew uninstall --cask local-caffeine/)
         end
       end
     end
@@ -178,8 +178,8 @@ RSpec.describe Homebrew::MissingFormula do
       let(:command) { "info" }
 
       specify(:aggregate_failures) do
-        expect(subject).to match(/Found a cask named "local-caffeine" instead./) # rubocop:todo RSpec/NamedSubject
-        expect(subject).to match(/local-caffeine: 1.2.3/) # rubocop:todo RSpec/NamedSubject
+        expect(reason).to match(/Found a cask named "local-caffeine" instead./)
+        expect(reason).to match(/local-caffeine: 1.2.3/)
       end
     end
   end


### PR DESCRIPTION
- Keep the lint baseline moving without changing runtime behaviour.
- Use named subjects where the examples assert on an instance.
- Use `described_class` for module checks that do not need a subject.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
