### PR TITLE
Preserve manual resource stanzas

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -281,7 +281,7 @@ module Homebrew
           end
 
           stanzas_to_add = []
-          new_mirrors&.each { |mirror| stanzas_to_add << [:mirror, mirror] } if new_url.present?
+          new_mirrors&.each { |mirror| stanzas_to_add << [:mirror, "mirror #{mirror.inspect}"] } if new_url.present?
           if forced_version && new_version != "0"
             if formula_ast.stable_stanza?(:version)
               formula_ast.replace_stable_stanza_value(:version, T.must(new_version))

--- a/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
@@ -3,6 +3,7 @@
 
 require "cmd/shared_examples/args_parse"
 require "dev-cmd/bump-formula-pr"
+require "utils/pypi"
 
 RSpec.describe Homebrew::DevCmd::BumpFormulaPr do
   subject(:bump_formula_pr) { described_class.new(["test"]) }
@@ -14,6 +15,51 @@ RSpec.describe Homebrew::DevCmd::BumpFormulaPr do
   end
 
   it_behaves_like "parseable arguments"
+
+  describe "#run" do
+    it "adds updated mirrors as string literals" do
+      formula_path = CoreTap.instance.new_formula_path("couchdb")
+      formula_path.dirname.mkpath
+      formula_path.write <<~RUBY
+        class Couchdb < Formula
+          url "https://www.apache.org/dyn/closer.lua?path=couchdb/source/3.5.1/apache-couchdb-3.5.1.tar.gz"
+          mirror "https://archive.apache.org/dist/couchdb/source/3.5.1/apache-couchdb-3.5.1.tar.gz"
+          sha256 "#{"a" * 64}"
+        end
+      RUBY
+      CoreTap.instance.clear_cache
+      Formulary.clear_cache
+      Formula.clear_cache
+      formula = Formulary.from_contents("couchdb", formula_path, formula_path.read)
+
+      resource_path = mktmpdir/"apache-couchdb-3.5.2.tar.gz"
+      resource_path.write("couchdb")
+      updated_mirror = "https://archive.apache.org/dist/couchdb/source/3.5.2/apache-couchdb-3.5.2.tar.gz"
+      command = described_class.new(["--write-only", "--no-audit", "--version=3.5.2", "couchdb"])
+
+      allow(Homebrew).to receive(:install_bundler_gems!)
+      allow(CoreTap.instance).to receive_messages(allow_bump?: true, git?: true,
+                                                  remote_repository: "Homebrew/homebrew-core")
+      allow(command).to receive(:check_new_version)
+      allow(command).to receive(:fetch_resource_and_forced_version).and_return([resource_path, false])
+      allow(command).to receive_messages(run_audit: false, update_matching_version_resources!: {})
+      allow(PyPI).to receive(:update_python_resources!)
+      allow(Utils::Tar).to receive(:validate_file).with(resource_path)
+      allow(command.args.named).to receive(:to_formulae).and_return([formula])
+      allow(Formula).to receive(:[]).with("couchdb").and_return(formula)
+      expect_any_instance_of(Utils::AST::FormulaAST)
+        .to receive(:add_stable_stanzas_after) do |formula_ast, name, stanzas|
+        expect(name).to eq(:url)
+        expect(stanzas).to include([:mirror, "mirror #{updated_mirror.inspect}"])
+        formula_ast.add_stanzas_after(name, stanzas, parent: formula_ast.stanza(:stable, type: :block_call))
+      end
+
+      command.run
+
+      expect(formula_path.read).to include "  mirror #{updated_mirror.inspect}\n  " \
+                                           "sha256 #{resource_path.sha256.inspect}\n"
+    end
+  end
 
   describe "::check_throttle" do
     let(:tap) { Tap.fetch("test", "tap") }

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "utils/pypi"
+require "formulary"
 
 RSpec.describe PyPI do
   let(:pypi_package_url) do
@@ -168,6 +169,72 @@ RSpec.describe PyPI do
       ).and_return('{"install":[]}')
 
       expect(described_class.pip_report([PyPI::Package.new("snakemake")])).to eq([])
+    end
+  end
+
+  describe ".update_python_resources!" do
+    it "keeps resources with livecheck blocks" do
+      path = mktmpdir/"foo.rb"
+      livecheck_resource = <<~RUBY
+        resource "aws-lambda-rie" do
+          url "https://github.com/aws/aws-lambda-runtime-interface-emulator/archive/refs/tags/v1.0.tar.gz"
+          sha256 "#{"c" * 64}"
+
+          livecheck do
+            url "https://github.com/aws/aws-lambda-runtime-interface-emulator/releases"
+            regex(/^v?(\\d+(?:\\.\\d+)+)$/i)
+          end
+        end
+      RUBY
+      contents = <<~RUBY
+        class Foo < Formula
+          url "https://files.pythonhosted.org/packages/foo-1.0.tar.gz"
+          sha256 "#{"a" * 64}"
+
+          resource "bar" do
+            url "https://files.pythonhosted.org/packages/bar-0.9.tar.gz"
+            sha256 "#{"b" * 64}"
+          end
+
+        #{livecheck_resource}
+
+          def install
+            bin.install "foo"
+          end
+        end
+      RUBY
+      path.write(contents)
+      package = PyPI::Package.new("bar==1.0")
+      livecheck_package = PyPI::Package.new("aws-lambda-rie==1.0")
+
+      allow(Formula).to receive(:[]).with("python").and_return(instance_double(Formula, ensure_installed!: true))
+      allow(described_class).to receive(:pip_report)
+        .and_return([PyPI::Package.new("foo==1.0"), package, livecheck_package])
+      allow(package).to receive(:pypi_info).and_return(
+        ["bar", "https://files.pythonhosted.org/packages/bar-1.0.tar.gz", "d" * 64, "1.0", nil],
+      )
+      expect(livecheck_package).not_to receive(:pypi_info)
+
+      described_class.update_python_resources!(Formulary.from_contents("foo", path, contents),
+                                               package_name: "foo", silent: true)
+
+      expect(path.read).to eq <<~RUBY
+        class Foo < Formula
+          url "https://files.pythonhosted.org/packages/foo-1.0.tar.gz"
+          sha256 "#{"a" * 64}"
+
+          resource "bar" do
+            url "https://files.pythonhosted.org/packages/bar-1.0.tar.gz"
+            sha256 "#{"d" * 64}"
+          end
+
+        #{livecheck_resource}
+
+          def install
+            bin.install "foo"
+          end
+        end
+      RUBY
     end
   end
 

--- a/Library/Homebrew/utils/ast.rb
+++ b/Library/Homebrew/utils/ast.rb
@@ -205,12 +205,18 @@ module Utils
         tree_rewriter.insert_after(preceding_expr, text)
       end
 
-      sig { params(resource_section: String, replace_existing: T::Boolean).returns(T.nilable(Symbol)) }
-      def replace_resource_stanzas(resource_section, replace_existing: true)
+      sig {
+        params(
+          resource_section:   String,
+          replace_existing:   T::Boolean,
+          preserve_livecheck: T::Boolean,
+        ).returns(T.nilable(Symbol))
+      }
+      def replace_resource_stanzas(resource_section, replace_existing: true, preserve_livecheck: false)
         resource_section = resource_section.gsub(/^(?!$)/, "  ") unless resource_section.match?(/\A\n* +/)
 
         if replace_existing
-          groups = resource_stanza_groups
+          groups = resource_stanza_groups(preserve_livecheck:)
           return :multiple_groups if groups.length > 1
 
           if (group = groups.first)
@@ -424,13 +430,17 @@ module Utils
         )
       end
 
-      sig { returns(T::Array[T::Array[BlockNode]]) }
-      def resource_stanza_groups
+      sig { params(preserve_livecheck: T::Boolean).returns(T::Array[T::Array[BlockNode]]) }
+      def resource_stanza_groups(preserve_livecheck: false)
         test_node = stanza(:test, type: :block_call)
         resource_nodes = stanzas(:resource, type: :block_call).filter_map do |node|
+          node = T.cast(node, BlockNode)
           next if test_node.present? && node.source_range.begin_pos > test_node.source_range.begin_pos
 
-          T.cast(node, BlockNode)
+          next if preserve_livecheck &&
+                  matching_stanzas(body_children(node.body), :livecheck, type: :block_call).present?
+
+          node
         end
 
         groups = T.let([], T::Array[T::Array[BlockNode]])

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -372,6 +372,7 @@ module PyPI
         exclude_packages.delete package
         next
       end
+      next if existing_resources_by_name[T.must(package.name)]&.livecheck_defined?
 
       ohai "Getting PyPI info for \"#{package}\"" if show_info
       name, url, checksum, version, package_error = package.pypi_info(ignore_errors: ignore_errors)
@@ -441,7 +442,8 @@ module PyPI
     formula_ast = Utils::AST::FormulaAST.new(formula.path.read)
     if formula_ast.replace_resource_stanzas(
       resource_section,
-      replace_existing: formula.resources.any? { |resource| !resource.name.start_with?("homebrew-") },
+      replace_existing:   formula.resources.any? { |resource| !resource.name.start_with?("homebrew-") },
+      preserve_livecheck: true,
     ) == :multiple_groups
       odie "Unable to update resource blocks for \"#{formula.name}\" automatically. Please update them manually."
     end


### PR DESCRIPTION
- Keep `livecheck` resources out of PyPI resource rewrites so manually managed downloads are not removed.
- Add generated `mirror` stanzas as Ruby source so raw URLs do not trip AST parsing when opening bump PRs.

Fixes https://github.com/Homebrew/brew/issues/22289
Fixes https://github.com/Homebrew/brew/issues/22291

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with manual review, testing and tweaking.

-----
