### PR TITLE
test/cask: speed up missing source test

### DIFF
--- a/Library/Homebrew/test/cask/artifact/app_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/app_spec.rb
@@ -15,8 +15,10 @@ RSpec.describe Cask::Artifact::App, :cask do
   let(:install_phase) { app.install_phase(command:, adopt:, force:, auto_updates:) }
   let(:uninstall_phase) { app.uninstall_phase(command:, force:) }
 
+  let(:setup_cask) { InstallHelper.install_without_artifacts(cask) }
+
   before do
-    InstallHelper.install_without_artifacts(cask)
+    setup_cask
   end
 
   describe "install_phase" do
@@ -271,12 +273,14 @@ RSpec.describe Cask::Artifact::App, :cask do
       end
     end
 
-    it "gives a warning if the source doesn't exist" do
-      FileUtils.rm_r(source_path)
+    context "when source doesn't exist" do
+      let(:setup_cask) { cask.staged_path.mkpath }
 
-      message = "It seems the App source '#{source_path}' is not there."
+      it "gives a warning if the source doesn't exist" do
+        message = "It seems the App source '#{source_path}' is not there."
 
-      expect { install_phase }.to raise_error(Cask::CaskError, message)
+        expect { install_phase }.to raise_error(Cask::CaskError, message)
+      end
     end
   end
 

--- a/Library/Homebrew/test/cask/artifact/app_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/app_spec.rb
@@ -315,8 +315,18 @@ RSpec.describe Cask::Artifact::App, :cask do
     let(:description) { app.class.english_description }
     let(:contents) { app.summarize_installed }
 
-    it "returns the correct english_description" do
-      expect(description).to eq("Apps")
+    context "without installation" do
+      let(:setup_cask) { nil }
+
+      it "returns the correct english_description" do
+        expect(description).to eq("Apps")
+      end
+
+      describe "app is missing" do
+        it "returns a warning and the supposed path to the app" do
+          expect(contents).to match(/.*Missing App.*: #{target_path}/)
+        end
+      end
     end
 
     describe "app is correctly installed" do
@@ -324,12 +334,6 @@ RSpec.describe Cask::Artifact::App, :cask do
         install_phase
 
         expect(contents).to eq("#{target_path} (#{target_path.abv})")
-      end
-    end
-
-    describe "app is missing" do
-      it "returns a warning and the supposed path to the app" do
-        expect(contents).to match(/.*Missing App.*: #{target_path}/)
       end
     end
   end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

I used `claude-code` to analyse where this test could be improved.

-----

The test for `when source doesn't exist` was needlessly unpacking the archive, to only remove it immediately. 
We can create the same case by creating an empty folder instead.

~33% speed increase.

| Version | Mean | σ | Min | Max |
  |---------|------|---|-----|-----|
  | Before | 3.332 s | ±0.029 s | 3.301 s | 3.366 s |
  | After | 2.240 s | ±0.071 s | 2.169 s | 2.335 s |
  | **Δ** | **−1.092 s** | | | |