### PR TITLE
Parallelise dependent test-bot tests

### DIFF
--- a/Library/Homebrew/dev-cmd/determine-test-runners.rb
+++ b/Library/Homebrew/dev-cmd/determine-test-runners.rb
@@ -24,6 +24,10 @@ module Homebrew
                description: "Determine runners for testing dependents. " \
                             "Requires `--eval-all` or `HOMEBREW_EVAL_ALL=1` to be set.",
                depends_on:  "--eval-all"
+        flag   "--dependent-shards=",
+               description: "Split each dependent runner into the given number of shards.",
+               depends_on:  "--dependents",
+               hidden:      true
 
         named_args max: 2
 
@@ -44,9 +48,16 @@ module Homebrew
           TestRunnerFormula.new(Formulary.factory(name), eval_all: args.eval_all?)
         end.freeze
         deleted_formulae = args.named.second&.split(",").to_a.freeze
+        dependent_shards = args.dependent_shards || "1"
+        unless dependent_shards.match?(/\A[1-9]\d*\z/)
+          raise UsageError,
+                "`--dependent-shards` must be a positive integer."
+        end
+
         runner_matrix = GitHubRunnerMatrix.new(testing_formulae, deleted_formulae,
                                                all_supported:    args.all_supported?,
-                                               dependent_matrix: args.dependents?)
+                                               dependent_matrix: args.dependents?,
+                                               dependent_shards: dependent_shards.to_i)
         runners = runner_matrix.active_runner_specs_hash
 
         ohai "Runners", JSON.pretty_generate(runners)

--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -106,6 +106,9 @@ module Homebrew
                                  "formulae dependents step."
         comma_array "--tested-formulae=",
                     description: "Use these tested formulae from formulae steps for a formulae dependents step."
+        flag   "--formulae-dependents-shard=",
+               description: "Only test the formulae dependents in the given <SHARD/TOTAL>.",
+               hidden:      true
         conflicts "--only-formulae-detect", "--testing-formulae"
         conflicts "--only-formulae-detect", "--added-formulae"
         conflicts "--only-formulae-detect", "--deleted-formulae"

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -40,7 +40,7 @@ class GitHubRunnerMatrix
   end
   private_constant :LinuxRunnerSpecHash
 
-  RunnerSpecHash = T.type_alias { T.any(LinuxRunnerSpecHash, MacOSRunnerSpecHash) }
+  RunnerSpecHash = T.type_alias { T::Hash[Symbol, T.untyped] }
   private_constant :RunnerSpecHash
   sig { returns(T::Array[GitHubRunner]) }
   attr_reader :runners
@@ -51,9 +51,10 @@ class GitHubRunnerMatrix
       deleted_formulae: T::Array[String],
       all_supported:    T::Boolean,
       dependent_matrix: T::Boolean,
+      dependent_shards: T.nilable(Integer),
     ).void
   }
-  def initialize(testing_formulae, deleted_formulae, all_supported:, dependent_matrix:)
+  def initialize(testing_formulae, deleted_formulae, all_supported:, dependent_matrix:, dependent_shards: nil)
     if all_supported && (testing_formulae.present? || deleted_formulae.present? || dependent_matrix)
       raise ArgumentError, "all_supported is mutually exclusive to other arguments"
     end
@@ -62,6 +63,7 @@ class GitHubRunnerMatrix
     @deleted_formulae = deleted_formulae
     @all_supported = all_supported
     @dependent_matrix = dependent_matrix
+    @dependent_shards = T.let(dependent_shards || 1, Integer)
     @compatible_testing_formulae = T.let({}, T::Hash[GitHubRunner, T::Array[TestRunnerFormula]])
     @formulae_with_untested_dependents = T.let({}, T::Hash[GitHubRunner, T::Array[TestRunnerFormula]])
 
@@ -73,9 +75,19 @@ class GitHubRunnerMatrix
 
   sig { returns(T::Array[RunnerSpecHash]) }
   def active_runner_specs_hash
-    runners.select(&:active)
-           .map(&:spec)
-           .map(&:to_h)
+    specs = runners.select(&:active)
+                   .map(&:spec)
+                   .map(&:to_h)
+    return specs if !@dependent_matrix || @dependent_shards == 1
+
+    specs.flat_map do |spec|
+      (1..@dependent_shards).map do |shard|
+        spec.merge(
+          name:                      "#{spec.fetch(:name)} shard #{shard}/#{@dependent_shards}",
+          formulae_dependents_shard: "#{shard}/#{@dependent_shards}",
+        )
+      end
+    end
   end
 
   private

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/test_bot_cmd.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/test_bot_cmd.rbi
@@ -33,6 +33,9 @@ class Homebrew::Cmd::TestBotCmd::Args < Homebrew::CLI::Args
   def fail_fast?; end
 
   sig { returns(T.nilable(String)) }
+  def formulae_dependents_shard; end
+
+  sig { returns(T.nilable(String)) }
   def git_email; end
 
   sig { returns(T.nilable(String)) }

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/determine_test_runners.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/determine_test_runners.rbi
@@ -17,6 +17,9 @@ class Homebrew::DevCmd::DetermineTestRunners::Args < Homebrew::CLI::Args
   sig { returns(T::Boolean) }
   def dependents?; end
 
+  sig { returns(T.nilable(String)) }
+  def dependent_shards; end
+
   sig { returns(T::Boolean) }
   def eval_all?; end
 end

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -178,6 +178,21 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
                                   .all?(&:active))
               .to be(true)
           end
+
+          it "splits active runners into shards" do
+            allow(Homebrew::EnvConfig).to receive(:eval_all?).and_return(true)
+            allow(Formula).to receive(:all).and_return([testball, testball_depender].map(&:formula))
+
+            runners = described_class.new([testball], [],
+                                          all_supported:    false,
+                                          dependent_matrix: true,
+                                          dependent_shards: 2)
+                                     .active_runner_specs_hash
+
+            expect(runners).to all(include(:formulae_dependents_shard))
+            expect(runners.map { |runner| runner.fetch(:formulae_dependents_shard) }.uniq).to eq(["1/2", "2/2"])
+            expect(runners.map { |runner| runner.fetch(:name) }).to all(match(%r{ shard [12]/2\z}))
+          end
         end
 
         context "when dependents require Linux" do

--- a/Library/Homebrew/test/test_bot/formulae_dependents_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_dependents_spec.rb
@@ -1,0 +1,54 @@
+# typed: false
+# frozen_string_literal: true
+
+require "test_bot"
+
+RSpec.describe Homebrew::TestBot::FormulaeDependents do
+  subject(:formulae_dependents) do
+    described_class.new(tap: nil, git: nil, dry_run: false, fail_fast: false, verbose: false)
+  end
+
+  describe "#dependents_for_shard" do
+    it "keeps dependent formulae that depend on each other in the same shard" do
+      dependency = formula "dependent-a" do
+        url "https://brew.sh/dependent-a-1.0.tar.gz"
+      end
+      dependent = formula "dependent-b" do
+        url "https://brew.sh/dependent-b-1.0.tar.gz"
+        depends_on "dependent-a"
+      end
+      independent = formula "dependent-c" do
+        url "https://brew.sh/dependent-c-1.0.tar.gz"
+      end
+
+      stub_formula_loader dependency
+      stub_formula_loader dependent
+      stub_formula_loader independent
+
+      shard = formulae_dependents.send(
+        :dependents_for_shard,
+        [
+          [dependency, dependency.deps.to_a],
+          [dependent, dependent.deps.to_a],
+          [independent, independent.deps.to_a],
+        ],
+        "1/2",
+      )
+
+      expect(shard.map { |formula, _| formula.name }).to contain_exactly("dependent-a", "dependent-b")
+    end
+
+    it "rejects invalid shard indexes" do
+      expect { formulae_dependents.send(:dependents_for_shard, [], "2/1") }
+        .to raise_error(UsageError, /must not be greater/)
+    end
+
+    it "returns no formulae for an empty shard" do
+      dependent = formula "dependent-a" do
+        url "https://brew.sh/dependent-a-1.0.tar.gz"
+      end
+
+      expect(formulae_dependents.send(:dependents_for_shard, [[dependent, dependent.deps.to_a]], "2/2")).to be_empty
+    end
+  end
+end

--- a/Library/Homebrew/test_bot/formulae_dependents.rb
+++ b/Library/Homebrew/test_bot/formulae_dependents.rb
@@ -4,6 +4,9 @@
 module Homebrew
   module TestBot
     class FormulaeDependents < TestFormulae
+      DependentWithDependencies = T.type_alias { [Formula, T::Array[Dependency]] }
+      private_constant :DependentWithDependencies
+
       sig { params(testing_formulae: T::Array[String]).returns(T::Array[String]) }
       attr_writer :testing_formulae
 
@@ -24,10 +27,17 @@ module Homebrew
         @testing_formulae_with_tested_dependents = T.let([], T::Array[String])
         @tested_dependents_list = T.let(nil, T.nilable(Pathname))
         @dependent_testing_formulae = T.let([], T::Array[String])
+        @tested_dependents = T.let([], T::Array[String])
+        @formulae_dependents_filter = T.let(nil, T.nilable(T::Array[String]))
+        @dependent_pairs_by_formula = T.let({}, T::Hash[String, T::Array[DependentWithDependencies]])
       end
 
       sig { params(args: Homebrew::Cmd::TestBotCmd::Args).void }
       def run!(args:)
+        if args.formulae_dependents_shard.present? && !args.only_formulae_dependents?
+          raise UsageError, "`--formulae-dependents-shard` requires `--only-formulae-dependents`."
+        end
+
         test "brew", "untap", "--force", "homebrew/cask" if !tap&.core_cask_tap? && CoreCaskTap.instance.installed?
 
         installable_bottles = @tested_formulae - @skipped_or_failed_formulae
@@ -54,6 +64,16 @@ module Homebrew
           end,
           T.nilable(T::Array[String]),
         )
+
+        if args.formulae_dependents_shard.present?
+          dependent_pairs = @dependent_testing_formulae.flat_map do |formula_name|
+            dependent_pairs_for_formula(Formulary.factory(formula_name), formula_name, args:)
+          end
+          dependent_pairs.uniq! { |dependent, _| dependent.full_name }
+
+          @formulae_dependents_filter = dependents_for_shard(dependent_pairs, args.formulae_dependents_shard.to_s)
+                                        .map { |dependent, _| dependent.full_name }
+        end
 
         @dependent_testing_formulae.each do |formula_name|
           dependent_formulae!(formula_name, args:)
@@ -137,6 +157,8 @@ module Homebrew
         bottled_dependents.each do |dependent|
           install_dependent(dependent, testable_dependents, args:)
         end
+
+        @tested_dependents |= (source_dependents + bottled_dependents).map(&:full_name)
       end
 
       sig {
@@ -146,60 +168,13 @@ module Homebrew
       def dependents_for_formula(formula, formula_name, args:)
         info_header "Determining dependents..."
 
-        # Always skip recursive dependents on Intel. It's really slow.
-        # Also skip recursive dependents on Linux unless it's a Linux-only formula.
-        #
-        skip_recursive_dependents = skip_recursive_dependents?(formula, args:)
-
-        uses_args = %w[--formula --eval-all]
-        uses_include_test_args = [*uses_args, "--include-test"]
-        uses_include_test_args << "--recursive" unless skip_recursive_dependents
-        dependents = with_env(HOMEBREW_STDERR: "1") do
-          Utils.safe_popen_read("brew", "uses", *uses_include_test_args, formula_name)
-               .split("\n")
-        end
-
-        # TODO: Consider handling the following case better.
-        #       `foo` has a build dependency on `bar`, and `bar` has a runtime dependency on
-        #       `baz`. When testing `baz` with `--build-dependents-from-source`, `foo` is
-        #       not tested, but maybe should be.
-        dependents += with_env(HOMEBREW_STDERR: "1") do
-          Utils.safe_popen_read("brew", "uses", *uses_args, "--include-build", formula_name)
-               .split("\n")
-        end
-        dependents.uniq!
-        dependents.sort!
-
-        dependents -= @tested_formulae
-        dependents = dependents.map { |d| Formulary.factory(d) }
-
-        dependents = dependents.zip(dependents.map do |f|
-          if skip_recursive_dependents
-            f.deps.reject(&:implicit?)
-          else
-            begin
-              Dependency.expand(f, cache_key: "test-bot-dependents") do |_, dependency|
-                next Dependable::SKIP if dependency.implicit?
-                next Dependable::KEEP_BUT_PRUNE_RECURSIVE_DEPS if dependency.build? || dependency.test?
-              end
-            rescue TapFormulaUnavailableError => e
-              raise if e.tap.installed?
-
-              e.tap.clear_cache
-              safe_system "brew", "tap", e.tap.name
-              retry
-            end
-          end.reject(&:optional?)
-        end)
-
-        # Defer formulae which could be tested later
-        # i.e. formulae that also depend on something else yet to be built in this test run.
-        unless args.only_formulae_dependents?
-          dependents.reject! do |_, deps|
-            still_to_test = @dependent_testing_formulae - @testing_formulae_with_tested_dependents
-            deps.map { |d| d.to_formula.full_name }.intersect?(still_to_test)
+        dependents = dependent_pairs_for_formula(formula, formula_name, args:)
+        if (filter = @formulae_dependents_filter)
+          dependents = dependents.select do |dependent, _|
+            filter.include?(dependent.name) || filter.include?(dependent.full_name)
           end
         end
+        dependents.reject! { |dependent, _| @tested_dependents.include?(dependent.full_name) }
 
         # Split into dependents that we could potentially be building from source and those
         # we should not. The criteria is that a dependent must have bottled dependencies, and
@@ -238,6 +213,139 @@ module Homebrew
         puts testable_dependents
 
         [source_dependents, bottled_dependents, testable_dependents]
+      end
+
+      sig {
+        params(formula: Formula, formula_name: String, args: Homebrew::Cmd::TestBotCmd::Args)
+          .returns(T::Array[DependentWithDependencies])
+      }
+      def dependent_pairs_for_formula(formula, formula_name, args:)
+        @dependent_pairs_by_formula[formula_name] ||= begin
+          # Always skip recursive dependents on Intel. It's really slow.
+          # Also skip recursive dependents on Linux unless it's a Linux-only formula.
+          #
+          skip_recursive_dependents = skip_recursive_dependents?(formula, args:)
+
+          uses_args = %w[--formula --eval-all]
+          uses_include_test_args = [*uses_args, "--include-test"]
+          uses_include_test_args << "--recursive" unless skip_recursive_dependents
+          dependents = with_env(HOMEBREW_STDERR: "1") do
+            Utils.safe_popen_read("brew", "uses", *uses_include_test_args, formula_name)
+                 .split("\n")
+          end
+
+          # TODO: Consider handling the following case better.
+          #       `foo` has a build dependency on `bar`, and `bar` has a runtime dependency on
+          #       `baz`. When testing `baz` with `--build-dependents-from-source`, `foo` is
+          #       not tested, but maybe should be.
+          dependents += with_env(HOMEBREW_STDERR: "1") do
+            Utils.safe_popen_read("brew", "uses", *uses_args, "--include-build", formula_name)
+                 .split("\n")
+          end
+          dependents.uniq!
+          dependents.sort!
+
+          dependents -= @tested_formulae
+          dependents = dependents.map { |d| Formulary.factory(d) }
+
+          dependents = dependents.zip(dependents.map do |f|
+            if skip_recursive_dependents
+              f.deps.reject(&:implicit?)
+            else
+              begin
+                Dependency.expand(f, cache_key: "test-bot-dependents") do |_, dependency|
+                  next Dependable::SKIP if dependency.implicit?
+                  next Dependable::KEEP_BUT_PRUNE_RECURSIVE_DEPS if dependency.build? || dependency.test?
+                end
+              rescue TapFormulaUnavailableError => e
+                raise if e.tap.installed?
+
+                e.tap.clear_cache
+                safe_system "brew", "tap", e.tap.name
+                retry
+              end
+            end.reject(&:optional?)
+          end)
+
+          # Defer formulae which could be tested later
+          # i.e. formulae that also depend on something else yet to be built in this test run.
+          unless args.only_formulae_dependents?
+            dependents.reject! do |_, deps|
+              still_to_test = @dependent_testing_formulae - @testing_formulae_with_tested_dependents
+              deps.map { |d| d.to_formula.full_name }.intersect?(still_to_test)
+            end
+          end
+
+          dependents
+        end
+      end
+
+      sig {
+        params(
+          dependents: T::Array[DependentWithDependencies],
+          shard:      String,
+        ).returns(T::Array[DependentWithDependencies])
+      }
+      def dependents_for_shard(dependents, shard)
+        unless shard.match?(%r{\A[1-9]\d*/[1-9]\d*\z})
+          raise UsageError, "`--formulae-dependents-shard` must use the format <SHARD/TOTAL>."
+        end
+
+        shard_parts = shard.split("/", 2)
+        shard_index = shard_parts.fetch(0).to_i
+        shard_count = shard_parts.fetch(1).to_i
+        if shard_index > shard_count
+          raise UsageError, "`--formulae-dependents-shard` must not be greater than the total shard count."
+        end
+
+        return dependents if shard_count == 1
+
+        dependents_by_name = dependents.to_h { |dependent, deps| [dependent.full_name, [dependent, deps]] }
+        edges = dependents.to_h { |dependent, _| [dependent.full_name, T.let([], T::Array[String])] }
+
+        dependents.each do |dependent, deps|
+          deps.each do |dep|
+            dep_name = dep.to_formula.full_name
+            next unless edges.key?(dep_name)
+
+            edges.fetch(dependent.full_name) << dep_name
+            edges.fetch(dep_name) << dependent.full_name
+          end
+        end
+
+        seen = T.let([], T::Array[String])
+        groups = T.let([], T::Array[T::Array[DependentWithDependencies]])
+
+        dependents.map(&:first).each do |dependent|
+          next if seen.include?(dependent.full_name)
+
+          group = T.let([], T::Array[DependentWithDependencies])
+          queue = T.let([dependent.full_name], T::Array[String])
+
+          until queue.empty?
+            name = queue.fetch(0)
+            queue.shift
+            next if seen.include?(name)
+
+            seen << name
+            group << dependents_by_name.fetch(name)
+            queue.concat(edges.fetch(name).reject { |edge| seen.include?(edge) })
+          end
+
+          groups << group
+        end
+
+        shards = Array.new(shard_count) { T.let([], T::Array[DependentWithDependencies]) }
+        groups.sort_by { |group| [-group.count, group.map { |dependent, _| dependent.full_name }.min.to_s] }
+              .each do |group|
+          shard_index = 0
+          shards.each_with_index do |current_shard, index|
+            shard_index = index if current_shard.count < shards.fetch(shard_index).count
+          end
+          shards.fetch(shard_index).concat(group)
+        end
+
+        shards.fetch(shard_index - 1).sort_by { |dependent, _| dependent.full_name }
       end
 
       sig {


### PR DESCRIPTION
- Fan out dependent runner matrices without changing the default serial path.
- Keep related dependent formulae on the same shard so dependency chains are not tested repeatedly across runners.

Part of https://github.com/Homebrew/homebrew-core/issues/206400

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review.

-----
