### PR TITLE
bump-cask-pr: tolerate idempotent stanza replace

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -374,7 +374,14 @@ module Homebrew
 
         cask_ast = Utils::AST::CaskAST.new(contents)
         replacement_count = cask_ast.replace_stanza_value(name, old_value, new_value)
-        raise "Could not find '#{name}' stanza with value #{old_value.inspect}!" if replacement_count.zero?
+        if replacement_count.zero?
+          # Treat an already-applied replacement as a successful no-op so the
+          # per-(os, arch) loop in `replace_version_and_checksum` can yield the
+          # same general version more than once without raising.
+          return contents if cask_ast.replace_stanza_value(name, new_value, new_value).positive?
+
+          raise "Could not find '#{name}' stanza with value #{old_value.inspect}!"
+        end
 
         cask_ast.process
       end

--- a/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
@@ -257,6 +257,40 @@ RSpec.describe Homebrew::DevCmd::BumpCaskPr do
     end
   end
 
+  describe "#replace_cask_stanza_value" do
+    let(:contents) do
+      <<~RUBY
+        cask "foo" do
+          arch arm: "Apple", intel: "Intel"
+
+          version "1.0"
+          sha256 arm:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                 intel: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+          url "https://brew.sh/foo-\#{arch}-\#{version}.dmg"
+          name "Foo"
+        end
+      RUBY
+    end
+
+    before do
+      Homebrew.install_bundler_gems!(groups: ["ast"])
+      require "utils/ast"
+    end
+
+    it "is idempotent when the replacement has already been applied" do
+      bumped = bump_cask_pr.send(:replace_cask_stanza_value, contents, :version, "1.0", "2.0")
+      expect(bumped).to include('version "2.0"')
+      expect { bump_cask_pr.send(:replace_cask_stanza_value, bumped, :version, "1.0", "2.0") }
+        .not_to raise_error
+    end
+
+    it "raises when the stanza is missing entirely" do
+      expect { bump_cask_pr.send(:replace_cask_stanza_value, contents, :version, "9.9", "2.0") }
+        .to raise_error(/Could not find 'version' stanza/)
+    end
+  end
+
   describe "::check_throttle" do
     let(:c_throttle) do
       Cask::Cask.new("throttle-test") do


### PR DESCRIPTION
- The per-`(os, arch)` loop in `replace_version_and_checksum` re-applies the same `version` replacement for casks with arch-specific stanzas but a single shared `version`, which raised `Could not find 'version' stanza` once the AST-based rewrite landed.
- Treat "`new_value` already in place at that stanza" as a successful no-op, mirroring the pre-refactor `Utils::Inreplace` behaviour where identical replacement pairs were `.uniq`'d.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Claude Code Opus 4.7 xhigh with local review and testing.

-----
