### PR TITLE
Omit platform for all bottles

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -200,7 +200,7 @@ class GitHubPackages
     @schema_json&.fetch(uri.to_s.gsub(/#.*/, ""))
   end
 
-  sig { params(schema_uri: String, json: T::Hash[String, T.untyped]).void }
+  sig { params(schema_uri: String, json: T::Hash[T.any(String, Symbol), T.untyped]).void }
   def validate_schema!(schema_uri, json)
     schema = JSONSchemer.schema(@schema_json&.fetch(schema_uri), ref_resolver: method(:schema_resolver))
     json = json.deep_stringify_keys
@@ -368,6 +368,7 @@ class GitHubPackages
 
     manifests += bottle_hash["bottle"]["tags"].map do |bottle_tag, tag_hash|
       bottle_tag = Utils::Bottles::Tag.from_symbol(bottle_tag.to_sym)
+      all_bottle = bottle_tag.to_sym == :all
 
       tag = GitHubPackages.version_rebuild(version, rebuild, bottle_tag.to_s)
 
@@ -439,7 +440,7 @@ class GitHubPackages
         "sh.brew.bottle.size"               => local_file_size.to_s,
         "sh.brew.bottle.installed_size"     => tag_hash["installed_size"].to_s,
         "sh.brew.license"                   => license,
-        "sh.brew.tab"                       => tab.to_json,
+        "sh.brew.tab"                       => (all_bottle ? tab.except("arch", "built_on") : tab).to_json,
         "sh.brew.path_exec_files"           => path_exec_files_string,
       }.compact_blank
 
@@ -477,9 +478,9 @@ class GitHubPackages
         mediaType:   "application/vnd.oci.image.manifest.v1+json",
         digest:      "sha256:#{manifest_json_sha256}",
         size:        manifest_json_size,
-        platform:    platform_hash,
+        platform:    all_bottle ? nil : platform_hash,
         annotations: descriptor_annotations_hash,
-      }
+      }.compact
     end
 
     index_json_sha256, index_json_size = write_image_index(manifests, blobs, formula_annotations_hash)
@@ -524,7 +525,7 @@ class GitHubPackages
     tar_gz_sha256
   end
 
-  sig { params(platform_hash: T::Hash[String, T.untyped], tar_sha256: String, blobs: Pathname).returns([String, Integer]) }
+  sig { params(platform_hash: T::Hash[T.any(String, Symbol), T.untyped], tar_sha256: String, blobs: Pathname).returns([String, Integer]) }
   def write_image_config(platform_hash, tar_sha256, blobs)
     image_config = platform_hash.merge({
       rootfs: {
@@ -536,7 +537,7 @@ class GitHubPackages
     write_hash(blobs, image_config)
   end
 
-  sig { params(manifests: T::Array[T::Hash[String, T.untyped]], blobs: Pathname, annotations: T::Hash[String, String]).returns([String, Integer]) }
+  sig { params(manifests: T::Array[T::Hash[T.any(String, Symbol), T.untyped]], blobs: Pathname, annotations: T::Hash[String, String]).returns([String, Integer]) }
   def write_image_index(manifests, blobs, annotations)
     image_index = {
       schemaVersion: 2,
@@ -562,7 +563,7 @@ class GitHubPackages
     write_hash(root, index_json, "index.json")
   end
 
-  sig { params(directory: Pathname, hash: T::Hash[String, T.untyped], filename: T.nilable(String)).returns([String, Integer]) }
+  sig { params(directory: Pathname, hash: T::Hash[T.any(String, Symbol), T.untyped], filename: T.nilable(String)).returns([String, Integer]) }
   def write_hash(directory, hash, filename = nil)
     json = JSON.pretty_generate(hash)
     sha256 = Digest::SHA256.hexdigest(json)

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -307,6 +307,56 @@ RSpec.describe Homebrew::DevCmd::Bottle do
         end
       EOS
     end
+
+    it "writes an all bottle JSON for matching platform bottles" do
+      core_tap.path.cd do
+        system "git", "-c", "init.defaultBranch=master", "init"
+        setup_test_formula "testball"
+        system "git", "add", "--all"
+        system "git", "commit", "-m", "testball 0.1"
+      end
+
+      mktmpdir.cd do
+        sha256 = "8f9aecd233463da6a4ea55f5f88fc5841718c013f3e2a7941350d6130f1dc149"
+        bottle_json_paths = ["arm64_big_sur", "big_sur"].map do |tag|
+          Pathname("testball--1.0.#{tag}.bottle.tar.gz").write("test")
+          Pathname("#{TEST_TMPDIR}/testball-1.0.#{tag}.bottle.json").tap do |path|
+            path.write stub_hash(
+              name:           "testball",
+              version:        "1.0",
+              path:           "#{core_tap.path}/Formula/testball.rb",
+              cellar:         "any_skip_relocation",
+              os:             tag,
+              filename:       "testball-1.0.#{tag}.bottle.tar.gz",
+              local_filename: "testball--1.0.#{tag}.bottle.tar.gz",
+              sha256:,
+            )
+          end
+        end
+
+        # RuboCop would align the `.and` with `.to_stdout` which is too floaty.
+        # rubocop:disable Layout/MultilineMethodCallIndentation
+        expect do
+          brew "bottle", "--merge", "--write", "--no-commit", *bottle_json_paths
+        end.to output(/sha256 cellar: :any_skip_relocation, all: "#{sha256}"/).to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+        # rubocop:enable Layout/MultilineMethodCallIndentation
+
+        all_bottle_hash = JSON.parse(Pathname("testball--1.0.all.bottle.json").read)
+        all_bottle_tag_hash = all_bottle_hash.dig("testball", "bottle", "tags", "all")
+
+        expect(all_bottle_hash.dig("testball", "bottle", "cellar")).to eq("any_skip_relocation")
+        expect(all_bottle_hash.dig("testball", "bottle", "tags").keys).to eq(["all"])
+        expect(all_bottle_tag_hash).to include(
+          "filename"       => "testball-1.0.all.bottle.tar.gz",
+          "local_filename" => "testball--1.0.all.bottle.tar.gz",
+          "sha256"         => sha256,
+        )
+        expect(all_bottle_tag_hash).not_to have_key("cellar")
+        expect(Pathname("testball--1.0.all.bottle.tar.gz")).to exist
+      end
+    end
   end
 
   describe "bottle_cmd" do

--- a/Library/Homebrew/test/github_packages_spec.rb
+++ b/Library/Homebrew/test/github_packages_spec.rb
@@ -1,0 +1,81 @@
+# typed: false
+# frozen_string_literal: true
+
+require "github_packages"
+
+RSpec.describe GitHubPackages do
+  describe "#upload_bottle" do
+    it "omits platform metadata from image index descriptors for all bottles" do
+      mktmpdir.cd do
+        bottle = Pathname("testball--1.0.all.bottle.tar.gz")
+        Zlib::GzipWriter.open(bottle) { |gz| gz.write("test") }
+
+        github_packages = Class.new(described_class) do
+          private
+
+          def validate_schema!(_schema_uri, _json); end
+        end.new
+
+        expect do
+          github_packages.send(:upload_bottle, "brewtest", "ghp_test", Pathname("skopeo"), "testball",
+                               {
+                                 "formula" => {
+                                   "name"             => "testball",
+                                   "pkg_version"      => "1.0",
+                                   "tap_git_path"     => "Formula/t/testball.rb",
+                                   "tap_git_revision" => "abcdef",
+                                   "desc"             => "Test formula",
+                                   "license"          => "MIT",
+                                   "homepage"         => "https://brew.sh/testball",
+                                 },
+                                 "bottle"  => {
+                                   "root_url" => "https://ghcr.io/v2/homebrew/core",
+                                   "rebuild"  => 0,
+                                   "date"     => "2026-05-10T00:00:00Z",
+                                   "tags"     => {
+                                     "all"          => {
+                                       "local_filename" => bottle.to_s,
+                                       "tab"            => {
+                                         "arch"     => "arm64",
+                                         "built_on" => {
+                                           "os"         => "Macintosh",
+                                           "os_version" => "macOS 15",
+                                         },
+                                       },
+                                       "installed_size" => 100,
+                                     },
+                                     "arm64_sonoma" => {
+                                       "local_filename" => bottle.to_s,
+                                       "tab"            => {
+                                         "arch"     => "arm64",
+                                         "built_on" => {
+                                           "os"         => "Macintosh",
+                                           "os_version" => "macOS 14",
+                                         },
+                                       },
+                                       "installed_size" => 100,
+                                     },
+                                   },
+                                 },
+                               },
+                               keep_old: false, dry_run: true, warn_on_error: false)
+        end.to output.to_stdout
+
+        index_json = JSON.parse(Pathname("testball--1.0/index.json").read)
+        image_index_sha256 = index_json.fetch("manifests").first.fetch("digest").delete_prefix("sha256:")
+        image_index = JSON.parse((Pathname("testball--1.0/blobs/sha256")/image_index_sha256).read)
+        manifests_by_tag = image_index.fetch("manifests").to_h do |manifest|
+          [manifest.fetch("annotations").fetch("org.opencontainers.image.ref.name"), manifest]
+        end
+
+        expect(manifests_by_tag.fetch("1.0.all")).not_to have_key("platform")
+        expect(JSON.parse(manifests_by_tag.fetch("1.0.all").fetch("annotations").fetch("sh.brew.tab")))
+          .not_to include("arch", "built_on")
+        expect(manifests_by_tag.fetch("1.0.arm64_sonoma"))
+          .to include("platform" => include("architecture" => "arm64", "os" => "darwin"))
+        expect(JSON.parse(manifests_by_tag.fetch("1.0.arm64_sonoma").fetch("annotations").fetch("sh.brew.tab")))
+          .to include("arch" => "arm64", "built_on" => include("os" => "Macintosh"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Avoid labelling `:all` OCI descriptors as platform-specific
- Strip platform build fields from `:all` tab annotations
- Cover the `brew bottle --merge` JSON that passes `all` onward
- Cover GitHub Packages descriptors for `all` bottles

Closes https://github.com/Homebrew/brew/issues/17395

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 with manual investigation, tweaking and review.

-----
