### PR TITLE
shims/super/ninja: omit `-j` flag when `MAKEFLAGS` advertises jobserver

### DIFF
--- a/Library/Homebrew/shims/super/ninja
+++ b/Library/Homebrew/shims/super/ninja
@@ -12,7 +12,9 @@ fi
 source "${HOMEBREW_LIBRARY}/Homebrew/shims/utils.sh"
 
 parallel_args=()
-if [[ -n "${HOMEBREW_MAKE_JOBS}" ]]
+# Defer to a POSIX FIFO jobserver if MAKEFLAGS advertises one; -j would
+# disable ninja's jobserver client. Other modes aren't usable on POSIX.
+if [[ -n "${HOMEBREW_MAKE_JOBS}" && "${MAKEFLAGS}" != *"--jobserver-auth=fifo:"* ]]
 then
   parallel_args+=(-j "${HOMEBREW_MAKE_JOBS}")
 fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

Ninja supports managed parallelism via a GNU jobserver when `MAKEFLAGS`
contains `--jobserver-auth=fifo:`. This is disabled when it is passed a
`-j` flag.[^1] This can result in more concurrent build jobs being
spawned than desired.

Let's fix this by omitting the `-j` flag when we detect a GNU jobserver
is in operation in the environment.

[^1]: https://ninja-build.org/manual.html#_gnu_jobserver_support

-----

I used Claude Opus 4.7 to double-check my understanding of the Ninja source, and to test that the change behaves as expected. I also reviewed this change manually.
