### PR TITLE
Add brew exec formulae environments

### DIFF
--- a/Library/Homebrew/cmd/exec.rb
+++ b/Library/Homebrew/cmd/exec.rb
@@ -11,13 +11,29 @@ module Homebrew
 
       cmd_args do
         usage_banner <<~EOS
-          `exec`, `x` [`--skip-update`] [`+`<formula> ...] <command> [<args> ...]
+          `exec`, `x` [`--skip-update`] [`--formulae=`<formulae>] [`--`] <command> [<args> ...]
 
-          Run a Homebrew executable, installing its formula if needed.
+          Run <command> in an environment populated by Homebrew formulae.
+
+          If `--formulae` is passed, Homebrew installs those comma-separated
+          formulae if needed, prepends their executable directories and those of
+          their dependencies to `PATH` and runs <command>. This allows <command>
+          to be a script path such as `./script.sh`.
+
+          If `--formulae` is omitted, Homebrew finds a formula that provides
+          <command>, installs it if needed and runs that executable.
+
+          Example: `brew exec --formulae=jq,yq -- ./script.sh`
+
+          Scripts can also use a shebang on systems with `env -S`:
+          `#!/usr/bin/env -S brew exec --formulae=jq,yq --`
         EOS
 
         switch "--skip-update",
                description: "Skip updating the executables database if any version exists on disk, no matter how old."
+        comma_array "--formulae",
+                    description: "Comma-separated formulae to install and add to `PATH` before running " \
+                                 "<command>."
 
         named_args min: 1
       end

--- a/Library/Homebrew/cmd/exec.sh
+++ b/Library/Homebrew/cmd/exec.sh
@@ -77,14 +77,27 @@ exec-add-formula-paths() {
 }
 
 homebrew-exec() {
-  local formula
   local formulae=()
+  local formulae_arg=""
+  local formulae_seen=0
 
   while [[ "$#" -gt 0 ]]
   do
     case "$1" in
       --skip-update)
         HOMEBREW_SKIP_UPDATE=1
+        shift
+        ;;
+      --formulae=*)
+        formulae_arg="${1#--formulae=}"
+        formulae_seen=1
+        shift
+        ;;
+      --formulae)
+        shift
+        [[ "$#" -gt 0 && "$1" != -* ]] || odie "\`--formulae\` requires a comma-separated formula list."
+        formulae_arg="$1"
+        formulae_seen=1
         shift
         ;;
       --help | -h)
@@ -100,17 +113,26 @@ homebrew-exec() {
         "${HOMEBREW_BREW_FILE}" help exec
         return 1
         ;;
-      +*)
-        formula="${1#+}"
-        [[ -n "${formula}" ]] || odie "Formula override '+' is missing a formula name."
-        formulae+=("${formula}")
-        shift
-        ;;
       *)
         break
         ;;
     esac
   done
+
+  if [[ "${formulae_seen}" -eq 1 ]]
+  then
+    [[ -n "${formulae_arg}" ]] || odie "\`--formulae\` requires a comma-separated formula list."
+    IFS=',' read -r -a formulae <<<"${formulae_arg}"
+    local formula formula_index
+    for formula_index in "${!formulae[@]}"
+    do
+      formula="${formulae[formula_index]}"
+      formula="${formula#"${formula%%[![:space:]]*}"}"
+      formula="${formula%"${formula##*[![:space:]]}"}"
+      [[ -n "${formula}" ]] || odie "\`--formulae\` entries must not be empty."
+      formulae[formula_index]="${formula}"
+    done
+  fi
 
   local executable="${1:-}"
   if [[ -z "${executable}" ]]
@@ -120,14 +142,16 @@ homebrew-exec() {
   fi
   shift
 
-  [[ "${executable}" != */* ]] || odie "Executable name must not contain path separators."
-
+  local provider_lookup=0
   if [[ "${#formulae[@]}" -eq 0 ]]
   then
+    [[ "${executable}" != */* ]] || odie "Executable name must not contain path separators without \`--formulae\`."
+
+    provider_lookup=1
     download_and_cache_executables_file >&2
 
     local -a matching_formulae=()
-    local cmds_text line selected_formula
+    local cmds_text line selected_formula formula
     selected_formula=""
     # Some executables are provided by multiple formulae. Prefer an already
     # installed provider to avoid unnecessary installs; otherwise use the first
@@ -167,41 +191,39 @@ homebrew-exec() {
     fi
   fi
 
+  local formula
   for formula in "${formulae[@]}"
   do
     if ! exec-formula-installed "${formula}"
     then
-      ohai "Installing \`${formula}\` because it provides \`${executable}\`." >&2
+      if [[ "${provider_lookup}" -eq 1 ]]
+      then
+        ohai "Installing \`${formula}\` because it provides \`${executable}\`." >&2
+      else
+        ohai "Installing \`${formula}\`." >&2
+      fi
       "${HOMEBREW_BREW_FILE}" install --formula "${formula}" >&2 || return
     fi
   done
 
-  local candidate executable_path formula_name keg
-  executable_path=""
-  for formula in "${formulae[@]}"
-  do
-    formula_name="$(exec-formula-name "${formula}")"
-    local -a executable_candidate_paths=(
-      "${HOMEBREW_PREFIX}/opt/${formula_name}/bin/${executable}"
-      "${HOMEBREW_PREFIX}/opt/${formula_name}/sbin/${executable}"
-    )
-
-    # Do not use `HOMEBREW_PREFIX`/bin or sbin here. A different provider may
-    # be linked there with the same executable name.
-    # `break 2` leaves both this candidate loop and the surrounding formula
-    # loop as soon as a path has been narrowed down.
-    for candidate in "${executable_candidate_paths[@]}"
+  local executable_path="${executable}"
+  if [[ "${provider_lookup}" -eq 1 ]]
+  then
+    local candidate formula_name keg
+    executable_path=""
+    for formula in "${formulae[@]}"
     do
-      if [[ -f "${candidate}" && -x "${candidate}" ]]
-      then
-        executable_path="${candidate}"
-        break 2
-      fi
-    done
+      formula_name="$(exec-formula-name "${formula}")"
+      local -a executable_candidate_paths=(
+        "${HOMEBREW_PREFIX}/opt/${formula_name}/bin/${executable}"
+        "${HOMEBREW_PREFIX}/opt/${formula_name}/sbin/${executable}"
+      )
 
-    if keg="$(exec-latest-keg "${formula}")"
-    then
-      for candidate in "${keg}/bin/${executable}" "${keg}/sbin/${executable}"
+      # Do not use `HOMEBREW_PREFIX`/bin or sbin here. A different provider may
+      # be linked there with the same executable name.
+      # `break 2` leaves both this candidate loop and the surrounding formula
+      # loop as soon as a path has been narrowed down.
+      for candidate in "${executable_candidate_paths[@]}"
       do
         if [[ -f "${candidate}" && -x "${candidate}" ]]
         then
@@ -209,10 +231,22 @@ homebrew-exec() {
           break 2
         fi
       done
-    fi
-  done
 
-  [[ -n "${executable_path}" ]] || odie "\`${executable}\` was not found in formulae: ${formulae[*]}."
+      if keg="$(exec-latest-keg "${formula}")"
+      then
+        for candidate in "${keg}/bin/${executable}" "${keg}/sbin/${executable}"
+        do
+          if [[ -f "${candidate}" && -x "${candidate}" ]]
+          then
+            executable_path="${candidate}"
+            break 2
+          fi
+        done
+      fi
+    done
+
+    [[ -n "${executable_path}" ]] || odie "\`${executable}\` was not found in formulae: ${formulae[*]}."
+  fi
 
   local -a exec_path_entries=()
   local dependency exec_path path_index

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/exec.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/exec.rbi
@@ -11,6 +11,9 @@ class Homebrew::Cmd::Exec
 end
 
 class Homebrew::Cmd::Exec::Args < Homebrew::CLI::Args
+  sig { returns(T.nilable(T::Array[String])) }
+  def formulae; end
+
   sig { returns(T::Boolean) }
   def skip_update?; end
 end

--- a/Library/Homebrew/test/cmd/exec_spec.rb
+++ b/Library/Homebrew/test/cmd/exec_spec.rb
@@ -19,9 +19,13 @@ RSpec.describe Homebrew::Cmd::Exec do
     end
     let(:db) { HOMEBREW_CACHE/"api/internal/executables.txt" }
     let(:active_executable) { shell_cellar/"#{formula_name}/2.10/bin/#{executable_name}" }
+    let(:env_formula_name) { "test-env" }
+    let(:env_executable_name) { "test-env-tool" }
+    let(:env_executable) { shell_cellar/"#{env_formula_name}/1.0/bin/#{env_executable_name}" }
     let(:installable_formula_name) { "test-installable" }
     let(:installable_executable_name) { "test-installable-tool" }
     let(:brew_wrapper) { HOMEBREW_TEMP/"brew-exec-wrapper/brew" }
+    let(:inline_script) { HOMEBREW_TEMP/"brew-exec-wrapper/script.sh" }
     let(:brew_sh_env) do
       {
         "HOMEBREW_BREW_SH"               => (HOMEBREW_PREFIX/"bin/brew").to_s,
@@ -55,11 +59,23 @@ RSpec.describe Homebrew::Cmd::Exec do
       (HOMEBREW_PREFIX/"opt").mkpath
       FileUtils.ln_sf active_executable.dirname.parent, HOMEBREW_PREFIX/"opt/#{formula_name}"
 
+      env_executable.dirname.mkpath
+      env_executable.write("#!/bin/sh\necho env-version \"$@\"\n")
+      FileUtils.chmod 0755, env_executable
+      FileUtils.ln_sf env_executable.dirname.parent, HOMEBREW_PREFIX/"opt/#{env_formula_name}"
+
       linked_executable = HOMEBREW_PREFIX/"bin/#{executable_name}"
       linked_executable.write("#!/bin/sh\necho linked-provider\n")
       FileUtils.chmod 0755, linked_executable
 
       brew_wrapper.dirname.mkpath
+      inline_script.write(<<~SH)
+        #!/bin/sh
+        #{executable_name} "$@"
+        #{env_executable_name} "$@"
+      SH
+      FileUtils.chmod 0755, inline_script
+
       brew_wrapper.write(<<~SH)
         #!/bin/sh
         case "$1" in
@@ -88,14 +104,16 @@ RSpec.describe Homebrew::Cmd::Exec do
 
     after do
       FileUtils.rm_rf shell_cellar/formula_name
+      FileUtils.rm_rf shell_cellar/env_formula_name
       FileUtils.rm_rf shell_cellar/installable_formula_name
       FileUtils.rm_rf HOMEBREW_PREFIX/"opt/#{formula_name}"
+      FileUtils.rm_rf HOMEBREW_PREFIX/"opt/#{env_formula_name}"
       FileUtils.rm_rf HOMEBREW_PREFIX/"opt/#{installable_formula_name}"
       FileUtils.rm_f HOMEBREW_PREFIX/"bin/#{executable_name}"
       FileUtils.rm_rf brew_wrapper.dirname
     end
 
-    it "runs the selected formula executable and supports the x alias", :aggregate_failures, :integration_test do
+    it "runs commands in formula environments and supports the x alias", :aggregate_failures, :integration_test do
       expect do
         expect(brew_sh("exec", "--skip-update", executable_name, "arg", brew_sh_env)).to be_a_success
       end.to(
@@ -111,7 +129,23 @@ RSpec.describe Homebrew::Cmd::Exec do
       )
 
       expect do
-        expect(brew_sh("exec", "--skip-update", installable_executable_name, "arg", brew_sh_env)).to be_a_success
+        expect(brew_sh("exec", "--formulae=#{formula_name}, #{env_formula_name}", "--", inline_script.to_s, "arg",
+                       brew_sh_env)).to be_a_success
+      end.to(
+        output("active-version arg\nenv-version arg\n").to_stdout
+          .and(output("").to_stderr),
+      )
+
+      expect do
+        expect(brew_sh("exec", "--formulae", "--skip-update", executable_name, brew_sh_env)).to be_a_failure
+      end.to(
+        output("").to_stdout
+          .and(output("Error: `--formulae` requires a comma-separated formula list.\n").to_stderr),
+      )
+
+      expect do
+        expect(brew_sh("exec", "--skip-update", installable_executable_name, "arg",
+                       brew_sh_env)).to be_a_success
       end.to(
         output("installable-version arg\n").to_stdout
           .and(

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -1144,6 +1144,7 @@ _brew_exec() {
     -*)
       __brewcomp "
       --debug
+      --formulae
       --help
       --quiet
       --skip-update
@@ -3329,6 +3330,7 @@ _brew_x() {
     -*)
       __brewcomp "
       --debug
+      --formulae
       --help
       --quiet
       --skip-update

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -802,8 +802,9 @@ __fish_brew_complete_arg 'environment' -l verbose -d 'Make some output more verb
 __fish_brew_complete_arg 'environment' -a '(__fish_brew_suggest_formulae_all)'
 
 
-__fish_brew_complete_cmd 'exec' 'Run a Homebrew executable, installing its formula if needed'
+__fish_brew_complete_cmd 'exec' 'Run command in an environment populated by Homebrew formulae'
 __fish_brew_complete_arg 'exec' -l debug -d 'Display any debugging information'
+__fish_brew_complete_arg 'exec' -l formulae -d 'Comma-separated formulae to install and add to `PATH` before running command'
 __fish_brew_complete_arg 'exec' -l help -d 'Show this message'
 __fish_brew_complete_arg 'exec' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'exec' -l skip-update -d 'Skip updating the executables database if any version exists on disk, no matter how old'
@@ -2125,8 +2126,9 @@ __fish_brew_complete_arg 'which-update' -l summary-file -d 'Output a summary of 
 __fish_brew_complete_arg 'which-update' -l verbose -d 'Make some output more verbose'
 
 
-__fish_brew_complete_cmd 'x' 'Run a Homebrew executable, installing its formula if needed'
+__fish_brew_complete_cmd 'x' 'Run command in an environment populated by Homebrew formulae'
 __fish_brew_complete_arg 'x' -l debug -d 'Display any debugging information'
+__fish_brew_complete_arg 'x' -l formulae -d 'Comma-separated formulae to install and add to `PATH` before running command'
 __fish_brew_complete_arg 'x' -l help -d 'Show this message'
 __fish_brew_complete_arg 'x' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'x' -l skip-update -d 'Skip updating the executables database if any version exists on disk, no matter how old'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -170,7 +170,7 @@ __brew_internal_commands() {
     'docs:Open Homebrew'\''s online documentation at https://docs.brew.sh in a browser'
     'doctor:Check your system for potential problems'
     'edit:Open a formula, cask or tap in the editor set by `$EDITOR` or `$HOMEBREW_EDITOR`, or open the Homebrew repository for editing if no argument is provided'
-    'exec:Run a Homebrew executable, installing its formula if needed'
+    'exec:Run command in an environment populated by Homebrew formulae'
     'extract:Look through repository history to find the most recent version of formula and create a copy in tap'
     'fetch:Download a bottle (if available) or source packages for formulae and binaries for casks'
     'formula:Display the path where formula is located'
@@ -1019,6 +1019,7 @@ _brew_environment() {
 _brew_exec() {
   _arguments \
     '--debug[Display any debugging information]' \
+    '--formulae[Comma-separated formulae to install and add to `PATH` before running command]' \
     '--help[Show this message]' \
     '--quiet[Make some output more quiet]' \
     '--skip-update[Skip updating the executables database if any version exists on disk, no matter how old]' \
@@ -2613,6 +2614,7 @@ _brew_which_update() {
 _brew_x() {
   _arguments \
     '--debug[Display any debugging information]' \
+    '--formulae[Comma-separated formulae to install and add to `PATH` before running command]' \
     '--help[Show this message]' \
     '--quiet[Make some output more quiet]' \
     '--skip-update[Skip updating the executables database if any version exists on disk, no matter how old]' \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -182,7 +182,7 @@ removed.
 : Check if all dependencies present in the `Brewfile` are installed.
 
 This provides a successful exit code if everything is up-to-date, making it
-useful for scripting.
+useful for scripting. Use `--verbose` to list unmet dependencies.
 
 `brew bundle list`
 
@@ -650,14 +650,32 @@ working fine: please don't worry or file an issue; just ignore this.
 
 : Enable debugging and profiling of audit methods.
 
-### `exec`, `x` \[`--skip-update`\] \[`+`*`formula`* ...\] *`command`* \[*`args`* ...\]
+### `exec`, `x` \[`--skip-update`\] \[`--formulae=`*`formulae`*\] \[`--`\] *`command`* \[*`args`* ...\]
 
-Run a Homebrew executable, installing its formula if needed.
+Run *`command`* in an environment populated by Homebrew formulae.
+
+If `--formulae` is passed, Homebrew installs those comma-separated formulae if
+needed, prepends their executable directories and those of their dependencies to
+`PATH` and runs *`command`*. This allows *`command`* to be a script path such as
+`./script.sh`.
+
+If `--formulae` is omitted, Homebrew finds a formula that provides *`command`*,
+installs it if needed and runs that executable.
+
+Example: `brew exec --formulae=jq,yq -- ./script.sh`
+
+Scripts can also use a shebang on systems with `env -S`: `#!/usr/bin/env -S brew
+exec --formulae=jq,yq --`
 
 `--skip-update`
 
 : Skip updating the executables database if any version exists on disk, no
   matter how old.
+
+`--formulae`
+
+: Comma-separated formulae to install and add to `PATH` before running
+  *`command`*.
 
 ### `fetch` \[*`options`*\] *`formula`*\|*`cask`* \[...\]
 

--- a/docs/Tips-and-Tricks.md
+++ b/docs/Tips-and-Tricks.md
@@ -43,6 +43,22 @@ This imports the `brew` environment into your existing shell; `gem` will pick up
 brew install --only-dependencies <formula>
 ```
 
+## Run a script with Homebrew formulae on `PATH`
+
+Use `brew exec` to install formulae required by a script and run it with those formulae's executable directories on `PATH`:
+
+```sh
+brew exec --formulae=jq,yq -- ./script.sh
+```
+
+Pass a comma-separated formula list with `--formulae`, then put the command and its arguments after `--`. Homebrew installs missing formulae, prepends their `bin` and `sbin` paths and the corresponding dependency paths, then replaces itself with the command. The command may be a path, which is useful for portable scripts, demos and CI bootstrap code that need Homebrew tools without writing a `Brewfile`.
+
+On systems with `env -S`, a script can declare this in its shebang:
+
+```sh
+#!/usr/bin/env -S brew exec --formulae=jq,yq --
+```
+
 ## Use the interactive Homebrew shell
 
 ```console

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -112,7 +112,7 @@ Unless \fB\-\-force\fP is passed, this returns a 1 exit code if anything would b
 \fBbrew bundle check\fP
 Check if all dependencies present in the \fBBrewfile\fP are installed\.
 .P
-This provides a successful exit code if everything is up\-to\-date, making it useful for scripting\.
+This provides a successful exit code if everything is up\-to\-date, making it useful for scripting\. Use \fB\-\-verbose\fP to list unmet dependencies\.
 .TP
 \fBbrew bundle list\fP
 List all dependencies present in the \fBBrewfile\fP\&\.
@@ -406,11 +406,22 @@ List all audit methods, which can be run individually if provided as arguments\.
 .TP
 \fB\-D\fP, \fB\-\-audit\-debug\fP
 Enable debugging and profiling of audit methods\.
-.SS "\fBexec\fP, \fBx\fP \fR[\fB\-\-skip\-update\fP] \fR[\fB+\fP\fIformula\fP \.\.\.] \fIcommand\fP \fR[\fIargs\fP \.\.\.]"
-Run a Homebrew executable, installing its formula if needed\.
+.SS "\fBexec\fP, \fBx\fP \fR[\fB\-\-skip\-update\fP] \fR[\fB\-\-formulae=\fP\fIformulae\fP] \fR[\fB\-\-\fP] \fIcommand\fP \fR[\fIargs\fP \.\.\.]"
+Run \fIcommand\fP in an environment populated by Homebrew formulae\.
+.P
+If \fB\-\-formulae\fP is passed, Homebrew installs those comma\-separated formulae if needed, prepends their executable directories and those of their dependencies to \fBPATH\fP and runs \fIcommand\fP\&\. This allows \fIcommand\fP to be a script path such as \fB\&\./script\.sh\fP\&\.
+.P
+If \fB\-\-formulae\fP is omitted, Homebrew finds a formula that provides \fIcommand\fP, installs it if needed and runs that executable\.
+.P
+Example: \fBbrew exec \-\-formulae=jq,yq \-\- \./script\.sh\fP
+.P
+Scripts can also use a shebang on systems with \fBenv \-S\fP: \fB#!/usr/bin/env \-S brew exec \-\-formulae=jq,yq \-\-\fP
 .TP
 \fB\-\-skip\-update\fP
 Skip updating the executables database if any version exists on disk, no matter how old\.
+.TP
+\fB\-\-formulae\fP
+Comma\-separated formulae to install and add to \fBPATH\fP before running \fIcommand\fP\&\.
 .SS "\fBfetch\fP \fR[\fIoptions\fP] \fIformula\fP|\fIcask\fP \fR[\.\.\.]"
 Download a bottle (if available) or source packages for \fIformula\fPe and binaries for \fIcask\fPs\. For files, also print SHA\-256 checksums\.
 .TP


### PR DESCRIPTION
- Let scripts and CI snippets declare temporary formula tools with `--formulae`
- Keep provider lookup available when `--formulae` is omitted
- Preserve `--skip-update` for cached executable database use

Breaks some backwards compatibility but this is yet to get into a stable release yet.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
