### PR TITLE
cmd/which-formula: don't downcase cmd

### DIFF
--- a/Library/Homebrew/cmd/which-formula.sh
+++ b/Library/Homebrew/cmd/which-formula.sh
@@ -100,11 +100,9 @@ homebrew-which-formula() {
     exit 1
   fi
 
-  for cms in "${args[@]}"
+  for cmd in "${args[@]}"
   do
     download_and_cache_executables_file
-
-    cmd="$(echo "${cms}" | tr '[:upper:]' '[:lower:]')"
 
     local formulae=()
     local formula cmds_text

--- a/Library/Homebrew/test/cmd/which-formula_spec.rb
+++ b/Library/Homebrew/test/cmd/which-formula_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Homebrew::Cmd::WhichFormula do
         foo(1.0.0):foo2 foo3
         bar(1.2.3):
         baz(10.4):baz
+        qux(4.5.6):QUX
       EOS
     end
 
@@ -26,6 +27,7 @@ RSpec.describe Homebrew::Cmd::WhichFormula do
       expect { brew_sh "which-formula", "--skip-update", "foo2" }.to output("foo\n").to_stdout
       expect { brew_sh "which-formula", "--skip-update", "baz" }.to output("baz\n").to_stdout
       expect { brew_sh "which-formula", "--skip-update", "bar" }.not_to output.to_stdout
+      expect { brew_sh "which-formula", "--skip-update", "QUX" }.to output("qux\n").to_stdout
     end
   end
 end


### PR DESCRIPTION
Since the beginning of the `which-formula` command [^1], the input command/executable has been downcased before it is searched for in the executables database. However, the executables database contains commands in their original case, so downcasing the input command can lead to it not being found, even if it exists in the database. There are a nontrivial number of such commands, the first being `ABYSS` from the `abyss` formula if you look at the database [^2], which `brew which-formula ABYSS` fails to find.

I don't see any reason to downcase the command, so I am proposing that we stop doing that. Although macOS's filesystem is case-insensitive by default so the casing of the command doesn't usually matter, it still looks better and more correct to me to being able to find the command in its canonical casing than the current behavior where you simply can't find it at all.

[^1]: https://github.com/Homebrew/homebrew-command-not-found/commit/c7741be9960e4a3403c873079cc60e575b5ebf3c
[^2]: https://formulae.brew.sh/api/internal/executables.txt

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
