### PR TITLE
Fix bottled default config upgrades

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1585,6 +1585,8 @@ class Formula
     etc_var_dirs = [bottle_prefix/"etc", bottle_prefix/"var"]
     Find.find(*etc_var_dirs.select(&:directory?)) do |path|
       path = Pathname.new(path)
+      # Bottle installs and test-bot cleanup both restore `.bottle` files
+      # through `InstallRenamed`, matching formula-level `etc.install` handling.
       path.extend(InstallRenamed)
       path.cp_path_sub(bottle_prefix, HOMEBREW_PREFIX)
       path

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -522,6 +522,8 @@ class FormulaInstaller
   def build_bottle_postinstall
     etc_var_postinstall = Find.find(*ETC_VAR_DIRS.select(&:directory?)).to_a
     (etc_var_postinstall - @etc_var_preinstall).each do |file|
+      # Keep new `etc`/`var` files in `.bottle` so `Formula#install_etc_var`
+      # can restore them later with `InstallRenamed` config handling.
       Pathname.new(file).cp_path_sub(HOMEBREW_PREFIX, formula.bottle_prefix)
     end
   end

--- a/Library/Homebrew/install_renamed.rb
+++ b/Library/Homebrew/install_renamed.rb
@@ -42,10 +42,25 @@ module InstallRenamed
 
   sig { params(src: Pathname, dst: Pathname).returns(Pathname) }
   def append_default_if_different(src, dst)
-    if dst.file? && !FileUtils.identical?(src, dst)
-      Pathname.new("#{dst}.default")
-    else
-      dst
+    return dst if !dst.file? || FileUtils.identical?(src, dst)
+
+    # Bottle installs restore config from `<keg>/.bottle/etc` through this
+    # helper. If the live config still matches an older bottled default, replace
+    # it so untouched configs advance on upgrade. Modified configs still receive
+    # the new default as `*.default`.
+    src.ascend do |path|
+      next if path.basename.to_s != ".bottle" || path.parent.parent.parent != HOMEBREW_CELLAR
+
+      path.parent.parent.subdirs.each do |prefix|
+        next if prefix == path.parent
+
+        default_file = prefix/".bottle"/src.relative_path_from(path)
+        return dst if default_file.file? && FileUtils.identical?(dst, default_file)
+      end
+
+      break
     end
+
+    Pathname.new("#{dst}.default")
   end
 end

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -84,6 +84,38 @@ RSpec.describe FormulaInstaller do
     end
   end
 
+  describe "#build_bottle_postinstall" do
+    let(:f) do
+      formula "bottle-config" do
+        url "foo-1.0"
+      end
+    end
+    let(:config_file) { HOMEBREW_PREFIX/"etc/bottle-config.conf" }
+
+    before do
+      FileUtils.rm_rf f.rack
+      FileUtils.rm_f config_file
+      FileUtils.rm_f Pathname("#{config_file}.default")
+    end
+
+    after do
+      FileUtils.rm_rf f.rack
+      FileUtils.rm_f config_file
+      FileUtils.rm_f Pathname("#{config_file}.default")
+    end
+
+    it "stores new prefix config where install_etc_var restores it from" do
+      installer = described_class.new(f)
+      installer.build_bottle_preinstall
+      config_file.dirname.mkpath
+      config_file.write "new\n"
+
+      installer.build_bottle_postinstall
+
+      expect((f.bottle_prefix/"etc/bottle-config.conf").read).to eq("new\n")
+    end
+  end
+
   describe "#verify_deps_exist" do
     it "does not install an untapped dependency tap" do
       formula = Testball.new

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1037,6 +1037,47 @@ RSpec.describe Formula do
     expect(f2).not_to have_post_install_defined
   end
 
+  describe "#install_etc_var" do
+    let(:f) do
+      formula "config-upgrade" do
+        url "foo-2.0"
+        version "2.0"
+      end
+    end
+    let(:config_file) { HOMEBREW_PREFIX/"etc/config-upgrade.conf" }
+    let(:default_config_file) { Pathname("#{config_file}.default") }
+    let(:old_default_file) { f.rack/"1.0/.bottle/etc/config-upgrade.conf" }
+    let(:new_default_file) { f.bottle_prefix/"etc/config-upgrade.conf" }
+
+    before do
+      FileUtils.rm_rf f.rack
+      FileUtils.rm_f config_file
+      FileUtils.rm_f default_config_file
+
+      old_default_file.dirname.mkpath
+      old_default_file.write "old\n"
+      new_default_file.dirname.mkpath
+      new_default_file.write "new\n"
+      config_file.dirname.mkpath
+    end
+
+    it "replaces config that matches the previous default" do
+      config_file.write "old\n"
+
+      f.install_etc_var
+
+      expect([config_file.read, default_config_file.exist?]).to eq(["new\n", false])
+    end
+
+    it "writes a default file when the config was modified" do
+      config_file.write "custom\n"
+
+      f.install_etc_var
+
+      expect([config_file.read, default_config_file.read]).to eq(["custom\n", "new\n"])
+    end
+  end
+
   specify "test fixtures" do
     f1 = formula do
       url "foo-1.0"

--- a/Library/Homebrew/test/test_bot/formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_spec.rb
@@ -46,4 +46,47 @@ RSpec.describe Homebrew::TestBot::Formulae do
       end
     end
   end
+
+  describe "#cleanup_bottle_etc_var" do
+    it "restores bottled config with InstallRenamed handling" do
+      Dir.mktmpdir do |tmpdir|
+        formula_class = Class.new(Formula)
+        T.unsafe(formula_class).url "foo-2.0"
+        T.unsafe(formula_class).version "2.0"
+        f = formula_class.new("test-bot-config", Formulary.core_path("test-bot-config"), :stable)
+        config_file = HOMEBREW_PREFIX/"etc/test-bot-config.conf"
+        default_config_file = Pathname.new("#{config_file}.default")
+        old_default_file = f.rack/"1.0/.bottle/etc/test-bot-config.conf"
+        new_default_file = f.bottle_prefix/"etc/test-bot-config.conf"
+
+        begin
+          FileUtils.rm_rf f.rack
+          FileUtils.rm_f config_file
+          FileUtils.rm_f default_config_file
+
+          old_default_file.dirname.mkpath
+          old_default_file.write "old\n"
+          new_default_file.dirname.mkpath
+          new_default_file.write "new\n"
+          config_file.dirname.mkpath
+          config_file.write "old\n"
+
+          described_class.new(
+            tap: nil, git: "git", dry_run: true, fail_fast: false, verbose: false,
+            output_paths: {
+              bottle:                     Pathname.new("#{tmpdir}/bottle.txt"),
+              linkage:                    Pathname.new("#{tmpdir}/linkage.txt"),
+              skipped_or_failed_formulae: Pathname.new("#{tmpdir}/skipped.txt"),
+            }
+          ).send(:cleanup_bottle_etc_var, f)
+
+          expect([config_file.read, default_config_file.exist?]).to eq(["new\n", false])
+        ensure
+          FileUtils.rm_rf f.rack
+          FileUtils.rm_f config_file
+          FileUtils.rm_f default_config_file
+        end
+      end
+    end
+  end
 end

--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -216,7 +216,8 @@ module Homebrew
 
       sig { params(formula: Formula).void }
       def cleanup_bottle_etc_var(formula)
-        # Restore etc/var files from bottle so dependents can use them.
+        # Restore bottled `etc`/`var` through `Formula#install_etc_var`, keeping
+        # test-bot cleanup aligned with `InstallRenamed` config handling.
         formula.install_etc_var
       end
 


### PR DESCRIPTION
- Preserve user edits while allowing untouched configs to advance.
- Compare live configs with older `.bottle` defaults before using `*.default`.
- Cover the bottling and test-bot paths that restore `etc` files.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local testing and review and tweaking.

-----
