### PR TITLE
Move macOS sandbox logic

### DIFF
--- a/Library/Homebrew/extend/os/mac/sandbox.rb
+++ b/Library/Homebrew/extend/os/mac/sandbox.rb
@@ -1,9 +1,62 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "erb"
+require "fcntl"
+
 module OS
   module Mac
     module Sandbox
+      extend T::Helpers
+
+      requires_ancestor { ::Sandbox }
+
+      SANDBOX_EXEC = "/usr/bin/sandbox-exec"
+
+      # This is defined in the macOS SDK but Ruby unfortunately does not expose it.
+      # This value can be found by compiling a C program that prints TIOCSCTTY.
+      TIOCSCTTY = 0x20007461
+
+      SEATBELT_ERB = <<~ERB
+        (version 1)
+        (debug deny) ; log all denied operations to /var/log/system.log
+        <%= rules.join("\n") %>
+        (allow file-write*
+            (literal "/dev/ptmx")
+            (literal "/dev/dtracehelper")
+            (literal "/dev/null")
+            (literal "/dev/random")
+            (literal "/dev/zero")
+            (regex #"^/dev/fd/[0-9]+$")
+            (regex #"^/dev/tty[a-z0-9]*$")
+            )
+        (deny file-write*) ; deny non-allowlist file write operations
+        (deny file-write-setugid) ; deny non-allowlist file write SUID/SGID operations
+        (deny file-write-mode) ; deny non-allowlist file write mode operations
+        (allow process-exec
+            (literal "/bin/ps")
+            (with no-sandbox)
+            ) ; allow certain processes running without sandbox
+        (allow default) ; allow everything else
+      ERB
+
+      private_constant :SANDBOX_EXEC, :TIOCSCTTY, :SEATBELT_ERB
+
+      sig { void }
+      def allow_write_temp_and_cache
+        allow_write_path "/private/tmp"
+        allow_write_path "/private/var/tmp"
+        allow_write path: "^/private/var/folders/[^/]+/[^/]+/[C,T]/", type: :regex
+        super
+      end
+
+      # Xcode projects expect access to certain cache/archive dirs.
+      sig { void }
+      def allow_write_xcode
+        allow_write_path "#{Dir.home(ENV.fetch("USER"))}/Library/Developer"
+        allow_write_path "#{Dir.home(ENV.fetch("USER"))}/Library/Caches/org.swift.swiftpm"
+      end
+
       module ClassMethods
         extend T::Helpers
 
@@ -11,11 +64,100 @@ module OS
 
         sig { returns(T::Boolean) }
         def available?
-          File.executable?(::Sandbox::SANDBOX_EXEC)
+          File.executable?(SANDBOX_EXEC)
+        end
+
+        sig { returns(Integer) }
+        def terminal_ioctl_request
+          TIOCSCTTY
+        end
+      end
+
+      private
+
+      sig { params(args: T::Array[T.any(String, ::Pathname)], tmpdir: String).returns(T::Array[T.any(String, ::Pathname)]) }
+      def sandbox_command(args, tmpdir)
+        seatbelt = File.new(File.join(tmpdir, "homebrew.sb"), "wx")
+        seatbelt.write(seatbelt_profile)
+        seatbelt.close
+
+        [SANDBOX_EXEC, "-f", seatbelt.path, *args]
+      end
+
+      sig { returns(T::Boolean) }
+      def allow_network_for_error_pipe?
+        true
+      end
+
+      sig { void }
+      def ensure_child_tty_available
+        # We're opening and immediately closing so this is safe.
+        # rubocop:disable Style/FileOpen
+        File.open("/dev/tty", Fcntl::O_WRONLY).close # Workaround for https://developer.apple.com/forums/thread/663632
+        # rubocop:enable Style/FileOpen
+      end
+
+      sig { void }
+      def record_sandbox_log
+        sleep 0.1 # wait for a bit to let syslog catch up the latest events.
+        syslog_args = [
+          "-F", "$((Time)(local)) $(Sender)[$(PID)]: $(Message)",
+          "-k", "Time", "ge", T.must(start).to_i.to_s,
+          "-k", "Message", "S", "deny",
+          "-k", "Sender", "kernel",
+          "-o",
+          "-k", "Time", "ge", T.must(start).to_i.to_s,
+          "-k", "Message", "S", "deny",
+          "-k", "Sender", "sandboxd"
+        ]
+        logs = Utils.popen_read("syslog", *syslog_args)
+
+        # These messages are confusing and non-fatal, so don't report them.
+        logs = logs.lines.grep_v(/^.*Python\(\d+\) deny file-write.*pyc$/).join
+
+        return if logs.empty?
+
+        if (logfile_path = logfile)
+          File.open(logfile_path, "w") do |log|
+            log.write logs
+            log.write "\nWe use time to filter sandbox log. Therefore, unrelated logs may be recorded.\n"
+          end
+        end
+
+        return if !failed || !Homebrew::EnvConfig.verbose?
+
+        ohai "Sandbox Log", logs
+        $stdout.flush # without it, brew test-bot would fail to catch the log
+      end
+
+      sig { returns(String) }
+      def seatbelt_profile
+        ERB.new(SEATBELT_ERB).result_with_hash(rules: profile.rules.map { |rule| seatbelt_rule(rule) })
+      end
+
+      sig { params(rule: T.untyped).returns(String) }
+      def seatbelt_rule(rule)
+        s = +"("
+        s << (rule.allow ? "allow" : "deny")
+        s << " #{rule.operation}"
+        s << " (#{seatbelt_path_filter(rule.filter)})" if rule.filter
+        s << " (with #{rule.modifier})" if rule.modifier
+        s << ")"
+        s.freeze
+      end
+
+      sig { params(filter: T.untyped).returns(String) }
+      def seatbelt_path_filter(filter)
+        case filter.type
+        when :regex   then "regex #\"#{filter.path}\""
+        when :subpath then "subpath \"#{filter.path}\""
+        when :literal then "literal \"#{filter.path}\""
+        else raise ArgumentError, "Invalid path filter type: #{filter.type}"
         end
       end
     end
   end
 end
 
+Sandbox.prepend(OS::Mac::Sandbox)
 Sandbox.singleton_class.prepend(OS::Mac::Sandbox::ClassMethods)

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -1,7 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "erb"
 require "io/console"
 require "pty"
 require "tempfile"
@@ -12,31 +11,91 @@ require "utils/output"
 class Sandbox
   include Utils::Output::Mixin
 
-  SANDBOX_EXEC = "/usr/bin/sandbox-exec"
+  class SandboxPathFilter
+    sig { returns(String) }
+    attr_reader :path
 
-  # This is defined in the macOS SDK but Ruby unfortunately does not expose it.
-  # This value can be found by compiling a C program that prints TIOCSCTTY.
-  # The value is different on Linux but that's not a problem as we only support macOS in this file.
-  TIOCSCTTY = 0x20007461
-  private_constant :TIOCSCTTY
+    sig { returns(Symbol) }
+    attr_reader :type
+
+    sig { params(path: String, type: Symbol).void }
+    def initialize(path:, type:)
+      @path = T.let(path.freeze, String)
+      @type = type
+    end
+  end
+  private_constant :SandboxPathFilter
+
+  class SandboxRule
+    sig { returns(T::Boolean) }
+    attr_reader :allow
+
+    sig { returns(String) }
+    attr_reader :operation
+
+    sig { returns(T.nilable(SandboxPathFilter)) }
+    attr_reader :filter
+
+    sig { returns(T.nilable(String)) }
+    attr_reader :modifier
+
+    sig {
+      params(allow: T::Boolean, operation: String, filter: T.nilable(SandboxPathFilter),
+             modifier: T.nilable(String)).void
+    }
+    def initialize(allow:, operation:, filter:, modifier:)
+      @allow = allow
+      @operation = operation
+      @filter = filter
+      @modifier = modifier
+    end
+  end
+  private_constant :SandboxRule
+
+  # Configuration profile for a sandbox.
+  class SandboxProfile
+    sig { returns(T::Array[SandboxRule]) }
+    attr_reader :rules
+
+    sig { void }
+    def initialize
+      @rules = T.let([], T::Array[SandboxRule])
+    end
+
+    sig { params(rule: SandboxRule).void }
+    def add_rule(rule)
+      @rules << rule
+    end
+  end
+  private_constant :SandboxProfile
 
   sig { returns(T::Boolean) }
   def self.available?
     false
   end
 
+  sig { returns(Integer) }
+  def self.terminal_ioctl_request
+    raise NotImplementedError, "Sandbox is not implemented for this OS."
+  end
+
   sig { void }
   def initialize
     @profile = T.let(SandboxProfile.new, SandboxProfile)
     @failed = T.let(false, T::Boolean)
+    @logfile = T.let(nil, T.nilable(T.any(String, Pathname)))
+    @start = T.let(nil, T.nilable(Time))
   end
 
   sig { params(file: T.any(String, Pathname)).void }
   def record_log(file)
-    @logfile = T.let(file, T.nilable(T.any(String, Pathname)))
+    @logfile = file
   end
 
-  sig { params(allow: T::Boolean, operation: String, filter: T.nilable(String), modifier: T.nilable(String)).void }
+  sig {
+    params(allow: T::Boolean, operation: String, filter: T.nilable(SandboxPathFilter),
+           modifier: T.nilable(String)).void
+  }
   def add_rule(allow:, operation:, filter: nil, modifier: nil)
     rule = SandboxRule.new(allow:, operation:, filter:, modifier:)
     @profile.add_rule(rule)
@@ -66,9 +125,6 @@ class Sandbox
 
   sig { void }
   def allow_write_temp_and_cache
-    allow_write_path "/private/tmp"
-    allow_write_path "/private/var/tmp"
-    allow_write path: "^/private/var/folders/[^/]+/[^/]+/[C,T]/", type: :regex
     allow_write_path HOMEBREW_TEMP
     allow_write_path HOMEBREW_CACHE
   end
@@ -91,12 +147,8 @@ class Sandbox
     allow_write_path formula.var
   end
 
-  # Xcode projects expect access to certain cache/archive dirs.
   sig { void }
-  def allow_write_xcode
-    allow_write_path "#{Dir.home(ENV.fetch("USER"))}/Library/Developer"
-    allow_write_path "#{Dir.home(ENV.fetch("USER"))}/Library/Caches/org.swift.swiftpm"
-  end
+  def allow_write_xcode; end
 
   sig { params(formula: Formula).void }
   def allow_write_log(formula)
@@ -127,15 +179,11 @@ class Sandbox
   sig { params(args: T.any(String, Pathname)).void }
   def run(*args)
     Dir.mktmpdir("homebrew-sandbox", HOMEBREW_TEMP) do |tmpdir|
-      allow_network path: File.join(tmpdir, "socket"), type: :literal # Make sure we have access to the error pipe.
-
-      seatbelt = File.new(File.join(tmpdir, "homebrew.sb"), "wx")
-      seatbelt.write(@profile.dump)
-      seatbelt.close
+      allow_network path: File.join(tmpdir, "socket"), type: :literal if allow_network_for_error_pipe?
       @start = T.let(Time.now, T.nilable(Time))
 
       begin
-        command = [SANDBOX_EXEC, "-f", seatbelt.path, *args]
+        command = sandbox_command(args, tmpdir)
         # Start sandbox in a pseudoterminal to prevent access of the parent terminal.
         PTY.open do |controller, worker|
           # Set the PTY's window size to match the parent terminal.
@@ -174,12 +222,9 @@ class Sandbox
                 # Child side
                 Process.setsid
                 controller.close
-                worker.ioctl(TIOCSCTTY, 0) # Make this the controlling terminal.
+                worker.ioctl(self.class.terminal_ioctl_request, 0) # Make this the controlling terminal.
 
-                # We're opening and immediately closing so this is safe.
-                # rubocop:disable Style/FileOpen
-                File.open("/dev/tty", Fcntl::O_WRONLY).close # Workaround for https://developer.apple.com/forums/thread/663632
-                # rubocop:enable Style/FileOpen
+                ensure_child_tty_available
 
                 worker.close_on_exec = true
                 exec(*command, in: worker, out: worker, err: worker) # And map everything to the PTY.
@@ -217,56 +262,58 @@ class Sandbox
         @failed = true
         raise
       ensure
-        sleep 0.1 # wait for a bit to let syslog catch up the latest events.
-        syslog_args = [
-          "-F", "$((Time)(local)) $(Sender)[$(PID)]: $(Message)",
-          "-k", "Time", "ge", @start.to_i.to_s,
-          "-k", "Message", "S", "deny",
-          "-k", "Sender", "kernel",
-          "-o",
-          "-k", "Time", "ge", @start.to_i.to_s,
-          "-k", "Message", "S", "deny",
-          "-k", "Sender", "sandboxd"
-        ]
-        logs = Utils.popen_read("syslog", *syslog_args)
-
-        # These messages are confusing and non-fatal, so don't report them.
-        logs = logs.lines.grep_v(/^.*Python\(\d+\) deny file-write.*pyc$/).join
-
-        unless logs.empty?
-          if @logfile
-            File.open(@logfile, "w") do |log|
-              log.write logs
-              log.write "\nWe use time to filter sandbox log. Therefore, unrelated logs may be recorded.\n"
-            end
-          end
-
-          if @failed && Homebrew::EnvConfig.verbose?
-            ohai "Sandbox Log", logs
-            $stdout.flush # without it, brew test-bot would fail to catch the log
-          end
-        end
+        record_sandbox_log
       end
     end
   end
 
   # @api private
-  sig { params(path: T.any(String, Pathname), type: Symbol).returns(String) }
+  sig { params(path: T.any(String, Pathname), type: Symbol).returns(SandboxPathFilter) }
   def path_filter(path, type)
     invalid_char = ['"', "'", "(", ")", "\n", "\\"].find do |c|
       path.to_s.include?(c)
     end
     raise ArgumentError, "Invalid character '#{invalid_char}' in path: #{path}" if invalid_char
 
-    case type
-    when :regex   then "regex #\"#{path}\""
-    when :subpath then "subpath \"#{expand_realpath(Pathname.new(path))}\""
-    when :literal then "literal \"#{expand_realpath(Pathname.new(path))}\""
+    filter_path = case type
+    when :regex   then path.to_s
+    when :subpath, :literal
+      expand_realpath(Pathname.new(path)).to_s
     else raise ArgumentError, "Invalid path filter type: #{type}"
     end
+
+    SandboxPathFilter.new(path: filter_path, type:)
   end
 
   private
+
+  sig { returns(SandboxProfile) }
+  attr_reader :profile
+
+  sig { returns(T::Boolean) }
+  attr_reader :failed
+
+  sig { returns(T.nilable(T.any(String, Pathname))) }
+  attr_reader :logfile
+
+  sig { returns(T.nilable(Time)) }
+  attr_reader :start
+
+  sig { params(_args: T::Array[T.any(String, Pathname)], _tmpdir: String).returns(T::Array[T.any(String, Pathname)]) }
+  def sandbox_command(_args, _tmpdir)
+    raise NotImplementedError, "Sandbox is not implemented for this OS."
+  end
+
+  sig { returns(T::Boolean) }
+  def allow_network_for_error_pipe?
+    false
+  end
+
+  sig { void }
+  def ensure_child_tty_available; end
+
+  sig { void }
+  def record_sandbox_log; end
 
   sig { params(path: Pathname).returns(Pathname) }
   def expand_realpath(path)
@@ -274,80 +321,6 @@ class Sandbox
 
     path.exist? ? path.realpath : expand_realpath(path.parent)/path.basename
   end
-
-  class SandboxRule
-    sig { returns(T::Boolean) }
-    attr_reader :allow
-
-    sig { returns(String) }
-    attr_reader :operation
-
-    sig { returns(T.nilable(String)) }
-    attr_reader :filter
-
-    sig { returns(T.nilable(String)) }
-    attr_reader :modifier
-
-    sig { params(allow: T::Boolean, operation: String, filter: T.nilable(String), modifier: T.nilable(String)).void }
-    def initialize(allow:, operation:, filter:, modifier:)
-      @allow = allow
-      @operation = operation
-      @filter = filter
-      @modifier = modifier
-    end
-  end
-  private_constant :SandboxRule
-
-  # Configuration profile for a sandbox.
-  class SandboxProfile
-    SEATBELT_ERB = <<~ERB
-      (version 1)
-      (debug deny) ; log all denied operations to /var/log/system.log
-      <%= rules.join("\n") %>
-      (allow file-write*
-          (literal "/dev/ptmx")
-          (literal "/dev/dtracehelper")
-          (literal "/dev/null")
-          (literal "/dev/random")
-          (literal "/dev/zero")
-          (regex #"^/dev/fd/[0-9]+$")
-          (regex #"^/dev/tty[a-z0-9]*$")
-          )
-      (deny file-write*) ; deny non-allowlist file write operations
-      (deny file-write-setugid) ; deny non-allowlist file write SUID/SGID operations
-      (deny file-write-mode) ; deny non-allowlist file write mode operations
-      (allow process-exec
-          (literal "/bin/ps")
-          (with no-sandbox)
-          ) ; allow certain processes running without sandbox
-      (allow default) ; allow everything else
-    ERB
-
-    sig { returns(T::Array[String]) }
-    attr_reader :rules
-
-    sig { void }
-    def initialize
-      @rules = T.let([], T::Array[String])
-    end
-
-    sig { params(rule: SandboxRule).void }
-    def add_rule(rule)
-      s = +"("
-      s << (rule.allow ? "allow" : "deny")
-      s << " #{rule.operation}"
-      s << " (#{rule.filter})" if rule.filter
-      s << " (with #{rule.modifier})" if rule.modifier
-      s << ")"
-      @rules << s.freeze
-    end
-
-    sig { returns(String) }
-    def dump
-      ERB.new(SEATBELT_ERB).result(binding)
-    end
-  end
-  private_constant :SandboxProfile
 end
 
 require "extend/os/sandbox"


### PR DESCRIPTION
This will make it easier to add Linux sandboxing.

- Keep `Sandbox` focused on shared rule collection and PTY execution.
- Move Seatbelt rendering, `sandbox-exec` setup and syslog handling into `extend/os/mac/sandbox.rb`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with manual review and testing.

-----
