### PR TITLE
Embed executables in API JSON

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -214,13 +214,13 @@ module Homebrew
       end
     end
 
-    sig { void }
-    def self.write_names_and_aliases
+    sig { params(legacy_executables_fallback: T::Boolean).void }
+    def self.write_names_and_aliases(legacy_executables_fallback: false)
       if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.write_formula_names_and_aliases
+        Homebrew::API::Internal.write_formula_names_and_aliases(legacy_executables_fallback:)
         Homebrew::API::Internal.write_cask_names
       else
-        Homebrew::API::Formula.write_names_and_aliases
+        Homebrew::API::Formula.write_names_and_aliases(legacy_executables_fallback:)
         Homebrew::API::Cask.write_names
       end
     end
@@ -248,6 +248,80 @@ module Homebrew
         aliases_path.write(aliases_text.sort.join("\n"))
         return true
       end
+
+      false
+    end
+
+    sig {
+      params(
+        formulae:                    T::Hash[String, T::Hash[String, T.untyped]],
+        regenerate:                  T::Boolean,
+        legacy_executables_fallback: T::Boolean,
+      ).returns(T::Boolean)
+    }
+    def self.write_executables_file!(formulae, regenerate:, legacy_executables_fallback: false)
+      executables_path = HOMEBREW_CACHE_API/"internal/executables.txt"
+      executables_lines = formulae.filter_map do |name, hash|
+        executables = T.cast(hash["executables"], T.nilable(T::Array[String]))
+        next if executables.blank?
+
+        "#{name}:#{executables.join(" ")}"
+      end
+      if executables_lines.empty?
+        return false if executables_path.exist? && !executables_path.empty?
+        return false unless legacy_executables_fallback
+
+        # TODO: Remove this fallback once formula JSON always includes executables.
+        return download_executables_file_from_github_packages!(executables_path)
+      end
+
+      contents = "#{executables_lines.sort.join("\n")}\n"
+      if !executables_path.exist? || regenerate || executables_path.read != contents
+        executables_path.dirname.mkpath
+        executables_path.unlink if executables_path.exist?
+        executables_path.write(contents)
+        return true
+      end
+
+      false
+    end
+
+    sig { params(target: Pathname).returns(T::Boolean) }
+    def self.download_executables_file_from_github_packages!(target)
+      github_packages_url = "https://ghcr.io/v2/homebrew/command-not-found/executables"
+      manifest_args = [
+        "--fail", "--location",
+        "--header", "Accept: application/vnd.oci.image.manifest.v1+json",
+        "#{github_packages_url}/manifests/latest"
+      ]
+      if HOMEBREW_GITHUB_PACKAGES_AUTH.present?
+        manifest_args.insert(-2, "--header", "Authorization: #{HOMEBREW_GITHUB_PACKAGES_AUTH}")
+      end
+
+      manifest_output = Utils::Curl.curl_output(*manifest_args, show_error: false)
+      return false unless manifest_output.success?
+
+      manifest = JSON.parse(manifest_output.stdout)
+      layers = T.cast(manifest.fetch("layers"), T::Array[T::Hash[String, T.untyped]])
+      layer = layers.find do |candidate|
+        candidate.dig("annotations", "org.opencontainers.image.title") == target.basename.to_s
+      end
+      return false if layer.nil?
+
+      digest = T.cast(layer["digest"], T.nilable(String))
+      return false if digest.blank?
+
+      download_args = ["--fail"]
+      if HOMEBREW_GITHUB_PACKAGES_AUTH.present?
+        download_args += ["--header", "Authorization: #{HOMEBREW_GITHUB_PACKAGES_AUTH}"]
+      end
+      download_args << "#{github_packages_url}/blobs/#{digest}"
+      target.dirname.mkpath
+      Utils::Curl.curl_download(*download_args, to: target, show_error: false)
+      FileUtils.touch(target)
+      true
+    rescue ErrorDuringExecution, JSON::ParserError, KeyError, TypeError
+      target.unlink if target.exist? && target.empty?
 
       false
     end

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -201,12 +201,13 @@ module Homebrew
         cache.fetch("tap_migrations")
       end
 
-      sig { params(regenerate: T::Boolean).void }
-      def self.write_names_and_aliases(regenerate: false)
+      sig { params(regenerate: T::Boolean, legacy_executables_fallback: T::Boolean).void }
+      def self.write_names_and_aliases(regenerate: false, legacy_executables_fallback: false)
         download_and_cache_data! unless cache.key?("formulae")
 
         Homebrew::API.write_names_file!(all_formulae.keys, "formula", regenerate:)
         Homebrew::API.write_aliases_file!(all_aliases, "formula", regenerate:)
+        Homebrew::API.write_executables_file!(all_formulae, regenerate:, legacy_executables_fallback:)
       end
     end
   end

--- a/Library/Homebrew/api/formula_struct.rb
+++ b/Library/Homebrew/api/formula_struct.rb
@@ -93,6 +93,7 @@ module Homebrew
       const :deprecate_args, T::Hash[Symbol, T.nilable(T.any(String, Symbol))], default: {}
       const :desc, String
       const :disable_args, T::Hash[Symbol, T.nilable(T.any(String, Symbol))], default: {}
+      const :executables, T::Array[String], default: []
       const :head_dependencies, T::Array[DependsOnArgs], default: []
       const :head_url_args, [String, T::Hash[Symbol, T.anything]], default: ["", {}]
       const :head_uses_from_macos, T::Array[UsesFromMacOSArgs], default: []

--- a/Library/Homebrew/api/internal.rb
+++ b/Library/Homebrew/api/internal.rb
@@ -90,12 +90,13 @@ module Homebrew
       end
       private_class_method :download_and_cache_data!
 
-      sig { params(regenerate: T::Boolean).void }
-      def self.write_formula_names_and_aliases(regenerate: false)
+      sig { params(regenerate: T::Boolean, legacy_executables_fallback: T::Boolean).void }
+      def self.write_formula_names_and_aliases(regenerate: false, legacy_executables_fallback: false)
         download_and_cache_data! unless cache.key?("formula_hashes")
 
         Homebrew::API.write_names_file!(formula_hashes.keys, "formula", regenerate:)
         Homebrew::API.write_aliases_file!(formula_aliases, "formula", regenerate:)
+        Homebrew::API.write_executables_file!(formula_hashes, regenerate:, legacy_executables_fallback:)
       end
 
       sig { params(regenerate: T::Boolean).void }

--- a/Library/Homebrew/cmd/exec.rb
+++ b/Library/Homebrew/cmd/exec.rb
@@ -11,7 +11,7 @@ module Homebrew
 
       cmd_args do
         usage_banner <<~EOS
-          `exec`, `x` [`--skip-update`] [`--formulae=`<formulae>] [`--`] <command> [<args> ...]
+          `exec`, `x` [`--formulae=`<formulae>] [`--`] <command> [<args> ...]
 
           Run <command> in an environment populated by Homebrew formulae.
 
@@ -29,8 +29,6 @@ module Homebrew
           `#!/usr/bin/env -S brew exec --formulae=jq,yq --`
         EOS
 
-        switch "--skip-update",
-               description: "Skip updating the executables database if any version exists on disk, no matter how old."
         comma_array "--formulae",
                     description: "Comma-separated formulae to install and add to `PATH` before running " \
                                  "<command>."

--- a/Library/Homebrew/cmd/exec.sh
+++ b/Library/Homebrew/cmd/exec.sh
@@ -84,10 +84,6 @@ homebrew-exec() {
   while [[ "$#" -gt 0 ]]
   do
     case "$1" in
-      --skip-update)
-        HOMEBREW_SKIP_UPDATE=1
-        shift
-        ;;
       --formulae=*)
         formulae_arg="${1#--formulae=}"
         formulae_seen=1
@@ -148,7 +144,7 @@ homebrew-exec() {
     [[ "${executable}" != */* ]] || odie "Executable name must not contain path separators without \`--formulae\`."
 
     provider_lookup=1
-    download_and_cache_executables_file >&2
+    ensure_executables_file >&2
 
     local -a matching_formulae=()
     local selected_formula formula

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -101,7 +101,9 @@ module Homebrew
         end
 
         # Check if we can parse the JSON and do any Ruby-side follow-up.
-        Homebrew::API.write_names_and_aliases unless Homebrew::EnvConfig.no_install_from_api?
+        unless Homebrew::EnvConfig.no_install_from_api?
+          Homebrew::API.write_names_and_aliases(legacy_executables_fallback: true)
+        end
 
         Homebrew.failed = true if ENV["HOMEBREW_UPDATE_FAILED"]
         return if Homebrew::EnvConfig.disable_load_formula?

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -11,7 +11,7 @@
 # HOMEBREW_FORCE_BREWED_CURL, HOMEBREW_FORCE_BREWED_GIT,
 # HOMEBREW_SYSTEM_CURL_TOO_OLD, HOMEBREW_USER_AGENT_CURL are set by brew.sh
 # shellcheck disable=SC2154
-source "${HOMEBREW_LIBRARY}/Homebrew/utils/executables.sh"
+source "${HOMEBREW_LIBRARY}/Homebrew/utils/api.sh"
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/lock.sh"
 
 macos_version_name() {
@@ -428,8 +428,6 @@ fetch_api_file() {
     do
       time_cond+=("${arg}")
     done < <(api_time_cond_args "${cache_path}")
-    # Keep curl request handling in sync with `download_and_cache_executables_file`
-    # in Library/Homebrew/utils/executables.sh.
     curl \
       "${CURL_DISABLE_CURLRC_ARGS[@]}" \
       --fail --compressed --silent \
@@ -684,12 +682,6 @@ EOS
   fi
 
   safe_cd "${HOMEBREW_REPOSITORY}"
-
-  # This means the user has run `brew which-formula` before and we should fetch executables.txt
-  if [[ "$(git config get --type=bool homebrew.commandnotfound 2>/dev/null)" == "true" ]]
-  then
-    export HOMEBREW_FETCH_EXECUTABLES_TXT=1
-  fi
 
   # if an older system had a newer curl installed, change each repo's remote URL from git to https
   if [[ -n "${HOMEBREW_SYSTEM_CURL_TOO_OLD}" && -x "${HOMEBREW_PREFIX}/opt/curl/bin/curl" ]] &&
@@ -1030,13 +1022,6 @@ EOS
     then
       echo "HOMEBREW_NO_INSTALL_FROM_API set: skipping API JSON downloads."
     fi
-  fi
-
-  # Update executables.txt if the user has ever run `brew which-formula` before.
-  if [[ -n "${HOMEBREW_FETCH_EXECUTABLES_TXT}" ]]
-  then
-    ohai "Downloading executables.txt"
-    fetch_api_file "${HOMEBREW_EXECUTABLES_TXT_ENDPOINT}" "${update_failed_file}"
   fi
 
   if [[ -f "${update_failed_file}" ]]

--- a/Library/Homebrew/cmd/which-formula.rb
+++ b/Library/Homebrew/cmd/which-formula.rb
@@ -22,8 +22,6 @@ module Homebrew
         EOS
         switch "--explain",
                description: "Output explanation of how to get <command> by installing one of the providing formulae."
-        switch "--skip-update",
-               description: "Skip updating the executables database if any version exists on disk, no matter how old."
         named_args :command, min: 1
       end
     end

--- a/Library/Homebrew/cmd/which-formula.sh
+++ b/Library/Homebrew/cmd/which-formula.sh
@@ -13,10 +13,6 @@ homebrew-which-formula() {
         HOMEBREW_EXPLAIN=1
         shift
         ;;
-      --skip-update)
-        HOMEBREW_SKIP_UPDATE=1
-        shift
-        ;;
       --*)
         echo "Unknown option: $1" >&2
         brew help which-formula
@@ -37,7 +33,7 @@ homebrew-which-formula() {
 
   for cmd in "${args[@]}"
   do
-    download_and_cache_executables_file
+    ensure_executables_file
 
     local formulae=()
     local formula

--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 require "abstract_command"
+require "api"
+require "executables_db"
 require "fileutils"
 require "formula"
 
@@ -37,6 +39,15 @@ module Homebrew
           FileUtils.mkdir_p directories
         end
 
+        executables_path = Pathname("api/internal/executables.txt")
+        # Use the existing executables database as the API generation source.
+        # It is generated from GitHub Packages metadata, not generated API JSON.
+        if !args.dry_run? &&
+           !Homebrew::API.download_executables_file_from_github_packages!(executables_path)
+          odie "Failed to download #{executables_path}"
+        end
+        executables = ExecutablesDB.new(executables_path.to_s).to_hash
+
         Homebrew.with_no_api_env do
           tap_migrations_json = JSON.dump(tap.tap_migrations)
           File.write("api/formula_tap_migrations.json", tap_migrations_json) unless args.dry_run?
@@ -51,6 +62,7 @@ module Homebrew
               formula = Formulary.factory(name)
               name = formula.name
               all_formulae[name] = formula.to_hash_with_variations
+              all_formulae[name]["executables"] = executables[name] if executables.key?(name)
               json = JSON.pretty_generate(all_formulae[name])
               html_template_name = html_template(name)
 

--- a/Library/Homebrew/dev-cmd/generate-internal-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-internal-api.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 require "abstract_command"
+require "api"
+require "executables_db"
 require "fileutils"
 require "formula"
 require "cask/cask"
@@ -32,6 +34,15 @@ module Homebrew
           FileUtils.mkdir_p "api/internal"
         end
 
+        executables_path = Pathname("api/internal/executables.txt")
+        # Use the existing executables database as the API generation source.
+        # It is generated from GitHub Packages metadata, not generated API JSON.
+        if !args.dry_run? &&
+           !Homebrew::API.download_executables_file_from_github_packages!(executables_path)
+          odie "Failed to download #{executables_path}"
+        end
+        executables = ExecutablesDB.new(executables_path.to_s).to_hash
+
         Homebrew.with_no_api_env do
           Formulary.enable_factory_cache!
           Formula.generating_hash!
@@ -45,6 +56,7 @@ module Homebrew
               formula = Formulary.factory(name)
               name = formula.name
               all_formulae[name] = formula.to_hash_with_variations
+              all_formulae[name]["executables"] = executables[name] if executables.key?(name)
             rescue
               onoe "Error while generating data for formula '#{name}'."
               raise

--- a/Library/Homebrew/executables_db.rb
+++ b/Library/Homebrew/executables_db.rb
@@ -33,6 +33,11 @@ module Homebrew
       end
     end
 
+    sig { returns(T::Hash[String, T::Array[String]]) }
+    def to_hash
+      @exes.transform_values(&:dup)
+    end
+
     sig { params(bottle_json_dir: T.nilable(String), removed_formulae: T::Array[String]).void }
     def update!(bottle_json_dir: nil, removed_formulae: [])
       if (json_dir = bottle_json_dir.presence) && Pathname(json_dir).directory?

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/exec.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/exec.rbi
@@ -13,7 +13,4 @@ end
 class Homebrew::Cmd::Exec::Args < Homebrew::CLI::Args
   sig { returns(T.nilable(T::Array[String])) }
   def formulae; end
-
-  sig { returns(T::Boolean) }
-  def skip_update?; end
 end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/which_formula.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/which_formula.rbi
@@ -13,7 +13,4 @@ end
 class Homebrew::Cmd::WhichFormula::Args < Homebrew::CLI::Args
   sig { returns(T::Boolean) }
   def explain?; end
-
-  sig { returns(T::Boolean) }
-  def skip_update?; end
 end

--- a/Library/Homebrew/startup/bootsnap.rb
+++ b/Library/Homebrew/startup/bootsnap.rb
@@ -40,7 +40,11 @@ module Homebrew
     def self.load!(compile_cache: true)
       return unless enabled?
 
-      require ENV.fetch("HOMEBREW_BOOTSNAP_GEM_PATH")
+      begin
+        require ENV.fetch("HOMEBREW_BOOTSNAP_GEM_PATH")
+      rescue LoadError
+        return
+      end
 
       ::Bootsnap.setup(
         cache_dir:,

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Homebrew::API::Formula do
   before do
     stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
     stub_const("Homebrew::API::HOMEBREW_CACHE_API_SOURCE", source_cache_dir)
+    described_class.clear_cache
   end
 
   def mock_curl_download(stdout:)
@@ -28,7 +29,8 @@ RSpec.describe Homebrew::API::Formula do
         [{
           "name": "foo",
           "url": "https://brew.sh/foo",
-          "aliases": ["foo-alias1", "foo-alias2"]
+          "aliases": ["foo-alias1", "foo-alias2"],
+          "executables": ["foo-bin", "food"]
         }, {
           "name": "bar",
           "url": "https://brew.sh/bar",
@@ -42,7 +44,11 @@ RSpec.describe Homebrew::API::Formula do
     end
     let(:formulae_hash) do
       {
-        "foo" => { "url" => "https://brew.sh/foo", "aliases" => ["foo-alias1", "foo-alias2"] },
+        "foo" => {
+          "url"         => "https://brew.sh/foo",
+          "aliases"     => ["foo-alias1", "foo-alias2"],
+          "executables" => ["foo-bin", "food"],
+        },
         "bar" => { "url" => "https://brew.sh/bar", "aliases" => ["bar-alias"] },
         "baz" => { "url" => "https://brew.sh/baz", "aliases" => [] },
       }
@@ -65,6 +71,59 @@ RSpec.describe Homebrew::API::Formula do
       mock_curl_download stdout: formulae_json
       aliases_output = described_class.all_aliases
       expect(aliases_output).to eq formulae_aliases
+    end
+
+    it "writes formula executables from the formula JSON list" do
+      mock_curl_download stdout: formulae_json
+      described_class.write_names_and_aliases
+
+      expect((cache_dir/"internal/executables.txt").read).to eq("foo:foo-bin food\n")
+    end
+
+    it "downloads the executables database if formula JSON has no executable entries" do
+      allow(Utils::Curl).to receive(:curl_download) do |*args, **kwargs|
+        raise "unexpected download URL: #{args.last}" unless args.last.end_with?("formula.jws.json")
+
+        kwargs[:to].write <<~JSON
+          [{
+            "name": "foo",
+            "url": "https://brew.sh/foo",
+            "aliases": []
+          }]
+        JSON
+      end
+      allow(Homebrew::API).to receive(:download_executables_file_from_github_packages!) do |target|
+        target.dirname.mkpath
+        target.write "foo:foo-bin\n"
+        true
+      end
+      allow(Homebrew::API).to receive(:verify_and_parse_jws) do |json_data|
+        [true, json_data]
+      end
+
+      described_class.write_names_and_aliases(legacy_executables_fallback: true)
+
+      expect((cache_dir/"internal/executables.txt").read).to eq("foo:foo-bin\n")
+    end
+
+    it "does not download the executables database while reading formula JSON" do
+      allow(Utils::Curl).to receive(:curl_download) do |*args, **kwargs|
+        raise "unexpected download URL: #{args.last}" unless args.last.end_with?("formula.jws.json")
+
+        kwargs[:to].write <<~JSON
+          [{
+            "name": "foo",
+            "url": "https://brew.sh/foo",
+            "aliases": []
+          }]
+        JSON
+      end
+      allow(Homebrew::API).to receive(:verify_and_parse_jws) do |json_data|
+        [true, json_data]
+      end
+
+      expect(described_class.all_formulae).to eq("foo" => { "url" => "https://brew.sh/foo", "aliases" => [] })
+      expect(cache_dir/"internal/executables.txt").not_to exist
     end
   end
 

--- a/Library/Homebrew/test/api/formula_struct_spec.rb
+++ b/Library/Homebrew/test/api/formula_struct_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Homebrew::API::FormulaStruct do
     def build_formula_struct(checksums)
       Homebrew::API::FormulaStruct.new(
         desc:                 "sample formula",
+        executables:          ["sample"],
         homepage:             "https://example.com",
         license:              "MIT",
         ruby_source_checksum: "abc123",
@@ -136,6 +137,7 @@ RSpec.describe Homebrew::API::FormulaStruct do
       bottle_tag = Utils::Bottles::Tag.from_symbol(:arm64_sequoia)
       hash = {
         "desc"                 => "test formula",
+        "executables"          => ["foo"],
         "homepage"             => "https://example.com",
         "license"              => "MIT",
         "ruby_source_checksum" => "abc123",
@@ -149,6 +151,7 @@ RSpec.describe Homebrew::API::FormulaStruct do
 
       expect(struct.bottle?).to be(true)
       expect(struct.bottle_checksums).to eq([{ cellar: :any, arm64_sequoia: "checksum1" }])
+      expect(struct.executables).to eq(["foo"])
     end
 
     it "sets bottle_present to false when no bottle_checksum is present" do
@@ -267,6 +270,7 @@ RSpec.describe Homebrew::API::FormulaStruct do
         stable_present:         true,
         stable_url_args:        ["https://example.com/foo-1.0.tar.gz", {}],
         stable_dependencies:    ["dep1", { "dep2" => :build }],
+        executables:            ["foo"],
         stable_uses_from_macos: [["zlib", {}]],
         bottle_present:         true,
         bottle_checksums:       [{ cellar: :any, arm64_sequoia: "checksum1" }],

--- a/Library/Homebrew/test/api/internal_spec.rb
+++ b/Library/Homebrew/test/api/internal_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Homebrew::API::Internal do
         "formulae": {
           "foo": {
             "desc": "Foo formula",
+            "executables": ["foo-bin", "food"],
             "homepage": "https://example.com/foo",
             "license": "MIT",
             "ruby_source_checksum": "09f88b61e36045188ddb1b1ba8e402b9f3debee1770cc4ca91355eeccb5f4a38",
@@ -87,6 +88,7 @@ RSpec.describe Homebrew::API::Internal do
     {
       "foo" => {
         "desc"                 => "Foo formula",
+        "executables"          => ["foo-bin", "food"],
         "homepage"             => "https://example.com/foo",
         "license"              => "MIT",
         "ruby_source_checksum" => "09f88b61e36045188ddb1b1ba8e402b9f3debee1770cc4ca91355eeccb5f4a38",
@@ -185,6 +187,7 @@ RSpec.describe Homebrew::API::Internal do
   before do
     FileUtils.mkdir_p(cache_dir/"internal")
     stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
+    described_class.clear_cache
     allow(Utils::Curl).to receive(:curl_download) do |*_args, **kwargs|
       kwargs[:to].write packages_json
     end
@@ -208,6 +211,13 @@ RSpec.describe Homebrew::API::Internal do
   it "returns the expected formula hashes" do
     formula_hashes_output = described_class.formula_hashes
     expect(formula_hashes_output).to eq formula_hashes
+  end
+
+  it "writes formula executables from the internal packages JSON" do
+    allow(Homebrew::EnvConfig).to receive(:use_internal_api?).and_return(true)
+    Homebrew::API.write_names_and_aliases
+
+    expect((cache_dir/"internal/executables.txt").read).to eq("foo:foo-bin food\n")
   end
 
   it "returns the expected cask hashes" do

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -113,6 +113,39 @@ RSpec.describe Homebrew::API do
     end
   end
 
+  describe "::download_executables_file_from_github_packages!" do
+    it "downloads executables.txt from the GitHub Packages OCI artifact" do
+      target = mktmpdir/"executables.txt"
+      stub_const("HOMEBREW_GITHUB_PACKAGES_AUTH", "Bearer QQ==")
+      manifest = {
+        "layers" => [{
+          "digest"      => "sha256:abc123",
+          "annotations" => {
+            "org.opencontainers.image.title" => "executables.txt",
+          },
+        }],
+      }
+
+      expect(Utils::Curl).to receive(:curl_output).with(
+        "--fail", "--location",
+        "--header", "Accept: application/vnd.oci.image.manifest.v1+json",
+        "--header", "Authorization: Bearer QQ==",
+        "https://ghcr.io/v2/homebrew/command-not-found/executables/manifests/latest",
+        show_error: false
+      ).and_return(instance_double(SystemCommand::Result, stdout: JSON.generate(manifest), success?: true))
+      expect(Utils::Curl).to receive(:curl_download).with(
+        "--fail",
+        "--header", "Authorization: Bearer QQ==",
+        "https://ghcr.io/v2/homebrew/command-not-found/executables/blobs/sha256:abc123",
+        to:         target,
+        show_error: false
+      ) { |*_args, **kwargs| kwargs[:to].write "foo:foo-bin\n" }
+
+      expect(described_class.download_executables_file_from_github_packages!(target)).to be true
+      expect(target.read).to eq("foo:foo-bin\n")
+    end
+  end
+
   describe "::tap_from_source_download" do
     let(:api_cache_root) { Homebrew::API::HOMEBREW_CACHE_API_SOURCE }
     let(:cache_path) do

--- a/Library/Homebrew/test/cmd/exec_spec.rb
+++ b/Library/Homebrew/test/cmd/exec_spec.rb
@@ -115,14 +115,14 @@ RSpec.describe Homebrew::Cmd::Exec do
 
     it "runs commands in formula environments and supports the x alias", :aggregate_failures, :integration_test do
       expect do
-        expect(brew_sh("exec", "--skip-update", executable_name, "arg", brew_sh_env)).to be_a_success
+        expect(brew_sh("exec", executable_name, "arg", brew_sh_env)).to be_a_success
       end.to(
         output("active-version arg\n").to_stdout
           .and(output("").to_stderr),
       )
 
       expect do
-        expect(brew_sh("x", "--skip-update", executable_name, brew_sh_env)).to be_a_success
+        expect(brew_sh("x", executable_name, brew_sh_env)).to be_a_success
       end.to(
         output("active-version\n").to_stdout
           .and(output("").to_stderr),
@@ -137,14 +137,14 @@ RSpec.describe Homebrew::Cmd::Exec do
       )
 
       expect do
-        expect(brew_sh("exec", "--formulae", "--skip-update", executable_name, brew_sh_env)).to be_a_failure
+        expect(brew_sh("exec", "--formulae=", executable_name, brew_sh_env)).to be_a_failure
       end.to(
         output("").to_stdout
           .and(output("Error: `--formulae` requires a comma-separated formula list.\n").to_stderr),
       )
 
       expect do
-        expect(brew_sh("exec", "--skip-update", installable_executable_name, "arg",
+        expect(brew_sh("exec", installable_executable_name, "arg",
                        brew_sh_env)).to be_a_success
       end.to(
         output("installable-version arg\n").to_stdout

--- a/Library/Homebrew/test/cmd/update_spec.rb
+++ b/Library/Homebrew/test/cmd/update_spec.rb
@@ -105,51 +105,6 @@ RSpec.describe Homebrew::Cmd::Update do
     expect(args_file.read).to eq("update-report\n--auto-update\n")
   end
 
-  it "announces executables.txt downloads" do
-    fetched_file = test_root/"fetched-file.txt"
-    setup_update_utils
-    (test_root/"cache").mkpath
-    (test_root/"cache/all_commands_list.txt").write("")
-    (test_root/"repository").mkpath
-
-    stdout, stderr, status = run_update_shell(
-      <<~SH,
-        source "#{repository_root}/Library/Homebrew/utils.sh"
-        source "#{update_script}"
-        brew() { :; }
-        fetch_api_file() { printf '%s\\n' "$1" > "#{fetched_file}"; }
-        git() {
-          [[ "$1" == "--version" ]] && return 0
-          return 1
-        }
-        git_init_if_necessary() { :; }
-        lock() { :; }
-        setup_ca_certificates() { :; }
-        setup_curl() { :; }
-        setup_git() { :; }
-        homebrew-update
-      SH
-      {
-        "HOMEBREW_CACHE"                   => (test_root/"cache").to_s,
-        "HOMEBREW_CELLAR"                  => (test_root/"cellar").to_s,
-        "HOMEBREW_DEVELOPER"               => nil,
-        "HOMEBREW_FETCH_EXECUTABLES_TXT"   => "1",
-        "HOMEBREW_LIBRARY"                 => (test_root/"Library").to_s,
-        "HOMEBREW_BREW_DEFAULT_GIT_REMOTE" => "https://example.com/Homebrew/brew",
-        "HOMEBREW_BREW_GIT_REMOTE"         => "https://example.com/Homebrew/brew",
-        "HOMEBREW_NO_INSTALL_FROM_API"     => "1",
-        "HOMEBREW_PREFIX"                  => (test_root/"prefix").to_s,
-        "HOMEBREW_QUIET"                   => "1",
-        "HOMEBREW_REPOSITORY"              => (test_root/"repository").to_s,
-      },
-    )
-
-    expect(status.success?).to be true
-    expect(stdout).to eq("==> Downloading executables.txt\n")
-    expect(stderr).to be_empty
-    expect(fetched_file.read).to eq("internal/executables.txt\n")
-  end
-
   it "preserves `update-report` arguments and exit status with the Rust frontend enabled" do
     args_file = test_root/"brew-args.txt"
     brew_wrapper = test_root/"brew-wrapper"

--- a/Library/Homebrew/test/cmd/which-formula_spec.rb
+++ b/Library/Homebrew/test/cmd/which-formula_spec.rb
@@ -3,8 +3,6 @@
 
 require "cmd/shared_examples/args_parse"
 require "cmd/which-formula"
-require "open3"
-require "shellwords"
 
 RSpec.describe Homebrew::Cmd::WhichFormula do
   it_behaves_like "parseable arguments"
@@ -42,58 +40,22 @@ RSpec.describe Homebrew::Cmd::WhichFormula do
     end
 
     it "prints plain formula names when outputting to a non-TTY", :integration_test do
-      expect { brew_sh "which-formula", "--skip-update", "foo2", brew_sh_env }.to output("foo\n").to_stdout
+      expect { brew_sh "which-formula", "foo2", brew_sh_env }.to output("foo\n").to_stdout
       expect do
-        brew_sh "which-formula", "--skip-update", "foo2", brew_sh_env.merge("HOMEBREW_NO_EMOJI" => "1")
+        brew_sh "which-formula", "foo2", brew_sh_env.merge("HOMEBREW_NO_EMOJI" => "1")
       end.to output("foo\n").to_stdout
-      expect { brew_sh "which-formula", "--skip-update", "baz", brew_sh_env }.to output("baz\n").to_stdout
-      expect { brew_sh "which-formula", "--skip-update", "bar" }.not_to output.to_stdout
-      expect { brew_sh "which-formula", "--skip-update", "QUX", brew_sh_env }.to output("qux\n").to_stdout
-      expect { brew_sh "which-formula", "--skip-update", "quux", brew_sh_env }.to output("quux\n").to_stdout
+      expect { brew_sh "which-formula", "baz", brew_sh_env }.to output("baz\n").to_stdout
+      expect { brew_sh "which-formula", "bar" }.not_to output.to_stdout
+      expect { brew_sh "which-formula", "QUX", brew_sh_env }.to output("qux\n").to_stdout
+      expect { brew_sh "which-formula", "quux", brew_sh_env }.to output("quux\n").to_stdout
     end
 
-    it "announces executable database downloads" do
-      mktmpdir do |path|
-        database = path/"api/internal/executables.txt"
-        repository = path/"repository"
-        fake_curl = path/"curl"
-        fake_curl.write <<~SH
-          #!/bin/sh
-          while [ "$#" -gt 0 ]; do
-            if [ "$1" = "--output" ]; then
-              output="$2"
-              shift 2
-            else
-              shift
-            fi
-          done
-          mkdir -p "$(dirname "$output")"
-          printf 'downloaded-formula(1.0):downloaded\\n' > "$output"
-        SH
-        fake_curl.chmod 0755
-        (repository/".git").mkpath
+    it "errors if the API is disabled and the executable database is missing", :integration_test do
+      described_class::DATABASE_FILE.unlink
 
-        stdout, stderr, status = Open3.capture3(
-          {
-            "HOMEBREW_API_DEFAULT_DOMAIN" => "https://example.com",
-            "HOMEBREW_CACHE"              => path.to_s,
-            "HOMEBREW_COLOR"              => nil,
-            "HOMEBREW_CURL"               => fake_curl.to_s,
-            "HOMEBREW_CURL_SPEED_LIMIT"   => "100",
-            "HOMEBREW_CURL_SPEED_TIME"    => "1",
-            "HOMEBREW_LIBRARY"            => HOMEBREW_LIBRARY_PATH.parent.to_s,
-            "HOMEBREW_REPOSITORY"         => repository.to_s,
-            "HOMEBREW_USER_AGENT_CURL"    => "Homebrew tests",
-          },
-          "/bin/bash",
-          "-c",
-          "source #{Shellwords.escape((HOMEBREW_LIBRARY_PATH/"cmd/which-formula.sh").to_s)}; " \
-          "download_and_cache_executables_file",
-        )
-
-        expect([status.success?, stdout, stderr, database.read])
-          .to eq([true, "==> Downloading executables.txt\n", "", "downloaded-formula(1.0):downloaded\n"])
-      end
+      expect do
+        expect(brew_sh("which-formula", "foo2", "HOMEBREW_NO_INSTALL_FROM_API" => "1")).to be_a_failure
+      end.to output(/HOMEBREW_NO_INSTALL_FROM_API must be unset/).to_stderr
     end
   end
 end

--- a/Library/Homebrew/test/dev-cmd/generate-formula-api_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-formula-api_spec.rb
@@ -6,4 +6,40 @@ require "dev-cmd/generate-formula-api"
 
 RSpec.describe Homebrew::DevCmd::GenerateFormulaApi do
   it_behaves_like "parseable arguments"
+
+  it "writes formula executables to generated formula data" do
+    core_tap = instance_double(CoreTap, installed?: true, name: "homebrew/core", formula_names: ["foo"],
+                                        alias_table: {}, formula_renames: {}, git_head: "formula-head",
+                                        tap_migrations: {})
+    bottle_tag = Utils::Bottles::Tag.from_symbol(:arm64_sonoma)
+
+    allow(CoreTap).to receive(:instance).and_return(core_tap)
+    allow(Formulary).to receive(:enable_factory_cache!)
+    allow(Formula).to receive(:generating_hash!)
+    allow(Formulary).to receive(:factory).with("foo").and_return(
+      instance_double(Formula, name: "foo", to_hash_with_variations: { "name" => "foo" }),
+    )
+    allow(Homebrew::API).to receive(:download_executables_file_from_github_packages!) do |target|
+      target.write "foo(1.0.0):foo-tool food\n"
+      true
+    end
+    allow(Homebrew::API::Formula::FormulaStructGenerator).to receive(:generate_formula_struct_hash)
+      .with({ "name" => "foo", "executables" => ["foo-tool", "food"] }, bottle_tag:)
+      .and_return(
+        instance_double(
+          Homebrew::API::FormulaStruct,
+          serialize: { "name" => "foo", "executables" => ["foo-tool", "food"] },
+        ),
+      )
+    stub_const("OnSystem::VALID_OS_ARCH_TAGS", [bottle_tag])
+
+    Dir.mktmpdir do |tmpdir|
+      path = Pathname.new(tmpdir)
+      path.cd { described_class.new([]).run }
+
+      expect(JSON.parse((path/"_data/formula/foo.json").read)["executables"]).to eq(["foo-tool", "food"])
+      expect(JSON.parse((path/"api/internal/formula.arm64_sonoma.json").read)
+        .dig("formulae", "foo", "executables")).to eq(["foo-tool", "food"])
+    end
+  end
 end

--- a/Library/Homebrew/test/dev-cmd/generate-internal-api_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-internal-api_spec.rb
@@ -7,7 +7,7 @@ require "dev-cmd/generate-internal-api"
 RSpec.describe Homebrew::DevCmd::GenerateInternalApi do
   it_behaves_like "parseable arguments"
 
-  it "writes metadata to each generated packages file" do
+  it "writes metadata and formula executables to each generated packages file" do
     core_tap = instance_double(CoreTap, installed?: true, name: "homebrew/core", formula_names: ["foo"],
                                         alias_table: {}, formula_renames: {}, git_head: "formula-head",
                                         tap_migrations: {})
@@ -26,9 +26,18 @@ RSpec.describe Homebrew::DevCmd::GenerateInternalApi do
     allow(Cask::CaskLoader).to receive(:load).with(Pathname("c.rb")).and_return(
       instance_double(Cask::Cask, token: "c", to_hash_with_variations: { "token" => "c" }),
     )
+    allow(Homebrew::API).to receive(:download_executables_file_from_github_packages!) do |target|
+      target.write "foo(1.0.0):foo-tool food\n"
+      true
+    end
     allow(Homebrew::API::Formula::FormulaStructGenerator).to receive(:generate_formula_struct_hash)
-      .with({ "name" => "foo" }, bottle_tag:)
-      .and_return(instance_double(Homebrew::API::FormulaStruct, serialize: { "name" => "foo" }))
+      .with({ "name" => "foo", "executables" => ["foo-tool", "food"] }, bottle_tag:)
+      .and_return(
+        instance_double(
+          Homebrew::API::FormulaStruct,
+          serialize: { "name" => "foo", "executables" => ["foo-tool", "food"] },
+        ),
+      )
     allow(Homebrew::API::Cask::CaskStructGenerator).to receive(:generate_cask_struct_hash)
       .with({ "token" => "c" }, bottle_tag:)
       .and_return(instance_double(Homebrew::API::CaskStruct, serialize: { "token" => "c" }))
@@ -39,11 +48,13 @@ RSpec.describe Homebrew::DevCmd::GenerateInternalApi do
     mktmpdir do |path|
       path.cd { described_class.new([]).run }
 
-      expect(JSON.parse((path/"api/internal/packages.arm64_sonoma.json").read)["metadata"]).to eq({
+      json = JSON.parse((path/"api/internal/packages.arm64_sonoma.json").read)
+      expect(json["metadata"]).to eq({
         "homebrew_version" => "4.2.18",
         "bottle_tag"       => "arm64_sonoma",
         "generated_at"     => 1_714_056_000,
       })
+      expect(json.dig("formulae", "foo", "executables")).to eq(["foo-tool", "food"])
     end
   end
 end

--- a/Library/Homebrew/test/startup/bootsnap_spec.rb
+++ b/Library/Homebrew/test/startup/bootsnap_spec.rb
@@ -1,0 +1,12 @@
+# typed: false
+# frozen_string_literal: true
+
+RSpec.describe Homebrew::Bootsnap do
+  describe "::load!" do
+    it "does not error when the configured gem path is unavailable" do
+      with_env(HOMEBREW_BOOTSNAP_GEM_PATH: "#{TEST_TMPDIR}/missing-bootsnap", HOMEBREW_NO_BOOTSNAP: nil) do
+        expect { described_class.load! }.not_to raise_error
+      end
+    end
+  end
+end

--- a/Library/Homebrew/utils/executables.sh
+++ b/Library/Homebrew/utils/executables.sh
@@ -1,11 +1,8 @@
 # Helpers for Homebrew's executables.txt database.
 
 # HOMEBREW_CACHE is set by utils/ruby.sh
-# HOMEBREW_LIBRARY is set by bin/brew
-# HOMEBREW_API_DEFAULT_DOMAIN HOMEBREW_API_DOMAIN HOMEBREW_CURL HOMEBREW_CURLRC
-# HOMEBREW_CURL_SPEED_LIMIT HOMEBREW_CURL_SPEED_TIME HOMEBREW_USER_AGENT_CURL are set by brew.sh
+# HOMEBREW_BREW_FILE and HOMEBREW_LIBRARY are set by bin/brew
 # shellcheck disable=SC2153,SC2154
-source "${HOMEBREW_LIBRARY}/Homebrew/utils/api.sh"
 source "${HOMEBREW_LIBRARY}/Homebrew/utils.sh"
 
 HOMEBREW_EXECUTABLES_TXT_ENDPOINT="internal/executables.txt"
@@ -14,70 +11,47 @@ executables_txt_cache_file() {
   echo "${HOMEBREW_CACHE}/api/${HOMEBREW_EXECUTABLES_TXT_ENDPOINT}"
 }
 
-download_and_cache_executables_file() {
+executables_file_fresh() {
   local database_file
   database_file="$(executables_txt_cache_file)"
 
-  if [[ -s "${database_file}" ]]
+  local -a stat_printf
+  local stat_format
+  if [[ -n "${HOMEBREW_MACOS}" ]]
   then
-    [[ -z "${HOMEBREW_SKIP_UPDATE}" ]] || return
-
-    local -a stat_printf
-    if [[ -n "${HOMEBREW_MACOS}" ]]
-    then
-      stat_printf=("/usr/bin/stat" "-f")
-    else
-      stat_printf=("/usr/bin/stat" "-c")
-    fi
-
-    local file_mtime
-    local current_time
-    local auto_update_secs
-    file_mtime="$("${stat_printf[@]}" %m "${database_file}")"
-    current_time=$(date +%s)
-    auto_update_secs=${HOMEBREW_API_AUTO_UPDATE_SECS:-450}
-
-    [[ $((current_time - auto_update_secs)) -ge ${file_mtime} ]] || return
+    stat_printf=("/usr/bin/stat" "-f")
+    stat_format="%m"
+  else
+    stat_printf=("/usr/bin/stat" "-c")
+    stat_format="%Y"
   fi
 
-  mkdir -p "${database_file%/*}"
-  ohai "Downloading executables.txt"
+  local file_mtime
+  local current_time
+  local auto_update_secs
+  file_mtime="$("${stat_printf[@]}" "${stat_format}" "${database_file}")"
+  current_time=$(date +%s)
+  auto_update_secs=${HOMEBREW_API_AUTO_UPDATE_SECS:-450}
 
-  local arg
-  local -a curl_disable_curlrc_args
-  while read -r arg
-  do
-    curl_disable_curlrc_args+=("${arg}")
-  done < <(api_curlrc_args)
+  [[ $((current_time - auto_update_secs)) -lt ${file_mtime} ]]
+}
 
-  local -a time_cond=()
-  while read -r arg
-  do
-    time_cond+=("${arg}")
-  done < <(api_time_cond_args "${database_file}")
+ensure_executables_file() {
+  local database_file
+  database_file="$(executables_txt_cache_file)"
 
-  local curl_exit_code url
-  # Keep curl request handling in sync with `fetch_api_file` in
-  # Library/Homebrew/cmd/update.sh.
-  while read -r url
-  do
-    ${HOMEBREW_CURL} \
-      "${curl_disable_curlrc_args[@]}" \
-      --fail --compressed --silent \
-      --speed-limit "${HOMEBREW_CURL_SPEED_LIMIT}" --speed-time "${HOMEBREW_CURL_SPEED_TIME}" \
-      --location --remote-time --output "${database_file}" \
-      "${time_cond[@]}" \
-      --user-agent "${HOMEBREW_USER_AGENT_CURL}" \
-      "${url}"
-    curl_exit_code=$?
-    [[ ${curl_exit_code} -eq 0 ]] && break
-  done < <(api_urls "${HOMEBREW_EXECUTABLES_TXT_ENDPOINT}")
+  if [[ -n "${HOMEBREW_NO_INSTALL_FROM_API}" ]]
+  then
+    odie "HOMEBREW_NO_INSTALL_FROM_API must be unset to use \`brew which-formula\` or \`brew exec\`."
+  fi
 
-  [[ ${curl_exit_code} -eq 0 ]] || return "${curl_exit_code}"
+  if [[ -s "${database_file}" ]] && executables_file_fresh
+  then
+    return
+  fi
 
-  touch "${database_file}"
-
-  git config --file="${HOMEBREW_REPOSITORY}/.git/config" --bool homebrew.commandnotfound true 2>/dev/null
+  "${HOMEBREW_BREW_FILE}" update --auto-update &>/dev/null || true
+  [[ -s "${database_file}" ]] || odie "The Homebrew executables database is unavailable. Run \`brew update\` and try again."
 }
 
 formulae_containing_executable() {

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -1147,7 +1147,6 @@ _brew_exec() {
       --formulae
       --help
       --quiet
-      --skip-update
       --verbose
       "
       return
@@ -3303,7 +3302,6 @@ _brew_which_formula() {
       --explain
       --help
       --quiet
-      --skip-update
       --verbose
       "
       return
@@ -3343,7 +3341,6 @@ _brew_x() {
       --formulae
       --help
       --quiet
-      --skip-update
       --verbose
       "
       return

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -807,7 +807,6 @@ __fish_brew_complete_arg 'exec' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'exec' -l formulae -d 'Comma-separated formulae to install and add to `PATH` before running command'
 __fish_brew_complete_arg 'exec' -l help -d 'Show this message'
 __fish_brew_complete_arg 'exec' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'exec' -l skip-update -d 'Skip updating the executables database if any version exists on disk, no matter how old'
 __fish_brew_complete_arg 'exec' -l verbose -d 'Make some output more verbose'
 
 
@@ -2119,7 +2118,6 @@ __fish_brew_complete_arg 'which-formula' -l debug -d 'Display any debugging info
 __fish_brew_complete_arg 'which-formula' -l explain -d 'Output explanation of how to get command by installing one of the providing formulae'
 __fish_brew_complete_arg 'which-formula' -l help -d 'Show this message'
 __fish_brew_complete_arg 'which-formula' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'which-formula' -l skip-update -d 'Skip updating the executables database if any version exists on disk, no matter how old'
 __fish_brew_complete_arg 'which-formula' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'which-formula' -a '(__fish_brew_suggest_commands)'
 
@@ -2141,7 +2139,6 @@ __fish_brew_complete_arg 'x' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'x' -l formulae -d 'Comma-separated formulae to install and add to `PATH` before running command'
 __fish_brew_complete_arg 'x' -l help -d 'Show this message'
 __fish_brew_complete_arg 'x' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'x' -l skip-update -d 'Skip updating the executables database if any version exists on disk, no matter how old'
 __fish_brew_complete_arg 'x' -l verbose -d 'Make some output more verbose'
 
 

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -1022,7 +1022,6 @@ _brew_exec() {
     '--formulae[Comma-separated formulae to install and add to `PATH` before running command]' \
     '--help[Show this message]' \
     '--quiet[Make some output more quiet]' \
-    '--skip-update[Skip updating the executables database if any version exists on disk, no matter how old]' \
     '--verbose[Make some output more verbose]'
 }
 
@@ -2602,7 +2601,6 @@ _brew_which_formula() {
     '--explain[Output explanation of how to get command by installing one of the providing formulae]' \
     '--help[Show this message]' \
     '--quiet[Make some output more quiet]' \
-    '--skip-update[Skip updating the executables database if any version exists on disk, no matter how old]' \
     '--verbose[Make some output more verbose]' \
     - command \
     '*:command:__brew_commands'
@@ -2629,7 +2627,6 @@ _brew_x() {
     '--formulae[Comma-separated formulae to install and add to `PATH` before running command]' \
     '--help[Show this message]' \
     '--quiet[Make some output more quiet]' \
-    '--skip-update[Skip updating the executables database if any version exists on disk, no matter how old]' \
     '--verbose[Make some output more verbose]'
 }
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -650,7 +650,7 @@ working fine: please don't worry or file an issue; just ignore this.
 
 : Enable debugging and profiling of audit methods.
 
-### `exec`, `x` \[`--skip-update`\] \[`--formulae=`*`formulae`*\] \[`--`\] *`command`* \[*`args`* ...\]
+### `exec`, `x` \[`--formulae=`*`formulae`*\] \[`--`\] *`command`* \[*`args`* ...\]
 
 Run *`command`* in an environment populated by Homebrew formulae.
 
@@ -666,11 +666,6 @@ Example: `brew exec --formulae=jq,yq -- ./script.sh`
 
 Scripts can also use a shebang on systems with `env -S`: `#!/usr/bin/env -S brew
 exec --formulae=jq,yq --`
-
-`--skip-update`
-
-: Skip updating the executables database if any version exists on disk, no
-  matter how old.
 
 `--formulae`
 
@@ -1968,7 +1963,7 @@ Extract a specific *`version`* of *`formula`* into a personal tap and install
 it. The default tap is *`user`*/versions. *`user`* uses the GitHub username if
 available and the local username otherwise.
 
-### `which-formula` \[`--explain`\] \[`--skip-update`\] *`command`* \[...\]
+### `which-formula` \[`--explain`\] *`command`* \[...\]
 
 Show which formula(e) provides the given command.
 
@@ -1976,11 +1971,6 @@ Show which formula(e) provides the given command.
 
 : Output explanation of how to get *`command`* by installing one of the
   providing formulae.
-
-`--skip-update`
-
-: Skip updating the executables database if any version exists on disk, no
-  matter how old.
 
 ### `--cache` \[*`options`*\] \[*`formula`*\|*`cask`* ...\]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -406,7 +406,7 @@ List all audit methods, which can be run individually if provided as arguments\.
 .TP
 \fB\-D\fP, \fB\-\-audit\-debug\fP
 Enable debugging and profiling of audit methods\.
-.SS "\fBexec\fP, \fBx\fP \fR[\fB\-\-skip\-update\fP] \fR[\fB\-\-formulae=\fP\fIformulae\fP] \fR[\fB\-\-\fP] \fIcommand\fP \fR[\fIargs\fP \.\.\.]"
+.SS "\fBexec\fP, \fBx\fP \fR[\fB\-\-formulae=\fP\fIformulae\fP] \fR[\fB\-\-\fP] \fIcommand\fP \fR[\fIargs\fP \.\.\.]"
 Run \fIcommand\fP in an environment populated by Homebrew formulae\.
 .P
 If \fB\-\-formulae\fP is passed, Homebrew installs those comma\-separated formulae if needed, prepends their executable directories and those of their dependencies to \fBPATH\fP and runs \fIcommand\fP\&\. This allows \fIcommand\fP to be a script path such as \fB\&\./script\.sh\fP\&\.
@@ -416,9 +416,6 @@ If \fB\-\-formulae\fP is omitted, Homebrew finds a formula that provides \fIcomm
 Example: \fBbrew exec \-\-formulae=jq,yq \-\- \./script\.sh\fP
 .P
 Scripts can also use a shebang on systems with \fBenv \-S\fP: \fB#!/usr/bin/env \-S brew exec \-\-formulae=jq,yq \-\-\fP
-.TP
-\fB\-\-skip\-update\fP
-Skip updating the executables database if any version exists on disk, no matter how old\.
 .TP
 \fB\-\-formulae\fP
 Comma\-separated formulae to install and add to \fBPATH\fP before running \fIcommand\fP\&\.
@@ -1215,14 +1212,11 @@ Include only formulae\.
 Include only casks\.
 .SS "\fBversion\-install\fP \fIformula\fP[@\fIversion\fP] \fR[\fIversion\fP]"
 Extract a specific \fIversion\fP of \fIformula\fP into a personal tap and install it\. The default tap is \fIuser\fP/versions\. \fIuser\fP uses the GitHub username if available and the local username otherwise\.
-.SS "\fBwhich\-formula\fP \fR[\fB\-\-explain\fP] \fR[\fB\-\-skip\-update\fP] \fIcommand\fP \fR[\.\.\.]"
+.SS "\fBwhich\-formula\fP \fR[\fB\-\-explain\fP] \fIcommand\fP \fR[\.\.\.]"
 Show which formula(e) provides the given command\.
 .TP
 \fB\-\-explain\fP
 Output explanation of how to get \fIcommand\fP by installing one of the providing formulae\.
-.TP
-\fB\-\-skip\-update\fP
-Skip updating the executables database if any version exists on disk, no matter how old\.
 .SS "\fB\-\-cache\fP \fR[\fIoptions\fP] \fR[\fIformula\fP|\fIcask\fP \.\.\.]"
 Display Homebrew\[u2019]s download cache\. See also \fB$HOMEBREW_CACHE\fP\&\.
 .P


### PR DESCRIPTION
- Avoid fetching `executables.txt` as a separate API artefact.
- Keep `which-formula` data generated from active formula JSON.
- Let internal API packages carry executable metadata.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review, tweaks and testing.

-----
