### PR TITLE
Support CPS metadata dirs

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -249,7 +249,7 @@ module Homebrew
     class PrettyListing
       sig { params(path: T.any(String, Pathname, Keg)).void }
       def initialize(path)
-        valid_lib_extensions = [".dylib", ".pc"]
+        valid_lib_extensions = [".cps", ".dylib", ".pc"]
         Pathname.new(path).children.sort_by { |p| p.to_s.downcase }.each do |pn|
           case pn.basename.to_s
           when "bin", "sbin"

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -97,7 +97,7 @@ class Keg
   # These paths relative to the keg's share directory should always be real
   # directories in the prefix, never symlinks.
   SHARE_PATHS = %w[
-    aclocal doc info java locale man
+    aclocal cps doc info java locale man
     man/man1 man/man2 man/man3 man/man4
     man/man5 man/man6 man/man7 man/man8
     man/cat1 man/cat2 man/cat3 man/cat4
@@ -170,11 +170,11 @@ class Keg
   sig { returns(T::Array[Pathname]) }
   def self.must_be_writable_directories
     @must_be_writable_directories ||= T.let((%w[
-      etc/bash_completion.d lib/pkgconfig
+      etc/bash_completion.d lib/cps lib/pkgconfig
       share/aclocal share/doc share/info share/locale share/man
       share/man/man1 share/man/man2 share/man/man3 share/man/man4
       share/man/man5 share/man/man6 share/man/man7 share/man/man8
-      share/zsh share/zsh/site-functions
+      share/cps share/zsh share/zsh/site-functions
       share/pwsh share/pwsh/completions
       var/log
     ].map { |dir| HOMEBREW_PREFIX/dir } + must_exist_subdirectories + [
@@ -531,7 +531,8 @@ class Keg
       case relative_path.to_s
       when "charset.alias"
         :skip_file
-      when "pkgconfig", # pkg-config database gets explicitly created
+      when "cps",       # Common Package Specification database gets explicitly created
+           "pkgconfig", # pkg-config database gets explicitly created
            "cmake",     # cmake database gets explicitly created
            "dtrace",    # lib/language folders also get explicitly created
            /^gdk-pixbuf/,

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -167,6 +167,20 @@ RSpec.describe Keg do
       expect(link.lstat).to be_a_directory
     end
 
+    specify "lib/cps directory is created" do
+      link = HOMEBREW_PREFIX/"lib"/"cps"
+      (keg/"lib"/"cps").mkpath
+      keg.link
+      expect(link.lstat).to be_a_directory
+    end
+
+    specify "share/cps directory is created" do
+      link = HOMEBREW_PREFIX/"share"/"cps"
+      (keg/"share"/"cps").mkpath
+      keg.link
+      expect(link.lstat).to be_a_directory
+    end
+
     specify "symlinks are linked directly" do
       link = HOMEBREW_PREFIX/"lib"/"pkgconfig"
 

--- a/docs/How-to-Build-Software-Outside-Homebrew-with-Homebrew-keg-only-Dependencies.md
+++ b/docs/How-to-Build-Software-Outside-Homebrew-with-Homebrew-keg-only-Dependencies.md
@@ -69,3 +69,11 @@ You can get `pkg-config` to print the default search path with:
 ```sh
 pkg-config --variable pc_path pkg-config
 ```
+
+### Common Package Specification detection
+
+CMake 4.3 and newer can read [Common Package Specification](https://cps-org.github.io/cps/) `.cps` files from package prefixes. If the tool you are attempting to build uses CMake and a keg-only dependency ships `.cps` files, prepend that dependency's prefix to `CMAKE_PREFIX_PATH`:
+
+```sh
+export CMAKE_PREFIX_PATH="$(brew --prefix openssl):${CMAKE_PREFIX_PATH}"
+```


### PR DESCRIPTION
- Keep `lib/cps` and `share/cps` as merged prefix dirs so multiple formulae can ship `.cps` metadata without conflicts.
- Include `.cps` in pretty library listings.
- Document CMake discovery for keg-only dependencies.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
