### PR TITLE
Fix cask OS dependency regressions

### DIFF
--- a/Library/Homebrew/cask/dsl/depends_on.rb
+++ b/Library/Homebrew/cask/dsl/depends_on.rb
@@ -73,6 +73,7 @@ module Cask
         pairs.each do |key, value|
           raise "invalid depends_on key: '#{key.inspect}'" unless VALID_KEYS.include?(key)
 
+          previous_macos = @macos if key == :macos
           __getobj__[key] = case key
           when :macos, :maximum_macos
             send(:"#{key}=", *value, set_in_block:)
@@ -80,6 +81,12 @@ module Cask
             send(:"#{key}=", *value)
           end
           record_os_requirement(key, set_in_block:)
+          next if key != :macos
+          next if value != :any
+          next unless previous_macos&.version_specified?
+
+          @macos = previous_macos
+          __getobj__[key] = previous_macos
         end
       end
 

--- a/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
@@ -127,16 +127,19 @@ module Homebrew
 
       sig { params(cask: Cask::Cask).returns(T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float]) }
       def filter_runners(cask)
-        filtered_macos_runners = RUNNERS.select do |runner, _|
-          runner[:symbol] != :linux &&
-            cask.depends_on.macos.present? &&
-            cask.depends_on.macos.allows?(MacOSVersion.from_symbol(runner.fetch(:symbol).to_sym))
-        end
+        filtered_runners = T.let({}, T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
+        if cask.supports_macos?
+          filtered_macos_runners = RUNNERS.select do |runner, _|
+            runner[:symbol] != :linux &&
+              cask.depends_on.macos.present? &&
+              cask.depends_on.macos.allows?(MacOSVersion.from_symbol(runner.fetch(:symbol).to_sym))
+          end
 
-        filtered_runners = if filtered_macos_runners.any?
-          filtered_macos_runners
-        else
-          MACOS_RUNNERS.dup
+          filtered_runners = if filtered_macos_runners.any?
+            filtered_macos_runners
+          else
+            MACOS_RUNNERS.dup
+          end
         end
 
         macos_archs = architectures(cask:, os: :macos)
@@ -226,11 +229,12 @@ module Homebrew
           # If the cask varies on a MacOS version, test it on every possible macOS version.
           [filtered_runners.keys, true]
         else
-          # Otherwise, select a runner from each architecture based on weighted random sample.
-          grouped_runners = filtered_runners.group_by { |runner, _| runner.fetch(:arch) }
-          selected_runners = grouped_runners.map do |_, runners|
-            random_runner(runners.to_h)
+          macos_runners, linux_runners = filtered_runners.partition do |runner, _|
+            runner.fetch(:symbol) != :linux
           end
+          selected_runners = macos_runners.group_by { |runner, _| runner.fetch(:arch) }.map do |_, runners|
+            random_runner(runners.to_h)
+          end + linux_runners.map(&:first)
           [selected_runners, false]
         end
       end

--- a/Library/Homebrew/rubocops/os_depends_on.rb
+++ b/Library/Homebrew/rubocops/os_depends_on.rb
@@ -111,12 +111,7 @@ module RuboCop
               T.cast(child, RuboCop::AST::BlockNode).send_node
             end
           end
-          return if stanzas.any? do |stanza|
-            next false if stanza.method_name != :depends_on
-
-            bare_os_depends_on?(stanza, :macos) || bare_os_depends_on?(stanza, :linux) ||
-            top_level_macos_depends_on?(stanza) || depends_on_pairs(stanza).any? { |pair| symbol_key(pair) == :linux }
-          end
+          return if os_depends_on?(body)
 
           macos_stanza = stanzas.find do |stanza|
             case stanza.method_name
@@ -194,6 +189,18 @@ module RuboCop
           parent = node.parent
           siblings = parent&.begin_type? ? parent.child_nodes : [node]
           siblings.select { |sibling| sibling.send_type? && sibling.method_name == :depends_on }
+        end
+
+        sig { params(node: RuboCop::AST::Node).returns(T::Boolean) }
+        def os_depends_on?(node)
+          node.each_node(:send).any? do |send_node|
+            send_node = T.cast(send_node, RuboCop::AST::SendNode)
+            next false if send_node.method_name != :depends_on
+
+            bare_os_depends_on?(send_node, :macos) || bare_os_depends_on?(send_node, :linux) ||
+              top_level_macos_depends_on?(send_node) ||
+              depends_on_pairs(send_node).any? { |pair| symbol_key(pair) == :linux }
+          end
         end
 
         sig { params(node: RuboCop::AST::SendNode, os: Symbol).returns(T::Boolean) }

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -1101,6 +1101,35 @@ RSpec.describe Cask::Audit, :cask do
       end
     end
 
+    describe "minimum OS checks" do
+      let(:online) { true }
+      let(:only) { ["min_os"] }
+      let(:cask) do
+        Cask::Cask.new("arch-min-os") do
+          version "1.0"
+          sha256 :no_check
+          url "https://brew.sh/arch-min-os.zip"
+          name "Arch Min OS"
+          homepage "https://brew.sh/"
+
+          on_arm do
+            depends_on macos: :big_sur
+          end
+
+          depends_on :macos
+
+          app "Arch Min OS.app"
+        end
+      end
+
+      before do
+        allow(audit).to receive_messages(cask_bundle_min_os:  MacOSVersion.from_symbol(:big_sur),
+                                         cask_sparkle_min_os: nil)
+      end
+
+      it { is_expected.to pass }
+    end
+
     describe "preferred download URL formats" do
       let(:only) { ["download_url_format"] }
       let(:message) { /URL format incorrect/ }

--- a/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
@@ -130,6 +130,20 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
       app "Test.app"
     end
   end
+  let(:c_linux) do
+    Cask::Cask.new("test-linux") do
+      version "0.0.1,2"
+
+      url "https://brew.sh/test-0.0.1.tar.gz"
+      name "Test"
+      desc "Test cask"
+      homepage "https://brew.sh"
+
+      depends_on :linux
+
+      binary "test"
+    end
+  end
   let(:c_app_only_macos) do
     Cask::Cask.new("test-on-macos-guarded-stanza") do
       os macos: "darwin", linux: "linux"
@@ -203,6 +217,16 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
       end
     end
 
+    context "when cask only supports Linux" do
+      it "returns an array including all Linux" do
+        expect(generate_matrix.filter_runners(c_linux))
+          .to eq({
+            { arch: :arm, name: arm_linux_runner, symbol: :linux }  => 1.0,
+            { arch: :intel, name: "ubuntu-latest", symbol: :linux } => 1.0,
+          })
+      end
+    end
+
     context "when cask does not have on_system blocks/calls but has `depends_on arch`" do
       it "returns an array only including macOS/`depends_on arch` value" do
         expect(generate_matrix.filter_runners(c_depends_macos_on_intel))
@@ -263,6 +287,20 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
             { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
           })
       end
+    end
+  end
+
+  describe "::runners" do
+    it "selects macOS and Linux runners independently" do
+      allow(generate_matrix).to receive(:random_runner) do |runners|
+        runners.keys.find { |runner| runner.fetch(:symbol) == :linux } || runners.keys.first
+      end
+
+      runners, multi_os = generate_matrix.send(:runners, cask: c)
+
+      expect(runners.map { |runner| [(runner.fetch(:symbol) == :linux) ? :linux : :macos, runner.fetch(:arch)] })
+        .to contain_exactly([:macos, :arm], [:macos, :intel], [:linux, :arm], [:linux, :intel])
+      expect(multi_os).to be(false)
     end
   end
 

--- a/Library/Homebrew/test/rubocops/os_depends_on_spec.rb
+++ b/Library/Homebrew/test/rubocops/os_depends_on_spec.rb
@@ -181,4 +181,25 @@ RSpec.describe RuboCop::Cop::Homebrew::OSDependsOn, :config do
       end
     RUBY
   end
+
+  it "accepts casks with explicit OS dependencies in nested blocks" do
+    expect_no_offenses(<<~RUBY)
+      cask "basic" do
+        version "1.0"
+        sha256 "abc"
+        url "https://example.com/basic.zip"
+        homepage "https://example.com"
+
+        on_arm do
+          depends_on macos: :big_sur
+        end
+
+        on_intel do
+          depends_on :macos
+        end
+
+        app "Basic.app"
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
- avoid forcing casks with arch-specific macOS requirements into a bare top-level marker that cannot express their real minimum OS
- preserve per-arch minimum OS data so audit does not report a false missing minimum after style autocorrection
- keep mixed macOS/Linux casks from losing macOS CI coverage when runner selection samples Linux runners for the same architecture

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with manual review and testing.

-----
