### PR TITLE
info: resolve installed formulae from receipt's tap and warn on shadow

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -370,7 +370,7 @@ module Homebrew
 
       sig { params(quiet: T::Boolean).void }
       def print_info(quiet: false)
-        qualified_inputs = args.named.select { |name| name.is_a?(String) && name.include?("/") }.to_set
+        qualified_inputs = args.named.select { |name| name.include?("/") }.to_set
 
         args.named.to_formulae_and_casks_and_unavailable.each_with_index do |obj, i|
           puts unless i.zero?
@@ -398,8 +398,7 @@ module Homebrew
 
         names = T.let([formula_or_cask.full_name.downcase], T::Array[String])
         if (tap = formula_or_cask.tap)
-          token = formula_or_cask.is_a?(Cask::Cask) ? formula_or_cask.token : formula_or_cask.name
-          names << "#{tap.name.downcase}/#{token.downcase}"
+          names << "#{tap.name.downcase}/#{Utils.name_or_token(formula_or_cask).downcase}"
         end
         names.any? { |n| qualified_inputs.include?(n) }
       end
@@ -457,7 +456,7 @@ module Homebrew
       def print_json(json, eval_all)
         raise FormulaOrCaskUnspecifiedError if !(eval_all || args.installed?) && args.no_named?
 
-        qualified_inputs = args.named.select { |name| name.is_a?(String) && name.include?("/") }.to_set
+        qualified_inputs = args.named.select { |name| name.include?("/") }.to_set
 
         json = case json_version(json)
         when :v1, :default

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -370,12 +370,15 @@ module Homebrew
 
       sig { params(quiet: T::Boolean).void }
       def print_info(quiet: false)
+        qualified_inputs = args.named.select { |name| name.is_a?(String) && name.include?("/") }.to_set
+
         args.named.to_formulae_and_casks_and_unavailable.each_with_index do |obj, i|
           puts unless i.zero?
 
           case obj
           when Formula, Cask::Cask
-            info_formula_or_cask(obj, quiet:)
+            user_qualified = formula_qualified_by_user?(obj, qualified_inputs)
+            info_formula_or_cask(obj, quiet:, user_qualified:)
           when FormulaOrCaskUnavailableError
             # The formula/cask could not be found
             ofail obj.message
@@ -389,14 +392,52 @@ module Homebrew
         end
       end
 
-      sig { params(formula_or_cask: T.any(Formula, Cask::Cask), quiet: T::Boolean).void }
-      def info_formula_or_cask(formula_or_cask, quiet:)
+      sig { params(formula_or_cask: T.any(Formula, Cask::Cask), qualified_inputs: T::Set[String]).returns(T::Boolean) }
+      def formula_qualified_by_user?(formula_or_cask, qualified_inputs)
+        return false if qualified_inputs.empty?
+
+        names = T.let([formula_or_cask.full_name.downcase], T::Array[String])
+        if (tap = formula_or_cask.tap)
+          token = formula_or_cask.is_a?(Cask::Cask) ? formula_or_cask.token : formula_or_cask.name
+          names << "#{tap.name.downcase}/#{token.downcase}"
+        end
+        names.any? { |n| qualified_inputs.include?(n) }
+      end
+
+      sig {
+        params(formula_or_cask: T.any(Formula, Cask::Cask), quiet: T::Boolean, user_qualified: T::Boolean).void
+      }
+      def info_formula_or_cask(formula_or_cask, quiet:, user_qualified: false)
         case formula_or_cask
         when Formula
-          quiet ? info_formula_summary(formula_or_cask) : info_formula(formula_or_cask)
+          if user_qualified
+            quiet ? info_formula_summary(formula_or_cask) : info_formula(formula_or_cask)
+          else
+            formula, shadowed_by = installed_resolution(formula_or_cask)
+            quiet ? info_formula_summary(formula) : info_formula(formula, shadowed_by:)
+          end
         when Cask::Cask
           quiet ? info_cask_summary(formula_or_cask) : info_cask(formula_or_cask)
         end
+      end
+
+      sig { params(formula: Formula).returns([Formula, T.nilable(Tap)]) }
+      def installed_resolution(formula)
+        return [formula, nil] if formula.installed_kegs.empty?
+
+        installed_tap = Tab.for_formula(formula).tap
+        return [formula, nil] if installed_tap.nil? || installed_tap == formula.tap
+
+        [Formulary.from_rack(formula.rack), formula.tap]
+      rescue FormulaUnavailableError, TapFormulaAmbiguityError
+        [formula, nil]
+      end
+
+      sig { params(formula: Formula, qualified_inputs: T::Set[String]).returns(Formula) }
+      def swap_to_installed_formula(formula, qualified_inputs)
+        return formula if formula_qualified_by_user?(formula, qualified_inputs)
+
+        installed_resolution(formula).first
       end
 
       sig { params(version: T.any(T::Boolean, String)).returns(Symbol) }
@@ -416,6 +457,8 @@ module Homebrew
       def print_json(json, eval_all)
         raise FormulaOrCaskUnspecifiedError if !(eval_all || args.installed?) && args.no_named?
 
+        qualified_inputs = args.named.select { |name| name.is_a?(String) && name.include?("/") }.to_set
+
         json = case json_version(json)
         when :v1, :default
           raise UsageError, "Cannot specify `--cask` when using `--json=v1`!" if args.cask?
@@ -425,7 +468,7 @@ module Homebrew
           elsif args.installed?
             Formula.installed.sort
           else
-            args.named.to_formulae
+            args.named.to_formulae.map { |f| swap_to_installed_formula(f, qualified_inputs) }
           end
 
           if args.variations?
@@ -443,7 +486,10 @@ module Homebrew
             elsif args.installed?
               [Formula.installed.sort, Cask::Caskroom.casks.sort_by(&:full_name)]
             else
-              T.cast(args.named.to_formulae_to_casks, [T::Array[Formula], T::Array[Cask::Cask]])
+              named_formulae, named_casks = T.cast(
+                args.named.to_formulae_to_casks, [T::Array[Formula], T::Array[Cask::Cask]]
+              )
+              [named_formulae.map { |f| swap_to_installed_formula(f, qualified_inputs) }, named_casks]
             end, [T::Array[Formula], T::Array[Cask::Cask]]
           )
 
@@ -530,8 +576,8 @@ module Homebrew
         end
       end
 
-      sig { params(formula: Formula).void }
-      def info_formula(formula)
+      sig { params(formula: Formula, shadowed_by: T.nilable(Tap)).void }
+      def info_formula(formula, shadowed_by: nil)
         specs = T.let([], T::Array[String])
 
         if (stable = formula.stable)
@@ -553,9 +599,17 @@ module Homebrew
                               kegs.max_by(&:scheme_and_version)&.version
           specs[0] = "#{installed_version} → #{upgrade_version}"
         end
-        name_with_status = pretty_install_status(formula.full_name, installed:, outdated:)
+        title_name = shadowed_by ? formula.name : formula.full_name
+        name_with_status = pretty_install_status(title_name, installed:, outdated:)
 
         puts "#{oh1_title(name_with_status)}: #{specs * ", "}#{" [#{attrs * ", "}]" unless attrs.empty?}"
+        if shadowed_by
+          puts Formatter.warning(
+            "the unqualified name `#{formula.name}` points to `#{formula.full_name}`, " \
+            "which shadows `#{shadowed_by.name}/#{formula.name}`.",
+            label: "Warning",
+          )
+        end
         puts formula.desc if formula.desc
         puts Formatter.url(formula.homepage) if formula.homepage
 

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -605,8 +605,7 @@ module Homebrew
         puts "#{oh1_title(name_with_status)}: #{specs * ", "}#{" [#{attrs * ", "}]" unless attrs.empty?}"
         if shadowed_by
           puts Formatter.warning(
-            "the unqualified name `#{formula.name}` points to `#{formula.full_name}`, " \
-            "which shadows `#{shadowed_by.name}/#{formula.name}`.",
+            "`#{formula.name}` shadows `#{shadowed_by.name}/#{formula.name}`.",
             label: "Warning",
           )
         end

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -160,13 +160,12 @@ module Homebrew
 
           if (start_with = args.start_with)
             formulae_and_casks.select! do |formula_or_cask|
-              name = formula_or_cask.is_a?(Cask::Cask) ? formula_or_cask.token : formula_or_cask.name
-              name.start_with?(start_with)
+              Utils.name_or_token(formula_or_cask).start_with?(start_with)
             end
           end
 
           formulae_and_casks = formulae_and_casks.sort_by do |formula_or_cask|
-            formula_or_cask.is_a?(Cask::Cask) ? formula_or_cask.token : formula_or_cask.name
+            Utils.name_or_token(formula_or_cask)
           end
 
           formulae_and_casks -= excluded_autobump

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -112,7 +112,7 @@ module Homebrew
 
             autobump_lists[tap] ||= tap.autobump
 
-            name = formula_or_cask.is_a?(Cask::Cask) ? formula_or_cask.token : formula_or_cask.name
+            name = Utils.name_or_token(formula_or_cask)
             next unless autobump_lists[tap].include?(name)
 
             odebug "Skipping #{name} as it is autobumped in #{tap}."
@@ -122,7 +122,7 @@ module Homebrew
         end
 
         formulae_and_casks_to_check = formulae_and_casks_to_check.sort_by do |formula_or_cask|
-          formula_or_cask.is_a?(Cask::Cask) ? formula_or_cask.token : formula_or_cask.name
+          Utils.name_or_token(formula_or_cask)
         end
 
         raise UsageError, "No formulae or casks to check." if formulae_and_casks_to_check.blank? && !skipped_autobump

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -298,7 +298,7 @@ RSpec.describe Homebrew::Cmd::Info do
     allow(formula).to receive(:core_formula?).and_return(false)
 
     expect { info.send(:info_formula, formula, shadowed_by: Tap.fetch("homebrew/core")) }
-      .to output(%r{Warning: .*unqualified name `testball`.*shadows `homebrew/core/testball`}).to_stdout
+      .to output(%r{Warning: `testball` shadows `homebrew/core/testball`}).to_stdout
       .and not_to_output.to_stderr
   end
 

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Homebrew::Cmd::Info do
 
     allow(Formula).to receive(:installed).and_return([formula])
     allow(Cask::Caskroom).to receive(:casks).and_return([cask])
-    expect(info).to receive(:info_formula).with(formula)
+    expect(info).to receive(:info_formula).with(formula, shadowed_by: nil)
     expect(info).to receive(:info_cask).with(cask)
 
     expect { info.run }
@@ -239,6 +239,135 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output(/Metadata/).to_stdout
       .and not_to_output(/supports macOS and Linux/).to_stdout
       .and not_to_output.to_stderr
+  end
+
+  it "reloads the formula from the install receipt's tap and reports the shadowing tap" do
+    info = described_class.new([])
+    formula = installed_info_formula
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.source["tap"] = "ataraxy-labs/tap"
+    tab.write
+
+    shadowing_tap = Tap.fetch("homebrew/core")
+    allow(formula).to receive(:tap).and_return(shadowing_tap)
+    keg_formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+    end
+    allow(Formulary).to receive(:from_rack).with(formula.rack).and_return(keg_formula)
+
+    expect(info.send(:installed_resolution, formula)).to eq([keg_formula, shadowing_tap])
+  end
+
+  it "returns the original formula and no shadowing tap when the install receipt has no tap" do
+    info = described_class.new([])
+    formula = installed_info_formula
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.write
+
+    expect(Formulary).not_to receive(:from_rack)
+    expect(info.send(:installed_resolution, formula)).to eq([formula, nil])
+  end
+
+  it "returns the original formula and no shadowing tap when the install receipt's tap matches" do
+    info = described_class.new([])
+    formula = installed_info_formula
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.source["tap"] = "homebrew/core"
+    tab.write
+
+    allow(formula).to receive(:tap).and_return(Tap.fetch("homebrew/core"))
+    expect(Formulary).not_to receive(:from_rack)
+    expect(info.send(:installed_resolution, formula)).to eq([formula, nil])
+  end
+
+  it "warns about a shadowing tap when info_formula is given one" do
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+    end
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula, shadowed_by: Tap.fetch("homebrew/core")) }
+      .to output(%r{Warning: .*unqualified name `testball`.*shadows `homebrew/core/testball`}).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "treats a `tap/name` input as user-qualified" do
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+    end
+    allow(formula).to receive(:tap).and_return(Tap.fetch("homebrew/core"))
+
+    qualified = Set["homebrew/core/testball"]
+    expect(info.send(:formula_qualified_by_user?, formula, qualified)).to be(true)
+  end
+
+  it "treats a bare unqualified input as not user-qualified" do
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+    end
+
+    expect(info.send(:formula_qualified_by_user?, formula, Set.new)).to be(false)
+  end
+
+  it "--json swaps an unqualified-input formula to its installed tap" do
+    info = described_class.new(["--json", "testball"])
+    shadowed_formula = installed_info_formula
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.source["tap"] = "ataraxy-labs/tap"
+    tab.write
+
+    allow(shadowed_formula).to receive(:tap).and_return(Tap.fetch("homebrew/core"))
+    installed_formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+    end
+    allow(installed_formula).to receive(:tap).and_return(Tap.fetch("ataraxy-labs/tap"))
+    allow(info.args.named).to receive(:to_formulae).and_return([shadowed_formula])
+    allow(Formulary).to receive(:from_rack).with(shadowed_formula.rack).and_return(installed_formula)
+
+    output = +""
+    expect { info.run }.to output(satisfy { |s|
+      output << s
+      true
+    }).to_stdout
+    expect(JSON.parse(output).first["tap"]).to eq("ataraxy-labs/tap")
+  end
+
+  it "--json honours a tap-qualified input without swapping" do
+    info = described_class.new(["--json", "homebrew/core/testball"])
+    formula = installed_info_formula
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.source["tap"] = "ataraxy-labs/tap"
+    tab.write
+
+    allow(formula).to receive(:tap).and_return(Tap.fetch("homebrew/core"))
+    allow(info.args.named).to receive(:to_formulae).and_return([formula])
+    expect(Formulary).not_to receive(:from_rack)
+
+    output = +""
+    expect { info.run }.to output(satisfy { |s|
+      output << s
+      true
+    }).to_stdout
+    expect(JSON.parse(output).first["tap"]).to eq("homebrew/core")
   end
 
   it "prints required, recursive runtime, and dependent counts in the dependencies section" do

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -47,6 +47,11 @@ module Utils
     name || full_name
   end
 
+  sig { params(formula_or_cask: T.any(Formula, Cask::Cask)).returns(String) }
+  def self.name_or_token(formula_or_cask)
+    formula_or_cask.is_a?(Cask::Cask) ? formula_or_cask.token : formula_or_cask.name
+  end
+
   sig { params(full_name: String).returns(T.nilable(String)) }
   def self.tap_from_full_name(full_name)
     user, repository, name = full_name.split("/", 3)


### PR DESCRIPTION
Handle packages from a third-party tap in a better way:

- Fixes so upgrade hint doesn't incorrectly show the latest `homebrew/core` version, that it currently does, when `brew upgrade weave -n` does show _tap's_ latest version.
- Show a warning about the shadowing, so user will know that they can also run `brew info homebrew/core/weave` to check the core package status instead.

```
❯ brew info weave
==> weave ↑: 0.1.6 → stable 0.2.7, HEAD
Warning: the unqualified name `weave` points to `ataraxy-labs/tap/weave`, which shadows `homebrew/core/weave`.
Entity-level semantic merge driver for Git — resolves conflicts by understanding code structure
https://github.com/Ataraxy-Labs/weave
Installed (on request)
/opt/homebrew/Cellar/weave/0.1.6 (11 files, 92.6MB) *
  Built from source on 2026-02-16 at 10:04:12
From: https://github.com/ataraxy-labs/homebrew-tap/blob/HEAD/Formula/weave.rb
License: MIT OR Apache-2.0
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code, Extra High Effort

-----

Related to https://github.com/Homebrew/brew/issues/19294.