### PR TITLE
info: show other installed versions

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -127,18 +127,38 @@ class Caveats
 
   sig { returns(T.nilable(String)) }
   def shadowed_path_text
-    return if formula.keg_only? && !formula.linked?
     return if Homebrew::EnvConfig.no_path_shadow_check?
+    return unless formula.any_version_installed?
 
     shadowed = shadowed_executables
+    shadowed = shadowed.select { |_, shadower| sibling_keg_name(shadower) } if formula.keg_only? && !formula.linked?
     return if shadowed.empty?
 
-    lines = shadowed.sort_by(&:first).map { |name, shadower| "  #{name} (shadowed by #{shadower})" }
-    s = <<~EOS
-      The following #{formula.name} executables are shadowed by other commands earlier in your PATH:
-      #{lines.join("\n")}
-      Running these by name will not invoke the version provided by Homebrew.
-    EOS
+    sibling, external = shadowed.sort_by(&:first).partition { |_, shadower| sibling_keg_name(shadower) }
+    blocks = []
+
+    if external.any?
+      lines = external.map { |name, shadower| "  #{name} (shadowed by #{shadower})" }
+      blocks << <<~EOS
+        The following #{formula.name} executables are shadowed by other commands earlier in your PATH:
+        #{lines.join("\n")}
+        Running these by name will not invoke the version provided by Homebrew.
+      EOS
+    end
+
+    if sibling.any?
+      lines = sibling.map do |name, shadower|
+        "  #{name} (shadowed by #{shadower} from #{sibling_keg_name(shadower)})"
+      end
+      blocks << <<~EOS
+        The following #{formula.name} executables are shadowed by other linked Homebrew commands:
+        #{lines.join("\n")}
+        Running these by name will not invoke the version provided by this formula.
+        Run `brew link #{formula.name}` to switch the active version to this keg.
+      EOS
+    end
+
+    s = blocks.join("\n").dup
     unless Homebrew::EnvConfig.no_env_hints?
       s << "Disable this behaviour by setting `HOMEBREW_NO_PATH_SHADOW_CHECK=1`.\n"
       s << "Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).\n"
@@ -147,6 +167,24 @@ class Caveats
   end
 
   private
+
+  sig { params(shadower: Pathname).returns(T.nilable(String)) }
+  def sibling_keg_name(shadower)
+    target = shadower.realpath
+    return unless target.to_s.start_with?("#{HOMEBREW_CELLAR.realpath}/")
+
+    name = target.relative_path_from(HOMEBREW_CELLAR.realpath).each_filename.first
+    return if name.nil? || name == formula.name
+
+    family = [
+      formula.unversioned_formula_name,
+      formula.name,
+      *formula.versioned_formulae_names,
+    ].compact
+    name if family.include?(name)
+  rescue Errno::ENOENT
+    nil
+  end
 
   sig { returns(T::Array[[String, Pathname]]) }
   def shadowed_executables

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -617,6 +617,8 @@ module Homebrew
         end
         puts formula.desc if formula.desc
         puts Formatter.url(formula.homepage) if formula.homepage
+        puts "Aliases: #{formula.aliases.join(", ")}" if formula.aliases.any?
+        puts "Old Names: #{formula.oldnames.join(", ")}" if formula.oldnames.any?
 
         deprecate_disable_info_string = DeprecateDisable.message(formula)
         if deprecate_disable_info_string.present?
@@ -655,11 +657,6 @@ module Homebrew
           end
         else
           puts self.class.installation_status(Tab.for_formula(formula))
-          kegs.each do |keg|
-            puts "#{keg} (#{keg.abv})#{" *" if keg.linked?}"
-            tab = keg.tab.to_s
-            puts "  #{tab}" unless tab.empty?
-          end
         end
 
         puts "From: #{Formatter.url(github_info(formula))}"
@@ -667,6 +664,12 @@ module Homebrew
         puts "License: #{SPDX.license_expression_to_string formula.license}" if formula.license.present?
         metadata = self.class.metadata_lines(formula)
         puts metadata if metadata.present?
+
+        installed_lines = installed_section_lines(formula, verbose: args.verbose?)
+        unless installed_lines.empty?
+          ohai "Installed Kegs and Versions"
+          installed_lines.each { |line| puts line }
+        end
 
         tab_runtime_deps = kegs.last&.runtime_dependencies
         installed_dependents = if $stdout.tty? && kegs.any?
@@ -749,6 +752,52 @@ module Homebrew
         return unless formula.core_formula?
 
         Utils::Analytics.formula_output(formula, args:)
+      end
+
+      sig { params(formula: Formula, verbose: T::Boolean).returns(T::Array[String]) }
+      def installed_section_lines(formula, verbose: false)
+        siblings = formula.versioned_formulae
+        parent = if (parent_name = formula.unversioned_formula_name)
+          begin
+            Formulary.factory(parent_name)
+          rescue FormulaUnavailableError
+            nil
+          end
+        end
+        related = [formula, parent, *siblings].compact.uniq(&:full_name)
+        installed = related.select { |f| f.installed_kegs.any? }
+        return [] if installed.empty?
+
+        ordered = installed.sort_by do |other|
+          newest_keg = other.installed_kegs.max_by(&:scheme_and_version)
+          newest_keg ? newest_keg.scheme_and_version : other.pkg_version
+        end.reverse
+        with_kegs = ordered.flat_map do |other|
+          heads, versioned = other.installed_kegs.partition { |keg| keg.version.head? }
+          ordered_kegs = [
+            *heads.sort_by { |keg| -keg.tab.time.to_i },
+            *versioned.sort_by(&:scheme_and_version).reverse,
+          ]
+          ordered_kegs.map { |keg| [other, keg] }
+        end
+        rows = with_kegs.map do |other, keg|
+          name_status = pretty_install_status(other.full_name, installed: true, outdated: other.outdated?)
+          linked_marker = keg.linked? ? "[Linked]" : ""
+          [name_status, keg.version.to_s, "(#{keg.abv})", linked_marker, keg]
+        end
+        name_width = rows.map { |r| Tty.strip_ansi(r[0]).length }.max || 0
+        version_width = rows.map { |r| r[1].length }.max || 0
+        size_width = rows.map { |r| r[2].length }.max || 0
+        rows.flat_map do |name_status, version, size, linked_marker, keg|
+          padded_name = name_status + (" " * (name_width - Tty.strip_ansi(name_status).length))
+          padded_size = linked_marker.empty? ? size : size.ljust(size_width)
+          line = "#{padded_name} #{version.ljust(version_width)} #{padded_size}" \
+                 "#{" #{linked_marker}" unless linked_marker.empty?}"
+          next [line] unless verbose
+
+          tab_string = keg.tab.to_s
+          tab_string.empty? ? [line] : [line, "  #{tab_string}"]
+        end
       end
 
       sig {

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -250,6 +250,7 @@ RSpec.describe Caveats do
         Pathname.new(f.opt_bin).mkpath
         FileUtils.touch(f.opt_bin/"foo")
         FileUtils.chmod(0755, f.opt_bin/"foo")
+        allow(f).to receive(:any_version_installed?).and_return(true)
         allow_any_instance_of(Object).to receive(:which).and_call_original
       end
 
@@ -291,6 +292,54 @@ RSpec.describe Caveats do
         expect(described_class.new(keg_only_f).caveats).not_to include("shadowed")
       end
 
+      it "does not warn when the queried formula itself is not installed" do
+        uninstalled_f = formula("foo@old") do
+          url "foo-1.0"
+          keg_only :versioned_formula
+        end
+        Pathname.new(uninstalled_f.opt_bin).mkpath
+        FileUtils.touch(uninstalled_f.opt_bin/"foo")
+        FileUtils.chmod(0755, uninstalled_f.opt_bin/"foo")
+
+        sibling_keg_bin = HOMEBREW_CELLAR/"foo@2.0/2.0/bin"
+        sibling_keg_bin.mkpath
+        sibling_shadower = sibling_keg_bin/"foo"
+        sibling_shadower.write("#!/bin/sh\n")
+        sibling_shadower.chmod(0755)
+
+        allow(uninstalled_f).to receive_messages(versioned_formulae_names: ["foo@2.0"],
+                                                 unversioned_formula_name: "foo",
+                                                 any_version_installed?:   false)
+        allow_any_instance_of(Object).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(sibling_shadower)
+
+        expect(described_class.new(uninstalled_f).caveats).not_to include("shadowed")
+      end
+
+      it "warns for a keg-only formula when a sibling keg is linked over it" do
+        keg_only_f = formula("foo@1.0") do
+          url "foo-1.0"
+          keg_only :versioned_formula
+        end
+        Pathname.new(keg_only_f.opt_bin).mkpath
+        FileUtils.touch(keg_only_f.opt_bin/"foo")
+        FileUtils.chmod(0755, keg_only_f.opt_bin/"foo")
+
+        sibling_keg_bin = HOMEBREW_CELLAR/"foo@2.0/2.0/bin"
+        sibling_keg_bin.mkpath
+        sibling_shadower = sibling_keg_bin/"foo"
+        sibling_shadower.write("#!/bin/sh\n")
+        sibling_shadower.chmod(0755)
+
+        allow(keg_only_f).to receive_messages(versioned_formulae_names: ["foo@2.0"],
+                                              unversioned_formula_name: "foo",
+                                              any_version_installed?:   true)
+        allow_any_instance_of(Object).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(sibling_shadower)
+
+        caveats = described_class.new(keg_only_f).caveats
+        expect(caveats).to include("foo (shadowed by #{sibling_shadower} from foo@2.0)")
+        expect(caveats).to include("Run `brew link foo@1.0`")
+      end
+
       it "warns when a keg-only formula has been linked" do
         keg_only_f = formula do
           url "foo-1.0"
@@ -299,7 +348,7 @@ RSpec.describe Caveats do
         Pathname.new(keg_only_f.opt_bin).mkpath
         FileUtils.touch(keg_only_f.opt_bin/"foo")
         FileUtils.chmod(0755, keg_only_f.opt_bin/"foo")
-        allow(keg_only_f).to receive(:linked?).and_return(true)
+        allow(keg_only_f).to receive_messages(linked?: true, any_version_installed?: true)
         shadower = Pathname.new("/usr/local/bin/foo")
         allow_any_instance_of(Object).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(shadower)
         allow(shadower).to receive(:realpath).and_return(shadower)
@@ -330,6 +379,47 @@ RSpec.describe Caveats do
         allow(Homebrew::EnvConfig).to receive(:no_env_hints?).and_return(true)
 
         expect(described_class.new(f).caveats).not_to include("HOMEBREW_NO_PATH_SHADOW_CHECK")
+      end
+
+      it "annotates sibling-keg shadowers with the keg name and adds a `brew link` hint" do
+        sibling_keg_bin = HOMEBREW_CELLAR/"#{f.name}@1.0/1.0/bin"
+        sibling_keg_bin.mkpath
+        sibling_shadower = sibling_keg_bin/"foo"
+        sibling_shadower.write("#!/bin/sh\n")
+        sibling_shadower.chmod(0755)
+
+        allow(f).to receive_messages(versioned_formulae_names: ["#{f.name}@1.0"], unversioned_formula_name: nil)
+        allow_any_instance_of(Object).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(sibling_shadower)
+
+        caveats = described_class.new(f).caveats
+        expect(caveats).to include("shadowed by other linked Homebrew commands")
+        expect(caveats).to include("foo (shadowed by #{sibling_shadower} from #{f.name}@1.0)")
+        expect(caveats).to include("Run `brew link #{f.name}`")
+        expect(caveats).not_to include("earlier in your PATH")
+      end
+
+      it "annotates only the sibling line when shadowers are mixed" do
+        Pathname.new(f.opt_bin).mkpath
+        FileUtils.touch(f.opt_bin/"bar")
+        FileUtils.chmod(0755, f.opt_bin/"bar")
+
+        sibling_keg_bin = HOMEBREW_CELLAR/"#{f.name}@1.0/1.0/bin"
+        sibling_keg_bin.mkpath
+        sibling_shadower = sibling_keg_bin/"foo"
+        sibling_shadower.write("#!/bin/sh\n")
+        sibling_shadower.chmod(0755)
+
+        bar_shadower = Pathname.new("/usr/local/bin/bar")
+        allow(bar_shadower).to receive(:realpath).and_return(bar_shadower)
+
+        allow(f).to receive_messages(versioned_formulae_names: ["#{f.name}@1.0"], unversioned_formula_name: nil)
+        allow_any_instance_of(Object).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(sibling_shadower)
+        allow_any_instance_of(Object).to receive(:which).with("bar", ORIGINAL_PATHS).and_return(bar_shadower)
+
+        caveats = described_class.new(f).caveats
+        expect(caveats).to include("foo (shadowed by #{sibling_shadower} from #{f.name}@1.0)")
+        expect(caveats).to include("bar (shadowed by #{bar_shadower})")
+        expect(caveats).to include("Run `brew link #{f.name}`")
       end
     end
 

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -1023,6 +1023,253 @@ RSpec.describe Homebrew::Cmd::Info do
     end
   end
 
+  describe "Aliases and Old Names rows" do
+    it "lists aliases on their own row when the formula has any" do
+      info = described_class.new([])
+      main_formula = formula("testball") do
+        url "https://brew.sh/testball-1.0.tar.gz"
+      end
+      allow(main_formula).to receive_messages(aliases: ["testball@1.0", "tball", "googleball"], oldnames: [])
+      allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
+
+      expect { info.send(:info_formula, main_formula) }
+        .to output(/^Aliases: testball@1\.0, tball, googleball$/).to_stdout
+        .and not_to_output(/^Old Names:/).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "renders aliases and old names on separate rows when both exist" do
+      info = described_class.new([])
+      main_formula = formula("testball") do
+        url "https://brew.sh/testball-1.0.tar.gz"
+      end
+      allow(main_formula).to receive_messages(aliases: ["testball@1.0", "tball"], oldnames: ["foo", "bar"])
+      allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
+
+      expect { info.send(:info_formula, main_formula) }
+        .to output(/^Aliases: testball@1\.0, tball\nOld Names: foo, bar$/).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "renders only an Old Names row when there are no aliases" do
+      info = described_class.new([])
+      main_formula = formula("testball") do
+        url "https://brew.sh/testball-1.0.tar.gz"
+      end
+      allow(main_formula).to receive_messages(aliases: [], oldnames: ["foo"])
+      allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
+
+      expect { info.send(:info_formula, main_formula) }
+        .to output(/^Old Names: foo$/).to_stdout
+        .and not_to_output(/^Aliases:/).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "omits both rows when there are none" do
+      info = described_class.new([])
+      main_formula = formula("testball") do
+        url "https://brew.sh/testball-1.0.tar.gz"
+      end
+      allow(main_formula).to receive_messages(aliases: [], oldnames: [])
+      allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
+
+      expect { info.send(:info_formula, main_formula) }
+        .to not_to_output(/^Aliases:/).to_stdout
+        .and not_to_output(/^Old Names:/).to_stdout
+        .and not_to_output.to_stderr
+    end
+  end
+
+  describe "Installed section" do
+    it "lists this formula alongside installed sibling versioned formulae" do
+      info = described_class.new([])
+      main_formula = formula("testball") do
+        url "https://brew.sh/testball-1.0.tar.gz"
+      end
+      versioned = formula("testball@0.9") do
+        url "https://brew.sh/testball-0.9.tar.gz"
+        keg_only :versioned_formula
+      end
+
+      main_keg = HOMEBREW_CELLAR/"testball/1.0"
+      main_keg.mkpath
+      main_tab = Tab.empty
+      main_tab.tabfile = main_keg/AbstractTab::FILENAME
+      main_tab.write
+
+      sibling_keg = HOMEBREW_CELLAR/"testball@0.9/0.9"
+      sibling_keg.mkpath
+      sibling_tab = Tab.empty
+      sibling_tab.tabfile = sibling_keg/AbstractTab::FILENAME
+      sibling_tab.write
+
+      allow(main_formula).to receive(:versioned_formulae).and_return([versioned])
+      allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
+
+      expect { info.send(:info_formula, main_formula) }
+        .to output(Regexp.new(
+                     "==> Installed Kegs and Versions\n" \
+                     ".*testball\\b.*\\s+1\\.0\\s+\\(.*\\)\n" \
+                     ".*testball@0\\.9\\b.*\\s+0\\.9\\s+\\(",
+                   )).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "marks the currently linked version with `*`" do
+      info = described_class.new([])
+      main_formula = formula("testball") do
+        url "https://brew.sh/testball-1.0.tar.gz"
+      end
+      versioned = formula("testball@0.9") do
+        url "https://brew.sh/testball-0.9.tar.gz"
+        keg_only :versioned_formula
+      end
+
+      main_keg = HOMEBREW_CELLAR/"testball/1.0"
+      main_keg.mkpath
+      main_tab = Tab.empty
+      main_tab.tabfile = main_keg/AbstractTab::FILENAME
+      main_tab.write
+      (HOMEBREW_LINKED_KEGS/"testball").parent.mkpath
+      FileUtils.ln_s(main_keg, HOMEBREW_LINKED_KEGS/"testball")
+
+      sibling_keg = HOMEBREW_CELLAR/"testball@0.9/0.9"
+      sibling_keg.mkpath
+      sibling_tab = Tab.empty
+      sibling_tab.tabfile = sibling_keg/AbstractTab::FILENAME
+      sibling_tab.write
+
+      allow(main_formula).to receive_messages(versioned_formulae: [versioned], linked?: true,
+                                              linked_version: PkgVersion.parse("1.0"))
+      allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
+
+      expect { info.send(:info_formula, main_formula) }
+        .to output(/.*testball\b.*\s+1\.0\s+\(.*\)\s+\[Linked\]/).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "includes the unversioned parent when run on a versioned formula" do
+      info = described_class.new([])
+      versioned = formula("testball@0.9") do
+        url "https://brew.sh/testball-0.9.tar.gz"
+        keg_only :versioned_formula
+      end
+      parent = formula("testball") do
+        url "https://brew.sh/testball-1.0.tar.gz"
+      end
+
+      versioned_keg = HOMEBREW_CELLAR/"testball@0.9/0.9"
+      versioned_keg.mkpath
+      versioned_tab = Tab.empty
+      versioned_tab.tabfile = versioned_keg/AbstractTab::FILENAME
+      versioned_tab.write
+
+      parent_keg = HOMEBREW_CELLAR/"testball/1.0"
+      (parent_keg/"bin").mkpath
+      parent_tab = Tab.empty
+      parent_tab.tabfile = parent_keg/AbstractTab::FILENAME
+      parent_tab.write
+
+      allow(versioned).to receive(:versioned_formulae).and_return([])
+      allow(Formulary).to receive(:factory).with("testball").and_return(parent)
+      allow(info).to receive(:github_info).with(versioned).and_return("https://example.com/testball.rb")
+
+      expect { info.send(:info_formula, versioned) }
+        .to output(Regexp.new(
+                     "==> Installed Kegs and Versions\n" \
+                     ".*testball\\b.*\\s+1\\.0\\s+\\(.*\\)\n" \
+                     ".*testball@0\\.9\\b.*\\s+0\\.9\\s+\\(",
+                   )).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "renders the section even when only the current formula is installed" do
+      info = described_class.new([])
+      main_formula = formula("testball") do
+        url "https://brew.sh/testball-1.0.tar.gz"
+      end
+
+      keg_path = HOMEBREW_CELLAR/"testball/1.0"
+      keg_path.mkpath
+      tab = Tab.empty
+      tab.tabfile = keg_path/AbstractTab::FILENAME
+      tab.write
+
+      allow(main_formula).to receive(:versioned_formulae).and_return([])
+      allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
+
+      expect { info.send(:info_formula, main_formula) }
+        .to output(/==> Installed Kegs and Versions\n.*testball\b.*\s+1\.0\s+\(/).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "renders the section when the queried formula is uninstalled but a sibling is installed" do
+      info = described_class.new([])
+      versioned = formula("testball@0.9") do
+        url "https://brew.sh/testball-0.9.tar.gz"
+        keg_only :versioned_formula
+      end
+      parent = formula("testball") do
+        url "https://brew.sh/testball-1.0.tar.gz"
+      end
+
+      parent_keg = HOMEBREW_CELLAR/"testball/1.0"
+      parent_keg.mkpath
+      parent_tab = Tab.empty
+      parent_tab.tabfile = parent_keg/AbstractTab::FILENAME
+      parent_tab.write
+
+      allow(versioned).to receive(:versioned_formulae).and_return([])
+      allow(Formulary).to receive(:factory).with("testball").and_return(parent)
+      allow(info).to receive(:github_info).with(versioned).and_return("https://example.com/testball.rb")
+
+      expect { info.send(:info_formula, versioned) }
+        .to output(/==> Installed Kegs and Versions\n.*testball\b.*\s+1\.0\s+\(/).to_stdout
+        .and not_to_output(/testball@0\.9 \(0\.9\)/).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "lists every installed keg of a formula, newest first" do
+      info = described_class.new([])
+      main_formula = formula("testball") do
+        url "https://brew.sh/testball-1.0.tar.gz"
+      end
+
+      ["0.9", "1.0", "0.10"].each do |version|
+        keg_path = HOMEBREW_CELLAR/"testball/#{version}"
+        keg_path.mkpath
+        tab = Tab.empty
+        tab.tabfile = keg_path/AbstractTab::FILENAME
+        tab.write
+      end
+
+      allow(main_formula).to receive(:versioned_formulae).and_return([])
+      allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
+
+      expect { info.send(:info_formula, main_formula) }
+        .to output(Regexp.new(
+                     "==> Installed Kegs and Versions\n" \
+                     ".*testball\\b.*\\s+1\\.0\\s+\\(.*\\)\n" \
+                     ".*testball\\b.*\\s+0\\.10\\s+\\(.*\\)\n" \
+                     ".*testball\\b.*\\s+0\\.9\\s+\\(",
+                   )).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "omits the section when nothing in the family is installed" do
+      info = described_class.new([])
+      main_formula = formula("testball") do
+        url "https://brew.sh/testball-1.0.tar.gz"
+      end
+      allow(main_formula).to receive(:versioned_formulae).and_return([])
+      allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
+
+      expect { info.send(:info_formula, main_formula) }
+        .to not_to_output(/==> Installed Kegs and Versions\b/).to_stdout
+        .and not_to_output.to_stderr
+    end
+  end
+
   describe "#github_info" do
     let(:tap) { CoreTap.instance }
 


### PR DESCRIPTION
Give user info about sibling formulae:

```
❯ brew info go@1.24
==> go@1.24 ✔: stable 1.24.13 (bottled) [keg-only]
Open source programming language to build simple/reliable/efficient software
https://go.dev/
Deprecated because it is not supported upstream! It will be disabled on 2027-02-11.
Installed (on request)
/opt/homebrew/Cellar/go@1.24/1.24.13_1 (14,126 files, 256.2MB)
  Poured from bottle using the internal formulae.brew.sh API on 2026-05-12 at 09:38:28
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/g/go@1.24.rb
License: BSD-3-Clause
==> Caveats
go@1.24 is keg-only, which means it was not symlinked into /opt/homebrew,
because this is an alternate version of another formula.

If you need to have go@1.24 first in your PATH, run:
  echo 'export PATH="/opt/homebrew/opt/go@1.24/bin:$PATH"' >> ~/.zshrc

The following go@1.24 executables are shadowed by other linked Homebrew commands:
  go (shadowed by /opt/homebrew/bin/go from go)
  gofmt (shadowed by /opt/homebrew/bin/gofmt from go)
Running these by name will not invoke the version provided by Homebrew.
Run `brew link go@1.24` to switch the active version to this keg.
==> Installed versions
  go, go@1.26 (1.26.2) *
  go@1.24 (1.24.13_1)
  go@1.22 (1.22.12)

❯ brew link go@1.24
Unlinking /opt/homebrew/Cellar/go/1.26.2... 2 symlinks removed.
Linking /opt/homebrew/Cellar/go@1.24/1.24.13_1... 2 symlinks created.

❯ brew info go
==> go ↑: 1.26.2 → stable 1.26.3 (bottled), HEAD
Open source programming language to build simple/reliable/efficient software
https://go.dev/
Installed (on request)
/opt/homebrew/Cellar/go/1.26.2 (14,948 files, 228.5MB)
  Poured from bottle using the formulae.brew.sh API on 2026-05-02 at 21:10:21
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/g/go.rb
License: BSD-3-Clause
==> Dependencies
Dependents: 2
==> Options
--HEAD
	Install HEAD version
==> Caveats
The following go executables are shadowed by other linked Homebrew commands:
  go (shadowed by /opt/homebrew/bin/go from go@1.24)
  gofmt (shadowed by /opt/homebrew/bin/gofmt from go@1.24)
Running these by name will not invoke the version provided by Homebrew.
Run `brew link go` to switch the active version to this keg.
==> Installed versions
  go, go@1.26 (1.26.2)
  go@1.24 (1.24.13_1) *
  go@1.22 (1.22.12)
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claud Code, Extra High

-----
