### PR TITLE
info: resolve aliased deps when checking installed status

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -751,17 +751,19 @@ module Homebrew
       def decorate_dependencies(dependencies, tab_runtime_deps: nil)
         dependencies.map do |dep|
           display = dep_display_s(dep)
-          full_name = if tab_runtime_deps
-            tab_runtime_deps.find do |d|
-              name = d["full_name"]
-              name == dep.name || name&.then { Utils.name_from_full_name(it) } == dep.name
-            end&.fetch("full_name")
-          else
-            dep.name
+          full_name = tab_runtime_deps&.find do |d|
+            name = d["full_name"]
+            name == dep.name || name&.then { Utils.name_from_full_name(it) } == dep.name
+          end&.fetch("full_name") || dep.name
+          rack = HOMEBREW_CELLAR/Utils.name_from_full_name(full_name)
+          installed = T.let(rack.directory? && !rack.subdirs.empty?, T::Boolean)
+          formula = begin
+            dep.to_formula
+          rescue FormulaUnavailableError, TapFormulaAmbiguityError
+            nil
           end
-          rack = HOMEBREW_CELLAR/Utils.name_from_full_name(full_name) if full_name
-          installed = !rack.nil? && rack.directory? && !rack.subdirs.empty?
-          outdated = installed ? dep.to_formula.outdated? : false
+          installed ||= formula.any_version_installed? if !installed && formula
+          outdated = T.let(installed && formula&.outdated? == true, T::Boolean)
           pretty_install_status(display, installed:, outdated:)
         end.join(", ")
       end

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -653,6 +653,35 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
+  it "marks an aliased dep as installed when the underlying rack exists under a different name" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      desc "Some test"
+
+      depends_on "pkg-config"
+    end
+    direct_dependency = formula.deps.required.first
+
+    pkgconf_keg_path = HOMEBREW_CELLAR/"pkgconf/2.5.1"
+    pkgconf_keg_path.mkpath
+    pkgconf_tab = Tab.empty
+    pkgconf_tab.tabfile = pkgconf_keg_path/AbstractTab::FILENAME
+    pkgconf_tab.write
+
+    pkgconf_formula = instance_double(Formula, any_version_installed?: true, outdated?: false)
+    allow(direct_dependency).to receive(:to_formula).and_return(pkgconf_formula)
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/Required \(1\): .*pkg-config.*✔/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
   it "marks a missing dep on an uninstalled formula as unsatisfied" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
@@ -672,7 +701,33 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
-  it "marks a dep absent from the installed keg's tab as unsatisfied" do
+  it "marks a dep absent from the installed keg's tab as unsatisfied when its rack is also missing" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      desc "Some test"
+
+      depends_on "bar"
+    end
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    keg_path.mkpath
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.runtime_dependencies = []
+    tab.write
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/Required \(1\): .*bar.*✘/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "marks a dep absent from the installed keg's tab as installed when its rack exists" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
     info = described_class.new([])
@@ -700,7 +755,7 @@ RSpec.describe Homebrew::Cmd::Info do
     allow(formula).to receive(:core_formula?).and_return(false)
 
     expect { info.send(:info_formula, formula) }
-      .to output(/Required \(1\): .*bar.*✘/).to_stdout
+      .to output(/Required \(1\): .*bar.*↑/).to_stdout
       .and not_to_output.to_stderr
   end
 


### PR DESCRIPTION
Dep shows as not installed when name is aliased: 

```
❯ brew info ataraxy-labs/tap/weave
==> ataraxy-labs/tap/weave ↑: 0.1.6 → stable 0.2.7, HEAD
Entity-level semantic merge driver for Git — resolves conflicts by understanding code structure
https://github.com/Ataraxy-Labs/weave
Installed (on request)
/opt/homebrew/Cellar/weave/0.1.6 (11 files, 92.6MB) *
  Built from source on 2026-02-16 at 10:04:12
From: https://github.com/ataraxy-labs/homebrew-tap/blob/HEAD/Formula/weave.rb
License: MIT OR Apache-2.0
==> Dependencies
Build (2): rust ↑, pkg-config ✘
Recursive Runtime (1): all installed ✔
```

```
❯ brew info pkg-config
==> pkgconf ✔: stable 2.5.1 (bottled), HEAD
Package compiler and linker metadata toolkit
https://github.com/pkgconf/pkgconf
Installed (on request)
/opt/homebrew/Cellar/pkgconf/2.5.1 (28 files, 532.2KB) *
  Poured from bottle using the formulae.brew.sh API on 2026-02-16 at 09:52:56
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/p/pkgconf.rb
License: ISC
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code, Extra High Effort

-----

