### PR TITLE
Add internal API metadata

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-internal-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-internal-api.rb
@@ -74,6 +74,11 @@ module Homebrew
             end
 
             json_contents = {
+              metadata:               {
+                homebrew_version: HOMEBREW_VERSION,
+                bottle_tag:       bottle_tag.to_s,
+                generated_at:     Time.now.to_i,
+              },
               formulae:,
               casks:,
               formula_aliases:        core_tap.alias_table,

--- a/Library/Homebrew/test/dev-cmd/generate-internal-api_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-internal-api_spec.rb
@@ -1,0 +1,49 @@
+# typed: false
+# frozen_string_literal: true
+
+require "cmd/shared_examples/args_parse"
+require "dev-cmd/generate-internal-api"
+
+RSpec.describe Homebrew::DevCmd::GenerateInternalApi do
+  it_behaves_like "parseable arguments"
+
+  it "writes metadata to each generated packages file" do
+    core_tap = instance_double(CoreTap, installed?: true, name: "homebrew/core", formula_names: ["foo"],
+                                        alias_table: {}, formula_renames: {}, git_head: "formula-head",
+                                        tap_migrations: {})
+    cask_tap = instance_double(CoreCaskTap, installed?: true, name: "homebrew/cask", cask_files: [Pathname("c.rb")],
+                                            cask_renames: {}, git_head: "cask-head", tap_migrations: {})
+    bottle_tag = Utils::Bottles::Tag.from_symbol(:arm64_sonoma)
+
+    allow(CoreTap).to receive(:instance).and_return(core_tap)
+    allow(CoreCaskTap).to receive(:instance).and_return(cask_tap)
+    allow(Formulary).to receive(:enable_factory_cache!)
+    allow(Formula).to receive(:generating_hash!)
+    allow(Cask::Cask).to receive(:generating_hash!)
+    allow(Formulary).to receive(:factory).with("foo").and_return(
+      instance_double(Formula, name: "foo", to_hash_with_variations: { "name" => "foo" }),
+    )
+    allow(Cask::CaskLoader).to receive(:load).with(Pathname("c.rb")).and_return(
+      instance_double(Cask::Cask, token: "c", to_hash_with_variations: { "token" => "c" }),
+    )
+    allow(Homebrew::API::Formula::FormulaStructGenerator).to receive(:generate_formula_struct_hash)
+      .with({ "name" => "foo" }, bottle_tag:)
+      .and_return(instance_double(Homebrew::API::FormulaStruct, serialize: { "name" => "foo" }))
+    allow(Homebrew::API::Cask::CaskStructGenerator).to receive(:generate_cask_struct_hash)
+      .with({ "token" => "c" }, bottle_tag:)
+      .and_return(instance_double(Homebrew::API::CaskStruct, serialize: { "token" => "c" }))
+    allow(Time).to receive(:now).and_return(Time.at(1_714_056_000))
+    stub_const("HOMEBREW_VERSION", "4.2.18")
+    stub_const("OnSystem::VALID_OS_ARCH_TAGS", [bottle_tag])
+
+    mktmpdir do |path|
+      path.cd { described_class.new([]).run }
+
+      expect(JSON.parse((path/"api/internal/packages.arm64_sonoma.json").read)["metadata"]).to eq({
+        "homebrew_version" => "4.2.18",
+        "bottle_tag"       => "arm64_sonoma",
+        "generated_at"     => 1_714_056_000,
+      })
+    end
+  end
+end


### PR DESCRIPTION
@Rylan12 small amount of file size increase but figure this makes these files more useful standalone in future?

- Record `HOMEBREW_VERSION`, bottle tag and generation time in internal package payloads so consumers can identify the file loaded.
- Cover the generated `metadata` payload for a representative tag.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
