### PR TITLE
tab: handle casks with no INSTALL_RECEIPT.json

### DIFF
--- a/Library/Homebrew/cask/tab.rb
+++ b/Library/Homebrew/cask/tab.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "tab"
+require "utils/topological_hash"
 
 module Cask
   class Tab < ::AbstractTab

--- a/Library/Homebrew/cmd/tab.rb
+++ b/Library/Homebrew/cmd/tab.rb
@@ -60,15 +60,31 @@ module Homebrew
       sig { params(formula_or_cask: T.any(Formula, Cask::Cask), installed_on_request: T::Boolean).void }
       def update_tab(formula_or_cask, installed_on_request:)
         name, tab = if formula_or_cask.is_a?(Formula)
-          [formula_or_cask.name, Tab.for_formula(formula_or_cask)]
-        else
-          [formula_or_cask.token, formula_or_cask.tab]
-        end
+          # Formulae have always written INSTALL_RECEIPT.json on install, so a
+          # missing Tab file means filesystem corruption or manual deletion.
+          formula_tab = Tab.for_formula(formula_or_cask)
+          formula_tabfile = formula_tab.tabfile
+          if formula_tabfile.blank? || !formula_tabfile.exist?
+            raise ArgumentError, "Tab file for #{formula_or_cask.name} does not exist."
+          end
 
-        tabfile = tab.tabfile
-        if tabfile.blank? || !tabfile.exist?
-          raise ArgumentError,
-                "Tab file for #{name} does not exist."
+          [formula_or_cask.name, formula_tab]
+        else
+          # Casks installed as a dependency, or installed before cask Tab
+          # support existed, can have no Tab file on disk. If we need to flip
+          # the on-request flag, build a fresh Tab so we have somewhere to
+          # write. When the desired state already matches the empty
+          # fallback's `installed_on_request: false`, the "already marked"
+          # early-return below handles it without synthesis.
+          cask = formula_or_cask
+          cask_tab = cask.tab
+          cask_tabfile = cask_tab.tabfile
+          tabfile_missing = cask_tabfile.blank? || !cask_tabfile.exist?
+          if tabfile_missing && cask_tab.installed_on_request != installed_on_request
+            opoo "No install receipt for #{cask.token}; creating one to record this flag."
+            cask_tab = Cask::Tab.create(cask)
+          end
+          [cask.token, cask_tab]
         end
 
         installed_on_request_str = "#{"not " unless installed_on_request}installed on request"

--- a/Library/Homebrew/test/cmd/tab_spec.rb
+++ b/Library/Homebrew/test/cmd/tab_spec.rb
@@ -4,6 +4,7 @@
 require "cmd/tab"
 require "cmd/shared_examples/args_parse"
 require "tab"
+require "cask"
 
 RSpec.describe Homebrew::Cmd::TabCmd do
   def installed_on_request?(formula)
@@ -30,5 +31,76 @@ RSpec.describe Homebrew::Cmd::TabCmd do
       .and output(/foo is now marked as not installed on request/).to_stdout
       .and not_to_output.to_stderr
     expect(installed_on_request?(foo)).to be false
+  end
+
+  context "with an installed cask" do
+    let(:cask) { Cask::CaskLoader.load(cask_path("local-caffeine")) }
+    let(:tabfile) { cask.metadata_main_container_path/AbstractTab::FILENAME }
+
+    before do
+      InstallHelper.install_with_caskfile(cask)
+      Cask::Tab.clear_cache
+    end
+
+    # Casks installed as a dependency, or installed before cask Tab support
+    # existed, can end up with no INSTALL_RECEIPT.json on disk. `brew tab`
+    # should still be able to record the on-request flag for them instead of
+    # erroring out (Homebrew/brew#22206).
+    specify "marks the cask as installed on request and creates the Tab file when none exists", :cask do
+      expect(cask).to be_installed
+      expect(tabfile).not_to exist
+
+      cmd = described_class.new(["--installed-on-request", "--cask", cask.token])
+      expect { cmd.run }
+        .to output(/local-caffeine is now marked as installed on request/).to_stdout
+        .and output(/No install receipt for local-caffeine; creating one to record this flag\./).to_stderr
+
+      expect(tabfile).to exist
+      Cask::Tab.clear_cache
+      tab = Cask::Tab.for_cask(cask)
+      expect(tab.installed_on_request).to be true
+      # Confirm `Cask::Tab.create` was used (vs `empty`) so the synthesized Tab
+      # carries real metadata, not just the on-request flag.
+      expect(tab.source["version"]).to eq(cask.version.to_s)
+      expect(tab.uninstall_artifacts).not_to be_nil
+    end
+
+    specify "treats --no-installed-on-request as a no-op when no Tab file exists", :cask do
+      expect(cask).to be_installed
+      expect(tabfile).not_to exist
+
+      cmd = described_class.new(["--no-installed-on-request", "--cask", cask.token])
+      expect { cmd.run }
+        .to output(/local-caffeine is already marked as not installed on request/).to_stdout
+        .and not_to_output(/No install receipt/).to_stderr
+
+      # The no-op path should not synthesize a Tab on disk.
+      expect(tabfile).not_to exist
+    end
+
+    specify "marks an existing-tabfile cask as installed on request without resynthesizing", :cask do
+      tab = Cask::Tab.create(cask)
+      tab.installed_on_request = false
+      # Stamp a sentinel that `Cask::Tab.create` would clobber if it ran again,
+      # so the assertion below catches any resynth regression even within the
+      # same wall-clock second (`Time.now.to_i` would otherwise be same-second).
+      tab.homebrew_version = "0.0.0-existing-tabfile-sentinel"
+      tab.write
+      Cask::Tab.clear_cache
+      expect(tabfile).to exist
+
+      cmd = described_class.new(["--installed-on-request", "--cask", cask.token])
+      expect { cmd.run }
+        .to output(/local-caffeine is now marked as installed on request/).to_stdout
+        .and not_to_output(/No install receipt/).to_stderr
+
+      Cask::Tab.clear_cache
+      reloaded = Cask::Tab.for_cask(cask)
+      expect(reloaded.installed_on_request).to be true
+      # The sentinel is preserved, proving the existing Tab was updated rather
+      # than replaced via `Cask::Tab.create` (which always overwrites
+      # `homebrew_version` to `HOMEBREW_VERSION`).
+      expect(reloaded.homebrew_version).to eq("0.0.0-existing-tabfile-sentinel")
+    end
   end
 end


### PR DESCRIPTION
Fixes #22206.

## Problem

`brew tab --installed-on-request --cask <cask>` errors with `Tab file for <cask> does not exist.` when the cask has no `INSTALL_RECEIPT.json` on disk. Easy to reproduce:

1. Install any cask, then move its `<caskroom>/<cask>/.metadata/INSTALL_RECEIPT.json` aside.
2. `brew info --cask <cask>` now shows "Installed (as dependency)" because the empty-fallback Tab from `Cask::Tab.for_cask` defaults `installed_on_request: false`.
3. `brew tab --installed-on-request --cask <cask>` errors at `Library/Homebrew/cmd/tab.rb:70`.

This is the state casks installed as a dependency end up in (and the user in #22206 ran into it on `discord`).

## Fix

Split the formula and cask paths in `Homebrew::Cmd::TabCmd#update_tab`:

- Formulae have always written `INSTALL_RECEIPT.json` on install, so a missing tab there is genuinely anomalous and still raises.
- For casks, when the tab file is missing AND the on-request flag would actually change, emit `opoo "No install receipt for <cask>; creating one to record this flag."` and synthesize a fresh Tab via `Cask::Tab.create(cask)`. The no-op case (`--no-installed-on-request` against a cask that already presents `installed_on_request: false`) keeps the existing "already marked" early-return without warning or writing.

`Library/Homebrew/cask/tab.rb` gets `require "utils/topological_hash"` because `Cask::Tab.runtime_deps_hash` references the constant; previously it was loaded transitively through `cask/installer.rb`, but the new path in `cmd/tab.rb` calls `Cask::Tab.create` directly without going through the installer.

## Tests

Three new specs in `Library/Homebrew/test/cmd/tab_spec.rb` covering all four flag×state combinations on cask:

- missing tabfile + flag-change, creates the tab and asserts metadata populated (proves `Cask::Tab.create` was used vs `empty`).
- missing tabfile + already-at-target, clean no-op, asserts no `opoo` and no file written.
- existing tabfile + flag-change, updates without resynthesizing, verified via a sentinel `homebrew_version` value that `Cask::Tab.create` would deterministically clobber.

Verified locally on macOS 26.4: `brew style`, `brew typecheck`, and `brew tests --changed` all green (~1167 specs).

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

I used Claude Code (Opus 4.7) for analysis, fix design, tests, and multi-pass code review. I reproduced the bug end-to-end on a real cask install (moved a real `INSTALL_RECEIPT.json` aside, ran `brew tab` against all four flag/state combinations, restored byte-identically), reviewed all generated code line-by-line, and ran the full Tab-touching test suite (`brew tests --only=cmd/tab,cask/tab,cmd/info,cask/info,cask/list,cask/installer`: 134 examples, all green) plus `brew lgtm` locally. I have zero open AI-assisted PRs in this repo so the one-at-a-time cap is satisfied. I will be responding to all review comments myself.

-----
