### PR TITLE
Add brew exec command

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -926,6 +926,7 @@ case "${HOMEBREW_COMMAND}" in
   -v) HOMEBREW_COMMAND="--version" ;;
   lc) HOMEBREW_COMMAND="livecheck" ;;
   tc) HOMEBREW_COMMAND="typecheck" ;;
+  x) HOMEBREW_COMMAND="exec" ;;
 esac
 if [[ ("${HOMEBREW_COMMAND}" == "audit" || "${HOMEBREW_COMMAND}" == "lgtm" ||
       "${HOMEBREW_COMMAND}" == "style" || "${HOMEBREW_COMMAND}" == "tests") &&

--- a/Library/Homebrew/cmd/exec.rb
+++ b/Library/Homebrew/cmd/exec.rb
@@ -1,0 +1,26 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "abstract_command"
+require "shell_command"
+
+module Homebrew
+  module Cmd
+    class Exec < AbstractCommand
+      include ShellCommand
+
+      cmd_args do
+        usage_banner <<~EOS
+          `exec`, `x` [`--skip-update`] [`+`<formula> ...] <command> [<args> ...]
+
+          Run a Homebrew executable, installing its formula if needed.
+        EOS
+
+        switch "--skip-update",
+               description: "Skip updating the executables database if any version exists on disk, no matter how old."
+
+        named_args min: 1
+      end
+    end
+  end
+end

--- a/Library/Homebrew/cmd/exec.sh
+++ b/Library/Homebrew/cmd/exec.sh
@@ -1,0 +1,247 @@
+# Documentation defined in Library/Homebrew/cmd/exec.rb
+
+# shellcheck disable=SC2154
+source "${HOMEBREW_LIBRARY}/Homebrew/cmd/which-formula.sh"
+
+exec-formula-name() {
+  local formula="$1"
+  echo "${formula##*/}"
+}
+
+exec-latest-keg() {
+  local formula_name
+  formula_name="$(exec-formula-name "$1")"
+
+  # `opt/<formula>` is Homebrew's active-version pointer. Prefer it over
+  # sorting Cellar directories; plain lexicographic sorting gets versions like
+  # `2.10` and `2.9` wrong.
+  local opt_prefix
+  opt_prefix="${HOMEBREW_PREFIX}/opt/${formula_name}"
+  if [[ -d "${opt_prefix}" ]]
+  then
+    local opt_keg
+    opt_keg="$(cd "${opt_prefix}" &>/dev/null && pwd -P)" || return 1
+    echo "${opt_keg}"
+    return
+  fi
+
+  local cellar="${HOMEBREW_CELLAR}/${formula_name}"
+  [[ -d "${cellar}" ]] || return 1
+
+  local keg
+  local -a installed_kegs=()
+  for keg in "${cellar}"/*
+  do
+    [[ -d "${keg}" ]] && installed_kegs+=("${keg}")
+  done
+
+  [[ "${#installed_kegs[@]}" -eq 1 ]] || return 1
+
+  echo "${installed_kegs[0]}"
+}
+
+exec-formula-installed() {
+  exec-latest-keg "$1" &>/dev/null
+}
+
+exec-add-path() {
+  # Bash arrays cannot be de-duplicated directly, so keep the PATH fragments
+  # ordered and skip entries we have already seen.
+  local path="$1"
+  [[ -d "${path}" ]] || return
+
+  local entry
+  for entry in "${exec_path_entries[@]}"
+  do
+    [[ "${entry}" == "${path}" ]] && return
+  done
+
+  exec_path_entries+=("${path}")
+}
+
+exec-add-formula-paths() {
+  # `exec_path_entries` is declared local in `homebrew-exec`. Bash uses dynamic
+  # scoping for `local`, so this helper can append to that caller-local array.
+  local formula="$1"
+  local formula_name keg
+  formula_name="$(exec-formula-name "${formula}")"
+
+  exec-add-path "${HOMEBREW_PREFIX}/opt/${formula_name}/bin"
+  exec-add-path "${HOMEBREW_PREFIX}/opt/${formula_name}/sbin"
+
+  if keg="$(exec-latest-keg "${formula}")"
+  then
+    exec-add-path "${keg}/bin"
+    exec-add-path "${keg}/sbin"
+  fi
+}
+
+homebrew-exec() {
+  local formula
+  local formulae=()
+
+  while [[ "$#" -gt 0 ]]
+  do
+    case "$1" in
+      --skip-update)
+        HOMEBREW_SKIP_UPDATE=1
+        shift
+        ;;
+      --help | -h)
+        "${HOMEBREW_BREW_FILE}" help exec
+        return
+        ;;
+      --)
+        shift
+        break
+        ;;
+      --*)
+        echo "Unknown option: $1" >&2
+        "${HOMEBREW_BREW_FILE}" help exec
+        return 1
+        ;;
+      +*)
+        formula="${1#+}"
+        [[ -n "${formula}" ]] || odie "Formula override '+' is missing a formula name."
+        formulae+=("${formula}")
+        shift
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  local executable="${1:-}"
+  if [[ -z "${executable}" ]]
+  then
+    "${HOMEBREW_BREW_FILE}" help exec
+    return 1
+  fi
+  shift
+
+  [[ "${executable}" != */* ]] || odie "Executable name must not contain path separators."
+
+  if [[ "${#formulae[@]}" -eq 0 ]]
+  then
+    download_and_cache_executables_file >&2
+
+    local -a matching_formulae=()
+    local cmds_text line selected_formula
+    selected_formula=""
+    # Some executables are provided by multiple formulae. Prefer an already
+    # installed provider to avoid unnecessary installs; otherwise use the first
+    # provider listed by the database.
+    while read -r line
+    do
+      [[ "${line}" == *:* ]] || continue
+
+      # `executables.txt` lines are `formula(version):exe exe...`. Use Bash's
+      # prefix/suffix removal instead of splitting with `IFS`, so executable
+      # lists are kept as one string for whole-word matching below.
+      formula="${line%%:*}"
+      cmds_text="${line#*:}"
+      [[ -z "${formula}" ]] && continue
+      [[ -z "${cmds_text}" ]] && continue
+
+      # Padding both sides with spaces avoids matching `foo` inside `foobar`.
+      if [[ " ${cmds_text} " == *" ${executable} "* ]]
+      then
+        formula="${formula%\(*}"
+        matching_formulae+=("${formula}")
+
+        if [[ -z "${selected_formula}" ]] && exec-formula-installed "${formula}"
+        then
+          selected_formula="${formula}"
+        fi
+      fi
+    done <"${DATABASE_FILE}" 2>/dev/null
+
+    [[ "${#matching_formulae[@]}" -gt 0 ]] || odie "No Homebrew formula found for \`${executable}\`."
+
+    if [[ -n "${selected_formula}" ]]
+    then
+      formulae=("${selected_formula}")
+    else
+      formulae=("${matching_formulae[0]}")
+    fi
+  fi
+
+  for formula in "${formulae[@]}"
+  do
+    if ! exec-formula-installed "${formula}"
+    then
+      ohai "Installing \`${formula}\` because it provides \`${executable}\`." >&2
+      "${HOMEBREW_BREW_FILE}" install --formula "${formula}" >&2 || return
+    fi
+  done
+
+  local candidate executable_path formula_name keg
+  executable_path=""
+  for formula in "${formulae[@]}"
+  do
+    formula_name="$(exec-formula-name "${formula}")"
+    local -a executable_candidate_paths=(
+      "${HOMEBREW_PREFIX}/opt/${formula_name}/bin/${executable}"
+      "${HOMEBREW_PREFIX}/opt/${formula_name}/sbin/${executable}"
+    )
+
+    # Do not use `HOMEBREW_PREFIX`/bin or sbin here. A different provider may
+    # be linked there with the same executable name.
+    # `break 2` leaves both this candidate loop and the surrounding formula
+    # loop as soon as a path has been narrowed down.
+    for candidate in "${executable_candidate_paths[@]}"
+    do
+      if [[ -f "${candidate}" && -x "${candidate}" ]]
+      then
+        executable_path="${candidate}"
+        break 2
+      fi
+    done
+
+    if keg="$(exec-latest-keg "${formula}")"
+    then
+      for candidate in "${keg}/bin/${executable}" "${keg}/sbin/${executable}"
+      do
+        if [[ -f "${candidate}" && -x "${candidate}" ]]
+        then
+          executable_path="${candidate}"
+          break 2
+        fi
+      done
+    fi
+  done
+
+  [[ -n "${executable_path}" ]] || odie "\`${executable}\` was not found in formulae: ${formulae[*]}."
+
+  local -a exec_path_entries=()
+  local dependency exec_path path_index
+  for formula in "${formulae[@]}"
+  do
+    exec-add-formula-paths "${formula}"
+  done
+
+  for formula in "${formulae[@]}"
+  do
+    # Process substitution keeps the `while` loop in this shell process.
+    # A pipeline would run the loop in a subshell on Bash, losing array changes.
+    while read -r dependency
+    do
+      [[ -n "${dependency}" ]] && exec-add-formula-paths "${dependency}"
+    done < <("${HOMEBREW_BREW_FILE}" deps --topological --formula "${formula}" 2>/dev/null)
+  done
+
+  exec_path="${HOMEBREW_PATH:-${PATH}}"
+  # Entries are collected in PATH priority order. Prepend them in reverse so the
+  # first collected directory remains first in the final PATH.
+  for ((path_index = ${#exec_path_entries[@]} - 1; path_index >= 0; path_index--))
+  do
+    exec_path="${exec_path_entries[path_index]}:${exec_path}"
+  done
+
+  PATH="${exec_path}"
+  export PATH
+  # Replace the shell with the target command so signals and exit status behave
+  # as if the executable had been run directly.
+  exec "${executable_path}" "$@"
+}

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -28,6 +28,7 @@ module Commands
     "-v"           => "--version",
     "lc"           => "livecheck",
     "tc"           => "typecheck",
+    "x"            => "exec",
   }.freeze, T::Hash[String, String])
   # This pattern is used to split descriptions at full stops. We only consider a
   # dot as a full stop if it is either followed by a whitespace or at the end of

--- a/Library/Homebrew/test/cmd/exec_spec.rb
+++ b/Library/Homebrew/test/cmd/exec_spec.rb
@@ -1,0 +1,128 @@
+# typed: false
+# frozen_string_literal: true
+
+require "cmd/exec"
+require "cmd/shared_examples/args_parse"
+
+RSpec.describe Homebrew::Cmd::Exec do
+  it_behaves_like "parseable arguments"
+
+  describe "exec" do
+    let(:formula_name) { "test-executable" }
+    let(:executable_name) { "test-executable-tool" }
+    let(:shell_cellar) do
+      if (HOMEBREW_LIBRARY_PATH.parent.parent/"Cellar").directory?
+        HOMEBREW_LIBRARY_PATH.parent.parent/"Cellar"
+      else
+        HOMEBREW_CELLAR
+      end
+    end
+    let(:db) { HOMEBREW_CACHE/"api/internal/executables.txt" }
+    let(:active_executable) { shell_cellar/"#{formula_name}/2.10/bin/#{executable_name}" }
+    let(:installable_formula_name) { "test-installable" }
+    let(:installable_executable_name) { "test-installable-tool" }
+    let(:brew_wrapper) { HOMEBREW_TEMP/"brew-exec-wrapper/brew" }
+    let(:brew_sh_env) do
+      {
+        "HOMEBREW_BREW_SH"               => (HOMEBREW_PREFIX/"bin/brew").to_s,
+        "HOMEBREW_FORCE_BREW_WRAPPER"    => brew_wrapper.to_s,
+        "HOMEBREW_NO_FORCE_BREW_WRAPPER" => "1",
+        "HOMEBREW_TEMP"                  => HOMEBREW_TEMP.to_s,
+        "HOMEBREW_COLOR"                 => nil,
+        "GITHUB_ACTIONS"                 => nil,
+      }
+    end
+
+    before do
+      FileUtils.ln_sf HOMEBREW_LIBRARY_PATH.parent.parent/"bin/brew", HOMEBREW_PREFIX/"bin/brew"
+
+      db.dirname.mkpath
+      db.write(<<~EOS)
+        test-uninstalled(1.0.0):#{executable_name}
+        #{formula_name}(1.0.0):#{executable_name}
+        #{installable_formula_name}(1.0.0):#{installable_executable_name}
+      EOS
+
+      old_executable = shell_cellar/"#{formula_name}/2.9/bin/#{executable_name}"
+      old_executable.dirname.mkpath
+      old_executable.write("#!/bin/sh\necho old-version\n")
+      FileUtils.chmod 0755, old_executable
+
+      active_executable.dirname.mkpath
+      active_executable.write("#!/bin/sh\necho active-version \"$@\"\n")
+      FileUtils.chmod 0755, active_executable
+
+      (HOMEBREW_PREFIX/"opt").mkpath
+      FileUtils.ln_sf active_executable.dirname.parent, HOMEBREW_PREFIX/"opt/#{formula_name}"
+
+      linked_executable = HOMEBREW_PREFIX/"bin/#{executable_name}"
+      linked_executable.write("#!/bin/sh\necho linked-provider\n")
+      FileUtils.chmod 0755, linked_executable
+
+      brew_wrapper.dirname.mkpath
+      brew_wrapper.write(<<~SH)
+        #!/bin/sh
+        case "$1" in
+          deps)
+            exit 0
+            ;;
+          install)
+            echo fake install stdout
+            echo fake install stderr >&2
+            mkdir -p "#{shell_cellar}/#{installable_formula_name}/1.0.0/bin" "#{HOMEBREW_PREFIX}/opt"
+            cat > "#{shell_cellar}/#{installable_formula_name}/1.0.0/bin/#{installable_executable_name}" <<'EOS'
+        #!/bin/sh
+        echo installable-version "$@"
+        EOS
+            chmod 755 "#{shell_cellar}/#{installable_formula_name}/1.0.0/bin/#{installable_executable_name}"
+            ln -sfn "#{shell_cellar}/#{installable_formula_name}/1.0.0" "#{HOMEBREW_PREFIX}/opt/#{installable_formula_name}"
+            ;;
+          *)
+            echo "unexpected brew wrapper call: $*" >&2
+            exit 1
+            ;;
+        esac
+      SH
+      FileUtils.chmod 0755, brew_wrapper
+    end
+
+    after do
+      FileUtils.rm_rf shell_cellar/formula_name
+      FileUtils.rm_rf shell_cellar/installable_formula_name
+      FileUtils.rm_rf HOMEBREW_PREFIX/"opt/#{formula_name}"
+      FileUtils.rm_rf HOMEBREW_PREFIX/"opt/#{installable_formula_name}"
+      FileUtils.rm_f HOMEBREW_PREFIX/"bin/#{executable_name}"
+      FileUtils.rm_rf brew_wrapper.dirname
+    end
+
+    it "runs the selected formula executable and supports the x alias", :aggregate_failures, :integration_test do
+      expect do
+        expect(brew_sh("exec", "--skip-update", executable_name, "arg", brew_sh_env)).to be_a_success
+      end.to(
+        output("active-version arg\n").to_stdout
+          .and(output("").to_stderr),
+      )
+
+      expect do
+        expect(brew_sh("x", "--skip-update", executable_name, brew_sh_env)).to be_a_success
+      end.to(
+        output("active-version\n").to_stdout
+          .and(output("").to_stderr),
+      )
+
+      expect do
+        expect(brew_sh("exec", "--skip-update", installable_executable_name, "arg", brew_sh_env)).to be_a_success
+      end.to(
+        output("installable-version arg\n").to_stdout
+          .and(
+            output(
+              "==> Installing `#{installable_formula_name}` because it provides " \
+              "`#{installable_executable_name}`.\n" \
+              "fake install stdout\n" \
+              "fake install stderr\n",
+            ).to_stderr,
+          ),
+      )
+    end
+  end
+end

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -1157,6 +1157,23 @@ _brew_environment() {
   __brew_complete_formulae
 }
 
+_brew_exec() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "${cur}" in
+    -*)
+      __brewcomp "
+      --debug
+      --help
+      --quiet
+      --skip-update
+      --verbose
+      "
+      return
+      ;;
+    *) ;;
+  esac
+}
+
 _brew_extract() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "${cur}" in
@@ -3383,6 +3400,23 @@ _brew_which_update() {
   esac
 }
 
+_brew_x() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "${cur}" in
+    -*)
+      __brewcomp "
+      --debug
+      --help
+      --quiet
+      --skip-update
+      --verbose
+      "
+      return
+      ;;
+    *) ;;
+  esac
+}
+
 _brew() {
   local i=1 cmd
 
@@ -3458,6 +3492,7 @@ _brew() {
     dr) _brew_dr ;;
     edit) _brew_edit ;;
     environment) _brew_environment ;;
+    exec) _brew_exec ;;
     extract) _brew_extract ;;
     fetch) _brew_fetch ;;
     formula) _brew_formula ;;
@@ -3556,6 +3591,7 @@ _brew() {
     version-install) _brew_version_install ;;
     which-formula) _brew_which_formula ;;
     which-update) _brew_which_update ;;
+    x) _brew_x ;;
     *) ;;
   esac
 }

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -812,6 +812,14 @@ __fish_brew_complete_arg 'environment' -l verbose -d 'Make some output more verb
 __fish_brew_complete_arg 'environment' -a '(__fish_brew_suggest_formulae_all)'
 
 
+__fish_brew_complete_cmd 'exec' 'Run a Homebrew executable, installing its formula if needed'
+__fish_brew_complete_arg 'exec' -l debug -d 'Display any debugging information'
+__fish_brew_complete_arg 'exec' -l help -d 'Show this message'
+__fish_brew_complete_arg 'exec' -l quiet -d 'Make some output more quiet'
+__fish_brew_complete_arg 'exec' -l skip-update -d 'Skip updating the executables database if any version exists on disk, no matter how old'
+__fish_brew_complete_arg 'exec' -l verbose -d 'Make some output more verbose'
+
+
 __fish_brew_complete_cmd 'extract' 'Look through repository history to find the most recent version of formula and create a copy in tap'
 __fish_brew_complete_arg 'extract' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'extract' -l force -d 'Overwrite the destination formula if it already exists'
@@ -2155,6 +2163,14 @@ __fish_brew_complete_arg 'which-update' -l stats -d 'Print statistics about the 
 __fish_brew_complete_arg 'which-update' -l summary-file -d 'Output a summary of the changes to a file'
 __fish_brew_complete_arg 'which-update' -l update-existing -d 'Update database entries with outdated formula versions'
 __fish_brew_complete_arg 'which-update' -l verbose -d 'Make some output more verbose'
+
+
+__fish_brew_complete_cmd 'x' 'Run a Homebrew executable, installing its formula if needed'
+__fish_brew_complete_arg 'x' -l debug -d 'Display any debugging information'
+__fish_brew_complete_arg 'x' -l help -d 'Show this message'
+__fish_brew_complete_arg 'x' -l quiet -d 'Make some output more quiet'
+__fish_brew_complete_arg 'x' -l skip-update -d 'Skip updating the executables database if any version exists on disk, no matter how old'
+__fish_brew_complete_arg 'x' -l verbose -d 'Make some output more verbose'
 
 
 

--- a/completions/internal_commands_list.txt
+++ b/completions/internal_commands_list.txt
@@ -43,6 +43,7 @@ doctor
 dr
 edit
 environment
+exec
 extract
 fetch
 formula
@@ -139,3 +140,4 @@ verify
 version-install
 which-formula
 which-update
+x

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -33,6 +33,7 @@ __brew_list_aliases() {
     '-v' '--version'
     lc livecheck
     tc typecheck
+    x exec
   )
   echo "${aliases}"
 }
@@ -170,6 +171,7 @@ __brew_internal_commands() {
     'docs:Open Homebrew'\''s online documentation at https://docs.brew.sh in a browser'
     'doctor:Check your system for potential problems'
     'edit:Open a formula, cask or tap in the editor set by `$EDITOR` or `$HOMEBREW_EDITOR`, or open the Homebrew repository for editing if no argument is provided'
+    'exec:Run a Homebrew executable, installing its formula if needed'
     'extract:Look through repository history to find the most recent version of formula and create a copy in tap'
     'fetch:Download a bottle (if available) or source packages for formulae and binaries for casks'
     'formula:Display the path where formula is located'
@@ -1027,6 +1029,16 @@ _brew_environment() {
     '--verbose[Make some output more verbose]' \
     - formula \
     '*:formula:__brew_formulae'
+}
+
+# brew exec
+_brew_exec() {
+  _arguments \
+    '--debug[Display any debugging information]' \
+    '--help[Show this message]' \
+    '--quiet[Make some output more quiet]' \
+    '--skip-update[Skip updating the executables database if any version exists on disk, no matter how old]' \
+    '--verbose[Make some output more verbose]'
 }
 
 # brew extract
@@ -2648,6 +2660,16 @@ _brew_which_update() {
     '(--commit --install-missing --update-existing --max-downloads)--stats[Print statistics about the database contents (number of commands and formulae, list of missing formulae)]' \
     '--summary-file[Output a summary of the changes to a file]' \
     '(--stats)--update-existing[Update database entries with outdated formula versions]' \
+    '--verbose[Make some output more verbose]'
+}
+
+# brew x
+_brew_x() {
+  _arguments \
+    '--debug[Display any debugging information]' \
+    '--help[Show this message]' \
+    '--quiet[Make some output more quiet]' \
+    '--skip-update[Skip updating the executables database if any version exists on disk, no matter how old]' \
     '--verbose[Make some output more verbose]'
 }
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -646,6 +646,15 @@ working fine: please don't worry or file an issue; just ignore this.
 
 : Enable debugging and profiling of audit methods.
 
+### `exec`, `x` \[`--skip-update`\] \[`+`*`formula`* ...\] *`command`* \[*`args`* ...\]
+
+Run a Homebrew executable, installing its formula if needed.
+
+`--skip-update`
+
+: Skip updating the executables database if any version exists on disk, no
+  matter how old.
+
 ### `fetch` \[*`options`*\] *`formula`*\|*`cask`* \[...\]
 
 Download a bottle (if available) or source packages for *`formula`*e and

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -404,6 +404,11 @@ List all audit methods, which can be run individually if provided as arguments\.
 .TP
 \fB\-D\fP, \fB\-\-audit\-debug\fP
 Enable debugging and profiling of audit methods\.
+.SS "\fBexec\fP, \fBx\fP \fR[\fB\-\-skip\-update\fP] \fR[\fB+\fP\fIformula\fP \.\.\.] \fIcommand\fP \fR[\fIargs\fP \.\.\.]"
+Run a Homebrew executable, installing its formula if needed\.
+.TP
+\fB\-\-skip\-update\fP
+Skip updating the executables database if any version exists on disk, no matter how old\.
 .SS "\fBfetch\fP \fR[\fIoptions\fP] \fIformula\fP|\fIcask\fP \fR[\.\.\.]"
 Download a bottle (if available) or source packages for \fIformula\fPe and binaries for \fIcask\fPs\. For files, also print SHA\-256 checksums\.
 .TP


### PR DESCRIPTION
- Let users run formula executables without knowing the providing formula upfront.
- Reuse `executables.txt` so lookup matches `which-formula`.
- Keep `x` as the short alias for `npmx`-style usage.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
