### PR TITLE
cask/upgrade: reopen closed apps during upgrade

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -70,6 +70,11 @@ module Cask
         to_h.flat_map { |key, val| Array(val).map { |v| "#{key.inspect} => #{v.inspect}" } }.join(", ")
       end
 
+      sig { returns(T::Array[String]) }
+      def bundle_ids_to_reopen
+        @bundle_ids_to_reopen ||= T.let([], T.nilable(T::Array[String]))
+      end
+
       private
 
       sig { params(options: DirectivesType).void }
@@ -210,8 +215,15 @@ module Cask
       end
 
       # :quit/:signal must come before :kext so the kext will not be in use by a running process
-      sig { params(bundle_ids: String, command: T.nilable(T.class_of(SystemCommand)), _kwargs: T.anything).void }
-      def uninstall_quit(*bundle_ids, command: nil, **_kwargs)
+      sig {
+        params(
+          bundle_ids: String,
+          command:    T.nilable(T.class_of(SystemCommand)),
+          upgrade:    T::Boolean,
+          _kwargs:    T.anything,
+        ).void
+      }
+      def uninstall_quit(*bundle_ids, command: nil, upgrade: false, **_kwargs)
         bundle_ids.each do |bundle_id|
           next unless running?(bundle_id)
 
@@ -222,6 +234,7 @@ module Cask
 
           ohai "Quitting application '#{bundle_id}'..."
 
+          quit_succeeded = T.let(false, T::Boolean)
           begin
             Timeout.timeout(10) do
               Kernel.loop do
@@ -230,12 +243,15 @@ module Cask
                 next if running?(bundle_id)
 
                 puts "Application '#{bundle_id}' quit successfully."
+                quit_succeeded = true
                 break
               end
             end
           rescue Timeout::Error
             opoo "Application '#{bundle_id}' did not quit. #{automation_access_instructions}"
           end
+
+          bundle_ids_to_reopen << bundle_id if upgrade && quit_succeeded
         end
       end
 

--- a/Library/Homebrew/cask/artifact/uninstall.rb
+++ b/Library/Homebrew/cask/artifact/uninstall.rb
@@ -42,7 +42,7 @@ module Cask
         end
 
         filtered_directives.each do |directive_sym|
-          dispatch_uninstall_directive(directive_sym, **options)
+          dispatch_uninstall_directive(directive_sym, **options, upgrade:)
         end
       end
 

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -307,6 +307,22 @@ module Cask
       false
     end
 
+    sig { params(old_cask: Cask).void }
+    def self.reopen_apps_after_upgrade(old_cask)
+      bundle_ids = old_cask.artifacts
+                           .grep(Artifact::Uninstall)
+                           .flat_map(&:bundle_ids_to_reopen)
+      return if bundle_ids.empty?
+
+      ohai "Reopening #{bundle_ids.count} #{::Utils.pluralize("application",
+                                                              bundle_ids.count)} closed during upgrade:"
+      bundle_ids.each do |bundle_id|
+        puts bundle_id
+        system("open", "-b", bundle_id)
+      end
+    end
+    private_class_method :reopen_apps_after_upgrade
+
     sig {
       params(
         old_cask:       Cask,
@@ -406,6 +422,8 @@ module Cask
 
         # If successful, wipe the old cask from staging.
         old_cask_installer.finalize_upgrade
+
+        reopen_apps_after_upgrade(old_cask)
       rescue => e
         new_cask_installer.uninstall_artifacts(successor: old_cask) if new_artifacts_installed
         new_cask_installer.purge_versioned_files

--- a/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
@@ -156,6 +156,49 @@ RSpec.describe Cask::Artifact::Uninstall, :cask do
     end
   end
 
+  describe "#bundle_ids_to_reopen" do
+    subject(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
+
+    let(:fake_system_command) { NeverSudoSystemCommand }
+    let(:cask) { Cask::CaskLoader.load(cask_path("with-uninstall-quit")) }
+    let(:bundle_id) { "my.fancy.package.app" }
+
+    before { allow(User.current).to receive(:gui?).and_return true }
+
+    it "tracks a successfully quit app during upgrade" do
+      allow(artifact).to receive(:running?).with(bundle_id).and_return(true, false)
+      allow(artifact).to receive(:quit).with(bundle_id)
+                                       .and_return(instance_double(SystemCommand::Result, success?: true))
+
+      artifact.send(:uninstall_quit, bundle_id, upgrade: true, command: fake_system_command)
+
+      expect(artifact.bundle_ids_to_reopen).to eq [bundle_id]
+    end
+
+    it "does not track during regular uninstall" do
+      allow(artifact).to receive(:running?).with(bundle_id).and_return(true, false)
+      allow(artifact).to receive(:quit).with(bundle_id)
+                                       .and_return(instance_double(SystemCommand::Result, success?: true))
+
+      artifact.send(:uninstall_quit, bundle_id, upgrade: false, command: fake_system_command)
+
+      expect(artifact.bundle_ids_to_reopen).to be_empty
+    end
+
+    it "does not track when quit times out" do
+      allow(artifact).to receive(:running?).with(bundle_id).and_return(true)
+      allow(artifact).to receive(:quit).with(bundle_id)
+                                       .and_return(instance_double(SystemCommand::Result, success?: false))
+      allow(Timeout).to receive(:timeout).and_raise(Timeout::Error)
+
+      expect do
+        artifact.send(:uninstall_quit, bundle_id, upgrade: true, command: fake_system_command)
+      end.to output(/did not quit/).to_stderr
+
+      expect(artifact.bundle_ids_to_reopen).to be_empty
+    end
+  end
+
   describe "#post_uninstall_phase" do
     subject(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

I used `claude-code` to help create the PR logic and tests.

-----

This PR is a companion to https://github.com/Homebrew/brew/pull/22295 that introduces a potential UX improvement where we systematically reopen closed applications after `brew upgrade` succeeds. ~~At present, this behaviour is gated behind the `HOMEBREW_REOPEN_CASK_APP_AFTER_UPGRADE` environment variable.~~

During the `uninstall` phase, if an app is closed, the bundle ID is stored, and then after the upgrade succeeds, any closed bundles are reopened.