### PR TITLE
Serialise bundle formula locks

### DIFF
--- a/Library/Homebrew/bundle/brew.rb
+++ b/Library/Homebrew/bundle/brew.rb
@@ -138,28 +138,12 @@ module Homebrew
         end
 
         # Returns recursive dependency names for lock conflict detection.
-        # When pouring bottles, only runtime deps acquire keg locks so build
-        # deps like cmake don't serialize unrelated bottle pours.  When
-        # building from source all deps (including build) must be considered.
-        sig { params(name: String, include_build: T::Boolean).returns(T::Set[String]) }
-        def recursive_dep_names(name, include_build: true)
+        sig { params(name: String).returns(T::Set[String]) }
+        def recursive_dep_names(name)
           require "formula"
-          f = Formula[name]
-          if include_build
-            f.recursive_dependencies
-          else
-            f.runtime_dependencies
-          end.to_set(&:name)
+          Formula[name].recursive_dependencies.to_set(&:name)
         rescue FormulaUnavailableError
           Set.new
-        end
-
-        sig { params(name: String).returns(T::Boolean) }
-        def formula_bottled?(name)
-          formula = find_formula(name)
-          return false if formula.blank?
-
-          formula.fetch(:bottled, false)
         end
 
         sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }

--- a/Library/Homebrew/bundle/parallel_installer.rb
+++ b/Library/Homebrew/bundle/parallel_installer.rb
@@ -126,17 +126,14 @@ module Homebrew
         end
 
         # Phase 3: Recursive dependency sets for lock conflict detection.
-        # Only include build deps when building from source.  Pouring bottles
-        # only locks runtime deps, so a shared build dep like cmake won't
-        # serialize unrelated bottle pours.
+        # `FormulaInstaller#lock` locks all recursive dependencies before
+        # installing, even when pouring bottles.
         cask_names = T.let(@entries.select { |e| e.cls == Homebrew::Bundle::Cask }.to_set(&:name), T::Set[String])
         recursive_deps = T.let({}, T::Hash[String, T::Set[String]])
         @entries.each do |entry|
           recursive_deps[entry.name] = case entry.cls.name
           when "Homebrew::Bundle::Brew"
-            building_from_source = Array(entry.options[:args]).any? { |a| a.to_s == "build-from-source" } ||
-                                   !Homebrew::Bundle::Brew.formula_bottled?(entry.name)
-            Homebrew::Bundle::Brew.recursive_dep_names(entry.name, include_build: building_from_source)
+            Homebrew::Bundle::Brew.recursive_dep_names(entry.name)
           when "Homebrew::Bundle::Cask"
             cask_dep_names(entry.name, cask_names)
           else

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -182,13 +182,10 @@ RSpec.describe Homebrew::Bundle::Installer do
     end
 
     it "installs independent formulae in parallel with jobs > 1" do
-      allow(Homebrew::Bundle::Brew).to receive(:formula_bottled?).and_return(true)
       allow(Homebrew::Bundle::Brew).to receive(:formulae_by_full_name).with("alpha").and_return({ dependencies: [] })
       allow(Homebrew::Bundle::Brew).to receive(:formulae_by_full_name).with("beta").and_return({ dependencies: [] })
-      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("alpha",
-                                                                          include_build: false).and_return(Set.new)
-      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("beta",
-                                                                          include_build: false).and_return(Set.new)
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("alpha").and_return(Set.new)
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("beta").and_return(Set.new)
       expect(Homebrew::Bundle::Brew).to receive(:install!)
         .with("alpha", preinstall: true, no_upgrade: false, verbose: false, force: false)
         .and_return(true)
@@ -212,14 +209,11 @@ RSpec.describe Homebrew::Bundle::Installer do
         true
       end
 
-      allow(Homebrew::Bundle::Brew).to receive(:formula_bottled?).and_return(true)
       allow(Homebrew::Bundle::Brew).to receive(:formulae_by_full_name).with("alpha")
                                                                       .and_return({ dependencies: ["beta"] })
       allow(Homebrew::Bundle::Brew).to receive(:formulae_by_full_name).with("beta").and_return({ dependencies: [] })
-      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("alpha",
-                                                                          include_build: false).and_return(Set.new)
-      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("beta",
-                                                                          include_build: false).and_return(Set.new)
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("alpha").and_return(Set.new)
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("beta").and_return(Set.new)
 
       success, failure = Homebrew::Bundle::ParallelInstaller.new(
         [alpha_entry, beta_entry],
@@ -229,6 +223,20 @@ RSpec.describe Homebrew::Bundle::Installer do
       expect(success).to eq(2)
       expect(failure).to eq(0)
       expect(install_order).to eq(["beta", "alpha"])
+    end
+
+    it "serializes formulae with shared build-only recursive dependencies" do
+      allow(Homebrew::Bundle::Brew).to receive(:formulae_by_full_name).with("alpha").and_return({ dependencies: [] })
+      allow(Homebrew::Bundle::Brew).to receive(:formulae_by_full_name).with("beta").and_return({ dependencies: [] })
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("alpha").and_return(Set["shared-build-dep"])
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("beta").and_return(Set["shared-build-dep"])
+
+      dependency_map = Homebrew::Bundle::ParallelInstaller.new(
+        [alpha_entry, beta_entry],
+        jobs: 2, no_upgrade: false, verbose: false, force: false, quiet: true,
+      ).send(:build_dependency_map)
+
+      expect(dependency_map.fetch("beta")).to eq(Set["alpha"])
     end
 
     it "installs unqualified formulae after Brewfile taps" do
@@ -247,8 +255,7 @@ RSpec.describe Homebrew::Bundle::Installer do
       install_order = []
 
       allow(Homebrew::API).to receive_messages(formula_names: [], formula_aliases: {}, formula_renames: {})
-      allow(Homebrew::Bundle::Brew).to receive_messages(formula_bottled?: true, formula_dep_names: [],
-                                                        recursive_dep_names: Set.new)
+      allow(Homebrew::Bundle::Brew).to receive_messages(formula_dep_names: [], recursive_dep_names: Set.new)
       allow(Homebrew::Bundle::Tap).to receive(:install!) do |name, **_options|
         install_order << name
         true


### PR DESCRIPTION
- Avoid parallel `brew bundle` installs racing over recursive formula locks.
- Match `FormulaInstaller#lock` so bottle pours wait on shared build deps.
- Cover shared build-only deps in `installer_spec.rb`.

Fixes https://github.com/Homebrew/brew/issues/22293

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
