### PR TITLE
aliases: break load-time cycle with cmd/alias

### DIFF
--- a/Library/Homebrew/aliases/alias.rb
+++ b/Library/Homebrew/aliases/alias.rb
@@ -31,7 +31,7 @@ module Homebrew
 
       sig { returns(T::Boolean) }
       def reserved?
-        RESERVED.include? name
+        Aliases.reserved.include? name
       end
 
       sig { returns(T::Boolean) }

--- a/Library/Homebrew/aliases/aliases.rb
+++ b/Library/Homebrew/aliases/aliases.rb
@@ -8,12 +8,19 @@ module Homebrew
   module Aliases
     extend Utils::Output::Mixin
 
-    RESERVED = T.let((
-        Commands.internal_commands +
-        Commands.internal_developer_commands +
-        Commands.internal_commands_aliases +
-        %w[alias unalias]
-      ).freeze, T::Array[String])
+    # Lazily computed to avoid a load-time cycle: `Commands.internal_commands`
+    # requires every `cmd/*.rb`, including `cmd/alias.rb`, which itself
+    # requires this file.
+    sig { returns(T::Array[String]) }
+    def self.reserved
+      @reserved ||= T.let(
+        (Commands.internal_commands +
+         Commands.internal_developer_commands +
+         Commands.internal_commands_aliases +
+         %w[alias unalias]).freeze,
+        T.nilable(T::Array[String]),
+      )
+    end
 
     sig { void }
     def self.init


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Claude Code Opus 4.7 with manual review and verification.

-----
Loading `cmd/alias.rb` (e.g. via `bundle exec rspec test/cmd/alias_spec.rb`) prints `warning: loading in progress, circular require considered harmful` because `Aliases::RESERVED`'s load-time initializer calls `Commands.internal_commands`, which re-requires every `cmd/*.rb` — including `cmd/alias.rb`, which is still mid-load.

Replace the constant with a memoized `Aliases.reserved` method so the cmd/* requires only fire on `brew alias` / `brew unalias`, breaking the cycle.