### PR TITLE
simulate-macos: use newest supported version

### DIFF
--- a/Library/Homebrew/extend/os/linux/simulate_system.rb
+++ b/Library/Homebrew/extend/os/linux/simulate_system.rb
@@ -8,7 +8,9 @@ module OS
         sig { returns(T.nilable(Symbol)) }
         def os
           @os ||= T.let(nil, T.nilable(Symbol))
-          return :macos if @os.blank? && Homebrew::EnvConfig.simulate_macos_on_linux?
+          if @os.blank? && Homebrew::EnvConfig.simulate_macos_on_linux?
+            return MacOSVersion.new(HOMEBREW_MACOS_NEWEST_SUPPORTED).to_sym
+          end
 
           @os
         end

--- a/Library/Homebrew/test/simulate_system_spec.rb
+++ b/Library/Homebrew/test/simulate_system_spec.rb
@@ -133,10 +133,10 @@ RSpec.describe Homebrew::SimulateSystem do
       expect(described_class.current_os).to eq MacOS.version.to_sym
     end
 
-    it "returns `:macos` on Linux with HOMEBREW_SIMULATE_MACOS_ON_LINUX", :needs_linux do
+    it "returns the newest supported macOS symbol on Linux with HOMEBREW_SIMULATE_MACOS_ON_LINUX", :needs_linux do
       described_class.clear
       ENV["HOMEBREW_SIMULATE_MACOS_ON_LINUX"] = "1"
-      expect(described_class.current_os).to eq :macos
+      expect(described_class.current_os).to eq MacOSVersion.new(HOMEBREW_MACOS_NEWEST_SUPPORTED).to_sym
     end
   end
 end


### PR DESCRIPTION
- `HOMEBREW_SIMULATE_MACOS_ON_LINUX=1` resolved the OS to the generic `:macos`, so `SimulateSystem.current_tag` built `x86_64_macos` / `arm64_macos` tags.
- The internal JSON API only publishes per-version files (e.g. `packages.tahoe.jws.json`), so fetching `packages.x86_64_macos.jws.json` returned `404` and broke any `brew test-bot --only-tap-syntax` run on Linux.
- Resolve to `HOMEBREW_MACOS_NEWEST_SUPPORTED` instead, matching what `generate-internal-api` and friends already do.

Fixes https://github.com/Homebrew/brew/issues/22247

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Claude Code Opus 4.7 xhigh with local review and testing.

-----
