### PR TITLE
Support pinning casks

### DIFF
--- a/Library/Homebrew/bundle/cask.rb
+++ b/Library/Homebrew/bundle/cask.rb
@@ -202,7 +202,8 @@ module Homebrew
         def outdated_cask_names
           return [] unless Bundle.cask_installed?
 
-          casks.select { |c| c.outdated?(greedy: false) }
+          casks.reject(&:pinned?)
+               .select { |c| c.outdated?(greedy: false) }
                .map(&:to_s)
         end
 
@@ -211,7 +212,7 @@ module Homebrew
           return false unless Bundle.cask_installed?
 
           cask = casks.find { |installed_cask| installed_cask.to_s == cask_name }
-          return false if cask.nil?
+          return false if cask.nil? || cask.pinned?
 
           cask.outdated?(greedy: true)
         end

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -277,6 +277,48 @@ module Cask
       installed_caskfile.dirname.dirname.dirname.basename.to_s
     end
 
+    sig { void }
+    def pin
+      return unless (installed_version = self.installed_version)
+
+      versioned_path = caskroom_path/installed_version
+      return unless versioned_path.exist?
+
+      HOMEBREW_PINNED_CASKS.mkpath
+      return if pinned?
+
+      pin_path.unlink if pin_path.file? || pin_path.symlink?
+      pin_path.make_relative_symlink(versioned_path)
+    end
+
+    sig { void }
+    def unpin
+      pin_path.unlink if pin_path.symlink?
+      HOMEBREW_PINNED_CASKS.rmdir_if_possible
+    end
+
+    sig { returns(T::Boolean) }
+    def pinned?
+      pin_path.symlink? && pin_path.exist?
+    end
+
+    sig { returns(T::Boolean) }
+    def pinnable?
+      return false unless (installed_version = self.installed_version)
+
+      (caskroom_path/installed_version).exist?
+    end
+
+    sig { returns(T.nilable(String)) }
+    def pinned_version
+      pin_path.resolved_path.basename.to_s if pinned?
+    end
+
+    sig { returns(Pathname) }
+    def pin_path
+      HOMEBREW_PINNED_CASKS/token
+    end
+
     sig { returns(T.nilable(String)) }
     def bundle_short_version
       bundle_version&.short_version
@@ -392,9 +434,13 @@ module Cask
           name:               token,
           installed_versions: [installed_version],
           current_version:    version,
+          pinned:             pinned?,
+          pinned_version:,
         }
       else
-        "#{token} (#{installed_version}) != #{version}"
+        pinned = " [pinned at #{pinned_version}]" if pinned?
+
+        "#{token} (#{installed_version}) != #{version}#{pinned}"
       end
     end
 
@@ -485,6 +531,8 @@ module Cask
         "installed_time"                  => install_time&.to_i,
         "bundle_version"                  => bundle_long_version,
         "bundle_short_version"            => bundle_short_version,
+        "pinned"                          => pinned?,
+        "pinned_version"                  => pinned_version,
         "outdated"                        => outdated?,
         "sha256"                          => sha256,
         "artifacts"                       => artifacts_list,
@@ -514,7 +562,7 @@ module Cask
       }
     end
 
-    HASH_KEYS_TO_SKIP = T.let(%w[outdated installed versions].freeze, T::Array[String])
+    HASH_KEYS_TO_SKIP = T.let(%w[outdated installed pinned pinned_version versions].freeze, T::Array[String])
     private_constant :HASH_KEYS_TO_SKIP
 
     AUTO_UPDATES_BAD_BUNDLE_VERSIONS = %w[0 0.0].freeze
@@ -686,6 +734,8 @@ module Cask
     def api_to_local_hash(hash)
       hash["token"] = token
       hash["installed"] = installed_version
+      hash["pinned"] = pinned?
+      hash["pinned_version"] = pinned_version
       hash["outdated"] = outdated?
       hash
     end

--- a/Library/Homebrew/cask/info.rb
+++ b/Library/Homebrew/cask/info.rb
@@ -23,6 +23,8 @@ module Cask
         output << "#{deprecate_disable}\n"
       end
       output << "#{installation_info(cask, installed:)}\n"
+      metadata = Homebrew::Cmd::Info.metadata_lines(cask)
+      output << "#{metadata.join("\n")}\n" if metadata.present?
       repo = repo_info(cask)
       output << "#{repo}\n" if repo
       deps = deps_info(cask)

--- a/Library/Homebrew/cask/migrator.rb
+++ b/Library/Homebrew/cask/migrator.rb
@@ -58,6 +58,11 @@ module Cask
         puts "mv #{new_caskroom_path}/#{old_installed_caskfile} #{new_caskroom_path}/#{new_installed_caskfile}"
         puts "rm -r #{old_caskroom_path}"
         puts "ln -s #{new_caskroom_path.basename} #{old_caskroom_path}"
+        if (old_pin_path = old_cask.pin_path).symlink? && (pinned_version = old_cask.pinned_version)
+          new_pin_path = new_cask.pin_path
+          puts "rm #{old_pin_path}"
+          puts "ln -s #{(new_caskroom_path/pinned_version).relative_path_from(new_pin_path.dirname)} #{new_pin_path}"
+        end
       else
         oh1 "Migrating cask #{Formatter.identifier(old_token)} to #{Formatter.identifier(new_token)}"
 
@@ -72,6 +77,14 @@ module Cask
 
         FileUtils.rm_r old_caskroom_path
         FileUtils.ln_s new_caskroom_path.basename, old_caskroom_path
+        if old_cask.pin_path.symlink? && (pinned_version = old_cask.pinned_version)
+          begin
+            new_cask.pin_path.make_relative_symlink(new_caskroom_path/pinned_version)
+            old_cask.unpin
+          rescue => e
+            opoo "Failed to migrate cask pin from #{old_token} to #{new_token}: #{e}"
+          end
+        end
       end
     end
 

--- a/Library/Homebrew/cask/uninstall.rb
+++ b/Library/Homebrew/cask/uninstall.rb
@@ -20,6 +20,8 @@ module Cask
 
         raise CaskNotInstalledError, cask if !cask.installed? && !force
 
+        next unless unpin_for_removal?(cask, force:)
+
         Installer.new(cask, binaries:, force:, verbose:).uninstall
       rescue => e
         caught_exceptions << e
@@ -31,6 +33,19 @@ module Cask
       raise MultipleCaskErrors, caught_exceptions if caught_exceptions.count > 1
 
       raise caught_exceptions.fetch(0)
+    end
+
+    sig { params(cask: ::Cask::Cask, force: T::Boolean).returns(T::Boolean) }
+    def self.unpin_for_removal?(cask, force:)
+      return true unless cask.pinned?
+
+      unless force
+        onoe "#{cask.full_name} is pinned. You must unpin it to uninstall."
+        return false
+      end
+
+      cask.unpin
+      true
     end
 
     sig { params(casks: ::Cask::Cask, named_args: T::Array[String]).void }

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -29,18 +29,19 @@ module Cask
         greedy:              T.nilable(T::Boolean),
         greedy_latest:       T.nilable(T::Boolean),
         greedy_auto_updates: T.nilable(T::Boolean),
+        summary_pinned:      T.nilable(T::Array[String]),
         summary_disabled:    T.nilable(T::Array[String]),
       ).returns(T::Array[Cask])
     }
     def self.outdated_casks(casks, args:, force:, quiet:,
                             greedy: false, greedy_latest: false, greedy_auto_updates: false,
-                            summary_disabled: nil)
+                            summary_pinned: nil, summary_disabled: nil)
       # Validate mutually exclusive opt-in/opt-out env vars before we start
       # selecting casks so `brew upgrade` errors consistently.
       Homebrew::EnvConfig.upgrade_auto_updates_casks?
       greedy = true if Homebrew::EnvConfig.upgrade_greedy?
 
-      if casks.empty?
+      outdated_casks = if casks.empty?
         Caskroom.casks(config: Config.from_args(args)).select do |cask|
           if cask.disabled?
             summary_disabled&.push(cask.full_name)
@@ -73,6 +74,18 @@ module Cask
           end
         end
       end
+
+      pinned_casks = outdated_casks.select(&:pinned?)
+      outdated_casks -= pinned_casks
+      summary_pinned&.concat(pinned_casks.map { |cask| "#{cask.full_name} #{cask.installed_version}" })
+
+      if pinned_casks.any? && (!quiet || casks.any?)
+        message = "Not upgrading #{pinned_casks.count} pinned #{::Utils.pluralize("package", pinned_casks.count)}:"
+        casks.any? ? ofail(message) : opoo(message)
+        $stderr.puts pinned_casks.map { |cask| "#{cask.full_name} #{cask.installed_version}" } * ", " unless quiet
+      end
+
+      outdated_casks
     end
 
     sig { params(cask_upgrades: T::Array[String], dry_run: T.nilable(T::Boolean)).void }
@@ -103,6 +116,7 @@ module Cask
         show_upgrade_summary: T::Boolean,
         download_queue:       T.nilable(Homebrew::DownloadQueue),
         summary_upgrades:     T.nilable(T::Array[String]),
+        summary_pinned:       T.nilable(T::Array[String]),
         summary_deprecated:   T.nilable(T::Array[String]),
         summary_disabled:     T.nilable(T::Array[String]),
       ).returns(T::Boolean)
@@ -125,6 +139,7 @@ module Cask
       show_upgrade_summary: true,
       download_queue: nil,
       summary_upgrades: nil,
+      summary_pinned: nil,
       summary_deprecated: nil,
       summary_disabled: nil
     )
@@ -132,7 +147,7 @@ module Cask
 
       outdated_casks =
         self.outdated_casks(casks, args:, greedy:, greedy_latest:, greedy_auto_updates:, force:, quiet:,
-                                   summary_disabled:)
+                                   summary_pinned:, summary_disabled:)
 
       manual_installer_casks = outdated_casks.select do |cask|
         cask.artifacts.any? do |artifact|

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -148,29 +148,40 @@ module Homebrew
         end
       end
 
-      sig { params(formula_or_cask: T.untyped).returns(T::Array[String]) }
+      sig { params(formula_or_cask: T.any(Formula, Cask::Cask)).returns(T::Array[String]) }
       def self.metadata_lines(formula_or_cask)
         return [] unless $stdout.tty?
 
-        if formula_or_cask.is_a?(Formula) || formula_or_cask.respond_to?(:pinned?)
+        case formula_or_cask
+        when Formula
           formula_metadata_lines(formula_or_cask)
-        elsif formula_or_cask.is_a?(Cask::Cask) || formula_or_cask.respond_to?(:supports_macos?)
-          []
+        when Cask::Cask
+          if formula_or_cask.pinned?
+            pinned = "Pinned: #{formula_or_cask.pinned_version}"
+            if (pinned_time = pin_path_mtime(formula_or_cask.pin_path))
+              pinned << " on #{formatted_time(pinned_time)}"
+            end
+            [pinned]
+          else
+            []
+          end
         else
-          raise TypeError, "Unsupported formula_or_cask type: #{formula_or_cask.class}"
+          T.absurd(formula_or_cask)
         end
       end
 
-      sig { params(formula_or_cask: T.untyped).returns(T::Array[String]) }
+      sig { params(formula_or_cask: T.any(Formula, Cask::Cask)).returns(T::Array[String]) }
       def self.requirements_lines(formula_or_cask)
         return [] unless $stdout.tty?
-        return [] if formula_or_cask.is_a?(Formula) || formula_or_cask.respond_to?(:pinned?)
-        if formula_or_cask.is_a?(Cask::Cask) || formula_or_cask.respond_to?(:supports_macos?)
-          return cask_requirements_lines(formula_or_cask)
-        end
 
-        raise TypeError,
-              "Unsupported formula_or_cask type: #{formula_or_cask.class}"
+        case formula_or_cask
+        when Formula
+          []
+        when Cask::Cask
+          cask_requirements_lines(formula_or_cask)
+        else
+          T.absurd(formula_or_cask)
+        end
       end
 
       sig { params(tab: T.any(Tab, Cask::Tab)).returns(String) }
@@ -233,12 +244,12 @@ module Homebrew
         end.sort.uniq
       end
 
-      sig { params(formula: T.untyped).returns(T::Array[String]) }
+      sig { params(formula: Formula).returns(T::Array[String]) }
       def self.formula_metadata_lines(formula)
         metadata = T.let([], T::Array[String])
         if formula.pinned?
           pinned = "Pinned: #{formula.pinned_version}"
-          if (pinned_time = formula_pinned_time(formula))
+          if (pinned_time = pin_path_mtime(FormulaPin.new(formula).path))
             pinned << " on #{formatted_time(pinned_time)}"
           end
           metadata << pinned
@@ -252,7 +263,7 @@ module Homebrew
         metadata
       end
 
-      sig { params(cask: T.untyped).returns(T::Array[String]) }
+      sig { params(cask: Cask::Cask).returns(T::Array[String]) }
       def self.cask_requirements_lines(cask)
         macos_requirements = [cask.depends_on.macos, cask.depends_on.maximum_macos].compact
         requirement = if macos_requirements.present?
@@ -280,9 +291,8 @@ module Homebrew
         time.strftime("%Y-%m-%d at %H:%M:%S")
       end
 
-      sig { params(formula: T.untyped).returns(T.nilable(Time)) }
-      def self.formula_pinned_time(formula)
-        pin_path = FormulaPin.new(formula).path
+      sig { params(pin_path: Pathname).returns(T.nilable(Time)) }
+      def self.pin_path_mtime(pin_path)
         pin_path.lstat.mtime if pin_path.symlink? || pin_path.exist?
       rescue Errno::ENOENT
         nil
@@ -332,7 +342,7 @@ module Homebrew
         end
       end
 
-      private_class_method :formula_metadata_lines, :formatted_time, :formula_pinned_time,
+      private_class_method :formula_metadata_lines, :formatted_time, :pin_path_mtime,
                            :formula_installs_from_source?, :cask_requirements_lines
 
       private

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -34,8 +34,8 @@ module Homebrew
         switch "--multiple",
                description: "Only show formulae with multiple versions installed. Implies `--versions`."
         switch "--pinned",
-               description: "List only pinned formulae, or only the specified (pinned) " \
-                            "formulae if <formula> are provided. See also `pin`, `unpin`."
+               description: "List only pinned packages, or only the specified (pinned) packages if <formula> or " \
+                            "<cask> are provided. See also `pin`, `unpin`."
         switch "--installed-on-request",
                description: "List the formulae installed on request."
         switch "--installed-as-dependency",
@@ -60,7 +60,6 @@ module Homebrew
                             "Has no effect when a formula or cask name is passed as an argument."
 
         conflicts "--formula", "--cask"
-        conflicts "--pinned", "--cask"
         conflicts "--multiple", "--cask"
         conflicts "--pinned", "--multiple"
         ["--installed-on-request", "--installed-as-dependency",
@@ -107,7 +106,57 @@ module Homebrew
             puts full_cask_names if full_cask_names.present?
           end
         elsif args.pinned?
-          filtered_list
+          pinned = if args.no_named?
+            entries = T.let([], T::Array[String])
+            unless args.cask?
+              Formula.racks.each do |rack|
+                entry = pinned_formula_entry(rack.basename.to_s)
+                entries << entry if entry
+              end
+            end
+
+            if !args.formula? && Cask::Caskroom.path.directory?
+              Cask::Caskroom.path.children.reject(&:file?).each do |path|
+                entry = pinned_cask_entry(path.basename.to_s)
+                entries << entry if entry
+              end
+            end
+            entries
+          else
+            args.named.filter_map do |name|
+              entry = T.let(nil, T.nilable(String))
+              package_found = T.let(false, T::Boolean)
+              package_name = T.let(nil, T.nilable(String))
+
+              unless args.cask?
+                rack = Formulary.to_rack(name)
+                if rack.exist?
+                  package_found = true
+                  package_name = rack.basename.to_s
+                  entry ||= pinned_formula_entry(rack.basename.to_s)
+                end
+              end
+
+              unless args.formula?
+                token = ::Utils.name_from_full_name(name).to_s
+                caskroom_path = Cask::Caskroom.path/token
+                if caskroom_path.exist? || caskroom_path.symlink?
+                  package_found = true
+                  package_name ||= token
+                  entry ||= pinned_cask_entry(token)
+                end
+              end
+
+              if package_found && entry.nil?
+                opoo "#{package_name || name} not pinned"
+              elsif !package_found
+                Homebrew.failed = true
+              end
+              entry
+            end
+          end
+
+          puts pinned.sort(&Cask::List::TAP_AND_NAME_COMPARISON)
         elsif args.versions? || args.multiple?
           filtered_list unless args.cask?
           list_casks if args.cask? || (!args.formula? && !args.multiple? && args.no_named?)
@@ -185,6 +234,22 @@ module Homebrew
 
       private
 
+      sig { params(name: String).returns(T.nilable(String)) }
+      def pinned_formula_entry(name)
+        pin_path = HOMEBREW_PINNED_KEGS/name
+        return unless pin_path.symlink?
+
+        "#{name}#{" #{pin_path.readlink.basename}" if args.versions?}"
+      end
+
+      sig { params(token: String).returns(T.nilable(String)) }
+      def pinned_cask_entry(token)
+        pin_path = HOMEBREW_PINNED_CASKS/token
+        return if !pin_path.symlink? || !pin_path.exist?
+
+        "#{token}#{" #{pin_path.resolved_path.basename}" if args.versions?}"
+      end
+
       sig { void }
       def filtered_list
         names = if args.no_named?
@@ -196,22 +261,11 @@ module Homebrew
             rack.exist?
           end
         end
-        if args.pinned?
-          pinned_versions = {}
-          names.sort.each do |d|
-            keg_pin = (HOMEBREW_PINNED_KEGS/d.basename.to_s)
-            pinned_versions[d] = keg_pin.readlink.basename.to_s if keg_pin.exist? || keg_pin.symlink?
-          end
-          pinned_versions.each do |d, version|
-            puts d.basename.to_s.concat(args.versions? ? " #{version}" : "")
-          end
-        else # --versions without --pinned
-          names.sort.each do |d|
-            versions = d.subdirs.map { |pn| pn.basename.to_s }
-            next if args.multiple? && versions.length < 2
+        names.sort.each do |d|
+          versions = d.subdirs.map { |pn| pn.basename.to_s }
+          next if args.multiple? && versions.length < 2
 
-            puts "#{d.basename} #{versions * " "}"
-          end
+          puts "#{d.basename} #{versions * " "}"
         end
       end
 

--- a/Library/Homebrew/cmd/pin.rb
+++ b/Library/Homebrew/cmd/pin.rb
@@ -3,31 +3,46 @@
 
 require "abstract_command"
 require "formula"
+require "cask/cask"
 
 module Homebrew
   module Cmd
     class Pin < AbstractCommand
       cmd_args do
         description <<~EOS
-          Pin the specified <formula>, preventing them from being upgraded when
-          issuing the `brew upgrade` <formula> command. See also `unpin`.
+          Pin the specified package, preventing it from being upgraded when
+          issuing the `brew upgrade` <formula> or <cask> command. See also `unpin`.
 
           *Note:* Other packages which depend on newer versions of a pinned formula
           might not install or run correctly.
+          Pinned casks with `auto_updates true` may update themselves outside Homebrew.
         EOS
 
-        named_args :installed_formula, min: 1
+        switch "--formula", "--formulae",
+               description: "Treat all named arguments as formulae."
+        switch "--cask", "--casks",
+               description: "Treat all named arguments as casks."
+
+        conflicts "--formula", "--cask"
+
+        named_args [:installed_formula, :installed_cask], min: 1
       end
 
       sig { override.void }
       def run
-        args.named.to_resolved_formulae.each do |f|
-          if f.pinned?
-            opoo "#{f.name} already pinned"
-          elsif !f.pinnable?
-            ofail "#{f.name} not installed"
+        formulae, casks = args.named.to_resolved_formulae_to_casks
+
+        (formulae + casks).each do |package|
+          if package.pinned?
+            opoo "#{package.full_name} already pinned"
+          elsif !package.pinnable?
+            ofail "#{package.full_name} not installed"
           else
-            f.pin
+            package.pin
+            if package.is_a?(Cask::Cask) && package.auto_updates
+              opoo "#{package.full_name} has `auto_updates true` and may update itself outside Homebrew despite " \
+                   "being pinned."
+            end
           end
         end
       end

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -145,6 +145,13 @@ module Homebrew
         end
 
         formulae = Homebrew::Attestation.sort_formulae_for_install(formulae) if Homebrew::Attestation.enabled?
+        casks = casks.filter_map do |cask|
+          if cask.pinned?
+            onoe "#{cask.full_name} is pinned. You must unpin it to reinstall."
+            next
+          end
+          cask
+        end
         shared_download_queue = T.let(nil, T.nilable(Homebrew::DownloadQueue))
         casks_prefetched = T.let(false, T::Boolean)
 

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -86,6 +86,8 @@ module Homebrew
 
               raise Cask::CaskNotInstalledError, cask if !cask.installed? && !args.force?
 
+              next unless Cask::Uninstall.unpin_for_removal?(cask, force: args.force?)
+
               Cask::Installer.new(cask, verbose: args.verbose?, force: args.force?).zap
             rescue => e
               caught_exceptions << e

--- a/Library/Homebrew/cmd/unpin.rb
+++ b/Library/Homebrew/cmd/unpin.rb
@@ -3,28 +3,48 @@
 
 require "abstract_command"
 require "formula"
+require "cask/cask"
 
 module Homebrew
   module Cmd
     class Unpin < AbstractCommand
       cmd_args do
         description <<~EOS
-          Unpin <formula>, allowing them to be upgraded by `brew upgrade` <formula>.
+          Unpin the specified package, allowing it to be upgraded by `brew upgrade` <formula> or <cask>.
           See also `pin`.
         EOS
 
-        named_args :installed_formula, min: 1
+        switch "--formula", "--formulae",
+               description: "Treat all named arguments as formulae."
+        switch "--cask", "--casks",
+               description: "Treat all named arguments as casks."
+
+        conflicts "--formula", "--cask"
+
+        named_args [:installed_formula, :installed_cask], min: 1
       end
 
       sig { override.void }
       def run
-        args.named.to_resolved_formulae.each do |f|
-          if f.pinned?
-            f.unpin
-          elsif !f.pinnable?
-            onoe "#{f.name} not installed"
+        formulae, casks = args.named.to_resolved_formulae_to_casks
+
+        formulae.each do |formula|
+          if formula.pinned?
+            formula.unpin
+          elsif !formula.pinnable?
+            onoe "#{formula.full_name} not installed"
           else
-            opoo "#{f.name} not pinned"
+            opoo "#{formula.full_name} not pinned"
+          end
+        end
+
+        casks.each do |cask|
+          if cask.pinned? || cask.pin_path.symlink?
+            cask.unpin
+          elsif !cask.pinnable?
+            onoe "#{cask.full_name} not installed"
+          else
+            opoo "#{cask.full_name} not pinned"
           end
         end
       end

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -23,6 +23,7 @@ module Homebrew
       class FinalUpgradeSummary < T::Struct
         prop :version_changes, T::Array[String], default: []
         prop :pinned_formulae, T::Array[String], default: []
+        prop :pinned_casks, T::Array[String], default: []
         prop :deprecated, T::Array[String], default: []
         prop :disabled, T::Array[String], default: []
         prop :source_build_formulae, T::Array[String], default: []
@@ -30,9 +31,9 @@ module Homebrew
 
       cmd_args do
         description <<~EOS
-          Upgrade outdated casks and outdated, unpinned formulae using the same options they were originally
-          installed with, plus any appended brew formula options. If <cask> or <formula> are specified,
-          upgrade only the given <cask> or <formula> kegs (unless they are pinned; see `pin`, `unpin`).
+          Upgrade outdated, unpinned packages using the same options they were originally installed with,
+          plus any appended brew formula options. If <cask> or <formula> are specified, upgrade only the given
+          <cask> or <formula> (unless they are pinned; see `pin`, `unpin`).
 
           Unless `$HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK` is set, `brew upgrade` or `brew reinstall` will be run for
           outdated dependents and dependents with broken linkage, respectively.
@@ -409,7 +410,7 @@ module Homebrew
       sig { void }
       def show_final_upgrade_summary
         summary = final_upgrade_summary
-        return if summary.version_changes.empty? && summary.pinned_formulae.empty? &&
+        return if summary.version_changes.empty? && summary.pinned_formulae.empty? && summary.pinned_casks.empty? &&
                   summary.deprecated.empty? && summary.disabled.empty? && summary.source_build_formulae.empty?
 
         if summary.version_changes.present?
@@ -425,6 +426,13 @@ module Homebrew
           show_final_upgrade_summary_section(
             "#{pinned_count} Pinned #{Utils.pluralize("formula", pinned_count)}",
             summary.pinned_formulae,
+          )
+        end
+        if summary.pinned_casks.present?
+          pinned_count = summary.pinned_casks.uniq.count
+          show_final_upgrade_summary_section(
+            "#{pinned_count} Pinned #{Utils.pluralize("cask", pinned_count)}",
+            summary.pinned_casks,
           )
         end
         deprecate_disable_summary = summary.deprecated.map { |item| "#{item} (deprecated)" } +
@@ -640,6 +648,7 @@ module Homebrew
           show_upgrade_summary:,
           download_queue:,
           summary_upgrades:     final_upgrade_summary.version_changes,
+          summary_pinned:       final_upgrade_summary.pinned_casks,
           summary_deprecated:   final_upgrade_summary.deprecated,
           summary_disabled:     final_upgrade_summary.disabled,
           args:,

--- a/Library/Homebrew/mcp_server.rb
+++ b/Library/Homebrew/mcp_server.rb
@@ -72,9 +72,9 @@ module Homebrew
       },
       upgrade:   {
         name:        "upgrade",
-        description: "Upgrade outdated casks and outdated, unpinned formulae using the same options they were " \
-                     "originally installed with, plus any appended brew formula options. If <cask> or <formula> " \
-                     "are specified, upgrade only the given <cask> or <formula> kegs (unless they are pinned).",
+        description: "Upgrade outdated, unpinned packages using the same options they were originally " \
+                     "installed with, plus any appended brew formula options. If <cask> or <formula> " \
+                     "are specified, upgrade only the given <cask> or <formula> (unless they are pinned).",
         command:     "brew upgrade",
         inputSchema: { type: "object", properties: FORMULA_OR_CASK_PROPERTIES },
       },

--- a/Library/Homebrew/startup/config.rb
+++ b/Library/Homebrew/startup/config.rb
@@ -53,6 +53,9 @@ HOMEBREW_LINKED_KEGS = (HOMEBREW_PREFIX/"var/homebrew/linked").freeze
 # Where we store symlinks to currently version-pinned kegs
 HOMEBREW_PINNED_KEGS = (HOMEBREW_PREFIX/"var/homebrew/pinned").freeze
 
+# Where we store symlinks to currently version-pinned casks
+HOMEBREW_PINNED_CASKS = (HOMEBREW_PREFIX/"var/homebrew/pinned_casks").freeze
+
 # Where we store lock files
 HOMEBREW_LOCKS = (HOMEBREW_PREFIX/"var/homebrew/locks").freeze
 

--- a/Library/Homebrew/test/bundle/cask_spec.rb
+++ b/Library/Homebrew/test/bundle/cask_spec.rb
@@ -82,11 +82,19 @@ RSpec.describe Homebrew::Bundle::Cask do
       end
 
       it "wants to greedily update foo if there is an update available" do
+        allow(foo).to receive(:pinned?).and_return(false)
         expect(foo).to receive(:outdated?).with(greedy: true).and_return(true)
         expect(dumper.cask_is_outdated_using_greedy?("foo")).to be(true)
       end
 
+      it "does not want to greedily update foo if it is pinned" do
+        allow(foo).to receive(:pinned?).and_return(true)
+        expect(foo).not_to receive(:outdated?)
+        expect(dumper.cask_is_outdated_using_greedy?("foo")).to be(false)
+      end
+
       it "does not want to greedily update bar if there is no update available" do
+        allow(bar).to receive(:pinned?).and_return(false)
         expect(bar).to receive(:outdated?).with(greedy: true).and_return(false)
         expect(dumper.cask_is_outdated_using_greedy?("bar")).to be(false)
       end
@@ -180,6 +188,16 @@ RSpec.describe Homebrew::Bundle::Cask do
         it "returns empty array" do
           described_class.reset!
           expect(described_class.outdated_casks).to eql([])
+        end
+
+        it "does not include pinned casks" do
+          pinned_cask = instance_double(Cask::Cask, to_s: "google-chrome", pinned?: true)
+          unpinned_cask = instance_double(Cask::Cask, to_s: "firefox", pinned?: false)
+          allow(pinned_cask).to receive(:outdated?).with(greedy: false).and_return(true)
+          allow(unpinned_cask).to receive(:outdated?).with(greedy: false).and_return(true)
+          allow(Cask::Caskroom).to receive(:casks).and_return([pinned_cask, unpinned_cask])
+
+          expect(described_class.outdated_casks).to eql(["firefox"])
         end
       end
 

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -76,6 +76,35 @@ RSpec.describe Cask::Cask, :cask do
     end
   end
 
+  describe "#pinned?" do
+    it "ignores and replaces a dangling pin" do
+      HOMEBREW_PINNED_CASKS.mkpath
+      cask.pin_path.make_relative_symlink(cask.caskroom_path/"missing")
+
+      expect(cask).not_to be_pinned
+      expect(cask.pinned_version).to be_nil
+
+      allow(cask).to receive(:installed_version).and_return("1.0")
+      (cask.caskroom_path/"1.0").mkpath
+      cask.pin
+
+      expect(cask).to be_pinned
+      expect(cask.pinned_version).to eq("1.0")
+    end
+
+    it "replaces a regular file pin record" do
+      HOMEBREW_PINNED_CASKS.mkpath
+      cask.pin_path.write("not a symlink")
+      allow(cask).to receive(:installed_version).and_return("1.0")
+      (cask.caskroom_path/"1.0").mkpath
+
+      cask.pin
+
+      expect(cask).to be_pinned
+      expect(cask.pin_path).to be_a_symlink
+    end
+  end
+
   describe "load" do
     let(:tap_path) { CoreCaskTap.instance.path }
     let(:file_dirname) { Pathname.new(__FILE__).dirname }
@@ -516,6 +545,20 @@ RSpec.describe Cask::Cask, :cask do
   describe "#supports_macos?" do
     it "returns false for casks with bare depends_on :linux" do
       expect(Cask::CaskLoader.load("with-depends-on-linux-bare").supports_macos?).to be false
+    end
+  end
+
+  describe "#outdated_info" do
+    it "includes pinned cask details" do
+      cask = Cask::CaskLoader.load("local-caffeine")
+      allow(cask).to receive_messages(outdated_version: "1.2.2", pinned?: true, pinned_version: "1.2.2")
+
+      expect(cask.outdated_info(false, true, false, false, false))
+        .to eq("local-caffeine (1.2.2) != 1.2.3 [pinned at 1.2.2]")
+      expect(cask.outdated_info(false, false, true, false, false)).to include(
+        pinned:         true,
+        pinned_version: "1.2.2",
+      )
     end
   end
 

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -156,6 +156,18 @@ RSpec.describe Cask::Info, :cask do
     EOS
   end
 
+  it "prints pinned cask metadata" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+    cask = Cask::CaskLoader.load("local-caffeine")
+    InstallHelper.stub_cask_installation(cask)
+    cask.pin
+
+    expect { described_class.info(cask, args:) }
+      .to output(/Pinned: 1\.2\.3 on \d{4}-\d{2}-\d{2} at \d{2}:\d{2}:\d{2}/).to_stdout
+
+    cask.unpin
+  end
+
   it "prints caveats if the Cask provided one" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 

--- a/Library/Homebrew/test/cask/migrator_spec.rb
+++ b/Library/Homebrew/test/cask/migrator_spec.rb
@@ -42,4 +42,64 @@ RSpec.describe Cask::Migrator do
       end
     end
   end
+
+  describe "#migrate" do
+    let(:old_caskroom_path) { Pathname("/tmp/Caskroom/old-token") }
+    let(:new_caskroom_path) { Pathname("/tmp/Caskroom/new-token") }
+    let(:old_caskfile) { old_caskroom_path/".metadata/1.0/20240101000000/Casks/old-token.rb" }
+    let(:new_caskfile) { new_caskroom_path/".metadata/1.0/20240101000000/Casks/new-token.rb" }
+    let(:old_pin_path) { Pathname("/tmp/pinned_casks/old-token") }
+    let(:new_pin_path) { Pathname("/tmp/pinned_casks/new-token") }
+    let(:old_cask) do
+      instance_double(
+        Cask::Cask,
+        token:              "old-token",
+        caskroom_path:      old_caskroom_path,
+        installed_caskfile: old_caskfile,
+        pin_path:           old_pin_path,
+        pinned_version:     "1.0",
+      )
+    end
+    let(:new_cask) do
+      instance_double(
+        Cask::Cask,
+        token:         "new-token",
+        caskroom_path: new_caskroom_path,
+        installed?:    true,
+        pin_path:      new_pin_path,
+      )
+    end
+
+    before do
+      allow(old_pin_path).to receive(:symlink?).and_return(true)
+      allow(FileUtils).to receive(:cp_r).with(old_caskroom_path, new_caskroom_path)
+      allow(FileUtils).to receive(:mv).with(new_caskroom_path/old_caskfile.relative_path_from(old_caskroom_path),
+                                            new_caskfile)
+      allow(FileUtils).to receive(:rm_r).with(old_caskroom_path)
+      allow(FileUtils).to receive(:ln_s).with(new_caskroom_path.basename, old_caskroom_path)
+      allow(described_class).to receive(:replace_caskfile_token).with(new_caskfile, "old-token", "new-token")
+    end
+
+    it "moves a cask pin to the new token" do
+      expect(old_cask).to receive(:unpin)
+      expect(new_pin_path).to receive(:make_relative_symlink).with(new_caskroom_path/"1.0")
+
+      described_class.new(old_cask, new_cask).migrate
+    end
+
+    it "prints relative cask pin targets in dry run" do
+      expect do
+        described_class.new(old_cask, new_cask).migrate(dry_run: true)
+      end.to output(%r{ln -s ../Caskroom/new-token/1\.0 /tmp/pinned_casks/new-token}).to_stdout
+    end
+
+    it "does not remove the old cask pin when creating the new pin fails" do
+      allow(new_pin_path).to receive(:make_relative_symlink).and_raise(RuntimeError, "failed")
+      expect(old_cask).not_to receive(:unpin)
+
+      expect do
+        described_class.new(old_cask, new_cask).migrate
+      end.to output(/Failed to migrate cask pin from old-token to new-token: failed/).to_stderr
+    end
+  end
 end

--- a/Library/Homebrew/test/cask/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/uninstall_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe Cask::Uninstall, :cask do
       end.not_to raise_error
     end
 
+    it "does not uninstall a pinned Cask" do
+      caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
+      InstallHelper.stub_cask_installation(caffeine)
+      caffeine.pin
+
+      expect(Cask::Installer).not_to receive(:new)
+      expect do
+        described_class.uninstall_casks(caffeine)
+      end.to output(/local-caffeine is pinned\. You must unpin it to uninstall\./).to_stderr
+
+      expect(caffeine).to be_pinned
+      caffeine.unpin
+    end
+
     it "can uninstall and unlink multiple Casks at once" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
       transmission = Cask::CaskLoader.load(cask_path("local-transmission-zip"))

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -172,6 +172,46 @@ RSpec.describe Cask::Upgrade, :cask do
         expect(summary_deprecated).to include("local-caffeine")
       end
 
+      it "excludes pinned Casks" do
+        local_caffeine.pin
+        summary_pinned = []
+
+        begin
+          expect(described_class).not_to receive(:upgrade_cask)
+          expect(described_class).to receive(:show_upgrade_summary) do |cask_upgrades, dry_run:|
+            expect(dry_run).to be(true)
+            expect(cask_upgrades).to include(
+              "local-transmission-zip 2.60 -> 2.61",
+              "auto-updates 2.57 -> 2.61",
+              "renamed-app 1.0.0 -> 2.0.0",
+            )
+            expect(cask_upgrades.grep(/local-caffeine/)).to be_empty
+          end
+
+          described_class.upgrade_casks!(dry_run: true, quiet: true, summary_pinned:, args:)
+          expect(summary_pinned).to include("local-caffeine 1.2.2")
+        ensure
+          local_caffeine.unpin
+        end
+      end
+
+      it "fails and skips explicitly named pinned Casks" do
+        local_caffeine.pin
+
+        begin
+          expect(described_class).not_to receive(:upgrade_cask)
+
+          expect do
+            described_class.upgrade_casks!(local_caffeine, dry_run: true, args:)
+          end.to not_to_output.to_stdout
+             .and output(/Not upgrading 1 pinned package:.*local-caffeine 1\.2\.2/m).to_stderr
+          expect(Homebrew).to be_failed
+        ensure
+          local_caffeine.unpin
+          Homebrew.failed = false
+        end
+      end
+
       it "would update only the Casks specified in the command line" do
         expect(described_class).not_to receive(:upgrade_cask)
         expect(described_class).to receive(:show_upgrade_summary)

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -966,21 +966,39 @@ RSpec.describe Homebrew::Cmd::Info do
     before { allow($stdout).to receive(:tty?).and_return(true) }
 
     it "returns summary lines for pinned formulae" do
-      formula = instance_double(
-        Formula,
-        any_version_installed?: true,
-        pinned?:                true,
-        pinned_version:         "1.0",
-      )
+      test_formula = formula("testball") do
+        url "https://brew.sh/testball-1.0"
+      end
+      allow(test_formula).to receive_messages(any_version_installed?: true, pinned?: true, pinned_version: "1.0")
 
       mktmpdir do |dir|
         pin_path = Pathname(dir/"testball")
         pin_path.write("pin")
         pin_time = Time.at(1_720_189_900)
         File.utime(pin_time, pin_time, pin_path)
-        allow(FormulaPin).to receive(:new).with(formula).and_return(instance_double(FormulaPin, path: pin_path))
+        allow(FormulaPin).to receive(:new).with(test_formula).and_return(instance_double(FormulaPin, path: pin_path))
 
-        expect(described_class.metadata_lines(formula)).to eq([
+        expect(described_class.metadata_lines(test_formula)).to eq([
+          "Pinned: 1.0 on #{pin_time.strftime("%Y-%m-%d at %H:%M:%S")}",
+        ])
+      end
+    end
+
+    it "returns summary lines for pinned casks" do
+      cask = Cask::Cask.new("test-cask") do
+        version "1.0"
+        url "https://brew.sh/test-cask.zip"
+      end
+      allow(cask).to receive_messages(pinned?: true, pinned_version: "1.0")
+
+      mktmpdir do |dir|
+        pin_path = Pathname(dir/"test-cask")
+        pin_path.write("pin")
+        pin_time = Time.at(1_720_189_900)
+        File.utime(pin_time, pin_time, pin_path)
+        allow(cask).to receive(:pin_path).and_return(pin_path)
+
+        expect(described_class.metadata_lines(cask)).to eq([
           "Pinned: 1.0 on #{pin_time.strftime("%Y-%m-%d at %H:%M:%S")}",
         ])
       end

--- a/Library/Homebrew/test/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cmd/list_spec.rb
@@ -25,4 +25,50 @@ RSpec.describe Homebrew::Cmd::List do
       .to be_a_success
       .and not_to_output.to_stderr
   end
+
+  it "prints pinned formulae and casks", :cask, :integration_test do
+    setup_test_formula "testball", tab_attributes: { installed_on_request: true }
+    Formula["testball"].pin
+    cask = Cask::CaskLoader.load("local-caffeine")
+    InstallHelper.stub_cask_installation(cask)
+    cask.pin
+
+    expect { brew "list", "--pinned", "--versions" }
+      .to output("local-caffeine 1.2.3\ntestball 0.1\n").to_stdout
+      .and be_a_success
+
+    cask.unpin
+  end
+
+  it "fails only for explicitly named missing pinned packages", :cask, :integration_test do
+    setup_test_formula "testball", tab_attributes: { installed_on_request: true }
+    Formula["testball"].pin
+    cask = Cask::CaskLoader.load("local-caffeine")
+    InstallHelper.stub_cask_installation(cask)
+    cask.pin
+
+    expect { brew "list", "--pinned", "--versions", "testball", "local-caffeine", "missing" }
+      .to output("local-caffeine 1.2.3\ntestball 0.1\n").to_stdout
+      .and be_a_failure
+
+    cask.unpin
+  end
+
+  it "warns for explicitly named unpinned packages", :cask, :integration_test do
+    cask = Cask::CaskLoader.load("local-caffeine")
+    InstallHelper.stub_cask_installation(cask)
+
+    expect { brew "list", "--pinned", "--cask", "local-caffeine" }
+      .to not_to_output.to_stdout
+      .and output(/local-caffeine not pinned/).to_stderr
+      .and be_a_success
+  end
+
+  it "does not fail for unpinned Caskroom entries without named arguments", :cask, :integration_test do
+    (Cask::Caskroom.path/"broken").mkpath
+
+    expect { brew "list", "--pinned", "--cask" }
+      .to not_to_output.to_stdout
+      .and be_a_success
+  end
 end

--- a/Library/Homebrew/test/cmd/pin_spec.rb
+++ b/Library/Homebrew/test/cmd/pin_spec.rb
@@ -13,6 +13,28 @@ RSpec.describe Homebrew::Cmd::Pin do
     expect { brew "pin", "testball" }.to be_a_success
   end
 
+  it "pins a Cask's version", :cask, :integration_test do
+    cask = Cask::CaskLoader.load("local-caffeine")
+    InstallHelper.stub_cask_installation(cask)
+
+    expect { brew "pin", "--cask", "local-caffeine" }.to be_a_success
+
+    expect(cask).to be_pinned
+    expect(cask.pinned_version).to eq("1.2.3")
+    cask.unpin
+  end
+
+  it "warns when pinning a Cask with auto_updates true", :cask, :integration_test do
+    cask = Cask::CaskLoader.load("auto-updates")
+    InstallHelper.stub_cask_installation(cask)
+
+    expect do
+      expect { brew "pin", "--cask", "auto-updates" }.to be_a_success
+    end.to output(/auto-updates has `auto_updates true`.*outside Homebrew/).to_stderr
+
+    cask.unpin
+  end
+
   it "fails with an uninstalled Formula", :integration_test do
     setup_test_formula "testball"
 

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -24,6 +24,22 @@ RSpec.describe Homebrew::Cmd::Reinstall do
     expect(Homebrew).to have_failed
   end
 
+  it "does not reinstall a pinned Cask" do
+    cask = Cask::Cask.new("local-caffeine")
+    allow(cask).to receive_messages(pinned?: true, full_name: "local-caffeine")
+
+    cmd = described_class.new(["local-caffeine"])
+    allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable)
+      .with(method: :resolve)
+      .and_return([cask])
+    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
+    allow(Homebrew.messages).to receive(:display_messages)
+
+    expect(Cask::Reinstall).not_to receive(:reinstall_casks)
+    expect { cmd.run }
+      .to output(/local-caffeine is pinned\. You must unpin it to reinstall\./).to_stderr
+  end
+
   it "reinstalls a Formula", :aggregate_failures, :integration_test do
     formula_name = "testball_bottle"
     formula_prefix = HOMEBREW_CELLAR/formula_name/"0.1"

--- a/Library/Homebrew/test/cmd/unpin_spec.rb
+++ b/Library/Homebrew/test/cmd/unpin_spec.rb
@@ -13,4 +13,28 @@ RSpec.describe Homebrew::Cmd::Unpin do
 
     expect { brew "unpin", "testball" }.to be_a_success
   end
+
+  it "unpins a Cask's version", :cask, :integration_test do
+    cask = Cask::CaskLoader.load("local-caffeine")
+    InstallHelper.stub_cask_installation(cask)
+    cask.pin
+
+    expect { brew "unpin", "--cask", "local-caffeine" }.to be_a_success
+
+    expect(cask).not_to be_pinned
+  end
+
+  it "removes a dangling Cask pin", :cask, :integration_test do
+    cask = Cask::CaskLoader.load("local-caffeine")
+    InstallHelper.stub_cask_installation(cask)
+    cask.pin
+    FileUtils.rm_r(cask.caskroom_path/"1.2.3")
+
+    expect(cask).not_to be_pinned
+    expect(cask.pin_path).to be_a_symlink
+
+    expect { brew "unpin", "--cask", "local-caffeine" }.to be_a_success
+
+    expect(cask.pin_path).not_to be_a_symlink
+  end
 end

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -239,6 +239,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     summary = described_class::FinalUpgradeSummary.new(
       version_changes:       ["testball 0.1 -> 0.2"],
       pinned_formulae:       ["pinnedball 1.0"],
+      pinned_casks:          ["pinned-cask 2.0"],
       deprecated:            ["oldball"],
       disabled:              ["disabledball"],
       source_build_formulae: ["sourceball"],
@@ -251,6 +252,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       testball 0.1 -> 0.2
       ==> 1 Pinned formula
       pinnedball 1.0
+      ==> 1 Pinned cask
+      pinned-cask 2.0
       ==> 2 Deprecated or disabled packages
       oldball (deprecated)
       disabledball (disabled)

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -305,6 +305,7 @@ RSpec.configure do |config|
         *Keg.must_exist_subdirectories,
         HOMEBREW_LINKED_KEGS,
         HOMEBREW_PINNED_KEGS,
+        HOMEBREW_PINNED_CASKS,
         HOMEBREW_PREFIX/"Caskroom",
         HOMEBREW_PREFIX/"Frameworks",
         HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-cask",

--- a/Library/Homebrew/test/support/fixtures/cask/everything-with-variations.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything-with-variations.json
@@ -23,6 +23,8 @@
   "installed_time": null,
   "bundle_version": null,
   "bundle_short_version": null,
+  "pinned": false,
+  "pinned_version": null,
   "outdated": false,
   "sha256": "c64c05bdc0be845505d6e55e69e696a7f50d40846e76155f0c85d5ff5e7bbb84",
   "artifacts": [

--- a/Library/Homebrew/test/support/fixtures/cask/everything.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything.json
@@ -23,6 +23,8 @@
   "installed_time": null,
   "bundle_version": null,
   "bundle_short_version": null,
+  "pinned": false,
+  "pinned_version": null,
   "outdated": false,
   "sha256": "c64c05bdc0be845505d6e55e69e696a7f50d40846e76155f0c85d5ff5e7bbb84",
   "artifacts": [

--- a/Library/Homebrew/test/support/lib/startup/config.rb
+++ b/Library/Homebrew/test/support/lib/startup/config.rb
@@ -31,6 +31,7 @@ HOMEBREW_CACHE         = (HOMEBREW_PREFIX.parent/"cache").freeze
 HOMEBREW_CACHE_FORMULA = (HOMEBREW_PREFIX.parent/"formula_cache").freeze
 HOMEBREW_LINKED_KEGS   = (HOMEBREW_PREFIX/"var/homebrew/linked").freeze
 HOMEBREW_PINNED_KEGS   = (HOMEBREW_PREFIX/"var/homebrew/pinned").freeze
+HOMEBREW_PINNED_CASKS  = (HOMEBREW_PREFIX/"var/homebrew/pinned_casks").freeze
 HOMEBREW_LOCKS         = (HOMEBREW_PREFIX/"var/homebrew/locks").freeze
 HOMEBREW_TEMP_CELLAR   = (HOMEBREW_PREFIX/"var/homebrew/tmp/.cellar").freeze
 HOMEBREW_CELLAR        = (HOMEBREW_PREFIX/"Cellar").freeze

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -1994,7 +1994,9 @@ _brew_pin() {
   case "${cur}" in
     -*)
       __brewcomp "
+      --cask
       --debug
+      --formula
       --help
       --quiet
       --verbose
@@ -2004,6 +2006,7 @@ _brew_pin() {
     *) ;;
   esac
   __brew_complete_installed_formulae
+  __brew_complete_installed_casks
 }
 
 _brew_post_install() {
@@ -2911,7 +2914,9 @@ _brew_unpin() {
   case "${cur}" in
     -*)
       __brewcomp "
+      --cask
       --debug
+      --formula
       --help
       --quiet
       --verbose
@@ -2921,6 +2926,7 @@ _brew_unpin() {
     *) ;;
   esac
   __brew_complete_installed_formulae
+  __brew_complete_installed_casks
 }
 
 _brew_untap() {

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1180,7 +1180,7 @@ __fish_brew_complete_arg 'list' -l help -d 'Show this message'
 __fish_brew_complete_arg 'list' -l installed-as-dependency -d 'List the formulae installed as dependencies'
 __fish_brew_complete_arg 'list' -l installed-on-request -d 'List the formulae installed on request'
 __fish_brew_complete_arg 'list' -l multiple -d 'Only show formulae with multiple versions installed. Implies `--versions`'
-__fish_brew_complete_arg 'list' -l pinned -d 'List only pinned formulae, or only the specified (pinned) formulae if formula are provided. See also `pin`, `unpin`'
+__fish_brew_complete_arg 'list' -l pinned -d 'List only pinned packages, or only the specified (pinned) packages if formula or cask are provided. See also `pin`, `unpin`'
 __fish_brew_complete_arg 'list' -l poured-from-bottle -d 'List the formulae installed from a bottle'
 __fish_brew_complete_arg 'list' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'list' -l verbose -d 'Make some output more verbose'
@@ -1251,7 +1251,7 @@ __fish_brew_complete_arg 'ls' -l help -d 'Show this message'
 __fish_brew_complete_arg 'ls' -l installed-as-dependency -d 'List the formulae installed as dependencies'
 __fish_brew_complete_arg 'ls' -l installed-on-request -d 'List the formulae installed on request'
 __fish_brew_complete_arg 'ls' -l multiple -d 'Only show formulae with multiple versions installed. Implies `--versions`'
-__fish_brew_complete_arg 'ls' -l pinned -d 'List only pinned formulae, or only the specified (pinned) formulae if formula are provided. See also `pin`, `unpin`'
+__fish_brew_complete_arg 'ls' -l pinned -d 'List only pinned packages, or only the specified (pinned) packages if formula or cask are provided. See also `pin`, `unpin`'
 __fish_brew_complete_arg 'ls' -l poured-from-bottle -d 'List the formulae installed from a bottle'
 __fish_brew_complete_arg 'ls' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'ls' -l verbose -d 'Make some output more verbose'
@@ -1328,12 +1328,15 @@ __fish_brew_complete_arg 'outdated; and not __fish_seen_argument -l cask -l cask
 __fish_brew_complete_arg 'outdated; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
-__fish_brew_complete_cmd 'pin' 'Pin the specified formula, preventing them from being upgraded when issuing the `brew upgrade` formula command'
+__fish_brew_complete_cmd 'pin' 'Pin the specified package, preventing it from being upgraded when issuing the `brew upgrade` formula or cask command'
+__fish_brew_complete_arg 'pin' -l cask -d 'Treat all named arguments as casks'
 __fish_brew_complete_arg 'pin' -l debug -d 'Display any debugging information'
+__fish_brew_complete_arg 'pin' -l formula -d 'Treat all named arguments as formulae'
 __fish_brew_complete_arg 'pin' -l help -d 'Show this message'
 __fish_brew_complete_arg 'pin' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'pin' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'pin' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'pin; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'pin; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
 
 
 __fish_brew_complete_cmd 'post_install' 'Rerun the post-install steps for formula'
@@ -1888,12 +1891,15 @@ __fish_brew_complete_arg 'unpack; and not __fish_seen_argument -l cask -l casks'
 __fish_brew_complete_arg 'unpack; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
-__fish_brew_complete_cmd 'unpin' 'Unpin formula, allowing them to be upgraded by `brew upgrade` formula'
+__fish_brew_complete_cmd 'unpin' 'Unpin the specified package, allowing it to be upgraded by `brew upgrade` formula or cask'
+__fish_brew_complete_arg 'unpin' -l cask -d 'Treat all named arguments as casks'
 __fish_brew_complete_arg 'unpin' -l debug -d 'Display any debugging information'
+__fish_brew_complete_arg 'unpin' -l formula -d 'Treat all named arguments as formulae'
 __fish_brew_complete_arg 'unpin' -l help -d 'Show this message'
 __fish_brew_complete_arg 'unpin' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'unpin' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'unpin' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'unpin; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'unpin; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
 
 
 __fish_brew_complete_cmd 'untap' 'Remove a tapped formula repository'
@@ -2008,7 +2014,7 @@ __fish_brew_complete_arg 'update-test' -l to-tag -d 'Set `$HOMEBREW_UPDATE_TO_TA
 __fish_brew_complete_arg 'update-test' -l verbose -d 'Make some output more verbose'
 
 
-__fish_brew_complete_cmd 'upgrade' 'Upgrade outdated casks and outdated, unpinned formulae using the same options they were originally installed with, plus any appended brew formula options'
+__fish_brew_complete_cmd 'upgrade' 'Upgrade outdated, unpinned packages using the same options they were originally installed with, plus any appended brew formula options'
 __fish_brew_complete_arg 'upgrade' -l appdir -d 'Target location for Applications (default: `/Applications`)'
 __fish_brew_complete_arg 'upgrade' -l ask -d 'Ask for confirmation before downloading and upgrading formulae. Print download, install and net install sizes of bottles and dependencies. Enabled by default if `$HOMEBREW_ASK` is set'
 __fish_brew_complete_arg 'upgrade' -l audio-unit-plugindir -d 'Target location for Audio Unit Plugins (default: `~/Library/Audio/Plug-Ins/Components`)'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -202,7 +202,7 @@ __brew_internal_commands() {
     'nodenv-sync:Create symlinks for Homebrew'\''s installed NodeJS versions in `~/.nodenv/versions`'
     'options:Show install options specific to formula'
     'outdated:List installed casks and formulae that have an updated version available'
-    'pin:Pin the specified formula, preventing them from being upgraded when issuing the `brew upgrade` formula command'
+    'pin:Pin the specified package, preventing it from being upgraded when issuing the `brew upgrade` formula or cask command'
     'postinstall:Rerun the post-install steps for formula'
     'pr-automerge:Find pull requests that can be automatically merged using `brew pr-publish`'
     'pr-publish:Publish bottles for a pull request with GitHub Actions'
@@ -237,7 +237,7 @@ __brew_internal_commands() {
     'uninstall:Uninstall a formula or cask'
     'unlink:Remove symlinks for formula from Homebrew'\''s prefix'
     'unpack:Unpack the files for the formula or cask into subdirectories of the current working directory'
-    'unpin:Unpin formula, allowing them to be upgraded by `brew upgrade` formula'
+    'unpin:Unpin the specified package, allowing it to be upgraded by `brew upgrade` formula or cask'
     'untap:Remove a tapped formula repository'
     'update:Fetch the newest version of Homebrew and all formulae from GitHub using `git`(1) and perform any necessary migrations'
     'update-if-needed:Runs `brew update --auto-update` only if needed'
@@ -249,7 +249,7 @@ __brew_internal_commands() {
     'update-reset:Fetch and reset Homebrew and all tap repositories (or any specified repository) using `git`(1) to their latest `origin/HEAD`'
     'update-sponsors:Update the list of GitHub Sponsors in the `Homebrew/brew` README'
     'update-test:Run a test of `brew update` with a new repository clone'
-    'upgrade:Upgrade outdated casks and outdated, unpinned formulae using the same options they were originally installed with, plus any appended brew formula options'
+    'upgrade:Upgrade outdated, unpinned packages using the same options they were originally installed with, plus any appended brew formula options'
     'uses:Show formulae and casks that specify formula as a dependency; that is, show dependents of formula'
     'vendor-gems:Install and commit Homebrew'\''s vendored gems'
     'verify:Verify the build provenance of bottles using GitHub'\''s attestation tools'
@@ -1464,7 +1464,7 @@ _brew_list() {
     '(--cask --versions --multiple --pinned -l)--installed-as-dependency[List the formulae installed as dependencies]' \
     '(--cask --versions --multiple --pinned -l)--installed-on-request[List the formulae installed on request]' \
     '(--cask --pinned --installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source -1 -l -r -t --full-name)--multiple[Only show formulae with multiple versions installed. Implies `--versions`]' \
-    '(--cask --multiple --installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source -1 -l -r -t --full-name)--pinned[List only pinned formulae, or only the specified (pinned) formulae if formula are provided. See also `pin`, `unpin`]' \
+    '(--multiple --installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source -1 -l -r -t --full-name)--pinned[List only pinned packages, or only the specified (pinned) packages if formula or cask are provided. See also `pin`, `unpin`]' \
     '(--cask --versions --multiple --pinned -l)--poured-from-bottle[List the formulae installed from a bottle]' \
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
@@ -1477,7 +1477,7 @@ _brew_list() {
     '(--cask)--formula[List only formulae, or treat all named arguments as formulae]' \
     '*:installed_formula:__brew_installed_formulae' \
     - installed_cask \
-    '(--formula --pinned --multiple --installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source)--cask[List only casks, or treat all named arguments as casks]' \
+    '(--formula --multiple --installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source)--cask[List only casks, or treat all named arguments as casks]' \
     '*:installed_cask:__brew_installed_casks'
 }
 
@@ -1550,7 +1550,7 @@ _brew_ls() {
     '(--cask --versions --multiple --pinned -l)--installed-as-dependency[List the formulae installed as dependencies]' \
     '(--cask --versions --multiple --pinned -l)--installed-on-request[List the formulae installed on request]' \
     '(--cask --pinned --installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source -1 -l -r -t --full-name)--multiple[Only show formulae with multiple versions installed. Implies `--versions`]' \
-    '(--cask --multiple --installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source -1 -l -r -t --full-name)--pinned[List only pinned formulae, or only the specified (pinned) formulae if formula are provided. See also `pin`, `unpin`]' \
+    '(--multiple --installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source -1 -l -r -t --full-name)--pinned[List only pinned packages, or only the specified (pinned) packages if formula or cask are provided. See also `pin`, `unpin`]' \
     '(--cask --versions --multiple --pinned -l)--poured-from-bottle[List the formulae installed from a bottle]' \
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
@@ -1563,7 +1563,7 @@ _brew_ls() {
     '(--cask)--formula[List only formulae, or treat all named arguments as formulae]' \
     '*:installed_formula:__brew_installed_formulae' \
     - installed_cask \
-    '(--formula --pinned --multiple --installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source)--cask[List only casks, or treat all named arguments as casks]' \
+    '(--formula --multiple --installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source)--cask[List only casks, or treat all named arguments as casks]' \
     '*:installed_cask:__brew_installed_casks'
 }
 
@@ -1657,7 +1657,11 @@ _brew_pin() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - installed_formula \
-    '*:installed_formula:__brew_installed_formulae'
+    '(--cask)--formula[Treat all named arguments as formulae]' \
+    '*:installed_formula:__brew_installed_formulae' \
+    - installed_cask \
+    '(--formula)--cask[Treat all named arguments as casks]' \
+    '*:installed_cask:__brew_installed_casks'
 }
 
 # brew post_install
@@ -2330,7 +2334,11 @@ _brew_unpin() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - installed_formula \
-    '*:installed_formula:__brew_installed_formulae'
+    '(--cask)--formula[Treat all named arguments as formulae]' \
+    '*:installed_formula:__brew_installed_formulae' \
+    - installed_cask \
+    '(--formula)--cask[Treat all named arguments as casks]' \
+    '*:installed_cask:__brew_installed_casks'
 }
 
 # brew untap

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -33,7 +33,7 @@ Or upgrade a specific formula with:
 
 To stop something from being updated/upgraded:
 
-    brew pin <formula>
+    brew pin <formula_or_cask>
 
 If you also do not want Homebrew to automatically learn about newer versions until you choose to, disable auto-updating entirely:
 
@@ -41,11 +41,13 @@ If you also do not want Homebrew to automatically learn about newer versions unt
 
 For the tradeoffs and alternatives, see [Locking installed formulae at specific versions](Versions.md#locking-installed-formulae-at-specific-versions).
 
-To allow that formulae to update again:
+To allow that package to update again:
 
-    brew unpin <formula>
+    brew unpin <formula_or_cask>
 
 Note that pinned, outdated formulae that another formula depends on need to be upgraded when required, as we do not allow formulae to be built against outdated versions. If this is not desired, see [Locking installed formulae at specific versions](Versions.md#locking-installed-formulae-at-specific-versions) instead.
+
+Pinned casks are skipped by `brew upgrade`, but an app’s own updater may still update it outside Homebrew.
 
 ## How do I uninstall Homebrew?
 
@@ -244,7 +246,7 @@ When software uses its built-in mechanisms to upgrade itself, it happens without
 
 There are a few ideas to fix this problem:
 
-* Try to prevent the software’s automated updates. It wouldn’t be a universal solution and may cause it to break. Most software on Homebrew Cask is closed-source, so we’d be guessing. This is also why pinning casks to a version isn’t available.
+* Try to prevent the software’s automated updates. `brew pin <cask>` can prevent Homebrew from upgrading a cask, but it does not disable an app’s own updater. Most software on Homebrew Cask is closed-source, so trying to control that for every app would be guesswork.
 * Try to extract the installed software’s version and compare it to the cask, deciding what to do at that time. It’d be a complicated solution that would break other parts of our methodology, such as using versions to interpolate `url` values (a definite win for maintainability). This solution also isn’t universal, as many software developers are inconsistent in their versioning schemes (and app bundles are meant to have two version strings) and it doesn’t work for all types of software we support.
 
 So we let software be. Anything installed with Homebrew Cask should behave the same as if it were installed manually. But since we also want to support software that doesn’t self-upgrade, we add [`auto_updates true`](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/a/alfred.rb#L18) to casks for software that does. These casks may still be skipped by `brew upgrade` unless you explicitly include them. You can also set `HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS=1` so Homebrew will try to upgrade them automatically when it can detect that the version currently installed in the user’s `appdir` is older than the latest version in the tap. This will become the default behavior in Homebrew 5.2.0.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1064,8 +1064,8 @@ paths within its current keg. If *`cask`* is provided, list its artifacts.
 
 `--pinned`
 
-: List only pinned formulae, or only the specified (pinned) formulae if
-  *`formula`* are provided. See also `pin`, `unpin`.
+: List only pinned packages, or only the specified (pinned) packages if
+  *`formula`* or *`cask`* are provided. See also `pin`, `unpin`.
 
 `--installed-on-request`
 
@@ -1255,13 +1255,22 @@ otherwise.
 : Also include outdated `auto_updates true` casks that would otherwise be
   skipped.
 
-### `pin` *`installed_formula`* \[...\]
+### `pin` \[`--formula`\] \[`--cask`\] *`installed_formula`*\|*`installed_cask`* \[...\]
 
-Pin the specified *`formula`*, preventing them from being upgraded when issuing
-the `brew upgrade` *`formula`* command. See also `unpin`.
+Pin the specified package, preventing it from being upgraded when issuing the
+`brew upgrade` *`formula`* or *`cask`* command. See also `unpin`.
 
 *Note:* Other packages which depend on newer versions of a pinned formula might
-not install or run correctly.
+not install or run correctly. Pinned casks with `auto_updates true` may update
+themselves outside Homebrew.
+
+`--formula`
+
+: Treat all named arguments as formulae.
+
+`--cask`
+
+: Treat all named arguments as casks.
 
 ### `postinstall`, `post_install` *`installed_formula`* \[...\]
 
@@ -1705,10 +1714,18 @@ brew link` *`formula`*
 : List files which would be unlinked without actually unlinking or deleting any
   files.
 
-### `unpin` *`installed_formula`* \[...\]
+### `unpin` \[`--formula`\] \[`--cask`\] *`installed_formula`*\|*`installed_cask`* \[...\]
 
-Unpin *`formula`*, allowing them to be upgraded by `brew upgrade` *`formula`*.
-See also `pin`.
+Unpin the specified package, allowing it to be upgraded by `brew upgrade`
+*`formula`* or *`cask`*. See also `pin`.
+
+`--formula`
+
+: Treat all named arguments as formulae.
+
+`--cask`
+
+: Treat all named arguments as casks.
 
 ### `untap` \[`--force`\] *`tap`* \[...\]
 
@@ -1758,10 +1775,10 @@ Fetch and reset Homebrew and all tap repositories (or any specified
 
 ### `upgrade` \[*`options`*\] \[*`installed_formula`*\|*`installed_cask`* ...\]
 
-Upgrade outdated casks and outdated, unpinned formulae using the same options
-they were originally installed with, plus any appended brew formula options. If
-*`cask`* or *`formula`* are specified, upgrade only the given *`cask`* or
-*`formula`* kegs (unless they are pinned; see `pin`, `unpin`).
+Upgrade outdated, unpinned packages using the same options they were originally
+installed with, plus any appended brew formula options. If *`cask`* or
+*`formula`* are specified, upgrade only the given *`cask`* or *`formula`*
+(unless they are pinned; see `pin`, `unpin`).
 
 Unless `$HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK` is set, `brew upgrade` or `brew
 reinstall` will be run for outdated dependents and dependents with broken

--- a/docs/Versions.md
+++ b/docs/Versions.md
@@ -38,7 +38,7 @@ If you want something else, choose the smallest tool that fits:
 
 ### `brew pin`
 
-Use `brew pin <formula>` when you want `brew upgrade` to stop upgrading a formula you already have installed.
+Use `brew pin <formula_or_cask>` when you want `brew upgrade` to stop upgrading a package you already have installed.
 
 Pros:
 
@@ -46,8 +46,9 @@ Pros:
 
 Cons:
 
-* you will not receive updates for that formula, including security updates, while it remains pinned
+* you will not receive updates for that package, including security updates, while it remains pinned
 * pinned formulae can block installs or upgrades when other formulae require a newer version
+* pinned casks may still update themselves outside Homebrew
 
 ### `$HOMEBREW_NO_AUTO_UPDATE`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -660,7 +660,7 @@ Show the version number for installed formulae, or only the specified formulae i
 Only show formulae with multiple versions installed\. Implies \fB\-\-versions\fP\&\.
 .TP
 \fB\-\-pinned\fP
-List only pinned formulae, or only the specified (pinned) formulae if \fIformula\fP are provided\. See also \fBpin\fP, \fBunpin\fP\&\.
+List only pinned packages, or only the specified (pinned) packages if \fIformula\fP or \fIcask\fP are provided\. See also \fBpin\fP, \fBunpin\fP\&\.
 .TP
 \fB\-\-installed\-on\-request\fP
 List the formulae installed on request\.
@@ -779,10 +779,16 @@ Also include outdated casks including those with \fBversion :latest\fP\&\.
 .TP
 \fB\-\-greedy\-auto\-updates\fP
 Also include outdated \fBauto_updates true\fP casks that would otherwise be skipped\.
-.SS "\fBpin\fP \fIinstalled_formula\fP \fR[\.\.\.]"
-Pin the specified \fIformula\fP, preventing them from being upgraded when issuing the \fBbrew upgrade\fP \fIformula\fP command\. See also \fBunpin\fP\&\.
+.SS "\fBpin\fP \fR[\fB\-\-formula\fP] \fR[\fB\-\-cask\fP] \fIinstalled_formula\fP|\fIinstalled_cask\fP \fR[\.\.\.]"
+Pin the specified package, preventing it from being upgraded when issuing the \fBbrew upgrade\fP \fIformula\fP or \fIcask\fP command\. See also \fBunpin\fP\&\.
 .P
-\fINote:\fP Other packages which depend on newer versions of a pinned formula might not install or run correctly\.
+\fINote:\fP Other packages which depend on newer versions of a pinned formula might not install or run correctly\. Pinned casks with \fBauto_updates true\fP may update themselves outside Homebrew\.
+.TP
+\fB\-\-formula\fP
+Treat all named arguments as formulae\.
+.TP
+\fB\-\-cask\fP
+Treat all named arguments as casks\.
 .SS "\fBpostinstall\fP, \fBpost_install\fP \fIinstalled_formula\fP \fR[\.\.\.]"
 Rerun the post\-install steps for \fIformula\fP\&\.
 .SS "\fBpyenv\-sync\fP"
@@ -1054,8 +1060,14 @@ Remove symlinks for \fIformula\fP from Homebrew\[u2019]s prefix\. This can be us
 .TP
 \fB\-n\fP, \fB\-\-dry\-run\fP
 List files which would be unlinked without actually unlinking or deleting any files\.
-.SS "\fBunpin\fP \fIinstalled_formula\fP \fR[\.\.\.]"
-Unpin \fIformula\fP, allowing them to be upgraded by \fBbrew upgrade\fP \fIformula\fP\&\. See also \fBpin\fP\&\.
+.SS "\fBunpin\fP \fR[\fB\-\-formula\fP] \fR[\fB\-\-cask\fP] \fIinstalled_formula\fP|\fIinstalled_cask\fP \fR[\.\.\.]"
+Unpin the specified package, allowing it to be upgraded by \fBbrew upgrade\fP \fIformula\fP or \fIcask\fP\&\. See also \fBpin\fP\&\.
+.TP
+\fB\-\-formula\fP
+Treat all named arguments as formulae\.
+.TP
+\fB\-\-cask\fP
+Treat all named arguments as casks\.
 .SS "\fBuntap\fP \fR[\fB\-\-force\fP] \fItap\fP \fR[\.\.\.]"
 Remove a tapped formula repository\.
 .TP
@@ -1085,7 +1097,7 @@ Fetch and reset Homebrew and all tap repositories (or any specified \fIrepositor
 .P
 \fINote:\fP this will destroy all your uncommitted or committed changes\.
 .SS "\fBupgrade\fP \fR[\fIoptions\fP] \fR[\fIinstalled_formula\fP|\fIinstalled_cask\fP \.\.\.]"
-Upgrade outdated casks and outdated, unpinned formulae using the same options they were originally installed with, plus any appended brew formula options\. If \fIcask\fP or \fIformula\fP are specified, upgrade only the given \fIcask\fP or \fIformula\fP kegs (unless they are pinned; see \fBpin\fP, \fBunpin\fP)\.
+Upgrade outdated, unpinned packages using the same options they were originally installed with, plus any appended brew formula options\. If \fIcask\fP or \fIformula\fP are specified, upgrade only the given \fIcask\fP or \fIformula\fP (unless they are pinned; see \fBpin\fP, \fBunpin\fP)\.
 .P
 Unless \fB$HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK\fP is set, \fBbrew upgrade\fP or \fBbrew reinstall\fP will be run for outdated dependents and dependents with broken linkage, respectively\.
 .P


### PR DESCRIPTION
- `brew pin` should cover casks now that upgrades skip both package types.
- Cask pin records keep list, info and upgrade output consistent.
- `auto_updates true` casks need a warning because app updaters bypass Homebrew.

Fixes https://github.com/Homebrew/brew/issues/12425
Fixes https://github.com/Homebrew/brew/issues/11860
Fixes https://github.com/Homebrew/brew/issues/4898

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing

-----
