### PR TITLE
cmd/outdated: fix handling of auto_updates

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -220,7 +220,6 @@ module Homebrew
             formula_or_cask.outdated?(fetch_head: args.fetch_HEAD?)
           else
             cask_greedy = upgrade_greedy_cask?(args.greedy?, formula_or_cask)
-            next false if formula_or_cask.auto_updates && !cask_greedy && !args.greedy_auto_updates?
 
             formula_or_cask.outdated?(greedy:              cask_greedy,
                                       greedy_latest:       args.greedy_latest?,

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -7,11 +7,13 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Outdated do
   it_behaves_like "parseable arguments"
 
-  it "skips auto-updating casks without --greedy-auto-updates", :cask do
+  it "excludes non-outdated auto-updating casks without --greedy-auto-updates", :cask do
     cask = Cask::CaskLoader.load(cask_path("auto-updates"))
     cmd = described_class.new([])
 
-    expect(cask).not_to receive(:outdated?)
+    expect(cask).to receive(:outdated?)
+      .with(greedy: false, greedy_latest: false, greedy_auto_updates: false)
+      .and_return(false)
     expect(cmd.send(:select_outdated, [cask])).to be_empty
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Codex (GPT-5.5) was used to help update the test suite to match the new logic.

-----

`brew outdated` was not reflecting the full picture of what `brew upgrade` would do with the `HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS` environment variable set. We were filtering out `auto_updates` casks early, and not passing them through to the function(s) that check the outdated status.

Changes;
  - Update the `brew outdated` auto-updates cask spec to match the current bundle-check behavior.
  - Assert that auto-updating casks are checked with `greedy_auto_updates: false` and excluded when not outdated.

Fixes https://github.com/Homebrew/brew/pull/21882#issuecomment-4444123716