### PR TITLE
feat(livecheck): allow making `header:` callable

### DIFF
--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -187,7 +187,7 @@ class Livecheck
       # URL to check for version information.
       url:           T.any(String, Symbol),
       cookies:       T.nilable(T::Hash[String, String]),
-      header:        T.nilable(T.any(String, T::Array[String])),
+      header:        T.nilable(T.any(String, T::Array[String], T.proc.returns(T.any(String, T::Array[String])))),
       homebrew_curl: T.nilable(T::Boolean),
       post_form:     T.nilable(T::Hash[Symbol, String]),
       post_json:     T.nilable(T::Hash[Symbol, T.anything]),

--- a/Library/Homebrew/livecheck/options.rb
+++ b/Library/Homebrew/livecheck/options.rb
@@ -12,8 +12,9 @@ module Homebrew
       # Cookies for curl to use when making a request.
       prop :cookies, T.nilable(T::Hash[String, String])
 
-      # Header(s) for curl to use when making a request.
-      prop :header, T.nilable(T.any(String, T::Array[String]))
+      # Header(s) for curl to use when making a request. Can be a callable that
+      # returns a header string/array, evaluated lazily before each request.
+      prop :header, T.nilable(T.any(String, T::Array[String], T.proc.returns(T.any(String, T::Array[String]))))
 
       # Whether to use brewed curl.
       prop :homebrew_curl, T.nilable(T::Boolean)

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -219,6 +219,9 @@ module Homebrew
           [:default, :browser]
         end
 
+        header = options.header
+        resolved_header = header.is_a?(Proc) ? header.call : header
+
         user_agents.each do |user_agent|
           begin
             parsed_output = curl_headers(
@@ -229,7 +232,7 @@ module Homebrew
               wanted_headers:    ["location", "content-disposition"],
               use_homebrew_curl: options.homebrew_curl || false,
               cookies:           options.cookies,
-              header:            options.header,
+              header:            resolved_header,
               referer:           options.referer,
               user_agent:,
               **DEFAULT_CURL_OPTIONS,
@@ -268,6 +271,9 @@ module Homebrew
           [:default, :browser]
         end
 
+        header = options.header
+        resolved_header = header.is_a?(Proc) ? header.call : header
+
         stderr = T.let(nil, T.nilable(String))
         user_agents.each do |user_agent|
           stdout, stderr, status = curl_output(
@@ -278,7 +284,7 @@ module Homebrew
                                !curl_supports_fail_with_body? ||
                                false,
             cookies:           options.cookies,
-            header:            options.header,
+            header:            resolved_header,
             referer:           options.referer,
             user_agent:
           )

--- a/Library/Homebrew/test/livecheck/strategy_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy_spec.rb
@@ -218,6 +218,19 @@ RSpec.describe Homebrew::Livecheck::Strategy do
       ).to eq([responses.first[:headers]])
     end
 
+    it "handles callable `header` `url` option" do
+      allow(strategy).to receive(:curl_headers).and_return({ responses:, body: })
+      header_lambda = -> { "Accept: */*" }
+      expect(header_lambda).to receive(:call).and_call_original
+
+      expect(
+        strategy.page_headers(
+          url,
+          options: Homebrew::Livecheck::Options.new(header: header_lambda),
+        ),
+      ).to eq([responses.first[:headers]])
+    end
+
     it "handles `post_form` `url` options" do
       allow(strategy).to receive(:curl_headers).and_return({ responses:, body: })
 
@@ -311,6 +324,20 @@ RSpec.describe Homebrew::Livecheck::Strategy do
           options: Homebrew::Livecheck::Options.new(
             header: ["Accept: */*", "X-Requested-With: XMLHttpRequest"],
           ),
+        ),
+      ).to eq({ content: body })
+    end
+
+    it "handles callable `header` `url` option" do
+      allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
+      allow(strategy).to receive(:curl_output).and_return([response_text[:ok], nil, success_status])
+      header_lambda = -> { "Accept: */*" }
+      expect(header_lambda).to receive(:call).and_call_original
+
+      expect(
+        strategy.page_content(
+          url,
+          options: Homebrew::Livecheck::Options.new(header: header_lambda),
         ),
       ).to eq({ content: body })
     end

--- a/docs/Brew-Livecheck.md
+++ b/docs/Brew-Livecheck.md
@@ -143,6 +143,33 @@ end
 
 `POST` support only applies to strategies that use `Strategy::page_headers` or `::page_content` (directly or indirectly), so it does not apply to `ExtractPlist`, `Git`, `GithubLatest`, `GithubReleases`, etc.
 
+### Custom request headers
+
+Some checks require custom HTTP headers (e.g. an `Authorization` header for a private endpoint). A static header string or array of strings can be passed via the `header` option:
+
+```ruby
+livecheck do
+  url "https://example.com/api/versions", header: "Authorization: Bearer mytoken"
+  strategy :json do |json|
+    json["version"]
+  end
+end
+```
+
+When the header value must be generated at check time (e.g. an OAuth token from a CLI command), pass a callable instead:
+
+```ruby
+livecheck do
+  url "https://example.com/api/versions",
+      header: -> { "Authorization: Bearer #{`my-auth-command`.strip}" }
+  strategy :json do |json|
+    json["version"]
+  end
+end
+```
+
+The callable is evaluated immediately before each request, so short-lived tokens are refreshed automatically. As with `POST` support, the `header` option only applies to strategies that use `Strategy::page_headers` or `::page_content`.
+
 ### `strategy` blocks
 
 If the upstream version format needs to be manipulated to match the formula/cask format, a `strategy` block can be used instead of a `regex`.


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

I did the design myself, used AI to write the Ruby.

Having the header be settable (what is in main today) is really useful for many
livecheck blocks, but especially for authentication, including a token in the
formula/cask definition obviously isn't a good idea. Many tools use helper CLI
commands to store and fetch secrets, so this makes that easy to do in a
livecheck block.

Extends the `header:` URL option to accept a `Proc` in addition to a
`String` or `Array[String]`. The callable is evaluated immediately before
each curl request, so short-lived tokens (e.g. OAuth) are always fresh.

Also added some docs.

Example:

```ruby
  livecheck do
    url "https://example.com/api/versions",
        header: -> { "Authorization: Bearer #{`my-auth-command`.strip}" }
    strategy :json do |json|
      json["version"]
    end
  end
```