### PR TITLE
show more tap info for packages

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -660,6 +660,8 @@ module Homebrew
         end
 
         puts "From: #{Formatter.url(github_info(formula))}"
+        formula_tap = formula.tap
+        puts "Tap: #{formula_tap.name}" if formula_tap && !formula_tap.official?
 
         puts "License: #{SPDX.license_expression_to_string formula.license}" if formula.license.present?
         metadata = self.class.metadata_lines(formula)

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -113,10 +113,11 @@ module Homebrew
           puts commands.join(", ")
         end
 
-        print_section(tap, "Formulae", formula_names, installed_formulae) do |name|
+        min_width = (formula_names + cask_tokens).map { |n| Tty.strip_ansi(pretty_uninstalled(n)).length }.max || 0
+        print_section(tap, "Formulae", formula_names, installed_formulae, min_width:) do |name|
           decorate_formula(tap, name, installed: installed_formula_names.include?(name))
         end
-        print_section(tap, "Casks", cask_tokens, installed_casks) do |token|
+        print_section(tap, "Casks", cask_tokens, installed_casks, min_width:) do |token|
           decorate_cask(tap, token, installed: installed_cask_tokens.include?(token))
         end
       end
@@ -127,18 +128,19 @@ module Homebrew
           label:     String,
           all:       T::Array[String],
           installed: T::Array[String],
+          min_width: Integer,
           block:     T.proc.params(name: String).returns(String),
         ).void
       }
-      def print_section(tap, label, all, installed, &block)
+      def print_section(tap, label, all, installed, min_width:, &block)
         return if all.none?
 
         if all.size <= LISTING_LIMIT
-          ohai label, Formatter.columns(all.map(&block))
+          ohai label, Formatter.columns(all.map(&block), min_width:)
         elsif installed.any?
           ohai label
           opoo "Tap has more than #{LISTING_LIMIT} #{label.downcase}; showing only installed entries."
-          puts Formatter.columns(installed.map(&block))
+          puts Formatter.columns(installed.map(&block), min_width:)
         else
           ohai label
           opoo "Tap has more than #{LISTING_LIMIT} #{label.downcase} and none are installed."

--- a/Library/Homebrew/help.rb
+++ b/Library/Homebrew/help.rb
@@ -3,6 +3,7 @@
 
 require "cli/parser"
 require "commands"
+require "tap"
 require "utils/output"
 
 module Homebrew
@@ -67,9 +68,13 @@ module Homebrew
 
       output ||= comment_help(path)
 
-      output ||= if output.blank?
+      if output
+        if (tap = Tap.from_path(path)) && !tap.official?
+          output = "From tap: #{tap.name}\n#{output}"
+        end
+      else
         opoo "No help text in: #{path}" if Homebrew::EnvConfig.developer?
-        HOMEBREW_HELP_MESSAGE
+        output = HOMEBREW_HELP_MESSAGE
       end
 
       output

--- a/Library/Homebrew/help.rb
+++ b/Library/Homebrew/help.rb
@@ -68,7 +68,7 @@ module Homebrew
 
       output ||= comment_help(path)
 
-      if output
+      if output.present?
         if (tap = Tap.from_path(path)) && !tap.official?
           output = "From tap: #{tap.name}\n#{output}"
         end

--- a/Library/Homebrew/test/cmd/help_spec.rb
+++ b/Library/Homebrew/test/cmd/help_spec.rb
@@ -14,6 +14,76 @@ RSpec.describe Homebrew::Cmd::HelpCmd, :integration_test do
         .and not_to_output.to_stderr
         .and be_a_success
     end
+
+    it "prints the originating tap for an external command from a third-party tap" do
+      tap_path = HOMEBREW_TAP_DIRECTORY/"thirdparty/homebrew-foo"
+      tap_path.mkpath
+      tap_path.cd do
+        system "git", "init"
+        system "git", "remote", "add", "origin", "https://github.com/thirdparty/homebrew-foo"
+        FileUtils.touch "readme"
+        system "git", "add", "--all"
+        system "git", "commit", "-m", "init"
+      end
+      cmd_path = tap_path/"cmd/hello-tap.rb"
+      cmd_path.dirname.mkpath
+      cmd_path.write <<~RUBY
+        # typed: strict
+        # frozen_string_literal: true
+
+        require "abstract_command"
+
+        module Homebrew
+          module Cmd
+            class HelloTap < AbstractCommand
+              cmd_args do
+                description "A friendly greeter from a tap."
+              end
+
+              sig { override.void }
+              def run; end
+            end
+          end
+        end
+      RUBY
+      cmd_path.chmod(0755)
+
+      expect { brew "help", "hello-tap" }
+        .to output(%r{^From tap: thirdparty/foo$}).to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+
+    it "does not print the originating tap for an external command from an official tap" do
+      tap_path = setup_test_tap
+      cmd_path = tap_path/"cmd/hello-tap.rb"
+      cmd_path.dirname.mkpath
+      cmd_path.write <<~RUBY
+        # typed: strict
+        # frozen_string_literal: true
+
+        require "abstract_command"
+
+        module Homebrew
+          module Cmd
+            class HelloTap < AbstractCommand
+              cmd_args do
+                description "A friendly greeter from a tap."
+              end
+
+              sig { override.void }
+              def run; end
+            end
+          end
+        end
+      RUBY
+      cmd_path.chmod(0755)
+
+      expect { brew "help", "hello-tap" }
+        .not_to output(/^From tap:/).to_stdout
+    end
   end
 
   describe "cat" do

--- a/Library/Homebrew/test/utils/formatter_spec.rb
+++ b/Library/Homebrew/test/utils/formatter_spec.rb
@@ -1,0 +1,38 @@
+# typed: false
+# frozen_string_literal: true
+
+require "utils/formatter"
+
+RSpec.describe Formatter do
+  describe "::columns" do
+    before do
+      allow($stdout).to receive(:tty?).and_return(true)
+      allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+      allow(Tty).to receive(:width).and_return(80)
+    end
+
+    it "stretches few short items into wide columns that fill the terminal" do
+      first_row = described_class.columns(%w[aa bb cc dd]).lines.first.chomp
+
+      expect(first_row.index("bb")).to be > 2
+    end
+
+    it "uses tighter columns when min_width fits more columns than the item count" do
+      default_first_row = described_class.columns(%w[aa bb cc dd]).lines.first.chomp
+      pinned_first_row = described_class.columns(%w[aa bb cc dd], min_width: 4).lines.first.chomp
+
+      expect(pinned_first_row.index("bb")).to be < default_first_row.index("bb")
+    end
+
+    it "produces matching column widths for two calls sharing the same min_width" do
+      many = (1..20).map { |i| "item#{i}" }
+      few = %w[a b c]
+      shared_min_width = (many + few).map(&:length).max
+
+      many_first_row = described_class.columns(many, min_width: shared_min_width).lines.first.chomp
+      few_first_row = described_class.columns(few, min_width: shared_min_width).lines.first.chomp
+
+      expect(many_first_row.index("item3")).to eq(few_first_row.index("b"))
+    end
+  end
+end

--- a/Library/Homebrew/utils/formatter.rb
+++ b/Library/Homebrew/utils/formatter.rb
@@ -132,8 +132,8 @@ module Formatter
   # Layout objects in columns that fit the current terminal width.
   #
   # @api internal
-  sig { params(objects: T::Array[String], gap_size: Integer).returns(String) }
-  def self.columns(objects, gap_size: 2)
+  sig { params(objects: T::Array[String], gap_size: Integer, min_width: Integer).returns(String) }
+  def self.columns(objects, gap_size: 2, min_width: 0)
     objects = objects.flatten.map(&:to_s)
 
     fallback = proc do
@@ -145,13 +145,13 @@ module Formatter
 
     console_width = Tty.width
     object_lengths = objects.map { |obj| Tty.strip_ansi(obj).length }
-    cols = (console_width + gap_size) / (T.must(object_lengths.max) + gap_size)
+    max_length = [*object_lengths, min_width].max || 0
+    cols = (console_width + gap_size) / (max_length + gap_size)
 
     fallback.call if cols < 2
 
     rows = (objects.count + cols - 1) / cols
-    cols = (objects.count + rows - 1) / rows # avoid empty trailing columns
-
+    cols = (objects.count + rows - 1) / rows if min_width.zero? # avoid empty trailing columns
     col_width = ((console_width + gap_size) / cols) - gap_size
 
     gap_string = "".rjust(gap_size)


### PR DESCRIPTION
Give more info about non-official taps:

- 'brew info' tells you about which tap (offical taps are excluded)
- 'brew help' for a command tells you about which tap (offical taps are excluded)
- 'brew tap-info' aligns the lists between formulae and casks so it looks better (see below)

```
❯ brew tap-info steipete/tap
steipete/tap: Installed
4 casks, 24 formulae
/opt/homebrew/Library/Taps/steipete/homebrew-tap (292 files, 443.9KB)
From: https://github.com/steipete/homebrew-tap
HEAD: 373e8757d7c27e8491576c010e9cbdb500d9b3f8
last commit: 3 days ago
==> Formulae
birdclaw ✘     clawdex ✘      gifgrep ✘      imsg ✘         ordercli ✘     remindctl ✘    sonoscli ✘     tmuxwatch ✘
blucli ✘       codexbar ✘     gogcli ✘       mcporter ✘     peekaboo ✘     sag ✘          spogo ✘        wacli ✘
camsnap ✘      discrawl ✘     goplaces ✘     oracle ✘       poltergeist ✘  songsee ✘      telecrawl ✘    wacrawl ✘
==> Casks
blackbar ✘     codexbar ✘     repobar ✘      trimmy ✘
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claud Code, Extra High

-----
