### PR TITLE
Annotate test-bot dependency impact

### DIFF
--- a/Library/Homebrew/test/test_bot/formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_spec.rb
@@ -4,6 +4,79 @@
 require "test_bot"
 
 RSpec.describe Homebrew::TestBot::Formulae do
+  describe "#dependency_name_match?" do
+    it "requires exact matches when either name is tap-qualified", :aggregate_failures do
+      Dir.mktmpdir do |tmpdir|
+        output_paths = {
+          bottle:                     Pathname.new("#{tmpdir}/bottle.txt"),
+          linkage:                    Pathname.new("#{tmpdir}/linkage.txt"),
+          skipped_or_failed_formulae: Pathname.new("#{tmpdir}/skipped.txt"),
+        }
+        formulae = described_class.new(
+          tap: nil, git: "git", dry_run: true, fail_fast: false, verbose: false,
+          output_paths:
+        )
+
+        expect(formulae.send(:dependency_name_match?, Dependency.new("foo"), "foo")).to be(true)
+        expect(formulae.send(:dependency_name_match?, Dependency.new("homebrew/core/foo"), "homebrew/core/foo"))
+          .to be(true)
+        expect(formulae.send(:dependency_name_match?, Dependency.new("homebrew/core/foo"), "foo")).to be(false)
+        expect(formulae.send(:dependency_name_match?, Dependency.new("homebrew/core/foo"), "user/tap/foo"))
+          .to be(false)
+      end
+    end
+  end
+
+  describe "#annotate_added_dependencies" do
+    it "writes a warning annotation for the new recursive dependency impact" do
+      T.bind(self, T.untyped)
+
+      formula = formula("foo") do
+        url "foo-1.0"
+        depends_on "existing"
+        depends_on "bar"
+      end
+      existing = formula("existing") { url "existing-1.0" }
+      bar = formula("bar") do
+        url "bar-1.0"
+        depends_on "existing"
+        depends_on "baz"
+      end
+      baz = formula("baz") { url "baz-1.0" }
+
+      [existing, bar, baz].each { |f| stub_formula_loader f }
+      [[bar, 1_000_000], [baz, 500_000]].each do |f, size|
+        allow(f).to receive(:bottle_for_tag)
+          .and_return(instance_double(Bottle, fetch_tab: nil, installed_size: size))
+      end
+      allow(Utils).to receive(:safe_popen_read).and_return <<~DIFF
+        @@ -2,0 +7,1 @@
+        +  depends_on "bar"
+      DIFF
+
+      Dir.mktmpdir do |tmpdir|
+        output_paths = {
+          bottle:                     Pathname.new("#{tmpdir}/bottle.txt"),
+          linkage:                    Pathname.new("#{tmpdir}/linkage.txt"),
+          skipped_or_failed_formulae: Pathname.new("#{tmpdir}/skipped.txt"),
+        }
+        formulae = described_class.new(
+          tap: nil, git: "git", dry_run: true, fail_fast: false, verbose: false,
+          output_paths:
+        )
+
+        with_env(GITHUB_ACTIONS: "true") do
+          expect { formulae.send(:annotate_added_dependencies, formula) }
+            .to output(
+              "::warning file=#{formula.path.relative_path_from(CoreTap.instance.path)},line=7," \
+              "title=foo: new dependency impact::Adding `bar` adds 2 new recursive dependencies " \
+              "on #{Utils::Bottles.tag} (1.5MB).\n",
+            ).to_stdout
+        end
+      end
+    end
+  end
+
   describe "#testing_portable_ruby?" do
     it "returns false (not nil) when tap is nil" do
       # Regression test: without `!!`, tap&.core_tap? returns nil when tap is nil,

--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -358,6 +358,108 @@ module Homebrew
       sig { params(args: Homebrew::Cmd::TestBotCmd::Args).void }
       def setup_bottle_sudo_purge!(args:); end
 
+      sig { params(dependency: Dependency, dependency_name: String).returns(T::Boolean) }
+      def dependency_name_match?(dependency, dependency_name)
+        return true if dependency.name == dependency_name
+        return false if Utils.tap_from_full_name(dependency.name).present?
+        return false if Utils.tap_from_full_name(dependency_name).present?
+
+        Utils.name_from_full_name(dependency.name) == Utils.name_from_full_name(dependency_name)
+      end
+
+      sig { params(formula: Formula, dependencies: T::Array[Dependency]).returns(T::Array[String]) }
+      def recursive_runtime_dependency_names(formula, dependencies)
+        Dependency.expand(formula, dependencies).map { |dependency| dependency.to_formula.full_name }.uniq
+      end
+
+      sig { params(formula: Formula).void }
+      def annotate_added_dependencies(formula)
+        return unless GitHub::Actions.env_set?
+        return if @added_formulae.include?(formula.name)
+        return if (git = self.git).nil?
+
+        direct_runtime_dependencies = formula.deps.reject do |dependency|
+          dependency.build? || dependency.optional? || dependency.test?
+        end
+
+        new_line = T.let(nil, T.nilable(Integer))
+        Utils.safe_popen_read(
+          git, "-C", repository, "diff", "--no-ext-diff", "--unified=0", "origin/HEAD", "HEAD", "--",
+          formula.path.relative_path_from(repository).to_s
+        ).each_line do |diff_line|
+          if (match = diff_line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/))
+            new_line = match[1]&.to_i
+            next
+          end
+
+          line = new_line
+          next if line.nil?
+
+          if diff_line.start_with?("+") && !diff_line.start_with?("+++")
+            dependency_name = diff_line[/^\+\s*depends_on\s+["']([^"']+)["']/, 1]
+            new_line = line + 1
+          elsif !diff_line.start_with?("-") || diff_line.start_with?("---")
+            new_line = line + 1
+            next
+          else
+            next
+          end
+          next if dependency_name.blank?
+
+          dependency = direct_runtime_dependencies.find do |runtime_dependency|
+            dependency_name_match?(runtime_dependency, dependency_name)
+          end
+          next if dependency.nil?
+
+          dependency_formula = dependency.to_formula
+          existing_runtime_dependency_names = recursive_runtime_dependency_names(
+            formula,
+            direct_runtime_dependencies.reject do |runtime_dependency|
+              dependency_name_match?(runtime_dependency, dependency.name)
+            end,
+          )
+          new_recursive_dependency_names =
+            (
+              [dependency_formula.full_name] +
+              recursive_runtime_dependency_names(
+                dependency_formula,
+                dependency_formula.runtime_dependencies(read_from_tab: false, undeclared: false),
+              )
+            ).uniq - existing_runtime_dependency_names
+          next if new_recursive_dependency_names.blank?
+
+          sizes = new_recursive_dependency_names.map do |formula_name|
+            installed_sizes = @dependency_impact_installed_sizes ||=
+              T.let({}, T.nilable(T::Hash[String, T.nilable(Integer)]))
+            next installed_sizes[formula_name] if installed_sizes.key?(formula_name)
+
+            installed_sizes[formula_name] =
+              if (bottle = Formulary.factory(formula_name).bottle_for_tag(Utils::Bottles.tag))
+                bottle.fetch_tab(quiet: true)
+                bottle.installed_size
+              end
+          rescue DownloadError, FormulaUnavailableError, Resource::BottleManifest::Error
+            nil
+          end
+          dependency_count = new_recursive_dependency_names.count
+          message = "Adding `#{dependency_name}` adds #{dependency_count} new recursive " \
+                    "#{Utils.pluralize("dependency", dependency_count)} " \
+                    "on #{Utils::Bottles.tag} (#{Formatter.disk_usage_readable(sizes.compact.sum)}"
+          unknown_size_count = sizes.count(&:nil?)
+          message << ", plus #{Utils.pluralize("unknown size", unknown_size_count, include_count: true)}" \
+            if unknown_size_count.positive?
+          puts GitHub::Actions::Annotation.new(
+            :warning,
+            "#{message}).",
+            file:  formula.path.to_s.delete_prefix("#{repository}/"),
+            line:,
+            title: "#{formula}: new dependency impact",
+          )
+        end
+      rescue => e
+        opoo "Failed to determine dependency impact for #{formula.full_name}: #{e}"
+      end
+
       sig { params(formula: Formula).void }
       def livecheck(formula)
         return unless formula.livecheck_defined?
@@ -433,6 +535,9 @@ module Homebrew
             return
           end
 
+          new_formula = @added_formulae.include?(formula_name)
+          annotate_added_dependencies(formula) unless new_formula
+
           test "brew", "deps", "--tree", "--prune", "--annotate", "--include-build", "--include-test",
                named_args: formula_name
 
@@ -451,7 +556,6 @@ module Homebrew
             return
           end
 
-          new_formula = @added_formulae.include?(formula_name)
           ignore_failures = !args.test_default_formula? && !bottled_on_current_version && !new_formula
 
           deps = []


### PR DESCRIPTION
This should help us avoid accidentally adding huge dependency trees in PRs.

- Surface added `depends_on` cost in PR review annotations.
- Show each platform's new recursive dependency count and size.
- Keep impact warnings inline with the changed formula line.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
