### PR TITLE
Clarify Brewfile snapshots documentation

### DIFF
--- a/Library/Homebrew/cmd/bundle.rb
+++ b/Library/Homebrew/cmd/bundle.rb
@@ -52,6 +52,8 @@ module Homebrew
           `brew bundle` [`install`]:
           Install and upgrade (by default) all dependencies from the `Brewfile`.
 
+          Use this to restore a recorded installed state from a `Brewfile`.
+
           You can specify the `Brewfile` location using `--file` or by setting the `$HOMEBREW_BUNDLE_FILE` environment variable.
 
           You can skip the installation of dependencies by adding space-separated values to one or more of the following environment variables: `$HOMEBREW_BUNDLE_BREW_SKIP`, `$HOMEBREW_BUNDLE_CASK_SKIP`, `$HOMEBREW_BUNDLE_MAS_SKIP`, `$HOMEBREW_BUNDLE_TAP_SKIP`.
@@ -60,7 +62,7 @@ module Homebrew
           Shorthand for `brew bundle install --upgrade`.
 
           `brew bundle dump`:
-          Write all installed casks/formulae/images/taps into a `Brewfile` in the current directory or to a custom file specified with the `--file` option.
+          Write all installed casks/formulae/images/taps into a `Brewfile` in the current directory or to a custom file specified with the `--file` option. This is useful as an installed-state snapshot and can be kept in version control and diffed.
 
           `brew bundle cleanup`:
           Uninstall all dependencies not present in the `Brewfile`.

--- a/docs/Brew-Bundle-and-Brewfile.md
+++ b/docs/Brew-Bundle-and-Brewfile.md
@@ -103,7 +103,7 @@ for how you might use a `Brewfile` and `brew bundle` to install project dependen
 
 ### `brew bundle dump`
 
-`Brewfile`s can also be used as a way of saving all supported packages into a single file.
+`Brewfile`s can also be used as a way of saving all supported packages into a single file. `brew bundle dump` is Homebrew's installed-state snapshot command: it records supported installed formulae, casks, taps and other package types as a `Brewfile`.
 
 You can do this with `brew bundle dump --global --force` to write to e.g. `~/.Brewfile` (check `man brew` for the exact path used in your configuration):
 
@@ -124,11 +124,13 @@ might add something like the following:
 brew "ruby"
 ```
 
-You can then reinstall (and, by default, upgrade) all of these with:
+You can then restore (and, by default, upgrade) all of these with:
 
 ```console
 brew bundle --global
 ````
+
+You can keep multiple snapshots by writing to different `Brewfile`s with `--file`, commit them to version control and compare them with standard diff tools. To make the active installed state match a snapshot more closely, run `brew bundle cleanup --force --file=/path/to/Brewfile` after installing it to remove supported dependencies not listed in that `Brewfile`.
 
 ## Advanced Usage
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -146,6 +146,8 @@ Note: Flatpak support is only available on Linux.
 
 : Install and upgrade (by default) all dependencies from the `Brewfile`.
 
+Use this to restore a recorded installed state from a `Brewfile`.
+
 You can specify the `Brewfile` location using `--file` or by setting the
 `$HOMEBREW_BUNDLE_FILE` environment variable.
 
@@ -161,7 +163,9 @@ to one or more of the following environment variables:
 `brew bundle dump`
 
 : Write all installed casks/formulae/images/taps into a `Brewfile` in the
-  current directory or to a custom file specified with the `--file` option.
+  current directory or to a custom file specified with the `--file` option. This
+  is useful as an installed-state snapshot and can be kept in version control
+  and diffed.
 
 `brew bundle cleanup`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -90,6 +90,8 @@ Note: Flatpak support is only available on Linux\.
 \fBbrew bundle\fP [\fBinstall\fP]
 Install and upgrade (by default) all dependencies from the \fBBrewfile\fP\&\.
 .P
+Use this to restore a recorded installed state from a \fBBrewfile\fP\&\.
+.P
 You can specify the \fBBrewfile\fP location using \fB\-\-file\fP or by setting the \fB$HOMEBREW_BUNDLE_FILE\fP environment variable\.
 .P
 You can skip the installation of dependencies by adding space\-separated values to one or more of the following environment variables: \fB$HOMEBREW_BUNDLE_BREW_SKIP\fP, \fB$HOMEBREW_BUNDLE_CASK_SKIP\fP, \fB$HOMEBREW_BUNDLE_MAS_SKIP\fP, \fB$HOMEBREW_BUNDLE_TAP_SKIP\fP\&\.
@@ -98,7 +100,7 @@ You can skip the installation of dependencies by adding space\-separated values 
 Shorthand for \fBbrew bundle install \-\-upgrade\fP\&\.
 .TP
 \fBbrew bundle dump\fP
-Write all installed casks/formulae/images/taps into a \fBBrewfile\fP in the current directory or to a custom file specified with the \fB\-\-file\fP option\.
+Write all installed casks/formulae/images/taps into a \fBBrewfile\fP in the current directory or to a custom file specified with the \fB\-\-file\fP option\. This is useful as an installed\-state snapshot and can be kept in version control and diffed\.
 .TP
 \fBbrew bundle cleanup\fP
 Uninstall all dependencies not present in the \fBBrewfile\fP\&\.


### PR DESCRIPTION
- Explain `brew bundle dump` as the existing installed-state snapshot workflow so users do not look for a separate command.
- Document restoring from a `Brewfile` in command help and generated manpages.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review.

-----
