### PR TITLE
Allow cask macOS dep migration

### DIFF
--- a/Library/Homebrew/cask/dsl/depends_on.rb
+++ b/Library/Homebrew/cask/dsl/depends_on.rb
@@ -75,7 +75,12 @@ module Cask
         pairs.each do |key, value|
           raise "invalid depends_on key: '#{key.inspect}'" unless VALID_KEYS.include?(key)
 
-          __getobj__[key] = send(:"#{key}=", *value)
+          __getobj__[key] = case key
+          when :macos, :maximum_macos
+            send(:"#{key}=", *value, set_in_block:)
+          else
+            send(:"#{key}=", *value)
+          end
           record_os_requirement(key, set_in_block:)
         end
       end
@@ -90,20 +95,15 @@ module Cask
         cask.concat(args)
       end
 
-      sig { params(args: T.any(String, Symbol)).returns(T.nilable(MacOSRequirement)) }
-      def macos=(*args)
-        raise "Only a single 'depends_on macos' is allowed." if @macos
-
-        begin
-          @macos = MacOSRequirement.parse(args, comparator: ">=")
-        rescue MacOSVersion::Error, TypeError => e
-          raise "invalid 'depends_on macos' value: #{e}"
-        end
+      sig { params(args: T.any(String, Symbol), set_in_block: T::Boolean).returns(T.nilable(MacOSRequirement)) }
+      def macos=(*args, set_in_block: false)
+        @macos = MacOSRequirement.parse(args, comparator: ">=")
+      rescue MacOSVersion::Error, TypeError => e
+        raise "invalid 'depends_on macos' value: #{e}"
       end
 
-      sig { params(args: T.any(String, Symbol)).returns(T.nilable(MacOSRequirement)) }
-      def maximum_macos=(*args)
-        raise "Only a single 'depends_on maximum_macos' is allowed." if @maximum_macos
+      sig { params(args: T.any(String, Symbol), set_in_block: T::Boolean).returns(T.nilable(MacOSRequirement)) }
+      def maximum_macos=(*args, set_in_block: false)
         raise "invalid 'depends_on maximum_macos' value: only a single macOS version is allowed" if args.count != 1
 
         maximum_macos = begin
@@ -193,15 +193,31 @@ module Cask
         raise "`depends_on :linux` cannot be combined with `depends_on macos:`" if requires_linux?
 
         if !requirement.version_specified?
-          raise "`depends_on :macos` cannot be combined with another macOS `depends_on`" if requires_macos?
+          raise "`depends_on :macos` cannot be combined with another macOS `depends_on`" if @macos_bare_set_top_level
+
+          if @macos_version_set_top_level || @maximum_macos_set_top_level
+            # odeprecated "`depends_on :macos` with `depends_on macos:`"
+          end
 
           @macos_bare_set_top_level = true
         elsif requirement.comparator == "<="
-          raise "`depends_on maximum_macos:` cannot be combined with `depends_on :macos`" if @macos_bare_set_top_level
+          if @macos_bare_set_top_level
+            # odeprecated "`depends_on :macos` with `depends_on maximum_macos:`"
+          end
+
+          if @maximum_macos_set_top_level
+            raise "`depends_on maximum_macos:` cannot be combined with another macOS `depends_on`"
+          end
 
           @maximum_macos_set_top_level = true
         else
-          raise "`depends_on macos:` cannot be combined with `depends_on :macos`" if @macos_bare_set_top_level
+          if @macos_bare_set_top_level
+            # odeprecated "`depends_on :macos` with `depends_on macos:`"
+          end
+
+          if @macos_version_set_top_level
+            raise "`depends_on macos:` cannot be combined with another macOS `depends_on`"
+          end
 
           @macos_version_set_top_level = true
         end

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -476,8 +476,26 @@ RSpec.describe Cask::DSL, :cask, :no_api do
     context "when bare macOS and a macOS version are used" do
       let(:token) { "invalid-depends-on-macos-bare-and-version" }
 
-      it "refuses to load" do
-        expect { cask }.to raise_error(Cask::CaskInvalidError)
+      it "allows the migration-only combination" do
+        expect(cask.depends_on.macos).to eq(MacOSRequirement.new([:monterey], comparator: ">="))
+        expect(cask.depends_on.requires_macos?).to be true
+      end
+    end
+
+    context "when bare macOS and a block-scoped macOS version are used" do
+      it "allows the active block to provide the macOS version" do
+        Homebrew::SimulateSystem.with(os: :tahoe, arch: :intel) do
+          cask = Cask::Cask.new("with-block-scoped-macos-version") do
+            depends_on :macos
+
+            on_intel do
+              depends_on macos: :ventura
+            end
+          end
+
+          expect(cask.depends_on.macos).to eq(MacOSRequirement.new([:ventura], comparator: ">="))
+          expect(cask.depends_on.requires_macos?).to be true
+        end
       end
     end
   end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-bare-and-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-bare-and-version.rb
@@ -7,8 +7,7 @@ cask "invalid-depends-on-macos-bare-and-version" do
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
   homepage "https://brew.sh/invalid-depends-on-macos-bare-and-version"
 
-  depends_on_arg = :macos
-  depends_on depends_on_arg
+  depends_on :macos
   depends_on macos: :monterey
 
   app "Caffeine.app"


### PR DESCRIPTION
- Let casks combine `depends_on :macos` with macOS versions during the migration window.
- Preserve top-level duplicate checks through explicit state flags.
- Allow active `on_*` blocks to provide a specific macOS version.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with manual review and testing.

-----
