### PR TITLE
cmd/bundle: fix `check --quiet`

### DIFF
--- a/Library/Homebrew/cmd/bundle.rb
+++ b/Library/Homebrew/cmd/bundle.rb
@@ -217,6 +217,7 @@ module Homebrew
         else
           args.no_upgrade?.present?
         end
+        quiet = args.quiet?
         verbose = args.verbose?
         force = args.force?
         jobs_arg = args.jobs || ENV.fetch("HOMEBREW_BUNDLE_JOBS", nil)
@@ -246,8 +247,7 @@ module Homebrew
         case subcommand
         when nil, "install", "upgrade"
           require "bundle/commands/install"
-          Homebrew::Bundle::Commands::Install.run(global:, file:, no_upgrade:, verbose:, force:, jobs:,
-                                                  quiet: args.quiet?)
+          Homebrew::Bundle::Commands::Install.run(global:, file:, no_upgrade:, verbose:, force:, jobs:, quiet:)
 
           cleanup = if ENV.fetch("HOMEBREW_BUNDLE_INSTALL_CLEANUP", nil)
             args.global?
@@ -296,7 +296,7 @@ module Homebrew
           )
         when "check"
           require "bundle/commands/check"
-          Homebrew::Bundle::Commands::Check.run(global:, file:, no_upgrade:, verbose:)
+          Homebrew::Bundle::Commands::Check.run(global:, file:, no_upgrade:, verbose:, quiet:)
         when "list"
           extension_list_options = BUNDLE_EXTENSIONS.to_h do |extension|
             [extension.type, self.class.extension_selected?(args, extension) || args.all?]


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

Quick fix, this just wasn't being passed through

```console
$ brew bundle check -q
The Brewfile's dependencies are satisfied.
```

Now
```
$ brew bundle check -q
```