### PR TITLE
workflows/incomplete-prs: allow deleting PR template comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,8 @@
 
 -----
 
-- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.
+<!-- Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->
+
+- [ ] AI was used to generate or assist with generating this PR.
 
 -----

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,8 +11,8 @@
 
 -----
 
-<!-- Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->
-
 - [ ] AI was used to generate or assist with generating this PR.
+
+<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->
 
 -----

--- a/.github/workflows/incomplete-prs.yml
+++ b/.github/workflows/incomplete-prs.yml
@@ -79,6 +79,9 @@ jobs:
           CHECKBOX_MARKER = /\A- \[[ xX]\] /
           CHECKED_CHECKBOX_MARKER = /\A- \[[xX]\] /
           NORMALISED_CHECKBOX_MARKER = '- [ ] '
+          MARKDOWN_HORIZONTAL_LINE = /\A-+\z/
+          HTML_COMMENT = /\A<!--.*-->\z/
+          # 75% of template lines should be in the PR description.
           REQUIRED_TEMPLATE_PERCENTAGE = 75
           PERCENTAGE_SCALE = 100
 
@@ -88,10 +91,17 @@ jobs:
                 .lines(chomp: true)
           end
 
-          def normalise_lines(path)
+          def normalise_lines(path, template: false)
             lines(path).each_with_object([]) do |line, normalised_lines|
               line = line.strip.sub(CHECKBOX_MARKER, NORMALISED_CHECKBOX_MARKER)
-              normalised_lines << line unless line.empty?
+              # Ignore blank lines.
+              next if line.empty?
+              # Ignore --- markdown horizontal lines.
+              next if template && line.match?(MARKDOWN_HORIZONTAL_LINE)
+              # Ignore <!-- HTML comments -->
+              next if template && line.match?(HTML_COMMENT)
+
+              normalised_lines << line
             end.uniq
           end
 
@@ -99,7 +109,7 @@ jobs:
           template_path = ARGV.fetch(1)
 
           pr_lines = normalise_lines(pr_body_path)
-          template_lines = normalise_lines(template_path)
+          template_lines = normalise_lines(template_path, template: true)
           matching_template_lines = template_lines.count { |line| pr_lines.include?(line) }
           scaled_matching_percentage = matching_template_lines * PERCENTAGE_SCALE
           scaled_required_percentage = template_lines.count * REQUIRED_TEMPLATE_PERCENTAGE

--- a/.github/workflows/incomplete-prs.yml
+++ b/.github/workflows/incomplete-prs.yml
@@ -78,10 +78,9 @@ jobs:
               "${RUNNER_TEMP}/incomplete-prs/template" <<'RUBY'
           CHECKBOX_MARKER = /\A- \[[ xX]\] /
           CHECKED_CHECKBOX_MARKER = /\A- \[[xX]\] /
-          NORMALISED_CHECKBOX_MARKER = '- [ ] '
+          HTML_COMMENT_LINE = /\A<!--.*-->\z/
           MARKDOWN_HORIZONTAL_LINE = /\A-+\z/
-          HTML_COMMENT = /\A<!--.*-->\z/
-          # 75% of template lines should be in the PR description.
+          NORMALISED_CHECKBOX_MARKER = '- [ ] '
           REQUIRED_TEMPLATE_PERCENTAGE = 75
           PERCENTAGE_SCALE = 100
 
@@ -91,15 +90,15 @@ jobs:
                 .lines(chomp: true)
           end
 
-          def normalise_lines(path, template: false)
+          def normalise_lines(path)
             lines(path).each_with_object([]) do |line, normalised_lines|
               line = line.strip.sub(CHECKBOX_MARKER, NORMALISED_CHECKBOX_MARKER)
               # Ignore blank lines.
               next if line.empty?
               # Ignore --- markdown horizontal lines.
-              next if template && line.match?(MARKDOWN_HORIZONTAL_LINE)
+              next if line.match?(MARKDOWN_HORIZONTAL_LINE)
               # Ignore <!-- HTML comments -->
-              next if template && line.match?(HTML_COMMENT)
+              next if line.match?(HTML_COMMENT_LINE)
 
               normalised_lines << line
             end.uniq
@@ -109,7 +108,7 @@ jobs:
           template_path = ARGV.fetch(1)
 
           pr_lines = normalise_lines(pr_body_path)
-          template_lines = normalise_lines(template_path, template: true)
+          template_lines = normalise_lines(template_path)
           matching_template_lines = template_lines.count { |line| pr_lines.include?(line) }
           scaled_matching_percentage = matching_template_lines * PERCENTAGE_SCALE
           scaled_required_percentage = template_lines.count * REQUIRED_TEMPLATE_PERCENTAGE


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

Unsure how to test this. Will the changed check run on this PR?

-----

<!-- Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

- [x] AI was used to generate or assist with generating this PR.

AI did the initial investigation, I made the changes.

-----

The goal is to ensure people include the key lines from the template,
while not requiring them to exactly keep the text verbatim. In my
PR I accidentally changed too many lines, which caused my PR to
be auto-closed, despite me including all the checkboxes.

This makes the following changes:

1. Don't consider `---` markdown ruler lines as required
2. Don't consider `<!-- HTML comments -->` as required
3. Use `<!-- HTML -->` comments for the AI note as well as for the other
   ones.

Refs: https://github.com/Homebrew/brew/pull/22249#issuecomment-4432511352

Full AI investigation:

```markdown
The check works by normalizing lines (stripping, replacing any [ ]/[x]/[X] with [ ]) and checking that ≥75% of the template's unique non-empty lines appear in the PR body.

The template has 9 unique non-empty lines after normalization:

1. -----
2. <!-- Do not tick a checkbox if you haven't performed its action... -->
3. <!-- Use [x] to mark item done... -->
4–8. The five main checkboxes
4. - [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
Non-maintainers may only have one AI-assisted/generated PR open at a time.

Your PR body matches 6 of those 9:

- Misses the 2 HTML comments — you stripped them (as most authors do)
- Misses the AI checkbox line — you replaced the full template text with AI was used to generate or assist with generating this PR -> Did the design myself, used AI to write the Ruby., which
 no longer matches the template text

6/9 = 66.7%, which is below the 75% threshold.

If you'd only dropped the HTML comments (8/9 = 88.9%) or only modified the AI checkbox (8/9 = 88.9%), each would pass on its own. Both together pushes it under.

Fix: Keep the AI checkbox text verbatim as it appears in the template, and put your note on a separate line below it (which is exactly what "Please specify below" intends):

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
Non-maintainers may only have one AI-assisted/generated PR open at a time.
```