### PR TITLE
Add parser subcommand scaffolding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,4 +57,5 @@ When running Ruby directly (e.g. `ruby -e ...`, `gem`, profiling tools), never u
 7. Keep diffs as minimal as possible.
 8. Prefer shelling out via `HOMEBREW_BREW_FILE` instead of requiring `cmd/` or `dev-cmd` when composing brew commands.
 9. Inline new or existing methods as methods or local variables unless they are reused 2+ times or needed for unit tests.
-10. Keep `extend/os/*` prepends as thin as possible; put the `prepend` in the OS-specific `linux` or `macos` file rather than the shared `extend/os/*` loader with an inline `if`, and prefer putting substantive logic in shared code outside `extend/` when practical so it can be tested on all platforms instead of relying on `:needs_linux` or `:needs_macos` specs.
+10. Avoid `T.must`; prefer explicit nil checks or APIs that return non-nil values.
+11. Keep `extend/os/*` prepends as thin as possible; put the `prepend` in the OS-specific `linux` or `macos` file rather than the shared `extend/os/*` loader with an inline `if`, and prefer putting substantive logic in shared code outside `extend/` when practical so it can be tested on all platforms instead of relying on `:needs_linux` or `:needs_macos` specs.

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -43,6 +43,7 @@ Style/Documentation:
     - Homebrew
   Include:
     - abstract_command.rb
+    - abstract_subcommand.rb
     - autobump_constants.rb
     - cask/cask.rb
     - cask/dsl.rb

--- a/Library/Homebrew/abstract_subcommand.rb
+++ b/Library/Homebrew/abstract_subcommand.rb
@@ -1,0 +1,99 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "cli/parser"
+require "abstract_command"
+require "utils/output"
+
+module Homebrew
+  # Subclass this to implement a subcommand for a `brew` command.
+  #
+  # @api public
+  class AbstractSubcommand
+    extend T::Helpers
+    include Utils::Output::Mixin
+
+    abstract!
+
+    class << self
+      sig { returns(String) }
+      def subcommand_name
+        require "utils"
+
+        class_name = name
+        raise TypeError, "anonymous subcommands do not have names" if class_name.nil?
+
+        Utils.underscore(class_name.split("::").fetch(-1))
+             .tr("_", "-")
+             .delete_suffix("-subcommand")
+      end
+
+      sig { params(command: T.class_of(Homebrew::AbstractCommand)).returns(T::Array[T.class_of(AbstractSubcommand)]) }
+      def subcommands_for(command)
+        namespace = "#{command.name}::"
+        subclasses.select do |subcommand|
+          subcommand.name&.start_with?(namespace)
+        end
+      end
+
+      sig { params(parser: CLI::Parser, command: T.class_of(Homebrew::AbstractCommand)).void }
+      def define_all(parser, command:)
+        subcommands_for(command).each do |subcommand|
+          subcommand.define(parser)
+        end
+      end
+
+      sig { params(parser: CLI::Parser).void }
+      def define(parser)
+        parser_block = @parser_block
+        raise TypeError, "subcommand arguments have not been defined" if parser_block.nil?
+
+        parser.subcommand(subcommand_name, aliases: @aliases || [], default: @default || false) do
+          instance_eval(&parser_block)
+        end
+      end
+
+      private
+
+      # The description and arguments of the subcommand should be defined within this block.
+      #
+      # @api public
+      sig { params(aliases: T::Array[String], default: T::Boolean, block: T.proc.bind(CLI::Parser).void).void }
+      def subcommand_args(aliases: [], default: false, &block)
+        @aliases = T.let(aliases, T.nilable(T::Array[String]))
+        @default = T.let(default, T.nilable(T::Boolean))
+        @parser_block = T.let(block, T.nilable(T.proc.void))
+      end
+    end
+
+    sig { returns(T.untyped) }
+    attr_reader :args
+
+    sig { params(args: T.untyped, context: T.untyped, targets: T.untyped, quiet: T::Boolean, cleanup: T::Boolean).void }
+    def initialize(args, context: nil, targets: nil, quiet: false, cleanup: true)
+      @args = args
+      @context = context
+      @targets = targets
+      @quiet = quiet
+      @cleanup = cleanup
+    end
+
+    sig { returns(T.untyped) }
+    attr_reader :context
+
+    sig { returns(T.untyped) }
+    attr_reader :targets
+
+    sig { returns(T::Boolean) }
+    attr_reader :quiet
+
+    sig { returns(T::Boolean) }
+    attr_reader :cleanup
+
+    # This method will be invoked when the subcommand is run.
+    #
+    # @api public
+    sig { abstract.void }
+    def run; end
+  end
+end

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -20,10 +20,23 @@ module Homebrew
       ArgType = T.type_alias { T.nilable(T.any(Symbol, T::Array[String], T::Array[Symbol])) }
       HIDDEN_DESC_PLACEHOLDER = "@@HIDDEN@@"
       SYMBOL_TO_USAGE_MAPPING = T.let({
+        service:       "<service>",
         text_or_regex: "<text>|`/`<regex>`/`",
         url:           "<URL>",
       }.freeze, T::Hash[Symbol, String])
       private_constant :ArgType, :HIDDEN_DESC_PLACEHOLDER, :SYMBOL_TO_USAGE_MAPPING
+
+      class Subcommand < T::Struct
+        const :name, String
+        const :aliases, T::Array[String], default: []
+        prop :description, T.nilable(String), default: nil
+        prop :usage_banner, T.nilable(String), default: nil
+        const :default, T::Boolean, default: false
+        prop :named_args_type, ArgType, default: nil
+        prop :max_named_args, T.nilable(Integer), default: nil
+        prop :min_named_args, T.nilable(Integer), default: nil
+        prop :named_args_without_api, T::Boolean, default: false
+      end
 
       sig { returns(Args) }
       attr_reader :args
@@ -34,8 +47,8 @@ module Homebrew
       sig { returns(T::Boolean) }
       attr_reader :hide_from_man_page
 
-      sig { returns(ArgType) }
-      attr_reader :named_args_type
+      sig { returns(T::Array[Subcommand]) }
+      attr_reader :subcommands
 
       sig { params(cmd_path: Pathname).returns(T.nilable(CLI::Parser)) }
       def self.from_cmd_path(cmd_path)
@@ -164,6 +177,9 @@ module Homebrew
         @constraints = T.let([], T::Array[[String, String]])
         @conflicts = T.let([], T::Array[T::Array[String]])
         @switch_sources = T.let({}, T::Hash[String, Symbol])
+        @option_sources = T.let({}, T::Hash[String, Symbol])
+        @option_subcommands = T.let({}, T::Hash[String, T::Array[String]])
+        @option_types = T.let({}, T::Hash[String, Symbol])
         @processed_options = T.let([], Args::OptionsType)
         @non_global_processed_options = T.let([], T::Array[[String, ArgType]])
         @named_args_type = T.let(nil, T.nilable(ArgType))
@@ -175,6 +191,8 @@ module Homebrew
         @hide_from_man_page = T.let(false, T::Boolean)
         @formula_options = T.let(false, T::Boolean)
         @cask_options = T.let(false, T::Boolean)
+        @subcommands = T.let([], T::Array[Subcommand])
+        @current_subcommands = T.let(nil, T.nilable(T::Array[String]))
 
         self.class.global_options.each do |short, long, desc|
           switch short, long, description: desc, env: option_to_name(long), method: :on_tail
@@ -189,12 +207,14 @@ module Homebrew
         params(names: String, description: T.nilable(String), env: T.untyped,
                depends_on: T.nilable(String), method: Symbol,
                hidden: T::Boolean, replacement: T.nilable(T.any(String, FalseClass)),
-               odeprecated: T::Boolean, odisabled: T::Boolean, disable: T::Boolean).void
+               odeprecated: T::Boolean, odisabled: T::Boolean, disable: T::Boolean,
+               subcommands: T.nilable(T.any(String, T::Array[String]))).void
       }
       def switch(*names, description: nil, env: nil,
                  depends_on: nil, method: :on,
                  hidden: false, replacement: nil,
-                 odeprecated: false, odisabled: false, disable: false)
+                 odeprecated: false, odisabled: false, disable: false,
+                 subcommands: nil)
         global_switch = names.first.is_a?(Symbol)
         return if global_switch
 
@@ -215,10 +235,14 @@ module Homebrew
         env, counterpart = env
         env_hidden = Homebrew::EnvConfig::ENVS.fetch(:"HOMEBREW_#{env.upcase}", {}).fetch(:hidden, false) if env
         if env && @non_global_processed_options.any? && !hidden && !env_hidden
-          affix = counterpart ? " and `#{counterpart}` is passed." : "."
+          affix = if counterpart
+            " and `#{counterpart}` is passed."
+          else
+            "."
+          end
           description += " Enabled by default if `$HOMEBREW_#{env.upcase}` is set#{affix}"
         end
-        process_option(*names, description, type: :switch, hidden:) unless odisabled
+        process_option(*names, description, type: :switch, hidden:, subcommands:) unless odisabled
 
         @parser.public_send(method, *names, *wrap_option_desc(description)) do |value|
           # This odeprecated should stick around indefinitely.
@@ -250,27 +274,63 @@ module Homebrew
 
       sig { params(text: String).void }
       def usage_banner(text)
-        @usage_banner, @description = text.chomp.split("\n\n", 2)
+        banner, description = text.chomp.split("\n\n", 2)
+
+        if @current_subcommands.present?
+          subcommand_description = description
+          if subcommand_description.blank?
+            usage_banner_lines = text.chomp.lines
+            subcommand_description = usage_banner_lines.drop(1).join if usage_banner_lines.size > 1
+          end
+
+          @current_subcommands.each do |subcommand_name|
+            subcommand = subcommand_for_name(subcommand_name)
+            raise ArgumentError, "unknown subcommand: #{subcommand_name}" if subcommand.nil?
+
+            subcommand.usage_banner = text.chomp
+            next if subcommand.description.present? || subcommand_description.blank?
+
+            subcommand.description = subcommand_description.lines.first&.chomp
+          end
+          return
+        end
+
+        @usage_banner = banner
+        @description = description
       end
 
       sig { returns(T.nilable(String)) }
       def usage_banner_text = @parser.banner
 
-      sig { params(name: String, description: T.nilable(String), hidden: T::Boolean).void }
-      def comma_array(name, description: nil, hidden: false)
+      sig { returns(ArgType) }
+      def named_args_type
+        return @named_args_type if @subcommands.empty?
+
+        subcommand_names
+      end
+
+      sig {
+        params(name: String, description: T.nilable(String), hidden: T::Boolean,
+               subcommands: T.nilable(T.any(String, T::Array[String]))).void
+      }
+      def comma_array(name, description: nil, hidden: false, subcommands: nil)
         name = name.chomp "="
         description = option_description(description, name, hidden:)
-        process_option(name, description, type: :comma_array, hidden:)
+        process_option(name, description, type: :comma_array, hidden:, subcommands:)
         @parser.on(name, OptionParser::REQUIRED_ARGUMENT, Array, *wrap_option_desc(description)) do |list|
-          set_args_method(option_to_name(name).to_sym, list)
+          option_name = option_to_name(name)
+          @option_sources[option_name] = :args
+          @option_types[option_name] ||= :comma_array
+          set_args_method(option_name.to_sym, list)
         end
       end
 
       sig {
         params(names: String, description: T.nilable(String), replacement: T.nilable(T.any(Symbol, String)),
-               depends_on: T.nilable(String), hidden: T::Boolean).void
+               depends_on: T.nilable(String), hidden: T::Boolean,
+               subcommands: T.nilable(T.any(String, T::Array[String]))).void
       }
-      def flag(*names, description: nil, replacement: nil, depends_on: nil, hidden: false)
+      def flag(*names, description: nil, replacement: nil, depends_on: nil, hidden: false, subcommands: nil)
         required, flag_type = if names.any? { |name| name.end_with? "=" }
           [OptionParser::REQUIRED_ARGUMENT, :required_flag]
         else
@@ -279,7 +339,7 @@ module Homebrew
         names.map! { |name| name.chomp "=" }
         description = option_description(description, *names, hidden:)
         if replacement.nil?
-          process_option(*names, description, type: flag_type, hidden:)
+          process_option(*names, description, type: flag_type, hidden:, subcommands:)
         else
           description += " (disabled#{"; replaced by #{replacement}" if replacement.present?})"
         end
@@ -287,7 +347,10 @@ module Homebrew
           # This odisabled should stick around indefinitely.
           odisabled "the `#{names.first}` flag", replacement unless replacement.nil?
           names.each do |name|
-            set_args_method(option_to_name(name).to_sym, option_value)
+            option_name = option_to_name(name)
+            @option_sources[option_name] = :args
+            @option_types[option_name] ||= flag_type
+            set_args_method(option_name.to_sym, option_value)
           end
         end
 
@@ -309,6 +372,8 @@ module Homebrew
 
       sig { params(options: String).returns(T::Array[T::Array[String]]) }
       def conflicts(*options)
+        return @conflicts if options.empty?
+
         @conflicts << options.map { |option| option_to_name(option) }
       end
 
@@ -420,10 +485,25 @@ module Homebrew
           end
           check_constraint_violations
           check_named_args(named_args)
+          check_subcommand_violations(named_args)
         end
 
+        if @subcommands.present?
+          parsed_subcommand = subcommand_name(named_args)
+          set_args_method(:subcommand, parsed_subcommand)
+          named_args = if parsed_subcommand && named_args.present?
+            named_args.drop(1)
+          else
+            []
+          end
+        end
         @args.freeze_named_args!(named_args, cask_options: @cask_options, without_api: @named_args_without_api)
-        @args.freeze_remaining_args!(non_options.empty? ? remaining : [*remaining, "--", non_options])
+        remaining_args = if non_options.empty?
+          remaining
+        else
+          [*remaining, "--", non_options]
+        end
+        @args.freeze_remaining_args!(remaining_args)
         @args.freeze_processed_options!(@processed_options)
         @args.freeze
 
@@ -451,7 +531,7 @@ module Homebrew
                  .gsub(/`(.*?)`/m, "#{Tty.bold}\\1#{Tty.reset}")
                  .gsub(%r{<([^\s]+?://[^\s]+?)>}) { |url| Formatter.url(url) }
                  .gsub(/\*(.*?)\*|<(.*?)>/m) do |underlined|
-                   T.must(underlined[1...-1]).gsub(/^(\s*)(.*?)$/, "\\1#{Tty.underline}\\2#{Tty.reset}")
+                   underlined[1...-1].to_s.gsub(/^(\s*)(.*?)$/, "\\1#{Tty.underline}\\2#{Tty.reset}")
                  end
       end
 
@@ -486,6 +566,25 @@ module Homebrew
           raise ArgumentError, "Do not specify both `number`, `min` or `max` with `named_args :none`"
         end
 
+        if @current_subcommands.present?
+          @current_subcommands.each do |subcommand_name|
+            subcommand = subcommand_for_name(subcommand_name)
+            raise ArgumentError, "unknown subcommand: #{subcommand_name}" if subcommand.nil?
+
+            subcommand.named_args_type = type
+            if type == :none
+              subcommand.max_named_args = 0
+            elsif number
+              subcommand.min_named_args = subcommand.max_named_args = number
+            elsif min || max
+              subcommand.min_named_args = min
+              subcommand.max_named_args = max
+            end
+            subcommand.named_args_without_api = without_api
+          end
+          return
+        end
+
         @named_args_type = type
 
         if type == :none
@@ -503,6 +602,79 @@ module Homebrew
       sig { void }
       def hide_from_man_page!
         @hide_from_man_page = true
+      end
+
+      sig {
+        params(
+          name:        String,
+          aliases:     T::Array[String],
+          description: T.nilable(String),
+          default:     T::Boolean,
+          block:       T.nilable(T.proc.bind(Parser).void),
+        ).void
+      }
+      def subcommand(name, aliases: [], description: nil, default: false, &block)
+        previous_subcommands = @current_subcommands
+
+        @subcommands << Subcommand.new(
+          name:,
+          aliases:,
+          description:,
+          default:,
+        )
+
+        @current_subcommands = [name]
+        instance_eval(&block) if block
+      ensure
+        @current_subcommands = previous_subcommands
+      end
+
+      sig { returns(T::Array[String]) }
+      def subcommand_names = @subcommands.map(&:name)
+
+      sig { returns(T.nilable(Subcommand)) }
+      def default_subcommand = @subcommands.find(&:default)
+
+      sig { params(name: String).returns(T.nilable(Subcommand)) }
+      def subcommand_for_name(name)
+        @subcommands.find { |subcommand| subcommand.name == name || subcommand.aliases.include?(name) }
+      end
+
+      sig { params(subcommand_name: T.nilable(String)).returns(Args::OptionsType) }
+      def processed_options_for_subcommand(subcommand_name)
+        subcommand = if subcommand_name
+          subcommand_for_name(subcommand_name)
+        else
+          default_subcommand
+        end
+        canonical_subcommand = subcommand&.name
+
+        @processed_options.select do |short, long|
+          [short, long].compact.any? do |option|
+            option_allowed_for_subcommand?(option_to_name(option), canonical_subcommand)
+          end
+        end
+      end
+
+      sig { params(subcommand_name: String).returns(ArgType) }
+      def named_args_type_for_subcommand(subcommand_name)
+        subcommand_for_name(subcommand_name)&.named_args_type
+      end
+
+      sig { params(named_args: T::Array[String]).returns(T.nilable(String)) }
+      def subcommand_name(named_args)
+        subcommand = if named_args.empty?
+          default_subcommand
+        else
+          subcommand_for_name(named_args.fetch(0))
+        end
+
+        subcommand&.name
+      end
+
+      sig { params(option: String).returns(T::Array[String]) }
+      def subcommands_for_option(option)
+        @option_subcommands.fetch(option_to_name(option), [])
       end
 
       private
@@ -570,7 +742,7 @@ module Homebrew
         @parser.banner = <<~BANNER
           #{@usage_banner}
 
-          #{@description}
+          #{usage_description_text}
 
         BANNER
       end
@@ -578,8 +750,11 @@ module Homebrew
       sig { params(names: String, value: T.untyped, from: Symbol).void }
       def set_switch(*names, value:, from:)
         names.each do |name|
-          @switch_sources[option_to_name(name)] = from
-          set_args_method(:"#{option_to_name(name)}?", value)
+          option_name = option_to_name(name)
+          @switch_sources[option_name] = from
+          @option_sources[option_name] = from
+          @option_types[option_name] ||= :switch
+          set_args_method(:"#{option_name}?", value)
         end
       end
 
@@ -669,33 +844,119 @@ module Homebrew
         check_constraints
       end
 
-      sig { params(args: T::Array[String]).void }
-      def check_named_args(args)
-        types = Array(@named_args_type).filter_map do |type|
+      sig { params(args: T::Array[String], type: ArgType, min: T.nilable(Integer), max: T.nilable(Integer)).void }
+      def check_named_args_count(args, type, min, max)
+        types = Array(type).filter_map do |type|
           next type if type.is_a? Symbol
 
           :subcommand
         end.uniq
 
-        exception = if @min_named_args && @max_named_args && @min_named_args == @max_named_args &&
-                       args.size != @max_named_args
-          NumberOfNamedArgumentsError.new(@min_named_args, types:)
-        elsif @min_named_args && args.size < @min_named_args
-          MinNamedArgumentsError.new(@min_named_args, types:)
-        elsif @max_named_args && args.size > @max_named_args
-          MaxNamedArgumentsError.new(@max_named_args, types:)
+        exception = if min && max && min == max && args.size != max
+          NumberOfNamedArgumentsError.new(min, types:)
+        elsif min && args.size < min
+          MinNamedArgumentsError.new(min, types:)
+        elsif max && args.size > max
+          MaxNamedArgumentsError.new(max, types:)
         end
 
         raise exception if exception
       end
 
-      sig { params(args: String, type: Symbol, hidden: T::Boolean).void }
-      def process_option(*args, type:, hidden: false)
+      sig { params(args: T::Array[String]).void }
+      def check_named_args(args)
+        check_named_args_count(args, @named_args_type, @min_named_args, @max_named_args)
+      end
+
+      sig { params(args: T::Array[String]).void }
+      def check_subcommand_violations(args)
+        return if @subcommands.empty?
+
+        subcommand = if args.empty?
+          default_subcommand
+        else
+          subcommand_for_name(args.fetch(0))
+        end
+        raise UsageError, "unknown subcommand: `#{args.first}`" if subcommand.nil? && args.present?
+        return if subcommand.nil?
+
+        subcommand_args = if args.empty?
+          args
+        else
+          args.drop(1)
+        end
+        check_named_args_count(subcommand_args, subcommand.named_args_type, subcommand.min_named_args,
+                               subcommand.max_named_args)
+        @option_sources.each do |option, source|
+          next if source == :env
+          next if option_allowed_for_subcommand?(option, subcommand.name)
+
+          option_type = @option_types.fetch(option)
+          option_type_name = if option_type == :switch
+            "switch"
+          else
+            "flag"
+          end
+          raise UsageError, "The `#{subcommand.name}` subcommand does not accept the `#{name_to_option(option)}` " \
+                            "#{option_type_name}."
+        end
+      end
+
+      sig { returns(String) }
+      def usage_description_text
+        parts = T.let([], T::Array[String])
+        parts << @description if @description.present?
+        @subcommands.each do |subcommand|
+          usage_banner = subcommand.usage_banner
+          parts << usage_banner if usage_banner.present?
+        end
+        parts.join("\n\n")
+      end
+
+      sig { params(option: String, subcommand_name: T.nilable(String)).returns(T::Boolean) }
+      def option_allowed_for_subcommand?(option, subcommand_name)
+        subcommands = @option_subcommands[option]
+        return true if subcommands.blank?
+
+        subcommand_name.present? && subcommands.include?(subcommand_name)
+      end
+
+      sig { params(subcommands: T.nilable(T.any(String, T::Array[String]))).returns(T.nilable(T::Array[String])) }
+      def effective_subcommands(subcommands)
+        return @current_subcommands if subcommands.nil?
+
+        Array(subcommands).map do |subcommand|
+          subcommand_for_name(subcommand)&.name || subcommand
+        end
+      end
+
+      sig {
+        params(option_names: T::Array[String], type: Symbol,
+               subcommands: T.nilable(T.any(String, T::Array[String]))).void
+      }
+      def record_option_metadata(option_names, type:, subcommands:)
+        option_names.each do |name|
+          option_name = option_to_name(name)
+          @option_types[option_name] = type
+          effective_subcommands = effective_subcommands(subcommands)
+          next if effective_subcommands.blank?
+
+          @option_subcommands[option_name] = (@option_subcommands[option_name] || []) |
+                                             effective_subcommands
+        end
+      end
+
+      sig {
+        params(args: String, type: Symbol, hidden: T::Boolean,
+               subcommands: T.nilable(T.any(String, T::Array[String]))).void
+      }
+      def process_option(*args, type:, hidden: false, subcommands: nil)
         option, = @parser.make_switch(args)
         @processed_options.reject! { |existing| existing.second == option.long.first } if option.long.first.present?
         @processed_options << [option.short.first, option.long.first, option.desc.first, hidden]
 
         args.pop # last argument is the description
+        record_option_metadata(args, type:, subcommands:)
         if type == :switch
           disable_switch(*args)
         else

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -212,18 +212,21 @@ module Commands
     external_commands_file.atomic_write("#{external_commands.sort.join("\n")}\n")
   end
 
-  sig { params(command: String).returns(T.nilable(T::Array[[String, String]])) }
-  def self.command_options(command)
+  sig { params(command: String, subcommand: T.nilable(String)).returns(T.nilable(T::Array[[String, String]])) }
+  def self.command_options(command, subcommand: nil)
     return if command == "help"
 
     path = self.path(command)
     return if path.blank?
 
     if (cmd_parser = Homebrew::CLI::Parser.from_cmd_path(path))
-      cmd_parser.processed_options.filter_map do |short, long, desc, hidden|
+      cmd_parser.processed_options_for_subcommand(subcommand).filter_map do |short, long, desc, hidden|
         next if hidden
 
-        [T.must(long || short), desc]
+        option = long || short
+        next if option.nil?
+
+        [option, desc]
       end
     else
       options = []
@@ -258,7 +261,9 @@ module Commands
         match_data = /^#:  (?<desc>\w.*+)$/.match(line)
         next unless match_data
 
-        desc = T.must(match_data[:desc])
+        desc = match_data[:desc]
+        next if desc.nil?
+
         return desc.split(DESCRIPTION_SPLITTING_PATTERN).first if short
 
         return desc
@@ -267,15 +272,34 @@ module Commands
     end
   end
 
-  sig { params(command: String).returns(T.nilable(T.any(T::Array[Symbol], T::Array[String]))) }
-  def self.named_args_type(command)
+  sig { params(command: String).returns(T::Array[Homebrew::CLI::Parser::Subcommand]) }
+  def self.command_subcommands(command)
+    path = self.path(command)
+    return [] if path.blank?
+
+    cmd_parser = Homebrew::CLI::Parser.from_cmd_path(path)
+    return [] if cmd_parser.blank?
+
+    cmd_parser.subcommands
+  end
+
+  sig {
+    params(command: String, subcommand: T.nilable(String))
+      .returns(T.nilable(T.any(T::Array[Symbol], T::Array[String])))
+  }
+  def self.named_args_type(command, subcommand: nil)
     path = self.path(command)
     return if path.blank?
 
     cmd_parser = Homebrew::CLI::Parser.from_cmd_path(path)
     return if cmd_parser.blank?
 
-    Array(cmd_parser.named_args_type)
+    args_type = if subcommand
+      cmd_parser.named_args_type_for_subcommand(subcommand)
+    else
+      cmd_parser.named_args_type
+    end
+    Array(args_type)
   end
 
   # Returns the conflicts of a given `option` for `command`.

--- a/Library/Homebrew/completions.rb
+++ b/Library/Homebrew/completions.rb
@@ -39,6 +39,7 @@ module Homebrew
       command:           "__brew_complete_commands",
       diagnostic_check:  '__brewcomp "${__HOMEBREW_DOCTOR_CHECKS=$(brew doctor --list-checks)}"',
       file:              "__brew_complete_files",
+      service:           "__brew_complete_services",
     }.freeze, T::Hash[Symbol, String])
 
     ZSH_NAMED_ARGS_COMPLETION_FUNCTION_MAPPING = T.let({
@@ -53,6 +54,7 @@ module Homebrew
       command:           "__brew_commands",
       diagnostic_check:  "__brew_diagnostic_checks",
       file:              "__brew_formulae_or_ruby_files",
+      service:           "__brew_services",
     }.freeze, T::Hash[Symbol, String])
 
     FISH_NAMED_ARGS_COMPLETION_FUNCTION_MAPPING = T.let({
@@ -66,6 +68,7 @@ module Homebrew
       installed_tap:     "__fish_brew_suggest_taps_installed",
       command:           "__fish_brew_suggest_commands",
       diagnostic_check:  "__fish_brew_suggest_diagnostic_checks",
+      service:           "__fish_brew_suggest_services",
     }.freeze, T::Hash[Symbol, String])
 
     sig { void }
@@ -132,7 +135,12 @@ module Homebrew
 
     sig { params(command: String).returns(T::Boolean) }
     def self.command_gets_completions?(command)
-      command_options(command).any?
+      command_options(command).any? || Commands.command_subcommands(command).any?
+    end
+
+    sig { params(subcommands: T::Array[Homebrew::CLI::Parser::Subcommand]).returns(T::Array[String]) }
+    def self.subcommand_completion_names(subcommands)
+      subcommands.flat_map { |subcommand| [subcommand.name, *subcommand.aliases] }
     end
 
     sig { params(description: String, fish: T::Boolean).returns(String) }
@@ -145,10 +153,10 @@ module Homebrew
       description.gsub(/[<>]/, "").tr("\n", " ").chomp(".")
     end
 
-    sig { params(command: String).returns(T::Hash[String, String]) }
-    def self.command_options(command)
+    sig { params(command: String, subcommand: T.nilable(String)).returns(T::Hash[String, String]) }
+    def self.command_options(command, subcommand: nil)
       options = {}
-      Commands.command_options(command)&.each do |option|
+      Commands.command_options(command, subcommand:)&.each do |option|
         next if option.blank?
 
         name = option.first
@@ -163,22 +171,99 @@ module Homebrew
       options
     end
 
+    sig { params(types: T.nilable(T::Array[T.any(Symbol, String)])).returns(String) }
+    def self.generate_bash_named_args_completion(types)
+      named_completion_string = ""
+      return named_completion_string if types.blank?
+
+      named_args_strings, named_args_types = types.partition { |type| type.is_a? String }
+
+      T.cast(named_args_types, T::Array[Symbol]).each do |type|
+        next unless BASH_NAMED_ARGS_COMPLETION_FUNCTION_MAPPING.key? type
+
+        named_completion_string += "\n  #{BASH_NAMED_ARGS_COMPLETION_FUNCTION_MAPPING[type]}"
+      end
+
+      named_completion_string += "\n  __brewcomp \"#{named_args_strings.join(" ")}\"" if named_args_strings.any?
+      named_completion_string
+    end
+
+    sig { params(command: String, subcommands: T::Array[Homebrew::CLI::Parser::Subcommand]).returns(String) }
+    def self.generate_bash_nested_subcommand_completion(command, subcommands)
+      default_subcommand = subcommands.find(&:default)&.name
+      top_level_options = command_options(command, subcommand: default_subcommand).keys.sort.join("\n          ")
+      subcommand_names = subcommand_completion_names(subcommands).join(" ")
+      subcommand_cases = subcommands.map do |subcommand|
+        "      #{([subcommand.name] + subcommand.aliases).join("|")}) subcommand=\"#{subcommand.name}\"; break ;;"
+      end.join("\n")
+      option_cases = subcommands.map do |subcommand|
+        options = command_options(command, subcommand: subcommand.name).keys.sort.join("\n        ")
+        <<~EOS
+          #{subcommand.name})
+                  __brewcomp "
+                  #{options}
+                  "
+                  return
+                  ;;
+        EOS
+      end.join
+      named_arg_cases = subcommands.filter_map do |subcommand|
+        named_completion_string = generate_bash_named_args_completion(
+          Commands.named_args_type(command, subcommand: subcommand.name),
+        )
+        next if named_completion_string.blank?
+
+        <<~EOS
+          #{subcommand.name})#{named_completion_string}
+                  ;;
+        EOS
+      end.join
+
+      <<~COMPLETION
+        _brew_#{Commands.method_name command}() {
+          local cur="${COMP_WORDS[COMP_CWORD]}"
+          local subcommand=""
+          local i
+          for (( i = 2; i < COMP_CWORD; i++ ))
+          do
+            case "${COMP_WORDS[i]}" in
+        #{subcommand_cases}
+              *) ;;
+            esac
+          done
+          case "${cur}" in
+            -*)
+              case "${subcommand}" in
+                "")
+                  __brewcomp "
+                  #{top_level_options}
+                  "
+                  return
+                  ;;
+        #{option_cases.chomp}
+              esac
+              ;;
+            *) ;;
+          esac
+          case "${subcommand}" in
+            "")
+              __brewcomp "#{subcommand_names}"
+              ;;
+        #{named_arg_cases.chomp}
+            *) ;;
+          esac
+        }
+      COMPLETION
+    end
+
     sig { params(command: String).returns(T.nilable(String)) }
     def self.generate_bash_subcommand_completion(command)
       return unless command_gets_completions? command
 
-      named_completion_string = ""
-      if (types = Commands.named_args_type(command))
-        named_args_strings, named_args_types = types.partition { |type| type.is_a? String }
+      subcommands = Commands.command_subcommands(command)
+      return generate_bash_nested_subcommand_completion(command, subcommands) if subcommands.present?
 
-        T.cast(named_args_types, T::Array[Symbol]).each do |type|
-          next unless BASH_NAMED_ARGS_COMPLETION_FUNCTION_MAPPING.key? type
-
-          named_completion_string += "\n  #{BASH_NAMED_ARGS_COMPLETION_FUNCTION_MAPPING[type]}"
-        end
-
-        named_completion_string += "\n  __brewcomp \"#{named_args_strings.join(" ")}\"" if named_args_strings.any?
-      end
+      named_completion_string = generate_bash_named_args_completion(Commands.named_args_type(command))
 
       <<~COMPLETION
         _brew_#{Commands.method_name command}() {
@@ -212,14 +297,46 @@ module Homebrew
       ERB.new((TEMPLATE_DIR/"bash.erb").read, trim_mode: ">").result(variables.instance_eval { binding })
     end
 
+    sig { params(opt: String).returns(String) }
+    def self.format_zsh_argument(opt)
+      if opt.start_with?("- ")
+        opt
+      else
+        "'#{opt}'"
+      end
+    end
+
     sig { params(command: String).returns(T.nilable(String)) }
     def self.generate_zsh_subcommand_completion(command)
       return unless command_gets_completions? command
 
+      subcommands = Commands.command_subcommands(command)
+      return generate_zsh_nested_subcommand_completion(command, subcommands) if subcommands.present?
+
       options = command_options(command)
+      options = generate_zsh_arguments(command, options, Commands.named_args_type(command))
+
+      <<~COMPLETION
+        # brew #{command}
+        _brew_#{Commands.method_name command}() {
+          _arguments \\
+            #{options.map! { |opt| format_zsh_argument(opt) }.join(" \\\n    ")}
+        }
+      COMPLETION
+    end
+
+    sig {
+      params(
+        command: String,
+        options: T::Hash[String, String],
+        types:   T.nilable(T::Array[T.any(Symbol, String)]),
+      ).returns(T::Array[String])
+    }
+    def self.generate_zsh_arguments(command, options, types)
+      options = options.dup
 
       args_options = []
-      if (types = Commands.named_args_type(command))
+      if types
         named_args_strings, named_args_types = types.partition { |type| type.is_a? String }
 
         T.cast(named_args_types, T::Array[Symbol]).each do |type|
@@ -256,11 +373,61 @@ module Homebrew
       end
       options += args_options
 
+      options
+    end
+
+    sig { params(command: String, subcommands: T::Array[Homebrew::CLI::Parser::Subcommand]).returns(String) }
+    def self.generate_zsh_nested_subcommand_completion(command, subcommands)
+      subcommand_descriptions = subcommands.flat_map do |subcommand|
+        description = subcommand.description
+        ([subcommand.name] + subcommand.aliases).map do |subcommand_name|
+          if description.present?
+            "'#{subcommand_name}:#{format_description(description)}'"
+          else
+            "'#{subcommand_name}'"
+          end
+        end
+      end.join("\n    ")
+
+      subcommand_cases = subcommands.map do |subcommand|
+        names = ([subcommand.name] + subcommand.aliases).join("|")
+        options = generate_zsh_arguments(
+          command,
+          command_options(command, subcommand: subcommand.name),
+          Commands.named_args_type(command, subcommand: subcommand.name),
+        )
+        <<~EOS
+          #{names})
+                  _arguments \\
+                    #{options.map! { |opt| format_zsh_argument(opt) }.join(" \\\n          ")}
+                  ;;
+        EOS
+      end.join
+
       <<~COMPLETION
         # brew #{command}
         _brew_#{Commands.method_name command}() {
-          _arguments \\
-            #{options.map! { |opt| opt.start_with?("- ") ? opt : "'#{opt}'" }.join(" \\\n    ")}
+          local state
+          local -a subcommands
+          subcommands=(
+            #{subcommand_descriptions}
+          )
+
+          _arguments -C \\
+            '1:subcommand:->subcommand' \\
+            '*::arg:->args'
+
+          case "$state" in
+            subcommand)
+              _describe -t subcommands 'subcommand' subcommands
+              ;;
+            args)
+              case "$words[2]" in
+        #{subcommand_cases.chomp}
+                *) ;;
+              esac
+              ;;
+          esac
         }
       COMPLETION
     end
@@ -304,6 +471,9 @@ module Homebrew
     def self.generate_fish_subcommand_completion(command)
       return unless command_gets_completions? command
 
+      subcommands = Commands.command_subcommands(command)
+      return generate_fish_nested_subcommand_completion(command, subcommands) if subcommands.present?
+
       command_description = format_description Commands.command_description(command, short: true).to_s, fish: true
       lines = if COMPLETIONS_EXCLUSION_LIST.include?(command)
         []
@@ -346,6 +516,92 @@ module Homebrew
       end
 
       lines += subcommands + options + named_args
+      <<~COMPLETION
+        #{lines.join("\n").chomp}
+      COMPLETION
+    end
+
+    sig {
+      params(command: String, types: T.nilable(T::Array[T.any(Symbol, String)]),
+             subcommand: T.nilable(String)).returns(T::Array[String])
+    }
+    def self.generate_fish_named_args(command, types, subcommand: nil)
+      named_args = []
+      return named_args if types.blank?
+
+      named_args_strings, named_args_types = types.partition { |type| type.is_a? String }
+
+      T.cast(named_args_types, T::Array[Symbol]).each do |type|
+        next unless FISH_NAMED_ARGS_COMPLETION_FUNCTION_MAPPING.key? type
+
+        named_arg_function = FISH_NAMED_ARGS_COMPLETION_FUNCTION_MAPPING[type]
+        if subcommand
+          named_args << "__fish_brew_complete_sub_arg '#{command}' '#{subcommand}' -a '(#{named_arg_function})'"
+          next
+        end
+
+        named_arg_prefix = "__fish_brew_complete_arg '#{command}; and not __fish_seen_argument"
+
+        formula_option = command_options(command).key?("--formula")
+        cask_option = command_options(command).key?("--cask")
+
+        named_args << if formula_option && cask_option && type.to_s.end_with?("formula")
+          "#{named_arg_prefix} -l cask -l casks' -a '(#{named_arg_function})'"
+        elsif formula_option && cask_option && type.to_s.end_with?("cask")
+          "#{named_arg_prefix} -l formula -l formulae' -a '(#{named_arg_function})'"
+        else
+          "__fish_brew_complete_arg '#{command}' -a '(#{named_arg_function})'"
+        end
+      end
+
+      return named_args if subcommand
+
+      named_args_strings.map do |named_arg_string|
+        "__fish_brew_complete_sub_cmd '#{command}' '#{named_arg_string}'"
+      end + named_args
+    end
+
+    sig { params(command: String, subcommands: T::Array[Homebrew::CLI::Parser::Subcommand]).returns(String) }
+    def self.generate_fish_nested_subcommand_completion(command, subcommands)
+      command_description = format_description Commands.command_description(command, short: true).to_s, fish: true
+      lines = if COMPLETIONS_EXCLUSION_LIST.include?(command)
+        []
+      else
+        ["__fish_brew_complete_cmd '#{command}' '#{command_description}'"]
+      end
+
+      subcommands.each do |subcommand|
+        description = subcommand.description
+        ([subcommand.name] + subcommand.aliases).each do |subcommand_name|
+          line = "__fish_brew_complete_sub_cmd '#{command}' '#{subcommand_name}'"
+          line += " '#{format_description(description, fish: true)}'" if description.present?
+          lines << line
+        end
+      end
+
+      default_subcommand = subcommands.find(&:default)&.name
+      lines += command_options(command, subcommand: default_subcommand).sort.filter_map do |opt, desc|
+        arg_line = "__fish_brew_complete_arg '#{command}; and [ (count (__fish_brew_args)) = 1 ]' " \
+                   "-l #{opt.sub(/^-+/, "")}"
+        arg_line += " -d '#{format_description desc, fish: true}'" if desc.present?
+        arg_line
+      end
+
+      subcommands.each do |subcommand|
+        subcommand_names = ([subcommand.name] + subcommand.aliases).join(" ")
+        lines += command_options(command, subcommand: subcommand.name).sort.filter_map do |opt, desc|
+          arg_line = "__fish_brew_complete_sub_arg '#{command}' '#{subcommand_names}' " \
+                     "-l #{opt.sub(/^-+/, "")}"
+          arg_line += " -d '#{format_description desc, fish: true}'" if desc.present?
+          arg_line
+        end
+        lines += generate_fish_named_args(
+          command,
+          Commands.named_args_type(command, subcommand: subcommand.name),
+          subcommand: subcommand_names,
+        )
+      end
+
       <<~COMPLETION
         #{lines.join("\n").chomp}
       COMPLETION

--- a/Library/Homebrew/completions/bash.erb
+++ b/Library/Homebrew/completions/bash.erb
@@ -3,7 +3,9 @@
 #
 # - For changes to a command under `COMMANDS` or `DEVELOPER COMMANDS` sections):
 #   - Find the source file in `Library/Homebrew/[dev-]cmd/<command>.{rb,sh}`.
-#   - For `.rb` files, edit the `cmd_args` block.
+#   - For `.rb` files, edit the `cmd_args` block. For subcommand metadata,
+#     edit `Library/Homebrew/<command>/subcommand.rb` and
+#     `Library/Homebrew/<command>/subcommand/*.rb` if they exist.
 #   - For `.sh` files, edit the top comment, being sure to use the line prefix
 #     `#:` for the comments to be recognized as documentation. If in doubt,
 #     compare with already documented commands.

--- a/Library/Homebrew/completions/fish.erb
+++ b/Library/Homebrew/completions/fish.erb
@@ -3,7 +3,9 @@
 #
 # - For changes to a command under `COMMANDS` or `DEVELOPER COMMANDS` sections):
 #   - Find the source file in `Library/Homebrew/[dev-]cmd/<command>.{rb,sh}`.
-#   - For `.rb` files, edit the `cmd_args` block.
+#   - For `.rb` files, edit the `cmd_args` block. For subcommand metadata,
+#     edit `Library/Homebrew/<command>/subcommand.rb` and
+#     `Library/Homebrew/<command>/subcommand/*.rb` if they exist.
 #   - For `.sh` files, edit the top comment, being sure to use the line prefix
 #     `#:` for the comments to be recognized as documentation. If in doubt,
 #     compare with already documented commands.

--- a/Library/Homebrew/completions/zsh.erb
+++ b/Library/Homebrew/completions/zsh.erb
@@ -3,7 +3,9 @@
 #
 # - For changes to a command under `COMMANDS` or `DEVELOPER COMMANDS` sections):
 #   - Find the source file in `Library/Homebrew/[dev-]cmd/<command>.{rb,sh}`.
-#   - For `.rb` files, edit the `cmd_args` block.
+#   - For `.rb` files, edit the `cmd_args` block. For subcommand metadata,
+#     edit `Library/Homebrew/<command>/subcommand.rb` and
+#     `Library/Homebrew/<command>/subcommand/*.rb` if they exist.
 #   - For `.sh` files, edit the top comment, being sure to use the line prefix
 #     `#:` for the comments to be recognized as documentation. If in doubt,
 #     compare with already documented commands.

--- a/Library/Homebrew/manpages.rb
+++ b/Library/Homebrew/manpages.rb
@@ -196,7 +196,11 @@ module Homebrew
       ).returns(String)
     }
     def self.generate_option_doc(short, long, desc)
-      comma = (short && long) ? ", " : ""
+      comma = if short && long
+        ", "
+      else
+        ""
+      end
       <<~EOS
         #{format_opt(short)}#{comma}#{format_opt(long)}
 

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -3,7 +3,9 @@
 #
 # - For changes to a command under `COMMANDS` or `DEVELOPER COMMANDS` sections):
 #   - Find the source file in `Library/Homebrew/[dev-]cmd/<command>.{rb,sh}`.
-#   - For `.rb` files, edit the `<command>_args` method.
+#   - For `.rb` files, edit the `cmd_args` block. For subcommand metadata,
+#     edit `Library/Homebrew/<command>/subcommand.rb` and
+#     `Library/Homebrew/<command>/subcommand/*.rb` if they exist.
 #   - For `.sh` files, edit the top comment, being sure to use the line prefix
 #     `#:` for the comments to be recognized as documentation. If in doubt,
 #     compare with already documented commands.

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -569,7 +569,8 @@ module RuboCop
           install = find_method_def(formula_nodes.body_node, :install)
           return if install.blank?
 
-          correctable_shell_completion_node(install) do |node, shell, base_name, executable, subcmd, shell_parameter|
+          correctable_shell_completion_node(install) do |node, shell, base_name, executable, subcommand,
+                                                        shell_parameter|
             # generate_completions_from_executable only applicable if shell is passed
             next unless shell_parameter.match?(/(bash|zsh|fish|pwsh)/)
 
@@ -592,7 +593,7 @@ module RuboCop
 
             replacement_args = %w[]
             replacement_args << executable.source
-            replacement_args << subcmd.source
+            replacement_args << subcommand.source
             replacement_args << "base_name: \"#{base_name}\"" if base_name != @formula_name
             replacement_args << "shells: [:#{shell}]"
             unless shell_parameter_format.nil?
@@ -616,7 +617,8 @@ module RuboCop
           end
         end
 
-        # match ({bash,zsh,fish}_completion/"_?foo{.fish}?").write Utils.safe_popen_read(foo, subcmd, shell_parameter)
+        # match ({bash,zsh,fish}_completion/"_?foo{.fish}?").write
+        # Utils.safe_popen_read(foo, subcommand, shell_parameter)
         def_node_search :correctable_shell_completion_node, <<~EOS
           $(send
           (begin

--- a/Library/Homebrew/test/abstract_subcommand_spec.rb
+++ b/Library/Homebrew/test/abstract_subcommand_spec.rb
@@ -1,0 +1,76 @@
+# typed: false
+# frozen_string_literal: true
+
+require "abstract_command"
+require "abstract_subcommand"
+
+RSpec.describe Homebrew::AbstractSubcommand do
+  describe "subclasses" do
+    before do
+      subcommand = Class.new(described_class) do
+        subcommand_args aliases: ["ts"], default: true do
+          usage_banner <<~EOS
+            `brew test`:
+            Run the test subcommand.
+          EOS
+          switch "--foo"
+          named_args :none
+        end
+
+        def run; end
+      end
+      stub_const("TestSubcommand", subcommand)
+      stub_const("SubcommandTestCmd", Class.new(Homebrew::AbstractCommand))
+    end
+
+    it "defines parser metadata from subcommand_args" do
+      parser = Homebrew::CLI::Parser.new(SubcommandTestCmd) do
+        TestSubcommand.define(self)
+      end
+
+      expect(parser.subcommands.first.name).to eq("test")
+      expect(parser.subcommands.first.aliases).to eq(["ts"])
+      expect(parser.subcommands.first.default).to be(true)
+      expect(parser.processed_options_for_subcommand("test").map(&:second)).to include("--foo")
+    end
+
+    it "allows access to args" do
+      expect(TestSubcommand.new(:args).args).to eq(:args)
+    end
+
+    it "finds subcommands nested under a command class" do
+      nested_subcommand = Class.new(described_class) do
+        subcommand_args { named_args :none }
+        def run; end
+      end
+      stub_const("SubcommandTestCmd::NestedSubcommand", nested_subcommand)
+      stub_const("OtherSubcommandTestCmd", Class.new(Homebrew::AbstractCommand))
+      other_subcommand = Class.new(described_class) do
+        subcommand_args { named_args :none }
+        def run; end
+      end
+      stub_const("OtherSubcommandTestCmd::NestedSubcommand", other_subcommand)
+
+      expect(described_class.subcommands_for(SubcommandTestCmd)).to include(nested_subcommand)
+      expect(described_class.subcommands_for(SubcommandTestCmd)).not_to include(other_subcommand)
+    end
+
+    it "defines all subcommands nested under a command class" do
+      stub_const("SubcommandTestCmd::FirstSubcommand", Class.new(described_class) do
+        subcommand_args { named_args :none }
+        def run; end
+      end)
+      stub_const("SubcommandTestCmd::SecondSubcommand", Class.new(described_class) do
+        subcommand_args { named_args :none }
+        def run; end
+      end)
+
+      abstract_subcommand = described_class
+      parser = Homebrew::CLI::Parser.new(SubcommandTestCmd) do
+        abstract_subcommand.define_all(self, command: SubcommandTestCmd)
+      end
+
+      expect(parser.subcommand_names).to include("first", "second")
+    end
+  end
+end

--- a/Library/Homebrew/test/abstract_subcommand_spec.rbi
+++ b/Library/Homebrew/test/abstract_subcommand_spec.rbi
@@ -1,0 +1,5 @@
+# typed: strict
+
+class SubcommandTestCmd < Homebrew::AbstractCommand; end
+class TestSubcommand < Homebrew::AbstractSubcommand; end
+class OtherSubcommandTestCmd < Homebrew::AbstractCommand; end

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -575,6 +575,99 @@ RSpec.describe Homebrew::CLI::Parser do
     end
   end
 
+  describe "subcommands" do
+    def subcommand_parser
+      described_class.new(Cmd) do
+        switch "--global"
+
+        subcommand "install", default: true do
+          usage_banner <<~EOS
+            `test install`:
+            Install dependencies.
+          EOS
+          switch "--force"
+          named_args :none
+        end
+
+        subcommand "info", aliases: ["i"] do
+          usage_banner <<~EOS
+            `test info` <service>:
+            Show service information.
+          EOS
+          switch "--json"
+          named_args :service, min: 1
+        end
+      end
+    end
+
+    it "exposes subcommand metadata as named args" do
+      parser = subcommand_parser
+
+      expect(parser.named_args_type).to eq(%w[install info])
+      expect(parser.subcommands.map(&:name)).to eq(%w[install info])
+      expect(parser.subcommands.last.aliases).to eq(["i"])
+      expect(parser.subcommands.last.description).to eq("Show service information.")
+      expect(parser.subcommands.last.usage_banner).to include("`test info` <service>:")
+    end
+
+    it "combines subcommand usage banners with the main usage banner" do
+      expect(subcommand_parser.usage_banner_text).to include("`test install`:")
+      expect(subcommand_parser.usage_banner_text).to include("Show service information.")
+    end
+
+    it "stores the canonical subcommand name" do
+      args = subcommand_parser.parse(%w[i foo --json])
+
+      expect(args.subcommand).to eq("info")
+      expect(args.named).to eq(["foo"])
+      expect(args.json?).to be(true)
+    end
+
+    it "rejects multiple positional names when defining a subcommand" do
+      expect do
+        described_class.new(Cmd) do
+          subcommand "install", "upgrade"
+        end
+      end.to raise_error(ArgumentError, /wrong number of arguments/)
+    end
+
+    it "uses the default subcommand when one is not passed" do
+      args = subcommand_parser.parse(["--force"])
+
+      expect(args.subcommand).to eq("install")
+      expect(args.force?).to be(true)
+    end
+
+    it "validates named args for the matched subcommand" do
+      expect { subcommand_parser.parse(["info"]) }
+        .to raise_error(Homebrew::CLI::MinNamedArgumentsError, /at least 1 service argument/)
+    end
+
+    it "rejects options from other subcommands" do
+      expect { subcommand_parser.parse(%w[info foo --force]) }
+        .to raise_error(UsageError, /`info` subcommand does not accept the `--force` switch/)
+    end
+
+    it "allows global options on all subcommands" do
+      args = subcommand_parser.parse(%w[info foo --global])
+
+      expect(args.subcommand).to eq("info")
+      expect(args.global?).to be(true)
+    end
+
+    it "returns options for a specific subcommand" do
+      parser = subcommand_parser
+
+      install_options = parser.processed_options_for_subcommand("install").map { |_, long| long }
+      info_options = parser.processed_options_for_subcommand("info").map { |_, long| long }
+
+      expect(install_options).to include("--force")
+      expect(install_options).not_to include("--json")
+      expect(info_options).to include("--json")
+      expect(info_options).not_to include("--force")
+    end
+  end
+
   describe "--cask on linux", :needs_linux do
     context "without --formula switch" do
       subject(:parser) do

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -160,6 +160,60 @@ RSpec.describe Homebrew::Completions do
     #   end
     # end
 
+    let(:nested_completion_command) { "subcommand-test" }
+    let(:nested_completion_subcommands) do
+      [
+        Homebrew::CLI::Parser::Subcommand.new(
+          name:        "list",
+          aliases:     ["ls"],
+          description: "List test services.",
+          default:     true,
+        ),
+        Homebrew::CLI::Parser::Subcommand.new(
+          name:        "info",
+          aliases:     ["i"],
+          description: "Show service information.",
+        ),
+        Homebrew::CLI::Parser::Subcommand.new(
+          name:        "start",
+          aliases:     ["s"],
+          description: "Start a service.",
+        ),
+      ]
+    end
+
+    def stub_nested_completion_command(command, subcommands)
+      allow(Commands).to receive(:command_subcommands).and_call_original
+      allow(Commands).to receive(:command_subcommands).with(command).and_return(subcommands)
+      allow(Commands).to receive(:command_description).and_call_original
+      allow(Commands).to receive(:command_description)
+        .with(command, short: true)
+        .and_return("Manage test services.")
+      allow(Commands).to receive(:command_options).and_call_original
+      allow(Commands).to receive(:command_options)
+        .with(command, subcommand: nil)
+        .and_return([])
+      allow(Commands).to receive(:command_options)
+        .with(command, subcommand: "list")
+        .and_return([["--all", "Run <subcommand> on all services."]])
+      allow(Commands).to receive(:command_options)
+        .with(command, subcommand: "info")
+        .and_return([["--json", "Output as JSON."]])
+      allow(Commands).to receive(:command_options)
+        .with(command, subcommand: "start")
+        .and_return([["--file", "Use the service file from this location to `start` the service."]])
+      allow(Commands).to receive(:named_args_type).and_call_original
+      allow(Commands).to receive(:named_args_type)
+        .with(command, subcommand: "list")
+        .and_return([])
+      allow(Commands).to receive(:named_args_type)
+        .with(command, subcommand: "info")
+        .and_return([:service])
+      allow(Commands).to receive(:named_args_type)
+        .with(command, subcommand: "start")
+        .and_return([:service])
+    end
+
     describe ".format_description" do
       it "escapes single quotes" do
         expect(described_class.format_description("Homebrew's")).to eq "Homebrew'\\''s"
@@ -226,6 +280,18 @@ RSpec.describe Homebrew::Completions do
       it "overrides global options with local descriptions" do
         options = described_class.command_options("upgrade")
         expect(options["--verbose"]).to eq "Print the verification and post-install steps."
+      end
+
+      it "returns options for a nested subcommand" do
+        stub_nested_completion_command(nested_completion_command, nested_completion_subcommands)
+
+        info_options = described_class.command_options(nested_completion_command, subcommand: "info")
+        start_options = described_class.command_options(nested_completion_command, subcommand: "start")
+
+        expect(info_options).to include("--json")
+        expect(info_options).not_to include("--file")
+        expect(start_options).to include("--file")
+        expect(start_options).not_to include("--json")
       end
     end
 
@@ -299,6 +365,15 @@ RSpec.describe Homebrew::Completions do
         completion = described_class.generate_bash_subcommand_completion("upgrade")
         expect(completion).to match(/__brew_complete_installed_formulae\n  __brew_complete_installed_casks\n}$/)
       end
+
+      it "returns appropriate completion for a command with nested subcommands" do
+        stub_nested_completion_command(nested_completion_command, nested_completion_subcommands)
+        completion = described_class.generate_bash_subcommand_completion(nested_completion_command)
+
+        expect(completion).to include('info|i) subcommand="info"; break ;;')
+        expect(completion).to include('__brewcomp "list ls info i start s"')
+        expect(completion).to include("__brew_complete_services")
+      end
     end
 
     describe ".generate_bash_completion_file" do
@@ -364,6 +439,16 @@ RSpec.describe Homebrew::Completions do
           /'*:cask:__brew_casks'\n}$/,
         )
       end
+
+      it "returns appropriate completion for a command with nested subcommands" do
+        stub_nested_completion_command(nested_completion_command, nested_completion_subcommands)
+        completion = described_class.generate_zsh_subcommand_completion(nested_completion_command)
+
+        expect(completion).to include("'1:subcommand:->subcommand'")
+        expect(completion).to include("'i:Show service information'")
+        expect(completion).to include("info|i)")
+        expect(completion).to include("*:service:__brew_services")
+      end
     end
 
     describe ".generate_zsh_completion_file" do
@@ -423,6 +508,17 @@ RSpec.describe Homebrew::Completions do
         expect(completion).to match(
           /#{expected_line_start} -l formula -l formulae' -a '\(__fish_brew_suggest_casks_installed\)'/,
         )
+      end
+
+      it "returns appropriate completion for a command with nested subcommands" do
+        stub_nested_completion_command(nested_completion_command, nested_completion_subcommands)
+        completion = described_class.generate_fish_subcommand_completion(nested_completion_command)
+
+        expect(completion).to include("__fish_brew_complete_sub_cmd 'subcommand-test' 'info'")
+        expect(completion).to include("__fish_brew_complete_sub_cmd 'subcommand-test' 'i' " \
+                                      "'Show service information'")
+        expect(completion).to include("__fish_brew_complete_sub_arg 'subcommand-test' 'info i' " \
+                                      "-a '(__fish_brew_suggest_services)'")
       end
     end
 


### PR DESCRIPTION
- Homebrew commands need parser-owned nested actions for help and completions.
- Keep this first step behaviour-neutral for existing commands.
- Add focused tests for subcommand args, option scoping and metadata.

Fixes https://github.com/Homebrew/brew/issues/19639

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
