### PR TITLE
Extract CommitMessage class for commit message normalization

### DIFF
--- a/Library/Homebrew/commit_message.rb
+++ b/Library/Homebrew/commit_message.rb
@@ -1,0 +1,84 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Homebrew
+  # Parses and normalizes Git commit messages into subject, body and trailers.
+  class CommitMessage
+    TRAILER_PATTERN = T.let(
+      /^(
+        [a-z][\w-]*-by
+        |Closes
+        |Fixes
+        |Resolves
+        |Reviewed-on
+        |Change-Id
+        |Acked-by
+        |Tested-by
+        |Reported-by
+        |Cc
+        |Suggested-by
+        |Ref
+        |See-also
+        |Bug
+        |Issue
+      )\s*[:#]/ix,
+      Regexp,
+    )
+
+    sig { returns(String) }
+    attr_reader :subject, :body, :trailers
+
+    sig { params(subject: String, body: String, trailers: String).void }
+    def initialize(subject: "", body: "", trailers: "")
+      @subject = T.let(subject, String)
+      @body = T.let(body, String)
+      @trailers = T.let(trailers, String)
+    end
+
+    sig { params(message: String).returns(CommitMessage) }
+    def self.parse(message)
+      first_line = message.lines.first
+      return new unless first_line
+
+      trailer_lines, body_lines = message.lines.drop(1).partition { |s| s.match?(TRAILER_PATTERN) }
+
+      new(
+        subject:  first_line.strip,
+        body:     body_lines.join.strip.gsub(/\n{3,}/, "\n\n"),
+        trailers: trailer_lines.uniq.join.strip,
+      )
+    end
+
+    sig { returns(CommitMessage) }
+    def normalize
+      normalized_subject = subject.rstrip
+
+      normalized_body = body
+                        .lines
+                        .map(&:rstrip)
+                        .join("\n")
+                        .gsub(/\n{3,}/, "\n\n")
+                        .strip
+
+      normalized_trailers = trailers
+                            .lines
+                            .map(&:rstrip)
+                            .join("\n")
+                            .strip
+
+      self.class.new(
+        subject:  normalized_subject,
+        body:     normalized_body,
+        trailers: normalized_trailers,
+      )
+    end
+
+    sig { returns(String) }
+    def to_s
+      parts = [subject]
+      parts << "\n\n#{body}" unless body.empty?
+      parts << "\n\n#{trailers}" unless trailers.empty?
+      parts.join
+    end
+  end
+end

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "abstract_command"
+require "commit_message"
 require "fileutils"
 require "utils/github"
 require "utils/github/artifacts"
@@ -182,20 +183,10 @@ module Homebrew
         end
       end
 
-      # Separates a commit message into subject, body and trailers.
       sig { params(message: String).returns([String, String, String]) }
       def separate_commit_message(message)
-        first_line = message.lines.first
-        return ["", "", ""] unless first_line
-
-        # Skip the subject and separate lines that look like trailers (e.g. "Co-authored-by")
-        # from lines that look like regular body text.
-        trailers, body = message.lines.drop(1).partition { |s| s.match?(/^[a-z-]+-by:/i) }
-
-        trailers = trailers.uniq.join.strip
-        body = body.join.strip.gsub(/\n{3,}/, "\n\n")
-
-        [first_line.strip, body, trailers]
+        parsed = CommitMessage.parse(message)
+        [parsed.subject, parsed.body, parsed.trailers]
       end
 
       sig { params(git_repo: GitRepository, pull_request: T.nilable(String), dry_run: T::Boolean).void }

--- a/Library/Homebrew/test/commit_message_spec.rb
+++ b/Library/Homebrew/test/commit_message_spec.rb
@@ -1,0 +1,160 @@
+# typed: false
+# frozen_string_literal: true
+
+require "commit_message"
+
+RSpec.describe Homebrew::CommitMessage do
+  describe ".parse" do
+    it "parses a subject-only message" do
+      msg = described_class.parse("Fix something")
+      expect(msg.subject).to eq("Fix something")
+      expect(msg.body).to eq("")
+      expect(msg.trailers).to eq("")
+    end
+
+    it "parses subject and body" do
+      msg = described_class.parse("Fix something\n\nThis is the body.\nWith two lines.")
+      expect(msg.subject).to eq("Fix something")
+      expect(msg.body).to eq("This is the body.\nWith two lines.")
+      expect(msg.trailers).to eq("")
+    end
+
+    it "parses subject, body and Co-authored-by trailer" do
+      message = <<~MSG
+        Fix something
+
+        This is the body.
+
+        Co-authored-by: User <user@example.com>
+      MSG
+      msg = described_class.parse(message)
+      expect(msg.subject).to eq("Fix something")
+      expect(msg.body).to eq("This is the body.")
+      expect(msg.trailers).to eq("Co-authored-by: User <user@example.com>")
+    end
+
+    it "parses multiple trailers" do
+      message = <<~MSG
+        Fix something
+
+        Co-authored-by: User1 <u1@example.com>
+        Signed-off-by: User2 <u2@example.com>
+      MSG
+      msg = described_class.parse(message)
+      expect(msg.subject).to eq("Fix something")
+      expect(msg.trailers).to eq(
+        "Co-authored-by: User1 <u1@example.com>\nSigned-off-by: User2 <u2@example.com>",
+      )
+    end
+
+    it "recognizes Closes trailer" do
+      message = "Fix bug\n\nCloses #123"
+      msg = described_class.parse(message)
+      expect(msg.trailers).to eq("Closes #123")
+      expect(msg.body).to eq("")
+    end
+
+    it "recognizes Fixes trailer" do
+      message = "Fix bug\n\nFixes #456"
+      msg = described_class.parse(message)
+      expect(msg.trailers).to eq("Fixes #456")
+    end
+
+    it "recognizes Reviewed-on trailer" do
+      message = "Fix bug\n\nReviewed-on: https://example.com/review/1"
+      msg = described_class.parse(message)
+      expect(msg.trailers).to eq("Reviewed-on: https://example.com/review/1")
+    end
+
+    it "recognizes Change-Id trailer" do
+      message = "Fix bug\n\nChange-Id: I1234567890abcdef"
+      msg = described_class.parse(message)
+      expect(msg.trailers).to eq("Change-Id: I1234567890abcdef")
+    end
+
+    it "deduplicates identical trailers" do
+      message = <<~MSG
+        Fix something
+
+        Co-authored-by: User <u@example.com>
+        Co-authored-by: User <u@example.com>
+      MSG
+      msg = described_class.parse(message)
+      expect(msg.trailers).to eq("Co-authored-by: User <u@example.com>")
+    end
+
+    it "collapses excessive blank lines in body" do
+      message = "Fix something\n\nLine 1\n\n\n\n\nLine 2"
+      msg = described_class.parse(message)
+      expect(msg.body).to eq("Line 1\n\nLine 2")
+    end
+
+    it "handles empty message" do
+      msg = described_class.parse("")
+      expect(msg.subject).to eq("")
+      expect(msg.body).to eq("")
+      expect(msg.trailers).to eq("")
+    end
+  end
+
+  describe "#normalize" do
+    it "strips trailing whitespace from all lines" do
+      msg = described_class.new(
+        subject:  "Fix something   ",
+        body:     "Line 1   \nLine 2  ",
+        trailers: "Co-authored-by: User <u@example.com>  ",
+      )
+      normalized = msg.normalize
+      expect(normalized.subject).to eq("Fix something")
+      expect(normalized.body).to eq("Line 1\nLine 2")
+      expect(normalized.trailers).to eq("Co-authored-by: User <u@example.com>")
+    end
+
+    it "collapses 3+ consecutive blank lines into 2 in body" do
+      msg = described_class.new(subject: "Fix", body: "A\n\n\n\nB")
+      normalized = msg.normalize
+      expect(normalized.body).to eq("A\n\nB")
+    end
+
+    it "trims leading and trailing blank lines from body" do
+      msg = described_class.new(subject: "Fix", body: "\n\nActual body\n\n")
+      normalized = msg.normalize
+      expect(normalized.body).to eq("Actual body")
+    end
+
+    it "trims leading and trailing blank lines from trailers" do
+      msg = described_class.new(subject: "Fix", trailers: "\n\nCo-authored-by: U <u@x.com>\n\n")
+      normalized = msg.normalize
+      expect(normalized.trailers).to eq("Co-authored-by: U <u@x.com>")
+    end
+  end
+
+  describe "#to_s" do
+    it "formats subject only" do
+      msg = described_class.new(subject: "Fix something")
+      expect(msg.to_s).to eq("Fix something")
+    end
+
+    it "formats subject and body" do
+      msg = described_class.new(subject: "Fix something", body: "Details here.")
+      expect(msg.to_s).to eq("Fix something\n\nDetails here.")
+    end
+
+    it "formats subject, body and trailers" do
+      msg = described_class.new(
+        subject:  "Fix something",
+        body:     "Details here.",
+        trailers: "Co-authored-by: User <u@example.com>",
+      )
+      expect(msg.to_s).to eq("Fix something\n\nDetails here.\n\nCo-authored-by: User <u@example.com>")
+    end
+  end
+
+  describe "round-trip" do
+    it "preserves a well-formed message through parse and to_s" do
+      original = "Fix something\n\nBody text.\n\nCo-authored-by: User <u@example.com>"
+      msg = described_class.parse(original)
+      expect(msg.to_s).to eq(original)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Extract commit message parsing logic (`separate_commit_message`) from `PrPull` into a dedicated, reusable `Homebrew::CommitMessage` value class
- Improve trailer detection to recognize standard Git trailers beyond just `*-by:` patterns (e.g. `Closes`, `Fixes`, `Change-Id`, `Reviewed-on`, etc.)
- Add whitespace normalization (collapse blank lines, strip trailing whitespace)
- Update `pr-pull.rb` to delegate to the new class
- Add comprehensive RSpec tests (19 examples covering parsing, normalization, formatting, and round-trip)

## Test plan

- [x] `./bin/brew style --fix` passes on modified files
- [x] `./bin/brew typecheck` passes
- [x] `./bin/brew tests --only=commit_message` — all 19 tests pass
- [x] `./bin/brew tests --only=dev-cmd/pr-pull` — all existing tests still pass