### PR TITLE
audit: don't check livecheck throttle days offline

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -883,11 +883,11 @@ module Homebrew
 
       throttle_rate = formula.livecheck.throttle
       throttle_days = formula.livecheck.throttle_days
-      if (!throttle_rate.nil? || !throttle_days.nil?) &&
+      if throttle_days.nil? &&
+         !throttle_rate.nil? &&
          !Livecheck.throttle_allows_bump?(formula, stable.version, throttle_rate:, throttle_days:)
         throttle_items = []
         throttle_items << "#{throttle_rate} releases on multiples of #{throttle_rate}" if throttle_rate
-        throttle_items << "#{throttle_days} #{Utils.pluralize("day", throttle_days)}" if throttle_days
 
         problem "Should only be updated every #{throttle_items.join(" or ")}"
       end

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -932,7 +932,7 @@ RSpec.describe Homebrew::FormulaAuditor do
       expect(fa.problems).to be_empty
     end
 
-    it "doesn't allow patch versions that aren't multiples when throttle interval has not elapsed" do
+    it "allows patch versions that aren't multiples when throttle interval has not elapsed" do
       fa = formula_auditor "foo", <<~RUBY, core_tap: true
         class Foo < Formula
           url "https://brew.sh/foo-1.0.1.tgz"
@@ -944,8 +944,7 @@ RSpec.describe Homebrew::FormulaAuditor do
       allow(Homebrew::Livecheck).to receive(:throttle_interval_elapsed?).and_return(false)
 
       fa.audit_specs
-      expect(fa.problems.first[:message])
-        .to match "Should only be updated every 10 releases on multiples of 10 or 1 day"
+      expect(fa.problems).to be_empty
     end
 
     it "allows throttle with only days when throttle interval has elapsed" do
@@ -963,7 +962,7 @@ RSpec.describe Homebrew::FormulaAuditor do
       expect(fa.problems).to be_empty
     end
 
-    it "doesn't allow throttle with only days when throttle interval has not elapsed" do
+    it "allows throttle with only days when throttle interval has not elapsed" do
       fa = formula_auditor "foo", <<~RUBY, core_tap: true
         class Foo < Formula
           url "https://brew.sh/foo-1.0.1.tgz"
@@ -975,7 +974,7 @@ RSpec.describe Homebrew::FormulaAuditor do
       allow(Homebrew::Livecheck).to receive(:throttle_interval_elapsed?).and_return(false)
 
       fa.audit_specs
-      expect(fa.problems.first[:message]).to match "Should only be updated every 1 day"
+      expect(fa.problems).to be_empty
     end
 
     it "allows non-versioned formulae to have a `HEAD` spec" do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

I used `codex` to help create the change, have read the fix and tested it against Formula.

-----

A recent change to the way the `livecheck` - `throttle_days` is applied has caused some breakage on the `main` branch in `homebrew-core`. The throttle information can not be fetched when `audit` is ran in offline mode, so causes a failure. This PR unblocked `homebrew-core` CI.