### PR TITLE
Improve bundle check guidance

### DIFF
--- a/Library/Homebrew/bundle/commands/check.rb
+++ b/Library/Homebrew/bundle/commands/check.rb
@@ -37,6 +37,8 @@ module Homebrew
 
                 puts "→ #{error}"
               end
+            else
+              puts "Run `brew bundle check --verbose` to list unmet dependencies."
             end
 
             puts "Satisfy missing dependencies with `brew bundle install`."

--- a/Library/Homebrew/cmd/bundle.rb
+++ b/Library/Homebrew/cmd/bundle.rb
@@ -72,7 +72,7 @@ module Homebrew
           `brew bundle check`:
           Check if all dependencies present in the `Brewfile` are installed.
 
-          This provides a successful exit code if everything is up-to-date, making it useful for scripting.
+          This provides a successful exit code if everything is up-to-date, making it useful for scripting. Use `--verbose` to list unmet dependencies.
 
           `brew bundle list`:
           List all dependencies present in the `Brewfile`.
@@ -361,6 +361,7 @@ module Homebrew
             file:,
             subcommand:,
             services:   args.services?,
+            check:      args.check?,
             no_secrets: args.no_secrets?,
           )
         else

--- a/Library/Homebrew/test/cmd/bundle_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle_spec.rb
@@ -7,6 +7,50 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Bundle do
   it_behaves_like "parseable arguments"
 
+  [
+    ["exec", ["exec", "--check", "/usr/bin/true"], "/usr/bin/true"],
+    ["sh", ["sh", "--check"], "sh"],
+    ["env", ["env", "--check"], "env"],
+  ].each do |subcommand, args, command|
+    it "passes --check through to #{subcommand}" do
+      require "bundle/commands/exec"
+
+      with_env("HOMEBREW_BUNDLE_NO_SECRETS" => nil) do
+        expect(Homebrew::Bundle::Commands::Exec).to receive(:run)
+          .with(
+            command,
+            global:     false,
+            file:       nil,
+            subcommand:,
+            services:   false,
+            check:      true,
+            no_secrets: false,
+          )
+
+        described_class.new(args).run
+      end
+    end
+  end
+
+  it "passes HOMEBREW_BUNDLE_CHECK through to exec" do
+    require "bundle/commands/exec"
+
+    with_env("HOMEBREW_BUNDLE_CHECK" => "1", "HOMEBREW_BUNDLE_NO_SECRETS" => nil) do
+      expect(Homebrew::Bundle::Commands::Exec).to receive(:run)
+        .with(
+          "/usr/bin/true",
+          global:     false,
+          file:       nil,
+          subcommand: "exec",
+          services:   false,
+          check:      true,
+          no_secrets: false,
+        )
+
+      described_class.new(["exec", "/usr/bin/true"]).run
+    end
+  end
+
   it "checks if a Brewfile's dependencies are satisfied", :integration_test do
     HOMEBREW_REPOSITORY.cd do
       system "git", "init"

--- a/docs/Brew-Bundle-and-Brewfile.md
+++ b/docs/Brew-Bundle-and-Brewfile.md
@@ -54,6 +54,8 @@ You can use this behaviour in scripts like so:
 brew bundle check || brew bundle install
 ```
 
+If this fails without `--verbose`, run `brew bundle check --verbose` to list unmet dependencies.
+
 ### Types
 
 As well as supporting formulae (`brew "..."`), you can also use `brew bundle` with casks, taps, Mac App Store apps, VSCode extensions, Go packages, Cargo packages, uv tools, Flatpak packages and krew kubectl plugins and to start background services with `brew services`.
@@ -321,6 +323,15 @@ cask "google-cloud-sdk", postinstall: "${HOMEBREW_PREFIX}/bin/gcloud components 
 # Sets an environment variable to be used e.g. inside `brew bundle exec` or `system` commands in the `Brewfile`.
 # Note: HOMEBREW_PREFIX/bin is _not_ in the `PATH` by default so you can set it this way.
 ENV["SOME_ENV_VAR"] = "some_value"
+```
+
+### `version_file`
+
+Formula entries support `version_file:` to write the installed formula version to a file after `brew bundle install` processes that formula.
+This is useful when a project wants Homebrew to install a runtime and keep a conventional version file such as `.ruby-version` in sync.
+
+```ruby
+brew "ruby", version_file: ".ruby-version"
 ```
 
 ## Versions


### PR DESCRIPTION
- Explain why `brew bundle check --verbose` is useful when the fast check fails.
- Pass `--check` through to `brew bundle exec`, `sh` and `env` so the documented option is honoured.
- Document `version_file:` because projects use it to sync runtime version files.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Codex 5.5 xhigh with multiple rounds of local review.

-----
