### PR TITLE
Move away from RSpec's `described_class`

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -271,6 +271,9 @@ RSpec/NestedGroups:
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
 
+# Better for Sorbet if we don't use `described_class`.
+RSpec/DescribedClass:
+  EnforcedStyle: explicit
 RSpec/DescribedClassModuleWrapping:
   Enabled: true
 # Annoying to have these autoremoved.

--- a/Library/Homebrew/homebrew.rb
+++ b/Library/Homebrew/homebrew.rb
@@ -51,7 +51,7 @@ module Homebrew
       exit! 1 # never gets here unless exec failed
     end
     Process.wait(pid)
-    $CHILD_STATUS.success?
+    $CHILD_STATUS.success? || false
   end
   # TODO: make private_class_method when possible
   # private_class_method :_system

--- a/Library/Homebrew/test/PATH_spec.rb
+++ b/Library/Homebrew/test/PATH_spec.rb
@@ -4,31 +4,34 @@
 require "PATH"
 
 RSpec.describe PATH do
+  sig { returns(T.class_of(PATH)) }
+  let(:klass) { PATH }
+
   describe "#initialize" do
     it "can take multiple arguments" do
-      expect(described_class.new("/path1", "/path2")).to eq("/path1:/path2")
+      expect(klass.new("/path1", "/path2")).to eq("/path1:/path2")
     end
 
     it "can parse a mix of arrays and arguments" do
-      expect(described_class.new(["/path1", "/path2"], "/path3")).to eq("/path1:/path2:/path3")
+      expect(klass.new(["/path1", "/path2"], "/path3")).to eq("/path1:/path2:/path3")
     end
 
     it "splits an existing PATH" do
-      expect(described_class.new("/path1:/path2")).to eq(["/path1", "/path2"])
+      expect(klass.new("/path1:/path2")).to eq(["/path1", "/path2"])
     end
 
     it "removes duplicates" do
-      expect(described_class.new("/path1", "/path1")).to eq("/path1")
+      expect(klass.new("/path1", "/path1")).to eq("/path1")
     end
   end
 
   describe "#to_ary" do
     it "returns a PATH array" do
-      expect(described_class.new("/path1", "/path2").to_ary).to eq(["/path1", "/path2"])
+      expect(klass.new("/path1", "/path2").to_ary).to eq(["/path1", "/path2"])
     end
 
     it "does not allow mutating the original" do
-      path = described_class.new("/path1", "/path2")
+      path = klass.new("/path1", "/path2")
       path.to_ary << "/path3"
 
       expect(path).not_to include("/path3")
@@ -37,53 +40,53 @@ RSpec.describe PATH do
 
   describe "#to_str" do
     it "returns a PATH string" do
-      expect(described_class.new("/path1", "/path2").to_str).to eq("/path1:/path2")
+      expect(klass.new("/path1", "/path2").to_str).to eq("/path1:/path2")
     end
   end
 
   describe "#prepend" do
     specify(:aggregate_failures) do
-      expect(described_class.new("/path1").prepend("/path2").to_str).to eq("/path2:/path1")
-      expect(described_class.new("/path1").prepend("/path1").to_str).to eq("/path1")
+      expect(klass.new("/path1").prepend("/path2").to_str).to eq("/path2:/path1")
+      expect(klass.new("/path1").prepend("/path1").to_str).to eq("/path1")
     end
   end
 
   describe "#append" do
     specify(:aggregate_failures) do
-      expect(described_class.new("/path1").append("/path2").to_str).to eq("/path1:/path2")
-      expect(described_class.new("/path1").append("/path1").to_str).to eq("/path1")
+      expect(klass.new("/path1").append("/path2").to_str).to eq("/path1:/path2")
+      expect(klass.new("/path1").append("/path1").to_str).to eq("/path1")
     end
   end
 
   describe "#insert" do
     specify(:aggregate_failures) do
-      expect(described_class.new("/path1").insert(0, "/path2").to_str).to eq("/path2:/path1")
-      expect(described_class.new("/path1").insert(0, "/path2", "/path3")).to eq("/path2:/path3:/path1")
+      expect(klass.new("/path1").insert(0, "/path2").to_str).to eq("/path2:/path1")
+      expect(klass.new("/path1").insert(0, "/path2", "/path3")).to eq("/path2:/path3:/path1")
     end
   end
 
   describe "#==" do
     it "always returns false when comparing against something which does not respond to `#to_ary` or `#to_str`" do
-      expect(described_class.new).not_to eq Object.new
+      expect(klass.new).not_to eq Object.new
     end
   end
 
   describe "#include?" do
     it "returns true if a path is included", :aggregate_failures do
-      path = described_class.new("/path1", "/path2")
+      path = klass.new("/path1", "/path2")
       expect(path).to include("/path1")
       expect(path).to include("/path2")
-      expect(described_class.new("/path1", "/path2")).not_to include("/path1:")
+      expect(klass.new("/path1", "/path2")).not_to include("/path1:")
     end
 
     it "returns false if a path is not included" do
-      expect(described_class.new("/path1")).not_to include("/path2")
+      expect(klass.new("/path1")).not_to include("/path2")
     end
   end
 
   describe "#each" do
     it "loops through each path" do
-      enum = described_class.new("/path1", "/path2").each
+      enum = klass.new("/path1", "/path2").each
 
       expect(enum.next).to eq("/path1")
       expect(enum.next).to eq("/path2")
@@ -92,13 +95,13 @@ RSpec.describe PATH do
 
   describe "#select" do
     it "returns an object of the same class instead of an Array" do
-      expect(described_class.new.select { true }).to be_a(described_class)
+      expect(klass.new.select { true }).to be_a(klass)
     end
   end
 
   describe "#reject" do
     it "returns an object of the same class instead of an Array" do
-      expect(described_class.new.reject { true }).to be_a(described_class)
+      expect(klass.new.reject { true }).to be_a(klass)
     end
   end
 
@@ -107,13 +110,15 @@ RSpec.describe PATH do
       allow(File).to receive(:directory?).with("/path1").and_return(true)
       allow(File).to receive(:directory?).with("/path2").and_return(false)
 
-      path = described_class.new("/path1", "/path2")
-      expect(path.existing.to_ary).to eq(["/path1"])
+      path = klass.new("/path1", "/path2")
+      existing = path.existing
+      expect(existing).not_to be_nil
+      expect(existing&.to_ary).to eq(["/path1"])
       expect(path.to_ary).to eq(["/path1", "/path2"])
     end
 
-    it "returns nil instead of an empty #{described_class}" do
-      expect(described_class.new.existing).to be_nil
+    it "returns nil instead of an empty #{PATH}" do
+      expect(klass.new.existing).to be_nil
     end
   end
 end

--- a/Library/Homebrew/test/abstract_command_spec.rb
+++ b/Library/Homebrew/test/abstract_command_spec.rb
@@ -4,9 +4,11 @@
 require "abstract_command"
 
 RSpec.describe Homebrew::AbstractCommand do
+  let(:klass) { Homebrew::AbstractCommand }
+
   describe "subclasses" do
     before do
-      test_cat = Class.new(described_class) do
+      test_cat = Class.new(klass) do
         cmd_args do
           description "test"
           switch "--foo"
@@ -37,7 +39,7 @@ RSpec.describe Homebrew::AbstractCommand do
       end
 
       it "can lookup command" do
-        expect(described_class.command("test-cat")).to be(TestCat)
+        expect(klass.command("test-cat")).to be(TestCat)
       end
 
       it "removes -cmd suffix from command name" do
@@ -47,7 +49,7 @@ RSpec.describe Homebrew::AbstractCommand do
 
       describe "when command name is overridden" do
         before do
-          tac = Class.new(described_class) do
+          tac = Class.new(klass) do
             def self.command_name = "t-a-c"
             def run; end
           end
@@ -55,7 +57,7 @@ RSpec.describe Homebrew::AbstractCommand do
         end
 
         it "can be looked up by command name" do
-          expect(described_class.command("t-a-c")).to be(Tac)
+          expect(klass.command("t-a-c")).to be(Tac)
         end
       end
     end
@@ -67,7 +69,7 @@ RSpec.describe Homebrew::AbstractCommand do
         Dir[File.join(__dir__, "../#{dir}", "*.rb")].each do |file|
           filename = File.basename(file, ".rb")
           require(file)
-          command = described_class.command(filename)
+          command = klass.command(filename)
           expect(Pathname(File.join(__dir__, "../#{dir}/#{command.command_name}.rb"))).to exist
         end
       end

--- a/Library/Homebrew/test/abstract_subcommand_spec.rb
+++ b/Library/Homebrew/test/abstract_subcommand_spec.rb
@@ -5,9 +5,11 @@ require "abstract_command"
 require "abstract_subcommand"
 
 RSpec.describe Homebrew::AbstractSubcommand do
+  let(:klass) { Homebrew::AbstractSubcommand }
+
   describe "subclasses" do
     before do
-      subcommand = Class.new(described_class) do
+      subcommand = Class.new(klass) do
         subcommand_args aliases: ["ts"], default: true do
           usage_banner <<~EOS
             `brew test`:
@@ -39,33 +41,33 @@ RSpec.describe Homebrew::AbstractSubcommand do
     end
 
     it "finds subcommands nested under a command class" do
-      nested_subcommand = Class.new(described_class) do
+      nested_subcommand = Class.new(klass) do
         subcommand_args { named_args :none }
         def run; end
       end
       stub_const("SubcommandTestCmd::NestedSubcommand", nested_subcommand)
       stub_const("OtherSubcommandTestCmd", Class.new(Homebrew::AbstractCommand))
-      other_subcommand = Class.new(described_class) do
+      other_subcommand = Class.new(klass) do
         subcommand_args { named_args :none }
         def run; end
       end
       stub_const("OtherSubcommandTestCmd::NestedSubcommand", other_subcommand)
 
-      expect(described_class.subcommands_for(SubcommandTestCmd)).to include(nested_subcommand)
-      expect(described_class.subcommands_for(SubcommandTestCmd)).not_to include(other_subcommand)
+      expect(klass.subcommands_for(SubcommandTestCmd)).to include(nested_subcommand)
+      expect(klass.subcommands_for(SubcommandTestCmd)).not_to include(other_subcommand)
     end
 
     it "defines all subcommands nested under a command class" do
-      stub_const("SubcommandTestCmd::FirstSubcommand", Class.new(described_class) do
+      stub_const("SubcommandTestCmd::FirstSubcommand", Class.new(klass) do
         subcommand_args { named_args :none }
         def run; end
       end)
-      stub_const("SubcommandTestCmd::SecondSubcommand", Class.new(described_class) do
+      stub_const("SubcommandTestCmd::SecondSubcommand", Class.new(klass) do
         subcommand_args { named_args :none }
         def run; end
       end)
 
-      abstract_subcommand = described_class
+      abstract_subcommand = klass
       parser = Homebrew::CLI::Parser.new(SubcommandTestCmd) do
         abstract_subcommand.define_all(self, command: SubcommandTestCmd)
       end

--- a/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
+++ b/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
@@ -4,6 +4,8 @@
 require "api"
 
 RSpec.describe Homebrew::API::Cask::CaskStructGenerator do
+  let(:klass) { Homebrew::API::Cask::CaskStructGenerator }
+
   describe ":process_depends_on" do
     let(:depends_on_non_macos) do
       {
@@ -18,13 +20,13 @@ RSpec.describe Homebrew::API::Cask::CaskStructGenerator do
     let(:depends_on_maximum_macos) { { maximum_macos: MacOSRequirement.new([:sequoia], comparator: "<=") } }
 
     specify :aggregate_failures do
-      expect(described_class.process_depends_on(depends_on_non_macos)).to eq({ arch: :intel, formula: ["foo"] })
-      expect(described_class.process_depends_on(depends_on_linux)).to eq({ linux: :any })
-      expect(described_class.process_depends_on(depends_on_macos_equals)).to eq({ macos: [:sequoia] })
-      expect(described_class.process_depends_on(depends_on_macos_greater)).to eq({ macos: :sequoia })
-      expect(described_class.process_depends_on(depends_on_macos_bare)).to eq({ macos: :any })
-      expect(described_class.process_depends_on({ macos: {} })).to eq({ macos: :any })
-      expect(described_class.process_depends_on(depends_on_maximum_macos)).to eq({ maximum_macos: :sequoia })
+      expect(klass.process_depends_on(depends_on_non_macos)).to eq({ arch: :intel, formula: ["foo"] })
+      expect(klass.process_depends_on(depends_on_linux)).to eq({ linux: :any })
+      expect(klass.process_depends_on(depends_on_macos_equals)).to eq({ macos: [:sequoia] })
+      expect(klass.process_depends_on(depends_on_macos_greater)).to eq({ macos: :sequoia })
+      expect(klass.process_depends_on(depends_on_macos_bare)).to eq({ macos: :any })
+      expect(klass.process_depends_on({ macos: {} })).to eq({ macos: :any })
+      expect(klass.process_depends_on(depends_on_maximum_macos)).to eq({ maximum_macos: :sequoia })
     end
   end
 
@@ -41,7 +43,7 @@ RSpec.describe Homebrew::API::Cask::CaskStructGenerator do
       [:bar, ["arg1", "arg2"], { kwarg1: "value1" }, nil],
       [:baz, [], { kwarg1: "value1" }, nil],
     ]
-    output = described_class.process_artifacts(input)
+    output = klass.process_artifacts(input)
     expect(output).to eq expected_output
   end
 
@@ -57,7 +59,7 @@ RSpec.describe Homebrew::API::Cask::CaskStructGenerator do
       using:      :curl,
       bar:        "baz",
     }
-    output = described_class.process_url_specs(input)
+    output = klass.process_url_specs(input)
     expect(output).to eq expected_output
   end
 end

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -4,6 +4,8 @@
 require "api"
 
 RSpec.describe Homebrew::API::Cask do
+  let(:klass) { Homebrew::API::Cask }
+
   let(:cache_dir) { mktmpdir }
 
   before do
@@ -40,7 +42,7 @@ RSpec.describe Homebrew::API::Cask do
 
     it "returns the expected cask JSON list" do
       mock_curl_download stdout: casks_json
-      casks_output = described_class.all_casks
+      casks_output = klass.all_casks
       expect(casks_output).to eq casks_hash
     end
   end
@@ -68,7 +70,7 @@ RSpec.describe Homebrew::API::Cask do
         Checksum.new("00ae1ae330365f3d6e4387776f67a9c4b096da3d4546bd0827b5dcafa985234e"),
         any_args,
       ).and_call_original
-      described_class.source_download(cask)
+      klass.source_download(cask)
     end
   end
 end

--- a/Library/Homebrew/test/api/cask_struct_spec.rb
+++ b/Library/Homebrew/test/api/cask_struct_spec.rb
@@ -4,6 +4,8 @@
 require "api"
 
 RSpec.describe Homebrew::API::CaskStruct do
+  let(:klass) { Homebrew::API::CaskStruct }
+
   describe "::from_hash" do
     it "constructs a valid struct from a hash with all field types" do
       hash = {
@@ -25,7 +27,7 @@ RSpec.describe Homebrew::API::CaskStruct do
         "raw_caveats"          => "Requires restart.",
       }
 
-      struct = described_class.from_hash(hash)
+      struct = klass.from_hash(hash)
 
       expect(struct.sha256).to eq("abc123")
       expect(struct.version).to eq("1.0.0")
@@ -45,13 +47,13 @@ RSpec.describe Homebrew::API::CaskStruct do
         "another_unknown"      => 42,
       }
 
-      expect { described_class.from_hash(hash) }.not_to raise_error
+      expect { klass.from_hash(hash) }.not_to raise_error
     end
   end
 
   describe "predicate methods" do
     it "defaults all predicates to false for a minimal struct" do
-      struct = described_class.new(
+      struct = klass.new(
         sha256:               "abc123",
         version:              "1.0.0",
         ruby_source_checksum: { sha256: "def456" },
@@ -68,7 +70,7 @@ RSpec.describe Homebrew::API::CaskStruct do
         [:"#{predicate}_present", true]
       end
 
-      struct = described_class.new(
+      struct = klass.new(
         sha256:               "abc123",
         version:              "1.0.0",
         ruby_source_checksum: { sha256: "def456" },
@@ -84,7 +86,7 @@ RSpec.describe Homebrew::API::CaskStruct do
 
   describe "#artifacts" do
     it "replaces placeholders in artifact arguments" do
-      struct = described_class.new(
+      struct = klass.new(
         sha256:               "abc123",
         version:              "1.0.0",
         ruby_source_checksum: { sha256: "def456" },
@@ -99,7 +101,7 @@ RSpec.describe Homebrew::API::CaskStruct do
 
   describe "#caveats" do
     it "replaces placeholders in caveats string" do
-      struct = described_class.new(
+      struct = klass.new(
         sha256:               "abc123",
         version:              "1.0.0",
         ruby_source_checksum: { sha256: "def456" },
@@ -112,7 +114,7 @@ RSpec.describe Homebrew::API::CaskStruct do
     end
 
     it "returns nil when raw_caveats is nil" do
-      struct = described_class.new(
+      struct = klass.new(
         sha256:               "abc123",
         version:              "1.0.0",
         ruby_source_checksum: { sha256: "def456" },
@@ -123,7 +125,7 @@ RSpec.describe Homebrew::API::CaskStruct do
   end
 
   specify "#serialize_artifact_args", :aggregate_failures do
-    struct = described_class.new(
+    struct = klass.new(
       sha256:               "abc123",
       version:              "1.0.0",
       ruby_source_checksum: { sha256: "def456" },
@@ -137,29 +139,29 @@ RSpec.describe Homebrew::API::CaskStruct do
   end
 
   specify "::deserialize_artifact_args", :aggregate_failures do
-    expect(described_class.deserialize_artifact_args([:foo]))
+    expect(klass.deserialize_artifact_args([:foo]))
       .to eq([:foo, [], {}, nil])
 
-    expect(described_class.deserialize_artifact_args([:foo, ["abc", "def"]]))
+    expect(klass.deserialize_artifact_args([:foo, ["abc", "def"]]))
       .to eq([:foo, ["abc", "def"], {}, nil])
 
-    expect(described_class.deserialize_artifact_args([:foo, { ghi: "jkl" }]))
+    expect(klass.deserialize_artifact_args([:foo, { ghi: "jkl" }]))
       .to eq([:foo, [], { ghi: "jkl" }, nil])
 
-    expect(described_class.deserialize_artifact_args([:foo, :empty_block]))
-      .to eq([:foo, [], {}, described_class::EMPTY_BLOCK])
+    expect(klass.deserialize_artifact_args([:foo, :empty_block]))
+      .to eq([:foo, [], {}, klass::EMPTY_BLOCK])
 
-    expect(described_class.deserialize_artifact_args([:foo, ["abc", "def"], { ghi: "jkl" }]))
+    expect(klass.deserialize_artifact_args([:foo, ["abc", "def"], { ghi: "jkl" }]))
       .to eq([:foo, ["abc", "def"], { ghi: "jkl" }, nil])
 
-    expect(described_class.deserialize_artifact_args([:foo, ["abc", "def"], :empty_block]))
-      .to eq([:foo, ["abc", "def"], {}, described_class::EMPTY_BLOCK])
+    expect(klass.deserialize_artifact_args([:foo, ["abc", "def"], :empty_block]))
+      .to eq([:foo, ["abc", "def"], {}, klass::EMPTY_BLOCK])
 
-    expect(described_class.deserialize_artifact_args([:foo, { ghi: "jkl" }, :empty_block]))
-      .to eq([:foo, [], { ghi: "jkl" }, described_class::EMPTY_BLOCK])
+    expect(klass.deserialize_artifact_args([:foo, { ghi: "jkl" }, :empty_block]))
+      .to eq([:foo, [], { ghi: "jkl" }, klass::EMPTY_BLOCK])
 
-    expect(described_class.deserialize_artifact_args([:foo, ["abc", "def"], { ghi: "jkl" }, :empty_block]))
-      .to eq([:foo, ["abc", "def"], { ghi: "jkl" }, described_class::EMPTY_BLOCK])
+    expect(klass.deserialize_artifact_args([:foo, ["abc", "def"], { ghi: "jkl" }, :empty_block]))
+      .to eq([:foo, ["abc", "def"], { ghi: "jkl" }, klass::EMPTY_BLOCK])
   end
 
   describe "::deserialize" do
@@ -170,9 +172,9 @@ RSpec.describe Homebrew::API::CaskStruct do
         "ruby_source_checksum" => { sha256: "def456" },
       }
 
-      struct = described_class.deserialize(hash)
+      struct = klass.deserialize(hash)
 
-      described_class::PREDICATES.each do |predicate|
+      klass::PREDICATES.each do |predicate|
         expect(struct.send(:"#{predicate}?")).to be false
       end
     end
@@ -193,9 +195,9 @@ RSpec.describe Homebrew::API::CaskStruct do
         "ruby_source_checksum" => { sha256: "def456" },
       }
 
-      struct = described_class.deserialize(hash)
+      struct = klass.deserialize(hash)
 
-      described_class::PREDICATES.each do |predicate|
+      klass::PREDICATES.each do |predicate|
         expect(struct.send(:"#{predicate}?")).to be true
       end
     end
@@ -203,7 +205,7 @@ RSpec.describe Homebrew::API::CaskStruct do
 
   describe "serialize/deserialize round-trip" do
     it "reconstructs an equivalent struct after serialize then deserialize", :needs_macos do
-      original = described_class.new(
+      original = klass.new(
         auto_updates:         true,
         auto_updates_present: true,
         caveats_present:      true,
@@ -236,7 +238,7 @@ RSpec.describe Homebrew::API::CaskStruct do
       )
 
       serialized = original.serialize
-      restored = described_class.deserialize(serialized)
+      restored = klass.deserialize(serialized)
 
       expect(restored).to eq(original)
     end

--- a/Library/Homebrew/test/api/formula/formula_struct_generator_spec.rb
+++ b/Library/Homebrew/test/api/formula/formula_struct_generator_spec.rb
@@ -4,6 +4,8 @@
 require "api"
 
 RSpec.describe Homebrew::API::Formula::FormulaStructGenerator do
+  let(:klass) { Homebrew::API::Formula::FormulaStructGenerator }
+
   let(:raw_dependency_hash) do
     {
       "dependencies"           => [
@@ -99,27 +101,27 @@ RSpec.describe Homebrew::API::Formula::FormulaStructGenerator do
 
   specify "::process_dependencies_and_requirements", :aggregate_failures do
     expect(
-      described_class.process_dependencies_and_requirements(raw_dependency_hash, requirements_array, :stable),
+      klass.process_dependencies_and_requirements(raw_dependency_hash, requirements_array, :stable),
     ).to eq [dependency_args + stable_requirements_args, uses_from_macos_args]
 
     expect(
-      described_class.process_dependencies_and_requirements(raw_dependency_hash, requirements_array, :head),
+      klass.process_dependencies_and_requirements(raw_dependency_hash, requirements_array, :head),
     ).to eq [dependency_args + head_requirements_args, uses_from_macos_args]
 
     expect(
-      described_class.process_dependencies_and_requirements(raw_dependency_hash, nil, :head),
+      klass.process_dependencies_and_requirements(raw_dependency_hash, nil, :head),
     ).to eq [dependency_args, uses_from_macos_args]
 
     expect(
-      described_class.process_dependencies_and_requirements(nil, requirements_array, :stable),
+      klass.process_dependencies_and_requirements(nil, requirements_array, :stable),
     ).to eq [stable_requirements_args, []]
 
     expect(
-      described_class.process_dependencies_and_requirements(nil, requirements_array, :head),
+      klass.process_dependencies_and_requirements(nil, requirements_array, :head),
     ).to eq [head_requirements_args, []]
 
     expect(
-      described_class.process_dependencies_and_requirements(nil, nil, :stable),
+      klass.process_dependencies_and_requirements(nil, nil, :stable),
     ).to eq [[], []]
   end
 
@@ -138,24 +140,24 @@ RSpec.describe Homebrew::API::Formula::FormulaStructGenerator do
       "uses_from_macos_bounds"   => [],
     }
 
-    struct = described_class.generate_formula_struct_hash(hash)
+    struct = klass.generate_formula_struct_hash(hash)
 
     expect(struct.head_dependencies).not_to be_empty
     expect(struct.head_dependencies).to eq struct.stable_dependencies
   end
 
   specify "::symbolize_dependency_hash" do
-    output = described_class.symbolize_dependency_hash(raw_dependency_hash)
+    output = klass.symbolize_dependency_hash(raw_dependency_hash)
     expect(output).to eq symbolized_dependency_hash
   end
 
   specify "::process_dependencies" do
-    output = described_class.process_dependencies(symbolized_dependency_hash)
+    output = klass.process_dependencies(symbolized_dependency_hash)
     expect(output).to eq dependency_args
   end
 
   specify "::process_uses_from_macos" do
-    output = described_class.process_uses_from_macos(symbolized_dependency_hash)
+    output = klass.process_uses_from_macos(symbolized_dependency_hash)
     expect(output).to eq uses_from_macos_args
   end
 end

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -5,13 +5,14 @@ require "api"
 require "test/support/fixtures/testball"
 
 RSpec.describe Homebrew::API::Formula do
+  let(:klass) { Homebrew::API::Formula }
   let(:cache_dir) { mktmpdir }
   let(:source_cache_dir) { mktmpdir }
 
   before do
     stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
     stub_const("Homebrew::API::HOMEBREW_CACHE_API_SOURCE", source_cache_dir)
-    described_class.clear_cache
+    Homebrew::API::Formula.clear_cache
   end
 
   def mock_curl_download(stdout:)
@@ -63,19 +64,19 @@ RSpec.describe Homebrew::API::Formula do
 
     it "returns the expected formula JSON list" do
       mock_curl_download stdout: formulae_json
-      formulae_output = described_class.all_formulae
+      formulae_output = klass.all_formulae
       expect(formulae_output).to eq formulae_hash
     end
 
     it "returns the expected formula alias list" do
       mock_curl_download stdout: formulae_json
-      aliases_output = described_class.all_aliases
+      aliases_output = klass.all_aliases
       expect(aliases_output).to eq formulae_aliases
     end
 
     it "writes formula executables from the formula JSON list" do
       mock_curl_download stdout: formulae_json
-      described_class.write_names_and_aliases
+      Homebrew::API::Formula.write_names_and_aliases
 
       expect((cache_dir/"internal/executables.txt").read).to eq("foo:foo-bin food\n")
     end
@@ -99,7 +100,7 @@ RSpec.describe Homebrew::API::Formula do
       (cache_dir/"internal").mkpath
       (cache_dir/"internal/executables.txt").write "foo:foo-bin\n"
 
-      described_class.write_names_and_aliases
+      Homebrew::API::Formula.write_names_and_aliases
 
       expect(cache_dir/"internal/executables.txt").not_to exist
     end
@@ -120,7 +121,7 @@ RSpec.describe Homebrew::API::Formula do
         [true, json_data]
       end
 
-      expect(described_class.all_formulae).to eq("foo" => { "url" => "https://brew.sh/foo", "aliases" => [] })
+      expect(Homebrew::API::Formula.all_formulae).to eq("foo" => { "url" => "https://brew.sh/foo", "aliases" => [] })
       expect(cache_dir/"internal/executables.txt").not_to exist
     end
   end
@@ -142,7 +143,7 @@ RSpec.describe Homebrew::API::Formula do
       allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:symlink_location).and_return(regular_file)
       expect_any_instance_of(Homebrew::API::SourceDownload).to receive(:fetch)
 
-      described_class.source_download(f)
+      klass.source_download(f)
     end
 
     it "skips download when symlink_location is a valid symlink" do
@@ -154,7 +155,7 @@ RSpec.describe Homebrew::API::Formula do
       allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:symlink_location).and_return(symlink)
       expect_any_instance_of(Homebrew::API::SourceDownload).not_to receive(:fetch)
 
-      described_class.source_download(f)
+      klass.source_download(f)
     end
   end
 
@@ -175,7 +176,7 @@ RSpec.describe Homebrew::API::Formula do
       )
 
       expect do
-        described_class.source_download_formula(f)
+        klass.source_download_formula(f)
       end.to raise_error(CannotInstallFormulaError, /source code not found/)
     end
 
@@ -190,7 +191,7 @@ RSpec.describe Homebrew::API::Formula do
       allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:fetch)
       allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:symlink_location).and_return(source_path)
 
-      result = described_class.source_download_formula(f)
+      result = klass.source_download_formula(f)
       expect(result).to be_a(Formula)
       expect(result.name).to eq("testball")
     end
@@ -215,7 +216,7 @@ RSpec.describe Homebrew::API::Formula do
         download.symlink_location.write("patch contents")
       end
 
-      result = described_class.source_download_formula(f)
+      result = klass.source_download_formula(f)
 
       expect(result.patchlist.fetch(0).contents).to eq("patch contents")
     end

--- a/Library/Homebrew/test/api/formula_struct_spec.rb
+++ b/Library/Homebrew/test/api/formula_struct_spec.rb
@@ -4,6 +4,8 @@
 require "api"
 
 RSpec.describe Homebrew::API::FormulaStruct do
+  let(:klass) { Homebrew::API::FormulaStruct }
+
   describe "#serialize_bottle" do
     def build_formula_struct(checksums)
       Homebrew::API::FormulaStruct.new(
@@ -82,22 +84,22 @@ RSpec.describe Homebrew::API::FormulaStruct do
 
   describe "::format_arg_pair" do
     specify(:aggregate_failures) do
-      expect(described_class.format_arg_pair(["foo"], last: {})).to eq ["foo", {}]
-      expect(described_class.format_arg_pair([{ "foo" => :build }], last: {}))
+      expect(klass.format_arg_pair(["foo"], last: {})).to eq ["foo", {}]
+      expect(klass.format_arg_pair([{ "foo" => :build }], last: {}))
         .to eq [{ "foo" => :build }, {}]
-      expect(described_class.format_arg_pair([{ "foo" => :build, since: :catalina }], last: {}))
+      expect(klass.format_arg_pair([{ "foo" => :build, since: :catalina }], last: {}))
         .to eq [{ "foo" => :build, since: :catalina }, {}]
-      expect(described_class.format_arg_pair(["foo", { since: :catalina }], last: {}))
+      expect(klass.format_arg_pair(["foo", { since: :catalina }], last: {}))
         .to eq ["foo", { since: :catalina }]
 
-      expect(described_class.format_arg_pair([:foo], last: nil)).to eq [:foo, nil]
-      expect(described_class.format_arg_pair([:foo, :bar], last: nil)).to eq [:foo, :bar]
+      expect(klass.format_arg_pair([:foo], last: nil)).to eq [:foo, nil]
+      expect(klass.format_arg_pair([:foo, :bar], last: nil)).to eq [:foo, :bar]
     end
   end
 
   describe "predicate methods" do
     it "defaults all predicates to false when not set" do
-      struct = described_class.new(
+      struct = klass.new(
         desc:                 "test",
         homepage:             "https://example.com",
         license:              "MIT",
@@ -116,7 +118,7 @@ RSpec.describe Homebrew::API::FormulaStruct do
         [:"#{predicate}_present", true]
       end
 
-      struct = described_class.new(
+      struct = klass.new(
         desc:                 "test",
         homepage:             "https://example.com",
         license:              "MIT",
@@ -147,7 +149,7 @@ RSpec.describe Homebrew::API::FormulaStruct do
         "bottle_cellar"        => ":any",
       }
 
-      struct = described_class.deserialize(hash, bottle_tag:)
+      struct = klass.deserialize(hash, bottle_tag:)
 
       expect(struct.bottle?).to be(true)
       expect(struct.bottle_checksums).to eq([{ cellar: :any, arm64_sequoia: "checksum1" }])
@@ -164,7 +166,7 @@ RSpec.describe Homebrew::API::FormulaStruct do
         "stable_version"       => "1.0.0",
       }
 
-      struct = described_class.deserialize(hash, bottle_tag:)
+      struct = klass.deserialize(hash, bottle_tag:)
 
       expect(struct.bottle?).to be(false)
       expect(struct.bottle_checksums).to eq([])
@@ -182,7 +184,7 @@ RSpec.describe Homebrew::API::FormulaStruct do
         "keg_only_args"        => [":versioned_formula"],
       }
 
-      struct = described_class.deserialize(hash, bottle_tag:)
+      struct = klass.deserialize(hash, bottle_tag:)
 
       expect(struct.deprecate?).to be(true)
       expect(struct.keg_only?).to be(true)
@@ -200,7 +202,7 @@ RSpec.describe Homebrew::API::FormulaStruct do
         "stable_url_args"      => ["https://example.com/foo-1.0.tar.gz"],
       }
 
-      struct = described_class.deserialize(hash, bottle_tag:)
+      struct = klass.deserialize(hash, bottle_tag:)
 
       expect(struct.stable?).to be(true)
       expect(struct.stable_url_args).to eq(["https://example.com/foo-1.0.tar.gz", {}])
@@ -218,7 +220,7 @@ RSpec.describe Homebrew::API::FormulaStruct do
         "stable_uses_from_macos" => [["zlib"]],
       }
 
-      struct = described_class.deserialize(hash, bottle_tag:)
+      struct = klass.deserialize(hash, bottle_tag:)
 
       expect(struct.stable_uses_from_macos).to eq([["zlib", {}]])
     end
@@ -234,7 +236,7 @@ RSpec.describe Homebrew::API::FormulaStruct do
         "service_args"         => [[":run_type", ":immediate"]],
       }
 
-      struct = described_class.deserialize(hash, bottle_tag:)
+      struct = klass.deserialize(hash, bottle_tag:)
 
       expect(struct.service?).to be(true)
       expect(struct.service_args).to eq([[:run_type, :immediate]])
@@ -251,7 +253,7 @@ RSpec.describe Homebrew::API::FormulaStruct do
         "conflicts"            => [["other-formula"]],
       }
 
-      struct = described_class.deserialize(hash, bottle_tag:)
+      struct = klass.deserialize(hash, bottle_tag:)
 
       expect(struct.conflicts).to eq([["other-formula", {}]])
     end
@@ -261,7 +263,7 @@ RSpec.describe Homebrew::API::FormulaStruct do
     it "reconstructs an equivalent struct after serialize then deserialize", :needs_macos do
       bottle_tag = Utils::Bottles::Tag.from_symbol(:arm64_sequoia)
 
-      original = described_class.new(
+      original = klass.new(
         desc:                   "round-trip test",
         homepage:               "https://example.com",
         license:                "MIT",
@@ -281,7 +283,7 @@ RSpec.describe Homebrew::API::FormulaStruct do
       )
 
       serialized = original.serialize(bottle_tag:)
-      restored = described_class.deserialize(serialized, bottle_tag:)
+      restored = klass.deserialize(serialized, bottle_tag:)
 
       expect(restored).to eq(original)
     end

--- a/Library/Homebrew/test/api/internal_spec.rb
+++ b/Library/Homebrew/test/api/internal_spec.rb
@@ -4,6 +4,8 @@
 require "api/internal"
 
 RSpec.describe Homebrew::API::Internal do
+  let(:klass) { Homebrew::API::Internal }
+
   let(:cache_dir) { mktmpdir }
   let(:packages_json) do
     <<~JSON
@@ -187,7 +189,7 @@ RSpec.describe Homebrew::API::Internal do
   before do
     FileUtils.mkdir_p(cache_dir/"internal")
     stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
-    described_class.clear_cache
+    Homebrew::API::Internal.clear_cache
     allow(Utils::Curl).to receive(:curl_download) do |*_args, **kwargs|
       kwargs[:to].write packages_json
     end
@@ -198,18 +200,18 @@ RSpec.describe Homebrew::API::Internal do
 
   it "returns the expected formula structs" do
     formula_structs.each do |name, struct|
-      expect(described_class.formula_struct(name)).to eq struct
+      expect(klass.formula_struct(name)).to eq struct
     end
   end
 
   it "returns the expected cask structs" do
     cask_structs.each do |name, struct|
-      expect(described_class.cask_struct(name)).to eq struct
+      expect(klass.cask_struct(name)).to eq struct
     end
   end
 
   it "returns the expected formula hashes" do
-    formula_hashes_output = described_class.formula_hashes
+    formula_hashes_output = klass.formula_hashes
     expect(formula_hashes_output).to eq formula_hashes
   end
 
@@ -221,42 +223,42 @@ RSpec.describe Homebrew::API::Internal do
   end
 
   it "returns the expected cask hashes" do
-    cask_hashes_output = described_class.cask_hashes
+    cask_hashes_output = klass.cask_hashes
     expect(cask_hashes_output).to eq cask_hashes
   end
 
   it "returns the expected formula alias list" do
-    formula_aliases_output = described_class.formula_aliases
+    formula_aliases_output = klass.formula_aliases
     expect(formula_aliases_output).to eq formulae_aliases
   end
 
   it "returns the expected formula rename list" do
-    formula_renames_output = described_class.formula_renames
+    formula_renames_output = klass.formula_renames
     expect(formula_renames_output).to eq formulae_renames
   end
 
   it "returns the expected cask rename list" do
-    cask_renames_output = described_class.cask_renames
+    cask_renames_output = klass.cask_renames
     expect(cask_renames_output).to eq cask_renames
   end
 
   it "returns the expected formula tap git head" do
-    formula_tap_git_head_output = described_class.formula_tap_git_head
+    formula_tap_git_head_output = klass.formula_tap_git_head
     expect(formula_tap_git_head_output).to eq formula_tap_git_head
   end
 
   it "returns the expected cask tap git head" do
-    cask_tap_git_head_output = described_class.cask_tap_git_head
+    cask_tap_git_head_output = klass.cask_tap_git_head
     expect(cask_tap_git_head_output).to eq cask_tap_git_head
   end
 
   it "returns the expected formula tap migrations list" do
-    formula_tap_migrations_output = described_class.formula_tap_migrations
+    formula_tap_migrations_output = klass.formula_tap_migrations
     expect(formula_tap_migrations_output).to eq formula_tap_migrations
   end
 
   it "returns the expected cask tap migrations list" do
-    cask_tap_migrations_output = described_class.cask_tap_migrations
+    cask_tap_migrations_output = klass.cask_tap_migrations
     expect(cask_tap_migrations_output).to eq cask_tap_migrations
   end
 end

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -4,6 +4,8 @@
 require "api"
 
 RSpec.describe Homebrew::API do
+  let(:klass) { Homebrew::API }
+
   let(:text) { "foo" }
   let(:json) { '{"foo":"bar"}' }
   let(:json_hash) { JSON.parse(json) }
@@ -23,18 +25,18 @@ RSpec.describe Homebrew::API do
   describe "::fetch" do
     it "fetches a JSON file" do
       mock_curl_output stdout: json
-      fetched_json = described_class.fetch("foo.json")
+      fetched_json = klass.fetch("foo.json")
       expect(fetched_json).to eq json_hash
     end
 
     it "raises an error if the file does not exist" do
       mock_curl_output success: false
-      expect { described_class.fetch("bar.txt") }.to raise_error(ArgumentError, /No file found/)
+      expect { klass.fetch("bar.txt") }.to raise_error(ArgumentError, /No file found/)
     end
 
     it "raises an error if the JSON file is invalid" do
       mock_curl_output stdout: text
-      expect { described_class.fetch("baz.txt") }.to raise_error(ArgumentError, /Invalid JSON file/)
+      expect { klass.fetch("baz.txt") }.to raise_error(ArgumentError, /Invalid JSON file/)
     end
   end
 
@@ -47,20 +49,20 @@ RSpec.describe Homebrew::API do
 
     it "fetches a JSON file" do
       mock_curl_download stdout: json
-      fetched_json, = described_class.fetch_json_api_file("foo.json", target: cache_dir/"foo.json")
+      fetched_json, = klass.fetch_json_api_file("foo.json", target: cache_dir/"foo.json")
       expect(fetched_json).to eq json_hash
     end
 
     it "updates an existing JSON file" do
       mock_curl_download stdout: json
-      fetched_json, = described_class.fetch_json_api_file("bar.json", target: cache_dir/"bar.json")
+      fetched_json, = klass.fetch_json_api_file("bar.json", target: cache_dir/"bar.json")
       expect(fetched_json).to eq json_hash
     end
 
     it "raises an error if the JSON file is invalid" do
       mock_curl_download stdout: json_invalid
       expect do
-        described_class.fetch_json_api_file("baz.json", target: cache_dir/"baz.json")
+        klass.fetch_json_api_file("baz.json", target: cache_dir/"baz.json")
       end.to raise_error(SystemExit)
     end
 
@@ -73,7 +75,7 @@ RSpec.describe Homebrew::API do
       allow(Utils::Curl).to receive(:curl_download).and_raise(ErrorDuringExecution.new(["curl"], status: 1))
 
       expect do
-        described_class.fetch_json_api_file(
+        klass.fetch_json_api_file(
           "bar.json",
           target:        target,
           stale_seconds: 3600,
@@ -99,7 +101,7 @@ RSpec.describe Homebrew::API do
         kwargs[:to].write json
       end
 
-      described_class.fetch_json_api_file(
+      klass.fetch_json_api_file(
         "bar.json",
         target:        target,
         stale_seconds: 3600,
@@ -141,7 +143,7 @@ RSpec.describe Homebrew::API do
         show_error: false
       ) { |*_args, **kwargs| kwargs[:to].write "foo:foo-bin\n" }
 
-      expect(described_class.download_executables_file_from_github_packages!(target)).to be true
+      expect(Homebrew::API.download_executables_file_from_github_packages!(target)).to be true
       expect(target.read).to eq("foo:foo-bin\n")
     end
   end
@@ -165,7 +167,7 @@ RSpec.describe Homebrew::API do
         method.call(*args)
       end
 
-      expect(described_class.write_executables_file!(
+      expect(Homebrew::API.write_executables_file!(
                { "foo" => { "executables" => ["foo-bin"] } },
                regenerate: false,
              )).to be true
@@ -181,7 +183,7 @@ RSpec.describe Homebrew::API do
 
     context "when given a path inside the API source cache" do
       it "returns the corresponding tap" do
-        expect(described_class.tap_from_source_download(cache_path)).to eq CoreTap.instance
+        expect(klass.tap_from_source_download(cache_path)).to eq CoreTap.instance
       end
     end
 
@@ -189,13 +191,13 @@ RSpec.describe Homebrew::API do
       let(:api_cache_root) { mktmpdir }
 
       it "returns nil" do
-        expect(described_class.tap_from_source_download(cache_path)).to be_nil
+        expect(klass.tap_from_source_download(cache_path)).to be_nil
       end
     end
 
     context "when given a relative path that is not inside the API source cache" do
       it "returns nil" do
-        expect(described_class.tap_from_source_download(Pathname("../foo.rb"))).to be_nil
+        expect(klass.tap_from_source_download(Pathname("../foo.rb"))).to be_nil
       end
     end
   end
@@ -234,47 +236,47 @@ RSpec.describe Homebrew::API do
     end
 
     it "returns the original JSON if no variations are found" do
-      result = described_class.merge_variations(arm64_sequoia_result, bottle_tag: arm64_sequoia_tag)
+      result = klass.merge_variations(arm64_sequoia_result, bottle_tag: arm64_sequoia_tag)
       expect(result).to eq arm64_sequoia_result
     end
 
     it "returns the original JSON if no variations are found for the current system" do
-      result = described_class.merge_variations(arm64_sequoia_result)
+      result = klass.merge_variations(arm64_sequoia_result)
       expect(result).to eq arm64_sequoia_result
     end
 
     it "returns the original JSON without the variations if no matching variation is found" do
-      result = described_class.merge_variations(json, bottle_tag: x86_64_linux_tag)
+      result = klass.merge_variations(json, bottle_tag: x86_64_linux_tag)
       expect(result).to eq json.except("variations")
     end
 
     it "returns the original JSON without the variations if no matching variation is found for the current system" do
       Homebrew::SimulateSystem.with(os: :linux, arch: :intel) do
-        result = described_class.merge_variations(json)
+        result = klass.merge_variations(json)
         expect(result).to eq json.except("variations")
       end
     end
 
     it "returns the JSON with the matching variation applied from a string key" do
-      result = described_class.merge_variations(json, bottle_tag: arm64_sequoia_tag)
+      result = klass.merge_variations(json, bottle_tag: arm64_sequoia_tag)
       expect(result).to eq arm64_sequoia_result
     end
 
     it "returns the JSON with the matching variation applied from a string key for the current system" do
       Homebrew::SimulateSystem.with(os: :sequoia, arch: :arm) do
-        result = described_class.merge_variations(json)
+        result = klass.merge_variations(json)
         expect(result).to eq arm64_sequoia_result
       end
     end
 
     it "returns the JSON with the matching variation applied from a symbol key" do
-      result = described_class.merge_variations(json, bottle_tag: sonoma_tag)
+      result = klass.merge_variations(json, bottle_tag: sonoma_tag)
       expect(result).to eq sonoma_result
     end
 
     it "returns the JSON with the matching variation applied from a symbol key for the current system" do
       Homebrew::SimulateSystem.with(os: :sonoma, arch: :intel) do
-        result = described_class.merge_variations(json)
+        result = klass.merge_variations(json)
         expect(result).to eq sonoma_result
       end
     end

--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -4,6 +4,8 @@
 require "diagnostic"
 
 RSpec.describe Homebrew::Attestation do
+  let(:klass) { Homebrew::Attestation }
+
   let(:fake_gh) { Pathname.new("/extremely/fake/gh") }
   let(:fake_old_gh) { Pathname.new("/extremely/fake/old/gh") }
   let(:fake_gh_creds) { "fake-gh-api-token" }
@@ -77,11 +79,11 @@ RSpec.describe Homebrew::Attestation do
 
   describe "::gh_executable" do
     it "calls ensure_executable" do
-      expect(described_class).to receive(:ensure_executable!)
+      expect(klass).to receive(:ensure_executable!)
         .with("gh", reason: "verifying attestations", latest: true)
         .and_return(fake_gh)
 
-      described_class.gh_executable
+      klass.gh_executable
     end
   end
 
@@ -98,36 +100,36 @@ RSpec.describe Homebrew::Attestation do
 
     context "when `gh` is in the formula list" do
       it "moves `gh` formulae to the front of the list" do
-        expect(described_class).not_to receive(:gh_executable)
+        expect(klass).not_to receive(:gh_executable)
 
         [
           [[gh], [gh]],
           [[gh, other], [gh, other]],
           [[other, gh], [gh, other]],
         ].each do |input, output|
-          expect(described_class.sort_formulae_for_install(input.freeze)).to eq(output)
+          expect(klass.sort_formulae_for_install(input.freeze)).to eq(output)
         end
       end
     end
 
     context "when the formula list is empty" do
       it "checks for the `gh` executable" do
-        expect(described_class).to receive(:gh_executable).once
-        expect(described_class.sort_formulae_for_install([].freeze)).to eq([])
+        expect(klass).to receive(:gh_executable).once
+        expect(klass.sort_formulae_for_install([].freeze)).to eq([])
       end
     end
 
     context "when `gh` is not in the formula list" do
       it "checks for the `gh` executable" do
-        expect(described_class).to receive(:gh_executable).once
-        expect(described_class.sort_formulae_for_install([other].freeze)).to eq([other])
+        expect(klass).to receive(:gh_executable).once
+        expect(klass.sort_formulae_for_install([other].freeze)).to eq([other])
       end
     end
   end
 
   describe "::check_attestation" do
     before do
-      allow(described_class).to receive(:gh_executable)
+      allow(klass).to receive(:gh_executable)
         .and_return(fake_gh)
     end
 
@@ -136,97 +138,97 @@ RSpec.describe Homebrew::Attestation do
         .and_return(nil)
 
       expect do
-        described_class.check_attestation fake_bottle,
-                                          described_class::HOMEBREW_CORE_REPO
-      end.to raise_error(described_class::GhAuthNeeded)
+        klass.check_attestation fake_bottle,
+                                klass::HOMEBREW_CORE_REPO
+      end.to raise_error(klass::GhAuthNeeded)
     end
 
     it "raises when gh subprocess fails" do
       expect(GitHub::API).to receive(:credentials)
         .and_return(fake_gh_creds)
 
-      expect(described_class).to receive(:system_command!)
+      expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              described_class::HOMEBREW_CORE_REPO, "--format", "json"],
+                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_raise(ErrorDuringExecution.new(["foo"], status: fake_error_status))
 
       expect do
-        described_class.check_attestation fake_bottle,
-                                          described_class::HOMEBREW_CORE_REPO
-      end.to raise_error(described_class::InvalidAttestationError)
+        klass.check_attestation fake_bottle,
+                                klass::HOMEBREW_CORE_REPO
+      end.to raise_error(klass::InvalidAttestationError)
     end
 
     it "raises auth error when gh subprocess fails with auth exit code" do
       expect(GitHub::API).to receive(:credentials)
         .and_return(fake_gh_creds)
 
-      expect(described_class).to receive(:system_command!)
+      expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              described_class::HOMEBREW_CORE_REPO, "--format", "json"],
+                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_raise(ErrorDuringExecution.new(["foo"], status: fake_auth_status))
 
       expect do
-        described_class.check_attestation fake_bottle,
-                                          described_class::HOMEBREW_CORE_REPO
-      end.to raise_error(described_class::GhAuthInvalid)
+        klass.check_attestation fake_bottle,
+                                klass::HOMEBREW_CORE_REPO
+      end.to raise_error(klass::GhAuthInvalid)
     end
 
     it "raises when gh returns invalid JSON" do
       expect(GitHub::API).to receive(:credentials)
         .and_return(fake_gh_creds)
 
-      expect(described_class).to receive(:system_command!)
+      expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              described_class::HOMEBREW_CORE_REPO, "--format", "json"],
+                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_invalid_json)
 
       expect do
-        described_class.check_attestation fake_bottle,
-                                          described_class::HOMEBREW_CORE_REPO
-      end.to raise_error(described_class::InvalidAttestationError)
+        klass.check_attestation fake_bottle,
+                                klass::HOMEBREW_CORE_REPO
+      end.to raise_error(klass::InvalidAttestationError)
     end
 
     it "raises when gh returns other subjects" do
       expect(GitHub::API).to receive(:credentials)
         .and_return(fake_gh_creds)
 
-      expect(described_class).to receive(:system_command!)
+      expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              described_class::HOMEBREW_CORE_REPO, "--format", "json"],
+                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_json_resp_wrong_sub)
 
       expect do
-        described_class.check_attestation fake_bottle,
-                                          described_class::HOMEBREW_CORE_REPO
-      end.to raise_error(described_class::InvalidAttestationError)
+        klass.check_attestation fake_bottle,
+                                klass::HOMEBREW_CORE_REPO
+      end.to raise_error(klass::InvalidAttestationError)
     end
 
     it "checks subject prefix when the bottle is an :all bottle" do
       expect(GitHub::API).to receive(:credentials)
         .and_return(fake_gh_creds)
 
-      expect(described_class).to receive(:system_command!)
+      expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              described_class::HOMEBREW_CORE_REPO, "--format", "json"],
+                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_json_resp)
 
-      described_class.check_attestation fake_all_bottle, described_class::HOMEBREW_CORE_REPO
+      klass.check_attestation fake_all_bottle, klass::HOMEBREW_CORE_REPO
     end
   end
 
   describe "::check_core_attestation" do
     before do
-      allow(described_class).to receive(:gh_executable)
+      allow(klass).to receive(:gh_executable)
         .and_return(fake_gh)
 
       allow(GitHub::API).to receive(:credentials)
@@ -234,66 +236,66 @@ RSpec.describe Homebrew::Attestation do
     end
 
     it "calls gh with args for homebrew-core" do
-      expect(described_class).to receive(:system_command!)
+      expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              described_class::HOMEBREW_CORE_REPO, "--format", "json"],
+                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_json_resp)
 
-      described_class.check_core_attestation fake_bottle
+      klass.check_core_attestation fake_bottle
     end
 
     it "calls gh with args for homebrew-core and handles a multi-subject attestation" do
-      expect(described_class).to receive(:system_command!)
+      expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              described_class::HOMEBREW_CORE_REPO, "--format", "json"],
+                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_json_resp_multi_subject)
 
-      described_class.check_core_attestation fake_bottle
+      klass.check_core_attestation fake_bottle
     end
 
     it "calls gh with args for backfill when homebrew-core attestation is missing" do
-      expect(described_class).to receive(:system_command!)
+      expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              described_class::HOMEBREW_CORE_REPO, "--format", "json"],
+                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .once
-        .and_raise(described_class::MissingAttestationError)
+        .and_raise(klass::MissingAttestationError)
 
-      expect(described_class).to receive(:system_command!)
+      expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              described_class::BACKFILL_REPO, "--format", "json"],
+                              klass::BACKFILL_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_json_resp_backfill)
 
-      described_class.check_core_attestation fake_bottle
+      klass.check_core_attestation fake_bottle
     end
 
     it "raises when the backfilled attestation is too new" do
-      expect(described_class).to receive(:system_command!)
+      expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              described_class::HOMEBREW_CORE_REPO, "--format", "json"],
+                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
-        .exactly(described_class::ATTESTATION_MAX_RETRIES + 1)
-        .and_raise(described_class::MissingAttestationError)
+        .exactly(klass::ATTESTATION_MAX_RETRIES + 1)
+        .and_raise(klass::MissingAttestationError)
 
-      expect(described_class).to receive(:system_command!)
+      expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              described_class::BACKFILL_REPO, "--format", "json"],
+                              klass::BACKFILL_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
-        .exactly(described_class::ATTESTATION_MAX_RETRIES + 1)
+        .exactly(klass::ATTESTATION_MAX_RETRIES + 1)
         .and_return(fake_result_json_resp_too_new)
 
       expect do
-        described_class.check_core_attestation fake_bottle
-      end.to raise_error(described_class::InvalidAttestationError)
+        klass.check_core_attestation fake_bottle
+      end.to raise_error(klass::InvalidAttestationError)
     end
   end
 end

--- a/Library/Homebrew/test/bottle_filename_spec.rb
+++ b/Library/Homebrew/test/bottle_filename_spec.rb
@@ -5,8 +5,9 @@ require "formula"
 require "software_spec"
 
 RSpec.describe Bottle::Filename do
-  subject(:filename) { described_class.new(name, version, tag, rebuild) }
+  subject(:filename) { klass.new(name, version, tag, rebuild) }
 
+  let(:klass) { Bottle::Filename }
   let(:name) { "user/repo/foo" }
   let(:version) { PkgVersion.new(Version.new("1.0"), 0) }
   let(:tag) { Utils::Bottles::Tag.from_symbol(:x86_64_linux) }
@@ -48,7 +49,7 @@ RSpec.describe Bottle::Filename do
   end
 
   describe "::create" do
-    subject(:filename) { described_class.create(f, tag, rebuild) }
+    subject(:filename) { klass.create(f, tag, rebuild) }
 
     let(:f) do
       formula do

--- a/Library/Homebrew/test/bottle_spec.rb
+++ b/Library/Homebrew/test/bottle_spec.rb
@@ -5,12 +5,15 @@ require "bottle_specification"
 require "test/support/fixtures/testball_bottle"
 
 RSpec.describe Bottle do
+  sig { returns(T.class_of(Bottle)) }
+  let(:klass) { Bottle }
+
   describe "#filename" do
     it "renders the bottle filename" do
       bottle_spec = BottleSpecification.new
       bottle_spec.sha256(arm64_big_sur: "deadbeef" * 8)
       tag = Utils::Bottles::Tag.from_symbol :arm64_big_sur
-      bottle = described_class.new(TestballBottle.new, bottle_spec, tag)
+      bottle = klass.new(TestballBottle.new, bottle_spec, tag)
 
       expect(bottle.filename.to_s).to eq("testball_bottle--0.1.arm64_big_sur.bottle.tar.gz")
     end

--- a/Library/Homebrew/test/bottle_specification_spec.rb
+++ b/Library/Homebrew/test/bottle_specification_spec.rb
@@ -4,7 +4,9 @@
 require "bottle_specification"
 
 RSpec.describe BottleSpecification do
-  subject(:bottle_spec) { described_class.new }
+  subject(:bottle_spec) { klass.new }
+
+  let(:klass) { BottleSpecification }
 
   describe "#sha256" do
     it "works without cellar" do

--- a/Library/Homebrew/test/build_environment_spec.rb
+++ b/Library/Homebrew/test/build_environment_spec.rb
@@ -4,7 +4,7 @@
 require "build_environment"
 
 RSpec.describe BuildEnvironment do
-  let(:env) { described_class.new }
+  let(:env) { BuildEnvironment.new }
 
   describe "#<<" do
     it "returns itself" do
@@ -31,7 +31,7 @@ RSpec.describe BuildEnvironment do
 
   describe BuildEnvironment::DSL do
     let(:build_environment_dsl) do
-      klass = described_class
+      klass = BuildEnvironment::DSL
       Class.new do
         extend(klass)
       end

--- a/Library/Homebrew/test/build_options_spec.rb
+++ b/Library/Homebrew/test/build_options_spec.rb
@@ -5,15 +5,16 @@ require "build_options"
 require "options"
 
 RSpec.describe BuildOptions do
-  alias_matcher :be_built_with, :be_with
-  alias_matcher :be_built_without, :be_without
+  subject(:build_options) { klass.new(args, opts) }
 
-  subject(:build_options) { described_class.new(args, opts) }
-
-  let(:bad_build) { described_class.new(bad_args, opts) }
+  let(:klass) { BuildOptions }
+  let(:bad_build) { klass.new(bad_args, opts) }
   let(:args) { Options.create(%w[--with-foo --with-bar --without-qux]) }
   let(:opts) { Options.create(%w[--with-foo --with-bar --without-baz --without-qux]) }
   let(:bad_args) { Options.create(%w[--with-foo --with-bar --without-bas --without-qux --without-abc]) }
+
+  alias_matcher :be_built_with, :be_with
+  alias_matcher :be_built_without, :be_without
 
   specify do
     expect(build_options).to be_built_with("foo")

--- a/Library/Homebrew/test/bump_version_parser_spec.rb
+++ b/Library/Homebrew/test/bump_version_parser_spec.rb
@@ -4,6 +4,8 @@
 require "bump_version_parser"
 
 RSpec.describe Homebrew::BumpVersionParser do
+  let(:klass) { Homebrew::BumpVersionParser }
+
   let(:general_version) { "1.2.3" }
   let(:intel_version) { "2.3.4" }
   let(:arm_version) { "3.4.5" }
@@ -11,14 +13,14 @@ RSpec.describe Homebrew::BumpVersionParser do
   context "when initializing with no versions" do
     it "raises a usage error" do
       expect do
-        described_class.new
+        klass.new
       end.to raise_error(UsageError,
                          "Invalid usage: `--version` must not be empty.")
     end
   end
 
   context "when initializing with only an arm version" do
-    let(:new_version_arm) { described_class.new(arm: arm_version) }
+    let(:new_version_arm) { klass.new(arm: arm_version) }
 
     it "correctly parses arm version" do
       expect(new_version_arm.arm).to eq(Cask::DSL::Version.new(arm_version.to_s))
@@ -26,7 +28,7 @@ RSpec.describe Homebrew::BumpVersionParser do
   end
 
   context "when initializing with only an intel version" do
-    let(:new_version_intel) { described_class.new(intel: intel_version) }
+    let(:new_version_intel) { klass.new(intel: intel_version) }
 
     it "correctly parses intel version" do
       expect(new_version_intel.intel).to eq(Cask::DSL::Version.new(intel_version.to_s))
@@ -34,7 +36,7 @@ RSpec.describe Homebrew::BumpVersionParser do
   end
 
   context "when initializing with arm and intel versions" do
-    let(:new_version_arm_intel) { described_class.new(arm: arm_version, intel: intel_version) }
+    let(:new_version_arm_intel) { klass.new(arm: arm_version, intel: intel_version) }
 
     it "correctly parses arm and intel versions" do
       expect(new_version_arm_intel.arm).to eq(Cask::DSL::Version.new(arm_version.to_s))
@@ -43,9 +45,9 @@ RSpec.describe Homebrew::BumpVersionParser do
   end
 
   context "when initializing with all versions" do
-    let(:new_version) { described_class.new(general: general_version, arm: arm_version, intel: intel_version) }
+    let(:new_version) { klass.new(general: general_version, arm: arm_version, intel: intel_version) }
     let(:new_version_version) do
-      described_class.new(
+      klass.new(
         general: Version.new(general_version),
         arm:     Version.new(arm_version),
         intel:   Version.new(intel_version),
@@ -63,13 +65,13 @@ RSpec.describe Homebrew::BumpVersionParser do
 
     context "when the version is latest" do
       it "returns a version object for latest" do
-        new_version = described_class.new(general: "latest")
+        new_version = klass.new(general: "latest")
         expect(new_version.general.to_s).to eq("latest")
       end
 
       context "when the version is not latest" do
         it "returns a version object for the given version" do
-          new_version = described_class.new(general: general_version)
+          new_version = klass.new(general: general_version)
           expect(new_version.general.to_s).to eq(general_version)
         end
       end
@@ -77,14 +79,14 @@ RSpec.describe Homebrew::BumpVersionParser do
 
     context "when checking if VersionParser is blank" do
       it "returns false if any version is present" do
-        new_version = described_class.new(general: general_version.to_s, arm: "", intel: "")
+        new_version = klass.new(general: general_version.to_s, arm: "", intel: "")
         expect(new_version.blank?).to be(false)
       end
     end
   end
 
   describe "#==" do
-    let(:new_version) { described_class.new(general: general_version, arm: arm_version, intel: intel_version) }
+    let(:new_version) { klass.new(general: general_version, arm: arm_version, intel: intel_version) }
 
     context "when other object is not a `BumpVersionParser`" do
       it "returns false" do
@@ -94,19 +96,19 @@ RSpec.describe Homebrew::BumpVersionParser do
 
     context "when comparing objects with equal versions" do
       it "returns true" do
-        same_version = described_class.new(general: general_version, arm: arm_version, intel: intel_version)
+        same_version = klass.new(general: general_version, arm: arm_version, intel: intel_version)
         expect(new_version == same_version).to be(true)
       end
     end
 
     context "when comparing objects with different versions" do
       it "returns false" do
-        different_general_version = described_class.new(general: "3.2.1", arm: arm_version, intel: intel_version)
-        different_arm_version = described_class.new(general: general_version, arm: "4.3.2", intel: intel_version)
-        different_intel_version = described_class.new(general: general_version, arm: arm_version, intel: "5.4.3")
-        different_general_arm_versions = described_class.new(general: "3.2.1", arm: "4.3.2", intel: intel_version)
-        different_arm_intel_versions = described_class.new(general: general_version, arm: "4.3.2", intel: "5.4.3")
-        different_general_intel_versions = described_class.new(general: "3.2.1", arm: arm_version, intel: "5.4.3")
+        different_general_version = klass.new(general: "3.2.1", arm: arm_version, intel: intel_version)
+        different_arm_version = klass.new(general: general_version, arm: "4.3.2", intel: intel_version)
+        different_intel_version = klass.new(general: general_version, arm: arm_version, intel: "5.4.3")
+        different_general_arm_versions = klass.new(general: "3.2.1", arm: "4.3.2", intel: intel_version)
+        different_arm_intel_versions = klass.new(general: general_version, arm: "4.3.2", intel: "5.4.3")
+        different_general_intel_versions = klass.new(general: "3.2.1", arm: arm_version, intel: "5.4.3")
 
         expect(new_version == different_general_version).to be(false)
         expect(new_version == different_arm_version).to be(false)

--- a/Library/Homebrew/test/bundle/brew_services_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_services_spec.rb
@@ -5,9 +5,11 @@ require "bundle"
 require "bundle/brew_services"
 
 RSpec.describe Homebrew::Bundle::Brew::Services do
+  let(:klass) { Homebrew::Bundle::Brew::Services }
+
   describe ".started_services" do
     before do
-      described_class.reset!
+      klass.reset!
     end
 
     it "returns started services" do
@@ -27,25 +29,25 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
           }
         ]
       EOS
-      expect(described_class.started_services).to contain_exactly("nginx", "mysql")
+      expect(klass.started_services).to contain_exactly("nginx", "mysql")
     end
 
     it "returns empty array when no services exist" do
       allow(Utils).to receive(:safe_popen_read).and_return("[]\n")
-      expect(described_class.started_services).to eq([])
+      expect(klass.started_services).to eq([])
     end
 
     it "returns the missing daemon manager fallback when no daemon manager is available" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: false)
-      allow(described_class).to receive(:started_services_without_daemon_manager).and_return([])
+      allow(klass).to receive(:started_services_without_daemon_manager).and_return([])
 
-      expect(described_class.started_services).to eq([])
+      expect(klass.started_services).to eq([])
     end
 
     it "exits with error on macOS when no daemon manager is available", :needs_macos do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: false)
       expect do
-        described_class.started_services
+        klass.started_services
       end.to raise_error(SystemExit)
         .and output(/supported only on macOS or Linux/).to_stderr
     end
@@ -54,7 +56,7 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
   describe ".started_services_without_daemon_manager" do
     it "warns and returns an empty array on Linux", :needs_linux do
       expect do
-        expect(described_class.started_services_without_daemon_manager).to eq([])
+        expect(klass.started_services_without_daemon_manager).to eq([])
       end.to output(/Skipping `brew services list` due to missing systemctl/).to_stderr
     end
   end
@@ -62,53 +64,53 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
   context "when brew-services is installed" do
     context "when the service is stopped" do
       it "when the service is started" do
-        allow(described_class).to receive(:started_services).and_return(%w[nginx])
+        allow(klass).to receive(:started_services).and_return(%w[nginx])
         expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "services", "stop", "nginx",
                                                           verbose: false).and_return(true)
-        expect(described_class.stop("nginx")).to be(true)
-        expect(described_class.started_services).not_to include("nginx")
+        expect(klass.stop("nginx")).to be(true)
+        expect(klass.started_services).not_to include("nginx")
       end
 
       it "when the service is already stopped" do
-        allow(described_class).to receive(:started_services).and_return(%w[])
+        allow(klass).to receive(:started_services).and_return(%w[])
         expect(Homebrew::Bundle).not_to receive(:system).with(HOMEBREW_BREW_FILE, "services", "stop", "nginx",
                                                               verbose: false)
-        expect(described_class.stop("nginx")).to be(true)
-        expect(described_class.started_services).not_to include("nginx")
+        expect(klass.stop("nginx")).to be(true)
+        expect(klass.started_services).not_to include("nginx")
       end
     end
 
     it "starts the service" do
-      allow(described_class).to receive(:started_services).and_return([])
+      allow(klass).to receive(:started_services).and_return([])
       expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "services", "start", "nginx",
                                                         verbose: false).and_return(true)
-      expect(described_class.start("nginx")).to be(true)
-      expect(described_class.started_services).to include("nginx")
+      expect(klass.start("nginx")).to be(true)
+      expect(klass.started_services).to include("nginx")
     end
 
     it "runs the service" do
-      allow(described_class).to receive(:started_services).and_return([])
+      allow(klass).to receive(:started_services).and_return([])
       expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "services", "run", "nginx",
                                                         verbose: false).and_return(true)
-      expect(described_class.run("nginx")).to be(true)
-      expect(described_class.started_services).to include("nginx")
+      expect(klass.run("nginx")).to be(true)
+      expect(klass.started_services).to include("nginx")
     end
 
     it "restarts the service" do
-      allow(described_class).to receive(:started_services).and_return([])
+      allow(klass).to receive(:started_services).and_return([])
       expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "services", "restart", "nginx",
                                                         verbose: false).and_return(true)
-      expect(described_class.restart("nginx")).to be(true)
-      expect(described_class.started_services).to include("nginx")
+      expect(klass.restart("nginx")).to be(true)
+      expect(klass.started_services).to include("nginx")
     end
   end
 
   describe "#installed_and_up_to_date?" do
-    subject(:services) { described_class.new }
+    subject(:services) { klass.new }
 
     before do
-      described_class.reset!
-      allow(described_class).to receive(:started_services).and_return(%w[mailhog])
+      klass.reset!
+      allow(klass).to receive(:started_services).and_return(%w[mailhog])
       allow(services).to receive(:formula_needs_to_start?).and_return(true)
       allow(Homebrew::Bundle::Brew).to receive(:formula_oldnames).and_return({})
     end
@@ -156,7 +158,7 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
         allow(FileTest).to receive(:file?).and_call_original
         expect(FileTest).to receive(:file?).with(service_file.to_s).and_return(true)
 
-        expect(described_class.versioned_service_file(foo.name)).to eq(service_file)
+        expect(klass.versioned_service_file(foo.name)).to eq(service_file)
       end
     end
 

--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -10,8 +10,10 @@ require "tab"
 require "utils/bottles"
 
 RSpec.describe Homebrew::Bundle::Brew do
+  let(:klass) { Homebrew::Bundle::Brew }
+
   describe "dumping" do
-    subject(:dumper) { described_class }
+    subject(:dumper) { klass }
 
     let(:foo) do
       instance_double(Formula,
@@ -160,7 +162,7 @@ RSpec.describe Homebrew::Bundle::Brew do
     end
 
     before do
-      described_class.reset!
+      klass.reset!
     end
 
     describe "#formulae" do
@@ -181,7 +183,7 @@ RSpec.describe Homebrew::Bundle::Brew do
 
       it "exits on cyclic exceptions" do
         expect(Formula).to receive(:installed).and_return([foo, bar, baz])
-        expect_any_instance_of(described_class::Topo).to receive(:tsort).and_raise(
+        expect_any_instance_of(klass::Topo).to receive(:tsort).and_raise(
           TSort::Cyclic,
           'topological sort failed: ["foo", "bar"]',
         )
@@ -273,7 +275,7 @@ RSpec.describe Homebrew::Bundle::Brew do
   describe "installing" do
     let(:formula_name) { "mysql" }
     let(:options) { { args: ["with-option"] } }
-    let(:installer) { described_class.new(formula_name, options) }
+    let(:installer) { klass.new(formula_name, options) }
 
     before do
       # don't try to load gcc/glibc
@@ -284,13 +286,13 @@ RSpec.describe Homebrew::Bundle::Brew do
 
     context "when the formula is installed" do
       before do
-        allow_any_instance_of(described_class).to receive(:installed?).and_return(true)
+        allow_any_instance_of(klass).to receive(:installed?).and_return(true)
       end
 
       context "with a true start_service option" do
         before do
-          allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(true)
-          allow_any_instance_of(described_class).to receive(:installed?).and_return(true)
+          allow_any_instance_of(klass).to receive(:install_change_state!).and_return(true)
+          allow_any_instance_of(klass).to receive(:installed?).and_return(true)
           allow(Homebrew::Bundle).to receive(:brew).with("link", formula_name, verbose: false).and_return(true)
         end
 
@@ -302,15 +304,15 @@ RSpec.describe Homebrew::Bundle::Brew do
           context "with a successful installation" do
             it "start service" do
               expect(Homebrew::Bundle::Brew::Services).not_to receive(:start)
-              described_class.preinstall!(formula_name, start_service: true)
-              described_class.install!(formula_name, start_service: true)
+              klass.preinstall!(formula_name, start_service: true)
+              klass.install!(formula_name, start_service: true)
             end
           end
 
           context "with a skipped installation" do
             it "start service" do
               expect(Homebrew::Bundle::Brew::Services).not_to receive(:start)
-              described_class.install!(formula_name, preinstall: false, start_service: true)
+              klass.install!(formula_name, preinstall: false, start_service: true)
             end
           end
         end
@@ -324,8 +326,8 @@ RSpec.describe Homebrew::Bundle::Brew do
             it "start service" do
               expect(Homebrew::Bundle::Brew::Services).to \
                 receive(:start).with(formula_name, file: nil, verbose: false).and_return(true)
-              described_class.preinstall!(formula_name, start_service: true)
-              described_class.install!(formula_name, start_service: true)
+              klass.preinstall!(formula_name, start_service: true)
+              klass.install!(formula_name, start_service: true)
             end
           end
 
@@ -333,7 +335,7 @@ RSpec.describe Homebrew::Bundle::Brew do
             it "start service" do
               expect(Homebrew::Bundle::Brew::Services).to \
                 receive(:start).with(formula_name, file: nil, verbose: false).and_return(true)
-              described_class.install!(formula_name, preinstall: false, start_service: true)
+              klass.install!(formula_name, preinstall: false, start_service: true)
             end
           end
         end
@@ -341,8 +343,8 @@ RSpec.describe Homebrew::Bundle::Brew do
 
       context "with an always restart_service option" do
         before do
-          allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(true)
-          allow_any_instance_of(described_class).to receive(:installed?).and_return(true)
+          allow_any_instance_of(klass).to receive(:install_change_state!).and_return(true)
+          allow_any_instance_of(klass).to receive(:installed?).and_return(true)
           allow(Homebrew::Bundle).to receive(:brew).with("link", formula_name, verbose: false).and_return(true)
         end
 
@@ -350,8 +352,8 @@ RSpec.describe Homebrew::Bundle::Brew do
           it "restart service" do
             expect(Homebrew::Bundle::Brew::Services).to \
               receive(:restart).with(formula_name, file: nil, verbose: false).and_return(true)
-            described_class.preinstall!(formula_name, restart_service: :always)
-            described_class.install!(formula_name, restart_service: :always)
+            klass.preinstall!(formula_name, restart_service: :always)
+            klass.install!(formula_name, restart_service: :always)
           end
         end
 
@@ -359,90 +361,90 @@ RSpec.describe Homebrew::Bundle::Brew do
           it "restart service" do
             expect(Homebrew::Bundle::Brew::Services).to \
               receive(:restart).with(formula_name, file: nil, verbose: false).and_return(true)
-            described_class.install!(formula_name, preinstall: false, restart_service: :always)
+            klass.install!(formula_name, preinstall: false, restart_service: :always)
           end
         end
       end
 
       context "when the link option is true" do
         before do
-          allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(true)
+          allow_any_instance_of(klass).to receive(:install_change_state!).and_return(true)
         end
 
         it "links formula" do
-          allow_any_instance_of(described_class).to receive(:linked?).and_return(false)
+          allow_any_instance_of(klass).to receive(:linked?).and_return(false)
           expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "link", "mysql",
                                                             verbose: false).and_return(true)
-          described_class.preinstall!(formula_name, link: true)
-          described_class.install!(formula_name, link: true)
+          klass.preinstall!(formula_name, link: true)
+          klass.install!(formula_name, link: true)
         end
 
         it "force-links keg-only formula" do
-          allow_any_instance_of(described_class).to receive(:linked?).and_return(false)
-          allow_any_instance_of(described_class).to receive(:keg_only?).and_return(true)
+          allow_any_instance_of(klass).to receive(:linked?).and_return(false)
+          allow_any_instance_of(klass).to receive(:keg_only?).and_return(true)
           expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "link", "--force", "mysql",
                                                             verbose: false).and_return(true)
-          described_class.preinstall!(formula_name, link: true)
-          described_class.install!(formula_name, link: true)
+          klass.preinstall!(formula_name, link: true)
+          klass.install!(formula_name, link: true)
         end
       end
 
       context "when the link option is :overwrite" do
         before do
-          allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(true)
+          allow_any_instance_of(klass).to receive(:install_change_state!).and_return(true)
         end
 
         it "overwrite links formula" do
-          allow_any_instance_of(described_class).to receive(:linked?).and_return(false)
+          allow_any_instance_of(klass).to receive(:linked?).and_return(false)
           expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "link", "--overwrite", "mysql",
                                                             verbose: false).and_return(true)
-          described_class.preinstall!(formula_name, link: :overwrite)
-          described_class.install!(formula_name, link: :overwrite)
+          klass.preinstall!(formula_name, link: :overwrite)
+          klass.install!(formula_name, link: :overwrite)
         end
       end
 
       context "when the link option is false" do
         before do
-          allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(true)
+          allow_any_instance_of(klass).to receive(:install_change_state!).and_return(true)
         end
 
         it "unlinks formula" do
-          allow_any_instance_of(described_class).to receive(:linked?).and_return(true)
+          allow_any_instance_of(klass).to receive(:linked?).and_return(true)
           expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "unlink", "mysql",
                                                             verbose: false).and_return(true)
-          described_class.preinstall!(formula_name, link: false)
-          described_class.install!(formula_name, link: false)
+          klass.preinstall!(formula_name, link: false)
+          klass.install!(formula_name, link: false)
         end
       end
 
       context "when the link option is nil and formula is unlinked and not keg-only" do
         before do
-          allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(true)
-          allow_any_instance_of(described_class).to receive(:linked?).and_return(false)
-          allow_any_instance_of(described_class).to receive(:keg_only?).and_return(false)
+          allow_any_instance_of(klass).to receive(:install_change_state!).and_return(true)
+          allow_any_instance_of(klass).to receive(:linked?).and_return(false)
+          allow_any_instance_of(klass).to receive(:keg_only?).and_return(false)
         end
 
         it "links formula" do
           expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "link", "mysql",
                                                             verbose: false).and_return(true)
-          described_class.preinstall!(formula_name, link: nil)
-          described_class.install!(formula_name, link: nil)
+          klass.preinstall!(formula_name, link: nil)
+          klass.install!(formula_name, link: nil)
         end
       end
 
       context "when the link option is nil and formula is linked and keg-only" do
         before do
-          allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(true)
-          allow_any_instance_of(described_class).to receive(:linked?).and_return(true)
-          allow_any_instance_of(described_class).to receive(:keg_only?).and_return(true)
+          allow_any_instance_of(klass).to receive(:install_change_state!).and_return(true)
+          allow_any_instance_of(klass).to receive(:linked?).and_return(true)
+          allow_any_instance_of(klass).to receive(:keg_only?).and_return(true)
         end
 
         it "unlinks formula" do
           expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "unlink", "mysql",
                                                             verbose: false).and_return(true)
-          described_class.preinstall!(formula_name, link: nil)
+          klass.preinstall!(formula_name, link: nil)
 
-          described_class.install!(formula_name, link: nil)
+          klass.install!(formula_name, link: nil)
         end
       end
 
@@ -452,14 +454,14 @@ RSpec.describe Homebrew::Bundle::Brew do
             url "mysql-1.0"
             conflicts_with "mysql55"
           }
-          allow(described_class).to receive(:formula_installed?).and_return(true)
-          allow_any_instance_of(described_class).to receive(:install_formula!).and_return(true)
-          allow_any_instance_of(described_class).to receive(:upgrade_formula!).and_return(true)
+          allow(klass).to receive(:formula_installed?).and_return(true)
+          allow_any_instance_of(klass).to receive(:install_formula!).and_return(true)
+          allow_any_instance_of(klass).to receive(:upgrade_formula!).and_return(true)
         end
 
         it "unlinks conflicts and stops their services" do
           verbose = false
-          allow_any_instance_of(described_class).to receive(:linked?).and_return(true)
+          allow_any_instance_of(klass).to receive(:linked?).and_return(true)
           expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "unlink", "mysql55",
                                                             verbose:).and_return(true)
           expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "unlink", "mysql56",
@@ -468,13 +470,13 @@ RSpec.describe Homebrew::Bundle::Brew do
           expect(Homebrew::Bundle::Brew::Services).to receive(:stop).with("mysql56", verbose:).and_return(true)
           expect(Homebrew::Bundle::Brew::Services).to receive(:restart).with(formula_name, file:    nil,
                                                                                            verbose:).and_return(true)
-          described_class.preinstall!(formula_name, restart_service: :always, conflicts_with: ["mysql56"])
-          described_class.install!(formula_name, restart_service: :always, conflicts_with: ["mysql56"])
+          klass.preinstall!(formula_name, restart_service: :always, conflicts_with: ["mysql56"])
+          klass.install!(formula_name, restart_service: :always, conflicts_with: ["mysql56"])
         end
 
         it "prints a message" do
-          allow_any_instance_of(described_class).to receive(:linked?).and_return(true)
-          allow_any_instance_of(described_class).to receive(:puts)
+          allow_any_instance_of(klass).to receive(:linked?).and_return(true)
+          allow_any_instance_of(klass).to receive(:puts)
           verbose = true
           expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "unlink", "mysql55",
                                                             verbose:).and_return(true)
@@ -484,47 +486,47 @@ RSpec.describe Homebrew::Bundle::Brew do
           expect(Homebrew::Bundle::Brew::Services).to receive(:stop).with("mysql56", verbose:).and_return(true)
           expect(Homebrew::Bundle::Brew::Services).to receive(:restart).with(formula_name, file:    nil,
                                                                                            verbose:).and_return(true)
-          described_class.preinstall!(formula_name, restart_service: :always, conflicts_with: ["mysql56"],
+          klass.preinstall!(formula_name, restart_service: :always, conflicts_with: ["mysql56"],
           verbose: true)
-          described_class.install!(formula_name, restart_service: :always, conflicts_with: ["mysql56"],
+          klass.install!(formula_name, restart_service: :always, conflicts_with: ["mysql56"],
           verbose: true)
         end
       end
 
       context "when the postinstall option is provided" do
         before do
-          allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(true)
-          allow_any_instance_of(described_class).to receive(:installed?).and_return(true)
+          allow_any_instance_of(klass).to receive(:install_change_state!).and_return(true)
+          allow_any_instance_of(klass).to receive(:installed?).and_return(true)
           allow(Homebrew::Bundle).to receive(:brew).with("link", formula_name, verbose: false).and_return(true)
         end
 
         context "when formula has changed" do
           before do
-            allow_any_instance_of(described_class).to receive(:changed?).and_return(true)
+            allow_any_instance_of(klass).to receive(:changed?).and_return(true)
           end
 
           it "runs the postinstall command" do
             expect(Kernel).to receive(:system).with("custom command").and_return(true)
-            described_class.preinstall!(formula_name, postinstall: "custom command")
-            described_class.install!(formula_name, postinstall: "custom command")
+            klass.preinstall!(formula_name, postinstall: "custom command")
+            klass.install!(formula_name, postinstall: "custom command")
           end
 
           it "reports a failure" do
             expect(Kernel).to receive(:system).with("custom command").and_return(false)
-            described_class.preinstall!(formula_name, postinstall: "custom command")
-            expect(described_class.install!(formula_name, postinstall: "custom command")).to be(false)
+            klass.preinstall!(formula_name, postinstall: "custom command")
+            expect(klass.install!(formula_name, postinstall: "custom command")).to be(false)
           end
         end
 
         context "when formula has not changed" do
           before do
-            allow_any_instance_of(described_class).to receive(:changed?).and_return(false)
+            allow_any_instance_of(klass).to receive(:changed?).and_return(false)
           end
 
           it "does not run the postinstall command" do
             expect(Kernel).not_to receive(:system)
-            described_class.preinstall!(formula_name, postinstall: "custom command")
-            described_class.install!(formula_name, postinstall: "custom command")
+            klass.preinstall!(formula_name, postinstall: "custom command")
+            klass.install!(formula_name, postinstall: "custom command")
           end
         end
       end
@@ -533,9 +535,9 @@ RSpec.describe Homebrew::Bundle::Brew do
         before do
           Homebrew::Bundle.reset!
 
-          allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(true)
-          allow_any_instance_of(described_class).to receive(:installed?).and_return(true)
-          allow_any_instance_of(described_class).to receive(:linked?).and_return(true)
+          allow_any_instance_of(klass).to receive(:install_change_state!).and_return(true)
+          allow_any_instance_of(klass).to receive(:installed?).and_return(true)
+          allow_any_instance_of(klass).to receive(:linked?).and_return(true)
         end
 
         let(:version_file) { "version.txt" }
@@ -543,22 +545,22 @@ RSpec.describe Homebrew::Bundle::Brew do
 
         context "when formula versions are changed and specified by the environment" do
           before do
-            allow_any_instance_of(described_class).to receive(:changed?).and_return(false)
+            allow_any_instance_of(klass).to receive(:changed?).and_return(false)
             ENV["HOMEBREW_BUNDLE_EXEC_FORMULA_VERSION_#{formula_name.upcase}"] = version
           end
 
           it "writes the version to the file" do
             expect(File).to receive(:write).with(version_file, "#{version}\n")
-            described_class.preinstall!(formula_name, version_file:)
-            described_class.install!(formula_name, version_file:)
+            klass.preinstall!(formula_name, version_file:)
+            klass.install!(formula_name, version_file:)
           end
         end
 
         context "when using the latest formula" do
           it "writes the version to the file" do
             expect(File).to receive(:write).with(version_file, "#{version}\n")
-            described_class.preinstall!(formula_name, version_file:)
-            described_class.install!(formula_name, version_file:)
+            klass.preinstall!(formula_name, version_file:)
+            klass.install!(formula_name, version_file:)
           end
         end
       end
@@ -566,49 +568,49 @@ RSpec.describe Homebrew::Bundle::Brew do
 
     context "when a formula isn't installed" do
       before do
-        allow_any_instance_of(described_class).to receive(:installed?).and_return(false)
-        allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(false)
+        allow_any_instance_of(klass).to receive(:installed?).and_return(false)
+        allow_any_instance_of(klass).to receive(:install_change_state!).and_return(false)
       end
 
       it "did not call restart service" do
         expect(Homebrew::Bundle::Brew::Services).not_to receive(:restart)
-        described_class.preinstall!(formula_name, restart_service: true)
+        klass.preinstall!(formula_name, restart_service: true)
       end
     end
 
     describe ".outdated_formulae" do
       it "calls Homebrew" do
-        described_class.reset!
-        expect(described_class).to receive(:formulae).and_return(
+        klass.reset!
+        expect(klass).to receive(:formulae).and_return(
           [
             { name: "a", outdated?: true },
             { name: "b", outdated?: true },
             { name: "c", outdated?: false },
           ],
         )
-        expect(described_class.outdated_formulae).to eql(%w[a b])
+        expect(klass.outdated_formulae).to eql(%w[a b])
       end
     end
 
     describe ".pinned_formulae" do
       it "calls Homebrew" do
-        described_class.reset!
-        expect(described_class).to receive(:formulae).and_return(
+        klass.reset!
+        expect(klass).to receive(:formulae).and_return(
           [
             { name: "a", pinned?: true },
             { name: "b", pinned?: true },
             { name: "c", pinned?: false },
           ],
         )
-        expect(described_class.pinned_formulae).to eql(%w[a b])
+        expect(klass.pinned_formulae).to eql(%w[a b])
       end
     end
 
     describe ".formula_installed_and_up_to_date?" do
       before do
-        described_class.reset!
+        klass.reset!
         allow_any_instance_of(Formula).to receive(:outdated?).and_return(true)
-        allow(described_class).to receive_messages(outdated_formulae: %w[bar], formulae: [
+        allow(klass).to receive_messages(outdated_formulae: %w[bar], formulae: [
           {
             name:         "foo",
             full_name:    "homebrew/tap/foo",
@@ -633,19 +635,19 @@ RSpec.describe Homebrew::Bundle::Brew do
       end
 
       it "returns result" do
-        expect(described_class.formula_installed_and_up_to_date?("foo")).to be(true)
-        expect(described_class.formula_installed_and_up_to_date?("foobar")).to be(true)
-        expect(described_class.formula_installed_and_up_to_date?("bar")).to be(false)
-        expect(described_class.formula_installed_and_up_to_date?("baz")).to be(false)
+        expect(klass.formula_installed_and_up_to_date?("foo")).to be(true)
+        expect(klass.formula_installed_and_up_to_date?("foobar")).to be(true)
+        expect(klass.formula_installed_and_up_to_date?("bar")).to be(false)
+        expect(klass.formula_installed_and_up_to_date?("baz")).to be(false)
       end
     end
 
     context "when brew is installed" do
       context "when no formula is installed" do
         before do
-          allow(described_class).to receive(:installed_formulae).and_return([])
-          allow_any_instance_of(described_class).to receive(:conflicts_with).and_return([])
-          allow_any_instance_of(described_class).to receive(:linked?).and_return(true)
+          allow(klass).to receive(:installed_formulae).and_return([])
+          allow_any_instance_of(klass).to receive(:conflicts_with).and_return([])
+          allow_any_instance_of(klass).to receive(:linked?).and_return(true)
         end
 
         it "install formula" do
@@ -667,15 +669,15 @@ RSpec.describe Homebrew::Bundle::Brew do
 
       context "when formula is installed" do
         before do
-          allow(described_class).to receive(:installed_formulae).and_return([formula_name])
-          allow_any_instance_of(described_class).to receive(:conflicts_with).and_return([])
-          allow_any_instance_of(described_class).to receive(:linked?).and_return(true)
+          allow(klass).to receive(:installed_formulae).and_return([formula_name])
+          allow_any_instance_of(klass).to receive(:conflicts_with).and_return([])
+          allow_any_instance_of(klass).to receive(:linked?).and_return(true)
           allow_any_instance_of(Formula).to receive(:outdated?).and_return(true)
         end
 
         context "when formula upgradable" do
           before do
-            allow(described_class).to receive(:outdated_formulae).and_return([formula_name])
+            allow(klass).to receive(:outdated_formulae).and_return([formula_name])
           end
 
           it "upgrade formula" do
@@ -696,7 +698,7 @@ RSpec.describe Homebrew::Bundle::Brew do
 
           context "when formula pinned" do
             before do
-              allow(described_class).to receive(:pinned_formulae).and_return([formula_name])
+              allow(klass).to receive(:pinned_formulae).and_return([formula_name])
             end
 
             it "does not upgrade formula" do
@@ -708,7 +710,7 @@ RSpec.describe Homebrew::Bundle::Brew do
 
           context "when formula not upgraded" do
             before do
-              allow(described_class).to receive(:outdated_formulae).and_return([])
+              allow(klass).to receive(:outdated_formulae).and_return([])
             end
 
             it "does not upgrade formula" do
@@ -722,18 +724,18 @@ RSpec.describe Homebrew::Bundle::Brew do
 
     describe "#changed?" do
       it "is false by default" do
-        expect(described_class.new(formula_name).changed?).to be(false)
+        expect(klass.new(formula_name).changed?).to be(false)
       end
     end
 
     describe "#start_service?" do
       it "is false by default" do
-        expect(described_class.new(formula_name).start_service?).to be(false)
+        expect(klass.new(formula_name).start_service?).to be(false)
       end
 
       context "when the start_service option is true" do
         it "is true" do
-          expect(described_class.new(formula_name, start_service: true).start_service?).to be(true)
+          expect(klass.new(formula_name, start_service: true).start_service?).to be(true)
         end
       end
     end
@@ -745,11 +747,11 @@ RSpec.describe Homebrew::Bundle::Brew do
         end
 
         specify do
-          expect(described_class.new(formula_name).start_service_needed?).to be(false)
-          expect(described_class.new(formula_name, start_service: true).start_service_needed?).to be(false)
-          expect(described_class.new(formula_name, restart_service: true).start_service_needed?).to be(false)
-          expect(described_class.new(formula_name, restart_service: :changed).start_service_needed?).to be(false)
-          expect(described_class.new(formula_name, restart_service: :always).start_service_needed?).to be(false)
+          expect(klass.new(formula_name).start_service_needed?).to be(false)
+          expect(klass.new(formula_name, start_service: true).start_service_needed?).to be(false)
+          expect(klass.new(formula_name, restart_service: true).start_service_needed?).to be(false)
+          expect(klass.new(formula_name, restart_service: :changed).start_service_needed?).to be(false)
+          expect(klass.new(formula_name, restart_service: :always).start_service_needed?).to be(false)
         end
       end
 
@@ -759,65 +761,65 @@ RSpec.describe Homebrew::Bundle::Brew do
         end
 
         specify do
-          expect(described_class.new(formula_name).start_service_needed?).to be(false)
-          expect(described_class.new(formula_name, start_service: true).start_service_needed?).to be(true)
-          expect(described_class.new(formula_name, restart_service: true).start_service_needed?).to be(true)
-          expect(described_class.new(formula_name, restart_service: :changed).start_service_needed?).to be(true)
-          expect(described_class.new(formula_name, restart_service: :always).start_service_needed?).to be(true)
+          expect(klass.new(formula_name).start_service_needed?).to be(false)
+          expect(klass.new(formula_name, start_service: true).start_service_needed?).to be(true)
+          expect(klass.new(formula_name, restart_service: true).start_service_needed?).to be(true)
+          expect(klass.new(formula_name, restart_service: :changed).start_service_needed?).to be(true)
+          expect(klass.new(formula_name, restart_service: :always).start_service_needed?).to be(true)
         end
       end
     end
 
     describe "#restart_service?" do
       it "is false by default" do
-        expect(described_class.new(formula_name).restart_service?).to be(false)
+        expect(klass.new(formula_name).restart_service?).to be(false)
       end
 
       context "when the restart_service option is true" do
         it "is true" do
-          expect(described_class.new(formula_name, restart_service: true).restart_service?).to be(true)
+          expect(klass.new(formula_name, restart_service: true).restart_service?).to be(true)
         end
       end
 
       context "when the restart_service option is always" do
         it "is true" do
-          expect(described_class.new(formula_name, restart_service: :always).restart_service?).to be(true)
+          expect(klass.new(formula_name, restart_service: :always).restart_service?).to be(true)
         end
       end
 
       context "when the restart_service option is changed" do
         it "is true" do
-          expect(described_class.new(formula_name, restart_service: :changed).restart_service?).to be(true)
+          expect(klass.new(formula_name, restart_service: :changed).restart_service?).to be(true)
         end
       end
     end
 
     describe "#restart_service_needed?" do
       it "is false by default" do
-        expect(described_class.new(formula_name).restart_service_needed?).to be(false)
+        expect(klass.new(formula_name).restart_service_needed?).to be(false)
       end
 
       context "when a service is unchanged" do
         before do
-          allow_any_instance_of(described_class).to receive(:changed?).and_return(false)
+          allow_any_instance_of(klass).to receive(:changed?).and_return(false)
         end
 
         specify do
-          expect(described_class.new(formula_name, restart_service: true).restart_service_needed?).to be(false)
-          expect(described_class.new(formula_name, restart_service: :always).restart_service_needed?).to be(true)
-          expect(described_class.new(formula_name, restart_service: :changed).restart_service_needed?).to be(false)
+          expect(klass.new(formula_name, restart_service: true).restart_service_needed?).to be(false)
+          expect(klass.new(formula_name, restart_service: :always).restart_service_needed?).to be(true)
+          expect(klass.new(formula_name, restart_service: :changed).restart_service_needed?).to be(false)
         end
       end
 
       context "when a service is changed" do
         before do
-          allow_any_instance_of(described_class).to receive(:changed?).and_return(true)
+          allow_any_instance_of(klass).to receive(:changed?).and_return(true)
         end
 
         specify do
-          expect(described_class.new(formula_name, restart_service: true).restart_service_needed?).to be(true)
-          expect(described_class.new(formula_name, restart_service: :always).restart_service_needed?).to be(true)
-          expect(described_class.new(formula_name, restart_service: :changed).restart_service_needed?).to be(true)
+          expect(klass.new(formula_name, restart_service: true).restart_service_needed?).to be(true)
+          expect(klass.new(formula_name, restart_service: :always).restart_service_needed?).to be(true)
+          expect(klass.new(formula_name, restart_service: :changed).restart_service_needed?).to be(true)
         end
       end
     end

--- a/Library/Homebrew/test/bundle/brewfile_spec.rb
+++ b/Library/Homebrew/test/bundle/brewfile_spec.rb
@@ -5,9 +5,11 @@ require "bundle"
 require "bundle/brewfile"
 
 RSpec.describe Homebrew::Bundle::Brewfile do
+  let(:klass) { Homebrew::Bundle::Brewfile }
+
   describe "path" do
     subject(:path) do
-      described_class.path(dash_writes_to_stdout:, global: has_global, file: file_value)
+      klass.path(dash_writes_to_stdout:, global: has_global, file: file_value)
     end
 
     let(:dash_writes_to_stdout) { false }

--- a/Library/Homebrew/test/bundle/bundle_spec.rb
+++ b/Library/Homebrew/test/bundle/bundle_spec.rb
@@ -5,28 +5,30 @@ require "bundle"
 require "bundle/dsl"
 
 RSpec.describe Homebrew::Bundle do
+  let(:klass) { Homebrew::Bundle }
+
   context "when the system call succeeds" do
     it "omits all stdout output if verbose is false" do
-      expect { described_class.system "echo", "foo", verbose: false }.not_to output.to_stdout_from_any_process
+      expect { klass.system "echo", "foo", verbose: false }.not_to output.to_stdout_from_any_process
     end
 
     it "emits all stdout output if verbose is true" do
-      expect { described_class.system "echo", "foo", verbose: true }.to output("foo\n").to_stdout_from_any_process
+      expect { klass.system "echo", "foo", verbose: true }.to output("foo\n").to_stdout_from_any_process
     end
   end
 
   context "when the system call fails" do
     it "emits all stdout output even if verbose is false" do
       expect do
-        described_class.system "/bin/bash", "-c", "echo foo && false",
-                               verbose: false
+        klass.system "/bin/bash", "-c", "echo foo && false",
+                     verbose: false
       end.to output("foo\n").to_stdout_from_any_process
     end
 
     it "emits all stdout output only once if verbose is true" do
       expect do
-        described_class.system "/bin/bash", "-c", "echo foo && true",
-                               verbose: true
+        klass.system "/bin/bash", "-c", "echo foo && true",
+                     verbose: true
       end.to output("foo\n").to_stdout_from_any_process
     end
   end
@@ -37,12 +39,12 @@ RSpec.describe Homebrew::Bundle do
       allow(File).to receive(:directory?)
         .with("#{HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask")
         .and_return(true)
-      expect(described_class.cask_installed?).to be(true)
+      expect(klass.cask_installed?).to be(true)
     end
   end
 
   describe ".mark_as_installed_on_request!", :no_api do
-    subject(:mark_installed!) { described_class.mark_as_installed_on_request!(entries) }
+    subject(:mark_installed!) { klass.mark_as_installed_on_request!(entries) }
 
     let(:entries) { dsl.entries }
     let(:dsl) { Homebrew::Bundle::Dsl.new(Pathname.new("/fake/Brewfile")) }

--- a/Library/Homebrew/test/bundle/cargo_spec.rb
+++ b/Library/Homebrew/test/bundle/cargo_spec.rb
@@ -6,6 +6,8 @@ require "bundle/dsl"
 require "bundle/extensions/cargo"
 
 RSpec.describe Homebrew::Bundle::Cargo do
+  let(:klass) { Homebrew::Bundle::Cargo }
+
   around do |example|
     with_env({
       "HOMEBREW_CARGO_HOME"         => "~/.cargo",
@@ -20,12 +22,12 @@ RSpec.describe Homebrew::Bundle::Cargo do
   end
 
   describe "dumping" do
-    subject(:dumper) { described_class }
+    subject(:dumper) { klass }
 
     context "when cargo is not installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(nil)
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(nil)
       end
 
       specify do
@@ -36,12 +38,12 @@ RSpec.describe Homebrew::Bundle::Cargo do
 
     context "when cargo is installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("cargo"))
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("cargo"))
       end
 
       it "returns package list" do
-        expect(described_class).to receive(:`).with("cargo install --list") do
+        expect(klass).to receive(:`).with("cargo install --list") do
           expect(ENV.fetch("CARGO_HOME", nil)).to eq("~/.cargo")
           expect(ENV.fetch("CARGO_INSTALL_ROOT", nil)).to eq("~/.cargo/bin")
           expect(ENV.fetch("RUSTUP_HOME", nil)).to eq("~/.rustup")
@@ -65,39 +67,39 @@ RSpec.describe Homebrew::Bundle::Cargo do
   describe "installing" do
     context "when Cargo is not installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(nil)
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "tries to install rust" do
         expect(Homebrew::Bundle).to \
           receive(:system).with(HOMEBREW_BREW_FILE, "install", "--formula", "rust", verbose: false)
                           .and_return(true)
-        expect { described_class.preinstall!("ripgrep") }.to raise_error(RuntimeError)
+        expect { klass.preinstall!("ripgrep") }.to raise_error(RuntimeError)
       end
     end
 
     context "when Cargo is installed" do
       before do
-        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("cargo"))
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("cargo"))
       end
 
       context "when package is installed" do
         before do
-          allow(described_class).to receive(:installed_packages)
+          allow(klass).to receive(:installed_packages)
             .and_return(["ripgrep"])
         end
 
         it "skips" do
           expect(Homebrew::Bundle).not_to receive(:system)
-          expect(described_class.preinstall!("ripgrep")).to be(false)
+          expect(klass.preinstall!("ripgrep")).to be(false)
         end
       end
 
       context "when package is not installed" do
         before do
-          allow(described_class).to receive_messages(package_manager_executable: Pathname.new("/tmp/rust/bin/cargo"),
-                                                     installed_packages:         [])
+          allow(klass).to receive_messages(package_manager_executable: Pathname.new("/tmp/rust/bin/cargo"),
+                                           installed_packages:         [])
         end
 
         it "installs package" do
@@ -110,8 +112,8 @@ RSpec.describe Homebrew::Bundle::Cargo do
             expect(verbose).to be(false)
             true
           end
-          expect(described_class.preinstall!("ripgrep")).to be(true)
-          expect(described_class.install!("ripgrep")).to be(true)
+          expect(klass.preinstall!("ripgrep")).to be(true)
+          expect(klass.install!("ripgrep")).to be(true)
         end
       end
     end
@@ -119,8 +121,8 @@ RSpec.describe Homebrew::Bundle::Cargo do
 
   describe "cleanup" do
     before do
-      described_class.reset!
-      allow(described_class).to receive_messages(
+      klass.reset!
+      allow(klass).to receive_messages(
         package_manager_executable: Pathname.new("/tmp/rust/bin/cargo"),
         packages:                   %w[ripgrep fd-find bat],
         installed_packages:         %w[ripgrep fd-find bat],
@@ -129,13 +131,13 @@ RSpec.describe Homebrew::Bundle::Cargo do
 
     it "returns packages not in Brewfile entries" do
       entries = [Homebrew::Bundle::Dsl::Entry.new(:cargo, "ripgrep")]
-      expect(described_class.cleanup_items(entries)).to eql(%w[fd-find bat])
+      expect(klass.cleanup_items(entries)).to eql(%w[fd-find bat])
     end
 
     it "returns frozen empty array when cargo is not installed" do
-      allow(described_class).to receive(:package_manager_installed?).and_return(false)
+      allow(klass).to receive(:package_manager_installed?).and_return(false)
       entries = [Homebrew::Bundle::Dsl::Entry.new(:cargo, "ripgrep")]
-      expect(described_class.cleanup_items(entries)).to eql([])
+      expect(klass.cleanup_items(entries)).to eql([])
     end
   end
 end

--- a/Library/Homebrew/test/bundle/cask_spec.rb
+++ b/Library/Homebrew/test/bundle/cask_spec.rb
@@ -6,12 +6,14 @@ require "bundle/cask"
 require "cask"
 
 RSpec.describe Homebrew::Bundle::Cask do
+  let(:klass) { Homebrew::Bundle::Cask }
+
   describe "dumping" do
-    subject(:dumper) { described_class }
+    subject(:dumper) { klass }
 
     context "when brew-cask is not installed" do
       before do
-        described_class.reset!
+        klass.reset!
         allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(false)
       end
 
@@ -23,7 +25,7 @@ RSpec.describe Homebrew::Bundle::Cask do
 
     context "when there is no cask" do
       before do
-        described_class.reset!
+        klass.reset!
         allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(true)
         allow(Cask::Caskroom).to receive(:casks).and_return([])
       end
@@ -57,7 +59,7 @@ RSpec.describe Homebrew::Bundle::Cask do
       end
 
       before do
-        described_class.reset!
+        klass.reset!
 
         allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(true)
         allow(Cask::Caskroom).to receive(:casks).and_return([foo, bar, baz])
@@ -102,7 +104,7 @@ RSpec.describe Homebrew::Bundle::Cask do
 
     describe "#cask_oldnames" do
       before do
-        described_class.reset!
+        klass.reset!
       end
 
       it "returns an empty string when no casks are installed" do
@@ -124,7 +126,7 @@ RSpec.describe Homebrew::Bundle::Cask do
     describe "#formula_dependencies" do
       context "when the given casks don't have formula dependencies" do
         before do
-          described_class.reset!
+          klass.reset!
         end
 
         it "returns an empty array" do
@@ -134,7 +136,7 @@ RSpec.describe Homebrew::Bundle::Cask do
 
       context "when multiple casks have the same dependency" do
         before do
-          described_class.reset!
+          klass.reset!
           foo = instance_double(Cask::Cask, to_s: "foo", depends_on: { formula: ["baz", "qux"] })
           bar = instance_double(Cask::Cask, to_s: "bar", depends_on: {})
           allow(Cask::Caskroom).to receive(:casks).and_return([foo, bar])
@@ -151,43 +153,43 @@ RSpec.describe Homebrew::Bundle::Cask do
   describe "installing" do
     describe ".installed_casks" do
       before do
-        described_class.reset!
+        klass.reset!
       end
 
       it "shells out" do
-        expect { described_class.installed_casks }.not_to raise_error
+        expect { klass.installed_casks }.not_to raise_error
       end
     end
 
     describe ".cask_installed_and_up_to_date?" do
       it "returns result" do
-        described_class.reset!
-        allow(described_class).to receive_messages(installed_casks: ["foo", "baz"],
-                                                   outdated_casks:  ["baz"])
-        expect(described_class.cask_installed_and_up_to_date?("foo")).to be(true)
-        expect(described_class.cask_installed_and_up_to_date?("baz")).to be(false)
+        klass.reset!
+        allow(klass).to receive_messages(installed_casks: ["foo", "baz"],
+                                         outdated_casks:  ["baz"])
+        expect(klass.cask_installed_and_up_to_date?("foo")).to be(true)
+        expect(klass.cask_installed_and_up_to_date?("baz")).to be(false)
       end
     end
 
     context "when brew-cask is not installed" do
       describe ".outdated_casks" do
         it "returns empty array" do
-          described_class.reset!
-          expect(described_class.outdated_casks).to eql([])
+          klass.reset!
+          expect(klass.outdated_casks).to eql([])
         end
       end
     end
 
     context "when brew-cask is installed" do
       before do
-        described_class.reset!
+        klass.reset!
         allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(true)
       end
 
       describe ".outdated_casks" do
         it "returns empty array" do
-          described_class.reset!
-          expect(described_class.outdated_casks).to eql([])
+          klass.reset!
+          expect(klass.outdated_casks).to eql([])
         end
 
         it "does not include pinned casks" do
@@ -197,64 +199,64 @@ RSpec.describe Homebrew::Bundle::Cask do
           allow(unpinned_cask).to receive(:outdated?).with(greedy: false).and_return(true)
           allow(Cask::Caskroom).to receive(:casks).and_return([pinned_cask, unpinned_cask])
 
-          expect(described_class.outdated_casks).to eql(["firefox"])
+          expect(klass.outdated_casks).to eql(["firefox"])
         end
       end
 
       context "when cask is installed" do
         before do
-          described_class.reset!
-          allow(described_class).to receive(:installed_casks).and_return(["google-chrome"])
+          klass.reset!
+          allow(klass).to receive(:installed_casks).and_return(["google-chrome"])
         end
 
         it "skips" do
           expect(Homebrew::Bundle).not_to receive(:system)
-          expect(described_class.preinstall!("google-chrome")).to be(false)
+          expect(klass.preinstall!("google-chrome")).to be(false)
         end
       end
 
       context "when cask is outdated" do
         before do
-          allow(described_class).to receive_messages(installed_casks: ["google-chrome"],
-                                                     outdated_casks:  ["google-chrome"])
+          allow(klass).to receive_messages(installed_casks: ["google-chrome"],
+                                           outdated_casks:  ["google-chrome"])
         end
 
         it "upgrades" do
           expect(Homebrew::Bundle).to \
             receive(:system).with(HOMEBREW_BREW_FILE, "upgrade", "--cask", "google-chrome", verbose: false)
                             .and_return(true)
-          expect(described_class.preinstall!("google-chrome")).to be(true)
-          expect(described_class.install!("google-chrome")).to be(true)
+          expect(klass.preinstall!("google-chrome")).to be(true)
+          expect(klass.install!("google-chrome")).to be(true)
         end
       end
 
       context "when cask is outdated and uses auto-update" do
         before do
-          described_class.reset!
-          allow(described_class).to receive_messages(cask_names: ["opera"], outdated_cask_names: [])
-          allow(described_class).to receive(:cask_is_outdated_using_greedy?).with("opera").and_return(true)
+          klass.reset!
+          allow(klass).to receive_messages(cask_names: ["opera"], outdated_cask_names: [])
+          allow(klass).to receive(:cask_is_outdated_using_greedy?).with("opera").and_return(true)
         end
 
         it "upgrades" do
           expect(Homebrew::Bundle).to \
             receive(:system).with(HOMEBREW_BREW_FILE, "upgrade", "--cask", "opera", verbose: false)
                             .and_return(true)
-          expect(described_class.preinstall!("opera", greedy: true)).to be(true)
-          expect(described_class.install!("opera", greedy: true)).to be(true)
+          expect(klass.preinstall!("opera", greedy: true)).to be(true)
+          expect(klass.install!("opera", greedy: true)).to be(true)
         end
       end
 
       context "when cask is not installed" do
         before do
-          allow(described_class).to receive(:installed_casks).and_return([])
+          allow(klass).to receive(:installed_casks).and_return([])
         end
 
         it "installs cask" do
           expect(Homebrew::Bundle).to receive(:brew).with("install", "--cask", "google-chrome", "--adopt",
                                                           verbose: false)
                                                     .and_return(true)
-          expect(described_class.preinstall!("google-chrome")).to be(true)
-          expect(described_class.install!("google-chrome")).to be(true)
+          expect(klass.preinstall!("google-chrome")).to be(true)
+          expect(klass.install!("google-chrome")).to be(true)
         end
 
         it "installs cask with arguments" do
@@ -263,16 +265,16 @@ RSpec.describe Homebrew::Bundle::Cask do
                                 verbose: false)
                             .and_return(true),
           )
-          expect(described_class.preinstall!("firefox", args: { appdir: "/Applications" })).to be(true)
-          expect(described_class.install!("firefox", args: { appdir: "/Applications" })).to be(true)
+          expect(klass.preinstall!("firefox", args: { appdir: "/Applications" })).to be(true)
+          expect(klass.install!("firefox", args: { appdir: "/Applications" })).to be(true)
         end
 
         it "reports a failure" do
           expect(Homebrew::Bundle).to receive(:brew).with("install", "--cask", "google-chrome", "--adopt",
                                                           verbose: false)
                                                     .and_return(false)
-          expect(described_class.preinstall!("google-chrome")).to be(true)
-          expect(described_class.install!("google-chrome")).to be(false)
+          expect(klass.preinstall!("google-chrome")).to be(true)
+          expect(klass.install!("google-chrome")).to be(false)
         end
 
         context "with boolean arguments" do
@@ -280,38 +282,38 @@ RSpec.describe Homebrew::Bundle::Cask do
             expect(Homebrew::Bundle).to receive(:brew).with("install", "--cask", "iterm", "--force",
                                                             verbose: false)
                                                       .and_return(true)
-            expect(described_class.preinstall!("iterm", args: { force: true })).to be(true)
-            expect(described_class.install!("iterm", args: { force: true })).to be(true)
+            expect(klass.preinstall!("iterm", args: { force: true })).to be(true)
+            expect(klass.install!("iterm", args: { force: true })).to be(true)
           end
 
           it "does not include a flag if false" do
             expect(Homebrew::Bundle).to receive(:brew).with("install", "--cask", "iterm", "--adopt", verbose: false)
                                                       .and_return(true)
-            expect(described_class.preinstall!("iterm", args: { force: false })).to be(true)
-            expect(described_class.install!("iterm", args: { force: false })).to be(true)
+            expect(klass.preinstall!("iterm", args: { force: false })).to be(true)
+            expect(klass.install!("iterm", args: { force: false })).to be(true)
           end
         end
       end
 
       context "when the postinstall option is provided" do
         before do
-          described_class.reset!
-          allow(described_class).to receive_messages(cask_names:          ["google-chrome"],
-                                                     outdated_cask_names: ["google-chrome"])
+          klass.reset!
+          allow(klass).to receive_messages(cask_names:          ["google-chrome"],
+                                           outdated_cask_names: ["google-chrome"])
           allow(Homebrew::Bundle).to receive(:brew).and_return(true)
-          allow(described_class).to receive(:upgrading?).and_return(true)
+          allow(klass).to receive(:upgrading?).and_return(true)
         end
 
         it "runs the postinstall command" do
           expect(Kernel).to receive(:system).with("custom command").and_return(true)
-          expect(described_class.preinstall!("google-chrome", postinstall: "custom command")).to be(true)
-          expect(described_class.install!("google-chrome", postinstall: "custom command")).to be(true)
+          expect(klass.preinstall!("google-chrome", postinstall: "custom command")).to be(true)
+          expect(klass.install!("google-chrome", postinstall: "custom command")).to be(true)
         end
 
         it "reports a failure when postinstall fails" do
           expect(Kernel).to receive(:system).with("custom command").and_return(false)
-          expect(described_class.preinstall!("google-chrome", postinstall: "custom command")).to be(true)
-          expect(described_class.install!("google-chrome", postinstall: "custom command")).to be(false)
+          expect(klass.preinstall!("google-chrome", postinstall: "custom command")).to be(true)
+          expect(klass.install!("google-chrome", postinstall: "custom command")).to be(false)
         end
       end
     end

--- a/Library/Homebrew/test/bundle/dsl_spec.rb
+++ b/Library/Homebrew/test/bundle/dsl_spec.rb
@@ -5,8 +5,10 @@ require "bundle"
 require "bundle/dsl"
 
 RSpec.describe Homebrew::Bundle::Dsl do
+  let(:klass) { Homebrew::Bundle::Dsl }
+
   def dsl_from_string(string)
-    described_class.new(StringIO.new(string))
+    klass.new(StringIO.new(string))
   end
 
   context "with a DSL example" do
@@ -32,7 +34,7 @@ RSpec.describe Homebrew::Bundle::Dsl do
     end
 
     before do
-      allow_any_instance_of(described_class).to receive(:system)
+      allow_any_instance_of(klass).to receive(:system)
         .with("/usr/libexec/java_home --failfast")
         .and_return(false)
     end
@@ -150,19 +152,19 @@ RSpec.describe Homebrew::Bundle::Dsl do
   end
 
   it ".sanitize_brew_name" do
-    expect(described_class.send(:sanitize_brew_name, "homebrew/homebrew/foo")).to eql("foo")
-    expect(described_class.send(:sanitize_brew_name, "homebrew/homebrew-bar/foo")).to eql("homebrew/bar/foo")
-    expect(described_class.send(:sanitize_brew_name, "homebrew/bar/foo")).to eql("homebrew/bar/foo")
-    expect(described_class.send(:sanitize_brew_name, "foo")).to eql("foo")
+    expect(klass.send(:sanitize_brew_name, "homebrew/homebrew/foo")).to eql("foo")
+    expect(klass.send(:sanitize_brew_name, "homebrew/homebrew-bar/foo")).to eql("homebrew/bar/foo")
+    expect(klass.send(:sanitize_brew_name, "homebrew/bar/foo")).to eql("homebrew/bar/foo")
+    expect(klass.send(:sanitize_brew_name, "foo")).to eql("foo")
   end
 
   it ".sanitize_tap_name" do
-    expect(described_class.send(:sanitize_tap_name, "homebrew/homebrew-foo")).to eql("homebrew/foo")
-    expect(described_class.send(:sanitize_tap_name, "homebrew/foo")).to eql("homebrew/foo")
+    expect(klass.send(:sanitize_tap_name, "homebrew/homebrew-foo")).to eql("homebrew/foo")
+    expect(klass.send(:sanitize_tap_name, "homebrew/foo")).to eql("homebrew/foo")
   end
 
   it ".sanitize_cask_name" do
-    expect(described_class.send(:sanitize_cask_name, "homebrew/cask-versions/adoptopenjdk8")).to eql("adoptopenjdk8")
-    expect(described_class.send(:sanitize_cask_name, "adoptopenjdk8")).to eql("adoptopenjdk8")
+    expect(klass.send(:sanitize_cask_name, "homebrew/cask-versions/adoptopenjdk8")).to eql("adoptopenjdk8")
+    expect(klass.send(:sanitize_cask_name, "adoptopenjdk8")).to eql("adoptopenjdk8")
   end
 end

--- a/Library/Homebrew/test/bundle/dumper_spec.rb
+++ b/Library/Homebrew/test/bundle/dumper_spec.rb
@@ -7,7 +7,9 @@ require "bundle/brew_services"
 require "cask"
 
 RSpec.describe Homebrew::Bundle::Dumper do
-  subject(:dumper) { described_class }
+  subject(:dumper) { klass }
+
+  let(:klass) { Homebrew::Bundle::Dumper }
 
   before do
     ENV["HOMEBREW_BUNDLE_FILE"] = ""

--- a/Library/Homebrew/test/bundle/flatpak_spec.rb
+++ b/Library/Homebrew/test/bundle/flatpak_spec.rb
@@ -6,11 +6,13 @@ require "bundle/dsl"
 require "bundle/extensions/flatpak"
 
 RSpec.describe Homebrew::Bundle::Flatpak do
+  let(:klass) { Homebrew::Bundle::Flatpak }
+
   describe "checking" do
-    subject(:checker) { described_class.new }
+    subject(:checker) { klass.new }
 
     before do
-      allow(described_class).to receive(:package_installed?).and_return(false)
+      allow(klass).to receive(:package_installed?).and_return(false)
     end
 
     describe "#installed_and_up_to_date?", :needs_linux do
@@ -19,13 +21,13 @@ RSpec.describe Homebrew::Bundle::Flatpak do
       end
 
       it "returns true when package is installed" do
-        allow(described_class).to receive(:package_installed?).and_return(true)
+        allow(klass).to receive(:package_installed?).and_return(true)
         expect(checker.installed_and_up_to_date?("org.gnome.Calculator")).to be(true)
       end
 
       describe "3-tier remote handling" do
         it "checks Tier 1 package with default remote (flathub)" do
-          allow(described_class).to receive(:package_installed?)
+          allow(klass).to receive(:package_installed?)
             .with("org.gnome.Calculator", remote: "flathub")
             .and_return(true)
 
@@ -36,7 +38,7 @@ RSpec.describe Homebrew::Bundle::Flatpak do
         end
 
         it "checks Tier 1 package with named remote" do
-          allow(described_class).to receive(:package_installed?)
+          allow(klass).to receive(:package_installed?)
             .with("org.gnome.Calculator", remote: "fedora")
             .and_return(true)
 
@@ -47,7 +49,7 @@ RSpec.describe Homebrew::Bundle::Flatpak do
         end
 
         it "checks Tier 2 package with URL remote (resolves to single-app remote)" do
-          allow(described_class).to receive(:package_installed?)
+          allow(klass).to receive(:package_installed?)
             .with("org.godotengine.Godot", remote: "org.godotengine.Godot-origin")
             .and_return(true)
 
@@ -58,7 +60,7 @@ RSpec.describe Homebrew::Bundle::Flatpak do
         end
 
         it "checks Tier 2 package with .flatpakref by name only" do
-          allow(described_class).to receive(:package_installed?)
+          allow(klass).to receive(:package_installed?)
             .with("org.example.App")
             .and_return(true)
 
@@ -69,7 +71,7 @@ RSpec.describe Homebrew::Bundle::Flatpak do
         end
 
         it "checks Tier 3 package with URL and remote name" do
-          allow(described_class).to receive(:package_installed?)
+          allow(klass).to receive(:package_installed?)
             .with("org.godotengine.Godot", remote: "flathub-beta")
             .and_return(true)
 
@@ -96,18 +98,18 @@ RSpec.describe Homebrew::Bundle::Flatpak do
 
     context "when on macOS", :needs_macos do
       it "flatpak is not available" do
-        expect(described_class.package_manager_installed?).to be(false)
+        expect(klass.package_manager_installed?).to be(false)
       end
     end
   end
 
   describe "dumping" do
-    subject(:dumper) { described_class }
+    subject(:dumper) { klass }
 
     context "when flatpak is not installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(nil)
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "returns an empty list and dumps an empty string" do
@@ -118,13 +120,13 @@ RSpec.describe Homebrew::Bundle::Flatpak do
 
     context "when flatpak is installed", :needs_linux do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("flatpak"))
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("flatpak"))
       end
 
       it "returns remote URLs" do
-        allow(described_class).to receive(:`).with("flatpak remote-list --system --columns=name,url 2>/dev/null")
-                                             .and_return("flathub\thttps://dl.flathub.org/repo/\nfedora\thttps://registry.fedoraproject.org/\n")
+        allow(klass).to receive(:`).with("flatpak remote-list --system --columns=name,url 2>/dev/null")
+                                   .and_return("flathub\thttps://dl.flathub.org/repo/\nfedora\thttps://registry.fedoraproject.org/\n")
         expect(dumper.remote_urls).to eql({
           "flathub" => "https://dl.flathub.org/repo/",
           "fedora"  => "https://registry.fedoraproject.org/",
@@ -132,10 +134,10 @@ RSpec.describe Homebrew::Bundle::Flatpak do
       end
 
       it "returns package list with remotes and URLs" do
-        allow(described_class).to receive(:`)
+        allow(klass).to receive(:`)
           .with("flatpak list --app --columns=application,origin 2>/dev/null")
           .and_return("org.gnome.Calculator\tflathub\ncom.spotify.Client\tflathub\n")
-        allow(described_class).to receive(:`)
+        allow(klass).to receive(:`)
           .with("flatpak remote-list --system --columns=name,url 2>/dev/null")
           .and_return("flathub\thttps://dl.flathub.org/repo/\n")
         expect(dumper.packages_with_remotes).to eql([
@@ -145,10 +147,10 @@ RSpec.describe Homebrew::Bundle::Flatpak do
       end
 
       it "returns package names only" do
-        allow(described_class).to receive(:`)
+        allow(klass).to receive(:`)
           .with("flatpak list --app --columns=application,origin 2>/dev/null")
           .and_return("org.gnome.Calculator\tflathub\ncom.spotify.Client\tflathub\n")
-        allow(described_class).to receive(:`)
+        allow(klass).to receive(:`)
           .with("flatpak remote-list --system --columns=name,url 2>/dev/null")
           .and_return("flathub\thttps://dl.flathub.org/repo/\n")
         expect(dumper.packages).to eql(["com.spotify.Client", "org.gnome.Calculator"])
@@ -218,10 +220,10 @@ RSpec.describe Homebrew::Bundle::Flatpak do
       end
 
       it "handles packages without origin" do
-        allow(described_class).to receive(:`).with("flatpak list --app --columns=application,origin 2>/dev/null")
-                                             .and_return("org.gnome.Calculator\n")
-        allow(described_class).to receive(:`).with("flatpak remote-list --system --columns=name,url 2>/dev/null")
-                                             .and_return("flathub\thttps://dl.flathub.org/repo/\n")
+        allow(klass).to receive(:`).with("flatpak list --app --columns=application,origin 2>/dev/null")
+                                   .and_return("org.gnome.Calculator\n")
+        allow(klass).to receive(:`).with("flatpak remote-list --system --columns=name,url 2>/dev/null")
+                                   .and_return("flathub\thttps://dl.flathub.org/repo/\n")
         expect(dumper.packages_with_remotes).to eql([
           { name: "org.gnome.Calculator", remote: "flathub", remote_url: "https://dl.flathub.org/repo/" },
         ])
@@ -232,37 +234,37 @@ RSpec.describe Homebrew::Bundle::Flatpak do
   describe "installing" do
     context "when Flatpak is not installed", :needs_linux do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(nil)
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "returns false without attempting installation" do
         expect(Homebrew::Bundle).not_to receive(:system)
-        expect(described_class.preinstall!("org.gnome.Calculator")).to be(false)
-        expect(described_class.install!("org.gnome.Calculator")).to be(true)
+        expect(klass.preinstall!("org.gnome.Calculator")).to be(false)
+        expect(klass.install!("org.gnome.Calculator")).to be(true)
       end
     end
 
     context "when Flatpak is installed", :needs_linux do
       before do
-        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("flatpak"))
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("flatpak"))
       end
 
       context "when package is installed" do
         before do
-          allow(described_class).to receive(:installed_packages)
+          allow(klass).to receive(:installed_packages)
             .and_return([{ name: "org.gnome.Calculator", remote: "flathub" }])
         end
 
         it "skips" do
           expect(Homebrew::Bundle).not_to receive(:system)
-          expect(described_class.preinstall!("org.gnome.Calculator")).to be(false)
+          expect(klass.preinstall!("org.gnome.Calculator")).to be(false)
         end
       end
 
       context "when package is not installed" do
         before do
-          allow(described_class).to receive(:installed_packages).and_return([])
+          allow(klass).to receive(:installed_packages).and_return([])
         end
 
         describe "Tier 1: no URL (flathub default)" do
@@ -271,8 +273,8 @@ RSpec.describe Homebrew::Bundle::Flatpak do
               receive(:system).with("flatpak", "install", "-y", "--system", "flathub", "org.gnome.Calculator",
                                     verbose: false)
                               .and_return(true)
-            expect(described_class.preinstall!("org.gnome.Calculator")).to be(true)
-            expect(described_class.install!("org.gnome.Calculator")).to be(true)
+            expect(klass.preinstall!("org.gnome.Calculator")).to be(true)
+            expect(klass.install!("org.gnome.Calculator")).to be(true)
           end
 
           it "installs package from named remote" do
@@ -280,14 +282,14 @@ RSpec.describe Homebrew::Bundle::Flatpak do
               receive(:system).with("flatpak", "install", "-y", "--system", "fedora", "org.gnome.Calculator",
                                     verbose: false)
                               .and_return(true)
-            expect(described_class.preinstall!("org.gnome.Calculator", remote: "fedora")).to be(true)
-            expect(described_class.install!("org.gnome.Calculator", remote: "fedora")).to be(true)
+            expect(klass.preinstall!("org.gnome.Calculator", remote: "fedora")).to be(true)
+            expect(klass.install!("org.gnome.Calculator", remote: "fedora")).to be(true)
           end
         end
 
         describe "Tier 2: URL only (single-app remote)" do
           it "creates single-app remote with -origin suffix" do
-            allow(described_class).to receive(:get_remote_url).and_return(nil)
+            allow(klass).to receive(:get_remote_url).and_return(nil)
 
             expect(Homebrew::Bundle).to \
               receive(:system).with("flatpak", "remote-add", "--if-not-exists", "--system",
@@ -299,14 +301,14 @@ RSpec.describe Homebrew::Bundle::Flatpak do
                                     "org.godotengine.Godot", verbose: false)
                               .and_return(true)
 
-            expect(described_class.preinstall!("org.godotengine.Godot", remote: "https://dl.flathub.org/beta-repo/"))
+            expect(klass.preinstall!("org.godotengine.Godot", remote: "https://dl.flathub.org/beta-repo/"))
               .to be(true)
-            expect(described_class.install!("org.godotengine.Godot", remote: "https://dl.flathub.org/beta-repo/"))
+            expect(klass.install!("org.godotengine.Godot", remote: "https://dl.flathub.org/beta-repo/"))
               .to be(true)
           end
 
           it "replaces single-app remote when URL changes" do
-            allow(described_class).to receive(:get_remote_url)
+            allow(klass).to receive(:get_remote_url)
               .with(anything, "org.godotengine.Godot-origin")
               .and_return("https://old.url/repo/")
 
@@ -324,27 +326,27 @@ RSpec.describe Homebrew::Bundle::Flatpak do
                                     "org.godotengine.Godot", verbose: false)
                               .and_return(true)
 
-            expect(described_class.install!("org.godotengine.Godot", remote: "https://dl.flathub.org/beta-repo/"))
+            expect(klass.install!("org.godotengine.Godot", remote: "https://dl.flathub.org/beta-repo/"))
               .to be(true)
           end
 
           it "installs from .flatpakref directly" do
-            allow(described_class).to receive(:`).with("flatpak list --app --columns=application,origin 2>/dev/null")
-                                                 .and_return("org.example.App\texample-origin\n")
+            allow(klass).to receive(:`).with("flatpak list --app --columns=application,origin 2>/dev/null")
+                                       .and_return("org.example.App\texample-origin\n")
 
             expect(Homebrew::Bundle).to \
               receive(:system).with("flatpak", "install", "-y", "--system",
                                     "https://example.com/app.flatpakref", verbose: false)
                               .and_return(true)
 
-            expect(described_class.install!("org.example.App", remote: "https://example.com/app.flatpakref"))
+            expect(klass.install!("org.example.App", remote: "https://example.com/app.flatpakref"))
               .to be(true)
           end
         end
 
         describe "Tier 3: URL + name (shared remote)" do
           it "creates named shared remote" do
-            allow(described_class).to receive(:get_remote_url).and_return(nil)
+            allow(klass).to receive(:get_remote_url).and_return(nil)
 
             expect(Homebrew::Bundle).to \
               receive(:system).with("flatpak", "remote-add", "--if-not-exists", "--system", "--no-gpg-verify",
@@ -355,14 +357,14 @@ RSpec.describe Homebrew::Bundle::Flatpak do
                                     "org.godotengine.Godot", verbose: false)
                               .and_return(true)
 
-            expect(described_class.install!("org.godotengine.Godot",
-                                            remote: "flathub-beta",
-                                            url:    "https://dl.flathub.org/beta-repo/"))
+            expect(klass.install!("org.godotengine.Godot",
+                                  remote: "flathub-beta",
+                                  url:    "https://dl.flathub.org/beta-repo/"))
               .to be(true)
           end
 
           it "warns but uses existing remote with different URL" do
-            allow(described_class).to receive(:get_remote_url)
+            allow(klass).to receive(:get_remote_url)
               .with(anything, "flathub-beta")
               .and_return("https://different.url/repo/")
 
@@ -378,14 +380,14 @@ RSpec.describe Homebrew::Bundle::Flatpak do
                                     "org.godotengine.Godot", verbose: false)
                               .and_return(true)
 
-            expect(described_class.install!("org.godotengine.Godot",
-                                            remote: "flathub-beta",
-                                            url:    "https://dl.flathub.org/beta-repo/"))
+            expect(klass.install!("org.godotengine.Godot",
+                                  remote: "flathub-beta",
+                                  url:    "https://dl.flathub.org/beta-repo/"))
               .to be(true)
           end
 
           it "reuses existing shared remote when URL matches" do
-            allow(described_class).to receive(:get_remote_url)
+            allow(klass).to receive(:get_remote_url)
               .with(anything, "flathub-beta")
               .and_return("https://dl.flathub.org/beta-repo/")
 
@@ -398,9 +400,9 @@ RSpec.describe Homebrew::Bundle::Flatpak do
                                     "org.godotengine.Godot", verbose: false)
                               .and_return(true)
 
-            expect(described_class.install!("org.godotengine.Godot",
-                                            remote: "flathub-beta",
-                                            url:    "https://dl.flathub.org/beta-repo/"))
+            expect(klass.install!("org.godotengine.Godot",
+                                  remote: "flathub-beta",
+                                  url:    "https://dl.flathub.org/beta-repo/"))
               .to be(true)
           end
         end
@@ -409,12 +411,12 @@ RSpec.describe Homebrew::Bundle::Flatpak do
 
     describe ".generate_single_app_remote_name" do
       it "generates name with -origin suffix" do
-        expect(described_class.generate_single_app_remote_name("org.godotengine.Godot"))
+        expect(klass.generate_single_app_remote_name("org.godotengine.Godot"))
           .to eq("org.godotengine.Godot-origin")
       end
 
       it "handles various app ID formats" do
-        expect(described_class.generate_single_app_remote_name("com.example.App"))
+        expect(klass.generate_single_app_remote_name("com.example.App"))
           .to eq("com.example.App-origin")
       end
     end

--- a/Library/Homebrew/test/bundle/go_spec.rb
+++ b/Library/Homebrew/test/bundle/go_spec.rb
@@ -6,13 +6,15 @@ require "bundle/dsl"
 require "bundle/extensions/go"
 
 RSpec.describe Homebrew::Bundle::Go do
+  let(:klass) { Homebrew::Bundle::Go }
+
   describe "dumping" do
-    subject(:dumper) { described_class }
+    subject(:dumper) { klass }
 
     context "when go is not installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(nil)
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(nil)
       end
 
       specify do
@@ -23,19 +25,19 @@ RSpec.describe Homebrew::Bundle::Go do
 
     context "when go is installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("go"))
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("go"))
       end
 
       it "returns package list" do
-        allow(described_class).to receive(:`).with("go env GOBIN").and_return("")
-        allow(described_class).to receive(:`).with("go env GOPATH").and_return("/Users/test/go")
+        allow(klass).to receive(:`).with("go env GOBIN").and_return("")
+        allow(klass).to receive(:`).with("go env GOPATH").and_return("/Users/test/go")
         allow(File).to receive(:directory?).with("/Users/test/go/bin").and_return(true)
         allow(Dir).to receive(:glob).with("/Users/test/go/bin/*").and_return(["/Users/test/go/bin/crush"])
         allow(File).to receive(:executable?).with("/Users/test/go/bin/crush").and_return(true)
         allow(File).to receive(:directory?).with("/Users/test/go/bin/crush").and_return(false)
-        allow(described_class).to receive(:`).with("go version -m \"/Users/test/go/bin/crush\" 2>/dev/null")
-                                             .and_return("\tpath\tgithub.com/charmbracelet/crush\n")
+        allow(klass).to receive(:`).with("go version -m \"/Users/test/go/bin/crush\" 2>/dev/null")
+                                   .and_return("\tpath\tgithub.com/charmbracelet/crush\n")
         expect(dumper.packages).to eql(["github.com/charmbracelet/crush"])
       end
 
@@ -49,15 +51,15 @@ RSpec.describe Homebrew::Bundle::Go do
   describe "installing" do
     context "when Go is not installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(nil)
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "tries to install go" do
         expect(Homebrew::Bundle).to \
           receive(:system).with(HOMEBREW_BREW_FILE, "install", "--formula", "go", verbose: false)
                           .and_return(true)
-        expect { described_class.preinstall!("github.com/charmbracelet/crush") }.to raise_error(RuntimeError)
+        expect { klass.preinstall!("github.com/charmbracelet/crush") }.to raise_error(RuntimeError)
       end
 
       it "preserves upgrade_formulae while bootstrapping Go" do
@@ -66,39 +68,39 @@ RSpec.describe Homebrew::Bundle::Go do
         expect(Homebrew::Bundle).to \
           receive(:system).with(HOMEBREW_BREW_FILE, "install", "--formula", "go", verbose: false)
                           .and_return(true)
-        expect { described_class.preinstall!("github.com/charmbracelet/crush") }.to raise_error(RuntimeError)
+        expect { klass.preinstall!("github.com/charmbracelet/crush") }.to raise_error(RuntimeError)
         expect(Homebrew::Bundle.upgrade_formulae).to eql(["foo", "bar"])
       end
     end
 
     context "when Go is installed" do
       before do
-        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("go"))
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("go"))
       end
 
       context "when package is installed" do
         before do
-          allow(described_class).to receive(:installed_packages)
+          allow(klass).to receive(:installed_packages)
             .and_return(["github.com/charmbracelet/crush"])
         end
 
         it "skips" do
           expect(Homebrew::Bundle).not_to receive(:system)
-          expect(described_class.preinstall!("github.com/charmbracelet/crush")).to be(false)
+          expect(klass.preinstall!("github.com/charmbracelet/crush")).to be(false)
         end
       end
 
       context "when package is not installed" do
         before do
-          allow(described_class).to receive_messages(packages: [], installed_packages: [])
+          allow(klass).to receive_messages(packages: [], installed_packages: [])
         end
 
         it "installs package" do
           expect(Homebrew::Bundle).to \
             receive(:system).with("go", "install", "github.com/charmbracelet/crush@latest", verbose: false)
                             .and_return(true)
-          expect(described_class.preinstall!("github.com/charmbracelet/crush")).to be(true)
-          expect(described_class.install!("github.com/charmbracelet/crush")).to be(true)
+          expect(klass.preinstall!("github.com/charmbracelet/crush")).to be(true)
+          expect(klass.install!("github.com/charmbracelet/crush")).to be(true)
         end
 
         it "updates dump output after install in the same process" do
@@ -106,9 +108,9 @@ RSpec.describe Homebrew::Bundle::Go do
             receive(:system).with("go", "install", "github.com/charmbracelet/crush@latest", verbose: false)
                             .and_return(true)
 
-          described_class.install!("github.com/charmbracelet/crush")
+          klass.install!("github.com/charmbracelet/crush")
 
-          expect(described_class.dump).to eql('go "github.com/charmbracelet/crush"')
+          expect(klass.dump).to eql('go "github.com/charmbracelet/crush"')
         end
       end
     end
@@ -116,9 +118,9 @@ RSpec.describe Homebrew::Bundle::Go do
 
   describe "cleanup" do
     before do
-      described_class.reset!
+      klass.reset!
       pkgs = %w[github.com/charmbracelet/crush github.com/golangci/golangci-lint/v2/cmd/golangci-lint]
-      allow(described_class).to receive_messages(
+      allow(klass).to receive_messages(
         package_manager_executable: Pathname.new("go"),
         packages:                   pkgs,
         installed_packages:         pkgs,
@@ -127,14 +129,14 @@ RSpec.describe Homebrew::Bundle::Go do
 
     it "returns packages not in Brewfile entries" do
       entries = [Homebrew::Bundle::Dsl::Entry.new(:go, "github.com/charmbracelet/crush")]
-      expect(described_class.cleanup_items(entries))
+      expect(klass.cleanup_items(entries))
         .to eql(%w[github.com/golangci/golangci-lint/v2/cmd/golangci-lint])
     end
 
     it "returns frozen empty array when go is not installed" do
-      allow(described_class).to receive(:package_manager_installed?).and_return(false)
+      allow(klass).to receive(:package_manager_installed?).and_return(false)
       entries = [Homebrew::Bundle::Dsl::Entry.new(:go, "github.com/charmbracelet/crush")]
-      expect(described_class.cleanup_items(entries)).to eql([])
+      expect(klass.cleanup_items(entries)).to eql([])
     end
   end
 end

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -7,13 +7,15 @@ require "bundle/installer"
 require "bundle/parallel_installer"
 
 RSpec.describe Homebrew::Bundle::Installer do
+  let(:klass) { Homebrew::Bundle::Installer }
+
   let(:formula_entry) { Homebrew::Bundle::Dsl::Entry.new(:brew, "mysql") }
   let(:second_formula_entry) { Homebrew::Bundle::Dsl::Entry.new(:brew, "redis") }
   let(:cask_options) { { args: {}, full_name: "homebrew/cask/google-chrome" } }
   let(:cask_entry) { Homebrew::Bundle::Dsl::Entry.new(:cask, "google-chrome", cask_options) }
 
   before do
-    described_class.reset!
+    klass.reset!
     allow(Homebrew::Bundle::Skipper).to receive(:skip?).and_return(false)
     allow(Homebrew::Bundle::Brew).to receive_messages(formula_upgradable?: false, install!: true)
     allow(Homebrew::Bundle::Brew).to receive_messages(formula_installed_and_up_to_date?: false,
@@ -31,8 +33,8 @@ RSpec.describe Homebrew::Bundle::Installer do
 
     expect(Homebrew::Bundle::Cask.cask_names).to eq(["stale"])
 
-    described_class.reset!
-    described_class.install!([cask_entry], verbose: false, force: false, quiet: true)
+    klass.reset!
+    klass.install!([cask_entry], verbose: false, force: false, quiet: true)
   end
 
   it "prefetches installable formulae and casks before installing" do
@@ -55,7 +57,7 @@ RSpec.describe Homebrew::Bundle::Installer do
       .ordered
       .and_return(true)
 
-    described_class.install!([formula_entry, cask_entry], verbose: false, force: false, quiet: true)
+    klass.install!([formula_entry, cask_entry], verbose: false, force: false, quiet: true)
   end
 
   it "skips fetching when no formulae or casks need installation or upgrade" do
@@ -64,7 +66,7 @@ RSpec.describe Homebrew::Bundle::Installer do
 
     expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
 
-    described_class.install!([formula_entry], no_upgrade: true, quiet: true)
+    klass.install!([formula_entry], no_upgrade: true, quiet: true)
   end
 
   it "skips fetching formulae from untapped taps" do
@@ -76,7 +78,7 @@ RSpec.describe Homebrew::Bundle::Installer do
 
     expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
 
-    described_class.install!([tap_entry, tapped_formula_entry], quiet: true)
+    klass.install!([tap_entry, tapped_formula_entry], quiet: true)
   end
 
   it "skips fetching formulae from fully qualified untapped taps" do
@@ -87,7 +89,7 @@ RSpec.describe Homebrew::Bundle::Installer do
 
     expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
 
-    described_class.install!([tapped_formula_entry], quiet: true)
+    klass.install!([tapped_formula_entry], quiet: true)
   end
 
   it "skips fetching unqualified formulae when Brewfile taps are untapped" do
@@ -98,7 +100,7 @@ RSpec.describe Homebrew::Bundle::Installer do
 
     expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
 
-    described_class.install!([tap_entry, untapped_formula_entry], quiet: true)
+    klass.install!([tap_entry, untapped_formula_entry], quiet: true)
   end
 
   it "warns and skips fetching unqualified formulae when API metadata is unavailable" do
@@ -107,10 +109,10 @@ RSpec.describe Homebrew::Bundle::Installer do
 
     allow(Homebrew::API).to receive(:formula_names).and_raise("API unavailable")
 
-    expect(described_class).to receive(:opoo).with(/could not check API metadata: API unavailable/)
+    expect(klass).to receive(:opoo).with(/could not check API metadata: API unavailable/)
     expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
 
-    described_class.install!([tap_entry, untapped_formula_entry], quiet: true)
+    klass.install!([tap_entry, untapped_formula_entry], quiet: true)
   end
 
   it "prefetches unqualified formulae available without untapped Brewfile taps" do
@@ -125,7 +127,7 @@ RSpec.describe Homebrew::Bundle::Installer do
       .with("fetch", "mysql", verbose: false)
       .and_return(true)
 
-    described_class.install!([tap_entry, formula_entry], quiet: true)
+    klass.install!([tap_entry, formula_entry], quiet: true)
   end
 
   it "skips fetching fully qualified casks from untapped taps" do
@@ -133,7 +135,7 @@ RSpec.describe Homebrew::Bundle::Installer do
 
     expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
 
-    described_class.install!([tapped_cask_entry], quiet: true)
+    klass.install!([tapped_cask_entry], quiet: true)
   end
 
   it "skips fetching unqualified casks when Brewfile taps are untapped" do
@@ -145,7 +147,7 @@ RSpec.describe Homebrew::Bundle::Installer do
 
     expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
 
-    described_class.install!([tap_entry, untapped_cask_entry], quiet: true)
+    klass.install!([tap_entry, untapped_cask_entry], quiet: true)
   end
 
   it "prefetches unqualified casks available without untapped Brewfile taps" do
@@ -160,7 +162,7 @@ RSpec.describe Homebrew::Bundle::Installer do
       .with("fetch", "google-chrome", verbose: false)
       .and_return(true)
 
-    described_class.install!([tap_entry, cask_entry], quiet: true)
+    klass.install!([tap_entry, cask_entry], quiet: true)
   end
 
   describe "parallel installation" do
@@ -328,7 +330,7 @@ RSpec.describe Homebrew::Bundle::Installer do
       expect(Homebrew::Bundle::Brew).to receive(:preinstall!)
         .with("redis", no_upgrade: false, verbose: false).ordered.and_return(true)
 
-      described_class.install!([formula_entry, second_formula_entry], jobs: 1, quiet: true)
+      klass.install!([formula_entry, second_formula_entry], jobs: 1, quiet: true)
     end
   end
 end

--- a/Library/Homebrew/test/bundle/krew_spec.rb
+++ b/Library/Homebrew/test/bundle/krew_spec.rb
@@ -6,13 +6,15 @@ require "bundle/dsl"
 require "bundle/extensions/krew"
 
 RSpec.describe Homebrew::Bundle::Krew do
+  let(:klass) { Homebrew::Bundle::Krew }
+
   describe "dumping" do
-    subject(:dumper) { described_class }
+    subject(:dumper) { klass }
 
     context "when krew is not installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_installed?).and_return(false)
+        klass.reset!
+        allow(klass).to receive(:package_manager_installed?).and_return(false)
       end
 
       it "returns an empty list and dumps an empty string" do
@@ -23,19 +25,19 @@ RSpec.describe Homebrew::Bundle::Krew do
 
     context "when krew is installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive_messages(package_manager_installed?: true,
-                                                   package_manager_executable: Pathname.new("kubectl-krew"))
+        klass.reset!
+        allow(klass).to receive_messages(package_manager_installed?: true,
+                                         package_manager_executable: Pathname.new("kubectl-krew"))
       end
 
       it "returns plugin list" do
-        allow(described_class).to receive(:`).and_return("ctx\nneat\nns\n")
+        allow(klass).to receive(:`).and_return("ctx\nneat\nns\n")
 
         expect(dumper.packages).to eql(%w[ctx neat ns])
       end
 
       it "handles empty output" do
-        allow(described_class).to receive(:`).and_return("")
+        allow(klass).to receive(:`).and_return("")
 
         expect(dumper.packages).to be_empty
       end
@@ -50,15 +52,15 @@ RSpec.describe Homebrew::Bundle::Krew do
   describe "installing" do
     context "when kubectl-krew is not found" do
       before do
-        described_class.reset!
-        allow(described_class).to receive_messages(package_manager_executable: nil, package_manager_installed?: false)
+        klass.reset!
+        allow(klass).to receive_messages(package_manager_executable: nil, package_manager_installed?: false)
       end
 
       it "tries to install krew" do
         expect(Homebrew::Bundle).to \
           receive(:system).with(HOMEBREW_BREW_FILE, "install", "--formula", "krew", verbose: false)
                           .and_return(true)
-        expect { described_class.preinstall!("ctx") }.to raise_error(RuntimeError)
+        expect { klass.preinstall!("ctx") }.to raise_error(RuntimeError)
       end
 
       it "preserves upgrade_formulae while bootstrapping krew" do
@@ -67,14 +69,14 @@ RSpec.describe Homebrew::Bundle::Krew do
         expect(Homebrew::Bundle).to \
           receive(:system).with(HOMEBREW_BREW_FILE, "install", "--formula", "krew", verbose: false)
                           .and_return(true)
-        expect { described_class.preinstall!("ctx") }.to raise_error(RuntimeError)
+        expect { klass.preinstall!("ctx") }.to raise_error(RuntimeError)
         expect(Homebrew::Bundle.upgrade_formulae).to eql(["foo", "bar"])
       end
     end
 
     context "when kubectl-krew is installed" do
       before do
-        allow(described_class).to receive_messages(
+        allow(klass).to receive_messages(
           package_manager_executable: Pathname.new("/usr/local/bin/kubectl-krew"),
           package_manager_installed?: true,
         )
@@ -82,19 +84,19 @@ RSpec.describe Homebrew::Bundle::Krew do
 
       context "when plugin is installed" do
         before do
-          allow(described_class).to receive(:installed_packages).and_return(["ctx"])
+          allow(klass).to receive(:installed_packages).and_return(["ctx"])
         end
 
         it "skips" do
           expect(Homebrew::Bundle).not_to receive(:system)
-          expect(described_class.preinstall!("ctx")).to be(false)
+          expect(klass.preinstall!("ctx")).to be(false)
         end
       end
 
       context "when plugin is not installed" do
         before do
-          described_class.reset!
-          allow(described_class).to receive_messages(
+          klass.reset!
+          allow(klass).to receive_messages(
             package_manager_executable: Pathname.new("/usr/local/bin/kubectl-krew"),
             package_manager_installed?: true,
             installed_packages:         [],
@@ -108,8 +110,8 @@ RSpec.describe Homebrew::Bundle::Krew do
             expect(verbose).to be(false)
             true
           end
-          expect(described_class.preinstall!("ctx")).to be(true)
-          expect(described_class.install!("ctx")).to be(true)
+          expect(klass.preinstall!("ctx")).to be(true)
+          expect(klass.install!("ctx")).to be(true)
         end
 
         it "updates dump output after install" do
@@ -119,9 +121,9 @@ RSpec.describe Homebrew::Bundle::Krew do
             true
           end
 
-          described_class.install!("ctx")
+          klass.install!("ctx")
 
-          expect(described_class.dump).to eql('krew "ctx"')
+          expect(klass.dump).to eql('krew "ctx"')
         end
       end
     end

--- a/Library/Homebrew/test/bundle/mac_app_store_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_spec.rb
@@ -6,13 +6,15 @@ require "bundle/dsl"
 require "bundle/extensions/mac_app_store"
 
 RSpec.describe Homebrew::Bundle::MacAppStore do
+  let(:klass) { Homebrew::Bundle::MacAppStore }
+
   describe "dumping" do
-    subject(:dumper) { described_class }
+    subject(:dumper) { klass }
 
     context "when mas is not installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(nil)
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(nil)
       end
 
       specify do
@@ -23,8 +25,8 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
 
     context "when there is no apps" do
       before do
-        described_class.reset!
-        allow(described_class).to receive_messages(package_manager_executable: Pathname.new("mas"), "`": "")
+        klass.reset!
+        allow(klass).to receive_messages(package_manager_executable: Pathname.new("mas"), "`": "")
       end
 
       specify do
@@ -35,8 +37,8 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
 
     context "when apps `foo`, `bar` and `baz` are installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive_messages(
+        klass.reset!
+        allow(klass).to receive_messages(
           package_manager_executable: Pathname.new("mas"),
           "`":                        "123 foo (1.0)\n" \
                                       "456 bar (2.0)\n" \
@@ -51,10 +53,10 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
 
     context "when apps `foo`, `bar`, `baz` and `qux` are installed including right-justified IDs" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("mas"))
-        allow(described_class).to receive(:`).and_return("123 foo (1.0)\n456 bar (2.0)\n789 baz (3.0)")
-        allow(described_class).to receive(:`).and_return("123 foo (1.0)\n456 bar (2.0)\n789 baz (3.0)\n 10 qux (4.0)")
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("mas"))
+        allow(klass).to receive(:`).and_return("123 foo (1.0)\n456 bar (2.0)\n789 baz (3.0)")
+        allow(klass).to receive(:`).and_return("123 foo (1.0)\n456 bar (2.0)\n789 baz (3.0)\n 10 qux (4.0)")
       end
 
       it "returns list %w[foo bar baz qux]" do
@@ -136,9 +138,9 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
       end
 
       before do
-        described_class.reset!
-        allow(described_class).to receive_messages(package_manager_executable: Pathname.new("mas"),
-                                                   "`":                        invalid_mas_output)
+        klass.reset!
+        allow(klass).to receive_messages(package_manager_executable: Pathname.new("mas"),
+                                         "`":                        invalid_mas_output)
       end
 
       specify do
@@ -165,9 +167,9 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
       end
 
       before do
-        described_class.reset!
-        allow(described_class).to receive_messages(package_manager_executable: Pathname.new("mas"),
-                                                   "`":                        new_mas_output)
+        klass.reset!
+        allow(klass).to receive_messages(package_manager_executable: Pathname.new("mas"),
+                                         "`":                        new_mas_output)
       end
 
       it "parses the app names without trailing whitespace" do
@@ -183,85 +185,85 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
 
     describe ".installed_app_ids" do
       it "shells out" do
-        expect { described_class.installed_app_ids }.not_to raise_error
+        expect { klass.installed_app_ids }.not_to raise_error
       end
     end
 
     describe ".app_id_installed_and_up_to_date?" do
       it "returns result" do
-        allow(described_class).to receive_messages(installed_app_ids: [123, 456], outdated_app_ids: [456])
-        expect(described_class.app_id_installed_and_up_to_date?(123)).to be(true)
-        expect(described_class.app_id_installed_and_up_to_date?(456)).to be(false)
+        allow(klass).to receive_messages(installed_app_ids: [123, 456], outdated_app_ids: [456])
+        expect(klass.app_id_installed_and_up_to_date?(123)).to be(true)
+        expect(klass.app_id_installed_and_up_to_date?(456)).to be(false)
       end
     end
 
     context "when mas is not installed" do
       before do
-        allow(described_class).to receive(:package_manager_executable).and_return(nil)
+        allow(klass).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "tries to install mas" do
         expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "install", "mas",
                                                           verbose: false).and_return(true)
-        expect { described_class.preinstall!("foo", 123) }.to raise_error(RuntimeError)
+        expect { klass.preinstall!("foo", 123) }.to raise_error(RuntimeError)
       end
 
       describe ".outdated_app_ids" do
         it "does not shell out" do
-          expect(described_class).not_to receive(:`)
-          described_class.reset!
-          described_class.outdated_app_ids
+          expect(klass).not_to receive(:`)
+          klass.reset!
+          klass.outdated_app_ids
         end
       end
     end
 
     context "when mas is installed" do
       before do
-        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("mas"))
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("mas"))
       end
 
       describe ".outdated_app_ids" do
         it "returns app ids" do
-          expect(described_class).to receive(:`).and_return("foo 123")
-          described_class.reset!
-          described_class.outdated_app_ids
+          expect(klass).to receive(:`).and_return("foo 123")
+          klass.reset!
+          klass.outdated_app_ids
         end
       end
 
       context "when app is installed" do
         before do
-          allow(described_class).to receive(:installed_app_ids).and_return([123])
+          allow(klass).to receive(:installed_app_ids).and_return([123])
         end
 
         it "skips" do
           expect(Homebrew::Bundle).not_to receive(:system)
-          expect(described_class.preinstall!("foo", 123)).to be(false)
+          expect(klass.preinstall!("foo", 123)).to be(false)
         end
       end
 
       context "when app is outdated" do
         before do
-          allow(described_class).to receive_messages(installed_app_ids: [123], outdated_app_ids: [123])
+          allow(klass).to receive_messages(installed_app_ids: [123], outdated_app_ids: [123])
         end
 
         it "upgrades" do
           expect(Homebrew::Bundle).to receive(:system).with(Pathname("mas"), "upgrade", "123", verbose: false)
                                                       .and_return(true)
-          expect(described_class.preinstall!("foo", 123)).to be(true)
-          expect(described_class.install!("foo", 123)).to be(true)
+          expect(klass.preinstall!("foo", 123)).to be(true)
+          expect(klass.install!("foo", 123)).to be(true)
         end
       end
 
       context "when app is not installed" do
         before do
-          allow(described_class).to receive(:installed_app_ids).and_return([])
+          allow(klass).to receive(:installed_app_ids).and_return([])
         end
 
         it "installs app" do
           expect(Homebrew::Bundle).to receive(:system).with(Pathname("mas"), "install", "123", verbose: false)
                                                       .and_return(true)
-          expect(described_class.preinstall!("foo", 123)).to be(true)
-          expect(described_class.install!("foo", 123)).to be(true)
+          expect(klass.preinstall!("foo", 123)).to be(true)
+          expect(klass.install!("foo", 123)).to be(true)
         end
 
         it "falls back to `mas get` when `mas install` fails" do
@@ -269,8 +271,8 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
                                                       .and_return(false)
           expect(Homebrew::Bundle).to receive(:system).with(Pathname("mas"), "get", "123", verbose: false)
                                                       .and_return(true)
-          expect(described_class.preinstall!("foo", 123)).to be(true)
-          expect(described_class.install!("foo", 123)).to be(true)
+          expect(klass.preinstall!("foo", 123)).to be(true)
+          expect(klass.install!("foo", 123)).to be(true)
         end
       end
     end

--- a/Library/Homebrew/test/bundle/npm_spec.rb
+++ b/Library/Homebrew/test/bundle/npm_spec.rb
@@ -6,13 +6,15 @@ require "bundle/dsl"
 require "bundle/extensions/npm"
 
 RSpec.describe Homebrew::Bundle::Npm do
+  let(:klass) { Homebrew::Bundle::Npm }
+
   describe "dumping" do
-    subject(:dumper) { described_class }
+    subject(:dumper) { klass }
 
     context "when npm is not installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(nil)
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(nil)
       end
 
       specify do
@@ -23,12 +25,12 @@ RSpec.describe Homebrew::Bundle::Npm do
 
     context "when npm is installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("npm"))
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("npm"))
       end
 
       it "returns package list" do
-        allow(described_class).to receive(:`).with("npm list -g --depth=0 --json 2>/dev/null").and_return(<<~JSON)
+        allow(klass).to receive(:`).with("npm list -g --depth=0 --json 2>/dev/null").and_return(<<~JSON)
           {
             "dependencies": {
               "npm": { "version": "11.11.0" },
@@ -46,8 +48,8 @@ RSpec.describe Homebrew::Bundle::Npm do
         npm.dirname.mkpath
         npm.write("")
 
-        allow(described_class).to receive(:package_manager_executable).and_return(npm)
-        expect(described_class).to receive(:`).with("#{npm} list -g --depth=0 --json 2>/dev/null") do
+        allow(klass).to receive(:package_manager_executable).and_return(npm)
+        expect(klass).to receive(:`).with("#{npm} list -g --depth=0 --json 2>/dev/null") do
           expect(ENV.fetch("PATH", "")).to start_with("#{npm.dirname}:")
           '{"dependencies":{"eslint":{"version":"10.4.0"}}}'
         end
@@ -56,7 +58,7 @@ RSpec.describe Homebrew::Bundle::Npm do
       end
 
       it "excludes npm itself from the package list" do
-        allow(described_class).to receive(:`).with("npm list -g --depth=0 --json 2>/dev/null").and_return(<<~JSON)
+        allow(klass).to receive(:`).with("npm list -g --depth=0 --json 2>/dev/null").and_return(<<~JSON)
           {
             "dependencies": {
               "npm": { "version": "11.11.0" }
@@ -68,13 +70,13 @@ RSpec.describe Homebrew::Bundle::Npm do
       end
 
       it "handles invalid JSON" do
-        allow(described_class).to receive(:`).with("npm list -g --depth=0 --json 2>/dev/null").and_return("not json")
+        allow(klass).to receive(:`).with("npm list -g --depth=0 --json 2>/dev/null").and_return("not json")
 
         expect(dumper.packages).to be_empty
       end
 
       it "handles empty output" do
-        allow(described_class).to receive(:`).with("npm list -g --depth=0 --json 2>/dev/null").and_return("")
+        allow(klass).to receive(:`).with("npm list -g --depth=0 --json 2>/dev/null").and_return("")
 
         expect(dumper.packages).to be_empty
       end
@@ -88,8 +90,8 @@ RSpec.describe Homebrew::Bundle::Npm do
 
   describe "cleanup" do
     before do
-      described_class.reset!
-      allow(described_class).to receive_messages(
+      klass.reset!
+      allow(klass).to receive_messages(
         package_manager_executable: Pathname.new("/opt/homebrew/bin/npm"),
         packages:                   %w[vercel typescript prettier],
         installed_packages:         %w[vercel typescript prettier],
@@ -98,7 +100,7 @@ RSpec.describe Homebrew::Bundle::Npm do
 
     it "returns packages not in Brewfile entries" do
       entries = [Homebrew::Bundle::Dsl::Entry.new(:npm, "vercel")]
-      expect(described_class.cleanup_items(entries)).to eql(%w[typescript prettier])
+      expect(klass.cleanup_items(entries)).to eql(%w[typescript prettier])
     end
 
     it "returns empty when all packages are in Brewfile" do
@@ -107,51 +109,51 @@ RSpec.describe Homebrew::Bundle::Npm do
         Homebrew::Bundle::Dsl::Entry.new(:npm, "typescript"),
         Homebrew::Bundle::Dsl::Entry.new(:npm, "prettier"),
       ]
-      expect(described_class.cleanup_items(entries)).to eql([])
+      expect(klass.cleanup_items(entries)).to eql([])
     end
 
     it "returns frozen empty array when npm is not installed" do
-      allow(described_class).to receive(:package_manager_installed?).and_return(false)
+      allow(klass).to receive(:package_manager_installed?).and_return(false)
       entries = [Homebrew::Bundle::Dsl::Entry.new(:npm, "vercel")]
-      expect(described_class.cleanup_items(entries)).to eql([])
+      expect(klass.cleanup_items(entries)).to eql([])
     end
   end
 
   describe "installing" do
     context "when npm is not installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(nil)
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "tries to install node" do
         expect(Homebrew::Bundle).to \
           receive(:system).with(HOMEBREW_BREW_FILE, "install", "--formula", "node", verbose: false)
                           .and_return(true)
-        expect { described_class.preinstall!("vercel") }.to raise_error(RuntimeError)
+        expect { klass.preinstall!("vercel") }.to raise_error(RuntimeError)
       end
     end
 
     context "when npm is installed" do
       before do
-        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("npm"))
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("npm"))
       end
 
       context "when package is installed" do
         before do
-          allow(described_class).to receive(:installed_packages)
+          allow(klass).to receive(:installed_packages)
             .and_return(["vercel"])
         end
 
         it "skips" do
           expect(Homebrew::Bundle).not_to receive(:system)
-          expect(described_class.preinstall!("vercel")).to be(false)
+          expect(klass.preinstall!("vercel")).to be(false)
         end
       end
 
       context "when package is not installed" do
         before do
-          allow(described_class).to receive_messages(
+          allow(klass).to receive_messages(
             package_manager_executable: Pathname.new("/opt/homebrew/bin/npm"),
             installed_packages:         [],
           )
@@ -161,8 +163,8 @@ RSpec.describe Homebrew::Bundle::Npm do
           expect(Homebrew::Bundle).to receive(:system)
             .with("/opt/homebrew/bin/npm", "install", "-g", "vercel", verbose: false)
             .and_return(true)
-          expect(described_class.preinstall!("vercel")).to be(true)
-          expect(described_class.install!("vercel")).to be(true)
+          expect(klass.preinstall!("vercel")).to be(true)
+          expect(klass.install!("vercel")).to be(true)
         end
       end
     end

--- a/Library/Homebrew/test/bundle/remover_spec.rb
+++ b/Library/Homebrew/test/bundle/remover_spec.rb
@@ -5,8 +5,9 @@ require "bundle"
 require "bundle/remover"
 
 RSpec.describe Homebrew::Bundle::Remover do
-  subject(:remover) { described_class }
+  subject(:remover) { klass }
 
+  let(:klass) { Homebrew::Bundle::Remover }
   let(:name) { "foo" }
 
   before { allow(Formulary).to receive(:factory).with(name).and_raise(FormulaUnavailableError.new(name)) }

--- a/Library/Homebrew/test/bundle/skipper_spec.rb
+++ b/Library/Homebrew/test/bundle/skipper_spec.rb
@@ -6,7 +6,9 @@ require "bundle/skipper"
 require "bundle/dsl"
 
 RSpec.describe Homebrew::Bundle::Skipper do
-  subject(:skipper) { described_class }
+  subject(:skipper) { klass }
+
+  let(:klass) { Homebrew::Bundle::Skipper }
 
   before do
     allow(ENV).to receive(:[]).and_return(nil)

--- a/Library/Homebrew/test/bundle/tap_spec.rb
+++ b/Library/Homebrew/test/bundle/tap_spec.rb
@@ -6,12 +6,14 @@ require "bundle/skipper"
 require "bundle/tap"
 
 RSpec.describe Homebrew::Bundle::Tap do
+  let(:klass) { Homebrew::Bundle::Tap }
+
   describe "dumping" do
-    subject(:dumper) { described_class }
+    subject(:dumper) { klass }
 
     context "when there is no tap" do
       before do
-        described_class.reset!
+        klass.reset!
         allow(Tap).to receive(:select).and_return []
       end
 
@@ -23,7 +25,7 @@ RSpec.describe Homebrew::Bundle::Tap do
 
     context "with taps" do
       before do
-        described_class.reset!
+        klass.reset!
 
         bar = instance_double(Tap, name: "bitbucket/bar", custom_remote?: true,
                               remote: "https://bitbucket.org/bitbucket/bar.git")
@@ -62,35 +64,35 @@ RSpec.describe Homebrew::Bundle::Tap do
   describe "installing" do
     describe ".installed_taps" do
       before do
-        described_class.reset!
+        klass.reset!
       end
 
       it "calls Homebrew" do
-        expect { described_class.installed_taps }.not_to raise_error
+        expect { klass.installed_taps }.not_to raise_error
       end
     end
 
     context "when tap is installed" do
       before do
-        allow(described_class).to receive(:installed_taps).and_return(["homebrew/cask"])
+        allow(klass).to receive(:installed_taps).and_return(["homebrew/cask"])
       end
 
       it "skips" do
         expect(Homebrew::Bundle).not_to receive(:system)
-        expect(described_class.preinstall!("homebrew/cask")).to be(false)
+        expect(klass.preinstall!("homebrew/cask")).to be(false)
       end
     end
 
     context "when tap is not installed" do
       before do
-        allow(described_class).to receive(:installed_taps).and_return([])
+        allow(klass).to receive(:installed_taps).and_return([])
       end
 
       it "taps" do
         expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "tap", "homebrew/cask",
                                                           verbose: false).and_return(true)
-        expect(described_class.preinstall!("homebrew/cask")).to be(true)
-        expect(described_class.install!("homebrew/cask")).to be(true)
+        expect(klass.preinstall!("homebrew/cask")).to be(true)
+        expect(klass.install!("homebrew/cask")).to be(true)
       end
 
       context "with clone target" do
@@ -98,16 +100,16 @@ RSpec.describe Homebrew::Bundle::Tap do
           expect(Homebrew::Bundle).to \
             receive(:system).with(HOMEBREW_BREW_FILE, "tap", "homebrew/cask", "clone_target_path",
                                   verbose: false).and_return(true)
-          expect(described_class.preinstall!("homebrew/cask", clone_target: "clone_target_path")).to be(true)
-          expect(described_class.install!("homebrew/cask", clone_target: "clone_target_path")).to be(true)
+          expect(klass.preinstall!("homebrew/cask", clone_target: "clone_target_path")).to be(true)
+          expect(klass.install!("homebrew/cask", clone_target: "clone_target_path")).to be(true)
         end
 
         it "fails" do
           expect(Homebrew::Bundle).to \
             receive(:system).with(HOMEBREW_BREW_FILE, "tap", "homebrew/cask", "clone_target_path",
                                   verbose: false).and_return(false)
-          expect(described_class.preinstall!("homebrew/cask", clone_target: "clone_target_path")).to be(true)
-          expect(described_class.install!("homebrew/cask", clone_target: "clone_target_path")).to be(false)
+          expect(klass.preinstall!("homebrew/cask", clone_target: "clone_target_path")).to be(true)
+          expect(klass.install!("homebrew/cask", clone_target: "clone_target_path")).to be(false)
         end
       end
     end

--- a/Library/Homebrew/test/bundle/uv_spec.rb
+++ b/Library/Homebrew/test/bundle/uv_spec.rb
@@ -6,12 +6,14 @@ require "bundle/dsl"
 require "bundle/extensions/uv"
 
 RSpec.describe Homebrew::Bundle::Uv do
+  let(:klass) { Homebrew::Bundle::Uv }
+
   describe "checking" do
-    subject(:checker) { described_class.new }
+    subject(:checker) { klass.new }
 
     describe "#installed_and_up_to_date?" do
       it "returns false when package is not installed" do
-        allow(described_class).to receive(:package_installed?).and_return(false)
+        allow(klass).to receive(:package_installed?).and_return(false)
         expect(
           checker.installed_and_up_to_date?(
             { name: "mkdocs", options: { with: ["mkdocs-material<10"] } },
@@ -20,7 +22,7 @@ RSpec.describe Homebrew::Bundle::Uv do
       end
 
       it "returns true when package and options match" do
-        expect(described_class).to receive(:package_installed?)
+        expect(klass).to receive(:package_installed?)
           .with("mkdocs", with: ["mkdocs-material<10"])
           .and_return(true)
 
@@ -50,10 +52,10 @@ RSpec.describe Homebrew::Bundle::Uv do
       end
 
       it "checks uv entries and passes normalized options to installer checks" do
-        expect(described_class).to receive(:package_installed?)
+        expect(klass).to receive(:package_installed?)
           .with("ruff", with: [])
           .and_return(true)
-        expect(described_class).to receive(:package_installed?)
+        expect(klass).to receive(:package_installed?)
           .with("mkdocs", with: ["mkdocs-material<10"])
           .and_return(true)
 
@@ -62,7 +64,7 @@ RSpec.describe Homebrew::Bundle::Uv do
       end
 
       it "returns missing uv tools from full check flow" do
-        allow(described_class).to receive(:package_installed?) do |name, **|
+        allow(klass).to receive(:package_installed?) do |name, **|
           name == "ruff"
         end
 
@@ -73,7 +75,7 @@ RSpec.describe Homebrew::Bundle::Uv do
   end
 
   describe "dumping" do
-    subject(:dumper) { described_class }
+    subject(:dumper) { klass }
 
     let(:uv_tool_list_command) do
       [
@@ -86,8 +88,8 @@ RSpec.describe Homebrew::Bundle::Uv do
 
     context "when uv is not installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(nil)
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "returns empty packages and dump output" do
@@ -98,12 +100,12 @@ RSpec.describe Homebrew::Bundle::Uv do
 
     context "when uv is installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("uv"))
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("uv"))
       end
 
       it "returns normalized package entries sorted by package name" do
-        allow(described_class).to receive(:`).with(uv_tool_list_command).and_return(<<~OUTPUT)
+        allow(klass).to receive(:`).with(uv_tool_list_command).and_return(<<~OUTPUT)
           ruff v0.14.14
           - ruff
           mkdocs v1.6.1 [with: mkdocs-material<10]
@@ -123,7 +125,7 @@ RSpec.describe Homebrew::Bundle::Uv do
       end
 
       it "dumps correct Brewfile entries" do
-        allow(described_class).to receive(:`).with(uv_tool_list_command).and_return(<<~OUTPUT)
+        allow(klass).to receive(:`).with(uv_tool_list_command).and_return(<<~OUTPUT)
           ruff v0.14.14 [with: httpx>=0.27]
           - ruff
         OUTPUT
@@ -132,7 +134,7 @@ RSpec.describe Homebrew::Bundle::Uv do
       end
 
       it "handles tools with no optional metadata" do
-        allow(described_class).to receive(:`).with(uv_tool_list_command).and_return(<<~OUTPUT)
+        allow(klass).to receive(:`).with(uv_tool_list_command).and_return(<<~OUTPUT)
           ruff v0.14.14
           - ruff
         OUTPUT
@@ -141,14 +143,14 @@ RSpec.describe Homebrew::Bundle::Uv do
       end
 
       it "returns empty packages when no tools are installed" do
-        allow(described_class).to receive(:`).with(uv_tool_list_command).and_return("")
+        allow(klass).to receive(:`).with(uv_tool_list_command).and_return("")
 
         expect(dumper.packages).to be_empty
         expect(dumper.dump).to eql("")
       end
 
       it "handles multiple with dependencies" do
-        allow(described_class).to receive(:`).with(uv_tool_list_command).and_return(<<~OUTPUT)
+        allow(klass).to receive(:`).with(uv_tool_list_command).and_return(<<~OUTPUT)
           mkdocs v1.6.1 [with: mkdocs-material, mkdocs-awesome-page-plugin]
           - mkdocs
         OUTPUT
@@ -157,7 +159,7 @@ RSpec.describe Homebrew::Bundle::Uv do
       end
 
       it "keeps comma-constrained with requirements as a single requirement" do
-        allow(described_class).to receive(:`).with(uv_tool_list_command).and_return(<<~OUTPUT)
+        allow(klass).to receive(:`).with(uv_tool_list_command).and_return(<<~OUTPUT)
           ruff v0.14.14 [with: httpx>=0.27, <0.29]
           - ruff
         OUTPUT
@@ -167,7 +169,7 @@ RSpec.describe Homebrew::Bundle::Uv do
       end
 
       it "preserves extras for the main tool requirement" do
-        allow(described_class).to receive(:`).with(uv_tool_list_command).and_return(<<~OUTPUT)
+        allow(klass).to receive(:`).with(uv_tool_list_command).and_return(<<~OUTPUT)
           fastapi v0.129.0 [extras: all, standard]
           - fastapi
         OUTPUT
@@ -181,26 +183,26 @@ RSpec.describe Homebrew::Bundle::Uv do
   describe "installing" do
     context "when uv is not installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(nil)
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(nil)
       end
 
       it "tries to install uv" do
         expect(Homebrew::Bundle).to \
           receive(:system).with(HOMEBREW_BREW_FILE, "install", "--formula", "uv", verbose: false)
                           .and_return(true)
-        expect { described_class.preinstall!("mkdocs") }.to raise_error(RuntimeError)
+        expect { klass.preinstall!("mkdocs") }.to raise_error(RuntimeError)
       end
     end
 
     context "when uv is installed" do
       before do
-        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("uv"))
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("uv"))
       end
 
       context "when package is installed with matching options" do
         before do
-          allow(described_class).to receive(:installed_packages).and_return([
+          allow(klass).to receive(:installed_packages).and_return([
             {
               name: "mkdocs",
               with: ["mkdocs-material<10"],
@@ -210,11 +212,11 @@ RSpec.describe Homebrew::Bundle::Uv do
 
         it "skips install" do
           expect(Homebrew::Bundle).not_to receive(:system)
-          expect(described_class.preinstall!("mkdocs", with: ["mkdocs-material<10"])).to be(false)
+          expect(klass.preinstall!("mkdocs", with: ["mkdocs-material<10"])).to be(false)
         end
 
         it "skips install for package with no options" do
-          allow(described_class).to receive(:installed_packages).and_return([
+          allow(klass).to receive(:installed_packages).and_return([
             {
               name: "ruff",
               with: [],
@@ -222,11 +224,11 @@ RSpec.describe Homebrew::Bundle::Uv do
           ])
 
           expect(Homebrew::Bundle).not_to receive(:system)
-          expect(described_class.preinstall!("ruff")).to be(false)
+          expect(klass.preinstall!("ruff")).to be(false)
         end
 
         it "treats matching with requirements as installed" do
-          allow(described_class).to receive(:installed_packages).and_return([
+          allow(klass).to receive(:installed_packages).and_return([
             {
               name: "ruff",
               with: ["httpx>=0.27"],
@@ -234,7 +236,7 @@ RSpec.describe Homebrew::Bundle::Uv do
           ])
 
           expect(
-            described_class.package_installed?(
+            klass.package_installed?(
               "ruff",
               with: ["httpx>=0.27"],
             ),
@@ -242,7 +244,7 @@ RSpec.describe Homebrew::Bundle::Uv do
         end
 
         it "treats extras with different ordering as installed" do
-          allow(described_class).to receive(:installed_packages).and_return([
+          allow(klass).to receive(:installed_packages).and_return([
             {
               name: "fastapi[all,standard]",
               with: [],
@@ -250,7 +252,7 @@ RSpec.describe Homebrew::Bundle::Uv do
           ])
 
           expect(
-            described_class.package_installed?(
+            klass.package_installed?(
               "fastapi[standard,all]",
             ),
           ).to be(true)
@@ -259,7 +261,7 @@ RSpec.describe Homebrew::Bundle::Uv do
 
       context "when package is installed but with options differ" do
         before do
-          allow(described_class).to receive(:installed_packages).and_return([
+          allow(klass).to receive(:installed_packages).and_return([
             {
               name: "mkdocs",
               with: ["mkdocs-material<10"],
@@ -268,22 +270,22 @@ RSpec.describe Homebrew::Bundle::Uv do
         end
 
         it "does not treat mismatched with dependencies as installed" do
-          expect(described_class.package_installed?("mkdocs", with: ["mkdocs-material<9"])).to be(false)
+          expect(klass.package_installed?("mkdocs", with: ["mkdocs-material<9"])).to be(false)
         end
       end
 
       context "when package is not installed" do
         before do
-          allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("/tmp/uv/bin/uv"))
-          allow(described_class).to receive_messages(packages: [], installed_packages: [])
+          allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("/tmp/uv/bin/uv"))
+          allow(klass).to receive_messages(packages: [], installed_packages: [])
         end
 
         it "installs package with no options" do
           expect(Homebrew::Bundle).to receive(:system)
             .with("/tmp/uv/bin/uv", "tool", "install", "ruff", verbose: false).and_return(true)
 
-          expect(described_class.preinstall!("ruff")).to be(true)
-          expect(described_class.install!("ruff")).to be(true)
+          expect(klass.preinstall!("ruff")).to be(true)
+          expect(klass.install!("ruff")).to be(true)
         end
 
         it "installs package with all supported options" do
@@ -292,8 +294,8 @@ RSpec.describe Homebrew::Bundle::Uv do
                   "--with", "mkdocs-material<10",
                   verbose: false).and_return(true)
 
-          expect(described_class.preinstall!("mkdocs", with: ["mkdocs-material<10"])).to be(true)
-          expect(described_class.install!("mkdocs", with: ["mkdocs-material<10"])).to be(true)
+          expect(klass.preinstall!("mkdocs", with: ["mkdocs-material<10"])).to be(true)
+          expect(klass.install!("mkdocs", with: ["mkdocs-material<10"])).to be(true)
         end
 
         it "updates dump output after install in the same process" do
@@ -302,9 +304,9 @@ RSpec.describe Homebrew::Bundle::Uv do
                   "--with", "mkdocs-material<10",
                   verbose: false).and_return(true)
 
-          described_class.install!("mkdocs", with: ["mkdocs-material<10"])
+          klass.install!("mkdocs", with: ["mkdocs-material<10"])
 
-          expect(described_class.dump).to eql('uv "mkdocs", with: ["mkdocs-material<10"]')
+          expect(klass.dump).to eql('uv "mkdocs", with: ["mkdocs-material<10"]')
         end
       end
     end
@@ -312,13 +314,13 @@ RSpec.describe Homebrew::Bundle::Uv do
 
   describe "cleanup" do
     before do
-      described_class.reset!
+      klass.reset!
       tools = [
         { name: "ruff", with: [] },
         { name: "mkdocs", with: ["mkdocs-material<10"] },
         { name: "black", with: [] },
       ]
-      allow(described_class).to receive_messages(
+      allow(klass).to receive_messages(
         package_manager_executable: Pathname.new("/tmp/uv/bin/uv"),
         packages:                   tools,
         installed_packages:         tools,
@@ -327,13 +329,13 @@ RSpec.describe Homebrew::Bundle::Uv do
 
     it "returns tools not in Brewfile entries" do
       entries = [Homebrew::Bundle::Dsl::Entry.new(:uv, "ruff")]
-      expect(described_class.cleanup_items(entries)).to eql(%w[mkdocs black])
+      expect(klass.cleanup_items(entries)).to eql(%w[mkdocs black])
     end
 
     it "returns frozen empty array when uv is not installed" do
-      allow(described_class).to receive(:package_manager_installed?).and_return(false)
+      allow(klass).to receive(:package_manager_installed?).and_return(false)
       entries = [Homebrew::Bundle::Dsl::Entry.new(:uv, "ruff")]
-      expect(described_class.cleanup_items(entries)).to eql([])
+      expect(klass.cleanup_items(entries)).to eql([])
     end
   end
 end

--- a/Library/Homebrew/test/bundle/vscode_extension_spec.rb
+++ b/Library/Homebrew/test/bundle/vscode_extension_spec.rb
@@ -7,13 +7,15 @@ require "bundle/extensions/vscode_extension"
 require "extend/kernel"
 
 RSpec.describe Homebrew::Bundle::VscodeExtension do
+  let(:klass) { Homebrew::Bundle::VscodeExtension }
+
   describe "dumping" do
-    subject(:dumper) { described_class }
+    subject(:dumper) { klass }
 
     context "when vscode is not installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive_messages(package_manager_executable: nil, "`": "")
+        klass.reset!
+        allow(klass).to receive_messages(package_manager_executable: nil, "`": "")
       end
 
       specify do
@@ -24,8 +26,8 @@ RSpec.describe Homebrew::Bundle::VscodeExtension do
 
     context "when vscode is installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("code"))
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("code"))
       end
 
       it "returns package list" do
@@ -36,7 +38,7 @@ RSpec.describe Homebrew::Bundle::VscodeExtension do
           tamasfe.even-better-toml
         EOF
 
-        allow(described_class).to receive(:`)
+        allow(klass).to receive(:`)
           .with('"code" --list-extensions 2>/dev/null')
           .and_return(output)
         expect(dumper.extensions).to eql([
@@ -52,8 +54,8 @@ RSpec.describe Homebrew::Bundle::VscodeExtension do
   describe "installing" do
     context "when VSCode is not installed" do
       before do
-        described_class.reset!
-        allow(described_class).to receive(:package_manager_executable).and_return(nil)
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(nil)
         allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(true)
       end
 
@@ -61,41 +63,41 @@ RSpec.describe Homebrew::Bundle::VscodeExtension do
         expect(Homebrew::Bundle).to \
           receive(:system).with(HOMEBREW_BREW_FILE, "install", "--cask", "visual-studio-code", verbose: false)
                           .and_return(true)
-        expect { described_class.preinstall!("foo") }.to raise_error(RuntimeError)
+        expect { klass.preinstall!("foo") }.to raise_error(RuntimeError)
       end
     end
 
     context "when VSCode is installed" do
       before do
-        allow(described_class).to receive(:package_manager_executable).and_return(Pathname("code"))
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname("code"))
       end
 
       context "when extension is installed" do
         before do
-          allow(described_class).to receive(:installed_extensions).and_return(["foo"])
+          allow(klass).to receive(:installed_extensions).and_return(["foo"])
         end
 
         it "skips" do
           expect(Homebrew::Bundle).not_to receive(:system)
-          expect(described_class.preinstall!("foo")).to be(false)
+          expect(klass.preinstall!("foo")).to be(false)
         end
 
         it "skips ignoring case" do
           expect(Homebrew::Bundle).not_to receive(:system)
-          expect(described_class.preinstall!("Foo")).to be(false)
+          expect(klass.preinstall!("Foo")).to be(false)
         end
       end
 
       context "when extension is not installed" do
         before do
-          allow(described_class).to receive(:installed_extensions).and_return([])
+          allow(klass).to receive(:installed_extensions).and_return([])
         end
 
         it "installs extension" do
           expect(Homebrew::Bundle).to \
             receive(:system).with(Pathname("code"), "--install-extension", "foo", verbose: false).and_return(true)
-          expect(described_class.preinstall!("foo")).to be(true)
-          expect(described_class.install!("foo")).to be(true)
+          expect(klass.preinstall!("foo")).to be(true)
+          expect(klass.install!("foo")).to be(true)
         end
 
         it "installs extension when euid != uid and Process::UID.re_exchangeable? returns true" do
@@ -107,8 +109,8 @@ RSpec.describe Homebrew::Bundle::VscodeExtension do
 
           expect(Homebrew::Bundle).to \
             receive(:system).with(Pathname("code"), "--install-extension", "foo", verbose: false).and_return(true)
-          expect(described_class.preinstall!("foo")).to be(true)
-          expect(described_class.install!("foo")).to be(true)
+          expect(klass.preinstall!("foo")).to be(true)
+          expect(klass.install!("foo")).to be(true)
         end
 
         it "installs extension when euid != uid and Process::UID.re_exchangeable? returns false" do
@@ -120,8 +122,8 @@ RSpec.describe Homebrew::Bundle::VscodeExtension do
 
           expect(Homebrew::Bundle).to \
             receive(:system).with(Pathname("code"), "--install-extension", "foo", verbose: false).and_return(true)
-          expect(described_class.preinstall!("foo")).to be(true)
-          expect(described_class.install!("foo")).to be(true)
+          expect(klass.preinstall!("foo")).to be(true)
+          expect(klass.install!("foo")).to be(true)
         end
       end
     end

--- a/Library/Homebrew/test/bundle_version_spec.rb
+++ b/Library/Homebrew/test/bundle_version_spec.rb
@@ -4,25 +4,27 @@
 require "bundle_version"
 
 RSpec.describe Homebrew::BundleVersion do
+  let(:klass) { Homebrew::BundleVersion }
+
   describe "#<=>" do
     it "compares both the `short_version` and `version`" do
-      expect(described_class.new("1.2.3", "3000")).to be < described_class.new("1.2.3", "4000")
-      expect(described_class.new("1.2.3", "4000")).to be <= described_class.new("1.2.3", "4000")
-      expect(described_class.new("1.2.3", "4000")).to be >= described_class.new("1.2.3", "4000")
-      expect(described_class.new("1.2.4", "4000")).to be > described_class.new("1.2.3", "4000")
+      expect(klass.new("1.2.3", "3000")).to be < klass.new("1.2.3", "4000")
+      expect(klass.new("1.2.3", "4000")).to be <= klass.new("1.2.3", "4000")
+      expect(klass.new("1.2.3", "4000")).to be >= klass.new("1.2.3", "4000")
+      expect(klass.new("1.2.4", "4000")).to be > klass.new("1.2.3", "4000")
     end
 
     it "compares `version` first" do
-      expect(described_class.new("1.2.4", "3000")).to be < described_class.new("1.2.3", "4000")
+      expect(klass.new("1.2.4", "3000")).to be < klass.new("1.2.3", "4000")
     end
 
     it "does not fail when `short_version` or `version` is missing" do
-      expect(described_class.new("1.06", nil)).to be < described_class.new("1.12", "1.12")
-      expect(described_class.new("1.06", "471")).to be > described_class.new(nil, "311")
-      expect(described_class.new("1.2.3", nil)).to be < described_class.new("1.2.4", nil)
-      expect(described_class.new(nil, "1.2.3")).to be < described_class.new(nil, "1.2.4")
-      expect(described_class.new("1.2.3", nil)).to be < described_class.new(nil, "1.2.3")
-      expect(described_class.new(nil, "1.2.3")).to be > described_class.new("1.2.3", nil)
+      expect(klass.new("1.06", nil)).to be < klass.new("1.12", "1.12")
+      expect(klass.new("1.06", "471")).to be > klass.new(nil, "311")
+      expect(klass.new("1.2.3", nil)).to be < klass.new("1.2.4", nil)
+      expect(klass.new(nil, "1.2.3")).to be < klass.new(nil, "1.2.4")
+      expect(klass.new("1.2.3", nil)).to be < klass.new(nil, "1.2.3")
+      expect(klass.new(nil, "1.2.3")).to be > klass.new("1.2.3", nil)
     end
   end
 
@@ -43,7 +45,7 @@ RSpec.describe Homebrew::BundleVersion do
 
     expected_mappings.each do |(short_version, version), expected_version|
       it "maps (#{short_version.inspect}, #{version.inspect}) to #{expected_version.inspect}" do
-        expect(described_class.new(short_version, version).nice_version)
+        expect(klass.new(short_version, version).nice_version)
           .to eq expected_version
       end
     end
@@ -51,11 +53,11 @@ RSpec.describe Homebrew::BundleVersion do
 
   describe "#to_h" do
     it "returns a hash containing non-nil instance variables" do
-      expect(described_class.new("1.2.3", "3000").to_h)
+      expect(klass.new("1.2.3", "3000").to_h)
         .to eq({ short_version: "1.2.3", version: "3000" })
-      expect(described_class.new(nil, "3000").to_h)
+      expect(klass.new(nil, "3000").to_h)
         .to eq({ version: "3000" })
-      expect(described_class.new("1.2.3", nil).to_h)
+      expect(klass.new("1.2.3", nil).to_h)
         .to eq({ short_version: "1.2.3" })
     end
   end

--- a/Library/Homebrew/test/cache_store_spec.rb
+++ b/Library/Homebrew/test/cache_store_spec.rb
@@ -4,16 +4,18 @@
 require "cache_store"
 
 RSpec.describe CacheStoreDatabase do
-  subject(:sample_db) { described_class.new(:sample) }
+  subject(:sample_db) { klass.new(:sample) }
+
+  let(:klass) { CacheStoreDatabase }
 
   describe "self.use" do
     let(:type) { :test }
 
     it "creates a new `DatabaseCache` instance" do
-      cache_store = instance_double(described_class, "cache_store", write_if_dirty!: nil)
-      expect(described_class).to receive(:new).with(type).and_return(cache_store)
+      cache_store = instance_double(klass, "cache_store", write_if_dirty!: nil)
+      expect(klass).to receive(:new).with(type).and_return(cache_store)
       expect(cache_store).to receive(:write_if_dirty!)
-      described_class.use(type) do |_db|
+      klass.use(type) do |_db|
         # do nothing
       end
     end

--- a/Library/Homebrew/test/cask/artifact/abstract_artifact_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/abstract_artifact_spec.rb
@@ -2,26 +2,28 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::AbstractArtifact, :cask do
+  let(:klass) { Cask::Artifact::AbstractArtifact }
+
   describe ".read_script_arguments" do
     let(:stanza) { :installer }
 
     it "accepts a string and uses it as the executable" do
       arguments = "something"
 
-      expect(described_class.read_script_arguments(arguments, stanza)).to eq(["something", {}])
+      expect(klass.read_script_arguments(arguments, stanza)).to eq(["something", {}])
     end
 
     it "accepts a hash with an executable" do
       arguments = { executable: "something" }
 
-      expect(described_class.read_script_arguments(arguments, stanza)).to eq(["something", {}])
+      expect(klass.read_script_arguments(arguments, stanza)).to eq(["something", {}])
     end
 
     it "does not mutate the original arguments in place" do
       arguments = { executable: "something" }
       clone = arguments.dup
 
-      described_class.read_script_arguments(arguments, stanza)
+      klass.read_script_arguments(arguments, stanza)
 
       expect(arguments).to eq(clone)
     end

--- a/Library/Homebrew/test/cask/artifact/alt_target_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/alt_target_spec.rb
@@ -2,11 +2,13 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::App, :cask do
+  let(:klass) { Cask::Artifact::App }
+
   describe "activate to alternate target" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-alt-target")) }
 
     let(:install_phase) do
-      cask.artifacts.grep(described_class).each do |artifact|
+      cask.artifacts.grep(klass).each do |artifact|
         artifact.install_phase(command: NeverSudoSystemCommand, force: false)
       end
     end

--- a/Library/Homebrew/test/cask/artifact/app_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/app_spec.rb
@@ -2,12 +2,14 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::App, :cask do
+  let(:klass) { Cask::Artifact::App }
+
   let(:cask) { Cask::CaskLoader.load(cask_path("local-caffeine")) }
   let(:command) { NeverSudoSystemCommand }
   let(:adopt) { false }
   let(:force) { false }
   let(:auto_updates) { false }
-  let(:app) { cask.artifacts.find { |a| a.is_a?(described_class) } }
+  let(:app) { cask.artifacts.find { |a| a.is_a?(klass) } }
 
   let(:source_path) { cask.staged_path.join("Caffeine.app") }
   let(:target_path) { cask.config.appdir.join("Caffeine.app") }

--- a/Library/Homebrew/test/cask/artifact/bashcompletion_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/bashcompletion_spec.rb
@@ -2,12 +2,14 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::BashCompletion, :cask do
+  let(:klass) { Cask::Artifact::BashCompletion }
+
   let(:cask) { Cask::CaskLoader.load(cask_token) }
 
   context "with install" do
     let(:install_phase) do
       lambda do
-        cask.artifacts.grep(described_class).each do |artifact|
+        cask.artifacts.grep(klass).each do |artifact|
           artifact.install_phase(command: NeverSudoSystemCommand, force: false)
         end
       end

--- a/Library/Homebrew/test/cask/artifact/binary_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/binary_spec.rb
@@ -2,12 +2,14 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Binary, :cask do
+  let(:klass) { Cask::Artifact::Binary }
+
   let(:cask) do
     Cask::CaskLoader.load(cask_path("with-binary")).tap do |cask|
       InstallHelper.install_without_artifacts(cask)
     end
   end
-  let(:artifacts) { cask.artifacts.grep(described_class) }
+  let(:artifacts) { cask.artifacts.grep(klass) }
   let(:binarydir) { cask.config.binarydir }
   let(:expected_path) { binarydir.join("binary") }
 

--- a/Library/Homebrew/test/cask/artifact/fishlcompletion_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/fishlcompletion_spec.rb
@@ -2,12 +2,14 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::FishCompletion, :cask do
+  let(:klass) { Cask::Artifact::FishCompletion }
+
   let(:cask) { Cask::CaskLoader.load(cask_token) }
 
   context "with install" do
     let(:install_phase) do
       lambda do
-        cask.artifacts.grep(described_class).each do |artifact|
+        cask.artifacts.grep(klass).each do |artifact|
           artifact.install_phase(command: NeverSudoSystemCommand, force: false)
         end
       end

--- a/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
+  let(:klass) { Cask::Artifact::GeneratedCompletion }
+
   let(:staged_path) { Pathname(Dir.mktmpdir) }
 
   let(:cask) do
@@ -31,7 +33,7 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
 
   describe "#install_phase" do
     it "generates completion scripts for default shells" do
-      artifact = cask.artifacts.grep(described_class).first
+      artifact = cask.artifacts.grep(klass).first
 
       allow(Utils).to receive(:safe_popen_read) do |env, *_args, **_opts|
         "#{env.fetch("SHELL")} completion output"
@@ -49,7 +51,7 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
 
     context "when generation fails for one shell" do
       it "warns and continues generating other shells" do
-        artifact = cask.artifacts.grep(described_class).first
+        artifact = cask.artifacts.grep(klass).first
 
         allow(Utils).to receive(:safe_popen_read) do |env, *_args, **_opts|
           raise "boom" if env.fetch("SHELL") == "bash"
@@ -67,7 +69,7 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
 
   describe "#uninstall_phase" do
     it "removes generated completion scripts" do
-      artifact = cask.artifacts.grep(described_class).first
+      artifact = cask.artifacts.grep(klass).first
 
       bash_dir.mkpath
       zsh_dir.mkpath
@@ -98,7 +100,7 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
     end
 
     it "generates only for the specified shell with the correct format" do
-      artifact = cask.artifacts.grep(described_class).first
+      artifact = cask.artifacts.grep(klass).first
       captured_args = nil
 
       allow(Utils).to receive(:safe_popen_read) do |_env, *args, **_opts|
@@ -129,7 +131,7 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
     end
 
     it "normalizes shells to symbols" do
-      artifact = cask.artifacts.grep(described_class).first
+      artifact = cask.artifacts.grep(klass).first
 
       expect(artifact.shells).to eq([:bash, :zsh, :fish, :pwsh])
     end

--- a/Library/Homebrew/test/cask/artifact/generic_artifact_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/generic_artifact_spec.rb
@@ -2,11 +2,13 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Artifact, :cask do
+  let(:klass) { Cask::Artifact::Artifact }
+
   let(:cask) { Cask::CaskLoader.load(cask_path("with-generic-artifact")) }
 
   let(:install_phase) do
     lambda do
-      cask.artifacts.grep(described_class).each do |artifact|
+      cask.artifacts.grep(klass).each do |artifact|
         artifact.install_phase(command: NeverSudoSystemCommand, force: false)
       end
     end

--- a/Library/Homebrew/test/cask/artifact/installer_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/installer_spec.rb
@@ -2,13 +2,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Installer, :cask do
-  subject(:installer) { described_class.new(cask, **args) }
+  subject(:installer) { klass.new(cask, **args) }
 
+  let(:klass) { Cask::Artifact::Installer }
   let(:staged_path) { mktmpdir }
   let(:cask) { instance_double(Cask::Cask, staged_path:) }
-
   let(:command) { SystemCommand }
-
   let(:args) { {} }
 
   describe "#install_phase" do

--- a/Library/Homebrew/test/cask/artifact/manpage_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/manpage_spec.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Manpage, :cask do
+  let(:klass) { Cask::Artifact::Manpage }
+
   let(:cask) { Cask::CaskLoader.load(cask_token) }
 
   context "without section" do
@@ -15,7 +17,7 @@ RSpec.describe Cask::Artifact::Manpage, :cask do
   context "with install" do
     let(:install_phase) do
       lambda do
-        cask.artifacts.grep(described_class).each do |artifact|
+        cask.artifacts.grep(klass).each do |artifact|
           artifact.install_phase(command: NeverSudoSystemCommand, force: false)
         end
       end

--- a/Library/Homebrew/test/cask/artifact/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/pkg_spec.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Pkg, :cask do
+  let(:klass) { Cask::Artifact::Pkg }
+
   let(:cask) { Cask::CaskLoader.load(cask_path("with-installable")) }
   let(:fake_system_command) { class_double(SystemCommand) }
 
@@ -11,7 +13,7 @@ RSpec.describe Cask::Artifact::Pkg, :cask do
 
   describe "install_phase" do
     it "runs the system installer on the specified pkgs" do
-      pkg = cask.artifacts.find { |a| a.is_a?(described_class) }
+      pkg = cask.artifacts.find { |a| a.is_a?(klass) }
 
       expect(fake_system_command).to receive(:run!).with(
         "/usr/sbin/installer",
@@ -34,7 +36,7 @@ RSpec.describe Cask::Artifact::Pkg, :cask do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-choices")) }
 
     it "passes the choice changes xml to the system installer" do
-      pkg = cask.artifacts.find { |a| a.is_a?(described_class) }
+      pkg = cask.artifacts.find { |a| a.is_a?(klass) }
 
       file = instance_double(Tempfile, path: Pathname.new("/tmp/choices.xml"))
 

--- a/Library/Homebrew/test/cask/artifact/postflight_block_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/postflight_block_spec.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::PostflightBlock, :cask do
+  let(:klass) { Cask::Artifact::PostflightBlock }
+
   describe "install_phase" do
     it "calls the specified block after installing, passing a Cask mini-dsl" do
       called = false
@@ -14,7 +16,7 @@ RSpec.describe Cask::Artifact::PostflightBlock, :cask do
         end
       end
 
-      cask.artifacts.grep(described_class).each do |artifact|
+      cask.artifacts.grep(klass).each do |artifact|
         artifact.install_phase(command: NeverSudoSystemCommand, force: false)
       end
 
@@ -35,7 +37,7 @@ RSpec.describe Cask::Artifact::PostflightBlock, :cask do
         end
       end
 
-      cask.artifacts.grep(described_class).each do |artifact|
+      cask.artifacts.grep(klass).each do |artifact|
         artifact.uninstall_phase(command: NeverSudoSystemCommand, force: false)
       end
 

--- a/Library/Homebrew/test/cask/artifact/preflight_block_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/preflight_block_spec.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::PreflightBlock, :cask do
+  let(:klass) { Cask::Artifact::PreflightBlock }
+
   describe "install_phase" do
     it "calls the specified block before installing, passing a Cask mini-dsl" do
       called = false
@@ -14,7 +16,7 @@ RSpec.describe Cask::Artifact::PreflightBlock, :cask do
         end
       end
 
-      cask.artifacts.grep(described_class).each do |artifact|
+      cask.artifacts.grep(klass).each do |artifact|
         artifact.install_phase(command: NeverSudoSystemCommand, force: false)
       end
 
@@ -35,7 +37,7 @@ RSpec.describe Cask::Artifact::PreflightBlock, :cask do
         end
       end
 
-      cask.artifacts.grep(described_class).each do |artifact|
+      cask.artifacts.grep(klass).each do |artifact|
         artifact.uninstall_phase(command: NeverSudoSystemCommand, force: false)
       end
 

--- a/Library/Homebrew/test/cask/artifact/relocated_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/relocated_spec.rb
@@ -4,6 +4,8 @@
 require "cask/artifact/relocated"
 
 RSpec.describe Cask::Artifact::Relocated, :cask do
+  let(:klass) { Cask::Artifact::Relocated }
+
   let(:cask) do
     Cask::Cask.new("test-cask") do
       url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
@@ -14,7 +16,7 @@ RSpec.describe Cask::Artifact::Relocated, :cask do
   end
 
   let(:command) { NeverSudoSystemCommand }
-  let(:artifact) { described_class.new(cask, "test_file.txt") }
+  let(:artifact) { klass.new(cask, "test_file.txt") }
 
   describe "#add_altname_metadata" do
     let(:file) { Pathname("/tmp/test_file.txt") }

--- a/Library/Homebrew/test/cask/artifact/suite_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/suite_spec.rb
@@ -2,11 +2,13 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Suite, :cask do
+  let(:klass) { Cask::Artifact::Suite }
+
   let(:cask) { Cask::CaskLoader.load(cask_path("with-suite")) }
 
   let(:install_phase) do
     lambda do
-      cask.artifacts.grep(described_class).each do |artifact|
+      cask.artifacts.grep(klass).each do |artifact|
         artifact.install_phase(command: NeverSudoSystemCommand, force: false)
       end
     end

--- a/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
@@ -2,11 +2,13 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::App, :cask do
+  let(:klass) { Cask::Artifact::App }
+
   describe "multiple apps" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-two-apps-correct")) }
 
     let(:install_phase) do
-      cask.artifacts.grep(described_class).each do |artifact|
+      cask.artifacts.grep(klass).each do |artifact|
         artifact.install_phase(command: NeverSudoSystemCommand, force: false)
       end
     end

--- a/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
@@ -2,10 +2,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Zap, :cask do
+  let(:klass) { Cask::Artifact::Zap }
+
   let(:cask) { Cask::CaskLoader.load(cask_path("with-installable")) }
 
   let(:zap_artifact) do
-    cask.artifacts.find { |a| a.is_a?(described_class) }
+    cask.artifacts.find { |a| a.is_a?(klass) }
   end
 
   before do

--- a/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
@@ -4,6 +4,8 @@
 require_relative "shared_examples/uninstall_zap"
 
 RSpec.describe Cask::Artifact::Uninstall, :cask do
+  let(:klass) { Cask::Artifact::Uninstall }
+
   describe "#uninstall_phase" do
     let(:fake_system_command) { NeverSudoSystemCommand }
 
@@ -12,7 +14,7 @@ RSpec.describe Cask::Artifact::Uninstall, :cask do
     describe "upgrade/reinstall uninstall directives" do
       context "with-uninstall-quit" do
         let(:cask) { Cask::CaskLoader.load(cask_path("with-uninstall-quit")) }
-        let(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
+        let(:artifact) { cask.artifacts.find { |a| a.is_a?(klass) } }
 
         it "invokes :quit during upgrade" do
           quit_called = false
@@ -39,7 +41,7 @@ RSpec.describe Cask::Artifact::Uninstall, :cask do
 
       context "with-uninstall-signal" do
         let(:cask) { Cask::CaskLoader.load(cask_path("with-uninstall-signal")) }
-        let(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
+        let(:artifact) { cask.artifacts.find { |a| a.is_a?(klass) } }
 
         it "skips :signal by default during upgrade" do
           signal_called = false
@@ -66,7 +68,7 @@ RSpec.describe Cask::Artifact::Uninstall, :cask do
 
       context "with-uninstall-signal-on-upgrade" do
         let(:cask) { Cask::CaskLoader.load(cask_path("with-uninstall-signal-on-upgrade")) }
-        let(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
+        let(:artifact) { cask.artifacts.find { |a| a.is_a?(klass) } }
 
         it "invokes :signal during upgrade" do
           signal_called = false
@@ -94,7 +96,7 @@ RSpec.describe Cask::Artifact::Uninstall, :cask do
 
     context "with-uninstall-both-on-upgrade" do
       let(:cask) { Cask::CaskLoader.load(cask_path("with-uninstall-both-on-upgrade")) }
-      let(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
+      let(:artifact) { cask.artifacts.find { |a| a.is_a?(klass) } }
 
       it "invokes both quit and signal during upgrade when on_upgrade: :signal" do
         quit_called = false
@@ -112,7 +114,7 @@ RSpec.describe Cask::Artifact::Uninstall, :cask do
 
     context "with-uninstall-quit-only-on-upgrade" do
       let(:cask) { Cask::CaskLoader.load(cask_path("with-uninstall-quit-only-on-upgrade")) }
-      let(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
+      let(:artifact) { cask.artifacts.find { |a| a.is_a?(klass) } }
 
       it "invokes quit but not signal during upgrade without on_upgrade: :signal" do
         quit_called = false
@@ -130,7 +132,7 @@ RSpec.describe Cask::Artifact::Uninstall, :cask do
   end
 
   describe "#bundle_ids_to_reopen" do
-    subject(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
+    subject(:artifact) { cask.artifacts.find { |a| a.is_a?(klass) } }
 
     let(:fake_system_command) { NeverSudoSystemCommand }
     let(:cask) { Cask::CaskLoader.load(cask_path("with-uninstall-quit")) }
@@ -173,7 +175,7 @@ RSpec.describe Cask::Artifact::Uninstall, :cask do
   end
 
   describe "#post_uninstall_phase" do
-    subject(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
+    subject(:artifact) { cask.artifacts.find { |a| a.is_a?(klass) } }
 
     context "when using :rmdir" do
       let(:fake_system_command) { NeverSudoSystemCommand }

--- a/Library/Homebrew/test/cask/artifact/zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/zap_spec.rb
@@ -4,11 +4,13 @@
 require_relative "shared_examples/uninstall_zap"
 
 RSpec.describe Cask::Artifact::Zap, :cask do
+  let(:klass) { Cask::Artifact::Zap }
+
   describe "#zap_phase" do
     include_examples "#uninstall_phase or #zap_phase"
 
     context "when using :rmdir" do
-      subject(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
+      subject(:artifact) { cask.artifacts.find { |a| a.is_a?(klass) } }
 
       let(:fake_system_command) { NeverSudoSystemCommand }
       let(:cask) { Cask::CaskLoader.load(cask_path("with-zap-rmdir")) }

--- a/Library/Homebrew/test/cask/artifact/zshcompletion_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/zshcompletion_spec.rb
@@ -2,12 +2,14 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::ZshCompletion, :cask do
+  let(:klass) { Cask::Artifact::ZshCompletion }
+
   let(:cask) { Cask::CaskLoader.load(cask_token) }
 
   context "with install" do
     let(:install_phase) do
       lambda do
-        cask.artifacts.grep(described_class).each do |artifact|
+        cask.artifacts.grep(klass).each do |artifact|
           artifact.install_phase(command: NeverSudoSystemCommand, force: false)
         end
       end

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -4,6 +4,23 @@
 require "cask/audit"
 
 RSpec.describe Cask::Audit, :cask do
+  let(:klass) { Cask::Audit }
+  let(:cask) { instance_double(Cask::Cask) }
+  let(:new_cask) { nil }
+  let(:online) { nil }
+  let(:only) { [] }
+  let(:except) { [] }
+  let(:strict) { nil }
+  let(:signing) { nil }
+  let(:audit) do
+    klass.new(cask, online:,
+                    strict:,
+                    new_cask:,
+                    signing:,
+                    only:,
+                    except:)
+  end
+
   def include_msg?(problems, msg)
     if msg.is_a?(Regexp)
       Array(problems).any? { |problem| msg.match?(problem[:message]) }
@@ -42,22 +59,6 @@ RSpec.describe Cask::Audit, :cask do
     failure_message do |audit|
       "expected to error with message #{message.inspect} but #{outcome(audit)}"
     end
-  end
-
-  let(:cask) { instance_double(Cask::Cask) }
-  let(:new_cask) { nil }
-  let(:online) { nil }
-  let(:only) { [] }
-  let(:except) { [] }
-  let(:strict) { nil }
-  let(:signing) { nil }
-  let(:audit) do
-    described_class.new(cask, online:,
-                              strict:,
-                              new_cask:,
-                              signing:,
-                              only:,
-                              except:)
   end
 
   describe "#new" do

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
+  let(:klass) { Cask::CaskLoader::FromAPILoader }
+
   shared_context "with API setup" do |local_token|
     let(:api_token) { "#{local_token}-api" }
     let(:cask_from_source) { Cask::CaskLoader.load(local_token) }
@@ -13,7 +15,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
       JSON.parse(json)
     end
     let(:casks_from_api_hash) { { api_token => cask_json.except("token") } }
-    let(:api_loader) { described_class.new(api_token, from_json: cask_json) }
+    let(:api_loader) { klass.new(api_token, from_json: cask_json) }
 
     before do
       allow(Homebrew::API::Cask)
@@ -44,7 +46,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
     # let(:cask_structs_from_api_hash) { { internal_api_token => cask_internal_struct } }
     let(:casks_from_internal_api_hash) { { internal_api_token => cask_internal_json.except("tap_git_head") } }
     let(:internal_api_loader) do
-      described_class.new(internal_api_token, from_json: cask_internal_json, from_internal_json: true)
+      klass.new(internal_api_token, from_json: cask_internal_json, from_internal_json: true)
     end
 
     before do
@@ -65,7 +67,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
       include_context "with API setup", "test-opera"
 
       it "returns false" do
-        expect(described_class.try_new(api_token)).to be_nil
+        expect(klass.try_new(api_token)).to be_nil
       end
     end
 
@@ -73,19 +75,19 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
       include_context "with API setup", "test-opera"
 
       it "returns a loader for valid token" do
-        expect(described_class.try_new(api_token))
-          .to be_a(described_class)
+        expect(klass.try_new(api_token))
+          .to be_a(klass)
           .and have_attributes(token: api_token)
       end
 
       it "returns a loader for valid full name" do
-        expect(described_class.try_new("homebrew/cask/#{api_token}"))
-          .to be_a(described_class)
+        expect(klass.try_new("homebrew/cask/#{api_token}"))
+          .to be_a(klass)
           .and have_attributes(token: api_token)
       end
 
       it "returns nil for full name with invalid tap" do
-        expect(described_class.try_new("homebrew/foo/#{api_token}")).to be_nil
+        expect(klass.try_new("homebrew/foo/#{api_token}")).to be_nil
       end
 
       context "with core tap migration renames" do
@@ -106,7 +108,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
           JSON
 
           loader = Cask::CaskLoader::FromNameLoader.try_new(old_token)
-          expect(loader).to be_a(described_class)
+          expect(loader).to be_a(klass)
           expect(loader.token).to eq api_token
           expect(loader.path).not_to exist
         end
@@ -118,7 +120,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
           JSON
 
           loader = Cask::CaskLoader::FromTapLoader.try_new("#{foo_tap}/#{old_token}")
-          expect(loader).to be_a(described_class)
+          expect(loader).to be_a(klass)
           expect(loader.token).to eq api_token
           expect(loader.path).not_to exist
         end
@@ -129,19 +131,19 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
       include_context "with internal API setup", "test-opera"
 
       it "returns a loader for valid token" do
-        expect(described_class.try_new(internal_api_token))
-          .to be_a(described_class)
+        expect(klass.try_new(internal_api_token))
+          .to be_a(klass)
           .and have_attributes(token: internal_api_token)
       end
 
       it "returns a loader for valid full name" do
-        expect(described_class.try_new("homebrew/cask/#{internal_api_token}"))
-          .to be_a(described_class)
+        expect(klass.try_new("homebrew/cask/#{internal_api_token}"))
+          .to be_a(klass)
           .and have_attributes(token: internal_api_token)
       end
 
       it "returns nil for full name with invalid tap" do
-        expect(described_class.try_new("homebrew/foo/#{internal_api_token}")).to be_nil
+        expect(klass.try_new("homebrew/foo/#{internal_api_token}")).to be_nil
       end
 
       context "with core tap migration renames" do
@@ -162,7 +164,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
           JSON
 
           loader = Cask::CaskLoader::FromNameLoader.try_new(old_token)
-          expect(loader).to be_a(described_class)
+          expect(loader).to be_a(klass)
           expect(loader.token).to eq internal_api_token
           expect(loader.path).not_to exist
         end
@@ -174,7 +176,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
           JSON
 
           loader = Cask::CaskLoader::FromTapLoader.try_new("#{foo_tap}/#{old_token}")
-          expect(loader).to be_a(described_class)
+          expect(loader).to be_a(klass)
           expect(loader.token).to eq internal_api_token
           expect(loader.path).not_to exist
         end

--- a/Library/Homebrew/test/cask/cask_loader/from_content_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_content_loader_spec.rb
@@ -2,55 +2,58 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromContentLoader do
+  sig { returns(T.class_of(Cask::CaskLoader::FromContentLoader)) }
+  let(:klass) { Cask::CaskLoader::FromContentLoader }
+
   describe "::try_new" do
     it "returns a loader for Casks specified with `cask \"token\" do … end`" do
-      expect(described_class.try_new(<<~RUBY)).not_to be_nil
+      expect(klass.try_new(<<~RUBY)).not_to be_nil
         cask "token" do
         end
       RUBY
     end
 
     it "returns a loader for Casks specified with `cask \"token\" do; end`" do
-      expect(described_class.try_new(<<~RUBY)).not_to be_nil
+      expect(klass.try_new(<<~RUBY)).not_to be_nil
         cask "token" do; end
       RUBY
     end
 
     it "returns a loader for Casks specified with `cask 'token' do … end`" do
-      expect(described_class.try_new(<<~RUBY)).not_to be_nil
+      expect(klass.try_new(<<~RUBY)).not_to be_nil
         cask 'token' do
         end
       RUBY
     end
 
     it "returns a loader for Casks specified with `cask 'token' do; end`" do
-      expect(described_class.try_new(<<~RUBY)).not_to be_nil
+      expect(klass.try_new(<<~RUBY)).not_to be_nil
         cask 'token' do; end
       RUBY
     end
 
     it "returns a loader for Casks specified with `cask(\"token\") { … }`" do
-      expect(described_class.try_new(<<~RUBY)).not_to be_nil
+      expect(klass.try_new(<<~RUBY)).not_to be_nil
         cask("token") {
         }
       RUBY
     end
 
     it "returns a loader for Casks specified with `cask(\"token\") {}`" do
-      expect(described_class.try_new(<<~RUBY)).not_to be_nil
+      expect(klass.try_new(<<~RUBY)).not_to be_nil
         cask("token") {}
       RUBY
     end
 
     it "returns a loader for Casks specified with `cask('token') { … }`" do
-      expect(described_class.try_new(<<~RUBY)).not_to be_nil
+      expect(klass.try_new(<<~RUBY)).not_to be_nil
         cask('token') {
         }
       RUBY
     end
 
     it "returns a loader for Casks specified with `cask('token') {}`" do
-      expect(described_class.try_new(<<~RUBY)).not_to be_nil
+      expect(klass.try_new(<<~RUBY)).not_to be_nil
         cask('token') {}
       RUBY
     end

--- a/Library/Homebrew/test/cask/cask_loader/from_path_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_path_loader_spec.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromPathLoader do
+  let(:klass) { Cask::CaskLoader::FromPathLoader }
+
   describe "#load" do
     context "when the file does not contain a cask" do
       let(:path) do
@@ -14,7 +16,7 @@ RSpec.describe Cask::CaskLoader::FromPathLoader do
 
       it "raises an error" do
         expect do
-          described_class.new(path).load(config: nil)
+          klass.new(path).load(config: nil)
         end.to raise_error(Cask::CaskUnreadableError, /does not contain a cask/)
       end
     end
@@ -30,7 +32,7 @@ RSpec.describe Cask::CaskLoader::FromPathLoader do
 
       it "raises an error" do
         expect do
-          described_class.new(path).load(config: nil)
+          klass.new(path).load(config: nil)
         end.to raise_error(Cask::CaskUnreadableError, /undefined local variable or method/)
       end
     end
@@ -38,7 +40,7 @@ RSpec.describe Cask::CaskLoader::FromPathLoader do
     context "when the file contains an outdated cask" do
       it "raises an error" do
         expect do
-          described_class.new(cask_path("invalid/invalid-depends-on-macos-bad-release")).load(config: nil)
+          klass.new(cask_path("invalid/invalid-depends-on-macos-bad-release")).load(config: nil)
         end.to raise_error(Cask::CaskInvalidError,
                            /invalid 'depends_on macos' value: unknown or unsupported macOS version:/)
       end
@@ -48,7 +50,7 @@ RSpec.describe Cask::CaskLoader::FromPathLoader do
       let(:sourcefile_path) { TEST_FIXTURE_DIR/"cask/everything.json" }
 
       it "loads a cask with a source file path" do
-        cask = described_class.new(sourcefile_path).load(config: nil)
+        cask = klass.new(sourcefile_path).load(config: nil)
         expect(cask.loaded_from_api?).to be true
         expect(cask.loaded_from_internal_api?).to be false
         expect(cask.sourcefile_path).to eq sourcefile_path
@@ -59,7 +61,7 @@ RSpec.describe Cask::CaskLoader::FromPathLoader do
       let(:sourcefile_path) { TEST_FIXTURE_DIR/"cask/everything.internal.json" }
 
       it "loads a cask with a source file path" do
-        cask = described_class.new(sourcefile_path).load(config: nil)
+        cask = klass.new(sourcefile_path).load(config: nil)
         expect(cask.loaded_from_api?).to be true
         expect(cask.loaded_from_internal_api?).to be true
         expect(cask.sourcefile_path).to eq sourcefile_path

--- a/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromTapLoader do
+  let(:klass) { Cask::CaskLoader::FromTapLoader }
+
   let(:tap) { CoreCaskTap.instance }
   let(:cask_name) { "testball" }
   let(:cask_full_name) { "homebrew/cask/#{cask_name}" }
@@ -18,18 +20,18 @@ RSpec.describe Cask::CaskLoader::FromTapLoader do
     end
 
     it "returns a Cask" do
-      expect(described_class.new(cask_full_name).load(config: nil)).to be_a(Cask::Cask)
+      expect(klass.new(cask_full_name).load(config: nil)).to be_a(Cask::Cask)
     end
 
     it "raises an error if the Cask cannot be found" do
-      expect { described_class.new("foo/bar/baz").load(config: nil) }.to raise_error(Cask::CaskUnavailableError)
+      expect { klass.new("foo/bar/baz").load(config: nil) }.to raise_error(Cask::CaskUnavailableError)
     end
 
     context "with sharded Cask directory", :no_api do
       let(:cask_path) { tap.cask_dir/cask_name[0]/"#{cask_name}.rb" }
 
       it "returns a Cask" do
-        expect(described_class.new(cask_full_name).load(config: nil)).to be_a(Cask::Cask)
+        expect(klass.new(cask_full_name).load(config: nil)).to be_a(Cask::Cask)
       end
     end
   end

--- a/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromURILoader do

--- a/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
@@ -2,22 +2,24 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromURILoader do
+  let(:klass) { Cask::CaskLoader::FromURILoader }
+
   describe "::try_new" do
     it "returns a loader when given an URI" do
-      expect(described_class.try_new(URI("https://brew.sh/"))).not_to be_nil
+      expect(klass.try_new(URI("https://brew.sh/"))).not_to be_nil
     end
 
     it "returns a loader when given a string which can be parsed to a URI" do
-      expect(described_class.try_new("https://brew.sh/")).not_to be_nil
+      expect(klass.try_new("https://brew.sh/")).not_to be_nil
     end
 
     it "returns nil when path loading is disabled" do
       ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = "1"
-      expect(described_class.try_new(URI("file://#{TEST_FIXTURE_DIR}/cask/Casks/local-caffeine.rb"))).to be_nil
+      expect(klass.try_new(URI("file://#{TEST_FIXTURE_DIR}/cask/Casks/local-caffeine.rb"))).to be_nil
     end
 
     it "returns nil when given a string with Cask contents containing a URL" do
-      expect(described_class.try_new(<<~RUBY)).to be_nil
+      expect(klass.try_new(<<~RUBY)).to be_nil
         cask 'token' do
           url 'https://brew.sh/'
         end
@@ -27,28 +29,28 @@ RSpec.describe Cask::CaskLoader::FromURILoader do
 
   describe "::load" do
     it "raises an error when given an https URL" do
-      loader = described_class.new("https://brew.sh/foo.rb")
+      loader = klass.new("https://brew.sh/foo.rb")
       expect do
         loader.load(config: nil)
       end.to raise_error(UnsupportedInstallationMethod)
     end
 
     it "raises an error when given an ftp URL" do
-      loader = described_class.new("ftp://brew.sh/foo.rb")
+      loader = klass.new("ftp://brew.sh/foo.rb")
       expect do
         loader.load(config: nil)
       end.to raise_error(UnsupportedInstallationMethod)
     end
 
     it "raises an error when given an sftp URL" do
-      loader = described_class.new("sftp://brew.sh/foo.rb")
+      loader = klass.new("sftp://brew.sh/foo.rb")
       expect do
         loader.load(config: nil)
       end.to raise_error(UnsupportedInstallationMethod)
     end
 
     it "does not raise an error when given a file URL", :needs_utils_curl do
-      loader = described_class.new("file://#{TEST_FIXTURE_DIR}/cask/Casks/local-caffeine.rb")
+      loader = klass.new("file://#{TEST_FIXTURE_DIR}/cask/Casks/local-caffeine.rb")
       expect do
         loader.load(config: nil)
       end.not_to raise_error

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader, :cask do
+  let(:klass) { Cask::CaskLoader }
+
   describe "::for" do
     let(:tap) { CoreCaskTap.instance }
 
@@ -11,7 +13,7 @@ RSpec.describe Cask::CaskLoader, :cask do
 
       let(:api_casks) do
         [old_token, new_token].to_h do |token|
-          hash = described_class.load(new_token).to_hash_with_variations
+          hash = klass.load(new_token).to_hash_with_variations
           json = JSON.pretty_generate(hash)
           cask_json = JSON.parse(json)
 
@@ -34,13 +36,13 @@ RSpec.describe Cask::CaskLoader, :cask do
       context "when not using the API", :no_api do
         it "warns when using the short token" do
           expect do
-            expect(described_class.for("version-newest")).to be_a Cask::CaskLoader::FromPathLoader
+            expect(klass.for("version-newest")).to be_a Cask::CaskLoader::FromPathLoader
           end.to output(/version-newest was renamed to version-latest/).to_stderr
         end
 
         it "warns when using the full token" do
           expect do
-            expect(described_class.for("homebrew/cask/version-newest")).to be_a Cask::CaskLoader::FromPathLoader
+            expect(klass.for("homebrew/cask/version-newest")).to be_a Cask::CaskLoader::FromPathLoader
           end.to output(/version-newest was renamed to version-latest/).to_stderr
         end
       end
@@ -48,13 +50,13 @@ RSpec.describe Cask::CaskLoader, :cask do
       context "when using the API" do
         it "warns when using the short token" do
           expect do
-            expect(described_class.for("version-newest")).to be_a Cask::CaskLoader::FromAPILoader
+            expect(klass.for("version-newest")).to be_a Cask::CaskLoader::FromAPILoader
           end.to output(/version-newest was renamed to version-latest/).to_stderr
         end
 
         it "warns when using the full token" do
           expect do
-            expect(described_class.for("homebrew/cask/version-newest")).to be_a Cask::CaskLoader::FromAPILoader
+            expect(klass.for("homebrew/cask/version-newest")).to be_a Cask::CaskLoader::FromAPILoader
           end.to output(/version-newest was renamed to version-latest/).to_stderr
         end
       end
@@ -97,25 +99,25 @@ RSpec.describe Cask::CaskLoader, :cask do
           # It would be preferable not to print a warning when installing with the short token
           it "warns when loading the short token" do
             expect do
-              described_class.for(token)
+              klass.for(token)
             end.to output(%r{Cask #{old_tap}/#{token} was renamed to #{new_tap}/#{token}\.}).to_stderr
           end
 
           it "warns with the canonical token when loading an uppercase short token" do
             expect do
-              described_class.for(token.upcase)
+              klass.for(token.upcase)
             end.to output(%r{Cask #{old_tap}/#{token} was renamed to #{new_tap}/#{token}\.}).to_stderr
           end
 
           it "does not warn when loading the full token in the new tap" do
             expect do
-              described_class.for("#{new_tap}/#{token}")
+              klass.for("#{new_tap}/#{token}")
             end.not_to output.to_stderr
           end
 
           it "warns when loading the full token in the old tap" do
             expect do
-              described_class.for("#{old_tap}/#{token}")
+              klass.for("#{old_tap}/#{token}")
             end.to output(%r{Cask #{old_tap}/#{token} was renamed to #{new_tap}/#{token}\.}).to_stderr
           end
 
@@ -124,7 +126,7 @@ RSpec.describe Cask::CaskLoader, :cask do
 
             expect(new_tap).not_to receive(:ensure_installed!)
 
-            expect { described_class.load("#{old_tap}/#{token}") }
+            expect { klass.load("#{old_tap}/#{token}") }
               .to raise_error(Cask::TapCaskUnavailableError, /If you trust this tap/)
           end
         end
@@ -142,7 +144,7 @@ RSpec.describe Cask::CaskLoader, :cask do
 
           it "does not warn when loading the short token" do
             expect do
-              described_class.for(token)
+              klass.for(token)
             end.not_to output.to_stderr
           end
         end
@@ -160,19 +162,19 @@ RSpec.describe Cask::CaskLoader, :cask do
 
           it "does not warn when loading the short token" do
             expect do
-              described_class.for(token)
+              klass.for(token)
             end.not_to output.to_stderr
           end
 
           it "does not warn when loading the full token in the default tap" do
             expect do
-              described_class.for("#{new_tap}/#{token}")
+              klass.for("#{new_tap}/#{token}")
             end.not_to output.to_stderr
           end
 
           it "warns when loading the full token in the old tap" do
             expect do
-              described_class.for("#{old_tap}/#{token}")
+              klass.for("#{old_tap}/#{token}")
             end.to output(%r{Cask #{old_tap}/#{token} was renamed to #{token}\.}).to_stderr
           end
 
@@ -186,7 +188,7 @@ RSpec.describe Cask::CaskLoader, :cask do
           #
           #   it "stops recursing" do
           #     expect do
-          #       described_class.for("#{new_tap}/#{token}")
+          #       klass.for("#{new_tap}/#{token}")
           #     end.not_to output.to_stderr
           #   end
           # end
@@ -208,46 +210,46 @@ RSpec.describe Cask::CaskLoader, :cask do
     let(:load_args) { { config: nil, warn: true } }
 
     before do
-      allow(described_class).to receive(:load).with("test-cask", load_args).and_return(cask_with_foo_tap)
-      allow(described_class).to receive(:load).with("user/foo/test-cask", load_args).and_return(cask_with_foo_tap)
-      allow(described_class).to receive(:load).with("user/bar/test-cask", load_args).and_return(cask_with_bar_tap)
+      allow(klass).to receive(:load).with("test-cask", load_args).and_return(cask_with_foo_tap)
+      allow(klass).to receive(:load).with("user/foo/test-cask", load_args).and_return(cask_with_foo_tap)
+      allow(klass).to receive(:load).with("user/bar/test-cask", load_args).and_return(cask_with_bar_tap)
     end
 
     it "returns the correct cask when no tap is specified and no tab exists" do
       allow_any_instance_of(Cask::Cask).to receive(:tab).and_return(blank_tab)
-      expect(described_class).to receive(:load).with("test-cask", load_args)
+      expect(klass).to receive(:load).with("test-cask", load_args)
 
-      expect(described_class.load_prefer_installed("test-cask").tap).to eq(foo_tap)
+      expect(klass.load_prefer_installed("test-cask").tap).to eq(foo_tap)
     end
 
     it "returns the correct cask when no tap is specified but a tab exists" do
       allow_any_instance_of(Cask::Cask).to receive(:tab).and_return(installed_tab)
-      expect(described_class).to receive(:load).with("user/bar/test-cask", load_args)
+      expect(klass).to receive(:load).with("user/bar/test-cask", load_args)
 
-      expect(described_class.load_prefer_installed("test-cask").tap).to eq(bar_tap)
+      expect(klass.load_prefer_installed("test-cask").tap).to eq(bar_tap)
     end
 
     it "returns the correct cask when a tap is specified and no tab exists" do
       allow_any_instance_of(Cask::Cask).to receive(:tab).and_return(blank_tab)
-      expect(described_class).to receive(:load).with("user/bar/test-cask", load_args)
+      expect(klass).to receive(:load).with("user/bar/test-cask", load_args)
 
-      expect(described_class.load_prefer_installed("user/bar/test-cask").tap).to eq(bar_tap)
+      expect(klass.load_prefer_installed("user/bar/test-cask").tap).to eq(bar_tap)
     end
 
     it "returns the correct cask when no tap is specified and a tab exists" do
       allow_any_instance_of(Cask::Cask).to receive(:tab).and_return(installed_tab)
-      expect(described_class).to receive(:load).with("user/foo/test-cask", load_args)
+      expect(klass).to receive(:load).with("user/foo/test-cask", load_args)
 
-      expect(described_class.load_prefer_installed("user/foo/test-cask").tap).to eq(foo_tap)
+      expect(klass.load_prefer_installed("user/foo/test-cask").tap).to eq(foo_tap)
     end
 
     it "returns the correct cask when no tap is specified and the tab lists an tap that isn't installed" do
       allow_any_instance_of(Cask::Cask).to receive(:tab).and_return(installed_tab)
-      expect(described_class).to receive(:load).with("user/bar/test-cask", load_args)
-                                               .and_raise(Cask::CaskUnavailableError.new("test-cask", bar_tap))
-      expect(described_class).to receive(:load).with("test-cask", load_args)
+      expect(klass).to receive(:load).with("user/bar/test-cask", load_args)
+                                     .and_raise(Cask::CaskUnavailableError.new("test-cask", bar_tap))
+      expect(klass).to receive(:load).with("test-cask", load_args)
 
-      expect(described_class.load_prefer_installed("test-cask").tap).to eq(foo_tap)
+      expect(klass.load_prefer_installed("test-cask").tap).to eq(foo_tap)
     end
   end
 

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -2,6 +2,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Cask, :cask do
+  let(:klass) { Cask::Cask }
+  let(:cask) { klass.new("versioned-cask") }
+
   def write_info_plist(path, short_version: nil, bundle_version: nil, contents: nil)
     info_plist = path/"Contents/Info.plist"
     info_plist.dirname.mkpath
@@ -53,8 +56,6 @@ RSpec.describe Cask::Cask, :cask do
 
     Cask::CaskLoader.load(path)
   end
-
-  let(:cask) { described_class.new("versioned-cask") }
 
   context "when multiple versions are installed" do
     describe "#installed_version" do
@@ -112,13 +113,13 @@ RSpec.describe Cask::Cask, :cask do
 
     it "returns an instance of the Cask for the given token" do
       c = Cask::CaskLoader.load("local-caffeine")
-      expect(c).to be_a(described_class)
+      expect(c).to be_a(klass)
       expect(c.token).to eq("local-caffeine")
     end
 
     it "returns an instance of the Cask from a specific file location" do
       c = Cask::CaskLoader.load("#{tap_path}/Casks/local-caffeine.rb")
-      expect(c).to be_a(described_class)
+      expect(c).to be_a(klass)
       expect(c).not_to be_loaded_from_api
       expect(c).not_to be_loaded_from_internal_api
       expect(c.token).to eq("local-caffeine")
@@ -126,7 +127,7 @@ RSpec.describe Cask::Cask, :cask do
 
     it "returns an instance of the Cask from a JSON file" do
       c = Cask::CaskLoader.load("#{TEST_FIXTURE_DIR}/cask/caffeine.json")
-      expect(c).to be_a(described_class)
+      expect(c).to be_a(klass)
       expect(c).to be_loaded_from_api
       expect(c).not_to be_loaded_from_internal_api
       expect(c.token).to eq("caffeine")
@@ -134,7 +135,7 @@ RSpec.describe Cask::Cask, :cask do
 
     it "returns an instance of the Cask from an internal JSON file" do
       c = Cask::CaskLoader.load("#{TEST_FIXTURE_DIR}/cask/caffeine.internal.json")
-      expect(c).to be_a(described_class)
+      expect(c).to be_a(klass)
       expect(c).to be_loaded_from_api
       expect(c).to be_loaded_from_internal_api
       expect(c.token).to eq("caffeine")
@@ -142,7 +143,7 @@ RSpec.describe Cask::Cask, :cask do
 
     it "returns an instance of the Cask from a URL", :needs_utils_curl do
       c = Cask::CaskLoader.load("file://#{tap_path}/Casks/local-caffeine.rb")
-      expect(c).to be_a(described_class)
+      expect(c).to be_a(klass)
       expect(c.token).to eq("local-caffeine")
     end
 
@@ -154,7 +155,7 @@ RSpec.describe Cask::Cask, :cask do
 
     it "returns an instance of the Cask from a relative file location" do
       c = Cask::CaskLoader.load(relative_tap_path/"Casks/local-caffeine.rb")
-      expect(c).to be_a(described_class)
+      expect(c).to be_a(klass)
       expect(c.token).to eq("local-caffeine")
     end
 
@@ -195,7 +196,7 @@ RSpec.describe Cask::Cask, :cask do
     describe "versioned casks" do
       subject { cask.outdated_version }
 
-      let(:cask) { described_class.new("basic-cask") }
+      let(:cask) { klass.new("basic-cask") }
 
       shared_examples "versioned casks" do |tap_version, expectations|
         expectations.each do |installed_version, expected_output|
@@ -359,7 +360,7 @@ RSpec.describe Cask::Cask, :cask do
     end
 
     describe ":latest casks" do
-      let(:cask) { described_class.new("basic-cask") }
+      let(:cask) { klass.new("basic-cask") }
 
       shared_examples ":latest cask" do |greedy, outdated_sha, tap_version, expectations|
         expectations.each do |installed_version, expected_output|
@@ -746,12 +747,12 @@ RSpec.describe Cask::Cask, :cask do
     # NOTE: The calls to `Cask.generating_hash!` and `Cask.generated_hash!`
     #       are not idempotent so they can only be used in one test.
     it "returns the correct hash placeholders" do
-      described_class.generating_hash!
-      expect(described_class).to be_generating_hash
+      klass.generating_hash!
+      expect(klass).to be_generating_hash
       c = Cask::CaskLoader.load("placeholders")
       h = c.to_hash_with_variations
-      described_class.generated_hash!
-      expect(described_class).not_to be_generating_hash
+      klass.generated_hash!
+      expect(klass).not_to be_generating_hash
 
       expect(h).to be_a(Hash)
       expect(h["artifacts"].first[:binary].first).to eq "$APPDIR/some/path"

--- a/Library/Homebrew/test/cask/caskroom_spec.rb
+++ b/Library/Homebrew/test/cask/caskroom_spec.rb
@@ -4,28 +4,30 @@
 require "cask/caskroom"
 
 RSpec.describe Cask::Caskroom do
-  before { described_class.instance_variable_set(:@expected_caskroom_group, nil) }
+  let(:klass) { Cask::Caskroom }
+
+  before { klass.instance_variable_set(:@expected_caskroom_group, nil) }
 
   describe ".ensure_caskroom_exists" do
     it "changes the group when sudo is unnecessary and the group is wrong" do
       Dir.mktmpdir do |dir|
         path = Pathname(dir)/"Caskroom"
-        allow(described_class).to receive(:path).and_return(path)
-        allow(described_class).to receive(:caskroom_group_correct?).with(path).and_return(false)
-        expect(described_class).to receive(:chgrp_path).with(path, false)
+        allow(klass).to receive(:path).and_return(path)
+        allow(klass).to receive(:caskroom_group_correct?).with(path).and_return(false)
+        expect(klass).to receive(:chgrp_path).with(path, false)
 
-        described_class.ensure_caskroom_exists
+        klass.ensure_caskroom_exists
       end
     end
 
     it "skips changing the group when it is already correct" do
       Dir.mktmpdir do |dir|
         path = Pathname(dir)/"Caskroom"
-        allow(described_class).to receive(:path).and_return(path)
-        allow(described_class).to receive(:caskroom_group_correct?).with(path).and_return(true)
-        expect(described_class).not_to receive(:chgrp_path)
+        allow(klass).to receive(:path).and_return(path)
+        allow(klass).to receive(:caskroom_group_correct?).with(path).and_return(true)
+        expect(klass).not_to receive(:chgrp_path)
 
-        described_class.ensure_caskroom_exists
+        klass.ensure_caskroom_exists
       end
     end
 
@@ -33,14 +35,14 @@ RSpec.describe Cask::Caskroom do
       Dir.mktmpdir do |dir|
         path = Pathname(dir)/"sub"/"Caskroom"
         parent = path.parent
-        allow(described_class).to receive_messages(path:, caskroom_group_correct?: false)
+        allow(klass).to receive_messages(path:, caskroom_group_correct?: false)
         allow(path).to receive(:parent).and_return(parent)
         allow(parent).to receive(:writable?).and_return(false)
         allow(SystemCommand).to receive(:run)
 
-        expect(described_class).to receive(:chgrp_path).with(path, true)
+        expect(klass).to receive(:chgrp_path).with(path, true)
 
-        described_class.ensure_caskroom_exists
+        klass.ensure_caskroom_exists
       end
     end
 
@@ -48,25 +50,25 @@ RSpec.describe Cask::Caskroom do
       Dir.mktmpdir do |dir|
         path = Pathname(dir)/"sub"/"Caskroom"
         parent = path.parent
-        allow(described_class).to receive_messages(path:, caskroom_group_correct?: true)
+        allow(klass).to receive_messages(path:, caskroom_group_correct?: true)
         allow(path).to receive(:parent).and_return(parent)
         allow(parent).to receive(:writable?).and_return(false)
         allow(SystemCommand).to receive(:run)
 
-        expect(described_class).not_to receive(:chgrp_path)
+        expect(klass).not_to receive(:chgrp_path)
 
-        described_class.ensure_caskroom_exists
+        klass.ensure_caskroom_exists
       end
     end
 
     it "skips sudo on Linux when the parent is user-writable", :needs_linux do
       Dir.mktmpdir do |dir|
         path = Pathname(dir)/"Caskroom"
-        allow(described_class).to receive(:path).and_return(path)
+        allow(klass).to receive(:path).and_return(path)
         expect(SystemCommand).not_to receive(:run).with(anything, hash_including(sudo: true))
         allow(SystemCommand).to receive(:run).and_call_original
 
-        described_class.ensure_caskroom_exists
+        klass.ensure_caskroom_exists
 
         expect(path).to be_directory
         expect(path.stat.gid).to eq(Process.egid)
@@ -80,7 +82,7 @@ RSpec.describe Cask::Caskroom do
       allow(path).to receive(:stat).and_return(instance_double(File::Stat, gid: 1))
       allow(Etc).to receive(:getgrnam).with("admin").and_return(instance_double(Etc::Group, gid: 1))
 
-      expect(described_class.caskroom_group_correct?(path)).to be true
+      expect(klass.caskroom_group_correct?(path)).to be true
     end
 
     it "checks the current user's primary group on Linux", :needs_linux do
@@ -90,46 +92,46 @@ RSpec.describe Cask::Caskroom do
       allow(Etc).to receive(:getgrgid).with(Process.egid).and_return(instance_double(Etc::Group, name: group_name))
       allow(Etc).to receive(:getgrnam).with(group_name).and_return(instance_double(Etc::Group, gid: 1))
 
-      expect(described_class.caskroom_group_correct?(path)).to be true
+      expect(klass.caskroom_group_correct?(path)).to be true
     end
 
     it "returns false when the expected group is unavailable" do
-      allow(described_class).to receive(:expected_caskroom_group).and_return("missing")
+      allow(klass).to receive(:expected_caskroom_group).and_return("missing")
       allow(Etc).to receive(:getgrnam).with("missing").and_return(nil)
 
-      expect(described_class.caskroom_group_correct?(Pathname("/tmp/Caskroom"))).to be false
+      expect(klass.caskroom_group_correct?(Pathname("/tmp/Caskroom"))).to be false
     end
   end
 
   describe ".corrupt_cask_dirs" do
     it "returns tokens for directories without valid caskfiles" do
       Dir.mktmpdir do |dir|
-        allow(described_class).to receive(:path).and_return(Pathname(dir))
+        allow(klass).to receive(:path).and_return(Pathname(dir))
         (Pathname(dir)/"corrupt-cask"/"1.0").mkpath
         casks_dir = (Pathname(dir)/"installed-cask"/".metadata"/"1.0"/"0"/"Casks")
         casks_dir.mkpath
         FileUtils.touch casks_dir/"installed-cask.rb"
 
-        expect(described_class.corrupt_cask_dirs).to eq(["corrupt-cask"])
+        expect(klass.corrupt_cask_dirs).to eq(["corrupt-cask"])
       end
     end
 
     it "returns empty array when all directories have valid caskfiles" do
       Dir.mktmpdir do |dir|
-        allow(described_class).to receive(:path).and_return(Pathname(dir))
+        allow(klass).to receive(:path).and_return(Pathname(dir))
         casks_dir = (Pathname(dir)/"installed-cask"/".metadata"/"1.0"/"0"/"Casks")
         casks_dir.mkpath
         FileUtils.touch casks_dir/"installed-cask.rb"
 
-        expect(described_class.corrupt_cask_dirs).to be_empty
+        expect(klass.corrupt_cask_dirs).to be_empty
       end
     end
 
     it "returns empty array when caskroom is empty" do
       Dir.mktmpdir do |dir|
-        allow(described_class).to receive(:path).and_return(Pathname(dir))
+        allow(klass).to receive(:path).and_return(Pathname(dir))
 
-        expect(described_class.corrupt_cask_dirs).to be_empty
+        expect(klass.corrupt_cask_dirs).to be_empty
       end
     end
   end

--- a/Library/Homebrew/test/cask/config_spec.rb
+++ b/Library/Homebrew/test/cask/config_spec.rb
@@ -2,11 +2,13 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Config, :cask do
-  subject(:config) { described_class.new }
+  subject(:config) { klass.new }
+
+  let(:klass) { Cask::Config }
 
   describe "::from_json" do
     it "deserializes a configuration in JSON format" do
-      config = described_class.from_json <<~EOS
+      config = klass.from_json <<~EOS
         {
           "default": {
             "appdir": "/path/to/apps"
@@ -37,7 +39,7 @@ RSpec.describe Cask::Config, :cask do
     end
 
     specify "specific overwrites default" do
-      config = described_class.new(explicit: { appdir: "/explicit/path/to/apps" })
+      config = klass.new(explicit: { appdir: "/explicit/path/to/apps" })
 
       expect(config.appdir).to eq(Pathname("/explicit/path/to/apps"))
     end
@@ -45,7 +47,7 @@ RSpec.describe Cask::Config, :cask do
     specify "explicit overwrites environment" do
       ENV["HOMEBREW_CASK_OPTS"] = "--appdir=/path/to/apps"
 
-      config = described_class.new(explicit: { appdir: "/explicit/path/to/apps" })
+      config = klass.new(explicit: { appdir: "/explicit/path/to/apps" })
 
       expect(config.appdir).to eq(Pathname("/explicit/path/to/apps"))
     end
@@ -61,8 +63,8 @@ RSpec.describe Cask::Config, :cask do
 
   describe "#explicit" do
     let(:config) do
-      described_class.new(explicit: { appdir:    "/explicit/path/to/apps",
-                                      languages: ["zh-TW", "en"] })
+      klass.new(explicit: { appdir:    "/explicit/path/to/apps",
+                            languages: ["zh-TW", "en"] })
     end
 
     it "returns directories explicitly given as arguments" do
@@ -85,7 +87,7 @@ RSpec.describe Cask::Config, :cask do
           "explicit": {}
         }
       EOS
-      described_class.from_json(json)
+      klass.from_json(json)
     end
 
     describe "#appdir" do

--- a/Library/Homebrew/test/cask/denylist_spec.rb
+++ b/Library/Homebrew/test/cask/denylist_spec.rb
@@ -4,6 +4,8 @@
 require "cask/denylist"
 
 RSpec.describe Cask::Denylist, :cask do
+  let(:klass) { Cask::Denylist }
+
   describe "::reason" do
     matcher :disallow do |name|
       match do |expected|
@@ -12,14 +14,14 @@ RSpec.describe Cask::Denylist, :cask do
     end
 
     specify(:aggregate_failures) do
-      expect(described_class).not_to disallow("adobe-air")
-      expect(described_class).to disallow("adobe-after-effects")
-      expect(described_class).to disallow("adobe-illustrator")
-      expect(described_class).to disallow("adobe-indesign")
-      expect(described_class).to disallow("adobe-photoshop")
-      expect(described_class).to disallow("adobe-premiere")
-      expect(described_class).to disallow("pharo")
-      expect(described_class).not_to disallow("allowed-cask")
+      expect(klass).not_to disallow("adobe-air")
+      expect(klass).to disallow("adobe-after-effects")
+      expect(klass).to disallow("adobe-illustrator")
+      expect(klass).to disallow("adobe-indesign")
+      expect(klass).to disallow("adobe-photoshop")
+      expect(klass).to disallow("adobe-premiere")
+      expect(klass).to disallow("pharo")
+      expect(klass).not_to disallow("allowed-cask")
     end
   end
 end

--- a/Library/Homebrew/test/cask/download_spec.rb
+++ b/Library/Homebrew/test/cask/download_spec.rb
@@ -2,10 +2,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Download, :cask do
-  describe "#download_name" do
-    subject(:download_name) { described_class.new(cask).send(:download_name) }
+  let(:klass) { Cask::Download }
 
-    let(:download) { described_class.new(cask) }
+  describe "#download_name" do
+    subject(:download_name) { klass.new(cask).send(:download_name) }
+
+    let(:download) { klass.new(cask) }
     let(:token) { "example-cask" }
     let(:full_token) { token }
     let(:url) { instance_double(URL, to_s: url_to_s, specs: {}) }
@@ -53,7 +55,7 @@ RSpec.describe Cask::Download, :cask do
   describe "#fetch" do
     it "fails before downloading if sha256 :no_check is used with --require-sha" do
       no_checksum = Cask::CaskLoader.load(cask_path("no-checksum"))
-      download = described_class.new(no_checksum, require_sha: true)
+      download = klass.new(no_checksum, require_sha: true)
 
       expect(download).not_to receive(:downloader)
       expect { download.fetch }.to raise_error(/--require-sha/)
@@ -61,7 +63,7 @@ RSpec.describe Cask::Download, :cask do
   end
 
   describe "#verify_download_integrity" do
-    subject(:verification) { described_class.new(cask).verify_download_integrity(downloaded_path) }
+    subject(:verification) { klass.new(cask).verify_download_integrity(downloaded_path) }
 
     let(:tap) { nil }
     let(:cask) { instance_double(Cask::Cask, token: "cask", sha256: expected_sha256, tap:) }

--- a/Library/Homebrew/test/cask/dsl/caveats_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/caveats_spec.rb
@@ -4,8 +4,9 @@
 require "test/cask/dsl/shared_examples/base"
 
 RSpec.describe Cask::DSL::Caveats, :cask do
-  subject(:caveats) { described_class.new(cask) }
+  subject(:caveats) { klass.new(cask) }
 
+  let(:klass) { Cask::DSL::Caveats }
   let(:cask) { Cask::CaskLoader.load(cask_path("basic-cask")) }
   let(:dsl) { caveats }
 

--- a/Library/Homebrew/test/cask/dsl/container_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/container_spec.rb
@@ -4,7 +4,9 @@
 require "test/cask/dsl/shared_examples/base"
 
 RSpec.describe Cask::DSL::Container do
-  subject(:container) { described_class.new(**params) }
+  subject(:container) { klass.new(**params) }
+
+  let(:klass) { Cask::DSL::Container }
 
   describe "#pairs" do
     let(:params) { { nested: "NestedApp.dmg" } }

--- a/Library/Homebrew/test/cask/dsl/postflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/postflight_spec.rb
@@ -5,9 +5,11 @@ require "test/cask/dsl/shared_examples/base"
 require "test/cask/dsl/shared_examples/staged"
 
 RSpec.describe Cask::DSL::Postflight, :cask do
+  let(:klass) { Cask::DSL::Postflight }
+
   let(:cask) { Cask::CaskLoader.load(cask_path("basic-cask")) }
   let(:fake_system_command) { class_double(SystemCommand) }
-  let(:dsl) { described_class.new(cask, fake_system_command) }
+  let(:dsl) { klass.new(cask, fake_system_command) }
 
   it_behaves_like Cask::DSL::Base
 

--- a/Library/Homebrew/test/cask/dsl/preflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/preflight_spec.rb
@@ -5,9 +5,11 @@ require "test/cask/dsl/shared_examples/base"
 require "test/cask/dsl/shared_examples/staged"
 
 RSpec.describe Cask::DSL::Preflight, :cask do
+  let(:klass) { Cask::DSL::Preflight }
+
   let(:cask) { Cask::CaskLoader.load(cask_path("basic-cask")) }
   let(:fake_system_command) { class_double(SystemCommand) }
-  let(:dsl) { described_class.new(cask, fake_system_command) }
+  let(:dsl) { klass.new(cask, fake_system_command) }
 
   it_behaves_like Cask::DSL::Base
 

--- a/Library/Homebrew/test/cask/dsl/rename_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/rename_spec.rb
@@ -2,8 +2,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::DSL::Rename do
-  subject(:rename) { described_class.new(from, to) }
+  subject(:rename) { klass.new(from, to) }
 
+  let(:klass) { Cask::DSL::Rename }
   let(:from) { "Source File*.pkg" }
   let(:to) { "Target File.pkg" }
 

--- a/Library/Homebrew/test/cask/dsl/uninstall_postflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/uninstall_postflight_spec.rb
@@ -4,8 +4,10 @@
 require "test/cask/dsl/shared_examples/base"
 
 RSpec.describe Cask::DSL::UninstallPostflight, :cask do
+  let(:klass) { Cask::DSL::UninstallPostflight }
+
   let(:cask) { Cask::CaskLoader.load(cask_path("basic-cask")) }
-  let(:dsl) { described_class.new(cask, class_double(SystemCommand)) }
+  let(:dsl) { klass.new(cask, class_double(SystemCommand)) }
 
   it_behaves_like Cask::DSL::Base
 end

--- a/Library/Homebrew/test/cask/dsl/uninstall_preflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/uninstall_preflight_spec.rb
@@ -5,9 +5,11 @@ require "test/cask/dsl/shared_examples/base"
 require "test/cask/dsl/shared_examples/staged"
 
 RSpec.describe Cask::DSL::UninstallPreflight, :cask do
+  let(:klass) { Cask::DSL::UninstallPreflight }
+
   let(:cask) { Cask::CaskLoader.load(cask_path("basic-cask")) }
   let(:fake_system_command) { class_double(SystemCommand) }
-  let(:dsl) { described_class.new(cask, fake_system_command) }
+  let(:dsl) { klass.new(cask, fake_system_command) }
 
   it_behaves_like Cask::DSL::Base
 

--- a/Library/Homebrew/test/cask/dsl/version_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/version_spec.rb
@@ -2,6 +2,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::DSL::Version, :cask do
+  let(:klass) { Cask::DSL::Version }
+  let(:version) { klass.new(raw_version) }
+
   shared_examples "expectations hash" do |input_name, expectations|
     expectations.each do |input_value, expected_output|
       context "when #{input_name} is #{input_value.inspect}" do
@@ -35,27 +38,25 @@ RSpec.describe Cask::DSL::Version, :cask do
       end
     end
 
-    context "when other is a #{described_class}" do
+    context "when other is a #{Cask::DSL::Version}" do
       context "when other.raw_version == self.raw_version" do
-        let(:other) { described_class.new("1.2.3") }
+        let(:other) { klass.new("1.2.3") }
 
         it { is_expected.to be true }
       end
 
       context "when other.raw_version != self.raw_version" do
-        let(:other) { described_class.new("1.2.3.4") }
+        let(:other) { klass.new("1.2.3.4") }
 
         it { is_expected.to be false }
       end
     end
   end
 
-  let(:version) { described_class.new(raw_version) }
-
   describe "#initialize" do
     it "raises an error when the version contains a slash" do
       expect do
-        described_class.new("0.1,../../directory/traversal")
+        klass.new("0.1,../../directory/traversal")
       end.to raise_error(TypeError, %r{invalid characters: /})
     end
   end
@@ -352,7 +353,7 @@ RSpec.describe Cask::DSL::Version, :cask do
       "8u202,b08:1961070e4c9b4e26a04e7f5a083f551e",
     ].each do |unstable_version|
       it "detects #{unstable_version.inspect} as unstable" do
-        expect(described_class.new(unstable_version)).to be_unstable
+        expect(klass.new(unstable_version)).to be_unstable
       end
     end
 
@@ -362,7 +363,7 @@ RSpec.describe Cask::DSL::Version, :cask do
       "b226",
     ].each do |stable_version|
       it "does not detect #{stable_version.inspect} as unstable" do
-        expect(described_class.new(stable_version)).not_to be_unstable
+        expect(klass.new(stable_version)).not_to be_unstable
       end
     end
   end

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -5,9 +5,10 @@ require "utils"
 require "cask/info"
 
 RSpec.describe Cask::Info, :cask do
-  include Utils::Output::Mixin
-
+  let(:klass) { Cask::Info }
   let(:args) { instance_double(Homebrew::Cmd::Info::Args) }
+
+  include Utils::Output::Mixin
 
   def uninstalled(string)
     "#{Tty.bold}#{string} #{Formatter.error("✘")}#{Tty.reset}"
@@ -29,7 +30,7 @@ RSpec.describe Cask::Info, :cask do
     allow(cask).to receive(:installed?).and_return(true)
     allow(Cask::CaskLoader).to receive(:load).and_call_original
     allow(Cask::CaskLoader).to receive(:load).with(cask_name).and_return(cask)
-    allow(described_class).to receive(:installation_info).and_wrap_original do |method, arg, **kwargs|
+    allow(klass).to receive(:installation_info).and_wrap_original do |method, arg, **kwargs|
       (arg.token == cask_name) ? "Installed" : method.call(arg, **kwargs)
     end
     (Cask::Caskroom.path/cask_name).mkpath
@@ -44,7 +45,7 @@ RSpec.describe Cask::Info, :cask do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
     expect do
-      described_class.info(Cask::CaskLoader.load("local-transmission"), args:)
+      klass.info(Cask::CaskLoader.load("local-transmission"), args:)
     end.to output(<<~EOS).to_stdout
       #{oh1_title uninstalled("local-transmission")} (Transmission): 2.61
       BitTorrent client
@@ -61,7 +62,7 @@ RSpec.describe Cask::Info, :cask do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
     expect do
-      described_class.info(Cask::CaskLoader.load("with-depends-on-cask-multiple"), args:)
+      klass.info(Cask::CaskLoader.load("with-depends-on-cask-multiple"), args:)
     end.to output(<<~EOS).to_stdout
       #{oh1_title uninstalled("with-depends-on-cask-multiple")}: 1.2.3
       #{Formatter.url("https://brew.sh/with-depends-on-cask-multiple")}
@@ -81,18 +82,18 @@ RSpec.describe Cask::Info, :cask do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
     allow(cask).to receive_messages(supports_linux?: false)
 
-    expect { described_class.info(cask, args:) }
+    expect { klass.info(cask, args:) }
       .to output(/Requirements\nRequired: .*macOS >= 10\.15.*✔/).to_stdout
-    expect { described_class.info(cask, args:) }.to not_to_output(/==> Name/).to_stdout
-    expect { described_class.info(cask, args:) }.to not_to_output(/==> Description/).to_stdout
-    expect { described_class.info(cask, args:) }.to not_to_output(/Metadata/).to_stdout
+    expect { klass.info(cask, args:) }.to not_to_output(/==> Name/).to_stdout
+    expect { klass.info(cask, args:) }.to not_to_output(/==> Description/).to_stdout
+    expect { klass.info(cask, args:) }.to not_to_output(/Metadata/).to_stdout
   end
 
   it "prints cask dependencies if the Cask has any" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
     mock_cask_installed("local-transmission-zip")
     expect do
-      described_class.info(Cask::CaskLoader.load("with-depends-on-cask-multiple"), args:)
+      klass.info(Cask::CaskLoader.load("with-depends-on-cask-multiple"), args:)
     end.to output(<<~EOS).to_stdout
       #{oh1_title uninstalled("with-depends-on-cask-multiple")}: 1.2.3
       #{Formatter.url("https://brew.sh/with-depends-on-cask-multiple")}
@@ -112,7 +113,7 @@ RSpec.describe Cask::Info, :cask do
     mock_cask_installed("local-caffeine")
     mock_cask_installed("local-transmission-zip")
     expect do
-      described_class.info(Cask::CaskLoader.load("with-depends-on-cask-multiple"), args:)
+      klass.info(Cask::CaskLoader.load("with-depends-on-cask-multiple"), args:)
     end.to output(/Recursive Runtime \(2\): all installed #{Formatter.success("✔")}/).to_stdout
   end
 
@@ -125,7 +126,7 @@ RSpec.describe Cask::Info, :cask do
     end
 
     expect do
-      described_class.info(Cask::CaskLoader.load("with-depends-on-everything"), args:)
+      klass.info(Cask::CaskLoader.load("with-depends-on-everything"), args:)
     end.to output(<<~EOS).to_stdout
       #{oh1_title uninstalled("with-depends-on-everything")}: 1.2.3
       #{Formatter.url("https://brew.sh/with-depends-on-everything")}
@@ -144,7 +145,7 @@ RSpec.describe Cask::Info, :cask do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
     expect do
-      described_class.info(Cask::CaskLoader.load("with-auto-updates"), args:)
+      klass.info(Cask::CaskLoader.load("with-auto-updates"), args:)
     end.to output(<<~EOS).to_stdout
       #{oh1_title uninstalled("with-auto-updates")} (AutoUpdates): 1.0 (auto_updates)
       https://brew.sh/autoupdates
@@ -162,7 +163,7 @@ RSpec.describe Cask::Info, :cask do
     InstallHelper.stub_cask_installation(cask)
     cask.pin
 
-    expect { described_class.info(cask, args:) }
+    expect { klass.info(cask, args:) }
       .to output(/Pinned: 1\.2\.3 on \d{4}-\d{2}-\d{2} at \d{2}:\d{2}:\d{2}/).to_stdout
 
     cask.unpin
@@ -172,7 +173,7 @@ RSpec.describe Cask::Info, :cask do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
     expect do
-      described_class.info(Cask::CaskLoader.load("with-caveats"), args:)
+      klass.info(Cask::CaskLoader.load("with-caveats"), args:)
     end.to output(<<~EOS).to_stdout
       #{oh1_title uninstalled("with-caveats")}: 1.2.3
       https://brew.sh/
@@ -198,7 +199,7 @@ RSpec.describe Cask::Info, :cask do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
     expect do
-      described_class.info(Cask::CaskLoader.load("with-conditional-caveats"), args:)
+      klass.info(Cask::CaskLoader.load("with-conditional-caveats"), args:)
     end.to output(<<~EOS).to_stdout
       #{oh1_title uninstalled("with-conditional-caveats")}: 1.2.3
       https://brew.sh/
@@ -214,7 +215,7 @@ RSpec.describe Cask::Info, :cask do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
     expect do
-      described_class.info(Cask::CaskLoader.load("with-languages"), args:)
+      klass.info(Cask::CaskLoader.load("with-languages"), args:)
     end.to output(<<~EOS).to_stdout
       #{oh1_title uninstalled("with-languages")}: 1.2.3
       https://brew.sh/
@@ -232,7 +233,7 @@ RSpec.describe Cask::Info, :cask do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
     expect do
-      described_class.info(Cask::CaskLoader.load("without-languages"), args:)
+      klass.info(Cask::CaskLoader.load("without-languages"), args:)
     end.to output(<<~EOS).to_stdout
       #{oh1_title uninstalled("without-languages")}: 1.2.3
       https://brew.sh/
@@ -263,7 +264,7 @@ RSpec.describe Cask::Info, :cask do
       allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
       expect do
-        described_class.info(cask, args:)
+        klass.info(cask, args:)
       end.to output(<<~EOS).to_stdout
         ==> #{installed("local-transmission")} (Transmission): 2.61
         BitTorrent client
@@ -298,7 +299,7 @@ RSpec.describe Cask::Info, :cask do
       allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
       expect do
-        described_class.info(cask, args:)
+        klass.info(cask, args:)
       end.to output(<<~EOS).to_stdout
         ==> #{installed("local-transmission")} (Transmission): 2.61
         BitTorrent client
@@ -318,7 +319,7 @@ RSpec.describe Cask::Info, :cask do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
     expect do
-      described_class.info(Cask::CaskLoader.load("with-non-executable-binary"), args:)
+      klass.info(Cask::CaskLoader.load("with-non-executable-binary"), args:)
     end.to output(<<~EOS).to_stdout
       #{oh1_title uninstalled("with-non-executable-binary")}: 1.2.3
       https://brew.sh/with-binary

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -2,11 +2,13 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Installer, :cask do
+  let(:klass) { Cask::Installer }
+
   describe "install" do
     it "downloads and installs a nice fresh Cask" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
 
-      described_class.new(caffeine).install
+      klass.new(caffeine).install
 
       expect(Cask::Caskroom.path.join("local-caffeine", caffeine.version)).to be_a_directory
       expect(caffeine.config.appdir.join("Caffeine.app")).to be_a_directory
@@ -15,7 +17,7 @@ RSpec.describe Cask::Installer, :cask do
     it "works with HFS+ dmg-based Casks" do
       asset = Cask::CaskLoader.load(cask_path("container-dmg"))
 
-      described_class.new(asset).install
+      klass.new(asset).install
 
       expect(Cask::Caskroom.path.join("container-dmg", asset.version)).to be_a_directory
       expect(asset.config.appdir.join("container")).to be_a_file
@@ -24,7 +26,7 @@ RSpec.describe Cask::Installer, :cask do
     it "works with tar-gz-based Casks" do
       asset = Cask::CaskLoader.load(cask_path("container-tar-gz"))
 
-      described_class.new(asset).install
+      klass.new(asset).install
 
       expect(Cask::Caskroom.path.join("container-tar-gz", asset.version)).to be_a_directory
       expect(asset.config.appdir.join("container")).to be_a_file
@@ -33,7 +35,7 @@ RSpec.describe Cask::Installer, :cask do
     it "works with xar-based Casks" do
       asset = Cask::CaskLoader.load(cask_path("container-xar"))
 
-      described_class.new(asset).install
+      klass.new(asset).install
 
       expect(Cask::Caskroom.path.join("container-xar", asset.version)).to be_a_directory
       expect(asset.config.appdir.join("container")).to be_a_file
@@ -42,7 +44,7 @@ RSpec.describe Cask::Installer, :cask do
     it "works with pure bzip2-based Casks" do
       asset = Cask::CaskLoader.load(cask_path("container-bzip2"))
 
-      described_class.new(asset).install
+      klass.new(asset).install
 
       expect(Cask::Caskroom.path.join("container-bzip2", asset.version)).to be_a_directory
       expect(asset.config.appdir.join("container")).to be_a_file
@@ -51,7 +53,7 @@ RSpec.describe Cask::Installer, :cask do
     it "works with pure gzip-based Casks" do
       asset = Cask::CaskLoader.load(cask_path("container-gzip"))
 
-      described_class.new(asset).install
+      klass.new(asset).install
 
       expect(Cask::Caskroom.path.join("container-gzip", asset.version)).to be_a_directory
       expect(asset.config.appdir.join("container")).to be_a_file
@@ -60,21 +62,21 @@ RSpec.describe Cask::Installer, :cask do
     it "blows up on a bad checksum" do
       bad_checksum = Cask::CaskLoader.load(cask_path("bad-checksum"))
       expect do
-        described_class.new(bad_checksum).install
+        klass.new(bad_checksum).install
       end.to raise_error(ChecksumMismatchError)
     end
 
     it "blows up on a missing checksum" do
       missing_checksum = Cask::CaskLoader.load(cask_path("missing-checksum"))
       expect do
-        described_class.new(missing_checksum).install
+        klass.new(missing_checksum).install
       end.to output(/Cannot verify integrity/).to_stderr
     end
 
     it "installs fine if sha256 :no_check is used" do
       no_checksum = Cask::CaskLoader.load(cask_path("no-checksum"))
 
-      described_class.new(no_checksum).install
+      klass.new(no_checksum).install
 
       expect(no_checksum).to be_installed
     end
@@ -82,21 +84,21 @@ RSpec.describe Cask::Installer, :cask do
     it "fails to install if sha256 :no_check is used with --require-sha" do
       no_checksum = Cask::CaskLoader.load(cask_path("no-checksum"))
       expect do
-        described_class.new(no_checksum, require_sha: true).install
+        klass.new(no_checksum, require_sha: true).install
       end.to raise_error(/--require-sha/)
     end
 
     it "fails to install if Linux is required" do
       linux_cask = Cask::CaskLoader.load("with-depends-on-linux-bare")
       expect do
-        described_class.new(linux_cask).check_stanza_os_requirements
+        klass.new(linux_cask).check_stanza_os_requirements
       end.to raise_error(Cask::CaskError, "Linux is required for this software.")
     end
 
     it "installs fine if sha256 :no_check is used with --require-sha and --force" do
       no_checksum = Cask::CaskLoader.load(cask_path("no-checksum"))
 
-      described_class.new(no_checksum, require_sha: true, force: true).install
+      klass.new(no_checksum, require_sha: true, force: true).install
 
       expect(no_checksum).to be_installed
     end
@@ -105,7 +107,7 @@ RSpec.describe Cask::Installer, :cask do
       with_caveats = Cask::CaskLoader.load(cask_path("with-caveats"))
 
       expect do
-        described_class.new(with_caveats).install
+        klass.new(with_caveats).install
       end.to output(/Here are some things you might want to know/).to_stdout
 
       expect(with_caveats).to be_installed
@@ -115,7 +117,7 @@ RSpec.describe Cask::Installer, :cask do
       with_installer_manual = Cask::CaskLoader.load(cask_path("with-installer-manual"))
 
       expect do
-        described_class.new(with_installer_manual).install
+        klass.new(with_installer_manual).install
       end.to output(
         <<~EOS,
           ==> Downloading file://#{HOMEBREW_LIBRARY_PATH}/test/support/fixtures/cask/caffeine.zip
@@ -132,7 +134,7 @@ RSpec.describe Cask::Installer, :cask do
     it "does not extract __MACOSX directories from zips" do
       with_macosx_dir = Cask::CaskLoader.load(cask_path("with-macosx-dir"))
 
-      described_class.new(with_macosx_dir).install
+      klass.new(with_macosx_dir).install
 
       expect(with_macosx_dir.staged_path.join("__MACOSX")).not_to be_a_directory
     end
@@ -142,10 +144,10 @@ RSpec.describe Cask::Installer, :cask do
 
       expect(with_auto_updates).not_to be_installed
 
-      described_class.new(with_auto_updates).install
+      klass.new(with_auto_updates).install
 
       expect do
-        described_class.new(with_auto_updates, force: true).install
+        klass.new(with_auto_updates, force: true).install
       end.not_to raise_error
     end
 
@@ -154,10 +156,10 @@ RSpec.describe Cask::Installer, :cask do
 
       expect(transmission).not_to be_installed
 
-      described_class.new(transmission).install
+      klass.new(transmission).install
 
       expect do
-        described_class.new(transmission, force: true).install
+        klass.new(transmission, force: true).install
       end.not_to raise_error
     end
 
@@ -166,7 +168,7 @@ RSpec.describe Cask::Installer, :cask do
 
       expect(transmission).not_to be_installed
 
-      described_class.new(transmission).install
+      klass.new(transmission).install
 
       expect(transmission).to be_installed
     end
@@ -174,7 +176,7 @@ RSpec.describe Cask::Installer, :cask do
     it "works naked-pkg-based Casks" do
       naked_pkg = Cask::CaskLoader.load(cask_path("container-pkg"))
 
-      described_class.new(naked_pkg).install
+      klass.new(naked_pkg).install
 
       expect(Cask::Caskroom.path.join("container-pkg", naked_pkg.version, "container.pkg")).to be_a_file
     end
@@ -182,7 +184,7 @@ RSpec.describe Cask::Installer, :cask do
     it "works properly with an overridden container :type" do
       naked_executable = Cask::CaskLoader.load(cask_path("naked-executable"))
 
-      described_class.new(naked_executable).install
+      klass.new(naked_executable).install
 
       expect(Cask::Caskroom.path.join("naked-executable", naked_executable.version, "naked_executable")).to be_a_file
     end
@@ -190,7 +192,7 @@ RSpec.describe Cask::Installer, :cask do
     it "works fine with a nested container" do
       nested_app = Cask::CaskLoader.load(cask_path("nested-app"))
 
-      described_class.new(nested_app).install
+      klass.new(nested_app).install
 
       expect(nested_app.config.appdir.join("MyNestedApp.app")).to be_a_directory
     end
@@ -198,7 +200,7 @@ RSpec.describe Cask::Installer, :cask do
     it "generates and finds a timestamped metadata directory for an installed Cask" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
 
-      described_class.new(caffeine).install
+      klass.new(caffeine).install
 
       m_path = caffeine.metadata_timestamped_path(timestamp: :now, create: true)
       expect(caffeine.metadata_timestamped_path(timestamp: :latest)).to eq(m_path)
@@ -207,7 +209,7 @@ RSpec.describe Cask::Installer, :cask do
     it "generates and finds a metadata subdirectory for an installed Cask" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
 
-      described_class.new(caffeine).install
+      klass.new(caffeine).install
 
       subdir_name = "Casks"
       m_subdir = caffeine.metadata_subdir(subdir_name, timestamp: :now, create: true)
@@ -217,14 +219,14 @@ RSpec.describe Cask::Installer, :cask do
     it "don't print cask installed message with --quiet option" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
       expect do
-        described_class.new(caffeine, quiet: true).install
+        klass.new(caffeine, quiet: true).install
       end.to output(nil).to_stdout
     end
 
     it "does NOT generate LATEST_DOWNLOAD_SHA256 file for installed Cask without version :latest" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
 
-      described_class.new(caffeine).install
+      klass.new(caffeine).install
 
       expect(caffeine.download_sha_path).not_to be_a_file
     end
@@ -232,7 +234,7 @@ RSpec.describe Cask::Installer, :cask do
     it "generates and finds LATEST_DOWNLOAD_SHA256 file for installed Cask with version :latest" do
       latest_cask = Cask::CaskLoader.load(cask_path("version-latest"))
 
-      described_class.new(latest_cask).install
+      klass.new(latest_cask).install
 
       expect(latest_cask.download_sha_path).to be_a_file
     end
@@ -249,7 +251,7 @@ RSpec.describe Cask::Installer, :cask do
         expect(caffeine).to receive(:loaded_from_api?).once.and_return(true)
         expect(caffeine).to receive(:caskfile_only?).once.and_return(true)
 
-        described_class.new(caffeine).install
+        klass.new(caffeine).install
         expect(Cask::CaskLoader.load(path)).to be_installed
       end
     end
@@ -269,7 +271,7 @@ RSpec.describe Cask::Installer, :cask do
         expect(Homebrew::API::Cask).not_to receive(:source_download)
 
         expect do
-          described_class.new(cask, download_queue:).enqueue_downloads
+          klass.new(cask, download_queue:).enqueue_downloads
         end.to raise_error(Cask::CaskError, "macOS is required")
       end
 
@@ -277,18 +279,18 @@ RSpec.describe Cask::Installer, :cask do
         expect(Homebrew::API::Cask).not_to receive(:source_download_cask)
 
         expect do
-          described_class.new(cask).fetch
+          klass.new(cask).fetch
         end.to raise_error(Cask::CaskError, "macOS is required")
       end
     end
 
     it "zap method reinstall cask" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
-      described_class.new(caffeine).install
+      klass.new(caffeine).install
 
       expect(caffeine).to be_installed
 
-      described_class.new(caffeine).zap
+      klass.new(caffeine).zap
 
       expect(caffeine).not_to be_installed
       expect(caffeine.config.appdir.join("Caffeine.app")).not_to be_a_symlink
@@ -298,7 +300,7 @@ RSpec.describe Cask::Installer, :cask do
   describe "uninstall" do
     it "fully uninstalls a Cask" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
-      installer = described_class.new(caffeine)
+      installer = klass.new(caffeine)
 
       installer.install
       installer.uninstall
@@ -312,7 +314,7 @@ RSpec.describe Cask::Installer, :cask do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
       mutated_version = "#{caffeine.version}.1"
 
-      described_class.new(caffeine).install
+      klass.new(caffeine).install
 
       expect(Cask::Caskroom.path.join("local-caffeine", caffeine.version)).to be_a_directory
       expect(Cask::Caskroom.path.join("local-caffeine", mutated_version)).not_to be_a_directory
@@ -321,7 +323,7 @@ RSpec.describe Cask::Installer, :cask do
       expect(Cask::Caskroom.path.join("local-caffeine", caffeine.version)).not_to be_a_directory
       expect(Cask::Caskroom.path.join("local-caffeine", mutated_version)).to be_a_directory
 
-      described_class.new(caffeine, force: true).uninstall
+      klass.new(caffeine, force: true).uninstall
 
       expect(Cask::Caskroom.path.join("local-caffeine", caffeine.version)).not_to be_a_directory
       expect(Cask::Caskroom.path.join("local-caffeine", mutated_version)).not_to be_a_directory
@@ -346,10 +348,10 @@ RSpec.describe Cask::Installer, :cask do
         expect(caffeine).to receive(:caskfile_only?).twice.and_return(true)
         expect(caffeine).to receive(:installed_caskfile).once.and_return(invalid_path)
 
-        described_class.new(caffeine).install
+        klass.new(caffeine).install
         expect(Cask::CaskLoader.load(path)).to be_installed
 
-        described_class.new(caffeine).uninstall
+        klass.new(caffeine).uninstall
         expect(Cask::CaskLoader.load(path)).not_to be_installed
       end
     end
@@ -358,14 +360,14 @@ RSpec.describe Cask::Installer, :cask do
   describe "uninstall_existing_cask" do
     it "uninstalls when cask file is outdated" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
-      described_class.new(caffeine).install
+      klass.new(caffeine).install
 
       expect(Cask::CaskLoader.load(cask_path("local-caffeine"))).to be_installed
 
       expect(caffeine).to receive(:installed?).once.and_return(true)
       outdate_caskfile = cask_path("invalid/invalid-depends-on-macos-bad-release")
       expect(caffeine).to receive(:installed_caskfile).once.and_return(outdate_caskfile)
-      described_class.new(caffeine).uninstall_existing_cask
+      klass.new(caffeine).uninstall_existing_cask
 
       expect(Cask::CaskLoader.load(cask_path("local-caffeine"))).not_to be_installed
     end
@@ -388,7 +390,7 @@ RSpec.describe Cask::Installer, :cask do
       end
 
       expect do
-        described_class.new(cask).forbidden_tap_check
+        klass.new(cask).forbidden_tap_check
       end.to raise_error(Cask::CaskCannotBeInstalledError, /has the tap #{homebrew_forbidden}/)
     end
 
@@ -398,7 +400,7 @@ RSpec.describe Cask::Installer, :cask do
       end
 
       expect do
-        described_class.new(cask).forbidden_tap_check
+        klass.new(cask).forbidden_tap_check
       end.to raise_error(Cask::CaskCannotBeInstalledError, /has the tap #{disallowed_third_party}/)
     end
 
@@ -407,7 +409,7 @@ RSpec.describe Cask::Installer, :cask do
         url "file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz"
       end
 
-      expect { described_class.new(cask).forbidden_tap_check }.not_to raise_error
+      expect { klass.new(cask).forbidden_tap_check }.not_to raise_error
     end
 
     it "raises on forbidden tap on dependency" do
@@ -429,7 +431,7 @@ RSpec.describe Cask::Installer, :cask do
       end
 
       expect do
-        described_class.new(cask).forbidden_tap_check
+        klass.new(cask).forbidden_tap_check
       end.to raise_error(Cask::CaskCannotBeInstalledError, /from the #{dep_tap} tap but/)
     ensure
       FileUtils.rm_r(dep_path.parent.parent)
@@ -444,7 +446,7 @@ RSpec.describe Cask::Installer, :cask do
       end
 
       expect do
-        described_class.new(cask).forbidden_cask_and_formula_check
+        klass.new(cask).forbidden_cask_and_formula_check
       end.to raise_error(Cask::CaskCannotBeInstalledError, /forbidden for installation/)
     end
 
@@ -465,7 +467,7 @@ RSpec.describe Cask::Installer, :cask do
       end
 
       expect do
-        described_class.new(cask).forbidden_cask_and_formula_check
+        klass.new(cask).forbidden_cask_and_formula_check
       end.to raise_error(Cask::CaskCannotBeInstalledError, /#{dep_name} formula was forbidden/)
     end
   end
@@ -479,7 +481,7 @@ RSpec.describe Cask::Installer, :cask do
       end
 
       expect do
-        described_class.new(cask).forbidden_cask_artifacts_check
+        klass.new(cask).forbidden_cask_artifacts_check
       end.to raise_error(Cask::CaskCannotBeInstalledError, /contains a 'pkg' artifact/)
     end
 
@@ -494,7 +496,7 @@ RSpec.describe Cask::Installer, :cask do
       end
 
       expect do
-        described_class.new(cask).forbidden_cask_artifacts_check
+        klass.new(cask).forbidden_cask_artifacts_check
       end.to raise_error(Cask::CaskCannotBeInstalledError, /contains a 'installer' artifact/)
     end
 
@@ -506,7 +508,7 @@ RSpec.describe Cask::Installer, :cask do
       end
 
       expect do
-        described_class.new(cask).forbidden_cask_artifacts_check
+        klass.new(cask).forbidden_cask_artifacts_check
       end.to raise_error(Cask::CaskCannotBeInstalledError, /contains a 'pkg' artifact/)
     end
 
@@ -517,7 +519,7 @@ RSpec.describe Cask::Installer, :cask do
         app "MyApp.app"
       end
 
-      expect { described_class.new(cask).forbidden_cask_artifacts_check }.not_to raise_error
+      expect { klass.new(cask).forbidden_cask_artifacts_check }.not_to raise_error
     end
   end
 
@@ -528,7 +530,7 @@ RSpec.describe Cask::Installer, :cask do
         url "file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz"
       end
       allow(cask).to receive_messages(loaded_from_api?: true, caskfile_only?: true)
-      installer = described_class.new(cask)
+      installer = klass.new(cask)
 
       expect(Homebrew::API::Cask).not_to receive(:source_download_cask)
       expect(installer).not_to receive(:download)
@@ -559,7 +561,7 @@ RSpec.describe Cask::Installer, :cask do
       # Mock the staged_path to point to our test directory
       allow(cask).to receive(:staged_path).and_return(staged_path)
 
-      installer = described_class.new(cask)
+      installer = klass.new(cask)
       installer.send(:process_rename_operations)
 
       expect(staged_path / "Renamed App.app").to be_a_directory
@@ -579,7 +581,7 @@ RSpec.describe Cask::Installer, :cask do
 
       allow(cask).to receive(:staged_path).and_return(staged_path)
 
-      installer = described_class.new(cask)
+      installer = klass.new(cask)
       installer.send(:process_rename_operations)
 
       expect(staged_path / "Final Name.app").to be_a_directory
@@ -599,7 +601,7 @@ RSpec.describe Cask::Installer, :cask do
 
       allow(cask).to receive(:staged_path).and_return(staged_path)
 
-      installer = described_class.new(cask)
+      installer = klass.new(cask)
       installer.send(:process_rename_operations)
 
       expect(staged_path / "Test App.pkg").to be_a_file
@@ -619,7 +621,7 @@ RSpec.describe Cask::Installer, :cask do
 
       allow(cask).to receive(:staged_path).and_return(staged_path)
 
-      installer = described_class.new(cask)
+      installer = klass.new(cask)
 
       expect { installer.send(:process_rename_operations) }.not_to raise_error
       expect(staged_path / "Different.app").to be_a_directory

--- a/Library/Homebrew/test/cask/list_spec.rb
+++ b/Library/Homebrew/test/cask/list_spec.rb
@@ -4,6 +4,8 @@
 require "cask/list"
 
 RSpec.describe Cask::List, :cask do
+  let(:klass) { Cask::List }
+
   it "lists the installed Casks in a pretty fashion" do
     casks = %w[local-caffeine local-transmission].map { |c| Cask::CaskLoader.load(c) }
 
@@ -12,7 +14,7 @@ RSpec.describe Cask::List, :cask do
     end
 
     expect do
-      described_class.list_casks
+      klass.list_casks
     end.to output(<<~EOS).to_stdout
       local-caffeine
       local-transmission
@@ -31,7 +33,7 @@ RSpec.describe Cask::List, :cask do
     end
 
     expect do
-      described_class.list_casks(one: true)
+      klass.list_casks(one: true)
     end.to output(<<~EOS).to_stdout
       local-caffeine
       local-transmission
@@ -51,7 +53,7 @@ RSpec.describe Cask::List, :cask do
     end
 
     expect do
-      described_class.list_casks(full_name: true)
+      klass.list_casks(full_name: true)
     end.to output(<<~EOS).to_stdout
       local-caffeine
       local-transmission
@@ -81,13 +83,13 @@ RSpec.describe Cask::List, :cask do
 
     it "of all installed Casks" do
       expect do
-        described_class.list_casks(versions: true)
+        klass.list_casks(versions: true)
       end.to output(expected_output).to_stdout
     end
 
     it "of given Casks" do
       expect do
-        described_class.list_casks(*casks, versions: true)
+        klass.list_casks(*casks, versions: true)
       end.to output(expected_output).to_stdout
     end
   end
@@ -105,7 +107,7 @@ RSpec.describe Cask::List, :cask do
       end
 
       expect do
-        described_class.list_casks(transmission, caffeine)
+        klass.list_casks(transmission, caffeine)
       end.to output(<<~EOS).to_stdout
         ==> App
         #{transmission.config.appdir.join("Transmission.app")} (#{transmission.config.appdir.join("Transmission.app").abv})
@@ -118,28 +120,28 @@ RSpec.describe Cask::List, :cask do
   describe "TAP_AND_NAME_COMPARISON" do
     describe "both strings are only names" do
       it "alphabetizes the strings" do
-        expect(%w[a b].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[a b])
-        expect(%w[b a].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[a b])
+        expect(%w[a b].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[a b])
+        expect(%w[b a].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[a b])
       end
     end
 
     describe "both strings include tap" do
       it "alphabetizes the strings" do
-        expect(%w[a/z/z b/z/z].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[a/z/z b/z/z])
-        expect(%w[b/z/z a/z/z].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[a/z/z b/z/z])
+        expect(%w[a/z/z b/z/z].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[a/z/z b/z/z])
+        expect(%w[b/z/z a/z/z].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[a/z/z b/z/z])
 
-        expect(%w[z/a/z z/b/z].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[z/a/z z/b/z])
-        expect(%w[z/b/z z/a/z].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[z/a/z z/b/z])
+        expect(%w[z/a/z z/b/z].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[z/a/z z/b/z])
+        expect(%w[z/b/z z/a/z].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[z/a/z z/b/z])
 
-        expect(%w[z/z/a z/z/b].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[z/z/a z/z/b])
-        expect(%w[z/z/b z/z/a].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[z/z/a z/z/b])
+        expect(%w[z/z/a z/z/b].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[z/z/a z/z/b])
+        expect(%w[z/z/b z/z/a].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[z/z/a z/z/b])
       end
     end
 
     describe "only one string includes tap" do
       it "prefers the string without tap" do
-        expect(%w[a/z/z z].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[z a/z/z])
-        expect(%w[z a/z/z].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[z a/z/z])
+        expect(%w[a/z/z z].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[z a/z/z])
+        expect(%w[z a/z/z].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[z a/z/z])
       end
     end
   end

--- a/Library/Homebrew/test/cask/macos_spec.rb
+++ b/Library/Homebrew/test/cask/macos_spec.rb
@@ -2,53 +2,55 @@
 # frozen_string_literal: true
 
 RSpec.describe MacOS, :cask do
+  let(:klass) { MacOS }
+
   specify do
-    expect(described_class).to be_undeletable(
+    expect(klass).to be_undeletable(
       "/",
     )
-    expect(described_class).to be_undeletable(
+    expect(klass).to be_undeletable(
       "/.",
     )
-    expect(described_class).to be_undeletable(
+    expect(klass).to be_undeletable(
       "/usr/local/Library/Taps/../../../..",
     )
-    expect(described_class).to be_undeletable(
+    expect(klass).to be_undeletable(
       "/Applications",
     )
-    expect(described_class).to be_undeletable(
+    expect(klass).to be_undeletable(
       "/Applications/",
     )
-    expect(described_class).to be_undeletable(
+    expect(klass).to be_undeletable(
       "/Applications/.",
     )
-    expect(described_class).to be_undeletable(
+    expect(klass).to be_undeletable(
       "/Applications/Mail.app/..",
     )
-    expect(described_class).to be_undeletable(
+    expect(klass).to be_undeletable(
       Dir.home,
     )
-    expect(described_class).to be_undeletable(
+    expect(klass).to be_undeletable(
       "#{Dir.home}/",
     )
-    expect(described_class).to be_undeletable(
+    expect(klass).to be_undeletable(
       "#{Dir.home}/Documents/..",
     )
-    expect(described_class).to be_undeletable(
+    expect(klass).to be_undeletable(
       "#{Dir.home}/Library",
     )
-    expect(described_class).to be_undeletable(
+    expect(klass).to be_undeletable(
       "#{Dir.home}/Library/",
     )
-    expect(described_class).to be_undeletable(
+    expect(klass).to be_undeletable(
       "#{Dir.home}/Library/.",
     )
-    expect(described_class).to be_undeletable(
+    expect(klass).to be_undeletable(
       "#{Dir.home}/Library/Preferences/..",
     )
-    expect(described_class).not_to be_undeletable(
+    expect(klass).not_to be_undeletable(
       "/Applications/.app",
     )
-    expect(described_class).not_to be_undeletable(
+    expect(klass).not_to be_undeletable(
       "/Applications/SnakeOil Professional.app",
     )
   end

--- a/Library/Homebrew/test/cask/migrator_spec.rb
+++ b/Library/Homebrew/test/cask/migrator_spec.rb
@@ -4,6 +4,8 @@
 require "cask/migrator"
 
 RSpec.describe Cask::Migrator do
+  let(:klass) { Cask::Migrator }
+
   describe ".migrate_if_needed" do
     let(:new_cask) do
       instance_double(
@@ -20,9 +22,9 @@ RSpec.describe Cask::Migrator do
 
       it "returns without loading or migrating" do
         expect(Cask::Cask).not_to receive(:new)
-        expect(described_class).not_to receive(:new)
+        expect(klass).not_to receive(:new)
 
-        described_class.migrate_if_needed(new_cask)
+        klass.migrate_if_needed(new_cask)
       end
     end
 
@@ -32,13 +34,13 @@ RSpec.describe Cask::Migrator do
 
       it "migrates using the installed token from the caskfile path" do
         old_cask = instance_double(Cask::Cask)
-        migrator = instance_double(described_class)
+        migrator = instance_double(klass)
 
         expect(Cask::Cask).to receive(:new).with("old-token").and_return(old_cask)
-        expect(described_class).to receive(:new).with(old_cask, new_cask).and_return(migrator)
+        expect(klass).to receive(:new).with(old_cask, new_cask).and_return(migrator)
         expect(migrator).to receive(:migrate).with(dry_run: false)
 
-        described_class.migrate_if_needed(new_cask)
+        klass.migrate_if_needed(new_cask)
       end
     end
   end
@@ -77,19 +79,19 @@ RSpec.describe Cask::Migrator do
                                             new_caskfile)
       allow(FileUtils).to receive(:rm_r).with(old_caskroom_path)
       allow(FileUtils).to receive(:ln_s).with(new_caskroom_path.basename, old_caskroom_path)
-      allow(described_class).to receive(:replace_caskfile_token).with(new_caskfile, "old-token", "new-token")
+      allow(klass).to receive(:replace_caskfile_token).with(new_caskfile, "old-token", "new-token")
     end
 
     it "moves a cask pin to the new token" do
       expect(old_cask).to receive(:unpin)
       expect(new_pin_path).to receive(:make_relative_symlink).with(new_caskroom_path/"1.0")
 
-      described_class.new(old_cask, new_cask).migrate
+      klass.new(old_cask, new_cask).migrate
     end
 
     it "prints relative cask pin targets in dry run" do
       expect do
-        described_class.new(old_cask, new_cask).migrate(dry_run: true)
+        klass.new(old_cask, new_cask).migrate(dry_run: true)
       end.to output(%r{ln -s ../Caskroom/new-token/1\.0 /tmp/pinned_casks/new-token}).to_stdout
     end
 
@@ -98,7 +100,7 @@ RSpec.describe Cask::Migrator do
       expect(old_cask).not_to receive(:unpin)
 
       expect do
-        described_class.new(old_cask, new_cask).migrate
+        klass.new(old_cask, new_cask).migrate
       end.to output(/Failed to migrate cask pin from old-token to new-token: failed/).to_stderr
     end
   end

--- a/Library/Homebrew/test/cask/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/pkg_spec.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Pkg, :cask do
+  let(:klass) { Cask::Pkg }
+
   describe "#uninstall" do
     let(:fake_system_command) { NeverSudoSystemCommand }
     let(:empty_response) do
@@ -11,7 +13,7 @@ RSpec.describe Cask::Pkg, :cask do
         plist:  { "volume" => "/", "install-location" => "", "paths" => {} },
       )
     end
-    let(:pkg) { described_class.new("my.fake.pkg", fake_system_command) }
+    let(:pkg) { klass.new("my.fake.pkg", fake_system_command) }
 
     it "removes files and dirs referenced by the pkg" do
       some_files = Array.new(3) { Pathname.new(Tempfile.new("plain_file").path) }
@@ -174,7 +176,7 @@ RSpec.describe Cask::Pkg, :cask do
     end
 
     it "correctly parses a Property List" do
-      pkg = described_class.new(pkg_id, fake_system_command)
+      pkg = klass.new(pkg_id, fake_system_command)
 
       expect(fake_system_command).to receive(:run!).with(
         "/usr/sbin/pkgutil",

--- a/Library/Homebrew/test/cask/quarantine_spec.rb
+++ b/Library/Homebrew/test/cask/quarantine_spec.rb
@@ -2,23 +2,25 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Quarantine do
+  let(:klass) { Cask::Quarantine }
+
   describe ".user_approved?" do
     let(:file) { Pathname("/tmp/Test.app") }
 
     before do
-      allow(described_class).to receive(:xattr).and_return(Pathname("/usr/bin/xattr"))
+      allow(klass).to receive(:xattr).and_return(Pathname("/usr/bin/xattr"))
     end
 
     it "returns true when the user approval flag is set" do
-      allow(described_class).to receive(:status).with(file).and_return("01c3;6723b9fa;Safari;event-id")
+      allow(klass).to receive(:status).with(file).and_return("01c3;6723b9fa;Safari;event-id")
 
-      expect(described_class.user_approved?(file)).to be(true)
+      expect(klass.user_approved?(file)).to be(true)
     end
 
     it "returns false when the user approval flag is not set" do
-      allow(described_class).to receive(:status).with(file).and_return("0183;6723b9fa;Safari;event-id")
+      allow(klass).to receive(:status).with(file).and_return("0183;6723b9fa;Safari;event-id")
 
-      expect(described_class.user_approved?(file)).to be(false)
+      expect(klass.user_approved?(file)).to be(false)
     end
   end
 
@@ -35,21 +37,21 @@ RSpec.describe Cask::Quarantine do
           Authority=Developer ID Application: Brew Test (ABCDE12345)
         EOS
       )
-      allow(described_class).to receive(:system_command).with("codesign", args: ["-dvvv", file], print_stderr: false)
-                                                        .and_return(result)
+      allow(klass).to receive(:system_command).with("codesign", args: ["-dvvv", file], print_stderr: false)
+                                              .and_return(result)
 
-      identity = described_class.signing_identity(file)
+      identity = klass.signing_identity(file)
 
       expect(identity).to have_attributes(identifier: "sh.brew.test-app", team_identifier: "ABCDE12345")
     end
 
     it "returns the signed identifier when the Team ID is missing" do
       result = instance_double(SystemCommand::Result, success?: true, merged_output: "Identifier=sh.brew.test-app\n")
-      allow(described_class).to receive(:system_command).with("codesign", args: ["-dvvv", file], print_stderr: false)
-                                                        .and_return(result)
+      allow(klass).to receive(:system_command).with("codesign", args: ["-dvvv", file], print_stderr: false)
+                                              .and_return(result)
 
-      expect(described_class.signing_identity(file)).to have_attributes(identifier:      "sh.brew.test-app",
-                                                                        team_identifier: nil)
+      expect(klass.signing_identity(file)).to have_attributes(identifier:      "sh.brew.test-app",
+                                                              team_identifier: nil)
     end
 
     it 'returns nil for the Team ID when it is "not set"' do
@@ -59,11 +61,11 @@ RSpec.describe Cask::Quarantine do
         merged_output: "Identifier=com.apple.calculator\n" \
                        "TeamIdentifier=not set\n",
       )
-      allow(described_class).to receive(:system_command).with("codesign", args: ["-dvvv", file], print_stderr: false)
-                                                        .and_return(result)
+      allow(klass).to receive(:system_command).with("codesign", args: ["-dvvv", file], print_stderr: false)
+                                              .and_return(result)
 
-      expect(described_class.signing_identity(file)).to have_attributes(identifier:      "com.apple.calculator",
-                                                                        team_identifier: nil)
+      expect(klass.signing_identity(file)).to have_attributes(identifier:      "com.apple.calculator",
+                                                              team_identifier: nil)
     end
   end
 end

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -5,6 +5,8 @@ require "cask/installer"
 require "cask/reinstall"
 
 RSpec.describe Cask::Reinstall, :cask do
+  let(:klass) { Cask::Reinstall }
+
   it "displays the reinstallation progress" do
     caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
 
@@ -22,7 +24,7 @@ RSpec.describe Cask::Reinstall, :cask do
     EOS
 
     expect do
-      described_class.reinstall_casks(Cask::CaskLoader.load("local-caffeine"))
+      klass.reinstall_casks(Cask::CaskLoader.load("local-caffeine"))
     end.to output(output).to_stdout
   end
 
@@ -45,7 +47,7 @@ RSpec.describe Cask::Reinstall, :cask do
     EOS
 
     expect do
-      described_class.reinstall_casks(Cask::CaskLoader.load("local-caffeine"), zap: true)
+      klass.reinstall_casks(Cask::CaskLoader.load("local-caffeine"), zap: true)
     end.to output(output).to_stdout
   end
 
@@ -54,7 +56,7 @@ RSpec.describe Cask::Reinstall, :cask do
 
     expect(Cask::CaskLoader.load(cask_path("local-transmission-zip"))).to be_installed
 
-    described_class.reinstall_casks(Cask::CaskLoader.load("local-transmission-zip"))
+    klass.reinstall_casks(Cask::CaskLoader.load("local-transmission-zip"))
     expect(Cask::CaskLoader.load(cask_path("local-transmission-zip"))).to be_installed
   end
 
@@ -77,13 +79,13 @@ RSpec.describe Cask::Reinstall, :cask do
     allow(Cask::Installer).to receive(:new).and_return(failing_installer, successful_installer)
 
     expect(successful_installer).to receive(:install)
-    expect { described_class.reinstall_casks(cask1, cask2) }.to raise_error(Cask::CaskError, "reinstall failed")
+    expect { klass.reinstall_casks(cask1, cask2) }.to raise_error(Cask::CaskError, "reinstall failed")
   end
 
   it "allows reinstalling a non installed Cask" do
     expect(Cask::CaskLoader.load(cask_path("local-transmission-zip"))).not_to be_installed
 
-    described_class.reinstall_casks(Cask::CaskLoader.load("local-transmission-zip"))
+    klass.reinstall_casks(Cask::CaskLoader.load("local-transmission-zip"))
     expect(Cask::CaskLoader.load(cask_path("local-transmission-zip"))).to be_installed
   end
 end

--- a/Library/Homebrew/test/cask/tab_spec.rb
+++ b/Library/Homebrew/test/cask/tab_spec.rb
@@ -4,6 +4,35 @@
 require "cask"
 
 RSpec.describe Cask::Tab, :cask do
+  subject(:tab) do
+    klass.new(
+      "homebrew_version"         => HOMEBREW_VERSION,
+      "loaded_from_api"          => false,
+      "loaded_from_internal_api" => false,
+      "uninstall_flight_blocks"  => true,
+      "installed_on_request"     => true,
+      "time"                     => time,
+      "runtime_dependencies"     => {
+        "cask" => [{ "full_name" => "bar", "version" => "2.0", "declared_directly" => false }],
+      },
+      "source"                   => {
+        "path"         => CoreCaskTap.instance.path.to_s,
+        "tap"          => CoreCaskTap.instance.to_s,
+        "tap_git_head" => "8b79aa759500f0ffdf65a23e12950cbe3bf8fe17",
+        "version"      => "1.2.3",
+      },
+      "arch"                     => Hardware::CPU.arch,
+      "uninstall_artifacts"      => [{ "app" => ["Foo.app"] }],
+      "built_on"                 => DevelopmentTools.build_system_info,
+    )
+  end
+
+  let(:klass) { Cask::Tab }
+  let(:time) { Time.now.to_i }
+  let(:f) { formula { url "foo-1.0" } }
+  let(:f_tab_path) { f.prefix/"INSTALL_RECEIPT.json" }
+  let(:f_tab_content) { (TEST_FIXTURE_DIR/"receipt.json").read }
+
   matcher :be_installed_on_request do
     match do |actual|
       actual.installed_on_request == true
@@ -28,39 +57,10 @@ RSpec.describe Cask::Tab, :cask do
     end
   end
 
-  subject(:tab) do
-    described_class.new(
-      "homebrew_version"         => HOMEBREW_VERSION,
-      "loaded_from_api"          => false,
-      "loaded_from_internal_api" => false,
-      "uninstall_flight_blocks"  => true,
-      "installed_on_request"     => true,
-      "time"                     => time,
-      "runtime_dependencies"     => {
-        "cask" => [{ "full_name" => "bar", "version" => "2.0", "declared_directly" => false }],
-      },
-      "source"                   => {
-        "path"         => CoreCaskTap.instance.path.to_s,
-        "tap"          => CoreCaskTap.instance.to_s,
-        "tap_git_head" => "8b79aa759500f0ffdf65a23e12950cbe3bf8fe17",
-        "version"      => "1.2.3",
-      },
-      "arch"                     => Hardware::CPU.arch,
-      "uninstall_artifacts"      => [{ "app" => ["Foo.app"] }],
-      "built_on"                 => DevelopmentTools.build_system_info,
-    )
-  end
-
-  let(:time) { Time.now.to_i }
-
-  let(:f) { formula { url "foo-1.0" } }
-  let(:f_tab_path) { f.prefix/"INSTALL_RECEIPT.json" }
-  let(:f_tab_content) { (TEST_FIXTURE_DIR/"receipt.json").read }
-
   specify "defaults" do
     stub_const("HOMEBREW_VERSION", "4.3.7")
 
-    tab = described_class.empty
+    tab = klass.empty
 
     expect(tab.homebrew_version).to eq(HOMEBREW_VERSION)
     expect(tab).not_to be_installed_on_request
@@ -74,7 +74,7 @@ RSpec.describe Cask::Tab, :cask do
   end
 
   specify "#runtime_dependencies" do
-    tab = described_class.new
+    tab = klass.new
     expect(tab.runtime_dependencies).to be_nil
 
     tab.runtime_dependencies = {}
@@ -90,7 +90,7 @@ RSpec.describe Cask::Tab, :cask do
     specify "with no dependencies" do
       cask = Cask::CaskLoader.load("local-transmission")
 
-      expect(described_class.runtime_deps_hash(cask)).to eq({})
+      expect(klass.runtime_deps_hash(cask)).to eq({})
     end
 
     specify "with cask dependencies" do
@@ -101,25 +101,25 @@ RSpec.describe Cask::Tab, :cask do
           { "full_name"=>"local-transmission-zip", "version"=>"2.61", "declared_directly"=>true },
         ],
       }
-      expect(described_class.runtime_deps_hash(cask)).to eq(expected_hash)
+      expect(klass.runtime_deps_hash(cask)).to eq(expected_hash)
     end
 
     it "ignores macos symbol dependencies" do
       cask = Cask::CaskLoader.load("with-depends-on-macos-symbol")
 
-      expect(described_class.runtime_deps_hash(cask)).to eq({})
+      expect(klass.runtime_deps_hash(cask)).to eq({})
     end
 
     it "ignores macos array dependencies" do
       cask = Cask::CaskLoader.load("with-depends-on-macos-array")
 
-      expect(described_class.runtime_deps_hash(cask)).to eq({})
+      expect(klass.runtime_deps_hash(cask)).to eq({})
     end
 
     it "ignores arch dependencies" do
       cask = Cask::CaskLoader.load("with-depends-on-arch")
 
-      expect(described_class.runtime_deps_hash(cask)).to eq({})
+      expect(klass.runtime_deps_hash(cask)).to eq({})
     end
 
     specify "with all types of dependencies" do
@@ -142,8 +142,8 @@ RSpec.describe Cask::Tab, :cask do
         ],
       }
 
-      runtime_deps_hash = described_class.runtime_deps_hash(cask)
-      tab = described_class.new
+      runtime_deps_hash = klass.runtime_deps_hash(cask)
+      tab = klass.new
       tab.runtime_dependencies = runtime_deps_hash
       expect(tab.runtime_dependencies).to eql(expected_hash)
     end
@@ -161,7 +161,7 @@ RSpec.describe Cask::Tab, :cask do
   describe "::from_file" do
     it "parses a cask Tab from a file" do
       path = Pathname.new("#{TEST_FIXTURE_DIR}/cask_receipt.json")
-      tab = described_class.from_file(path)
+      tab = klass.from_file(path)
       source_path = "/opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/f/foo.rb"
       runtime_dependencies = {
         "cask"    => [
@@ -202,7 +202,7 @@ RSpec.describe Cask::Tab, :cask do
   describe "::from_file_content" do
     it "parses a cask Tab from a file" do
       path = Pathname.new("#{TEST_FIXTURE_DIR}/cask_receipt.json")
-      tab = described_class.from_file_content(path.read, path)
+      tab = klass.from_file_content(path.read, path)
       source_path = "/opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/f/foo.rb"
       runtime_dependencies = {
         "cask"    => [
@@ -241,7 +241,7 @@ RSpec.describe Cask::Tab, :cask do
     end
 
     it "raises a parse exception message including the Tab filename" do
-      expect { described_class.from_file_content("''", "cask_receipt.json") }.to raise_error(
+      expect { klass.from_file_content("''", "cask_receipt.json") }.to raise_error(
         JSON::ParserError,
         /receipt.json:/,
       )
@@ -256,7 +256,7 @@ RSpec.describe Cask::Tab, :cask do
         { zap: [{ trash: "#{TEST_FIXTURE_DIR}/cask/caffeine/org.example.caffeine.plist" }] },
       ]
 
-      tab = described_class.create(cask)
+      tab = klass.create(cask)
       expect(tab).not_to be_loaded_from_api
       expect(tab).not_to be_loaded_from_internal_api
       expect(tab).not_to have_uninstall_flight_blocks
@@ -278,7 +278,7 @@ RSpec.describe Cask::Tab, :cask do
     let(:cask_tab_content) { (TEST_FIXTURE_DIR/"cask_receipt.json").read }
 
     it "creates a Tab for a given cask" do
-      tab = described_class.for_cask(cask)
+      tab = klass.for_cask(cask)
       expect(tab.source["path"]).to eq(cask.sourcefile_path.to_s)
     end
 
@@ -286,20 +286,20 @@ RSpec.describe Cask::Tab, :cask do
       cask_tab_path.dirname.mkpath
       cask_tab_path.write cask_tab_content
 
-      tab = described_class.for_cask(cask)
+      tab = klass.for_cask(cask)
       expect(tab.tabfile).to eq(cask_tab_path)
     end
 
     it "can create a Tab for a non-existent cask" do
       cask_tab_path.dirname.mkpath
 
-      tab = described_class.for_cask(cask)
+      tab = klass.for_cask(cask)
       expect(tab.tabfile).to be_nil
     end
   end
 
   specify "#to_json" do
-    json_tab = described_class.new(JSON.parse(tab.to_json))
+    json_tab = klass.new(JSON.parse(tab.to_json))
     expect(json_tab.homebrew_version).to eq(tab.homebrew_version)
     expect(json_tab.loaded_from_api).to eq(tab.loaded_from_api)
     expect(json_tab.loaded_from_internal_api).to eq(tab.loaded_from_internal_api)
@@ -321,7 +321,7 @@ RSpec.describe Cask::Tab, :cask do
     let(:time_string) { Time.at(1_720_189_863).strftime("%Y-%m-%d at %H:%M:%S") }
 
     it "returns install information for a Tab with a time that was loaded from the API" do
-      tab = described_class.new(
+      tab = klass.new(
         loaded_from_api: true,
         time:            1_720_189_863,
       )
@@ -330,7 +330,7 @@ RSpec.describe Cask::Tab, :cask do
     end
 
     it "returns install information for a Tab with a time that was loaded from the internal API" do
-      tab = described_class.new(
+      tab = klass.new(
         loaded_from_api:          true,
         loaded_from_internal_api: true,
         time:                     1_720_189_863,
@@ -340,7 +340,7 @@ RSpec.describe Cask::Tab, :cask do
     end
 
     it "returns install information for a Tab with a time that was not loaded from the API" do
-      tab = described_class.new(
+      tab = klass.new(
         loaded_from_api: false,
         time:            1_720_189_863,
       )
@@ -349,7 +349,7 @@ RSpec.describe Cask::Tab, :cask do
     end
 
     it "returns install information for a Tab without a time that was loaded from the API" do
-      tab = described_class.new(
+      tab = klass.new(
         loaded_from_api: true,
         time:            nil,
       )
@@ -358,7 +358,7 @@ RSpec.describe Cask::Tab, :cask do
     end
 
     it "returns install information for a Tab without a time that was loaded from the internal API" do
-      tab = described_class.new(
+      tab = klass.new(
         loaded_from_api:          true,
         loaded_from_internal_api: true,
         time:                     nil,
@@ -368,7 +368,7 @@ RSpec.describe Cask::Tab, :cask do
     end
 
     it "returns install information for a Tab without a time that was not loaded from the API" do
-      tab = described_class.new(
+      tab = klass.new(
         loaded_from_api: false,
         time:            nil,
       )

--- a/Library/Homebrew/test/cask/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/uninstall_spec.rb
@@ -4,6 +4,8 @@
 require "cask/uninstall"
 
 RSpec.describe Cask::Uninstall, :cask do
+  let(:klass) { Cask::Uninstall }
+
   describe ".uninstall_casks" do
     it "displays the uninstallation progress" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
@@ -18,14 +20,14 @@ RSpec.describe Cask::Uninstall, :cask do
       EOS
 
       expect do
-        described_class.uninstall_casks(caffeine)
+        klass.uninstall_casks(caffeine)
       end.to output(output).to_stdout
     end
 
     it "shows an error when a Cask is provided that's not installed" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
 
-      expect { described_class.uninstall_casks(caffeine) }
+      expect { klass.uninstall_casks(caffeine) }
         .to raise_error(Cask::CaskNotInstalledError, /is not installed/)
     end
 
@@ -33,7 +35,7 @@ RSpec.describe Cask::Uninstall, :cask do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
 
       expect do
-        described_class.uninstall_casks(caffeine, force: true)
+        klass.uninstall_casks(caffeine, force: true)
       end.not_to raise_error
     end
 
@@ -44,7 +46,7 @@ RSpec.describe Cask::Uninstall, :cask do
 
       expect(Cask::Installer).not_to receive(:new)
       expect do
-        described_class.uninstall_casks(caffeine)
+        klass.uninstall_casks(caffeine)
       end.to output(/local-caffeine is pinned\. You must unpin it to uninstall\./).to_stderr
 
       expect(caffeine).to be_pinned
@@ -61,7 +63,7 @@ RSpec.describe Cask::Uninstall, :cask do
       expect(caffeine).to be_installed
       expect(transmission).to be_installed
 
-      described_class.uninstall_casks(caffeine, transmission)
+      klass.uninstall_casks(caffeine, transmission)
 
       expect(caffeine).not_to be_installed
       expect(caffeine.config.appdir.join("Transmission.app")).not_to exist
@@ -78,13 +80,13 @@ RSpec.describe Cask::Uninstall, :cask do
 
       FileUtils.rm_r(cask.config.appdir.join("MyFancyApp.app"))
 
-      expect { described_class.uninstall_casks(cask) }
+      expect { klass.uninstall_casks(cask) }
         .to raise_error(Cask::CaskError, /uninstall script .* does not exist/)
 
       expect(cask).to be_installed
 
       expect do
-        described_class.uninstall_casks(cask, force: true)
+        klass.uninstall_casks(cask, force: true)
       end.not_to raise_error
 
       expect(cask).not_to be_installed
@@ -107,7 +109,7 @@ RSpec.describe Cask::Uninstall, :cask do
         instance
       end
 
-      expect { described_class.uninstall_casks(caffeine, transmission) }
+      expect { klass.uninstall_casks(caffeine, transmission) }
         .to raise_error(Cask::CaskError, /caffeine uninstall failed/)
 
       expect(caffeine).to be_installed
@@ -141,13 +143,13 @@ RSpec.describe Cask::Uninstall, :cask do
       end
 
       it "uninstalls one version at a time" do
-        described_class.uninstall_casks(Cask::Cask.new("versioned-cask"))
+        klass.uninstall_casks(Cask::Cask.new("versioned-cask"))
 
         expect(caskroom_path.join(first_installed_version)).to exist
         expect(caskroom_path.join(last_installed_version)).not_to exist
         expect(caskroom_path).to exist
 
-        described_class.uninstall_casks(Cask::Cask.new("versioned-cask"))
+        klass.uninstall_casks(Cask::Cask.new("versioned-cask"))
 
         expect(caskroom_path.join(first_installed_version)).not_to exist
         expect(caskroom_path).not_to exist
@@ -182,7 +184,7 @@ RSpec.describe Cask::Uninstall, :cask do
       end
 
       it "can still uninstall them" do
-        described_class.uninstall_casks(Cask::Cask.new("ive-been-renamed"))
+        klass.uninstall_casks(Cask::Cask.new("ive-been-renamed"))
 
         expect(app).not_to exist
         expect(caskroom_path).not_to exist
@@ -205,7 +207,7 @@ RSpec.describe Cask::Uninstall, :cask do
       EOS
 
       expect do
-        described_class.check_dependent_casks(local_transmission, named_args: ["local-transmission-zip"])
+        klass.check_dependent_casks(local_transmission, named_args: ["local-transmission-zip"])
       end.to output(output).to_stderr
     end
 
@@ -228,7 +230,7 @@ RSpec.describe Cask::Uninstall, :cask do
       EOS
 
       expect do
-        described_class.check_dependent_casks(local_transmission, named_args: ["local-transmission-zip"])
+        klass.check_dependent_casks(local_transmission, named_args: ["local-transmission-zip"])
       end.to output(output).to_stderr
     end
 
@@ -254,7 +256,7 @@ RSpec.describe Cask::Uninstall, :cask do
       EOS
 
       expect do
-        described_class.check_dependent_casks(local_transmission, local_caffeine, named_args:)
+        klass.check_dependent_casks(local_transmission, local_caffeine, named_args:)
       end.to output(output).to_stderr
     end
 
@@ -265,7 +267,7 @@ RSpec.describe Cask::Uninstall, :cask do
       allow(Cask::Caskroom).to receive(:casks).and_return([depends_on_cask, local_transmission])
 
       expect do
-        described_class.check_dependent_casks(depends_on_cask, named_args: ["with-depends-on-cask"])
+        klass.check_dependent_casks(depends_on_cask, named_args: ["with-depends-on-cask"])
       end.not_to output.to_stderr
     end
 
@@ -276,7 +278,7 @@ RSpec.describe Cask::Uninstall, :cask do
       allow(Cask::Caskroom).to receive(:casks).and_return([depends_on_cask, local_transmission])
 
       expect do
-        described_class.check_dependent_casks(
+        klass.check_dependent_casks(
           local_transmission,
           depends_on_cask,
           named_args: ["local-transmission-zip", "with-depends-on-cask"],
@@ -296,7 +298,7 @@ RSpec.describe Cask::Uninstall, :cask do
       ])
 
       expect do
-        described_class.check_dependent_casks(
+        klass.check_dependent_casks(
           local_transmission,
           depends_on_cask,
           named_args: ["local-transmission-zip", "with-depends-on-cask"],
@@ -319,7 +321,7 @@ RSpec.describe Cask::Uninstall, :cask do
       EOS
 
       expect do
-        described_class.check_dependent_casks(local_transmission, named_args:)
+        klass.check_dependent_casks(local_transmission, named_args:)
       end.to output(output).to_stderr
     end
   end

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -4,23 +4,7 @@
 require "cask/upgrade"
 
 RSpec.describe Cask::Upgrade, :cask do
-  def write_info_plist(path, short_version:, bundle_version:)
-    info_plist = path/"Contents/Info.plist"
-    info_plist.dirname.mkpath
-    info_plist.write <<~PLIST
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>CFBundleShortVersionString</key>
-        <string>#{short_version}</string>
-        <key>CFBundleVersion</key>
-        <string>#{bundle_version}</string>
-      </dict>
-      </plist>
-    PLIST
-  end
-
+  let(:klass) { Cask::Upgrade }
   let(:version_latest_paths) do
     [
       version_latest.config.appdir.join("Caffeine Mini.app"),
@@ -41,6 +25,23 @@ RSpec.describe Cask::Upgrade, :cask do
     parser = Homebrew::CLI::Parser.new(Homebrew::Cmd::Brew)
     parser.cask_options
     parser.args
+  end
+
+  def write_info_plist(path, short_version:, bundle_version:)
+    info_plist = path/"Contents/Info.plist"
+    info_plist.dirname.mkpath
+    info_plist.write <<~PLIST
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>CFBundleShortVersionString</key>
+        <string>#{short_version}</string>
+        <key>CFBundleVersion</key>
+        <string>#{bundle_version}</string>
+      </dict>
+      </plist>
+    PLIST
   end
 
   before do
@@ -67,8 +68,8 @@ RSpec.describe Cask::Upgrade, :cask do
 
     describe "without --greedy" do
       it 'includes "auto_updates true" casks when the installed bundle version is older than the tap version' do
-        expect(described_class).not_to receive(:upgrade_cask)
-        expect(described_class).to receive(:show_upgrade_summary) do |cask_upgrades, dry_run:|
+        expect(klass).not_to receive(:upgrade_cask)
+        expect(klass).to receive(:show_upgrade_summary) do |cask_upgrades, dry_run:|
           expect(dry_run).to be(true)
           expect(cask_upgrades).to include(
             "local-caffeine 1.2.2 -> 1.2.3",
@@ -92,7 +93,7 @@ RSpec.describe Cask::Upgrade, :cask do
         expect(renamed_app_new_path).not_to be_a_directory
         expect(renamed_app.installed_version).to eq "1.0.0"
 
-        described_class.upgrade_casks!(dry_run: true, args:)
+        klass.upgrade_casks!(dry_run: true, args:)
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -111,8 +112,8 @@ RSpec.describe Cask::Upgrade, :cask do
       it 'excludes "auto_updates true" casks when HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS is set' do
         allow(Homebrew::EnvConfig).to receive(:upgrade_auto_updates_casks?).and_return(false)
 
-        expect(described_class).not_to receive(:upgrade_cask)
-        expect(described_class).to receive(:show_upgrade_summary) do |cask_upgrades, dry_run:|
+        expect(klass).not_to receive(:upgrade_cask)
+        expect(klass).to receive(:show_upgrade_summary) do |cask_upgrades, dry_run:|
           expect(dry_run).to be(true)
           expect(cask_upgrades).to include(
             "local-caffeine 1.2.2 -> 1.2.3",
@@ -122,7 +123,7 @@ RSpec.describe Cask::Upgrade, :cask do
           expect(cask_upgrades.grep(/auto-updates/)).to be_empty
         end
 
-        described_class.upgrade_casks!(dry_run: true, args:)
+        klass.upgrade_casks!(dry_run: true, args:)
       end
 
       it "raises if HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS and HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS are set" do
@@ -132,7 +133,7 @@ RSpec.describe Cask::Upgrade, :cask do
           "HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS"    => "1",
           "HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS" => "1",
         ) do
-          expect { described_class.upgrade_casks!(dry_run: true, args:) }
+          expect { klass.upgrade_casks!(dry_run: true, args:) }
             .to raise_error(UsageError, /cannot both be set/i)
         end
       end
@@ -140,8 +141,8 @@ RSpec.describe Cask::Upgrade, :cask do
       it 'excludes "auto_updates true" casks when the installed bundle matches the tap version' do
         write_info_plist(auto_updates_path, short_version: "2.61", bundle_version: "2061")
 
-        expect(described_class).not_to receive(:upgrade_cask)
-        expect(described_class).to receive(:show_upgrade_summary) do |cask_upgrades, dry_run:|
+        expect(klass).not_to receive(:upgrade_cask)
+        expect(klass).to receive(:show_upgrade_summary) do |cask_upgrades, dry_run:|
           expect(dry_run).to be(true)
           expect(cask_upgrades).to include(
             "local-caffeine 1.2.2 -> 1.2.3",
@@ -151,7 +152,7 @@ RSpec.describe Cask::Upgrade, :cask do
           expect(cask_upgrades.grep(/auto-updates/)).to be_empty
         end
 
-        described_class.upgrade_casks!(dry_run: true, args:)
+        klass.upgrade_casks!(dry_run: true, args:)
       end
 
       it "records final cask upgrade summary details" do
@@ -159,7 +160,7 @@ RSpec.describe Cask::Upgrade, :cask do
         summary_deprecated = []
         allow(local_caffeine).to receive(:deprecated?).and_return(true)
 
-        described_class.upgrade_casks!(
+        klass.upgrade_casks!(
           local_caffeine,
           dry_run:              true,
           show_upgrade_summary: false,
@@ -177,8 +178,8 @@ RSpec.describe Cask::Upgrade, :cask do
         summary_pinned = []
 
         begin
-          expect(described_class).not_to receive(:upgrade_cask)
-          expect(described_class).to receive(:show_upgrade_summary) do |cask_upgrades, dry_run:|
+          expect(klass).not_to receive(:upgrade_cask)
+          expect(klass).to receive(:show_upgrade_summary) do |cask_upgrades, dry_run:|
             expect(dry_run).to be(true)
             expect(cask_upgrades).to include(
               "local-transmission-zip 2.60 -> 2.61",
@@ -188,7 +189,7 @@ RSpec.describe Cask::Upgrade, :cask do
             expect(cask_upgrades.grep(/local-caffeine/)).to be_empty
           end
 
-          described_class.upgrade_casks!(dry_run: true, quiet: true, summary_pinned:, args:)
+          klass.upgrade_casks!(dry_run: true, quiet: true, summary_pinned:, args:)
           expect(summary_pinned).to include("local-caffeine 1.2.2")
         ensure
           local_caffeine.unpin
@@ -199,10 +200,10 @@ RSpec.describe Cask::Upgrade, :cask do
         local_caffeine.pin
 
         begin
-          expect(described_class).not_to receive(:upgrade_cask)
+          expect(klass).not_to receive(:upgrade_cask)
 
           expect do
-            described_class.upgrade_casks!(local_caffeine, dry_run: true, args:)
+            klass.upgrade_casks!(local_caffeine, dry_run: true, args:)
           end.to not_to_output.to_stdout
              .and output(/Not upgrading 1 pinned package:.*local-caffeine 1\.2\.2/m).to_stderr
           expect(Homebrew).to be_failed
@@ -213,8 +214,8 @@ RSpec.describe Cask::Upgrade, :cask do
       end
 
       it "would update only the Casks specified in the command line" do
-        expect(described_class).not_to receive(:upgrade_cask)
-        expect(described_class).to receive(:show_upgrade_summary)
+        expect(klass).not_to receive(:upgrade_cask)
+        expect(klass).to receive(:show_upgrade_summary)
           .with(["local-caffeine 1.2.2 -> 1.2.3"], dry_run: true)
 
         expect(local_caffeine).to be_installed
@@ -225,7 +226,7 @@ RSpec.describe Cask::Upgrade, :cask do
         expect(local_transmission_path).to be_a_directory
         expect(local_transmission.installed_version).to eq "2.60"
 
-        described_class.upgrade_casks!(local_caffeine, dry_run: true, args:)
+        klass.upgrade_casks!(local_caffeine, dry_run: true, args:)
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -237,8 +238,8 @@ RSpec.describe Cask::Upgrade, :cask do
       end
 
       it 'would update "auto_updates" and "latest" Casks when their tokens are provided in the command line' do
-        expect(described_class).not_to receive(:upgrade_cask)
-        expect(described_class).to receive(:show_upgrade_summary)
+        expect(klass).not_to receive(:upgrade_cask)
+        expect(klass).to receive(:show_upgrade_summary)
           .with(["local-caffeine 1.2.2 -> 1.2.3", "auto-updates 2.57 -> 2.61"], dry_run: true)
 
         expect(local_caffeine).to be_installed
@@ -254,7 +255,7 @@ RSpec.describe Cask::Upgrade, :cask do
         expect(renamed_app_new_path).not_to be_a_directory
         expect(renamed_app.installed_version).to eq "1.0.0"
 
-        described_class.upgrade_casks!(local_caffeine, auto_updates, dry_run: true, args:)
+        klass.upgrade_casks!(local_caffeine, auto_updates, dry_run: true, args:)
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -273,7 +274,7 @@ RSpec.describe Cask::Upgrade, :cask do
 
     describe "with --greedy it checks additional Casks" do
       it 'would include the Casks with "auto_updates true" or "version latest"' do
-        expect(described_class).not_to receive(:upgrade_cask)
+        expect(klass).not_to receive(:upgrade_cask)
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -297,7 +298,7 @@ RSpec.describe Cask::Upgrade, :cask do
         version_latest.download_sha_path.write("fake download sha")
         expect(version_latest.outdated_download_sha?).to be(true)
 
-        described_class.upgrade_casks!(greedy: true, dry_run: true, args:)
+        klass.upgrade_casks!(greedy: true, dry_run: true, args:)
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -321,15 +322,15 @@ RSpec.describe Cask::Upgrade, :cask do
       end
 
       it 'would update outdated Casks with "auto_updates true"' do
-        expect(described_class).not_to receive(:upgrade_cask)
-        expect(described_class).to receive(:show_upgrade_summary)
+        expect(klass).not_to receive(:upgrade_cask)
+        expect(klass).to receive(:show_upgrade_summary)
           .with(["auto-updates 2.57 -> 2.61"], dry_run: true)
 
         expect(auto_updates).to be_installed
         expect(auto_updates_path).to be_a_directory
         expect(auto_updates.installed_version).to eq "2.57"
 
-        described_class.upgrade_casks!(auto_updates, dry_run: true, greedy: true, args:)
+        klass.upgrade_casks!(auto_updates, dry_run: true, greedy: true, args:)
 
         expect(auto_updates).to be_installed
         expect(auto_updates_path).to be_a_directory
@@ -337,8 +338,8 @@ RSpec.describe Cask::Upgrade, :cask do
       end
 
       it 'would update outdated Casks with "version latest"' do
-        expect(described_class).not_to receive(:upgrade_cask)
-        expect(described_class).to receive(:show_upgrade_summary)
+        expect(klass).not_to receive(:upgrade_cask)
+        expect(klass).to receive(:show_upgrade_summary)
           .with(["version-latest latest -> latest"], dry_run: true)
 
         expect(version_latest).to be_installed
@@ -348,7 +349,7 @@ RSpec.describe Cask::Upgrade, :cask do
         version_latest.download_sha_path.write("fake download sha")
         expect(version_latest.outdated_download_sha?).to be(true)
 
-        described_class.upgrade_casks!(version_latest, dry_run: true, greedy: true, args:)
+        klass.upgrade_casks!(version_latest, dry_run: true, greedy: true, args:)
 
         expect(version_latest).to be_installed
         expect(version_latest_paths).to all be_a_directory
@@ -377,7 +378,7 @@ RSpec.describe Cask::Upgrade, :cask do
                                                                                      "broken DSL"))
 
       expect do
-        described_class.upgrade_casks!(dry_run: true, args:)
+        klass.upgrade_casks!(dry_run: true, args:)
       end.to output(/The cask 'auto-updates' cannot be upgraded as-is/).to_stderr
     end
 
@@ -388,7 +389,7 @@ RSpec.describe Cask::Upgrade, :cask do
                                                                                         "syntax error"))
 
       expect do
-        described_class.upgrade_casks!(dry_run: true, args:)
+        klass.upgrade_casks!(dry_run: true, args:)
       end.to output(/The cask 'auto-updates' cannot be upgraded as-is/).to_stderr
     end
 
@@ -402,7 +403,7 @@ RSpec.describe Cask::Upgrade, :cask do
       end
 
       expect do
-        described_class.upgrade_casks!(auto_updates, dry_run: true, args:)
+        klass.upgrade_casks!(auto_updates, dry_run: true, args:)
       end.to output(/The cask 'auto-updates' cannot be upgraded as-is/).to_stderr
     end
   end
@@ -440,15 +441,15 @@ RSpec.describe Cask::Upgrade, :cask do
         expect(options[:quarantine]).to be(true)
         installer
       end
-      expect(described_class).to receive(:upgrade_cask)
+      expect(klass).to receive(:upgrade_cask)
 
-      described_class.upgrade_casks!(auto_updates, show_upgrade_summary: false, args:)
+      klass.upgrade_casks!(auto_updates, show_upgrade_summary: false, args:)
     end
 
     it "releases quarantine when Gatekeeper was already approved and identity matches" do
       allow(Cask::Quarantine).to receive(:signing_identity).with(auto_updates_path).and_return(auto_updates_identity)
 
-      expect(described_class.release_app_upgrade_quarantine?(
+      expect(klass.release_app_upgrade_quarantine?(
                outdated_auto_updates,
                auto_updates,
                { auto_updates_path.to_s => auto_updates_identity },
@@ -460,7 +461,7 @@ RSpec.describe Cask::Upgrade, :cask do
       allow(Cask::Quarantine).to receive(:signing_identity).with(auto_updates_path)
                                                            .and_return(auto_updates_changed_team_identity)
 
-      expect(described_class.release_app_upgrade_quarantine?(
+      expect(klass.release_app_upgrade_quarantine?(
                outdated_auto_updates,
                auto_updates,
                { auto_updates_path.to_s => auto_updates_identity },
@@ -472,7 +473,7 @@ RSpec.describe Cask::Upgrade, :cask do
       allow(Cask::Quarantine).to receive(:signing_identity).with(auto_updates_path)
                                                            .and_return(auto_updates_changed_identifier_identity)
 
-      expect(described_class.release_app_upgrade_quarantine?(
+      expect(klass.release_app_upgrade_quarantine?(
                outdated_auto_updates,
                auto_updates,
                { auto_updates_path.to_s => auto_updates_identity },
@@ -484,7 +485,7 @@ RSpec.describe Cask::Upgrade, :cask do
       allow(Cask::Quarantine).to receive(:signing_identity).with(auto_updates_path)
                                                            .and_return(auto_updates_identity)
 
-      expect(described_class.release_app_upgrade_quarantine?(
+      expect(klass.release_app_upgrade_quarantine?(
                outdated_auto_updates,
                auto_updates,
                { auto_updates_path.to_s => Cask::Quarantine::SigningIdentity.new(identifier:      nil,
@@ -496,7 +497,7 @@ RSpec.describe Cask::Upgrade, :cask do
     it "still keeps quarantine when Gatekeeper was not approved" do
       allow(Cask::Quarantine).to receive(:signing_identity).with(auto_updates_path).and_return(auto_updates_identity)
 
-      expect(described_class.release_app_upgrade_quarantine?(
+      expect(klass.release_app_upgrade_quarantine?(
                outdated_auto_updates,
                auto_updates,
                { auto_updates_path.to_s => auto_updates_identity },
@@ -509,7 +510,7 @@ RSpec.describe Cask::Upgrade, :cask do
       allow(Cask::Quarantine).to receive(:signing_identity).with(local_caffeine_path)
                                                            .and_return(local_caffeine_identity)
 
-      expect(described_class.release_app_upgrade_quarantine?(
+      expect(klass.release_app_upgrade_quarantine?(
                outdated_local_caffeine,
                local_caffeine,
                { local_caffeine_path.to_s => local_caffeine_identity },
@@ -521,7 +522,7 @@ RSpec.describe Cask::Upgrade, :cask do
       allow(Cask::Quarantine).to receive(:signing_identity).with(local_caffeine_path)
                                                            .and_return(local_caffeine_identity)
 
-      expect(described_class.release_app_upgrade_quarantine?(
+      expect(klass.release_app_upgrade_quarantine?(
                outdated_local_caffeine,
                local_caffeine,
                { local_caffeine_path.to_s => local_caffeine_identity },
@@ -536,10 +537,10 @@ RSpec.describe Cask::Upgrade, :cask do
     allow(cask).to receive(:outdated?).with(greedy: true).and_return(true)
     summary_disabled = []
 
-    expect(described_class).not_to receive(:upgrade_cask)
+    expect(klass).not_to receive(:upgrade_cask)
 
     expect do
-      described_class.upgrade_casks!(cask, dry_run: true, summary_disabled:, args:)
+      klass.upgrade_casks!(cask, dry_run: true, summary_disabled:, args:)
     end.to output(/Not upgrading livecheck-disabled, it is disabled/).to_stderr
     expect(summary_disabled).to eq(["livecheck-disabled"])
   end
@@ -571,7 +572,7 @@ RSpec.describe Cask::Upgrade, :cask do
       expect(will_fail_if_upgraded.installed_version).to eq "1.2.2"
 
       expect do
-        described_class.upgrade_casks!(will_fail_if_upgraded, args:)
+        klass.upgrade_casks!(will_fail_if_upgraded, args:)
       end.to raise_error(Cask::CaskError).and output(output_reverted).to_stderr
 
       expect(will_fail_if_upgraded).to be_installed
@@ -589,7 +590,7 @@ RSpec.describe Cask::Upgrade, :cask do
       expect(bad_checksum.installed_version).to eq "1.2.2"
 
       expect do
-        described_class.upgrade_casks!(bad_checksum, args:)
+        klass.upgrade_casks!(bad_checksum, args:)
       end.to raise_error(ChecksumMismatchError).and(not_to_output(output_reverted).to_stderr)
 
       expect(bad_checksum).to be_installed
@@ -632,7 +633,7 @@ RSpec.describe Cask::Upgrade, :cask do
       expect(bad_checksum_2.installed_version).to eq "1.2.2"
 
       expect do
-        described_class.upgrade_casks!(args:)
+        klass.upgrade_casks!(args:)
       end.to raise_error(Cask::MultipleCaskErrors)
 
       expect(bad_checksum).to be_installed

--- a/Library/Homebrew/test/cask/utils/trash_spec.rb
+++ b/Library/Homebrew/test/cask/utils/trash_spec.rb
@@ -4,15 +4,17 @@
 require "cask/utils/trash"
 
 RSpec.describe Cask::Utils::Trash do
+  let(:klass) { Cask::Utils::Trash }
+
   describe "::trash" do
     let(:path) { Pathname("/tmp/example") }
 
     it "uses the Swift trash implementation on macOS" do
-      expect(described_class).to receive(:swift_trash)
+      expect(klass).to receive(:swift_trash)
         .with(path, command: nil)
         .and_return([[path.to_s], []])
 
-      expect(described_class.trash(path)).to eq([[path.to_s], []])
+      expect(klass.trash(path)).to eq([[path.to_s], []])
     end
   end
 
@@ -21,13 +23,13 @@ RSpec.describe Cask::Utils::Trash do
     let(:system_command_result) { instance_double(SystemCommand::Result, stdout: "#{path}\n") }
 
     it "uses the Swift helper on macOS" do
-      expect(described_class).to receive(:system_command)
+      expect(klass).to receive(:system_command)
         .with(HOMEBREW_LIBRARY_PATH/"cask/utils/trash.swift",
               args:         [path],
               print_stderr: Homebrew::EnvConfig.developer?)
         .and_return(system_command_result)
 
-      expect(described_class.send(:swift_trash, path)).to eq([[path.to_s], []])
+      expect(klass.send(:swift_trash, path)).to eq([[path.to_s], []])
     end
   end
 
@@ -52,7 +54,7 @@ RSpec.describe Cask::Utils::Trash do
       path.write("example")
       allow(Time).to receive(:now).and_return(deletion_time)
 
-      trashed, untrashable = described_class.send(:freedesktop_trash, path)
+      trashed, untrashable = klass.send(:freedesktop_trash, path)
 
       expect(path).not_to exist
       expect(trashed).to eq([path.to_s])

--- a/Library/Homebrew/test/cask/utils_spec.rb
+++ b/Library/Homebrew/test/cask/utils_spec.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::Utils do
+  let(:klass) { Cask::Utils }
+
   let(:command) { NeverSudoSystemCommand }
   let(:dir) { mktmpdir }
   let(:path) { dir/"a/b/c" }
@@ -10,9 +12,9 @@ RSpec.describe Cask::Utils do
   describe "::gain_permissions_mkpath" do
     it "creates a directory" do
       expect(path).not_to exist
-      described_class.gain_permissions_mkpath(path, command:)
+      klass.gain_permissions_mkpath(path, command:)
       expect(path).to be_a_directory
-      described_class.gain_permissions_mkpath(path, command:)
+      klass.gain_permissions_mkpath(path, command:)
       expect(path).to be_a_directory
     end
 
@@ -28,9 +30,9 @@ RSpec.describe Cask::Utils do
         end
 
         expect(path).not_to exist
-        described_class.gain_permissions_mkpath(path, command:)
+        klass.gain_permissions_mkpath(path, command:)
         expect(path).to be_a_directory
-        described_class.gain_permissions_mkpath(path, command:)
+        klass.gain_permissions_mkpath(path, command:)
         expect(path).to be_a_directory
 
         expect(dir).not_to be_writable
@@ -49,12 +51,12 @@ RSpec.describe Cask::Utils do
       expect(link).to be_a_symlink
       expect(link.readlink).to eq path
 
-      described_class.gain_permissions_remove(link, command:)
+      klass.gain_permissions_remove(link, command:)
 
       expect(path).to be_a_file
       expect(link).not_to exist
 
-      described_class.gain_permissions_remove(path, command:)
+      klass.gain_permissions_remove(path, command:)
 
       expect(path).not_to exist
     end
@@ -67,12 +69,12 @@ RSpec.describe Cask::Utils do
       expect(link).to be_a_symlink
       expect(link.readlink).to eq path
 
-      described_class.gain_permissions_remove(link, command:)
+      klass.gain_permissions_remove(link, command:)
 
       expect(path).to be_a_directory
       expect(link).not_to exist
 
-      described_class.gain_permissions_remove(path, command:)
+      klass.gain_permissions_remove(path, command:)
 
       expect(path).not_to exist
     end

--- a/Library/Homebrew/test/cask_dependent_spec.rb
+++ b/Library/Homebrew/test/cask_dependent_spec.rb
@@ -5,8 +5,9 @@ require "cask/cask_loader"
 require "cask_dependent"
 
 RSpec.describe CaskDependent, :needs_macos do
-  subject(:dependent) { described_class.new test_cask }
+  subject(:dependent) { klass.new test_cask }
 
+  let(:klass) { CaskDependent }
   let :test_cask do
     Cask::CaskLoader.load(+<<-RUBY)
       cask "testing" do

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -5,8 +5,9 @@ require "formula"
 require "caveats"
 
 RSpec.describe Caveats do
-  subject(:caveats) { described_class.new(f) }
+  subject(:caveats) { klass.new(f) }
 
+  let(:klass) { Caveats }
   let(:f) { formula { url "foo-1.0" } }
 
   specify "#f" do
@@ -27,7 +28,7 @@ RSpec.describe Caveats do
         end
       end
 
-      expect(described_class.new(f)).not_to be_empty
+      expect(klass.new(f)).not_to be_empty
     end
   end
 
@@ -44,7 +45,7 @@ RSpec.describe Caveats do
             run [bin/"php", "test"]
           end
         end
-        caveats = described_class.new(f).caveats
+        caveats = klass.new(f).caveats
 
         expect(f.service?).to be(true)
         expect(caveats).to include("#{f.bin}/php test")
@@ -60,7 +61,7 @@ RSpec.describe Caveats do
         end
         expect(Utils::Service).to receive(:launchctl?).and_return(false)
         expect(Utils::Service).to receive(:systemctl?).and_return(false)
-        expect(described_class.new(f).caveats).to include("service which can only be used on macOS or systemd!")
+        expect(klass.new(f).caveats).to include("service which can only be used on macOS or systemd!")
       end
 
       it "prints service startup information when service.require_root is true" do
@@ -72,7 +73,7 @@ RSpec.describe Caveats do
           end
         end
         expect(Utils::Service).to receive(:running?).with(f).once.and_return(false)
-        expect(described_class.new(f).caveats).to include("startup")
+        expect(klass.new(f).caveats).to include("startup")
       end
 
       it "prints service login information" do
@@ -83,7 +84,7 @@ RSpec.describe Caveats do
           end
         end
         expect(Utils::Service).to receive(:running?).with(f).once.and_return(false)
-        expect(described_class.new(f).caveats).to include("restart at login")
+        expect(klass.new(f).caveats).to include("restart at login")
       end
 
       it "gives information about require_root restarting services after upgrade" do
@@ -94,7 +95,7 @@ RSpec.describe Caveats do
             require_root true
           end
         end
-        f_obj = described_class.new(f)
+        f_obj = klass.new(f)
         expect(Utils::Service).to receive(:running?).with(f).once.and_return(true)
         expect(f_obj.caveats).to include("  sudo brew services restart #{f.full_name}")
       end
@@ -106,7 +107,7 @@ RSpec.describe Caveats do
             run [bin/"cmd"]
           end
         end
-        f_obj = described_class.new(f)
+        f_obj = klass.new(f)
         expect(Utils::Service).to receive(:running?).with(f).once.and_return(true)
         expect(f_obj.caveats).to include("  brew services restart #{f.full_name}")
       end
@@ -119,7 +120,7 @@ RSpec.describe Caveats do
             require_root true
           end
         end
-        f_obj = described_class.new(f)
+        f_obj = klass.new(f)
         expect(Utils::Service).to receive(:running?).with(f).once.and_return(false)
         expect(f_obj.caveats).to include("  sudo brew services start #{f.full_name}")
       end
@@ -131,7 +132,7 @@ RSpec.describe Caveats do
             run [bin/"cmd"]
           end
         end
-        f_obj = described_class.new(f)
+        f_obj = klass.new(f)
         expect(Utils::Service).to receive(:running?).with(f).once.and_return(false)
         expect(f_obj.caveats).to include("  brew services start #{f.full_name}")
       end
@@ -145,7 +146,7 @@ RSpec.describe Caveats do
           end
         end
         cmd = "#{HOMEBREW_CELLAR}/formula_name/1.0/bin/cmd"
-        caveats = described_class.new(f).caveats
+        caveats = klass.new(f).caveats
 
         expect(caveats).to include("if you don't want/need a background service")
         expect(caveats).to include("VAR=\"foo\" #{cmd} start")
@@ -160,7 +161,7 @@ RSpec.describe Caveats do
         end
         expect(Utils::Service).to receive(:installed?).with(f).once.and_return(true)
         expect(Utils::Service).to receive(:running?).with(f).once.and_return(false)
-        expect(described_class.new(f).caveats).to include("restart at login")
+        expect(klass.new(f).caveats).to include("restart at login")
       end
     end
 
@@ -171,7 +172,7 @@ RSpec.describe Caveats do
           keg_only "some reason"
         end
       end
-      let(:caveats) { described_class.new(f).caveats }
+      let(:caveats) { klass.new(f).caveats }
 
       it "tells formula is keg_only" do
         expect(caveats).to include("keg-only")
@@ -231,7 +232,7 @@ RSpec.describe Caveats do
           end
         end
 
-        let(:caveats) { described_class.new(f).caveats }
+        let(:caveats) { klass.new(f).caveats }
 
         it "adds the correct amount of new lines to the output" do
           expect(Utils::Service).to receive(:launchctl?).at_least(:once).and_return(true)
@@ -266,7 +267,7 @@ RSpec.describe Caveats do
         allow(bar_shadower).to receive(:realpath).and_return(bar_shadower)
         allow(f.opt_bin).to receive(:children).and_return([f.opt_bin/"foo", f.opt_bin/"bar"])
 
-        caveats = described_class.new(f).caveats
+        caveats = klass.new(f).caveats
         expect(caveats).to include("foo (shadowed by #{foo_shadower})")
         expect(caveats.index("bar (shadowed by")).to be < caveats.index("foo (shadowed by")
       end
@@ -275,7 +276,7 @@ RSpec.describe Caveats do
         own = f.opt_bin/"foo"
         allow_any_instance_of(Object).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(own)
 
-        expect(described_class.new(f).caveats).not_to include("shadowed")
+        expect(klass.new(f).caveats).not_to include("shadowed")
       end
 
       it "does not warn for keg-only formulae" do
@@ -289,7 +290,7 @@ RSpec.describe Caveats do
         allow_any_instance_of(Object).to receive(:which)
           .with("foo", ORIGINAL_PATHS).and_return(Pathname.new("/usr/local/bin/foo"))
 
-        expect(described_class.new(keg_only_f).caveats).not_to include("shadowed")
+        expect(klass.new(keg_only_f).caveats).not_to include("shadowed")
       end
 
       it "does not warn when the queried formula itself is not installed" do
@@ -312,7 +313,7 @@ RSpec.describe Caveats do
                                                  any_version_installed?:   false)
         allow_any_instance_of(Object).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(sibling_shadower)
 
-        expect(described_class.new(uninstalled_f).caveats).not_to include("shadowed")
+        expect(klass.new(uninstalled_f).caveats).not_to include("shadowed")
       end
 
       it "warns for a keg-only formula when a sibling keg is linked over it" do
@@ -335,7 +336,7 @@ RSpec.describe Caveats do
                                               any_version_installed?:   true)
         allow_any_instance_of(Object).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(sibling_shadower)
 
-        caveats = described_class.new(keg_only_f).caveats
+        caveats = klass.new(keg_only_f).caveats
         expect(caveats).to include("foo (shadowed by #{sibling_shadower} from foo@2.0)")
         expect(caveats).to include("Run `brew link foo@1.0`")
       end
@@ -353,7 +354,7 @@ RSpec.describe Caveats do
         allow_any_instance_of(Object).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(shadower)
         allow(shadower).to receive(:realpath).and_return(shadower)
 
-        expect(described_class.new(keg_only_f).caveats).to include("foo (shadowed by #{shadower})")
+        expect(klass.new(keg_only_f).caveats).to include("foo (shadowed by #{shadower})")
       end
 
       it "does not warn when HOMEBREW_NO_PATH_SHADOW_CHECK is set" do
@@ -361,7 +362,7 @@ RSpec.describe Caveats do
         allow_any_instance_of(Object).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(shadower)
         allow(Homebrew::EnvConfig).to receive(:no_path_shadow_check?).and_return(true)
 
-        expect(described_class.new(f).caveats).not_to include("shadowed")
+        expect(klass.new(f).caveats).not_to include("shadowed")
       end
 
       it "shows the opt-out hint by default" do
@@ -369,7 +370,7 @@ RSpec.describe Caveats do
         allow_any_instance_of(Object).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(shadower)
         allow(shadower).to receive(:realpath).and_return(shadower)
 
-        expect(described_class.new(f).caveats).to include("HOMEBREW_NO_PATH_SHADOW_CHECK=1")
+        expect(klass.new(f).caveats).to include("HOMEBREW_NO_PATH_SHADOW_CHECK=1")
       end
 
       it "hides the opt-out hint when HOMEBREW_NO_ENV_HINTS is set" do
@@ -378,7 +379,7 @@ RSpec.describe Caveats do
         allow(shadower).to receive(:realpath).and_return(shadower)
         allow(Homebrew::EnvConfig).to receive(:no_env_hints?).and_return(true)
 
-        expect(described_class.new(f).caveats).not_to include("HOMEBREW_NO_PATH_SHADOW_CHECK")
+        expect(klass.new(f).caveats).not_to include("HOMEBREW_NO_PATH_SHADOW_CHECK")
       end
 
       it "annotates sibling-keg shadowers with the keg name and adds a `brew link` hint" do
@@ -391,7 +392,7 @@ RSpec.describe Caveats do
         allow(f).to receive_messages(versioned_formulae_names: ["#{f.name}@1.0"], unversioned_formula_name: nil)
         allow_any_instance_of(Object).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(sibling_shadower)
 
-        caveats = described_class.new(f).caveats
+        caveats = klass.new(f).caveats
         expect(caveats).to include("shadowed by other linked Homebrew commands")
         expect(caveats).to include("foo (shadowed by #{sibling_shadower} from #{f.name}@1.0)")
         expect(caveats).to include("Run `brew link #{f.name}`")
@@ -416,7 +417,7 @@ RSpec.describe Caveats do
         allow_any_instance_of(Object).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(sibling_shadower)
         allow_any_instance_of(Object).to receive(:which).with("bar", ORIGINAL_PATHS).and_return(bar_shadower)
 
-        caveats = described_class.new(f).caveats
+        caveats = klass.new(f).caveats
         expect(caveats).to include("foo (shadowed by #{sibling_shadower} from #{f.name}@1.0)")
         expect(caveats).to include("bar (shadowed by #{bar_shadower})")
         expect(caveats).to include("Run `brew link #{f.name}`")
@@ -429,7 +430,7 @@ RSpec.describe Caveats do
           url "foo-1.0"
         end
       end
-      let(:caveats) { described_class.new(f) }
+      let(:caveats) { klass.new(f) }
       let(:path) { f.prefix.resolved_path }
 
       let(:bash_completion_dir) { path/"etc/bash_completion.d" }

--- a/Library/Homebrew/test/checksum_spec.rb
+++ b/Library/Homebrew/test/checksum_spec.rb
@@ -4,17 +4,19 @@
 require "checksum"
 
 RSpec.describe Checksum do
+  let(:klass) { Checksum }
+
   describe "#empty?" do
-    subject { described_class.new("") }
+    subject { klass.new("") }
 
     it { is_expected.to be_empty }
   end
 
   describe "#==" do
-    subject(:checksum) { described_class.new(TEST_SHA256) }
+    subject(:checksum) { klass.new(TEST_SHA256) }
 
-    let(:other) { described_class.new(TEST_SHA256) }
-    let(:other_reversed) { described_class.new(TEST_SHA256.reverse) }
+    let(:other) { klass.new(TEST_SHA256) }
+    let(:other_reversed) { klass.new(TEST_SHA256.reverse) }
 
     specify(:aggregate_failures) do
       expect(checksum).to eq(other)

--- a/Library/Homebrew/test/cleaner_spec.rb
+++ b/Library/Homebrew/test/cleaner_spec.rb
@@ -5,10 +5,12 @@ require "cleaner"
 require "formula"
 
 RSpec.describe Cleaner do
+  let(:klass) { Cleaner }
+
   include FileUtils
 
   describe "#clean" do
-    subject(:cleaner) { described_class.new(f) }
+    subject(:cleaner) { klass.new(f) }
 
     let(:f) { formula("cleaner_test") { url "foo-1.0" } }
 
@@ -217,7 +219,7 @@ RSpec.describe Cleaner do
       f = stub_formula_skip_clean("bin")
       f.bin.mkpath
 
-      described_class.new(f).clean
+      klass.new(f).clean
 
       expect(f.bin).to be_a_directory
     end
@@ -227,7 +229,7 @@ RSpec.describe Cleaner do
       subdir = f.bin/"subdir"
       subdir.mkpath
 
-      described_class.new(f).clean
+      klass.new(f).clean
 
       expect(f.bin).to be_a_directory
       expect(subdir).to be_a_directory
@@ -239,7 +241,7 @@ RSpec.describe Cleaner do
       symlink = f.prefix/"symlink"
       ln_s "target", symlink
 
-      described_class.new(f).clean
+      klass.new(f).clean
 
       expect(symlink).to be_a_symlink
     end
@@ -252,7 +254,7 @@ RSpec.describe Cleaner do
       dir.mkpath
       ln_s dir.basename, symlink
 
-      described_class.new(f).clean
+      klass.new(f).clean
 
       expect(dir).not_to exist
       expect(symlink).to be_a_symlink
@@ -267,7 +269,7 @@ RSpec.describe Cleaner do
       dir.mkpath
       ln_s dir.basename, symlink
 
-      described_class.new(f).clean
+      klass.new(f).clean
 
       expect(dir).not_to exist
       expect(symlink).to be_a_symlink
@@ -282,7 +284,7 @@ RSpec.describe Cleaner do
       f.lib.mkpath
       touch file
 
-      described_class.new(f).clean
+      klass.new(f).clean
 
       expect(file).to exist
     end
@@ -294,7 +296,7 @@ RSpec.describe Cleaner do
 
       dir.mkpath
 
-      described_class.new(f).clean
+      klass.new(f).clean
 
       expect(dir).to be_a_directory
     end
@@ -308,7 +310,7 @@ RSpec.describe Cleaner do
       dir1.mkpath
       dir2.mkpath
 
-      described_class.new(f).clean
+      klass.new(f).clean
 
       expect(dir1).to exist
       expect(dir2).not_to exist

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -9,8 +9,9 @@ require "uninstall"
 require "fileutils"
 
 RSpec.describe Homebrew::Cleanup do
-  subject(:cleanup) { described_class.new }
+  subject(:cleanup) { klass.new }
 
+  let(:klass) { Homebrew::Cleanup }
   let(:ds_store) { Pathname.new("#{HOMEBREW_CELLAR}/.DS_Store") }
   let(:lock_file) { Pathname.new("#{HOMEBREW_LOCKS}/foo") }
 
@@ -37,11 +38,11 @@ RSpec.describe Homebrew::Cleanup do
     it "returns true when ctime and mtime < days_default" do
       allow_any_instance_of(Pathname).to receive(:ctime).and_return((DateTime.now - 2).to_time)
       allow_any_instance_of(Pathname).to receive(:mtime).and_return((DateTime.now - 2).to_time)
-      expect(described_class.prune?(path, 1)).to be true
+      expect(klass.prune?(path, 1)).to be true
     end
 
     it "returns false when ctime and mtime >= days_default" do
-      expect(described_class.prune?(path, 2)).to be false
+      expect(klass.prune?(path, 2)).to be false
     end
   end
 
@@ -54,7 +55,7 @@ RSpec.describe Homebrew::Cleanup do
     end
 
     it "doesn't remove anything if `dry_run` is true" do
-      described_class.new(dry_run: true).clean!
+      klass.new(dry_run: true).clean!
 
       expect(ds_store).to exist
       expect(lock_file).to exist
@@ -119,7 +120,7 @@ RSpec.describe Homebrew::Cleanup do
     it "does not print or uninstall formulae required by installed dependents" do
       expect(Homebrew::Uninstall).not_to receive(:uninstall_kegs)
 
-      expect { described_class.autoremove }.not_to output.to_stdout
+      expect { klass.autoremove }.not_to output.to_stdout
     end
   end
 
@@ -177,7 +178,7 @@ RSpec.describe Homebrew::Cleanup do
 
       it "doesn't remove anything and only prints removal steps if `dry_run` is true" do
         expect do
-          described_class.new(dry_run: true).prune_prefix_symlinks_and_directories
+          klass.new(dry_run: true).prune_prefix_symlinks_and_directories
         end.to output(<<~EOS).to_stdout
           Would remove (broken link): #{link_to_broken_link}
           Would remove (broken link): #{broken_link}
@@ -311,7 +312,7 @@ RSpec.describe Homebrew::Cleanup do
     end
 
     it "cleans all logs if prune is 0" do
-      described_class.new(days: 0).cleanup_logs
+      klass.new(days: 0).cleanup_logs
       expect(path).not_to exist
     end
 
@@ -403,7 +404,7 @@ RSpec.describe Homebrew::Cleanup do
       gist.mkpath
       FileUtils.touch svn
 
-      described_class.new(days: 0).cleanup_cache
+      klass.new(days: 0).cleanup_cache
 
       expect(git).not_to exist
       expect(gist).to exist
@@ -414,7 +415,7 @@ RSpec.describe Homebrew::Cleanup do
       git = (HOMEBREW_CACHE/"git")
       git.mkpath
 
-      described_class.new(days: 0).cleanup_cache
+      klass.new(days: 0).cleanup_cache
 
       expect(git).to exist
     end
@@ -424,14 +425,14 @@ RSpec.describe Homebrew::Cleanup do
       foo.mkpath
       allow_any_instance_of(Pathname).to receive(:ctime).and_return(Time.now - (2 * 60 * 60 * 24))
       allow_any_instance_of(Pathname).to receive(:mtime).and_return(Time.now - (2 * 60 * 60 * 24))
-      described_class.new(days: 1).cleanup_cache
+      klass.new(days: 1).cleanup_cache
       expect(foo).not_to exist
     end
 
     it "does not clean up VCS checkout directories with modified time >= prune time" do
       foo = (HOMEBREW_CACHE/"--foo")
       foo.mkpath
-      described_class.new(days: 1).cleanup_cache
+      klass.new(days: 1).cleanup_cache
       expect(foo).to exist
     end
 
@@ -451,7 +452,7 @@ RSpec.describe Homebrew::Cleanup do
       FileUtils.touch symlink_target
       FileUtils.ln_s symlink_target, nested_symlink
 
-      described_class.new(days: 0).cleanup_cache
+      klass.new(days: 0).cleanup_cache
 
       expect([root_file.exist?, nested_file.exist?, nested_symlink.exist?, nested_directory.exist?])
         .to eq([false, false, false, true])
@@ -510,7 +511,7 @@ RSpec.describe Homebrew::Cleanup do
       end
 
       it "cleans up file if `scrub` is true and formula not installed" do
-        described_class.new(scrub: true).cleanup_cache
+        klass.new(scrub: true).cleanup_cache
         expect(bottle).not_to exist
         expect(testball).not_to exist
         expect(testball_resource).not_to exist
@@ -604,7 +605,7 @@ RSpec.describe Homebrew::Cleanup do
 
       allow_any_instance_of(Pathname).to receive(:ctime).and_return(Time.now - (2 * 60 * 60 * 24))
       allow_any_instance_of(Pathname).to receive(:mtime).and_return(Time.now - (2 * 60 * 60 * 24))
-      described_class.new(days: 1).cleanup_python_site_packages
+      klass.new(days: 1).cleanup_python_site_packages
       expect(foo_pyc).not_to exist
     end
   end

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -4,6 +4,34 @@
 require "cli/named_args"
 
 RSpec.describe Homebrew::CLI::NamedArgs do
+  let(:klass) { Homebrew::CLI::NamedArgs }
+  let(:foo) do
+    formula "foo" do
+      url "https://brew.sh"
+      version "1.0"
+    end
+  end
+  let(:bar) do
+    formula "bar" do
+      url "https://brew.sh"
+      version "1.0"
+    end
+  end
+  let(:baz) do
+    Cask::CaskLoader::FromContentLoader.new(+<<~RUBY, tap: CoreCaskTap.instance).load(config: nil)
+      cask "baz" do
+        version "1.0"
+      end
+    RUBY
+  end
+  let(:foo_cask) do
+    Cask::CaskLoader::FromContentLoader.new(+<<~RUBY, tap: CoreCaskTap.instance).load(config: nil)
+      cask "foo" do
+        version "1.0"
+      end
+    RUBY
+  end
+
   def setup_unredable_formula(name)
     error = FormulaUnreadableError.new(name, RuntimeError.new("testing"))
     allow(Formulary).to receive(:factory).with(name, any_args).and_raise(error)
@@ -17,50 +45,20 @@ RSpec.describe Homebrew::CLI::NamedArgs do
     allow(Cask::Config).to receive(:from_args).and_return(config)
   end
 
-  let(:foo) do
-    formula "foo" do
-      url "https://brew.sh"
-      version "1.0"
-    end
-  end
-
-  let(:bar) do
-    formula "bar" do
-      url "https://brew.sh"
-      version "1.0"
-    end
-  end
-
-  let(:baz) do
-    Cask::CaskLoader::FromContentLoader.new(+<<~RUBY, tap: CoreCaskTap.instance).load(config: nil)
-      cask "baz" do
-        version "1.0"
-      end
-    RUBY
-  end
-
-  let(:foo_cask) do
-    Cask::CaskLoader::FromContentLoader.new(+<<~RUBY, tap: CoreCaskTap.instance).load(config: nil)
-      cask "foo" do
-        version "1.0"
-      end
-    RUBY
-  end
-
   describe "#to_formulae" do
     it "returns formulae" do
       stub_formula_loader foo, call_original: true
       stub_formula_loader bar
 
-      expect(described_class.new("foo", "bar").to_formulae).to eq [foo, bar]
+      expect(klass.new("foo", "bar").to_formulae).to eq [foo, bar]
     end
 
     it "raises an error when a Formula is unavailable" do
-      expect { described_class.new("mxcl").to_formulae }.to raise_error FormulaUnavailableError
+      expect { klass.new("mxcl").to_formulae }.to raise_error FormulaUnavailableError
     end
 
     it "returns an empty array when there are no Formulae" do
-      expect(described_class.new.to_formulae).to be_empty
+      expect(klass.new.to_formulae).to be_empty
     end
   end
 
@@ -69,7 +67,7 @@ RSpec.describe Homebrew::CLI::NamedArgs do
       stub_formula_loader foo, call_original: true
       stub_cask_loader baz, call_original: true
 
-      expect(described_class.new("foo", "baz").to_formulae_and_casks).to eq [foo, baz]
+      expect(klass.new("foo", "baz").to_formulae_and_casks).to eq [foo, baz]
     end
 
     context "when both formula and cask are present" do
@@ -79,15 +77,15 @@ RSpec.describe Homebrew::CLI::NamedArgs do
       end
 
       it "returns formula by default" do
-        expect(described_class.new("foo").to_formulae_and_casks).to eq [foo]
+        expect(klass.new("foo").to_formulae_and_casks).to eq [foo]
       end
 
       it "returns formula if loading formula only" do
-        expect(described_class.new("foo").to_formulae_and_casks(only: :formula)).to eq [foo]
+        expect(klass.new("foo").to_formulae_and_casks(only: :formula)).to eq [foo]
       end
 
       it "returns cask if loading cask only" do
-        expect(described_class.new("foo").to_formulae_and_casks(only: :cask)).to eq [foo_cask]
+        expect(klass.new("foo").to_formulae_and_casks(only: :cask)).to eq [foo_cask]
       end
     end
 
@@ -105,15 +103,15 @@ RSpec.describe Homebrew::CLI::NamedArgs do
       end
 
       it "returns the cask by default" do
-        expect(described_class.new("foo").to_formulae_and_casks).to eq [foo_cask]
+        expect(klass.new("foo").to_formulae_and_casks).to eq [foo_cask]
       end
 
       it "returns formula if loading formula only" do
-        expect(described_class.new("foo").to_formulae_and_casks(only: :formula)).to eq [non_core_formula]
+        expect(klass.new("foo").to_formulae_and_casks(only: :formula)).to eq [non_core_formula]
       end
 
       it "returns cask if loading cask only" do
-        expect(described_class.new("foo").to_formulae_and_casks(only: :cask)).to eq [foo_cask]
+        expect(klass.new("foo").to_formulae_and_casks(only: :cask)).to eq [foo_cask]
       end
     end
 
@@ -124,50 +122,50 @@ RSpec.describe Homebrew::CLI::NamedArgs do
       end
 
       it "raises an error" do
-        expect { described_class.new("foo").to_formulae_and_casks }.to raise_error(FormulaUnreadableError)
+        expect { klass.new("foo").to_formulae_and_casks }.to raise_error(FormulaUnreadableError)
       end
 
       it "raises an error if loading formula only" do
-        expect { described_class.new("foo").to_formulae_and_casks(only: :formula) }
+        expect { klass.new("foo").to_formulae_and_casks(only: :formula) }
           .to raise_error(FormulaUnreadableError)
       end
 
       it "raises an error if loading cask only" do
-        expect { described_class.new("foo").to_formulae_and_casks(only: :cask) }
+        expect { klass.new("foo").to_formulae_and_casks(only: :cask) }
           .to raise_error(Cask::CaskUnreadableError)
       end
     end
 
     it "raises an error when neither formula nor cask is present" do
-      expect { described_class.new("foo").to_formulae_and_casks }.to raise_error(FormulaOrCaskUnavailableError)
+      expect { klass.new("foo").to_formulae_and_casks }.to raise_error(FormulaOrCaskUnavailableError)
     end
 
     it "returns formula when formula is present and cask is unreadable", :needs_macos do
       stub_formula_loader foo
       setup_unredable_cask "foo"
 
-      expect(described_class.new("foo").to_formulae_and_casks).to eq [foo]
-      expect { described_class.new("foo").to_formulae_and_casks }.to output(/Failed to load cask: foo/).to_stderr
+      expect(klass.new("foo").to_formulae_and_casks).to eq [foo]
+      expect { klass.new("foo").to_formulae_and_casks }.to output(/Failed to load cask: foo/).to_stderr
     end
 
     it "returns cask when formula is unreadable and cask is present", :needs_macos do
       setup_unredable_formula "foo"
       stub_cask_loader foo_cask
 
-      expect(described_class.new("foo").to_formulae_and_casks).to eq [foo_cask]
-      expect { described_class.new("foo").to_formulae_and_casks }.to output(/Failed to load formula: foo/).to_stderr
+      expect(klass.new("foo").to_formulae_and_casks).to eq [foo_cask]
+      expect { klass.new("foo").to_formulae_and_casks }.to output(/Failed to load formula: foo/).to_stderr
     end
 
     it "raises an error when formula is absent and cask is unreadable", :needs_macos do
       setup_unredable_cask "foo"
 
-      expect { described_class.new("foo").to_formulae_and_casks }.to raise_error(Cask::CaskUnreadableError)
+      expect { klass.new("foo").to_formulae_and_casks }.to raise_error(Cask::CaskUnreadableError)
     end
 
     it "raises an error when formula is unreadable and cask is absent" do
       setup_unredable_formula "foo"
 
-      expect { described_class.new("foo").to_formulae_and_casks }.to raise_error(FormulaUnreadableError)
+      expect { klass.new("foo").to_formulae_and_casks }.to raise_error(FormulaUnreadableError)
     end
   end
 
@@ -175,7 +173,7 @@ RSpec.describe Homebrew::CLI::NamedArgs do
     it "returns resolved formulae" do
       allow(Formulary).to receive(:resolve).and_return(foo, bar)
 
-      expect(described_class.new("foo", "bar").to_resolved_formulae).to eq [foo, bar]
+      expect(klass.new("foo", "bar").to_resolved_formulae).to eq [foo, bar]
     end
   end
 
@@ -185,7 +183,7 @@ RSpec.describe Homebrew::CLI::NamedArgs do
       allow(Formulary).to receive(:resolve).with("foo", any_args).and_return foo
       stub_cask_loader baz, call_original: true
 
-      resolved_formulae, casks = described_class.new("foo", "baz").to_resolved_formulae_to_casks
+      resolved_formulae, casks = klass.new("foo", "baz").to_resolved_formulae_to_casks
 
       expect(resolved_formulae).to eq [foo]
       expect(casks).to eq [baz]
@@ -196,7 +194,7 @@ RSpec.describe Homebrew::CLI::NamedArgs do
     it "returns casks" do
       stub_cask_loader baz
 
-      expect(described_class.new("baz").to_casks).to eq [baz]
+      expect(klass.new("baz").to_casks).to eq [baz]
     end
   end
 
@@ -208,16 +206,16 @@ RSpec.describe Homebrew::CLI::NamedArgs do
     end
 
     it "resolves kegs with #resolve_kegs" do
-      expect(described_class.new("foo", "bar").to_kegs.map(&:name)).to eq ["foo", "foo", "bar"]
+      expect(klass.new("foo", "bar").to_kegs.map(&:name)).to eq ["foo", "foo", "bar"]
     end
 
     specify do
-      expect(described_class.new("foo").to_kegs.map { |k| k.version.version.to_s }.sort).to eq ["1.0", "2.0"]
-      expect(described_class.new.to_kegs).to be_empty
+      expect(klass.new("foo").to_kegs.map { |k| k.version.version.to_s }.sort).to eq ["1.0", "2.0"]
+      expect(klass.new.to_kegs).to be_empty
     end
 
     it "raises an error when a Keg is unavailable" do
-      expect { described_class.new("baz").to_kegs }.to raise_error NoSuchKegError
+      expect { klass.new("baz").to_kegs }.to raise_error NoSuchKegError
     end
 
     context "when a keg specifies a tap" do
@@ -230,19 +228,19 @@ RSpec.describe Homebrew::CLI::NamedArgs do
       it "returns kegs if no tap is specified" do
         stub_formula_loader bar, "user/repo/bar"
 
-        expect(described_class.new("bar").to_kegs.map(&:name)).to eq ["bar"]
+        expect(klass.new("bar").to_kegs.map(&:name)).to eq ["bar"]
       end
 
       it "returns kegs if the tap is specified" do
         stub_formula_loader bar, "user/repo/bar"
 
-        expect(described_class.new("user/repo/bar").to_kegs.map(&:name)).to eq ["bar"]
+        expect(klass.new("user/repo/bar").to_kegs.map(&:name)).to eq ["bar"]
       end
 
       it "raises an error if there is no tap match" do
         stub_formula_loader bar, "other/tap/bar"
 
-        expect { described_class.new("other/tap/bar").to_kegs }.to raise_error(NoSuchKegError, %r{from tap other/tap})
+        expect { klass.new("other/tap/bar").to_kegs }.to raise_error(NoSuchKegError, %r{from tap other/tap})
       end
     end
   end
@@ -257,15 +255,15 @@ RSpec.describe Homebrew::CLI::NamedArgs do
     end
 
     it "resolves kegs with #resolve_default_keg" do
-      expect(described_class.new("foo", "bar").to_default_kegs.map(&:name)).to eq ["foo", "bar"]
+      expect(klass.new("foo", "bar").to_default_kegs.map(&:name)).to eq ["foo", "bar"]
     end
 
     it "resolves the default keg" do
-      expect(described_class.new("foo").to_default_kegs.map { |k| k.version.version.to_s }).to eq ["2.0"]
+      expect(klass.new("foo").to_default_kegs.map { |k| k.version.version.to_s }).to eq ["2.0"]
     end
 
     it "when there are no matching kegs returns an empty array" do
-      expect(described_class.new.to_default_kegs).to be_empty
+      expect(klass.new.to_default_kegs).to be_empty
     end
   end
 
@@ -281,13 +279,13 @@ RSpec.describe Homebrew::CLI::NamedArgs do
     end
 
     it "resolves the latest kegs with #resolve_latest_keg" do
-      latest_kegs = described_class.new("foo", "bar", "baz").to_latest_kegs
+      latest_kegs = klass.new("foo", "bar", "baz").to_latest_kegs
       expect(latest_kegs.map(&:name)).to eq ["foo", "bar", "baz"]
       expect(latest_kegs.map { |k| k.version.version.to_s }).to eq ["2.0", "1.0", "HEAD-2"]
     end
 
     it "when there are no matching kegs returns an empty array" do
-      expect(described_class.new.to_latest_kegs).to be_empty
+      expect(klass.new.to_latest_kegs).to be_empty
     end
   end
 
@@ -299,7 +297,7 @@ RSpec.describe Homebrew::CLI::NamedArgs do
     it "returns kegs, as well as casks", :needs_macos do
       stub_cask_loader baz, call_original: true
 
-      kegs, casks = described_class.new("foo", "baz").to_kegs_to_casks
+      kegs, casks = klass.new("foo", "baz").to_kegs_to_casks
 
       expect(kegs.map(&:name)).to eq ["foo"]
       expect(casks).to eq [baz]
@@ -308,9 +306,9 @@ RSpec.describe Homebrew::CLI::NamedArgs do
 
   describe "#homebrew_tap_cask_names" do
     specify do
-      expect(described_class.new("foo", "homebrew/cask/local-caffeine").homebrew_tap_cask_names)
+      expect(klass.new("foo", "homebrew/cask/local-caffeine").homebrew_tap_cask_names)
         .to eq ["homebrew/cask/local-caffeine"]
-      expect(described_class.new("foo").homebrew_tap_cask_names).to be_empty
+      expect(klass.new("foo").homebrew_tap_cask_names).to be_empty
     end
   end
 
@@ -331,7 +329,7 @@ RSpec.describe Homebrew::CLI::NamedArgs do
       expect(Formulary).to receive(:path).with("foo").and_return(formula_path)
       expect(Cask::CaskLoader).to receive(:path).with("baz").and_return(cask_path)
 
-      expect(described_class.new("homebrew/core", "foo", "baz", existing_path.to_s).to_paths)
+      expect(klass.new("homebrew/core", "foo", "baz", existing_path.to_s).to_paths)
         .to eq [Tap.fetch("homebrew/core").path, formula_path, cask_path, existing_path]
     end
 
@@ -339,19 +337,19 @@ RSpec.describe Homebrew::CLI::NamedArgs do
       expect(Formulary).to receive(:path).with("foo").and_return(formula_path)
       expect(Cask::CaskLoader).to receive(:path).with("baz").and_return(cask_path)
 
-      expect(described_class.new("foo", "baz").to_paths).to eq [formula_path, cask_path]
+      expect(klass.new("foo", "baz").to_paths).to eq [formula_path, cask_path]
     end
 
     it "returns only formulae when `only: :formula` is specified" do
       expect(Formulary).to receive(:path).with("foo").and_return(formula_path)
 
-      expect(described_class.new("foo", "baz").to_paths(only: :formula)).to eq [formula_path, Formulary.path("baz")]
+      expect(klass.new("foo", "baz").to_paths(only: :formula)).to eq [formula_path, Formulary.path("baz")]
     end
 
     it "returns only casks when `only: :cask` is specified" do
       expect(Cask::CaskLoader).to receive(:path).with("foo").and_return(cask_path)
 
-      expect(described_class.new("foo", "baz").to_paths(only: :cask)).to eq [cask_path, Cask::CaskLoader.path("baz")]
+      expect(klass.new("foo", "baz").to_paths(only: :cask)).to eq [cask_path, Cask::CaskLoader.path("baz")]
     end
 
     context "when without_api: true" do
@@ -362,7 +360,7 @@ RSpec.describe Homebrew::CLI::NamedArgs do
         allow(Homebrew::API).to receive(:formula_names).and_return(["foo"])
         allow(Homebrew::API::Formula).to receive(:all_formulae).and_return("foo" => {})
 
-        named_args = described_class.new("foo", without_api: true)
+        named_args = klass.new("foo", without_api: true)
         paths = named_args.to_paths
 
         # to_paths returns a bare expanded path (not the core formula path) because
@@ -376,12 +374,12 @@ RSpec.describe Homebrew::CLI::NamedArgs do
 
   describe "#to_taps" do
     it "returns taps" do
-      taps = described_class.new("homebrew/foo", "bar/baz")
+      taps = klass.new("homebrew/foo", "bar/baz")
       expect(taps.to_taps.map(&:name)).to eq %w[homebrew/foo bar/baz]
     end
 
     it "raises an error for invalid tap" do
-      taps = described_class.new("homebrew/foo", "barbaz")
+      taps = klass.new("homebrew/foo", "barbaz")
       expect { taps.to_taps }.to raise_error(Tap::InvalidNameError, /Invalid tap name/)
     end
   end
@@ -392,17 +390,17 @@ RSpec.describe Homebrew::CLI::NamedArgs do
     end
 
     it "returns installed taps" do
-      taps = described_class.new("homebrew/foo")
+      taps = klass.new("homebrew/foo")
       expect(taps.to_installed_taps.map(&:name)).to eq %w[homebrew/foo]
     end
 
     it "raises an error for uninstalled tap" do
-      taps = described_class.new("homebrew/foo", "bar/baz")
+      taps = klass.new("homebrew/foo", "bar/baz")
       expect { taps.to_installed_taps }.to raise_error(TapUnavailableError)
     end
 
     it "raises an error for invalid tap" do
-      taps = described_class.new("homebrew/foo", "barbaz")
+      taps = klass.new("homebrew/foo", "barbaz")
       expect { taps.to_installed_taps }.to raise_error(Tap::InvalidNameError, /Invalid tap name/)
     end
   end

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -4,11 +4,13 @@
 require_relative "../../cli/parser"
 
 RSpec.describe Homebrew::CLI::Parser do
+  let(:klass) { Homebrew::CLI::Parser }
+
   before { stub_const("Cmd", Class.new(Homebrew::AbstractCommand)) }
 
   describe "test switch options" do
     subject(:parser) do
-      described_class.new(Cmd) do
+      klass.new(Cmd) do
         switch "--more-verbose", description: "Flag for higher verbosity"
         switch "--pry", env: :pry
         switch "--foo", env: :foo
@@ -26,7 +28,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
     context "when using binary options" do
       subject(:parser) do
-        described_class.new(Cmd) do
+        klass.new(Cmd) do
           switch "--[no-]positive"
         end
       end
@@ -54,7 +56,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
     context "when using negative options" do
       subject(:parser) do
-        described_class.new(Cmd) do
+        klass.new(Cmd) do
           switch "--no-positive"
         end
       end
@@ -126,7 +128,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
   describe "test long flag options" do
     subject(:parser) do
-      described_class.new(Cmd) do
+      klass.new(Cmd) do
         flag        "--filename=", description: "Name of the file"
         comma_array "--files",     description: "Comma-separated filenames"
         flag        "--hidden=",      hidden: true
@@ -157,7 +159,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
   describe "test short flag options" do
     subject(:parser) do
-      described_class.new(Cmd) do
+      klass.new(Cmd) do
         flag "-f", "--filename=", description: "Name of the file"
       end
     end
@@ -171,7 +173,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
   describe "test constraints for flag options" do
     subject(:parser) do
-      described_class.new(Cmd) do
+      klass.new(Cmd) do
         flag      "--flag1="
         flag      "--flag2=", depends_on: "--flag1="
         flag      "--flag3="
@@ -202,7 +204,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
   describe "test invalid constraints" do
     subject(:parser) do
-      described_class.new(Cmd) do
+      klass.new(Cmd) do
         flag      "--flag1="
         flag      "--flag2=", depends_on: "--flag1="
 
@@ -217,7 +219,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
   describe "test constraints for switch options" do
     subject(:parser) do
-      described_class.new(Cmd) do
+      klass.new(Cmd) do
         switch      "-a", "--switch-a", env: "switch_a"
         switch      "-b", "--switch-b", env: "switch_b"
         switch      "--switch-c", depends_on: "--switch-a"
@@ -264,7 +266,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
   describe "test immutability of args" do
     subject(:parser) do
-      described_class.new(Cmd) do
+      klass.new(Cmd) do
         switch "-a", "--switch-a"
         switch "-b", "--switch-b"
       end
@@ -278,7 +280,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
   describe "test inferrability of args" do
     subject(:parser) do
-      described_class.new(Cmd) do
+      klass.new(Cmd) do
         switch "--switch-a"
         switch "--switch-b"
         switch "--foo-switch"
@@ -314,7 +316,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
   describe "test argv extensions" do
     subject(:parser) do
-      described_class.new(Cmd) do
+      klass.new(Cmd) do
         switch "--foo"
         flag   "--bar"
         switch "-s"
@@ -344,7 +346,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
   describe "usage banner generation" do
     it "includes `[options]` if more than two non-global options are available" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         switch "--foo"
         switch "--baz"
         switch "--bar"
@@ -353,7 +355,7 @@ RSpec.describe Homebrew::CLI::Parser do
     end
 
     it "includes individual options if less than two non-global options are available" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         switch "--foo"
         switch "--bar"
       end
@@ -361,7 +363,7 @@ RSpec.describe Homebrew::CLI::Parser do
     end
 
     it "formats flags correctly when less than two non-global options are available" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         flag "--foo"
         flag "--bar="
       end
@@ -369,26 +371,26 @@ RSpec.describe Homebrew::CLI::Parser do
     end
 
     it "formats comma arrays correctly when less than two non-global options are available" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         comma_array "--foo"
       end
       expect(parser.generate_help_text).to match(/\[--foo=\]/)
     end
 
     it "does not include hidden options" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         switch "--foo", hidden: true
       end
       expect(parser.generate_help_text).not_to match(/\[--foo\]/)
     end
 
     it "doesn't include `[options]` if non non-global options are available" do
-      parser = described_class.new(Cmd)
+      parser = klass.new(Cmd)
       expect(parser.generate_help_text).not_to match(/\[options\]/)
     end
 
     it "includes a description" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         description <<~EOS
           This command does something
         EOS
@@ -397,14 +399,14 @@ RSpec.describe Homebrew::CLI::Parser do
     end
 
     it "allows the usage banner to be overridden" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         usage_banner "`test` [foo] <bar>"
       end
       expect(parser.generate_help_text).to match(/test \[foo\] bar/)
     end
 
     it "allows a usage banner and a description to be overridden" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         usage_banner "`test` [foo] <bar>"
         description <<~EOS
           This command does something
@@ -415,42 +417,42 @@ RSpec.describe Homebrew::CLI::Parser do
     end
 
     it "shows the correct usage for no named argument" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         named_args :none
       end
       expect(parser.generate_help_text).to match(/^Usage: [^\[]+$/s)
     end
 
     it "shows the correct usage for a single typed argument" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         named_args :formula, number: 1
       end
       expect(parser.generate_help_text).to match(/^Usage: .* formula$/s)
     end
 
     it "shows the correct usage for a subcommand argument with a maximum" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         named_args %w[off on], max: 1
       end
       expect(parser.generate_help_text).to match(/^Usage: .* \[subcommand\]$/s)
     end
 
     it "shows the correct usage for multiple typed argument with no maximum or minimum" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         named_args [:tap, :command]
       end
       expect(parser.generate_help_text).to match(/^Usage: .* \[tap|command ...\]$/s)
     end
 
     it "shows the correct usage for a subcommand argument with a minimum of 1" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         named_args :installed_formula, min: 1
       end
       expect(parser.generate_help_text).to match(/^Usage: .* installed_formula \[...\]$/s)
     end
 
     it "shows the correct usage for a subcommand argument with a minimum greater than 1" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         named_args :installed_formula, min: 2
       end
       expect(parser.generate_help_text).to match(/^Usage: .* installed_formula ...$/s)
@@ -459,19 +461,19 @@ RSpec.describe Homebrew::CLI::Parser do
 
   describe "named_args" do
     let(:parser_none) do
-      described_class.new(Cmd) do
+      klass.new(Cmd) do
         named_args :none
       end
     end
     let(:parser_number) do
-      described_class.new(Cmd) do
+      klass.new(Cmd) do
         named_args number: 1
       end
     end
 
     it "doesn't allow :none passed with a number" do
       expect do
-        described_class.new(Cmd) do
+        klass.new(Cmd) do
           named_args :none, number: 1
         end
       end.to raise_error(ArgumentError, /Do not specify both `number`, `min` or `max` with `named_args :none`/)
@@ -479,7 +481,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
     it "doesn't allow number and min" do
       expect do
-        described_class.new(Cmd) do
+        klass.new(Cmd) do
           named_args number: 1, min: 1
         end
       end.to raise_error(ArgumentError, /Do not specify both `number` and `min` or `max`/)
@@ -507,7 +509,7 @@ RSpec.describe Homebrew::CLI::Parser do
     end
 
     it "displays the correct error message with no arg types and min" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         named_args min: 2
       end
       expect { parser.parse([]) }.to raise_error(
@@ -516,7 +518,7 @@ RSpec.describe Homebrew::CLI::Parser do
     end
 
     it "displays the correct error message with no arg types and number" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         named_args number: 2
       end
       expect { parser.parse([]) }.to raise_error(
@@ -525,7 +527,7 @@ RSpec.describe Homebrew::CLI::Parser do
     end
 
     it "displays the correct error message with no arg types and max" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         named_args max: 1
       end
       expect { parser.parse(%w[foo bar]) }.to raise_error(
@@ -534,7 +536,7 @@ RSpec.describe Homebrew::CLI::Parser do
     end
 
     it "displays the correct error message with an array of strings" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         named_args %w[on off], number: 1
       end
       expect { parser.parse([]) }.to raise_error(
@@ -543,7 +545,7 @@ RSpec.describe Homebrew::CLI::Parser do
     end
 
     it "displays the correct error message with an array of symbols" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         named_args [:formula, :cask], min: 1
       end
       expect { parser.parse([]) }.to raise_error(
@@ -552,7 +554,7 @@ RSpec.describe Homebrew::CLI::Parser do
     end
 
     it "displays the correct error message with an array of symbols and max" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         named_args [:formula, :cask], max: 1
       end
       expect { parser.parse(%w[foo bar]) }.to raise_error(
@@ -561,14 +563,14 @@ RSpec.describe Homebrew::CLI::Parser do
     end
 
     it "accepts commands with :command" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         named_args :command
       end
       expect { parser.parse(["--prefix", "--version"]) }.not_to raise_error
     end
 
     it "doesn't accept invalid options with :command" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         named_args :command
       end
       expect { parser.parse(["--not-a-command"]) }.to raise_error(OptionParser::InvalidOption, /--not-a-command/)
@@ -577,7 +579,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
   describe "subcommands" do
     def subcommand_parser
-      described_class.new(Cmd) do
+      klass.new(Cmd) do
         usage_banner "`test` [<subcommand>]"
         description "Test command."
         switch "--global"
@@ -666,7 +668,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
     it "rejects multiple positional names when defining a subcommand" do
       expect do
-        described_class.new(Cmd) do
+        klass.new(Cmd) do
           subcommand "install", "upgrade"
         end
       end.to raise_error(ArgumentError, /wrong number of arguments/)
@@ -691,7 +693,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
     it "applies option constraints only for the matching subcommand", :aggregate_failures do
       parser = lambda do
-        described_class.new(Cmd) do
+        klass.new(Cmd) do
           subcommand "install", default: true do
             switch "--cleanup"
             switch "--zap", depends_on: "--cleanup"
@@ -719,7 +721,7 @@ RSpec.describe Homebrew::CLI::Parser do
     end
 
     it "applies implied options from subcommand aliases", :aggregate_failures do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         subcommand "install", alias_options: { "upgrade" => "--upgrade" } do
           switch "--upgrade"
           switch "--force"
@@ -751,7 +753,7 @@ RSpec.describe Homebrew::CLI::Parser do
   describe "--cask on linux", :needs_linux do
     context "without --formula switch" do
       subject(:parser) do
-        described_class.new(Cmd) do
+        klass.new(Cmd) do
           switch "--cask"
         end
       end
@@ -767,7 +769,7 @@ RSpec.describe Homebrew::CLI::Parser do
 
     context "with conflicting --formula switch" do
       subject(:parser) do
-        described_class.new(Cmd) do
+        klass.new(Cmd) do
           switch "--cask"
           switch "--formula"
           conflicts "--cask", "--formula"
@@ -783,13 +785,13 @@ RSpec.describe Homebrew::CLI::Parser do
 
   describe "--formula on linux", :needs_linux do
     it "doesn't set --formula when not defined" do
-      parser = described_class.new(Cmd)
+      parser = klass.new(Cmd)
       args = parser.parse([])
       expect(args.respond_to?(:formula?)).to be(false)
     end
 
     it "doesn't set --formula when defined" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         switch "--formula"
       end
       args = parser.parse([])
@@ -797,7 +799,7 @@ RSpec.describe Homebrew::CLI::Parser do
     end
 
     it "does not set --formula to true when --cask" do
-      parser = described_class.new(Cmd) do
+      parser = klass.new(Cmd) do
         switch "--cask"
       end
       args = parser.parse([])

--- a/Library/Homebrew/test/cmd/analytics_spec.rb
+++ b/Library/Homebrew/test/cmd/analytics_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Homebrew::Cmd::Analytics do
   it_behaves_like "parseable arguments"
 
   it "uses state as the default subcommand" do
-    expect(described_class.new([]).args.subcommand).to eq("state")
+    expect(Homebrew::Cmd::Analytics.new([]).args.subcommand).to eq("state")
   end
 
   it "rejects extra arguments for state" do
-    expect { described_class.new(%w[state foo]) }
+    expect { Homebrew::Cmd::Analytics.new(%w[state foo]) }
       .to raise_error(Homebrew::CLI::MaxNamedArgumentsError)
   end
 

--- a/Library/Homebrew/test/cmd/bundle/add_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/add_subcommand_spec.rb
@@ -7,18 +7,19 @@ require "cask/cask_loader"
 
 RSpec.describe Homebrew::Cmd::Bundle::AddSubcommand do
   subject(:add) do
-    described_class.new(args_object, context:).run
+    klass.new(args_object, context:).run
   end
 
-  before { FileUtils.touch file }
-  after { FileUtils.rm_f file }
-
+  let(:klass) { Homebrew::Cmd::Bundle::AddSubcommand }
   let(:global) { false }
   let(:context) { bundle_subcommand_context(:add, global:, file:, no_type_args: false) }
   let(:args_object) do
     args_for_subcommand(:add, *args, formulae?: type == :brew, casks?: type == :cask, taps?: type == :tap,
                                       describe?: false)
   end
+
+  before { FileUtils.touch file }
+  after { FileUtils.rm_f file }
 
   context "when called with a valid formula" do
     let(:args) { ["hello"] }

--- a/Library/Homebrew/test/cmd/bundle/check_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/check_subcommand_spec.rb
@@ -7,8 +7,10 @@ require "bundle/dsl"
 require "bundle/skipper"
 
 RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
+  let(:klass) { Homebrew::Cmd::Bundle::CheckSubcommand }
+
   let(:do_check) do
-    described_class.new(args_for_subcommand(:check), context:).run
+    klass.new(args_for_subcommand(:check), context:).run
   end
   let(:context) { bundle_subcommand_context(:check, no_upgrade:, verbose:) }
   let(:no_upgrade) { false }

--- a/Library/Homebrew/test/cmd/bundle/cleanup_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/cleanup_subcommand_spec.rb
@@ -6,9 +6,11 @@ require "bundle/subcommand/cleanup"
 require "utils"
 
 RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
+  let(:klass) { Homebrew::Cmd::Bundle::CleanupSubcommand }
+
   describe "read Brewfile and current installation", :no_api do
     before do
-      described_class.reset!
+      klass.reset!
 
       # don't try to load gcc/glibc
       allow(DevelopmentTools).to receive_messages(needs_libc_formula?: false, needs_compiler_formula?: false)
@@ -30,7 +32,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
         mas 'appstoreapp1', id: 1
         vscode 'VsCodeExtension1'
       EOS
-      described_class.read_dsl_from_brewfile!
+      klass.read_dsl_from_brewfile!
       %w[a b d2 homebrew/tap/f homebrew/tap/g homebrew/tap/h homebrew/tap/i2
          homebrew/tap/hasdependency hasbuilddependency1 hasbuilddependency2].each do |full_name|
         tap_name = Utils.tap_from_full_name(full_name)
@@ -45,7 +47,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
       cask_123 = instance_double(Cask::Cask, to_s: "123", old_tokens: [])
       cask_456 = instance_double(Cask::Cask, to_s: "456", old_tokens: [])
       allow(Homebrew::Bundle::Cask).to receive(:casks).and_return([cask_123, cask_456])
-      expect(described_class.casks_to_uninstall).to eql(%w[456])
+      expect(klass.casks_to_uninstall).to eql(%w[456])
     end
 
     it "computes which formulae to uninstall" do
@@ -88,7 +90,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
       end
 
       allow(Homebrew::Bundle::Cask).to receive(:formula_dependencies).and_return(%w[caskdependency])
-      expect(described_class.formulae_to_uninstall).to eql %w[
+      expect(klass.formulae_to_uninstall).to eql %w[
         c
         homebrew/tap/e
         other/tap/h
@@ -99,14 +101,14 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
     it "computes which tap to untap" do
       allow(Homebrew::Bundle::Tap).to \
         receive(:tap_names).and_return(%w[z homebrew/core homebrew/tap])
-      expect(described_class.taps_to_untap).to eql(%w[z])
+      expect(klass.taps_to_untap).to eql(%w[z])
     end
 
     it "keeps taps referenced by fully qualified formulae" do
       allow_any_instance_of(Pathname).to receive(:read).and_return <<~EOS
         brew "homebrew/tap/foo"
       EOS
-      described_class.read_dsl_from_brewfile!
+      klass.read_dsl_from_brewfile!
 
       allow(Homebrew::Bundle::Brew).to receive(:formulae).and_return([
         { name: "foo", full_name: "homebrew/tap/foo", dependencies: [], build_dependencies: [] },
@@ -115,15 +117,15 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
       allow(Homebrew::Bundle::Tap).to \
         receive(:tap_names).and_return(%w[homebrew/core homebrew/tap])
 
-      expect(described_class.formulae_to_uninstall).to be_empty
-      expect(described_class.taps_to_untap).to be_empty
+      expect(klass.formulae_to_uninstall).to be_empty
+      expect(klass.taps_to_untap).to be_empty
     end
 
     it "keeps taps referenced by fully qualified casks" do
       allow_any_instance_of(Pathname).to receive(:read).and_return <<~EOS
         cask "homebrew/tap/foo"
       EOS
-      described_class.read_dsl_from_brewfile!
+      klass.read_dsl_from_brewfile!
 
       allow(Homebrew::Bundle::Cask).to receive(:casks).and_return([
         instance_double(Cask::Cask, to_s: "foo", old_tokens: [], depends_on: {}),
@@ -132,21 +134,21 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
       allow(Homebrew::Bundle::Tap).to \
         receive(:tap_names).and_return(%w[homebrew/core homebrew/tap])
 
-      expect(described_class.casks_to_uninstall).to be_empty
-      expect(described_class.taps_to_untap).to be_empty
+      expect(klass.casks_to_uninstall).to be_empty
+      expect(klass.taps_to_untap).to be_empty
     end
 
     it "ignores unavailable formulae when computing which taps to keep" do
       allow_any_instance_of(Pathname).to receive(:read).and_return <<~EOS
         brew "foo"
       EOS
-      described_class.read_dsl_from_brewfile!
+      klass.read_dsl_from_brewfile!
 
       allow(Formulary).to \
         receive(:factory).and_raise(TapFormulaUnavailableError.new(Tap.fetch("homebrew/tap"), "foo"))
       allow(Homebrew::Bundle::Tap).to \
         receive(:tap_names).and_return(%w[z homebrew/core homebrew/tap])
-      expect(described_class.taps_to_untap).to eql(%w[z homebrew/tap])
+      expect(klass.taps_to_untap).to eql(%w[z homebrew/tap])
     end
 
     it "ignores formulae with .keepme references when computing which formulae to uninstall" do
@@ -159,99 +161,99 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
       allow(keg).to receive(:keepme_refs).and_return(["/some/file"])
       allow(f).to receive(:installed_kegs).and_return([keg])
 
-      expect(described_class.formulae_to_uninstall).to be_empty
+      expect(klass.formulae_to_uninstall).to be_empty
     end
 
     it "computes which VSCode extensions to uninstall" do
       allow(Homebrew::Bundle::VscodeExtension).to receive(:extensions).and_return(%w[z])
-      expect(Homebrew::Bundle::VscodeExtension.cleanup_items(described_class.dsl.entries)).to eql(%w[z])
+      expect(Homebrew::Bundle::VscodeExtension.cleanup_items(klass.dsl.entries)).to eql(%w[z])
     end
 
     it "computes which VSCode extensions to uninstall irrespective of case of the extension name" do
       allow(Homebrew::Bundle::VscodeExtension).to receive(:extensions).and_return(%w[z vscodeextension1])
-      expect(Homebrew::Bundle::VscodeExtension.cleanup_items(described_class.dsl.entries)).to eql(%w[z])
+      expect(Homebrew::Bundle::VscodeExtension.cleanup_items(klass.dsl.entries)).to eql(%w[z])
     end
 
     it "computes which flatpaks to uninstall", :needs_linux do
       allow_any_instance_of(Pathname).to receive(:read).and_return <<~EOS
         flatpak 'org.gnome.Calculator'
       EOS
-      described_class.read_dsl_from_brewfile!
+      klass.read_dsl_from_brewfile!
       allow(Homebrew::Bundle::Flatpak).to receive_messages(
         package_manager_installed?: true,
         packages:                   %w[org.gnome.Calculator org.mozilla.firefox],
       )
-      expect(Homebrew::Bundle::Flatpak.cleanup_items(described_class.dsl.entries)).to eql(%w[org.mozilla.firefox])
+      expect(Homebrew::Bundle::Flatpak.cleanup_items(klass.dsl.entries)).to eql(%w[org.mozilla.firefox])
     end
   end
 
   context "when there are no formulae to uninstall and no taps to untap" do
     before do
-      described_class.reset!
+      klass.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(described_class).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: [], taps_to_untap: [])
+      allow(klass).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: [], taps_to_untap: [])
       allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
       allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
     end
 
     it "does nothing" do
       expect(Kernel).not_to receive(:system)
-      expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      described_class.cleanup(force: true)
+      expect(klass).to receive(:system_output_no_stderr).and_return("")
+      klass.cleanup(force: true)
     end
   end
 
   context "when there are casks to uninstall" do
     before do
-      described_class.reset!
+      klass.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(described_class).to receive_messages(casks_to_uninstall: %w[a b], formulae_to_uninstall: [],
-                                                 taps_to_untap: [])
+      allow(klass).to receive_messages(casks_to_uninstall: %w[a b], formulae_to_uninstall: [],
+                                       taps_to_untap: [])
       allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
       allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
     end
 
     it "uninstalls casks" do
       expect(Kernel).to receive(:system).with(HOMEBREW_BREW_FILE, "uninstall", "--cask", "--force", "a", "b")
-      expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      expect { described_class.cleanup(force: true) }.to output(/Uninstalled 2 casks/).to_stdout
+      expect(klass).to receive(:system_output_no_stderr).and_return("")
+      expect { klass.cleanup(force: true) }.to output(/Uninstalled 2 casks/).to_stdout
     end
 
     it "does not uninstall casks if --formulae is disabled" do
       expect(Kernel).not_to receive(:system)
-      expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      expect { described_class.cleanup(force: true, casks: false) }.not_to output.to_stdout
+      expect(klass).to receive(:system_output_no_stderr).and_return("")
+      expect { klass.cleanup(force: true, casks: false) }.not_to output.to_stdout
     end
   end
 
   context "when there are casks to zap" do
     before do
-      described_class.reset!
+      klass.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(described_class).to receive_messages(casks_to_uninstall: %w[a b], formulae_to_uninstall: [],
-                                                 taps_to_untap: [])
+      allow(klass).to receive_messages(casks_to_uninstall: %w[a b], formulae_to_uninstall: [],
+                                       taps_to_untap: [])
       allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
       allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
     end
 
     it "uninstalls casks" do
       expect(Kernel).to receive(:system).with(HOMEBREW_BREW_FILE, "uninstall", "--cask", "--zap", "--force", "a", "b")
-      expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      expect { described_class.cleanup(force: true, zap: true) }.to output(/Uninstalled 2 casks/).to_stdout
+      expect(klass).to receive(:system_output_no_stderr).and_return("")
+      expect { klass.cleanup(force: true, zap: true) }.to output(/Uninstalled 2 casks/).to_stdout
     end
 
     it "does not uninstall casks if --casks is disabled" do
       expect(Kernel).not_to receive(:system)
-      expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      expect { described_class.cleanup(force: true, zap: true, casks: false) }.not_to output.to_stdout
+      expect(klass).to receive(:system_output_no_stderr).and_return("")
+      expect { klass.cleanup(force: true, zap: true, casks: false) }.not_to output.to_stdout
     end
   end
 
   context "when there are formulae to uninstall" do
     before do
-      described_class.reset!
-      allow(described_class).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: %w[a b],
-                                                 taps_to_untap: [])
+      klass.reset!
+      allow(klass).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: %w[a b],
+                                       taps_to_untap: [])
       allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
       allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
       allow(Homebrew::Bundle).to receive(:mark_as_installed_on_request!)
@@ -260,45 +262,45 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
 
     it "uninstalls formulae" do
       expect(Kernel).to receive(:system).with(HOMEBREW_BREW_FILE, "uninstall", "--formula", "--force", "a", "b")
-      expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      expect { described_class.cleanup(force: true) }.to output(/Uninstalled 2 formulae/).to_stdout
+      expect(klass).to receive(:system_output_no_stderr).and_return("")
+      expect { klass.cleanup(force: true) }.to output(/Uninstalled 2 formulae/).to_stdout
     end
 
     it "does not uninstall formulae if --casks is disabled" do
       expect(Kernel).not_to receive(:system)
-      expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      expect { described_class.cleanup(force: true, formulae: false) }.not_to output.to_stdout
+      expect(klass).to receive(:system_output_no_stderr).and_return("")
+      expect { klass.cleanup(force: true, formulae: false) }.not_to output.to_stdout
     end
   end
 
   context "when there are taps to untap" do
     before do
-      described_class.reset!
+      klass.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(described_class).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: [],
-                                                 taps_to_untap: %w[a b])
+      allow(klass).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: [],
+                                       taps_to_untap: %w[a b])
       allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
       allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
     end
 
     it "untaps taps" do
       expect(Kernel).to receive(:system).with(HOMEBREW_BREW_FILE, "untap", "a", "b")
-      expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      described_class.cleanup(force: true)
+      expect(klass).to receive(:system_output_no_stderr).and_return("")
+      klass.cleanup(force: true)
     end
 
     it "does not untap taps if --taps is disabled" do
       expect(Kernel).not_to receive(:system)
-      expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      described_class.cleanup(force: true, taps: false)
+      expect(klass).to receive(:system_output_no_stderr).and_return("")
+      klass.cleanup(force: true, taps: false)
     end
   end
 
   context "when there are VSCode extensions to uninstall" do
     before do
-      described_class.reset!
+      klass.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(described_class).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: [], taps_to_untap: [])
+      allow(klass).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: [], taps_to_untap: [])
       allow(Homebrew::Bundle::VscodeExtension).to receive_messages(package_manager_executable: Pathname("code"),
                                                                    cleanup_items:              %w[GitHub.codespaces])
       allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
@@ -306,46 +308,46 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
 
     it "uninstalls extensions" do
       expect(Kernel).to receive(:system).with("code", "--uninstall-extension", "GitHub.codespaces")
-      expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      described_class.cleanup(force: true)
+      expect(klass).to receive(:system_output_no_stderr).and_return("")
+      klass.cleanup(force: true)
     end
 
     it "does not uninstall extensions if --vscode is disabled" do
       expect(Kernel).not_to receive(:system)
-      expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      described_class.cleanup(force: true, extension_types: { vscode: false })
+      expect(klass).to receive(:system_output_no_stderr).and_return("")
+      klass.cleanup(force: true, extension_types: { vscode: false })
     end
   end
 
   context "when there are flatpaks to uninstall", :needs_linux do
     before do
-      described_class.reset!
+      klass.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(described_class).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: [], taps_to_untap: [])
+      allow(klass).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: [], taps_to_untap: [])
       allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
       allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return(%w[org.gnome.Calculator])
     end
 
     it "uninstalls flatpaks" do
       expect(Kernel).to receive(:system).with("flatpak", "uninstall", "-y", "--system", "org.gnome.Calculator")
-      expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      expect { described_class.cleanup(force: true) }.to output(/Uninstalled 1 flatpak/).to_stdout
+      expect(klass).to receive(:system_output_no_stderr).and_return("")
+      expect { klass.cleanup(force: true) }.to output(/Uninstalled 1 flatpak/).to_stdout
     end
 
     it "does not uninstall flatpaks if --flatpak is disabled" do
       expect(Kernel).not_to receive(:system)
-      expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      described_class.cleanup(force: true, extension_types: { flatpak: false })
+      expect(klass).to receive(:system_output_no_stderr).and_return("")
+      klass.cleanup(force: true, extension_types: { flatpak: false })
     end
   end
 
   context "when there are casks and formulae to uninstall and taps to untap but without passing `--force`" do
     before do
-      described_class.reset!
+      klass.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(described_class).to receive_messages(casks_to_uninstall:    %w[a b],
-                                                 formulae_to_uninstall: %w[a b],
-                                                 taps_to_untap:         %w[a b])
+      allow(klass).to receive_messages(casks_to_uninstall:    %w[a b],
+                                       formulae_to_uninstall: %w[a b],
+                                       taps_to_untap:         %w[a b])
       allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return(%w[a b])
       allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return(%w[a b])
     end
@@ -353,14 +355,14 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
     it "lists casks, formulae and taps" do
       expect(Formatter).to receive(:columns).with(%w[a b]).exactly(5).times.and_return("a b")
       expect(Kernel).not_to receive(:system)
-      expect(described_class).to receive(:system_output_no_stderr).and_return("")
+      expect(klass).to receive(:system_output_no_stderr).and_return("")
       output_pattern = Regexp.new(
         "Would uninstall casks:.*Would uninstall formulae:.*Would untap:.*" \
         "Would uninstall VSCode extensions:.*Would uninstall flatpaks:",
         Regexp::MULTILINE,
       )
       expect do
-        described_class.cleanup
+        klass.cleanup
       end.to raise_error(SystemExit)
         .and output(output_pattern).to_stdout
     end
@@ -368,28 +370,28 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
 
   context "when there is brew cleanup output" do
     before do
-      described_class.reset!
+      klass.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
-      allow(described_class).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: [], taps_to_untap: [])
+      allow(klass).to receive_messages(casks_to_uninstall: [], formulae_to_uninstall: [], taps_to_untap: [])
       allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
       allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
     end
 
     define_method(:sane?) do
-      expect(described_class).to receive(:system_output_no_stderr).and_return("cleaned")
+      expect(klass).to receive(:system_output_no_stderr).and_return("cleaned")
     end
 
     context "with --force" do
       it "prints output" do
         sane?
-        expect { described_class.cleanup(force: true) }.to output(/cleaned/).to_stdout
+        expect { klass.cleanup(force: true) }.to output(/cleaned/).to_stdout
       end
     end
 
     context "without --force" do
       it "prints output" do
         sane?
-        expect { described_class.cleanup }.to output(/cleaned/).to_stdout
+        expect { klass.cleanup }.to output(/cleaned/).to_stdout
       end
     end
   end
@@ -397,14 +399,14 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
   describe "#system_output_no_stderr" do
     it "shells out" do
       expect(IO).to receive(:popen).and_return(StringIO.new("true"))
-      described_class.system_output_no_stderr("true")
+      klass.system_output_no_stderr("true")
     end
   end
 
   context "when running with force" do
     before do
-      described_class.reset!
-      allow(described_class).to receive_messages(
+      klass.reset!
+      allow(klass).to receive_messages(
         casks_to_uninstall:    [],
         formulae_to_uninstall: %w[some_formula],
         taps_to_untap:         [],
@@ -412,13 +414,13 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
       allow(Homebrew::Bundle::VscodeExtension).to receive(:cleanup_items).and_return([])
       allow(Homebrew::Bundle::Flatpak).to receive(:cleanup_items).and_return([])
       allow(Kernel).to receive(:system)
-      allow(described_class).to receive(:system_output_no_stderr).and_return("")
+      allow(klass).to receive(:system_output_no_stderr).and_return("")
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
     end
 
     it "marks Brewfile formulae as installed_on_request before uninstalling" do
       expect(Homebrew::Bundle).to receive(:mark_as_installed_on_request!)
-      described_class.cleanup(force: true)
+      klass.cleanup(force: true)
     end
   end
 end

--- a/Library/Homebrew/test/cmd/bundle/dump_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/dump_subcommand_spec.rb
@@ -6,9 +6,10 @@ require "bundle/subcommand/dump"
 
 RSpec.describe Homebrew::Cmd::Bundle::DumpSubcommand do
   subject(:dump) do
-    described_class.new(args_object, context:).run
+    klass.new(args_object, context:).run
   end
 
+  let(:klass) { Homebrew::Cmd::Bundle::DumpSubcommand }
   let(:force) { false }
   let(:global) { false }
   let(:context) { bundle_subcommand_context(:dump, global:, force:, no_type_args: false) }

--- a/Library/Homebrew/test/cmd/bundle/exec_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/exec_subcommand_spec.rb
@@ -7,9 +7,11 @@ require "bundle/brewfile"
 require "bundle/brew_services"
 
 RSpec.describe Homebrew::Cmd::Bundle::ExecSubcommand do
+  let(:klass) { Homebrew::Cmd::Bundle::ExecSubcommand }
+
   context "when a Brewfile is not found" do
     it "raises an error" do
-      expect { described_class.run_external_command }.to raise_error(RuntimeError)
+      expect { klass.run_external_command }.to raise_error(RuntimeError)
     end
   end
 
@@ -31,17 +33,17 @@ RSpec.describe Homebrew::Cmd::Bundle::ExecSubcommand do
 
     context "with valid command setup" do
       before do
-        allow(described_class).to receive(:exec).and_return(nil)
+        allow(klass).to receive(:exec).and_return(nil)
         Homebrew::Bundle.reset!
       end
 
       it "does not raise an error" do
-        expect { described_class.run_external_command("bundle", "install") }.not_to raise_error
+        expect { klass.run_external_command("bundle", "install") }.not_to raise_error
       end
 
       it "does not raise an error when HOMEBREW_BUNDLE_EXEC_ALL_KEG_ONLY_DEPS is set" do
         ENV["HOMEBREW_BUNDLE_EXEC_ALL_KEG_ONLY_DEPS"] = "1"
-        expect { described_class.run_external_command("bundle", "install") }.not_to raise_error
+        expect { klass.run_external_command("bundle", "install") }.not_to raise_error
       end
 
       it "uses the formula version from the environment variable" do
@@ -49,18 +51,18 @@ RSpec.describe Homebrew::Cmd::Bundle::ExecSubcommand do
         ENV["PATH"] = "/opt/homebrew/opt/openssl/bin:/usr/bin:/bin"
         ENV["MANPATH"] = "/opt/homebrew/opt/openssl/man"
         ENV["HOMEBREW_BUNDLE_FORMULA_VERSION_OPENSSL"] = openssl_version
-        allow(described_class).to receive(:which).and_return(Pathname("/usr/bin/bundle"))
-        described_class.run_external_command("bundle", "install")
+        allow(klass).to receive(:which).and_return(Pathname("/usr/bin/bundle"))
+        klass.run_external_command("bundle", "install")
         expect(ENV.fetch("PATH")).to include("/Cellar/openssl/1.1.1/bin")
       end
 
       it "is able to run without bundle arguments" do
-        allow(described_class).to receive(:exec).with("bundle", "install").and_return(nil)
-        expect { described_class.run_external_command("bundle", "install") }.not_to raise_error
+        allow(klass).to receive(:exec).with("bundle", "install").and_return(nil)
+        expect { klass.run_external_command("bundle", "install") }.not_to raise_error
       end
 
       it "raises an exception if called without a command" do
-        expect { described_class.run_external_command }.to raise_error(RuntimeError)
+        expect { klass.run_external_command }.to raise_error(RuntimeError)
       end
 
       describe "--no-secrets" do
@@ -76,7 +78,7 @@ RSpec.describe Homebrew::Cmd::Bundle::ExecSubcommand do
         it "removes sensitive environment variables when requested" do
           ENV["SECRET_TOKEN"] = "password"
 
-          described_class.run_external_command("/usr/bin/true", subcommand: "exec", no_secrets: true)
+          klass.run_external_command("/usr/bin/true", subcommand: "exec", no_secrets: true)
 
           expect(ENV).not_to have_key("SECRET_TOKEN")
         end
@@ -84,7 +86,7 @@ RSpec.describe Homebrew::Cmd::Bundle::ExecSubcommand do
         it "preserves non-sensitive environment variables when removing secrets" do
           ENV["NORMAL_VAR"] = "value"
 
-          described_class.run_external_command("/usr/bin/true", subcommand: "exec", no_secrets: true)
+          klass.run_external_command("/usr/bin/true", subcommand: "exec", no_secrets: true)
 
           expect(ENV.fetch("NORMAL_VAR")).to eq("value")
         end
@@ -95,22 +97,22 @@ RSpec.describe Homebrew::Cmd::Bundle::ExecSubcommand do
       it "outputs the environment variables" do
         allow(OS).to receive(:linux?).and_return(true)
 
-        expect { described_class.run_external_command("env", subcommand: "env") }.to \
+        expect { klass.run_external_command("env", subcommand: "env") }.to \
           output(/export PATH=".+:\${PATH:-}"/).to_stdout
       end
     end
 
     it "raises if called with a command that's not on the PATH" do
-      allow(described_class).to receive_messages(exec: nil, which: nil)
-      expect { described_class.run_external_command("bundle", "install") }.to raise_error(RuntimeError)
+      allow(klass).to receive_messages(exec: nil, which: nil)
+      expect { klass.run_external_command("bundle", "install") }.to raise_error(RuntimeError)
     end
 
     it "prepends the path of the requested command to PATH before running" do
-      expect(described_class).to receive(:exec).with("bundle", "install").and_return(nil)
-      expect(described_class).to receive(:which).twice.and_return(Pathname("/usr/local/bin/bundle"))
+      expect(klass).to receive(:exec).with("bundle", "install").and_return(nil)
+      expect(klass).to receive(:which).twice.and_return(Pathname("/usr/local/bin/bundle"))
       allow(ENV).to receive(:prepend_path).with(any_args).and_call_original
       expect(ENV).to receive(:prepend_path).with("PATH", "/usr/local/bin").once.and_call_original
-      described_class.run_external_command("bundle", "install")
+      klass.run_external_command("bundle", "install")
     end
 
     describe "when running a command which exists but is not on the PATH" do
@@ -122,9 +124,9 @@ RSpec.describe Homebrew::Cmd::Bundle::ExecSubcommand do
 
       shared_examples "allows command execution" do |command|
         it "does not raise" do
-          allow(described_class).to receive(:exec).with(command).and_return(nil)
-          expect(described_class).not_to receive(:which)
-          expect { described_class.run_external_command(command) }.not_to raise_error
+          allow(klass).to receive(:exec).with(command).and_return(nil)
+          expect(klass).not_to receive(:which)
+          expect { klass.run_external_command(command) }.not_to raise_error
         end
       end
 
@@ -143,13 +145,13 @@ RSpec.describe Homebrew::Cmd::Bundle::ExecSubcommand do
       end
 
       it "prepends the path of the rbenv shims to PATH before running" do
-        allow(described_class).to receive(:exec).with("/usr/bin/true").and_return(0)
+        allow(klass).to receive(:exec).with("/usr/bin/true").and_return(0)
         allow(ENV).to receive(:fetch).with(any_args).and_call_original
         allow(ENV).to receive(:prepend_path).with(any_args).once.and_call_original
 
         expect(ENV).to receive(:fetch).with("HOMEBREW_RBENV_ROOT", "#{Dir.home}/.rbenv").once.and_call_original
         expect(ENV).to receive(:prepend_path).with("PATH", rbenv_root/"shims").once.and_call_original
-        described_class.run_external_command("/usr/bin/true")
+        klass.run_external_command("/usr/bin/true")
       end
     end
 
@@ -213,7 +215,7 @@ RSpec.describe Homebrew::Cmd::Bundle::ExecSubcommand do
         allow_any_instance_of(Pathname).to receive(:file?).and_return(true)
         allow_any_instance_of(Pathname).to receive(:realpath) { |path| path }
 
-        allow(described_class).to receive(:exit!).and_return(nil)
+        allow(klass).to receive(:exit!).and_return(nil)
       end
 
       shared_examples "handles service lifecycle correctly" do
@@ -264,7 +266,7 @@ RSpec.describe Homebrew::Cmd::Bundle::ExecSubcommand do
           # Restart registered services we stopped due to conflicts (skip httpd as not registered)
           expect(Homebrew::Bundle::Brew::Services).to receive(:run).with("redis@6.2").and_return(true).ordered
 
-          described_class.run_external_command("/usr/bin/true", services: true)
+          klass.run_external_command("/usr/bin/true", services: true)
         end
       end
 

--- a/Library/Homebrew/test/cmd/bundle/install_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/install_subcommand_spec.rb
@@ -7,12 +7,13 @@ require "bundle/skipper"
 
 RSpec.describe Homebrew::Cmd::Bundle::InstallSubcommand do
   subject(:install_subcommand) do
-    described_class.new(
+    klass.new(
       args_for_subcommand(:install, quiet?: false, global?: global, cleanup?: false),
       context: bundle_subcommand_context(:install, global:),
     )
   end
 
+  let(:klass) { Homebrew::Cmd::Bundle::InstallSubcommand }
   let(:global) { false }
 
   before do

--- a/Library/Homebrew/test/cmd/bundle/list_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/list_subcommand_spec.rb
@@ -24,9 +24,10 @@ end.freeze
 
 RSpec.describe Homebrew::Cmd::Bundle::ListSubcommand do
   subject(:list) do
-    described_class.new(args_object, context:).run
+    klass.new(args_object, context:).run
   end
 
+  let(:klass) { Homebrew::Cmd::Bundle::ListSubcommand }
   let(:context) { bundle_subcommand_context(:list, no_type_args:) }
   let(:args_object) do
     args_for_subcommand(:list, formulae?: formulae, casks?: casks, taps?: taps, mas?: mas, vscode?: vscode,

--- a/Library/Homebrew/test/cmd/bundle/remove_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/remove_subcommand_spec.rb
@@ -7,17 +7,18 @@ require "cask/cask_loader"
 
 RSpec.describe Homebrew::Cmd::Bundle::RemoveSubcommand do
   subject(:remove) do
-    described_class.new(args_object, context:).run
+    klass.new(args_object, context:).run
   end
 
-  before { File.write(file, content) }
-  after { FileUtils.rm_f file }
-
+  let(:klass) { Homebrew::Cmd::Bundle::RemoveSubcommand }
   let(:global) { false }
   let(:context) { bundle_subcommand_context(:remove, global:, file:, no_type_args: type == :none) }
   let(:args_object) do
     args_for_subcommand(:remove, *args, formulae?: type == :brew, casks?: type == :cask, taps?: type == :tap)
   end
+
+  before { File.write(file, content) }
+  after { FileUtils.rm_f file }
 
   context "when called with a valid formula" do
     let(:args) { ["hello"] }

--- a/Library/Homebrew/test/cmd/bundle_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle_spec.rb
@@ -6,26 +6,28 @@ require "cmd/shared_examples/args_parse"
 require "commands"
 
 RSpec.describe Homebrew::Cmd::Bundle do
+  let(:klass) { Homebrew::Cmd::Bundle }
+
   it_behaves_like "parseable arguments"
 
   it "handles default install subcommand options", :aggregate_failures do
     with_env("HOMEBREW_BUNDLE_INSTALL_CLEANUP" => nil) do
-      expect(described_class.new([]).args.subcommand).to eq("install")
-      expect(described_class.new(%w[--cleanup --zap]).args.subcommand).to eq("install")
-      expect { described_class.new(%w[--zap]) }
+      expect(klass.new([]).args.subcommand).to eq("install")
+      expect(klass.new(%w[--cleanup --zap]).args.subcommand).to eq("install")
+      expect { klass.new(%w[--zap]) }
         .to raise_error(UsageError, /`--zap` cannot be passed without `--cleanup`/)
     end
   end
 
   it "rejects install-only options for exec" do
-    expect { described_class.new(%w[exec --jobs=1 true]) }
+    expect { klass.new(%w[exec --jobs=1 true]) }
       .to raise_error(UsageError, /`exec` subcommand does not accept the `--jobs` flag/)
   end
 
   it "treats upgrade as install --upgrade", :aggregate_failures do
     with_env("HOMEBREW_BUNDLE_NO_UPGRADE" => "1") do
-      args = described_class.new(%w[upgrade -fq]).args
-      context = described_class.context(args, extensions: described_class::BUNDLE_EXTENSIONS)
+      args = klass.new(%w[upgrade -fq]).args
+      context = klass.context(args, extensions: klass::BUNDLE_EXTENSIONS)
 
       expect(args.subcommand).to eq("install")
       expect(args.upgrade?).to be(true)
@@ -50,7 +52,7 @@ RSpec.describe Homebrew::Cmd::Bundle do
   end
 
   it "uses subcommand-specific descriptions in help output", :aggregate_failures do
-    help_text = described_class.parser.generate_help_text(remaining_args: ["list"])
+    help_text = klass.parser.generate_help_text(remaining_args: ["list"])
 
     expect(help_text).to include("List VSCode (and forks/variants) extensions.")
     expect(help_text).not_to include("Clean up VSCode (and forks/variants) extensions.")
@@ -74,7 +76,7 @@ RSpec.describe Homebrew::Cmd::Bundle do
             no_secrets: false,
           )
 
-        described_class.new(args).run
+        klass.new(args).run
       end
     end
   end
@@ -92,7 +94,7 @@ RSpec.describe Homebrew::Cmd::Bundle do
           no_secrets: false,
         )
 
-      described_class.new(["exec", "/usr/bin/true"]).run
+      klass.new(["exec", "/usr/bin/true"]).run
     end
   end
 

--- a/Library/Homebrew/test/cmd/completions_spec.rb
+++ b/Library/Homebrew/test/cmd/completions_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Homebrew::Cmd::CompletionsCmd do
   it_behaves_like "parseable arguments"
 
   it "uses state as the default subcommand" do
-    expect(described_class.new([]).args.subcommand).to eq("state")
+    expect(Homebrew::Cmd::CompletionsCmd.new([]).args.subcommand).to eq("state")
   end
 
   it "rejects extra arguments for state" do
-    expect { described_class.new(%w[state foo]) }
+    expect { Homebrew::Cmd::CompletionsCmd.new(%w[state foo]) }
       .to raise_error(Homebrew::CLI::MaxNamedArgumentsError)
   end
 

--- a/Library/Homebrew/test/cmd/desc_spec.rb
+++ b/Library/Homebrew/test/cmd/desc_spec.rb
@@ -5,6 +5,8 @@ require "cmd/desc"
 require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::Desc do
+  let(:klass) { Homebrew::Cmd::Desc }
+
   it_behaves_like "parseable arguments"
 
   it "shows a given Formula's description", :integration_test do
@@ -24,7 +26,7 @@ RSpec.describe Homebrew::Cmd::Desc do
       desc "BitTorrent client"
       url "https://example.com/local-transmission.zip"
     end
-    cmd = described_class.new(["--cask", "local-transmission"])
+    cmd = klass.new(["--cask", "local-transmission"])
 
     allow(cmd.args.named).to receive(:to_formulae_and_casks).and_return([cask])
     allow(Cask::Caskroom).to receive(:casks).and_return([cask])
@@ -44,7 +46,7 @@ RSpec.describe Homebrew::Cmd::Desc do
       name "No Description"
       url "https://example.com/no-description.zip"
     end
-    cmd = described_class.new(["--cask", "no-description"])
+    cmd = klass.new(["--cask", "no-description"])
 
     allow(cmd.args.named).to receive(:to_formulae_and_casks).and_return([cask])
 

--- a/Library/Homebrew/test/cmd/developer_spec.rb
+++ b/Library/Homebrew/test/cmd/developer_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Homebrew::Cmd::Developer do
   it_behaves_like "parseable arguments"
 
   it "uses state as the default subcommand" do
-    expect(described_class.new([]).args.subcommand).to eq("state")
+    expect(Homebrew::Cmd::Developer.new([]).args.subcommand).to eq("state")
   end
 
   it "rejects extra arguments for state" do
-    expect { described_class.new(%w[state foo]) }
+    expect { Homebrew::Cmd::Developer.new(%w[state foo]) }
       .to raise_error(Homebrew::CLI::MaxNamedArgumentsError)
   end
 

--- a/Library/Homebrew/test/cmd/doctor_spec.rb
+++ b/Library/Homebrew/test/cmd/doctor_spec.rb
@@ -5,6 +5,8 @@ require "cmd/doctor"
 require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::Doctor do
+  let(:klass) { Homebrew::Cmd::Doctor }
+
   it_behaves_like "parseable arguments"
 
   specify "check_integration_test", :integration_test do
@@ -33,7 +35,7 @@ RSpec.describe Homebrew::Cmd::Doctor do
     (CoreCaskTap.instance.cask_dir/"local-caffeine.rb").unlink
     CoreCaskTap.instance.clear_cache
 
-    cmd = described_class.new(["check_cask_deprecated_disabled"])
+    cmd = klass.new(["check_cask_deprecated_disabled"])
 
     expect { cmd.run }
       .to not_to_output(/Unexpected method 'discontinued' called during caveats on Cask local-caffeine\./).to_stderr

--- a/Library/Homebrew/test/cmd/gist-logs_spec.rb
+++ b/Library/Homebrew/test/cmd/gist-logs_spec.rb
@@ -5,6 +5,8 @@ require "cmd/gist-logs"
 require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::GistLogs do
+  let(:klass) { Homebrew::Cmd::GistLogs }
+
   it_behaves_like "parseable arguments"
 
   describe ".truncate_text_to_approximate_size" do
@@ -14,7 +16,7 @@ RSpec.describe Homebrew::Cmd::GistLogs do
       n = 20
       long_s = "x" * 40
 
-      s = described_class.truncate_text_to_approximate_size(long_s, n)
+      s = klass.truncate_text_to_approximate_size(long_s, n)
       expect(s.length).to eq(n)
       expect(s).to match(/^x+#{Regexp.escape(glue)}x+$/)
     end
@@ -23,7 +25,7 @@ RSpec.describe Homebrew::Cmd::GistLogs do
       n = 20
       long_s = "x" * 40
 
-      s = described_class.truncate_text_to_approximate_size(long_s, n, front_weight: 0.0)
+      s = klass.truncate_text_to_approximate_size(long_s, n, front_weight: 0.0)
       expect(s).to eq(glue + ("x" * (n - glue.length)))
     end
 
@@ -31,7 +33,7 @@ RSpec.describe Homebrew::Cmd::GistLogs do
       n = 20
       long_s = "x" * 40
 
-      s = described_class.truncate_text_to_approximate_size(long_s, n, front_weight: 1.0)
+      s = klass.truncate_text_to_approximate_size(long_s, n, front_weight: 1.0)
       expect(s).to eq(("x" * (n - glue.length)) + glue)
     end
   end

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -5,6 +5,8 @@ require "cmd/info"
 require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::Info do
+  let(:klass) { Homebrew::Cmd::Info }
+
   RSpec::Matchers.define :a_json_string do
     match do |actual|
       JSON.parse(actual)
@@ -71,7 +73,7 @@ RSpec.describe Homebrew::Cmd::Info do
         Formula from homebrew/core
         Installed: 0.1 (on request)
       EOS
-      expect { described_class.new(["--installed"]).run }
+      expect { klass.new(["--installed"]).run }
         .to output(expected_output).to_stdout
         .and not_to_output.to_stderr
     end
@@ -94,7 +96,7 @@ RSpec.describe Homebrew::Cmd::Info do
         Cask from homebrew/cask
         Installed: 2.61 (dependency)
       EOS
-      expect { described_class.new(["--installed"]).run }
+      expect { klass.new(["--installed"]).run }
         .to output(expected_output).to_stdout
         .and not_to_output.to_stderr
     end
@@ -122,7 +124,7 @@ RSpec.describe Homebrew::Cmd::Info do
         Cask from homebrew/cask
         Installed: 1.0
       EOS
-      expect { described_class.new(["--installed"]).run }
+      expect { klass.new(["--installed"]).run }
         .to output(expected_output).to_stdout
         .and not_to_output.to_stderr
     end
@@ -153,7 +155,7 @@ RSpec.describe Homebrew::Cmd::Info do
         Cask from homebrew/cask
         Installed: 2.61
       EOS
-      expect { described_class.new(["--installed"]).run }
+      expect { klass.new(["--installed"]).run }
         .to output(expected_output).to_stdout
         .and not_to_output.to_stderr
     end
@@ -172,14 +174,14 @@ RSpec.describe Homebrew::Cmd::Info do
       )
       allow(Cask::Caskroom).to receive(:casks).and_return([])
 
-      expect { described_class.new(["--installed"]).run }
+      expect { klass.new(["--installed"]).run }
         .to output(/testball .*✔.*: Some test/).to_stdout
         .and not_to_output.to_stderr
     end
   end
 
   it "prints verbose installed inventory as full info" do
-    info = described_class.new(["--verbose", "--installed"])
+    info = klass.new(["--verbose", "--installed"])
     formula = installed_info_formula
     cask = installed_info_cask
 
@@ -194,7 +196,7 @@ RSpec.describe Homebrew::Cmd::Info do
   end
 
   it "prints quiet formula information in the slim inventory format" do
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       desc "Some test"
@@ -213,7 +215,7 @@ RSpec.describe Homebrew::Cmd::Info do
 
   it "uses slim formula information when quiet is passed", :integration_test do
     setup_test_formula "testball"
-    info = described_class.new(["--quiet", "testball"])
+    info = klass.new(["--quiet", "testball"])
 
     expect(info).to receive(:info_formula_summary).with(kind_of(Formula))
     expect { info.run }
@@ -223,7 +225,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "prints inline summary information for formulae" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       homepage "https://brew.sh/testball"
@@ -244,7 +246,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "marks a deprecated formula with `(deprecated)` in the title" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       desc "Some test"
@@ -261,7 +263,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "marks a disabled formula with `(disabled)` in the title" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       desc "Some test"
@@ -276,7 +278,7 @@ RSpec.describe Homebrew::Cmd::Info do
   end
 
   it "reloads the formula from the install receipt's tap and reports the shadowing tap" do
-    info = described_class.new([])
+    info = klass.new([])
     formula = installed_info_formula
 
     keg_path = HOMEBREW_CELLAR/"testball/0.1"
@@ -296,7 +298,7 @@ RSpec.describe Homebrew::Cmd::Info do
   end
 
   it "returns the original formula and no shadowing tap when the install receipt has no tap" do
-    info = described_class.new([])
+    info = klass.new([])
     formula = installed_info_formula
 
     keg_path = HOMEBREW_CELLAR/"testball/0.1"
@@ -309,7 +311,7 @@ RSpec.describe Homebrew::Cmd::Info do
   end
 
   it "returns the original formula and no shadowing tap when the install receipt's tap matches" do
-    info = described_class.new([])
+    info = klass.new([])
     formula = installed_info_formula
 
     keg_path = HOMEBREW_CELLAR/"testball/0.1"
@@ -324,7 +326,7 @@ RSpec.describe Homebrew::Cmd::Info do
   end
 
   it "warns about a shadowing tap when info_formula is given one" do
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
     end
@@ -337,7 +339,7 @@ RSpec.describe Homebrew::Cmd::Info do
   end
 
   it "treats a `tap/name` input as user-qualified" do
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
     end
@@ -348,7 +350,7 @@ RSpec.describe Homebrew::Cmd::Info do
   end
 
   it "treats a bare unqualified input as not user-qualified" do
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
     end
@@ -357,7 +359,7 @@ RSpec.describe Homebrew::Cmd::Info do
   end
 
   it "--json swaps an unqualified-input formula to its installed tap" do
-    info = described_class.new(["--json", "testball"])
+    info = klass.new(["--json", "testball"])
     shadowed_formula = installed_info_formula
 
     keg_path = HOMEBREW_CELLAR/"testball/0.1"
@@ -383,7 +385,7 @@ RSpec.describe Homebrew::Cmd::Info do
   end
 
   it "--json honours a tap-qualified input without swapping" do
-    info = described_class.new(["--json", "homebrew/core/testball"])
+    info = klass.new(["--json", "homebrew/core/testball"])
     formula = installed_info_formula
 
     keg_path = HOMEBREW_CELLAR/"testball/0.1"
@@ -407,7 +409,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "prints required, recursive runtime, and dependent counts in the dependencies section" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       homepage "https://brew.sh/testball"
@@ -462,7 +464,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "lists installed dependents inline under Dependencies with --verbose" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new(["--verbose"])
+    info = klass.new(["--verbose"])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       homepage "https://brew.sh/testball"
@@ -498,7 +500,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "summarises recursive runtime dependencies as all installed when none are missing" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       homepage "https://brew.sh/testball"
@@ -534,7 +536,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "marks a tab-listed dep with no installed rack as unsatisfied" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       desc "Some test"
@@ -560,7 +562,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "marks a tab-listed dep with an installed rack as satisfied when the dep formula is not outdated" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       desc "Some test"
@@ -596,7 +598,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "marks a tab-listed dep with an installed rack as outdated when the dep formula is outdated" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       desc "Some test"
@@ -632,7 +634,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "marks an installed dep on an uninstalled formula as satisfied" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       desc "Some test"
@@ -661,7 +663,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "marks an outdated installed dep on an uninstalled formula as upgradable" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       desc "Some test"
@@ -690,7 +692,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "marks an aliased dep as installed when the underlying rack exists under a different name" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       desc "Some test"
@@ -719,7 +721,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "does not mark a missing dep on an uninstalled formula" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       desc "Some test"
@@ -738,7 +740,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "marks a dep absent from the installed keg's tab as unsatisfied when its rack is also missing" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       desc "Some test"
@@ -764,7 +766,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "marks a dep absent from the installed keg's tab as installed when its rack exists" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       desc "Some test"
@@ -796,7 +798,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "omits build dependencies when a formula would pour from a bottle" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       homepage "https://brew.sh/testball"
@@ -823,7 +825,7 @@ RSpec.describe Homebrew::Cmd::Info do
   end
 
   it "shows the installed and stable versions in the headline when outdated" do
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       homepage "https://brew.sh/testball"
@@ -846,7 +848,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "prints Linux requirements through the requirements section" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       homepage "https://brew.sh/testball"
@@ -866,7 +868,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "hides source install metadata for formulae that only run on another OS" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       homepage "https://brew.sh/testball"
@@ -887,7 +889,7 @@ RSpec.describe Homebrew::Cmd::Info do
   end
 
   it "prints a Binaries section listing executables in bin and sbin with --verbose" do
-    info = described_class.new(["--verbose"])
+    info = klass.new(["--verbose"])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       homepage "https://brew.sh/testball"
@@ -915,7 +917,7 @@ RSpec.describe Homebrew::Cmd::Info do
   end
 
   it "prints a Binaries section from the bottle manifest when the formula is not installed with --verbose" do
-    info = described_class.new(["--verbose"])
+    info = klass.new(["--verbose"])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       homepage "https://brew.sh/testball"
@@ -938,7 +940,7 @@ RSpec.describe Homebrew::Cmd::Info do
   end
 
   it "omits the Binaries section without --verbose" do
-    info = described_class.new([])
+    info = klass.new([])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       homepage "https://brew.sh/testball"
@@ -963,7 +965,7 @@ RSpec.describe Homebrew::Cmd::Info do
   end
 
   it "omits the Binaries section when no executables are installed" do
-    info = described_class.new(["--verbose"])
+    info = klass.new(["--verbose"])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
       homepage "https://brew.sh/testball"
@@ -986,12 +988,12 @@ RSpec.describe Homebrew::Cmd::Info do
 
   describe "::installation_status" do
     it "prints on-request installs explicitly" do
-      expect(described_class.installation_status(instance_double(Tab, installed_on_request: true)))
+      expect(klass.installation_status(instance_double(Tab, installed_on_request: true)))
         .to eq("Installed (on request)")
     end
 
     it "treats non-requested installs as dependency installs" do
-      expect(described_class.installation_status(instance_double(Tab, installed_on_request: false)))
+      expect(klass.installation_status(instance_double(Tab, installed_on_request: false)))
         .to eq("Installed (as dependency)")
     end
   end
@@ -1012,7 +1014,7 @@ RSpec.describe Homebrew::Cmd::Info do
         File.utime(pin_time, pin_time, pin_path)
         allow(FormulaPin).to receive(:new).with(test_formula).and_return(instance_double(FormulaPin, path: pin_path))
 
-        expect(described_class.metadata_lines(test_formula)).to eq([
+        expect(klass.metadata_lines(test_formula)).to eq([
           "Pinned: 1.0 on #{pin_time.strftime("%Y-%m-%d at %H:%M:%S")}",
         ])
       end
@@ -1032,7 +1034,7 @@ RSpec.describe Homebrew::Cmd::Info do
         File.utime(pin_time, pin_time, pin_path)
         allow(cask).to receive(:pin_path).and_return(pin_path)
 
-        expect(described_class.metadata_lines(cask)).to eq([
+        expect(klass.metadata_lines(cask)).to eq([
           "Pinned: 1.0 on #{pin_time.strftime("%Y-%m-%d at %H:%M:%S")}",
         ])
       end
@@ -1043,23 +1045,23 @@ RSpec.describe Homebrew::Cmd::Info do
     let(:remote) { "https://github.com/Homebrew/homebrew-core" }
 
     specify "returns correct URLs" do
-      expect(described_class.new([]).github_remote_path(remote, "Formula/git.rb"))
+      expect(klass.new([]).github_remote_path(remote, "Formula/git.rb"))
         .to eq("https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/git.rb")
 
-      expect(described_class.new([]).github_remote_path("#{remote}.git", "Formula/git.rb"))
+      expect(klass.new([]).github_remote_path("#{remote}.git", "Formula/git.rb"))
         .to eq("https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/git.rb")
 
-      expect(described_class.new([]).github_remote_path("git@github.com:user/repo", "foo.rb"))
+      expect(klass.new([]).github_remote_path("git@github.com:user/repo", "foo.rb"))
         .to eq("https://github.com/user/repo/blob/HEAD/foo.rb")
 
-      expect(described_class.new([]).github_remote_path("https://mywebsite.com", "foo/bar.rb"))
+      expect(klass.new([]).github_remote_path("https://mywebsite.com", "foo/bar.rb"))
         .to eq("https://mywebsite.com/foo/bar.rb")
     end
   end
 
   describe "Aliases and Old Names rows" do
     it "lists aliases on their own row when the formula has any" do
-      info = described_class.new([])
+      info = klass.new([])
       main_formula = formula("testball") do
         url "https://brew.sh/testball-1.0.tar.gz"
       end
@@ -1073,7 +1075,7 @@ RSpec.describe Homebrew::Cmd::Info do
     end
 
     it "renders aliases and old names on separate rows when both exist" do
-      info = described_class.new([])
+      info = klass.new([])
       main_formula = formula("testball") do
         url "https://brew.sh/testball-1.0.tar.gz"
       end
@@ -1086,7 +1088,7 @@ RSpec.describe Homebrew::Cmd::Info do
     end
 
     it "renders only an Old Names row when there are no aliases" do
-      info = described_class.new([])
+      info = klass.new([])
       main_formula = formula("testball") do
         url "https://brew.sh/testball-1.0.tar.gz"
       end
@@ -1100,7 +1102,7 @@ RSpec.describe Homebrew::Cmd::Info do
     end
 
     it "omits both rows when there are none" do
-      info = described_class.new([])
+      info = klass.new([])
       main_formula = formula("testball") do
         url "https://brew.sh/testball-1.0.tar.gz"
       end
@@ -1116,7 +1118,7 @@ RSpec.describe Homebrew::Cmd::Info do
 
   describe "Installed section" do
     it "lists this formula alongside installed sibling versioned formulae" do
-      info = described_class.new([])
+      info = klass.new([])
       main_formula = formula("testball") do
         url "https://brew.sh/testball-1.0.tar.gz"
       end
@@ -1150,7 +1152,7 @@ RSpec.describe Homebrew::Cmd::Info do
     end
 
     it "shows installed → latest only on the newest installed keg of an outdated formula" do
-      info = described_class.new([])
+      info = klass.new([])
       main_formula = formula("testball") do
         url "https://brew.sh/testball-2.0.tar.gz"
         version "2.0"
@@ -1178,7 +1180,7 @@ RSpec.describe Homebrew::Cmd::Info do
     end
 
     it "marks the currently linked version with `*`" do
-      info = described_class.new([])
+      info = klass.new([])
       main_formula = formula("testball") do
         url "https://brew.sh/testball-1.0.tar.gz"
       end
@@ -1211,7 +1213,7 @@ RSpec.describe Homebrew::Cmd::Info do
     end
 
     it "includes the unversioned parent when run on a versioned formula" do
-      info = described_class.new([])
+      info = klass.new([])
       versioned = formula("testball@0.9") do
         url "https://brew.sh/testball-0.9.tar.gz"
         keg_only :versioned_formula
@@ -1246,7 +1248,7 @@ RSpec.describe Homebrew::Cmd::Info do
     end
 
     it "renders the section even when only the current formula is installed" do
-      info = described_class.new([])
+      info = klass.new([])
       main_formula = formula("testball") do
         url "https://brew.sh/testball-1.0.tar.gz"
       end
@@ -1266,7 +1268,7 @@ RSpec.describe Homebrew::Cmd::Info do
     end
 
     it "renders the section when the queried formula is uninstalled but a sibling is installed" do
-      info = described_class.new([])
+      info = klass.new([])
       versioned = formula("testball@0.9") do
         url "https://brew.sh/testball-0.9.tar.gz"
         keg_only :versioned_formula
@@ -1292,7 +1294,7 @@ RSpec.describe Homebrew::Cmd::Info do
     end
 
     it "lists every installed keg of a formula, newest first" do
-      info = described_class.new([])
+      info = klass.new([])
       main_formula = formula("testball") do
         url "https://brew.sh/testball-1.0.tar.gz"
       end
@@ -1319,7 +1321,7 @@ RSpec.describe Homebrew::Cmd::Info do
     end
 
     it "omits the section when nothing in the family is installed" do
-      info = described_class.new([])
+      info = klass.new([])
       main_formula = formula("testball") do
         url "https://brew.sh/testball-1.0.tar.gz"
       end
@@ -1343,7 +1345,7 @@ RSpec.describe Homebrew::Cmd::Info do
         url "https://brew.sh/testball-0.1.tar.gz"
       end
 
-      expect(described_class.new([]).send(:github_info, formula_instance))
+      expect(klass.new([]).send(:github_info, formula_instance))
         .to eq(keg_formula_path.to_s)
     end
 
@@ -1353,7 +1355,7 @@ RSpec.describe Homebrew::Cmd::Info do
         url "https://brew.sh/testball-0.1.tar.gz"
       end
 
-      expect(described_class.new([]).send(:github_info, formula_instance))
+      expect(klass.new([]).send(:github_info, formula_instance))
         .to eq("https://github.com/Homebrew/homebrew-core/blob/HEAD/" \
                "#{formula_path.relative_path_from(tap.path)}")
     end

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -5,6 +5,8 @@ require "cmd/install"
 require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::InstallCmd do
+  let(:klass) { Homebrew::Cmd::InstallCmd }
+
   include FileUtils
 
   it_behaves_like "parseable arguments"
@@ -173,7 +175,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
   end
 
   it "prints an ask mode environment hint when installing formulae" do
-    cmd = described_class.new(["testball"])
+    cmd = klass.new(["testball"])
     download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil)
     formula = formula("testball") { url "https://brew.sh/testball-0.1.tar.gz" }
     formula_installer = FormulaInstaller.new(formula)
@@ -196,7 +198,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
   end
 
   it "installs an explicitly requested tap before resolving a formula" do
-    cmd = described_class.new(["user/repo/foo"])
+    cmd = klass.new(["user/repo/foo"])
     tap = Tap.fetch("user", "repo")
 
     allow(Tap).to receive(:with_formula_name).with("user/repo/foo").and_return([tap, "foo"])
@@ -210,7 +212,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
   end
 
   it "does not install `homebrew/cask` when a cask remains unavailable" do
-    cmd = described_class.new(["foo"])
+    cmd = klass.new(["foo"])
     cask_tap = CoreCaskTap.instance
 
     require "search"
@@ -342,7 +344,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
   end
 
   it "prints a shared fetch heading and correct upgrade count", :cask do
-    cmd = described_class.new(["codex"])
+    cmd = klass.new(["codex"])
     download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil)
     formula = formula("testball_bottle") { url "https://brew.sh/testball_bottle-0.1.tar.gz" }
     formula_installer = instance_double(FormulaInstaller, formula:)

--- a/Library/Homebrew/test/cmd/link_spec.rb
+++ b/Library/Homebrew/test/cmd/link_spec.rb
@@ -5,6 +5,8 @@ require "cmd/link"
 require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::Link do
+  let(:klass) { Homebrew::Cmd::Link }
+
   it_behaves_like "parseable arguments"
 
   it "uses formula-aware conflict handling when linking a Formula" do
@@ -13,7 +15,7 @@ RSpec.describe Homebrew::Cmd::Link do
     end
     keg = instance_double(Keg, rack: HOMEBREW_CELLAR/"testball", linked?: false, name: "testball")
 
-    cmd = described_class.new(["testball"])
+    cmd = klass.new(["testball"])
     allow(cmd.args.named).to receive(:to_latest_kegs).and_return([keg])
     allow(Formulary).to receive(:keg_only?).with(keg.rack).and_return(false)
     allow(keg).to receive(:to_formula).and_return(formula)

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -5,6 +5,8 @@ require "cmd/outdated"
 require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::Outdated do
+  let(:klass) { Homebrew::Cmd::Outdated }
+
   it_behaves_like "parseable arguments"
 
   def install_formula_version(name, version, linked: false)
@@ -20,18 +22,18 @@ RSpec.describe Homebrew::Cmd::Outdated do
   end
 
   it "requires one named argument with --minimum-version" do
-    expect { described_class.new(["--minimum-version=1.2.3"]).run }
+    expect { klass.new(["--minimum-version=1.2.3"]).run }
       .to raise_error(UsageError, /`--minimum-version` requires exactly one formula or cask argument/)
   end
 
   it "rejects multiple named arguments with --minimum-version" do
-    expect { described_class.new(["foo", "bar", "--minimum-version=1.2.3"]).run }
+    expect { klass.new(["foo", "bar", "--minimum-version=1.2.3"]).run }
       .to raise_error(UsageError, /`--minimum-version` requires exactly one formula or cask argument/)
   end
 
   it "excludes non-outdated auto-updating casks without --greedy-auto-updates", :cask do
     cask = Cask::CaskLoader.load(cask_path("auto-updates"))
-    cmd = described_class.new([])
+    cmd = klass.new([])
 
     expect(cask).to receive(:outdated?)
       .with(greedy: false, greedy_latest: false, greedy_auto_updates: false)
@@ -41,7 +43,7 @@ RSpec.describe Homebrew::Cmd::Outdated do
 
   it "checks auto-updating casks with --greedy-auto-updates", :cask do
     cask = Cask::CaskLoader.load(cask_path("auto-updates"))
-    cmd = described_class.new(["--greedy-auto-updates"])
+    cmd = klass.new(["--greedy-auto-updates"])
 
     expect(cask).to receive(:outdated?)
       .with(greedy: false, greedy_latest: false, greedy_auto_updates: true)
@@ -110,7 +112,7 @@ RSpec.describe Homebrew::Cmd::Outdated do
   it "raises UsageError for an invalid cask --minimum-version", :cask do
     InstallHelper.stub_cask_installation(Cask::CaskLoader.load(cask_path("local-caffeine")))
 
-    expect { described_class.new(["--cask", "local-caffeine", "--minimum-version=1/2"]).run }
+    expect { klass.new(["--cask", "local-caffeine", "--minimum-version=1/2"]).run }
       .to raise_error(UsageError, %r{invalid `--minimum-version`: 1/2})
   end
 

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -6,6 +6,8 @@ require "cmd/reinstall"
 require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::Reinstall do
+  let(:klass) { Homebrew::Cmd::Reinstall }
+
   it_behaves_like "parseable arguments"
 
   it "reports unavailable names via ofail and continues reinstalling" do
@@ -13,7 +15,7 @@ RSpec.describe Homebrew::Cmd::Reinstall do
     formula = instance_double(Formula, full_name: "testball", pinned?: false)
     allow(formula).to receive(:latest_formula).and_return(formula)
 
-    cmd = described_class.new(["testball", "nonexistent"])
+    cmd = klass.new(["testball", "nonexistent"])
     allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable)
       .with(method: :resolve)
       .and_return([formula, error])
@@ -28,7 +30,7 @@ RSpec.describe Homebrew::Cmd::Reinstall do
     cask = Cask::Cask.new("local-caffeine")
     allow(cask).to receive_messages(pinned?: true, full_name: "local-caffeine")
 
-    cmd = described_class.new(["local-caffeine"])
+    cmd = klass.new(["local-caffeine"])
     allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable)
       .with(method: :resolve)
       .and_return([cask])
@@ -41,7 +43,7 @@ RSpec.describe Homebrew::Cmd::Reinstall do
   end
 
   it "asks for casks before shared prefetch when reinstalling formulae and casks" do
-    cmd = described_class.new(["--ask", "testball", "local-caffeine"])
+    cmd = klass.new(["--ask", "testball", "local-caffeine"])
     formula = formula("testball") { url "https://brew.sh/testball-0.1.tar.gz" }
     formula_installer = FormulaInstaller.new(formula)
     dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])

--- a/Library/Homebrew/test/cmd/search_spec.rb
+++ b/Library/Homebrew/test/cmd/search_spec.rb
@@ -5,6 +5,8 @@ require "cmd/search"
 require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::SearchCmd do
+  let(:klass) { Homebrew::Cmd::SearchCmd }
+
   it_behaves_like "parseable arguments"
 
   it "finds formula in search", :integration_test, :no_api do
@@ -16,7 +18,7 @@ RSpec.describe Homebrew::Cmd::SearchCmd do
   end
 
   describe "::print_missing_formula_help" do
-    let(:search_cmd) { described_class.new([""]) }
+    let(:search_cmd) { klass.new([""]) }
 
     context "when $stdout is not a TTY" do
       before { allow_any_instance_of(StringIO).to receive(:tty?).and_return(false) }

--- a/Library/Homebrew/test/cmd/services/cleanup_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/services/cleanup_subcommand_spec.rb
@@ -6,9 +6,11 @@ require "services/system"
 require "services/cli"
 
 RSpec.describe Homebrew::Cmd::Services::CleanupSubcommand do
+  let(:klass) { Homebrew::Cmd::Services::CleanupSubcommand }
+
   describe "#TRIGGERS" do
     it "contains all restart triggers" do
-      expect(described_class::TRIGGERS).to eq(%w[cleanup clean cl rm])
+      expect(klass::TRIGGERS).to eq(%w[cleanup clean cl rm])
     end
   end
 
@@ -19,7 +21,7 @@ RSpec.describe Homebrew::Cmd::Services::CleanupSubcommand do
       expect(Homebrew::Services::Cli).to receive(:remove_unused_service_files).once.and_return([])
 
       expect do
-        described_class.new(nil).run
+        klass.new(nil).run
       end.to output("All root services OK, nothing cleaned...\n").to_stdout
     end
 
@@ -29,7 +31,7 @@ RSpec.describe Homebrew::Cmd::Services::CleanupSubcommand do
       expect(Homebrew::Services::Cli).to receive(:remove_unused_service_files).once.and_return([])
 
       expect do
-        described_class.new(nil).run
+        klass.new(nil).run
       end.to output("All user-space services OK, nothing cleaned...\n").to_stdout
     end
 
@@ -39,7 +41,7 @@ RSpec.describe Homebrew::Cmd::Services::CleanupSubcommand do
       expect(Homebrew::Services::Cli).to receive(:remove_unused_service_files).once.and_return(["b"])
 
       expect do
-        described_class.new(nil).run
+        klass.new(nil).run
       end.not_to output("All user-space services OK, nothing cleaned...\n").to_stdout
     end
   end

--- a/Library/Homebrew/test/cmd/services/info_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/services/info_subcommand_spec.rb
@@ -4,20 +4,22 @@
 require "cmd/services"
 
 RSpec.describe Homebrew::Cmd::Services::InfoSubcommand do
+  let(:klass) { Homebrew::Cmd::Services::InfoSubcommand }
+
   before do
     allow_any_instance_of(IO).to receive(:tty?).and_return(false)
   end
 
   describe "#TRIGGERS" do
     it "contains all restart triggers" do
-      expect(described_class::TRIGGERS).to eq(%w[info i])
+      expect(klass::TRIGGERS).to eq(%w[info i])
     end
   end
 
   describe "#run" do
     it "fails with empty list" do
       expect do
-        described_class.new(Homebrew::Cmd::Services.new(%w[info testball]).args, targets: []).run
+        klass.new(Homebrew::Cmd::Services.new(%w[info testball]).args, targets: []).run
       end.to raise_error UsageError,
                          "Invalid usage: Formula(e) missing, please provide a formula name or use `--all`."
     end
@@ -34,8 +36,8 @@ RSpec.describe Homebrew::Cmd::Services::InfoSubcommand do
         schedulable: false,
       })
       expect do
-        described_class.new(Homebrew::Cmd::Services.new(%w[info testball]).args,
-                            targets: [formula_wrapper]).run
+        klass.new(Homebrew::Cmd::Services.new(%w[info testball]).args,
+                  targets: [formula_wrapper]).run
       end.to output(out).to_stdout
     end
 
@@ -52,8 +54,8 @@ RSpec.describe Homebrew::Cmd::Services::InfoSubcommand do
       out = "#{JSON.pretty_generate([formula])}\n"
       formula_wrapper = instance_double(Homebrew::Services::FormulaWrapper, to_hash: formula)
       expect do
-        described_class.new(Homebrew::Cmd::Services.new(%w[info testball --json]).args,
-                            targets: [formula_wrapper]).run
+        klass.new(Homebrew::Cmd::Services.new(%w[info testball --json]).args,
+                  targets: [formula_wrapper]).run
       end.to output(out).to_stdout
     end
   end
@@ -71,7 +73,7 @@ RSpec.describe Homebrew::Cmd::Services::InfoSubcommand do
         loaded:      true,
         schedulable: false,
       }
-      expect(described_class.output(formula, verbose: false)).to eq(out)
+      expect(klass.output(formula, verbose: false)).to eq(out)
     end
 
     it "returns normal output" do
@@ -88,7 +90,7 @@ RSpec.describe Homebrew::Cmd::Services::InfoSubcommand do
         schedulable: false,
         pid:         42,
       }
-      expect(described_class.output(formula, verbose: false)).to eq(out)
+      expect(klass.output(formula, verbose: false)).to eq(out)
     end
 
     it "returns verbose output" do
@@ -115,7 +117,7 @@ RSpec.describe Homebrew::Cmd::Services::InfoSubcommand do
         interval:       3600,
         cron:           "5 * * * *",
       }
-      expect(described_class.output(formula, verbose: true)).to eq(out)
+      expect(klass.output(formula, verbose: true)).to eq(out)
     end
   end
 end

--- a/Library/Homebrew/test/cmd/services/list_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/services/list_subcommand_spec.rb
@@ -4,9 +4,11 @@
 require "cmd/services"
 
 RSpec.describe Homebrew::Cmd::Services::ListSubcommand do
+  let(:klass) { Homebrew::Cmd::Services::ListSubcommand }
+
   describe "#TRIGGERS" do
     it "contains all restart triggers" do
-      expect(described_class::TRIGGERS).to eq([nil, "list", "ls"])
+      expect(klass::TRIGGERS).to eq([nil, "list", "ls"])
     end
   end
 
@@ -15,14 +17,14 @@ RSpec.describe Homebrew::Cmd::Services::ListSubcommand do
       expect(Homebrew::Services::Formulae).to receive(:services_list).and_return([])
       expect do
         allow($stderr).to receive(:tty?).and_return(true)
-        described_class.new(Homebrew::Cmd::Services.new(%w[list]).args).run
+        klass.new(Homebrew::Cmd::Services.new(%w[list]).args).run
       end.to output(a_string_including("No services available to control with `brew services`")).to_stderr
     end
 
     it "outputs empty JSON array with empty list and --json" do
       expect(Homebrew::Services::Formulae).to receive(:services_list).and_return([])
       expect do
-        described_class.new(Homebrew::Cmd::Services.new(%w[list --json]).args).run
+        klass.new(Homebrew::Cmd::Services.new(%w[list --json]).args).run
       end.to output("[]\n").to_stdout
     end
 
@@ -37,7 +39,7 @@ RSpec.describe Homebrew::Cmd::Services::ListSubcommand do
       }
       expect(Homebrew::Services::Formulae).to receive(:services_list).and_return([formula])
       expect do
-        described_class.new(Homebrew::Cmd::Services.new(%w[list]).args).run
+        klass.new(Homebrew::Cmd::Services.new(%w[list]).args).run
       end.to output(out).to_stdout
     end
 
@@ -52,12 +54,12 @@ RSpec.describe Homebrew::Cmd::Services::ListSubcommand do
         schedulable: false,
       }
 
-      filtered_formula = formula.slice(*described_class::JSON_FIELDS)
+      filtered_formula = formula.slice(*klass::JSON_FIELDS)
       expected_output = "#{JSON.pretty_generate([filtered_formula])}\n"
 
       expect(Homebrew::Services::Formulae).to receive(:services_list).and_return([formula])
       expect do
-        described_class.new(Homebrew::Cmd::Services.new(%w[list --json]).args).run
+        klass.new(Homebrew::Cmd::Services.new(%w[list --json]).args).run
       end.to output(expected_output).to_stdout
     end
   end
@@ -66,14 +68,14 @@ RSpec.describe Homebrew::Cmd::Services::ListSubcommand do
     it "prints all standard values" do
       formula = { name: "a", user: "u", file: Pathname.new("/tmp/file.file"), status: :stopped }
       expect do
-        described_class.print_table([formula])
+        klass.print_table([formula])
       end.to output("Name Status User File\na    stopped         u    \n").to_stdout
     end
 
     it "prints without user or file data" do
       formula = { name: "a", user: nil, file: nil, status: :started, loaded: true }
       expect do
-        described_class.print_table([formula])
+        klass.print_table([formula])
       end.to output("Name Status User File\na    started              \n").to_stdout
     end
 
@@ -82,7 +84,7 @@ RSpec.describe Homebrew::Cmd::Services::ListSubcommand do
       formula = { name: "a", user: "u", file: Pathname.new("/tmp/file.file"), status: :started, loaded: true }
       expected_output = "Name Status User File\na    started         u    ~/file.file\n"
       expect do
-        described_class.print_table([formula])
+        klass.print_table([formula])
       end.to output(expected_output).to_stdout
     end
 
@@ -91,7 +93,7 @@ RSpec.describe Homebrew::Cmd::Services::ListSubcommand do
       formula = { name: "a", user: "u", file:, status: :error, exit_code: 256, loaded: true }
       expected_output = "Name Status User File\na    error  256      u    /tmp/file.file\n"
       expect do
-        described_class.print_table([formula])
+        klass.print_table([formula])
       end.to output(expected_output).to_stdout
     end
   end
@@ -101,49 +103,49 @@ RSpec.describe Homebrew::Cmd::Services::ListSubcommand do
       formula = { name: "a", status: :stopped, user: "u", file: Pathname.new("/tmp/file.file") }
       expected_output = "#{JSON.pretty_generate([formula])}\n"
       expect do
-        described_class.print_json([formula])
+        klass.print_json([formula])
       end.to output(expected_output).to_stdout
     end
 
     it "prints without user or file data" do
       formula = { name: "a", user: nil, file: nil, status: :started, loaded: true }
-      filtered_formula = formula.slice(*described_class::JSON_FIELDS)
+      filtered_formula = formula.slice(*klass::JSON_FIELDS)
       expected_output = "#{JSON.pretty_generate([filtered_formula])}\n"
       expect do
-        described_class.print_json([formula])
+        klass.print_json([formula])
       end.to output(expected_output).to_stdout
     end
 
     it "includes an exit code" do
       file = Pathname.new("/tmp/file.file")
       formula = { name: "a", user: "u", file:, status: :error, exit_code: 256, loaded: true }
-      filtered_formula = formula.slice(*described_class::JSON_FIELDS)
+      filtered_formula = formula.slice(*klass::JSON_FIELDS)
       expected_output = "#{JSON.pretty_generate([filtered_formula])}\n"
       expect do
-        described_class.print_json([formula])
+        klass.print_json([formula])
       end.to output(expected_output).to_stdout
     end
   end
 
   describe "#get_status_string" do
     it "returns started" do
-      expect(described_class.get_status_string(:started)).to eq("started")
+      expect(klass.get_status_string(:started)).to eq("started")
     end
 
     it "returns stopped" do
-      expect(described_class.get_status_string(:stopped)).to eq("stopped")
+      expect(klass.get_status_string(:stopped)).to eq("stopped")
     end
 
     it "returns error" do
-      expect(described_class.get_status_string(:error)).to eq("error  ")
+      expect(klass.get_status_string(:error)).to eq("error  ")
     end
 
     it "returns unknown" do
-      expect(described_class.get_status_string(:unknown)).to eq("unknown")
+      expect(klass.get_status_string(:unknown)).to eq("unknown")
     end
 
     it "returns other" do
-      expect(described_class.get_status_string(:other)).to eq("other")
+      expect(klass.get_status_string(:other)).to eq("other")
     end
   end
 end

--- a/Library/Homebrew/test/cmd/services/restart_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/services/restart_subcommand_spec.rb
@@ -4,16 +4,18 @@
 require "cmd/services"
 
 RSpec.describe Homebrew::Cmd::Services::RestartSubcommand do
+  let(:klass) { Homebrew::Cmd::Services::RestartSubcommand }
+
   describe "#TRIGGERS" do
     it "contains all restart triggers" do
-      expect(described_class::TRIGGERS).to eq(%w[restart relaunch reload r])
+      expect(klass::TRIGGERS).to eq(%w[restart relaunch reload r])
     end
   end
 
   describe "#run" do
     it "fails with empty list" do
       expect do
-        described_class.new(Homebrew::Cmd::Services.new(%w[restart testball]).args, targets: []).run
+        klass.new(Homebrew::Cmd::Services.new(%w[restart testball]).args, targets: []).run
       end.to raise_error UsageError,
                          "Invalid usage: Formula(e) missing, please provide a formula name or use `--all`."
     end
@@ -24,7 +26,7 @@ RSpec.describe Homebrew::Cmd::Services::RestartSubcommand do
       expect(Homebrew::Services::Cli).to receive(:start).once
       service = instance_double(Homebrew::Services::FormulaWrapper, service_name: "name", loaded?: false)
       expect do
-        described_class.new(Homebrew::Cmd::Services.new(%w[restart testball]).args, targets: [service]).run
+        klass.new(Homebrew::Cmd::Services.new(%w[restart testball]).args, targets: [service]).run
       end.not_to raise_error
     end
 
@@ -35,7 +37,7 @@ RSpec.describe Homebrew::Cmd::Services::RestartSubcommand do
       service = instance_double(Homebrew::Services::FormulaWrapper, service_name: "name", loaded?: true,
 service_file_present?: true)
       expect do
-        described_class.new(Homebrew::Cmd::Services.new(%w[restart testball]).args, targets: [service]).run
+        klass.new(Homebrew::Cmd::Services.new(%w[restart testball]).args, targets: [service]).run
       end.not_to raise_error
     end
 
@@ -46,7 +48,7 @@ service_file_present?: true)
       service = instance_double(Homebrew::Services::FormulaWrapper, service_name: "name", loaded?: true,
 service_file_present?: false)
       expect do
-        described_class.new(Homebrew::Cmd::Services.new(%w[restart testball]).args, targets: [service]).run
+        klass.new(Homebrew::Cmd::Services.new(%w[restart testball]).args, targets: [service]).run
       end.not_to raise_error
     end
   end

--- a/Library/Homebrew/test/cmd/services_spec.rb
+++ b/Library/Homebrew/test/cmd/services_spec.rb
@@ -8,18 +8,20 @@ RSpec.describe Homebrew::Cmd::Services, :needs_daemon_manager do
   it_behaves_like "parseable arguments"
 
   it "sets canonical subcommand names", :aggregate_failures do
-    expect(described_class.new([]).args.subcommand).to eq("list")
-    expect(described_class.new(%w[i testball]).args.subcommand).to eq("info")
+    expect(Homebrew::Cmd::Services.new([]).args.subcommand).to eq("list")
+    expect(Homebrew::Cmd::Services.new(%w[i testball]).args.subcommand).to eq("info")
   end
 
   it "rejects file-only options for info" do
-    expect { described_class.new(%w[info testball --file=/tmp/service.plist]) }
+    expect { Homebrew::Cmd::Services.new(%w[info testball --file=/tmp/service.plist]) }
       .to raise_error(UsageError, /`info` subcommand does not accept the `--file` flag/)
   end
 
   it "uses operation-specific --all descriptions", :aggregate_failures do
     subcommand_options = lambda do |subcommand|
-      described_class.parser.processed_options_for_subcommand(subcommand).filter_map do |_, long, description, hidden|
+      Homebrew::Cmd::Services.parser
+                             .processed_options_for_subcommand(subcommand)
+                             .filter_map do |_, long, description, hidden|
         [long, description] unless hidden
       end.to_h
     end

--- a/Library/Homebrew/test/cmd/source_spec.rb
+++ b/Library/Homebrew/test/cmd/source_spec.rb
@@ -5,6 +5,8 @@ require "cmd/source"
 require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::Source do
+  let(:klass) { Homebrew::Cmd::Source }
+
   it_behaves_like "parseable arguments"
 
   it "opens the Homebrew repo when no formula is specified", :integration_test do
@@ -16,85 +18,85 @@ RSpec.describe Homebrew::Cmd::Source do
 
   describe "#github_repo_url" do
     it "extracts repository URL from GitHub URL" do
-      expect(described_class.new([]).send(:github_repo_url, "https://github.com/Homebrew/brew.git"))
+      expect(klass.new([]).send(:github_repo_url, "https://github.com/Homebrew/brew.git"))
         .to eq("https://github.com/Homebrew/brew")
     end
 
     it "handles GitHub archive URLs" do
-      expect(described_class.new([]).send(:github_repo_url, "https://github.com/Homebrew/testball/archive/refs/tags/v0.1.tar.gz"))
+      expect(klass.new([]).send(:github_repo_url, "https://github.com/Homebrew/testball/archive/refs/tags/v0.1.tar.gz"))
         .to eq("https://github.com/Homebrew/testball")
     end
 
     it "returns nil for non-GitHub URLs" do
-      expect(described_class.new([]).send(:github_repo_url, "https://example.com/repo.git"))
+      expect(klass.new([]).send(:github_repo_url, "https://example.com/repo.git"))
         .to be_nil
     end
   end
 
   describe "#gitlab_repo_url" do
     it "extracts repository URL from GitLab URL with nested groups" do
-      expect(described_class.new([]).send(:gitlab_repo_url, "https://gitlab.com/group/subgroup/project/-/archive/v1.0/project-v1.0.tar.gz"))
+      expect(klass.new([]).send(:gitlab_repo_url, "https://gitlab.com/group/subgroup/project/-/archive/v1.0/project-v1.0.tar.gz"))
         .to eq("https://gitlab.com/group/subgroup/project")
     end
 
     it "handles GitLab .git URLs" do
-      expect(described_class.new([]).send(:gitlab_repo_url, "https://gitlab.com/user/repo.git"))
+      expect(klass.new([]).send(:gitlab_repo_url, "https://gitlab.com/user/repo.git"))
         .to eq("https://gitlab.com/user/repo")
     end
 
     it "returns nil for non-GitLab URLs" do
-      expect(described_class.new([]).send(:gitlab_repo_url, "https://example.com/repo.git"))
+      expect(klass.new([]).send(:gitlab_repo_url, "https://example.com/repo.git"))
         .to be_nil
     end
   end
 
   describe "#bitbucket_repo_url" do
     it "extracts repository URL from Bitbucket URL" do
-      expect(described_class.new([]).send(:bitbucket_repo_url, "https://bitbucket.org/user/repo/get/v1.0.tar.gz"))
+      expect(klass.new([]).send(:bitbucket_repo_url, "https://bitbucket.org/user/repo/get/v1.0.tar.gz"))
         .to eq("https://bitbucket.org/user/repo")
     end
 
     it "handles Bitbucket .git URLs" do
-      expect(described_class.new([]).send(:bitbucket_repo_url, "https://bitbucket.org/user/repo.git"))
+      expect(klass.new([]).send(:bitbucket_repo_url, "https://bitbucket.org/user/repo.git"))
         .to eq("https://bitbucket.org/user/repo")
     end
 
     it "returns nil for non-Bitbucket URLs" do
-      expect(described_class.new([]).send(:bitbucket_repo_url, "https://example.com/repo.git"))
+      expect(klass.new([]).send(:bitbucket_repo_url, "https://example.com/repo.git"))
         .to be_nil
     end
   end
 
   describe "#codeberg_repo_url" do
     it "extracts repository URL from Codeberg URL" do
-      expect(described_class.new([]).send(:codeberg_repo_url, "https://codeberg.org/user/repo/archive/v1.0.tar.gz"))
+      expect(klass.new([]).send(:codeberg_repo_url, "https://codeberg.org/user/repo/archive/v1.0.tar.gz"))
         .to eq("https://codeberg.org/user/repo")
     end
 
     it "handles Codeberg .git URLs" do
-      expect(described_class.new([]).send(:codeberg_repo_url, "https://codeberg.org/user/repo.git"))
+      expect(klass.new([]).send(:codeberg_repo_url, "https://codeberg.org/user/repo.git"))
         .to eq("https://codeberg.org/user/repo")
     end
 
     it "returns nil for non-Codeberg URLs" do
-      expect(described_class.new([]).send(:codeberg_repo_url, "https://example.com/repo.git"))
+      expect(klass.new([]).send(:codeberg_repo_url, "https://example.com/repo.git"))
         .to be_nil
     end
   end
 
   describe "#sourcehut_repo_url" do
     it "extracts repository URL from SourceHut URL" do
-      expect(described_class.new([]).send(:sourcehut_repo_url, "https://git.sr.ht/~user/repo/archive/v1.0.tar.gz"))
+      expect(klass.new([]).send(:sourcehut_repo_url, "https://git.sr.ht/~user/repo/archive/v1.0.tar.gz"))
         .to eq("https://sr.ht/~user/repo")
     end
 
     it "handles sr.ht URLs without git subdomain" do
-      expect(described_class.new([]).send(:sourcehut_repo_url, "https://sr.ht/~user/repo"))
+      expect(klass.new([]).send(:sourcehut_repo_url, "https://sr.ht/~user/repo"))
         .to eq("https://sr.ht/~user/repo")
     end
 
     it "returns nil for non-SourceHut URLs" do
-      expect(described_class.new([]).send(:sourcehut_repo_url, "https://example.com/repo.git"))
+      expect(klass.new([]).send(:sourcehut_repo_url, "https://example.com/repo.git"))
         .to be_nil
     end
   end
@@ -117,7 +119,7 @@ RSpec.describe Homebrew::Cmd::Source do
           instance_double(Process::Status, success?: true),
         ])
 
-      expect(described_class.new([])
+      expect(klass.new([])
         .send(:pypi_repo_url,
               "https://files.pythonhosted.org/packages/24/62/ae72ff66c0f1fd959925b4c11f8c2dea61f47f6acaea75a08512cdfe3fed/numpy-2.4.1.tar.gz"))
         .to eq("https://github.com/numpy/numpy")
@@ -138,31 +140,31 @@ RSpec.describe Homebrew::Cmd::Source do
           instance_double(Process::Status, success?: true),
         ])
 
-      expect(described_class.new([])
+      expect(klass.new([])
         .send(:pypi_repo_url,
               "https://files.pythonhosted.org/packages/00/00/000000000000000000000000000000000000000000000000000000000000/foobar-0.0.1.tar.gz"))
         .to be_nil
     end
 
     it "returns nil for non-PyPI URLs" do
-      expect(described_class.new([]).send(:pypi_repo_url, "https://example.com/repo.git"))
+      expect(klass.new([]).send(:pypi_repo_url, "https://example.com/repo.git"))
         .to be_nil
     end
   end
 
   describe "#url_to_repo" do
     it "returns GitHub repo URL for GitHub URLs" do
-      expect(described_class.new([]).send(:url_to_repo, "https://github.com/Homebrew/brew"))
+      expect(klass.new([]).send(:url_to_repo, "https://github.com/Homebrew/brew"))
         .to eq("https://github.com/Homebrew/brew")
     end
 
     it "returns GitLab repo URL for GitLab URLs" do
-      expect(described_class.new([]).send(:url_to_repo, "https://gitlab.com/user/repo.git"))
+      expect(klass.new([]).send(:url_to_repo, "https://gitlab.com/user/repo.git"))
         .to eq("https://gitlab.com/user/repo")
     end
 
     it "returns nil for unsupported URLs" do
-      expect(described_class.new([]).send(:url_to_repo, "https://example.com/repo.tar.gz"))
+      expect(klass.new([]).send(:url_to_repo, "https://example.com/repo.tar.gz"))
         .to be_nil
     end
   end

--- a/Library/Homebrew/test/cmd/tab_spec.rb
+++ b/Library/Homebrew/test/cmd/tab_spec.rb
@@ -6,6 +6,8 @@ require "cmd/shared_examples/args_parse"
 require "tab"
 
 RSpec.describe Homebrew::Cmd::TabCmd do
+  let(:klass) { Homebrew::Cmd::TabCmd }
+
   def installed_on_request?(formula)
     # `brew` subprocesses can change the tab, invalidating the cached values.
     Tab.clear_cache
@@ -45,7 +47,7 @@ RSpec.describe Homebrew::Cmd::TabCmd do
 
     expect(tab_path).not_to exist
 
-    cmd = described_class.new(["--installed-on-request", "--cask", cask.token])
+    cmd = klass.new(["--installed-on-request", "--cask", cask.token])
     allow(cmd.args.named).to receive(:to_formulae_to_casks).and_return([[], [cask]])
     expect { cmd.run }
       .to output(/local-caffeine is now marked as installed on request/).to_stdout
@@ -56,7 +58,7 @@ RSpec.describe Homebrew::Cmd::TabCmd do
     tab_path.delete
     Cask::Tab.clear_cache
 
-    cmd = described_class.new(["--no-installed-on-request", "--cask", cask.token])
+    cmd = klass.new(["--no-installed-on-request", "--cask", cask.token])
     allow(cmd.args.named).to receive(:to_formulae_to_casks).and_return([[], [cask]])
     expect { cmd.run }
       .to output(/local-caffeine is already marked as not installed on request/).to_stdout

--- a/Library/Homebrew/test/cmd/tap-info_spec.rb
+++ b/Library/Homebrew/test/cmd/tap-info_spec.rb
@@ -5,6 +5,8 @@ require "cmd/shared_examples/args_parse"
 require "cmd/tap-info"
 
 RSpec.describe Homebrew::Cmd::TapInfo do
+  let(:klass) { Homebrew::Cmd::TapInfo }
+
   it_behaves_like "parseable arguments"
 
   it "gets information for a given Tap", :integration_test, :needs_network do
@@ -24,7 +26,7 @@ RSpec.describe Homebrew::Cmd::TapInfo do
   end
 
   describe "#decorate_formula" do
-    let(:tap_info) { described_class.new([]) }
+    let(:tap_info) { klass.new([]) }
     let(:tap) { instance_double(Tap, name: "homebrew/foo") }
 
     before do
@@ -66,7 +68,7 @@ RSpec.describe Homebrew::Cmd::TapInfo do
   end
 
   describe "#decorate_cask" do
-    let(:tap_info) { described_class.new([]) }
+    let(:tap_info) { klass.new([]) }
     let(:tap) { instance_double(Tap, name: "homebrew/foo") }
 
     before do
@@ -108,7 +110,7 @@ RSpec.describe Homebrew::Cmd::TapInfo do
   end
 
   describe "#print_tap_listings" do
-    let(:tap_info) { described_class.new([]) }
+    let(:tap_info) { klass.new([]) }
 
     before do
       allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)

--- a/Library/Homebrew/test/cmd/uninstall_spec.rb
+++ b/Library/Homebrew/test/cmd/uninstall_spec.rb
@@ -5,6 +5,8 @@ require "cmd/uninstall"
 require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::UninstallCmd do
+  let(:klass) { Homebrew::Cmd::UninstallCmd }
+
   it_behaves_like "parseable arguments"
 
   it "uninstalls a given Formula", :integration_test do
@@ -25,7 +27,7 @@ RSpec.describe Homebrew::Cmd::UninstallCmd do
     allow(Homebrew::Cleanup).to receive(:autoremove)
 
     cask = Cask::Cask.new("test-cask")
-    cmd = described_class.new(["test-cask"])
+    cmd = klass.new(["test-cask"])
     allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable).and_return([cask])
 
     expect { cmd.run }

--- a/Library/Homebrew/test/cmd/untap_spec.rb
+++ b/Library/Homebrew/test/cmd/untap_spec.rb
@@ -5,7 +5,9 @@ require "cmd/shared_examples/args_parse"
 require "cmd/untap"
 
 RSpec.describe Homebrew::Cmd::Untap do
-  let(:class_instance) { described_class.new(%w[arg1]) }
+  let(:klass) { Homebrew::Cmd::Untap }
+
+  let(:class_instance) { klass.new(%w[arg1]) }
 
   it_behaves_like "parseable arguments"
 

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -8,14 +8,18 @@ require "cmd/shared_examples/args_parse"
 require "cmd/shared_examples/reinstall_pkgconf_if_needed"
 
 RSpec.describe Homebrew::Cmd::UpdateReport do
+  let(:klass) { Homebrew::Cmd::UpdateReport }
+
   it_behaves_like "parseable arguments"
 
   it_behaves_like "reinstall_pkgconf_if_needed"
 
   describe Reporter do
+    let(:klass) { Reporter }
+
     let(:tap) { CoreTap.instance }
     let(:reporter_class) do
-      Class.new(described_class) do
+      Class.new(klass) do
         def initialize(tap)
           @tap = tap
 
@@ -43,7 +47,7 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
       ENV.delete_if { |k, _v| k.start_with? "HOMEBREW_UPDATE" }
 
       expect do
-        described_class.new(tap)
+        klass.new(tap)
       end.to raise_error(Reporter::ReporterRevisionUnsetError)
     end
 
@@ -157,10 +161,10 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
     describe "#diff" do
       context "when using the API" do
         subject(:reporter) do
-          described_class.new(tap,
-                              api_names_txt:        Pathname("formula_names.txt"),
-                              api_names_before_txt: Pathname("formula_names_before.txt"),
-                              api_dir_prefix:       HOMEBREW_CACHE/"api")
+          klass.new(tap,
+                    api_names_txt:        Pathname("formula_names.txt"),
+                    api_names_before_txt: Pathname("formula_names_before.txt"),
+                    api_dir_prefix:       HOMEBREW_CACHE/"api")
         end
 
         it "ignore lines that haven't changed" do
@@ -195,7 +199,9 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
   end
 
   describe ReporterHub do
-    let(:hub) { described_class.new }
+    let(:klass) { ReporterHub }
+
+    let(:hub) { klass.new }
 
     before do
       ENV["HOMEBREW_NO_COLOR"] = "1"

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -6,6 +6,8 @@ require "cmd/upgrade"
 require "cmd/shared_examples/reinstall_pkgconf_if_needed"
 
 RSpec.describe Homebrew::Cmd::UpgradeCmd do
+  let(:klass) { Homebrew::Cmd::UpgradeCmd }
+
   include FileUtils
 
   it_behaves_like "parseable arguments"
@@ -96,12 +98,12 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   end
 
   it "requires one named argument with --minimum-version" do
-    expect { described_class.new(["--minimum-version=1.2.3"]).run }
+    expect { klass.new(["--minimum-version=1.2.3"]).run }
       .to raise_error(UsageError, /`--minimum-version` requires exactly one formula or cask argument/)
   end
 
   it "rejects multiple named arguments with --minimum-version" do
-    expect { described_class.new(["foo", "bar", "--minimum-version=1.2.3"]).run }
+    expect { klass.new(["foo", "bar", "--minimum-version=1.2.3"]).run }
       .to raise_error(UsageError, /`--minimum-version` requires exactly one formula or cask argument/)
   end
 
@@ -127,7 +129,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     error = FormulaOrCaskUnavailableError.new("nonexistent")
     formula = instance_double(Formula, full_name: "testball")
 
-    cmd = described_class.new(["testball", "nonexistent"])
+    cmd = klass.new(["testball", "nonexistent"])
     allow(cmd.args.named).to receive(:present?).and_return(true)
     allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable)
       .with(method: :resolve)
@@ -144,7 +146,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   it "catches cask upgrade errors and sets Homebrew.failed" do
     allow(Cask::Upgrade).to receive(:upgrade_casks!).and_raise(Cask::CaskError.new("test cask error"))
 
-    cmd = described_class.new(["--cask"])
+    cmd = klass.new(["--cask"])
     expect { cmd.send(:upgrade_outdated_casks!, []) }
       .to output(/test cask error/).to_stderr
 
@@ -152,7 +154,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   end
 
   it "does not ask again when upgrading discovered outdated casks" do
-    cmd = described_class.new(["--ask", "--cask"])
+    cmd = klass.new(["--ask", "--cask"])
 
     expect(Homebrew::Install).not_to receive(:ask_casks)
     expect(Cask::Upgrade).to receive(:upgrade_casks!).and_return(true)
@@ -161,7 +163,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   end
 
   it "prints formula and cask ask plans before upgrading" do
-    cmd = described_class.new(["--ask"])
+    cmd = klass.new(["--ask"])
 
     expect(cmd).to receive(:upgrade_outdated_formulae!)
       .with([], dry_run: true, show_upgrade_summary: false)
@@ -193,7 +195,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   end
 
   it "does not ask before upgrading when nothing would upgrade" do
-    cmd = described_class.new(["--ask"])
+    cmd = klass.new(["--ask"])
 
     expect(cmd).to receive(:upgrade_outdated_formulae!)
       .with([], dry_run: true, show_upgrade_summary: false)
@@ -230,7 +232,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     formula = formula("testball") do
       url "https://brew.sh/testball-0.2"
     end
-    cmd = described_class.new(["--ask", "oldtestball"])
+    cmd = klass.new(["--ask", "oldtestball"])
     allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable)
       .with(method: :resolve)
       .and_return([formula])
@@ -256,7 +258,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   end
 
   it "prints formula download sizes in dry-run upgrade summaries" do
-    cmd = described_class.new(["--dry-run"])
+    cmd = klass.new(["--dry-run"])
     formula = formula("testball") do
       url "https://brew.sh/testball-0.2"
     end
@@ -313,8 +315,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   end
 
   it "does not print aggregate package sizes" do
-    cmd = described_class.new(["--dry-run"])
-    summary = described_class::FinalUpgradeSummary.new(
+    cmd = klass.new(["--dry-run"])
+    summary = klass::FinalUpgradeSummary.new(
       version_changes: ["testball 0.1 -> 0.2 (500B)", "codex 1.0 -> 2.0"],
     )
 
@@ -328,7 +330,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   end
 
   it "uses the final summary for dry-run upgrade lists" do
-    cmd = described_class.new(["--dry-run"])
+    cmd = klass.new(["--dry-run"])
 
     expect(cmd).to receive(:upgrade_outdated_formulae!)
       .with([], use_prefetched: false, show_upgrade_summary: false)
@@ -344,7 +346,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   end
 
   it "prints a combined upgrade summary before fetching combined downloads" do
-    cmd = described_class.new([])
+    cmd = klass.new([])
     download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, fetch_failed: false, shutdown: nil)
     cask = instance_double(
       Cask::Cask,
@@ -390,7 +392,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   end
 
   it "prints a bottle manifest heading before formula prefetches" do
-    cmd = described_class.new([])
+    cmd = klass.new([])
     formula = formula("deno") do
       url "https://brew.sh/deno-2.7.11.tar.gz"
 
@@ -411,7 +413,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   end
 
   it "omits the bottle manifest heading for cached formula manifests" do
-    cmd = described_class.new([])
+    cmd = Homebrew::Cmd::UpgradeCmd.new([])
     formula = formula("deno") do
       url "https://brew.sh/deno-2.7.11.tar.gz"
 
@@ -433,7 +435,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   end
 
   it "does not trust failed shared prefetches" do
-    cmd = described_class.new([])
+    cmd = klass.new([])
     download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, fetch_failed: true, shutdown: nil)
     cask = instance_double(
       Cask::Cask,
@@ -498,15 +500,15 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     (CoreCaskTap.instance.cask_dir/"local-caffeine.rb").unlink
     CoreCaskTap.instance.clear_cache
 
-    cmd = described_class.new(["--cask", "--dry-run"])
+    cmd = klass.new(["--cask", "--dry-run"])
 
     expect { cmd.send(:upgrade_outdated_casks!, []) }
       .to not_to_output(/Unexpected method 'discontinued' called during caveats on Cask local-caffeine\./).to_stderr
   end
 
   it "prints a narrow final upgrade summary" do
-    cmd = described_class.new([])
-    summary = described_class::FinalUpgradeSummary.new(
+    cmd = klass.new([])
+    summary = klass::FinalUpgradeSummary.new(
       version_changes:       ["testball 0.1 -> 0.2"],
       pinned_formulae:       ["pinnedball 1.0"],
       pinned_casks:          ["pinned-cask 2.0"],
@@ -554,8 +556,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     old_keg.mkpath
     allow(formula).to receive_messages(optlinked?: true, opt_prefix: old_keg)
 
-    cmd = described_class.new([])
-    context = described_class::FormulaeUpgradeContext.new(
+    cmd = klass.new([])
+    context = klass::FormulaeUpgradeContext.new(
       formulae_to_install: [formula, deprecated, disabled, source_build],
       formulae_installer:  [
         FormulaInstaller.new(formula),
@@ -586,10 +588,10 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     old_keg.mkpath
     new_keg.mkpath
     allow(formula).to receive_messages(optlinked?: true, opt_prefix: old_keg)
-    cmd = described_class.new([])
+    cmd = klass.new([])
 
     allow(cmd).to receive(:formulae_upgrade_context).and_return(
-      described_class::FormulaeUpgradeContext.new(
+      klass::FormulaeUpgradeContext.new(
         formulae_to_install: [formula],
         formulae_installer:  [FormulaInstaller.new(formula)],
         dependants:          Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: []),

--- a/Library/Homebrew/test/cmd/uses_spec.rb
+++ b/Library/Homebrew/test/cmd/uses_spec.rb
@@ -7,6 +7,8 @@ require "cmd/uses"
 require "fileutils"
 
 RSpec.describe Homebrew::Cmd::Uses do
+  let(:klass) { Homebrew::Cmd::Uses }
+
   include FileUtils
 
   it_behaves_like "parseable arguments"
@@ -58,7 +60,7 @@ RSpec.describe Homebrew::Cmd::Uses do
     expect_any_instance_of(Homebrew::CLI::NamedArgs)
       .to receive(:to_formulae)
       .and_raise(FormulaUnavailableError, "foo")
-    cmd = described_class.new(%w[foo --eval-all --include-optional --recursive])
+    cmd = klass.new(%w[foo --eval-all --include-optional --recursive])
     expect { cmd.run }
       .to output(/^(bar\noptional|optional\nbar)$/).to_stdout
       .and output(/Error: Missing formulae should not have dependents!\n/).to_stderr

--- a/Library/Homebrew/test/cmd/version-install_spec.rb
+++ b/Library/Homebrew/test/cmd/version-install_spec.rb
@@ -5,8 +5,9 @@ require "cmd/shared_examples/args_parse"
 require "cmd/version-install"
 
 RSpec.describe Homebrew::Cmd::VersionInstall do
-  subject(:version_install) { described_class.new(args) }
+  subject(:version_install) { klass.new(args) }
 
+  let(:klass) { Homebrew::Cmd::VersionInstall }
   let(:formulary_factory) { ->(ref, **_opts) { raise FormulaUnavailableError, ref } }
   let(:installed_taps) { [] }
   let(:installed_formula_names) { [] }

--- a/Library/Homebrew/test/cmd/which-formula_spec.rb
+++ b/Library/Homebrew/test/cmd/which-formula_spec.rb
@@ -5,6 +5,8 @@ require "cmd/shared_examples/args_parse"
 require "cmd/which-formula"
 
 RSpec.describe Homebrew::Cmd::WhichFormula do
+  let(:klass) { Homebrew::Cmd::WhichFormula }
+
   it_behaves_like "parseable arguments"
 
   describe "which_formula" do
@@ -19,10 +21,10 @@ RSpec.describe Homebrew::Cmd::WhichFormula do
 
     before do
       # Override DATABASE_FILE to use test environment's HOMEBREW_CACHE
-      test_db_file = HOMEBREW_CACHE/"api"/described_class::ENDPOINT
-      stub_const("#{described_class}::DATABASE_FILE", test_db_file)
+      test_db_file = HOMEBREW_CACHE/"api"/klass::ENDPOINT
+      stub_const("#{klass}::DATABASE_FILE", test_db_file)
 
-      db = described_class::DATABASE_FILE
+      db = klass::DATABASE_FILE
       db.dirname.mkpath
       db.write(<<~EOS)
         foo(1.0.0):foo2 foo3
@@ -51,7 +53,7 @@ RSpec.describe Homebrew::Cmd::WhichFormula do
     end
 
     it "errors if the API is disabled and the executable database is missing", :integration_test do
-      described_class::DATABASE_FILE.unlink
+      klass::DATABASE_FILE.unlink
 
       expect do
         expect(brew_sh("which-formula", "foo2", "HOMEBREW_NO_INSTALL_FROM_API" => "1")).to be_a_failure

--- a/Library/Homebrew/test/commands_spec.rb
+++ b/Library/Homebrew/test/commands_spec.rb
@@ -39,17 +39,19 @@ RSpec.shared_context "custom internal commands" do # rubocop:disable RSpec/Conte
 end
 
 RSpec.describe Commands do
+  let(:klass) { Commands }
+
   include_context "custom internal commands"
 
   specify "::internal_commands" do
-    cmds = described_class.internal_commands
+    cmds = klass.internal_commands
     expect(cmds).to include("rbcmd"), "Ruby commands files should be recognized"
     expect(cmds).to include("shcmd"), "Shell commands files should be recognized"
     expect(cmds).not_to include("rbdevcmd"), "Dev commands shouldn't be included"
   end
 
   specify "::internal_developer_commands" do
-    cmds = described_class.internal_developer_commands
+    cmds = klass.internal_developer_commands
     expect(cmds).to include("rbdevcmd"), "Ruby commands files should be recognized"
     expect(cmds).to include("shdevcmd"), "Shell commands files should be recognized"
     expect(cmds).not_to include("rbcmd"), "Non-dev commands shouldn't be included"
@@ -65,9 +67,9 @@ RSpec.describe Commands do
 
       FileUtils.touch "#{dir}/brew-t4"
 
-      allow(described_class).to receive(:tap_cmd_directories).and_return([dir])
+      allow(klass).to receive(:tap_cmd_directories).and_return([dir])
 
-      cmds = described_class.external_commands
+      cmds = klass.external_commands
 
       expect(cmds).to include("t0"), "Executable v2 Ruby files should be included"
       expect(cmds).to include("t1"), "Executable files should be included"
@@ -83,10 +85,10 @@ RSpec.describe Commands do
         stub_const("HOMEBREW_REPOSITORY", repository)
         (repository/"completions").mkpath
 
-        described_class.rebuild_internal_commands_completion_list
+        klass.rebuild_internal_commands_completion_list
 
         commands = (repository/"completions/internal_commands_list.txt").read.lines(chomp: true)
-        expect(commands & described_class.internal_commands_aliases).to be_empty
+        expect(commands & klass.internal_commands_aliases).to be_empty
       end
     end
   end
@@ -95,26 +97,26 @@ RSpec.describe Commands do
     it "omits internal command aliases from the cached command list" do
       mktmpdir do |cache|
         stub_const("HOMEBREW_CACHE", cache)
-        allow(described_class).to receive(:external_commands).and_return(["external"])
+        allow(klass).to receive(:external_commands).and_return(["external"])
 
-        described_class.rebuild_commands_completion_list
+        klass.rebuild_commands_completion_list
 
         commands = (cache/"all_commands_list.txt").read.lines(chomp: true)
-        expect(commands & described_class.internal_commands_aliases).to be_empty
+        expect(commands & klass.internal_commands_aliases).to be_empty
       end
     end
   end
 
   describe "::path" do
     specify "returns the path for an internal command" do
-      expect(described_class.path("rbcmd")).to eq(Commands::HOMEBREW_CMD_PATH/"rbcmd.rb")
-      expect(described_class.path("shcmd")).to eq(Commands::HOMEBREW_CMD_PATH/"shcmd.sh")
-      expect(described_class.path("idontexist1234")).to be_nil
+      expect(klass.path("rbcmd")).to eq(Commands::HOMEBREW_CMD_PATH/"rbcmd.rb")
+      expect(klass.path("shcmd")).to eq(Commands::HOMEBREW_CMD_PATH/"shcmd.sh")
+      expect(klass.path("idontexist1234")).to be_nil
     end
 
     specify "returns the path for an internal developer-command" do
-      expect(described_class.path("rbdevcmd")).to eq(Commands::HOMEBREW_DEV_CMD_PATH/"rbdevcmd.rb")
-      expect(described_class.path("shdevcmd")).to eq(Commands::HOMEBREW_DEV_CMD_PATH/"shdevcmd.sh")
+      expect(klass.path("rbdevcmd")).to eq(Commands::HOMEBREW_DEV_CMD_PATH/"rbdevcmd.rb")
+      expect(klass.path("shdevcmd")).to eq(Commands::HOMEBREW_DEV_CMD_PATH/"shdevcmd.sh")
     end
   end
 end

--- a/Library/Homebrew/test/compiler_failure_spec.rb
+++ b/Library/Homebrew/test/compiler_failure_spec.rb
@@ -4,25 +4,27 @@
 require "compilers"
 
 RSpec.describe CompilerFailure do
+  let(:klass) { CompilerFailure }
+
   alias_matcher :fail_with, :be_fails_with
 
   describe "::create" do
     it "creates a failure when given a symbol" do
-      failure = described_class.create(:clang)
+      failure = klass.create(:clang)
       expect(failure).to fail_with(
         instance_double(CompilerSelector::Compiler, "Compiler", type: :clang, name: :clang, version: 600),
       )
     end
 
     it "can be given a build number in a block" do
-      failure = described_class.create(:clang) { build 700 }
+      failure = klass.create(:clang) { build 700 }
       expect(failure).to fail_with(
         instance_double(CompilerSelector::Compiler, "Compiler", type: :clang, name: :clang, version: 700),
       )
     end
 
     it "can be given an empty block" do
-      failure = described_class.create(:clang) do
+      failure = klass.create(:clang) do
         # do nothing
       end
       expect(failure).to fail_with(
@@ -31,7 +33,7 @@ RSpec.describe CompilerFailure do
     end
 
     it "creates a failure when given a hash" do
-      failure = described_class.create(gcc: "7")
+      failure = klass.create(gcc: "7")
       expect(failure).to fail_with(
         instance_double(CompilerSelector::Compiler, "Compiler", type: :gcc, name: "gcc-7", version: Version.new("7")),
       )
@@ -48,7 +50,7 @@ RSpec.describe CompilerFailure do
     end
 
     it "creates a failure when given a hash and a block with aversion" do
-      failure = described_class.create(gcc: "7") { version "7.1" }
+      failure = klass.create(gcc: "7") { version "7.1" }
       expect(failure).to fail_with(
         instance_double(CompilerSelector::Compiler, "Compiler", type: :gcc, name: "gcc-7", version: Version.new("7")),
       )

--- a/Library/Homebrew/test/compiler_selector_spec.rb
+++ b/Library/Homebrew/test/compiler_selector_spec.rb
@@ -5,8 +5,9 @@ require "compilers"
 require "software_spec"
 
 RSpec.describe CompilerSelector do
-  subject(:selector) { described_class.new(software_spec, versions, compilers) }
+  subject(:selector) { klass.new(software_spec, versions, compilers) }
 
+  let(:klass) { CompilerSelector }
   let(:compilers) { [:clang, :gnu] }
   let(:software_spec) { SoftwareSpec.new }
   let(:cc) { :clang }

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -4,6 +4,8 @@
 require "completions"
 
 RSpec.describe Homebrew::Completions do
+  let(:klass) { Homebrew::Completions }
+
   let(:completions_dir) { HOMEBREW_REPOSITORY/"completions" }
   let(:internal_path) { HOMEBREW_REPOSITORY/"Library/Taps/homebrew/homebrew-bar" }
   let(:external_path) { HOMEBREW_REPOSITORY/"Library/Taps/foo/homebrew-bar" }
@@ -12,7 +14,7 @@ RSpec.describe Homebrew::Completions do
     HOMEBREW_REPOSITORY.cd do
       system "git", "init"
     end
-    described_class::SHELLS.each do |shell|
+    klass::SHELLS.each do |shell|
       (completions_dir/shell).mkpath
     end
     internal_path.mkpath
@@ -61,19 +63,19 @@ RSpec.describe Homebrew::Completions do
     describe ".link!" do
       it "sets homebrew.linkcompletions to true" do
         setup_completions_setting false
-        expect { described_class.link! }.not_to raise_error
+        expect { klass.link! }.not_to raise_error
         expect(read_completions_setting).to eq "true"
       end
 
       it "sets homebrew.linkcompletions to true if unset" do
         delete_completions_setting
-        expect { described_class.link! }.not_to raise_error
+        expect { klass.link! }.not_to raise_error
         expect(read_completions_setting).to eq "true"
       end
 
       it "keeps homebrew.linkcompletions set to true" do
         setup_completions_setting true
-        expect { described_class.link! }.not_to raise_error
+        expect { klass.link! }.not_to raise_error
         expect(read_completions_setting).to eq "true"
       end
     end
@@ -81,19 +83,19 @@ RSpec.describe Homebrew::Completions do
     describe ".unlink!" do
       it "sets homebrew.linkcompletions to false" do
         setup_completions_setting true
-        expect { described_class.unlink! }.not_to raise_error
+        expect { klass.unlink! }.not_to raise_error
         expect(read_completions_setting).to eq "false"
       end
 
       it "sets homebrew.linkcompletions to false if unset" do
         delete_completions_setting
-        expect { described_class.unlink! }.not_to raise_error
+        expect { klass.unlink! }.not_to raise_error
         expect(read_completions_setting).to eq "false"
       end
 
       it "keeps homebrew.linkcompletions set to false" do
         setup_completions_setting false
-        expect { described_class.unlink! }.not_to raise_error
+        expect { klass.unlink! }.not_to raise_error
         expect(read_completions_setting).to eq "false"
       end
     end
@@ -101,28 +103,28 @@ RSpec.describe Homebrew::Completions do
     describe ".link_completions?" do
       it "returns true if homebrew.linkcompletions is true" do
         setup_completions_setting true
-        expect(described_class.link_completions?).to be true
+        expect(klass.link_completions?).to be true
       end
 
       it "returns false if homebrew.linkcompletions is false" do
         setup_completions_setting false
-        expect(described_class.link_completions?).to be false
+        expect(klass.link_completions?).to be false
       end
 
       it "returns false if homebrew.linkcompletions is not set" do
-        expect(described_class.link_completions?).to be false
+        expect(klass.link_completions?).to be false
       end
     end
 
     describe ".completions_to_link?" do
       it "returns false if only internal taps have completions" do
         setup_completions external: false
-        expect(described_class.completions_to_link?).to be false
+        expect(klass.completions_to_link?).to be false
       end
 
       it "returns true if external taps have completions" do
         setup_completions external: true
-        expect(described_class.completions_to_link?).to be true
+        expect(klass.completions_to_link?).to be true
       end
     end
 
@@ -130,13 +132,13 @@ RSpec.describe Homebrew::Completions do
       it "doesn't show the message if there are no completions to link" do
         setup_completions external: false
         delete_completions_setting setting: :completionsmessageshown
-        expect { described_class.show_completions_message_if_needed }.not_to output.to_stdout
+        expect { klass.show_completions_message_if_needed }.not_to output.to_stdout
       end
 
       it "doesn't show the message if there are completions to link but the message has already been shown" do
         setup_completions external: true
         setup_completions_setting true, setting: :completionsmessageshown
-        expect { described_class.show_completions_message_if_needed }.not_to output.to_stdout
+        expect { klass.show_completions_message_if_needed }.not_to output.to_stdout
       end
 
       it "shows the message if there are completions to link and the message hasn't already been shown" do
@@ -144,7 +146,7 @@ RSpec.describe Homebrew::Completions do
         delete_completions_setting setting: :completionsmessageshown
 
         message = /Homebrew completions for external commands are unlinked by default!/
-        expect { described_class.show_completions_message_if_needed }
+        expect { klass.show_completions_message_if_needed }
           .to output(message).to_stdout
       end
     end
@@ -155,7 +157,7 @@ RSpec.describe Homebrew::Completions do
     #       an actual regression.
     # describe ".update_shell_completions!" do
     #   it "generates shell completions" do
-    #     described_class.update_shell_completions!
+    #     klass.update_shell_completions!
     #     expect(completions_dir/"bash/brew").to be_a_file
     #   end
     # end
@@ -216,23 +218,23 @@ RSpec.describe Homebrew::Completions do
 
     describe ".format_description" do
       it "escapes single quotes" do
-        expect(described_class.format_description("Homebrew's")).to eq "Homebrew'\\''s"
+        expect(klass.format_description("Homebrew's")).to eq "Homebrew'\\''s"
       end
 
       it "escapes single quotes for fish" do
-        expect(described_class.format_description("Homebrew's", fish: true)).to eq "Homebrew\\'s"
+        expect(klass.format_description("Homebrew's", fish: true)).to eq "Homebrew\\'s"
       end
 
       it "removes angle brackets" do
-        expect(described_class.format_description("<formula>")).to eq "formula"
+        expect(klass.format_description("<formula>")).to eq "formula"
       end
 
       it "replaces newlines with spaces" do
-        expect(described_class.format_description("Homebrew\ncommand")).to eq "Homebrew command"
+        expect(klass.format_description("Homebrew\ncommand")).to eq "Homebrew command"
       end
 
       it "removes trailing period" do
-        expect(described_class.format_description("Homebrew.")).to eq "Homebrew"
+        expect(klass.format_description("Homebrew.")).to eq "Homebrew"
       end
     end
 
@@ -246,7 +248,7 @@ RSpec.describe Homebrew::Completions do
           "--quiet"   => "Make some output more quiet.",
           "--verbose" => "Make some output more verbose.",
         }
-        expect(described_class.command_options("missing")).to eq expected_options
+        expect(klass.command_options("missing")).to eq expected_options
       end
 
       it "returns an array of options for a shell command" do
@@ -259,35 +261,35 @@ RSpec.describe Homebrew::Completions do
           "--quiet"       => "Make some output more quiet.",
           "--verbose"     => "Print the directories checked and `git` operations performed.",
         }
-        expect(described_class.command_options("update")).to eq expected_options
+        expect(klass.command_options("update")).to eq expected_options
       end
 
       it "handles --[no]- options correctly" do
-        options = described_class.command_options("audit")
+        options = klass.command_options("audit")
         expect(options.key?("--signing")).to be true
         expect(options.key?("--no-signing")).to be true
         expect(options["--signing"] == options["--no-signing"]).to be true
       end
 
       it "return an empty array if command is not found" do
-        expect(described_class.command_options("foobar")).to eq({})
+        expect(klass.command_options("foobar")).to eq({})
       end
 
       it "return an empty array for a command with no options" do
-        expect(described_class.command_options("help")).to eq({})
+        expect(klass.command_options("help")).to eq({})
       end
 
       it "overrides global options with local descriptions" do
-        options = described_class.command_options("upgrade")
+        options = klass.command_options("upgrade")
         expect(options["--verbose"]).to eq "Print the verification and post-install steps."
       end
 
       it "returns options for a nested subcommand" do
         stub_nested_completion_command(nested_completion_command, nested_completion_subcommands)
 
-        root_options = described_class.command_options(nested_completion_command)
-        info_options = described_class.command_options(nested_completion_command, subcommand: "info")
-        start_options = described_class.command_options(nested_completion_command, subcommand: "start")
+        root_options = klass.command_options(nested_completion_command)
+        info_options = klass.command_options(nested_completion_command, subcommand: "info")
+        start_options = klass.command_options(nested_completion_command, subcommand: "start")
 
         expect(root_options).to include("--global")
         expect(root_options).not_to include("--all")
@@ -300,25 +302,25 @@ RSpec.describe Homebrew::Completions do
 
     describe ".command_gets_completions?" do
       it "returns true for a non-cask command with options" do
-        expect(described_class.command_gets_completions?("install")).to be true
+        expect(klass.command_gets_completions?("install")).to be true
       end
 
       it "returns false for a non-cask command with no options" do
-        expect(described_class.command_gets_completions?("help")).to be false
+        expect(klass.command_gets_completions?("help")).to be false
       end
 
       it "returns false for a cask command" do
-        expect(described_class.command_gets_completions?("cask install")).to be false
+        expect(klass.command_gets_completions?("cask install")).to be false
       end
     end
 
     describe ".generate_bash_subcommand_completion" do
       it "returns nil if completions aren't needed" do
-        expect(described_class.generate_bash_subcommand_completion("help")).to be_nil
+        expect(klass.generate_bash_subcommand_completion("help")).to be_nil
       end
 
       it "returns appropriate completion for a ruby command" do
-        completion = described_class.generate_bash_subcommand_completion("missing")
+        completion = klass.generate_bash_subcommand_completion("missing")
         expect(completion).to eq <<~COMPLETION
           _brew_missing() {
             local cur="${COMP_WORDS[COMP_CWORD]}"
@@ -341,7 +343,7 @@ RSpec.describe Homebrew::Completions do
       end
 
       it "returns appropriate completion for a shell command" do
-        completion = described_class.generate_bash_subcommand_completion("update")
+        completion = klass.generate_bash_subcommand_completion("update")
         expect(completion).to eq <<~COMPLETION
           _brew_update() {
             local cur="${COMP_WORDS[COMP_CWORD]}"
@@ -365,13 +367,13 @@ RSpec.describe Homebrew::Completions do
       end
 
       it "returns appropriate completion for a command with multiple named arg types" do
-        completion = described_class.generate_bash_subcommand_completion("upgrade")
+        completion = klass.generate_bash_subcommand_completion("upgrade")
         expect(completion).to match(/__brew_complete_installed_formulae\n  __brew_complete_installed_casks\n}$/)
       end
 
       it "returns appropriate completion for a command with nested subcommands" do
         stub_nested_completion_command(nested_completion_command, nested_completion_subcommands)
-        completion = described_class.generate_bash_subcommand_completion(nested_completion_command)
+        completion = klass.generate_bash_subcommand_completion(nested_completion_command)
 
         expect(completion).to include('info|i) subcommand="info"; break ;;')
         expect(completion).to include('__brewcomp "list ls info i start s"')
@@ -385,7 +387,7 @@ RSpec.describe Homebrew::Completions do
 
     describe ".generate_bash_completion_file" do
       it "returns the correct completion file" do
-        file = described_class.generate_bash_completion_file(%w[install missing update])
+        file = klass.generate_bash_completion_file(%w[install missing update])
         expect(file).to match(/^__brewcomp\(\) {$/)
         expect(file).to match(/^_brew_install\(\) {$/)
         expect(file).to match(/^_brew_missing\(\) {$/)
@@ -398,7 +400,7 @@ RSpec.describe Homebrew::Completions do
       end
 
       it "doesn't add aliases to command completions" do
-        file = described_class.generate_bash_completion_file(%w[install missing up update])
+        file = klass.generate_bash_completion_file(%w[install missing up update])
         expect(file).not_to include("cmd_aliases")
         expect(file).not_to match(/^_brew_up\(\) {$/)
         expect(file).not_to match(/^ {4}up\) _brew_up ;;/)
@@ -411,11 +413,11 @@ RSpec.describe Homebrew::Completions do
 
     describe ".generate_zsh_subcommand_completion" do
       it "returns nil if completions aren't needed" do
-        expect(described_class.generate_zsh_subcommand_completion("help")).to be_nil
+        expect(klass.generate_zsh_subcommand_completion("help")).to be_nil
       end
 
       it "returns appropriate completion for a ruby command" do
-        completion = described_class.generate_zsh_subcommand_completion("missing")
+        completion = klass.generate_zsh_subcommand_completion("missing")
         expect(completion).to eq <<~COMPLETION
           # brew missing
           _brew_missing() {
@@ -432,7 +434,7 @@ RSpec.describe Homebrew::Completions do
       end
 
       it "returns appropriate completion for a shell command" do
-        completion = described_class.generate_zsh_subcommand_completion("update")
+        completion = klass.generate_zsh_subcommand_completion("update")
         expect(completion).to eq <<~COMPLETION
           # brew update
           _brew_update() {
@@ -449,7 +451,7 @@ RSpec.describe Homebrew::Completions do
       end
 
       it "returns appropriate completion for a command with multiple named arg types" do
-        completion = described_class.generate_zsh_subcommand_completion("livecheck")
+        completion = klass.generate_zsh_subcommand_completion("livecheck")
         expect(completion).to match(
           /'*:formula:__brew_formulae'/,
         )
@@ -460,7 +462,7 @@ RSpec.describe Homebrew::Completions do
 
       it "returns appropriate completion for a command with nested subcommands" do
         stub_nested_completion_command(nested_completion_command, nested_completion_subcommands)
-        completion = described_class.generate_zsh_subcommand_completion(nested_completion_command)
+        completion = klass.generate_zsh_subcommand_completion(nested_completion_command)
 
         expect(completion).to include("'1:subcommand:->subcommand'")
         expect(completion).to include("  _arguments -C \\\n    '--global[Use the global test file]' \\\n    " \
@@ -474,7 +476,7 @@ RSpec.describe Homebrew::Completions do
       end
 
       it "doesn't generate alias completion functions" do
-        file = described_class.generate_zsh_completion_file(%w[up update])
+        file = klass.generate_zsh_completion_file(%w[up update])
         expect(file).not_to match(/^# brew up$/)
         expect(file).not_to match(/^_brew_up\(\) {$/)
         expect(file).to match(/^    up update$/)
@@ -485,7 +487,7 @@ RSpec.describe Homebrew::Completions do
 
     describe ".generate_zsh_completion_file" do
       it "returns the correct completion file" do
-        file = described_class.generate_zsh_completion_file(%w[install missing update])
+        file = klass.generate_zsh_completion_file(%w[install missing update])
         expect(file).to match(/^__brew_list_aliases\(\) {$/)
         expect(file).to match(/^    up update$/)
         expect(file).to match(/^__brew_internal_commands\(\) {$/)
@@ -501,11 +503,11 @@ RSpec.describe Homebrew::Completions do
 
     describe ".generate_fish_subcommand_completion" do
       it "returns nil if completions aren't needed" do
-        expect(described_class.generate_fish_subcommand_completion("help")).to be_nil
+        expect(klass.generate_fish_subcommand_completion("help")).to be_nil
       end
 
       it "returns appropriate completion for a ruby command" do
-        completion = described_class.generate_fish_subcommand_completion("missing")
+        completion = klass.generate_fish_subcommand_completion("missing")
         expect(completion).to eq <<~COMPLETION
           __fish_brew_complete_cmd 'missing' 'Check the given formula kegs for missing dependencies'
           __fish_brew_complete_arg 'missing' -l debug -d 'Display any debugging information'
@@ -518,7 +520,7 @@ RSpec.describe Homebrew::Completions do
       end
 
       it "returns appropriate completion for a shell command" do
-        completion = described_class.generate_fish_subcommand_completion("update")
+        completion = klass.generate_fish_subcommand_completion("update")
         expect(completion).to eq <<~COMPLETION
           __fish_brew_complete_cmd 'update' 'Fetch the newest version of Homebrew and all formulae from GitHub using `git`(1) and perform any necessary migrations'
           __fish_brew_complete_arg 'update' -l auto-update -d 'Run on auto-updates (e.g. before `brew install`). Skips some slower steps'
@@ -532,7 +534,7 @@ RSpec.describe Homebrew::Completions do
       end
 
       it "returns appropriate completion for a command with multiple named arg types" do
-        completion = described_class.generate_fish_subcommand_completion("upgrade")
+        completion = klass.generate_fish_subcommand_completion("upgrade")
         expected_line_start = "__fish_brew_complete_arg 'upgrade; and not __fish_seen_argument"
         expect(completion).to match(
           /#{expected_line_start} -l cask -l casks' -a '\(__fish_brew_suggest_formulae_installed\)'/,
@@ -544,7 +546,7 @@ RSpec.describe Homebrew::Completions do
 
       it "returns appropriate completion for a command with nested subcommands" do
         stub_nested_completion_command(nested_completion_command, nested_completion_subcommands)
-        completion = described_class.generate_fish_subcommand_completion(nested_completion_command)
+        completion = klass.generate_fish_subcommand_completion(nested_completion_command)
 
         expect(completion).to include("__fish_brew_complete_sub_cmd 'subcommand-test' 'info'")
         expect(completion).to include("__fish_brew_complete_sub_cmd 'subcommand-test' 'i' " \
@@ -560,7 +562,7 @@ RSpec.describe Homebrew::Completions do
 
     describe ".generate_fish_completion_file" do
       it "returns the correct completion file" do
-        file = described_class.generate_fish_completion_file(%w[install missing update])
+        file = klass.generate_fish_completion_file(%w[install missing update])
         expect(file).to match(/^function __fish_brew_complete_cmd/)
         expect(file).to match(/^__fish_brew_complete_cmd 'install' 'Install a formula or cask'$/)
         expect(file).to match(/^__fish_brew_complete_cmd 'missing' 'Check the given formula kegs for .*'$/)
@@ -568,7 +570,7 @@ RSpec.describe Homebrew::Completions do
       end
 
       it "omits aliases from command completions" do
-        file = described_class.generate_fish_completion_file(%w[up update])
+        file = klass.generate_fish_completion_file(%w[up update])
         expect(file).not_to match(/^__fish_brew_complete_cmd 'up'/)
         expect(file).not_to match(/^__fish_brew_complete_arg 'up'/)
         expect(file).to match(/^        case 'up'$/)

--- a/Library/Homebrew/test/cxxstdlib_spec.rb
+++ b/Library/Homebrew/test/cxxstdlib_spec.rb
@@ -5,8 +5,10 @@ require "formula"
 require "cxxstdlib"
 
 RSpec.describe CxxStdlib do
-  let(:clang) { described_class.create(:libstdcxx, :clang) }
-  let(:lcxx) { described_class.create(:libcxx, :clang) }
+  let(:klass) { CxxStdlib }
+
+  let(:clang) { klass.create(:libstdcxx, :clang) }
+  let(:lcxx) { klass.create(:libcxx, :clang) }
 
   describe "#type_string" do
     specify "formatting" do

--- a/Library/Homebrew/test/dependencies_helpers_spec.rb
+++ b/Library/Homebrew/test/dependencies_helpers_spec.rb
@@ -4,6 +4,8 @@
 require "dependencies_helpers"
 
 RSpec.describe DependenciesHelpers do
+  let(:klass) { DependenciesHelpers }
+
   specify "#dependents" do
     foo = formula "foo" do
       url "foo"
@@ -36,7 +38,7 @@ RSpec.describe DependenciesHelpers do
       :any_version_installed?,
     ]
 
-    dependents = Class.new.extend(described_class).dependents([foo, foo_cask, bar, bar_cask])
+    dependents = Class.new.extend(klass).dependents([foo, foo_cask, bar, bar_cask])
 
     dependents.each do |dependent|
       methods.each do |method|

--- a/Library/Homebrew/test/dependencies_spec.rb
+++ b/Library/Homebrew/test/dependencies_spec.rb
@@ -5,7 +5,9 @@ require "dependencies"
 require "dependency"
 
 RSpec.describe Dependencies do
-  subject(:dependencies) { described_class.new }
+  subject(:dependencies) { klass.new }
+
+  let(:klass) { Dependencies }
 
   describe "#<<" do
     it "returns itself" do
@@ -58,8 +60,8 @@ RSpec.describe Dependencies do
   end
 
   specify "equality" do
-    a = described_class.new
-    b = described_class.new
+    a = klass.new
+    b = klass.new
 
     dep = Dependency.new("foo")
 

--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -4,9 +4,11 @@
 require "dependency_collector"
 
 RSpec.describe DependencyCollector do
-  alias_matcher :be_a_build_requirement, :be_build
+  subject(:collector) { klass.new }
 
-  subject(:collector) { described_class.new }
+  let(:klass) { DependencyCollector }
+
+  alias_matcher :be_a_build_requirement, :be_build
 
   def find_dependency(name)
     collector.deps.find { |dep| dep.name == name }

--- a/Library/Homebrew/test/dependency_expansion_spec.rb
+++ b/Library/Homebrew/test/dependency_expansion_spec.rb
@@ -4,13 +4,7 @@
 require "dependency"
 
 RSpec.describe Dependency do
-  def build_dep(name, tags = [], deps = [])
-    dep = described_class.new(name.to_s, tags)
-    allow(dep).to receive(:to_formula).and_return \
-      instance_double(Formula, deps:, name:, full_name: name)
-    dep
-  end
-
+  let(:klass) { Dependency }
   let(:foo) { build_dep(:foo) }
   let(:bar) { build_dep(:bar) }
   let(:baz) { build_dep(:baz) }
@@ -18,10 +12,17 @@ RSpec.describe Dependency do
   let(:deps) { [foo, bar, baz, qux] }
   let(:formula) { instance_double(Formula, deps:, name: "f") }
 
+  def build_dep(name, tags = [], deps = [])
+    dep = klass.new(name.to_s, tags)
+    allow(dep).to receive(:to_formula).and_return \
+      instance_double(Formula, deps:, name:, full_name: name)
+    dep
+  end
+
   describe "::expand" do
     it "yields dependent and dependency pairs" do
       i = 0
-      described_class.expand(formula) do |dependent, dep|
+      klass.expand(formula) do |dependent, dep|
         expect(dependent).to eq(formula)
         expect(deps[i]).to eq(dep)
         i += 1
@@ -29,16 +30,16 @@ RSpec.describe Dependency do
     end
 
     it "returns the dependencies" do
-      expect(described_class.expand(formula)).to eq(deps)
+      expect(klass.expand(formula)).to eq(deps)
     end
 
     it "prunes all when given a block with PRUNE" do
-      expect(described_class.expand(formula) { next described_class::PRUNE }).to be_empty
+      expect(klass.expand(formula) { next klass::PRUNE }).to be_empty
     end
 
     it "can prune selectively" do
-      deps = described_class.expand(formula) do |_, dep|
-        next described_class::PRUNE if dep.name == "foo"
+      deps = klass.expand(formula) do |_, dep|
+        next klass::PRUNE if dep.name == "foo"
       end
 
       expect(deps).to eq([bar, baz, qux])
@@ -47,20 +48,20 @@ RSpec.describe Dependency do
     it "preserves dependency order" do
       allow(foo).to receive(:to_formula).and_return \
         instance_double(Formula, name: "foo", full_name: "foo", deps: [qux, baz])
-      expect(described_class.expand(formula)).to eq([qux, baz, foo, bar])
+      expect(klass.expand(formula)).to eq([qux, baz, foo, bar])
     end
   end
 
   it "skips optionals by default" do
     deps = [build_dep(:foo, [:optional]), bar, baz, qux]
     f = instance_double(Formula, deps:, build: instance_double(BuildOptions, with?: false), name: "f")
-    expect(described_class.expand(f)).to eq([bar, baz, qux])
+    expect(klass.expand(f)).to eq([bar, baz, qux])
   end
 
   it "keeps recommended dependencies by default" do
     deps = [build_dep(:foo, [:recommended]), bar, baz, qux]
     f = instance_double(Formula, deps:, build: instance_double(BuildOptions, with?: true), name: "f")
-    expect(described_class.expand(f)).to eq(deps)
+    expect(klass.expand(f)).to eq(deps)
   end
 
   it "merges repeated dependencies with differing options" do
@@ -68,7 +69,7 @@ RSpec.describe Dependency do
     baz2 = build_dep(:baz, ["option"])
     deps << foo2 << baz2
     deps = [foo2, bar, baz2, qux]
-    deps.zip(described_class.expand(formula)) do |expected, actual|
+    deps.zip(klass.expand(formula)) do |expected, actual|
       expect(expected.tags).to eq(actual.tags)
       expect(expected).to eq(actual)
     end
@@ -79,7 +80,7 @@ RSpec.describe Dependency do
     foo3 = build_dep(:foo, ["option"])
     deps << foo2 << foo3
 
-    expect(described_class.expand(formula).first.tags).to eq(%w[option])
+    expect(klass.expand(formula).first.tags).to eq(%w[option])
   end
 
   it "skips parent but yields children with SKIP" do
@@ -92,8 +93,8 @@ RSpec.describe Dependency do
       ],
     )
 
-    deps = described_class.expand(f) do |_dependent, dep|
-      next described_class::SKIP if %w[foo qux].include? dep.name
+    deps = klass.expand(f) do |_dependent, dep|
+      next klass::SKIP if %w[foo qux].include? dep.name
     end
 
     expect(deps).to eq([bar, baz])
@@ -104,8 +105,8 @@ RSpec.describe Dependency do
     baz = build_dep(:baz, [:test])
     f = instance_double(Formula, name: "f", deps: [foo, baz])
 
-    deps = described_class.expand(f) do |_dependent, dep|
-      next described_class::KEEP_BUT_PRUNE_RECURSIVE_DEPS if dep.test?
+    deps = klass.expand(f) do |_dependent, dep|
+      next klass::KEEP_BUT_PRUNE_RECURSIVE_DEPS if dep.test?
     end
 
     expect(deps).to eq([foo, baz])
@@ -113,7 +114,7 @@ RSpec.describe Dependency do
 
   it "returns only the dependencies given as a collection as second argument" do
     expect(formula.deps).to eq([foo, bar, baz, qux])
-    expect(described_class.expand(formula, [bar, baz])).to eq([bar, baz])
+    expect(klass.expand(formula, [bar, baz])).to eq([bar, baz])
   end
 
   it "doesn't raise an error when a dependency is cyclic" do
@@ -122,14 +123,14 @@ RSpec.describe Dependency do
     allow(foo).to receive(:to_formula).and_return \
       instance_double(Formula, deps: [bar], name: foo.name, full_name: foo.name)
     f = instance_double(Formula, name: "f", full_name: "f", deps: [foo, bar])
-    expect { described_class.expand(f) }.not_to raise_error
+    expect { klass.expand(f) }.not_to raise_error
   end
 
   it "cleans the expand stack" do
     foo = build_dep(:foo)
     allow(foo).to receive(:to_formula).and_raise(FormulaUnavailableError, foo.name)
     f = instance_double(Formula, name: "f", deps: [foo])
-    expect { described_class.expand(f) }.to raise_error(FormulaUnavailableError)
-    expect(described_class.instance_variable_get(:@expand_stack)).to be_empty
+    expect { klass.expand(f) }.to raise_error(FormulaUnavailableError)
+    expect(klass.instance_variable_get(:@expand_stack)).to be_empty
   end
 end

--- a/Library/Homebrew/test/dependency_spec.rb
+++ b/Library/Homebrew/test/dependency_spec.rb
@@ -4,42 +4,44 @@
 require "dependency"
 
 RSpec.describe Dependency do
+  let(:klass) { Dependency }
+
   alias_matcher :be_a_build_dependency, :be_build
 
   describe "::new" do
     it "accepts a single tag" do
-      dep = described_class.new("foo", %w[bar])
+      dep = klass.new("foo", %w[bar])
       expect(dep.tags).to eq(%w[bar])
     end
 
     it "accepts multiple tags" do
-      dep = described_class.new("foo", %w[bar baz])
+      dep = klass.new("foo", %w[bar baz])
       expect(dep.tags.sort).to eq(%w[bar baz].sort)
     end
 
     it "preserves symbol tags" do
-      dep = described_class.new("foo", [:build])
+      dep = klass.new("foo", [:build])
       expect(dep.tags).to eq([:build])
     end
 
     it "accepts symbol and string tags" do
-      dep = described_class.new("foo", [:build, "bar"])
+      dep = klass.new("foo", [:build, "bar"])
       expect(dep.tags).to eq([:build, "bar"])
     end
 
     it "rejects nil names" do
-      expect { described_class.new(nil) }.to raise_error(TypeError)
+      expect { klass.new(nil) }.to raise_error(TypeError)
     end
   end
 
   describe "::merge_repeats" do
     it "merges duplicate dependencies" do
-      dep = described_class.new("foo", [:build])
-      dep2 = described_class.new("foo", ["bar"])
-      dep3 = described_class.new("xyz", ["abc"])
-      merged = described_class.merge_repeats([dep, dep2, dep3])
+      dep = klass.new("foo", [:build])
+      dep2 = klass.new("foo", ["bar"])
+      dep3 = klass.new("xyz", ["abc"])
+      merged = klass.merge_repeats([dep, dep2, dep3])
       expect(merged.count).to eq(2)
-      expect(merged.first).to be_a described_class
+      expect(merged.first).to be_a klass
 
       foo_named_dep = merged.find { |d| d.name == "foo" }
       expect(foo_named_dep.tags).to eq(["bar"])
@@ -49,23 +51,23 @@ RSpec.describe Dependency do
     end
 
     it "merges necessity tags" do
-      required_dep = described_class.new("foo")
-      recommended_dep = described_class.new("foo", [:recommended])
-      optional_dep = described_class.new("foo", [:optional])
+      required_dep = klass.new("foo")
+      recommended_dep = klass.new("foo", [:recommended])
+      optional_dep = klass.new("foo", [:optional])
 
-      deps = described_class.merge_repeats([required_dep, recommended_dep])
+      deps = klass.merge_repeats([required_dep, recommended_dep])
       expect(deps.count).to eq(1)
       expect(deps.first).to be_required
       expect(deps.first).not_to be_recommended
       expect(deps.first).not_to be_optional
 
-      deps = described_class.merge_repeats([required_dep, optional_dep])
+      deps = klass.merge_repeats([required_dep, optional_dep])
       expect(deps.count).to eq(1)
       expect(deps.first).to be_required
       expect(deps.first).not_to be_recommended
       expect(deps.first).not_to be_optional
 
-      deps = described_class.merge_repeats([recommended_dep, optional_dep])
+      deps = klass.merge_repeats([recommended_dep, optional_dep])
       expect(deps.count).to eq(1)
       expect(deps.first).not_to be_required
       expect(deps.first).to be_recommended
@@ -73,50 +75,50 @@ RSpec.describe Dependency do
     end
 
     it "merges temporality tags" do
-      normal_dep = described_class.new("foo")
-      build_dep = described_class.new("foo", [:build])
+      normal_dep = klass.new("foo")
+      build_dep = klass.new("foo", [:build])
 
-      deps = described_class.merge_repeats([normal_dep, build_dep])
+      deps = klass.merge_repeats([normal_dep, build_dep])
       expect(deps.count).to eq(1)
       expect(deps.first).not_to be_a_build_dependency
     end
   end
 
   specify "equality" do
-    foo1 = described_class.new("foo")
-    foo2 = described_class.new("foo")
+    foo1 = klass.new("foo")
+    foo2 = klass.new("foo")
     expect(foo1).to eq(foo2)
     expect(foo1).to eql(foo2)
 
-    bar = described_class.new("bar")
+    bar = klass.new("bar")
     expect(foo1).not_to eq(bar)
     expect(foo1).not_to eql(bar)
 
-    foo3 = described_class.new("foo", [:build])
+    foo3 = klass.new("foo", [:build])
     expect(foo1).not_to eq(foo3)
     expect(foo1).not_to eql(foo3)
   end
 
   describe "#tap" do
     it "returns a tap passed a fully-qualified name" do
-      dependency = described_class.new("foo/bar/dog")
+      dependency = klass.new("foo/bar/dog")
       expect(dependency.tap).to eq(Tap.fetch("foo", "bar"))
     end
 
     it "returns no tap passed a simple name" do
-      dependency = described_class.new("dog")
+      dependency = klass.new("dog")
       expect(dependency.tap).to be_nil
     end
   end
 
   specify "#option_names" do
-    dependency = described_class.new("foo/bar/dog")
+    dependency = klass.new("foo/bar/dog")
     expect(dependency.option_names).to eq(%w[dog])
   end
 
   describe "with no_linkage tag" do
     it "marks dependency as no_linkage" do
-      dep = described_class.new("foo", [:no_linkage])
+      dep = klass.new("foo", [:no_linkage])
       expect(dep).to be_no_linkage
       expect(dep).to be_required
       expect(dep).not_to be_build
@@ -125,7 +127,7 @@ RSpec.describe Dependency do
   end
 
   describe "Dependency#installed? with bottle_os_version" do
-    subject(:dependency) { described_class.new("foo") }
+    subject(:dependency) { klass.new("foo") }
 
     it "accepts macOS bottle_os_version parameter" do
       expect { dependency.installed?(bottle_os_version: "macOS 14") }.not_to raise_error
@@ -137,7 +139,7 @@ RSpec.describe Dependency do
   end
 
   describe "Dependency#satisfied? with bottle_os_version" do
-    subject(:dependency) { described_class.new("foo") }
+    subject(:dependency) { klass.new("foo") }
 
     it "accepts bottle_os_version parameter" do
       expect { dependency.satisfied?(bottle_os_version: "macOS 14") }.not_to raise_error
@@ -149,7 +151,7 @@ RSpec.describe Dependency do
   end
 
   describe "UsesFromMacOSDependency#installed? with bottle_os_version" do
-    subject(:uses_from_macos) { described_class.new("foo", bounds: { since: :sonoma }) }
+    subject(:uses_from_macos) { klass.new("foo", bounds: { since: :sonoma }) }
 
     it "accepts macOS bottle_os_version parameter" do
       expect { uses_from_macos.installed?(bottle_os_version: "macOS 14") }.not_to raise_error

--- a/Library/Homebrew/test/deprecate_disable_spec.rb
+++ b/Library/Homebrew/test/deprecate_disable_spec.rb
@@ -4,6 +4,8 @@
 require "deprecate_disable"
 
 RSpec.describe DeprecateDisable do
+  let(:klass) { DeprecateDisable }
+
   let(:deprecate_date) { Date.parse("2020-01-01") }
   let(:disable_date) { deprecate_date >> DeprecateDisable::REMOVE_DISABLED_TIME_WINDOW }
   let(:deprecated_formula) do
@@ -86,127 +88,127 @@ RSpec.describe DeprecateDisable do
 
   describe "::type" do
     it "returns :deprecated if the formula is deprecated" do
-      expect(described_class.type(deprecated_formula)).to eq :deprecated
+      expect(klass.type(deprecated_formula)).to eq :deprecated
     end
 
     it "returns :disabled if the formula is disabled" do
-      expect(described_class.type(disabled_formula)).to eq :disabled
+      expect(klass.type(disabled_formula)).to eq :disabled
     end
 
     it "returns :deprecated if the cask is deprecated" do
-      expect(described_class.type(deprecated_cask)).to eq :deprecated
+      expect(klass.type(deprecated_cask)).to eq :deprecated
     end
 
     it "returns :disabled if the cask is disabled" do
-      expect(described_class.type(disabled_cask)).to eq :disabled
+      expect(klass.type(disabled_cask)).to eq :disabled
     end
   end
 
   describe "::message" do
     it "returns a deprecation message with a preset formula reason" do
-      expect(described_class.message(deprecated_formula))
+      expect(klass.message(deprecated_formula))
         .to eq "deprecated because it does not build!"
     end
 
     it "returns a deprecation message with disable date" do
       allow(Date).to receive(:today).and_return(deprecate_date + 1)
-      expect(described_class.message(deprecated_formula_with_date))
+      expect(klass.message(deprecated_formula_with_date))
         .to eq "deprecated because it does not build! It will be disabled on #{disable_date}."
     end
 
     it "returns a disable message with a custom reason" do
-      expect(described_class.message(disabled_formula))
+      expect(klass.message(disabled_formula))
         .to eq "disabled because it is broken!"
     end
 
     it "returns a disable message with disable date" do
-      expect(described_class.message(disabled_formula_with_date))
+      expect(klass.message(disabled_formula_with_date))
         .to eq "disabled because it does not build! It was disabled on #{disable_date}."
     end
 
     it "returns a deprecation message with a preset cask reason" do
-      expect(described_class.message(deprecated_cask))
+      expect(klass.message(deprecated_cask))
         .to eq "deprecated because it is discontinued upstream!"
     end
 
     it "returns a deprecation message with no reason" do
-      expect(described_class.message(disabled_cask))
+      expect(klass.message(disabled_cask))
         .to eq "disabled!"
     end
 
     it "returns a replacement formula message for a deprecated formula" do
       allow(deprecated_formula_with_replacement).to receive_messages(deprecation_replacement_formula: "foo",
                                                                      deprecation_replacement_cask:    nil)
-      expect(described_class.message(deprecated_formula_with_replacement))
+      expect(klass.message(deprecated_formula_with_replacement))
         .to eq "deprecated because it does not build!\nReplacement:\n  brew install --formula foo\n"
     end
 
     it "returns a replacement cask message for a deprecated formula" do
       allow(deprecated_formula_with_replacement).to receive_messages(deprecation_replacement_formula: nil,
                                                                      deprecation_replacement_cask:    "foo")
-      expect(described_class.message(deprecated_formula_with_replacement))
+      expect(klass.message(deprecated_formula_with_replacement))
         .to eq "deprecated because it does not build!\nReplacement:\n  brew install --cask foo\n"
     end
 
     it "returns a replacement formula message for a disabled formula" do
       allow(disabled_formula_with_replacement).to receive_messages(disable_replacement_formula: "bar",
                                                                    disable_replacement_cask:    nil)
-      expect(described_class.message(disabled_formula_with_replacement))
+      expect(klass.message(disabled_formula_with_replacement))
         .to eq "disabled because it is broken!\nReplacement:\n  brew install --formula bar\n"
     end
 
     it "returns a replacement cask message for a disabled formula" do
       allow(disabled_formula_with_replacement).to receive_messages(disable_replacement_formula: nil,
                                                                    disable_replacement_cask:    "bar")
-      expect(described_class.message(disabled_formula_with_replacement))
+      expect(klass.message(disabled_formula_with_replacement))
         .to eq "disabled because it is broken!\nReplacement:\n  brew install --cask bar\n"
     end
 
     it "returns a replacement formula message for a deprecated cask" do
       allow(deprecated_cask_with_replacement).to receive_messages(deprecation_replacement_formula: "baz",
                                                                   deprecation_replacement_cask:    nil)
-      expect(described_class.message(deprecated_cask_with_replacement))
+      expect(klass.message(deprecated_cask_with_replacement))
         .to eq "deprecated because it is discontinued upstream!\nReplacement:\n  brew install --formula baz\n"
     end
 
     it "returns a replacement cask message for a deprecated cask" do
       allow(deprecated_cask_with_replacement).to receive_messages(deprecation_replacement_formula: nil,
                                                                   deprecation_replacement_cask:    "baz")
-      expect(described_class.message(deprecated_cask_with_replacement))
+      expect(klass.message(deprecated_cask_with_replacement))
         .to eq "deprecated because it is discontinued upstream!\nReplacement:\n  brew install --cask baz\n"
     end
 
     it "returns a replacement formula message for a disabled cask" do
       allow(disabled_cask_with_replacement).to receive_messages(disable_replacement_formula: "qux",
                                                                 disable_replacement_cask:    nil)
-      expect(described_class.message(disabled_cask_with_replacement))
+      expect(klass.message(disabled_cask_with_replacement))
         .to eq "disabled!\nReplacement:\n  brew install --formula qux\n"
     end
 
     it "returns a replacement cask message for a disabled cask" do
       allow(disabled_cask_with_replacement).to receive_messages(disable_replacement_formula: nil,
                                                                 disable_replacement_cask:    "qux")
-      expect(described_class.message(disabled_cask_with_replacement))
+      expect(klass.message(disabled_cask_with_replacement))
         .to eq "disabled!\nReplacement:\n  brew install --cask qux\n"
     end
   end
 
   describe "::to_reason_string_or_symbol" do
     it "returns the original string if it isn't a formula preset reason" do
-      expect(described_class.to_reason_string_or_symbol("discontinued", type: :formula)).to eq "discontinued"
+      expect(klass.to_reason_string_or_symbol("discontinued", type: :formula)).to eq "discontinued"
     end
 
     it "returns the original string if it isn't a cask preset reason" do
-      expect(described_class.to_reason_string_or_symbol("does_not_build", type: :cask)).to eq "does_not_build"
+      expect(klass.to_reason_string_or_symbol("does_not_build", type: :cask)).to eq "does_not_build"
     end
 
     it "returns a symbol if the original string is a formula preset reason" do
-      expect(described_class.to_reason_string_or_symbol("does_not_build", type: :formula))
+      expect(klass.to_reason_string_or_symbol("does_not_build", type: :formula))
         .to eq :does_not_build
     end
 
     it "returns a symbol if the original string is a cask preset reason" do
-      expect(described_class.to_reason_string_or_symbol("discontinued", type: :cask))
+      expect(klass.to_reason_string_or_symbol("discontinued", type: :cask))
         .to eq :discontinued
     end
   end

--- a/Library/Homebrew/test/description_cache_store_spec.rb
+++ b/Library/Homebrew/test/description_cache_store_spec.rb
@@ -5,8 +5,9 @@ require "cmd/update-report"
 require "description_cache_store"
 
 RSpec.describe DescriptionCacheStore do
-  subject(:cache_store) { described_class.new(database) }
+  subject(:cache_store) { klass.new(database) }
 
+  let(:klass) { DescriptionCacheStore }
   let(:database) { instance_double(CacheStoreDatabase, "database") }
   let(:formula_name) { "test_name" }
   let(:description) { "test_description" }
@@ -58,8 +59,9 @@ RSpec.describe DescriptionCacheStore do
   end
 
   describe CaskDescriptionCacheStore do
-    subject(:cache_store) { described_class.new(database) }
+    subject(:cache_store) { klass.new(database) }
 
+    let(:klass) { CaskDescriptionCacheStore }
     let(:database) { instance_double(CacheStoreDatabase, "database") }
 
     describe "#update_from_report!" do

--- a/Library/Homebrew/test/descriptions_spec.rb
+++ b/Library/Homebrew/test/descriptions_spec.rb
@@ -4,8 +4,9 @@
 require "descriptions"
 
 RSpec.describe Descriptions do
-  subject(:descriptions) { described_class.new(descriptions_hash) }
+  subject(:descriptions) { klass.new(descriptions_hash) }
 
+  let(:klass) { Descriptions }
   let(:descriptions_hash) { {} }
 
   it "can print description for a core Formula" do
@@ -78,7 +79,7 @@ RSpec.describe Descriptions do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
     descriptions_hash["homebrew/core/foo"] = "Core foo"
 
-    descriptions = described_class.new(
+    descriptions = klass.new(
       descriptions_hash,
       status_data: { "homebrew/core/foo" => { deprecated: true, disabled: false } },
     )

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -5,10 +5,12 @@ require "dev-cmd/audit"
 require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::DevCmd::Audit do
+  let(:klass) { Homebrew::DevCmd::Audit }
+
   it_behaves_like "parseable arguments"
 
   describe "#run" do
-    subject(:audit) { described_class.new(["--tap=homebrew/test"]) }
+    subject(:audit) { klass.new(["--tap=homebrew/test"]) }
 
     let(:tap_path) { mktmpdir }
     let(:macos_only_cask_file) { tap_path/"Casks/macos-only-example.rb" }

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -5,6 +5,8 @@ require "cmd/shared_examples/args_parse"
 require "dev-cmd/bottle"
 
 RSpec.describe Homebrew::DevCmd::Bottle do
+  let(:klass) { Homebrew::DevCmd::Bottle }
+
   def stub_hash(parameters)
     <<~EOS
       {
@@ -360,7 +362,7 @@ RSpec.describe Homebrew::DevCmd::Bottle do
   end
 
   describe "bottle_cmd" do
-    subject(:homebrew) { described_class.new(["foo"]) }
+    subject(:homebrew) { klass.new(["foo"]) }
 
     let(:hello_hash_big_sur) do
       JSON.parse stub_hash(

--- a/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
@@ -6,10 +6,10 @@ require "dev-cmd/bump-cask-pr"
 require "bump_version_parser"
 
 RSpec.describe Homebrew::DevCmd::BumpCaskPr do
-  subject(:bump_cask_pr) { described_class.new(["test"]) }
+  subject(:bump_cask_pr) { klass.new(["test"]) }
 
+  let(:klass) { Homebrew::DevCmd::BumpCaskPr }
   let(:newest_macos) { MacOSVersion.new(HOMEBREW_MACOS_NEWEST_SUPPORTED).to_sym }
-
   let(:c) do
     Cask::Cask.new("test") do
       version "0.0.1,2"
@@ -20,7 +20,6 @@ RSpec.describe Homebrew::DevCmd::BumpCaskPr do
       homepage "https://brew.sh"
     end
   end
-
   let(:c_depends_on_intel) do
     Cask::Cask.new("test-depends-on-intel") do
       version "0.0.1,2"
@@ -33,7 +32,6 @@ RSpec.describe Homebrew::DevCmd::BumpCaskPr do
       depends_on arch: :x86_64
     end
   end
-
   let(:c_on_system) do
     Cask::Cask.new("test-on-system") do
       os macos: "darwin", linux: "linux"
@@ -46,7 +44,6 @@ RSpec.describe Homebrew::DevCmd::BumpCaskPr do
       homepage "https://brew.sh"
     end
   end
-
   let(:c_on_system_depends_on_intel) do
     Cask::Cask.new("test-on-system-depends-on-intel") do
       os macos: "darwin", linux: "linux"
@@ -61,7 +58,6 @@ RSpec.describe Homebrew::DevCmd::BumpCaskPr do
       depends_on arch: :x86_64
     end
   end
-
   let(:c_arm_intel) do
     Cask::Cask.new("test") do
       on_arm do

--- a/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
@@ -6,8 +6,9 @@ require "dev-cmd/bump-formula-pr"
 require "utils/pypi"
 
 RSpec.describe Homebrew::DevCmd::BumpFormulaPr do
-  subject(:bump_formula_pr) { described_class.new(["test"]) }
+  subject(:bump_formula_pr) { klass.new(["test"]) }
 
+  let(:klass) { Homebrew::DevCmd::BumpFormulaPr }
   let(:f) do
     formula("test") do
       url "https://brew.sh/test-1.2.3.tgz"
@@ -35,7 +36,7 @@ RSpec.describe Homebrew::DevCmd::BumpFormulaPr do
       resource_path = mktmpdir/"apache-couchdb-3.5.2.tar.gz"
       resource_path.write("couchdb")
       updated_mirror = "https://archive.apache.org/dist/couchdb/source/3.5.2/apache-couchdb-3.5.2.tar.gz"
-      command = described_class.new(["--write-only", "--no-audit", "--version=3.5.2", "couchdb"])
+      command = klass.new(["--write-only", "--no-audit", "--version=3.5.2", "couchdb"])
 
       allow(Homebrew).to receive(:install_bundler_gems!)
       allow(CoreTap.instance).to receive_messages(allow_bump?: true, git?: true,

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -6,15 +6,15 @@ require "bump_version_parser"
 require "dev-cmd/bump"
 
 RSpec.describe Homebrew::DevCmd::Bump do
-  subject(:bump) { described_class.new(["test"]) }
+  subject(:bump) { klass.new(["test"]) }
 
+  let(:klass) { Homebrew::DevCmd::Bump }
   let(:f_basic) do
     formula("basic_formula") do
       desc "Basic formula"
       url "https://brew.sh/test-1.2.3.tgz"
     end
   end
-
   let(:c_basic) do
     Cask::CaskLoader.load(+<<-RUBY)
       cask "basic_cask" do
@@ -25,7 +25,6 @@ RSpec.describe Homebrew::DevCmd::Bump do
       end
     RUBY
   end
-
   let(:c_latest) do
     Cask::CaskLoader.load(+<<-RUBY)
       cask "latest_cask" do

--- a/Library/Homebrew/test/dev-cmd/cat_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/cat_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Homebrew::DevCmd::Cat do
     RUBY
     CoreTap.instance.clear_cache
 
-    cat = described_class.new(["testball"])
+    cat = Homebrew::DevCmd::Cat.new(["testball"])
     formula = instance_double(Formula)
 
     allow(Homebrew::EnvConfig).to receive_messages(bat?: true, bat_config_path: "/tmp/bat.conf", bat_theme: "ansi")

--- a/Library/Homebrew/test/dev-cmd/edit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/edit_spec.rb
@@ -5,6 +5,8 @@ require "cmd/shared_examples/args_parse"
 require "dev-cmd/edit"
 
 RSpec.describe Homebrew::DevCmd::Edit do
+  let(:klass) { Homebrew::DevCmd::Edit }
+
   it_behaves_like "parseable arguments"
 
   it "opens a given Formula in an editor", :integration_test do
@@ -42,8 +44,8 @@ RSpec.describe Homebrew::DevCmd::Edit do
       RUBY
     end
 
-    allow_any_instance_of(described_class).to receive(:exec_editor)
+    allow_any_instance_of(klass).to receive(:exec_editor)
 
-    described_class.new(["testball"]).run
+    klass.new(["testball"]).run
   end
 end

--- a/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
@@ -5,8 +5,9 @@ require "cmd/shared_examples/args_parse"
 require "dev-cmd/generate-cask-ci-matrix"
 
 RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
-  subject(:generate_matrix) { described_class.new(["test"]) }
+  subject(:generate_matrix) { klass.new(["test"]) }
 
+  let(:klass) { Homebrew::DevCmd::GenerateCaskCiMatrix }
   let(:c_on_system_depends_on_mixed) do
     Cask::Cask.new("test-on-system-depends-on-mixed") do
       os macos: "darwin", linux: "linux"

--- a/Library/Homebrew/test/dev-cmd/generate-formula-api_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-formula-api_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Homebrew::DevCmd::GenerateFormulaApi do
 
     Dir.mktmpdir do |tmpdir|
       path = Pathname.new(tmpdir)
-      path.cd { described_class.new([]).run }
+      path.cd { Homebrew::DevCmd::GenerateFormulaApi.new([]).run }
 
       expect(JSON.parse((path/"_data/formula/foo.json").read)["executables"]).to eq(["foo-tool", "food"])
       expect(JSON.parse((path/"api/internal/formula.arm64_sonoma.json").read)

--- a/Library/Homebrew/test/dev-cmd/generate-internal-api_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-internal-api_spec.rb
@@ -5,6 +5,8 @@ require "cmd/shared_examples/args_parse"
 require "dev-cmd/generate-internal-api"
 
 RSpec.describe Homebrew::DevCmd::GenerateInternalApi do
+  let(:klass) { Homebrew::DevCmd::GenerateInternalApi }
+
   it_behaves_like "parseable arguments"
 
   it "writes metadata and formula executables to each generated packages file" do
@@ -46,7 +48,7 @@ RSpec.describe Homebrew::DevCmd::GenerateInternalApi do
     stub_const("OnSystem::VALID_OS_ARCH_TAGS", [bottle_tag])
 
     mktmpdir do |path|
-      path.cd { described_class.new([]).run }
+      path.cd { klass.new([]).run }
 
       json = JSON.parse((path/"api/internal/packages.arm64_sonoma.json").read)
       expect(json["metadata"]).to eq({

--- a/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
@@ -5,7 +5,9 @@ require "cmd/shared_examples/args_parse"
 require "dev-cmd/generate-zap"
 
 RSpec.describe Homebrew::DevCmd::GenerateZap do
-  subject(:generate_zap) { described_class.new(["test"]) }
+  subject(:generate_zap) { klass.new(["test"]) }
+
+  let(:klass) { Homebrew::DevCmd::GenerateZap }
 
   it_behaves_like "parseable arguments"
 

--- a/Library/Homebrew/test/dev-cmd/lgtm_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/lgtm_spec.rb
@@ -8,10 +8,12 @@ require "dev-cmd/lgtm"
 require "utils/tty"
 
 RSpec.describe Homebrew::DevCmd::Lgtm do
+  let(:klass) { Homebrew::DevCmd::Lgtm }
+
   it_behaves_like "parseable arguments"
 
   describe "#run" do
-    subject(:lgtm) { described_class.new(args) }
+    subject(:lgtm) { klass.new(args) }
 
     let(:args) { [] }
 

--- a/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
@@ -7,9 +7,8 @@ require "tap"
 require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::DevCmd::PrPull do
-  include FileUtils
-
-  let(:pr_pull) { described_class.new(["foo"]) }
+  let(:klass) { Homebrew::DevCmd::PrPull }
+  let(:pr_pull) { klass.new(["foo"]) }
   let(:formula_rebuild) do
     <<~EOS
       class Foo < Formula
@@ -82,6 +81,8 @@ RSpec.describe Homebrew::DevCmd::PrPull do
   let(:formula_file) { tap.path/"Formula/foo.rb" }
   let(:cask_file) { tap.cask_dir/"food.rb" }
   let(:path) { Pathname(HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo") }
+
+  include FileUtils
 
   it_behaves_like "parseable arguments"
 

--- a/Library/Homebrew/test/dev-cmd/release_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/release_spec.rb
@@ -5,10 +5,12 @@ require "cmd/shared_examples/args_parse"
 require "dev-cmd/release"
 
 RSpec.describe Homebrew::DevCmd::Release do
+  let(:klass) { Homebrew::DevCmd::Release }
+
   it_behaves_like "parseable arguments"
 
   describe "release lookup helpers" do
-    let(:command) { described_class.new([]) }
+    let(:command) { klass.new([]) }
     let(:releases) do
       [
         {

--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -5,10 +5,12 @@ require "cmd/shared_examples/args_parse"
 require "dev-cmd/tests"
 
 RSpec.describe Homebrew::DevCmd::Tests do
+  let(:klass) { Homebrew::DevCmd::Tests }
+
   it_behaves_like "parseable arguments"
 
   describe "#check_test_environment!", :needs_linux do
-    subject(:tests) { described_class.new([]) }
+    subject(:tests) { klass.new([]) }
 
     before do
       require "extend/os/linux/dev-cmd/tests"

--- a/Library/Homebrew/test/dev-cmd/typecheck_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/typecheck_spec.rb
@@ -5,11 +5,13 @@ require "cmd/shared_examples/args_parse"
 require "dev-cmd/typecheck"
 
 RSpec.describe Homebrew::DevCmd::Typecheck do
+  let(:klass) { Homebrew::DevCmd::Typecheck }
+
   it_behaves_like "parseable arguments"
 
   describe "#trim_rubocop_rbi" do
     let(:rbi_file) { Pathname.new("#{TEST_FIXTURE_DIR}/rubocop@x.x.x.rbi") }
-    let(:typecheck) { described_class.new([]) }
+    let(:typecheck) { klass.new([]) }
 
     before do
       allow(Dir).to receive(:glob).and_return([rbi_file.to_s])

--- a/Library/Homebrew/test/dev-cmd/which-update_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/which-update_spec.rb
@@ -5,6 +5,8 @@ require "cmd/shared_examples/args_parse"
 require "dev-cmd/which-update"
 
 RSpec.describe Homebrew::DevCmd::WhichUpdate do
+  let(:klass) { Homebrew::DevCmd::WhichUpdate }
+
   it_behaves_like "parseable arguments"
 
   it "requires --pull-request when --repository is passed" do
@@ -12,7 +14,7 @@ RSpec.describe Homebrew::DevCmd::WhichUpdate do
       database = path/"executables.txt"
 
       expect do
-        described_class.new(["--repository=Homebrew/homebrew-core", database.to_s]).run
+        klass.new(["--repository=Homebrew/homebrew-core", database.to_s]).run
       end.to raise_error(Homebrew::CLI::OptionConstraintError)
     end
   end
@@ -23,7 +25,7 @@ RSpec.describe Homebrew::DevCmd::WhichUpdate do
 
       expect(GitHub::API).not_to receive(:paginate_rest)
       expect do
-        described_class.new([
+        klass.new([
           "--pull-request=123",
           "--repository=Homebrew/homebrew-core/extra",
           database.to_s,
@@ -58,7 +60,7 @@ RSpec.describe Homebrew::DevCmd::WhichUpdate do
         ]
       end
 
-      described_class.new([
+      klass.new([
         "--pull-request=123",
         "--repository=Homebrew/homebrew-core",
         database.to_s,

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -4,7 +4,9 @@
 require "diagnostic"
 
 RSpec.describe Homebrew::Diagnostic::Checks do
-  subject(:checks) { described_class.new }
+  subject(:checks) { klass.new }
+
+  let(:klass) { Homebrew::Diagnostic::Checks }
 
   specify "#inject_file_list" do
     expect(checks.inject_file_list([], "foo:\n")).to eq("foo:\n")

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -4,8 +4,9 @@
 require "download_queue"
 
 RSpec.describe Homebrew::DownloadQueue do
-  subject(:download_queue) { described_class.new }
+  subject(:download_queue) { klass.new }
 
+  let(:klass) { Homebrew::DownloadQueue }
   let(:cached_download) { HOMEBREW_CACHE/"downloads/testball--0.1.tar.gz" }
   let(:downloadable) do
     instance_double(

--- a/Library/Homebrew/test/download_strategies/abstract_file_spec.rb
+++ b/Library/Homebrew/test/download_strategies/abstract_file_spec.rb
@@ -4,7 +4,7 @@
 require "download_strategy"
 
 RSpec.describe AbstractFileDownloadStrategy do
-  subject(:strategy) { Class.new(described_class).new(url, "foo", "1.2.3") }
+  subject(:strategy) { Class.new(AbstractFileDownloadStrategy).new(url, "foo", "1.2.3") }
 
   let(:url) { "https://example.com/foo.tar.gz" }
 

--- a/Library/Homebrew/test/download_strategies/abstract_spec.rb
+++ b/Library/Homebrew/test/download_strategies/abstract_spec.rb
@@ -4,8 +4,9 @@
 require "download_strategy"
 
 RSpec.describe AbstractDownloadStrategy do
-  subject(:strategy) { Class.new(described_class).new(url, name, version, **specs) }
+  subject(:strategy) { Class.new(klass).new(url, name, version, **specs) }
 
+  let(:klass) { AbstractDownloadStrategy }
   let(:specs) { {} }
   let(:name) { "foo" }
   let(:url) { "https://example.com/foo.tar.gz" }

--- a/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
@@ -4,8 +4,9 @@
 require "download_strategy"
 
 RSpec.describe CurlGitHubPackagesDownloadStrategy do
-  subject(:strategy) { described_class.new(url, name, version, **specs) }
+  subject(:strategy) { klass.new(url, name, version, **specs) }
 
+  let(:klass) { CurlGitHubPackagesDownloadStrategy }
   let(:name) { "foo" }
   let(:url) { "https://#{GitHubPackages::URL_DOMAIN}/v2/homebrew/core/spec_test/manifests/1.2.3" }
   let(:version) { "1.2.3" }

--- a/Library/Homebrew/test/download_strategies/curl_post_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_post_spec.rb
@@ -4,8 +4,9 @@
 require "download_strategy"
 
 RSpec.describe CurlPostDownloadStrategy do
-  subject(:strategy) { described_class.new(url, name, version, **specs) }
+  subject(:strategy) { klass.new(url, name, version, **specs) }
 
+  let(:klass) { CurlPostDownloadStrategy }
   let(:name) { "foo" }
   let(:url) { "https://example.com/foo.tar.gz" }
   let(:version) { "1.2.3" }

--- a/Library/Homebrew/test/download_strategies/curl_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_spec.rb
@@ -4,8 +4,9 @@
 require "download_strategy"
 
 RSpec.describe CurlDownloadStrategy do
-  subject(:strategy) { described_class.new(url, name, version, **specs) }
+  subject(:strategy) { klass.new(url, name, version, **specs) }
 
+  let(:klass) { CurlDownloadStrategy }
   let(:name) { "foo" }
   let(:url) { "https://example.com/foo.tar.gz" }
   let(:version) { "1.2.3" }

--- a/Library/Homebrew/test/download_strategies/detector_spec.rb
+++ b/Library/Homebrew/test/download_strategies/detector_spec.rb
@@ -4,8 +4,10 @@
 require "download_strategy"
 
 RSpec.describe DownloadStrategyDetector do
+  let(:klass) { DownloadStrategyDetector }
+
   describe "::detect" do
-    subject(:strategy_detector) { described_class.detect(url, strategy) }
+    subject(:strategy_detector) { klass.detect(url, strategy) }
 
     let(:url) { "invalidurl" }
     let(:strategy) { nil }
@@ -42,7 +44,7 @@ RSpec.describe DownloadStrategyDetector do
 
     it "raises an error when passed an unrecognized strategy" do
       expect do
-        described_class.detect("foo", Class.new)
+        klass.detect("foo", Class.new)
       end.to raise_error(TypeError)
     end
   end

--- a/Library/Homebrew/test/download_strategies/git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/git_spec.rb
@@ -4,8 +4,9 @@
 require "download_strategy"
 
 RSpec.describe GitDownloadStrategy do
-  subject(:strategy) { described_class.new(url, name, version) }
+  subject(:strategy) { klass.new(url, name, version) }
 
+  let(:klass) { GitDownloadStrategy }
   let(:name) { "baz" }
   let(:url) { "https://github.com/homebrew/foo" }
   let(:version) { nil }

--- a/Library/Homebrew/test/download_strategies/github_git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/github_git_spec.rb
@@ -4,8 +4,9 @@
 require "download_strategy"
 
 RSpec.describe GitHubGitDownloadStrategy do
-  subject(:strategy) { described_class.new(url, name, version) }
+  subject(:strategy) { klass.new(url, name, version) }
 
+  let(:klass) { GitHubGitDownloadStrategy }
   let(:name) { "brew" }
   let(:url) { "https://github.com/homebrew/brew.git" }
   let(:version) { nil }

--- a/Library/Homebrew/test/download_strategies/pypi_spec.rb
+++ b/Library/Homebrew/test/download_strategies/pypi_spec.rb
@@ -4,8 +4,9 @@
 require "download_strategy"
 
 RSpec.describe PyPIDownloadStrategy do
-  subject(:strategy) { described_class.new(url, "foo", "1.2.3") }
+  subject(:strategy) { klass.new(url, "foo", "1.2.3") }
 
+  let(:klass) { PyPIDownloadStrategy }
   let(:url) { "https://files.pythonhosted.org/packages/ab/cd/efg/foo-1.2.3.tar.gz" }
   let(:last_modified) { Time.utc(2026, 5, 6, 13, 43, 5) }
 

--- a/Library/Homebrew/test/download_strategies/subversion_spec.rb
+++ b/Library/Homebrew/test/download_strategies/subversion_spec.rb
@@ -4,8 +4,9 @@
 require "download_strategy"
 
 RSpec.describe SubversionDownloadStrategy do
-  subject(:strategy) { described_class.new(url, name, version, **specs) }
+  subject(:strategy) { klass.new(url, name, version, **specs) }
 
+  let(:klass) { SubversionDownloadStrategy }
   let(:name) { "foo" }
   let(:url) { "https://example.com/foo.tar.gz" }
   let(:version) { "1.2.3" }

--- a/Library/Homebrew/test/download_strategies/vcs_spec.rb
+++ b/Library/Homebrew/test/download_strategies/vcs_spec.rb
@@ -4,13 +4,15 @@
 require "download_strategy"
 
 RSpec.describe VCSDownloadStrategy do
+  let(:klass) { VCSDownloadStrategy }
+
   let(:url) { "https://example.com/bar" }
   let(:version) { nil }
 
   describe "#cached_location" do
     it "returns the path of the cached resource" do
-      allow_any_instance_of(described_class).to receive(:cache_tag).and_return("foo")
-      downloader = Class.new(described_class).new(url, "baz", version)
+      allow_any_instance_of(klass).to receive(:cache_tag).and_return("foo")
+      downloader = Class.new(klass).new(url, "baz", version)
       expect(downloader.cached_location).to eq(HOMEBREW_CACHE/"baz--foo")
     end
   end

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -4,7 +4,9 @@
 require "diagnostic"
 
 RSpec.describe Homebrew::EnvConfig do
-  subject(:env_config) { described_class }
+  subject(:env_config) { klass }
+
+  let(:klass) { Homebrew::EnvConfig }
 
   describe "ENVS" do
     it "sorts alphabetically" do

--- a/Library/Homebrew/test/error_during_execution_spec.rb
+++ b/Library/Homebrew/test/error_during_execution_spec.rb
@@ -2,8 +2,9 @@
 # frozen_string_literal: true
 
 RSpec.describe ErrorDuringExecution do
-  subject(:error) { described_class.new(command, status:, output:) }
+  subject(:error) { klass.new(command, status:, output:) }
 
+  let(:klass) { ErrorDuringExecution }
   let(:command) { ["false"] }
   let(:status) { instance_double(Process::Status, exitstatus:, termsig: nil) }
   let(:exitstatus) { 1 }
@@ -12,19 +13,19 @@ RSpec.describe ErrorDuringExecution do
   describe "#initialize" do
     it "fails when only given a command" do
       expect do
-        described_class.new(command)
+        klass.new(command)
       end.to raise_error(ArgumentError)
     end
 
     it "fails when only given a status" do
       expect do
-        described_class.new(status:)
+        klass.new(status:)
       end.to raise_error(ArgumentError)
     end
 
     it "does not raise an error when given both a command and a status" do
       expect do
-        described_class.new(command, status:)
+        klass.new(command, status:)
       end.not_to raise_error
     end
   end

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -6,11 +6,13 @@ require "exceptions"
 RSpec.describe "Exception" do
   describe MultipleVersionsInstalledError do
     subject(:error) do
-      described_class.new <<~EOS
+      klass.new <<~EOS
         foo has multiple installed versions
         Run `brew uninstall --force foo` to remove all versions.
       EOS
     end
+
+    let(:klass) { MultipleVersionsInstalledError }
 
     it(:to_s) do
       expect(error.to_s).to eq <<~EOS
@@ -21,14 +23,16 @@ RSpec.describe "Exception" do
   end
 
   describe NoSuchKegError do
+    let(:klass) { NoSuchKegError }
+
     context "without a tap" do
-      subject(:error) { described_class.new("foo") }
+      subject(:error) { klass.new("foo") }
 
       it(:to_s) { expect(error.to_s).to eq("No such keg: #{HOMEBREW_CELLAR}/foo") }
     end
 
     context "with a tap" do
-      subject(:error) { described_class.new("foo", tap:) }
+      subject(:error) { klass.new("foo", tap:) }
 
       let(:tap) { instance_double(Tap, to_s: "u/r") }
 
@@ -37,7 +41,9 @@ RSpec.describe "Exception" do
   end
 
   describe FormulaValidationError do
-    subject(:error) { described_class.new("foo", "sha257", "magic") }
+    subject(:error) { klass.new("foo", "sha257", "magic") }
+
+    let(:klass) { FormulaValidationError }
 
     it(:to_s) do
       expect(error.to_s).to eq(%q(invalid attribute for formula 'foo': sha257 ("magic")))
@@ -45,8 +51,9 @@ RSpec.describe "Exception" do
   end
 
   describe TapFormulaOrCaskUnavailableError do
-    subject(:error) { described_class.new(tap, "foo") }
+    subject(:error) { klass.new(tap, "foo") }
 
+    let(:klass) { TapFormulaOrCaskUnavailableError }
     let(:tap) { instance_double(Tap, user: "u", repository: "r", to_s: "u/r", installed?: false) }
 
     it(:to_s) {
@@ -55,7 +62,9 @@ RSpec.describe "Exception" do
   end
 
   describe FormulaUnavailableError do
-    subject(:error) { described_class.new("foo") }
+    subject(:error) { klass.new("foo") }
+
+    let(:klass) { FormulaUnavailableError }
 
     describe "#dependent_s" do
       it "returns nil if there is no dependent" do
@@ -89,8 +98,9 @@ RSpec.describe "Exception" do
   end
 
   describe TapFormulaUnavailableError do
-    subject(:error) { described_class.new(tap, "foo") }
+    subject(:error) { klass.new(tap, "foo") }
 
+    let(:klass) { TapFormulaUnavailableError }
     let(:tap) { instance_double(Tap, user: "u", repository: "r", to_s: "u/r", installed?: false) }
 
     it(:to_s) {
@@ -99,8 +109,9 @@ RSpec.describe "Exception" do
   end
 
   describe FormulaClassUnavailableError do
-    subject(:error) { described_class.new("foo", "foo.rb", "Foo", list) }
+    subject(:error) { klass.new("foo", "foo.rb", "Foo", list) }
 
+    let(:klass) { FormulaClassUnavailableError }
     let(:mod) do
       Module.new do
         const_set :Bar, Class.new(Requirement)
@@ -132,50 +143,60 @@ RSpec.describe "Exception" do
   end
 
   describe FormulaUnreadableError do
-    subject(:error) { described_class.new("foo", formula_error) }
+    subject(:error) { klass.new("foo", formula_error) }
 
+    let(:klass) { FormulaUnreadableError }
     let(:formula_error) { LoadError.new("bar") }
 
     it(:to_s) { expect(error.to_s).to eq("foo: bar") }
   end
 
   describe TapUnavailableError do
-    subject(:error) { described_class.new("foo") }
+    subject(:error) { klass.new("foo") }
+
+    let(:klass) { TapUnavailableError }
 
     it(:to_s) { expect(error.to_s).to eq("No available tap foo.\nRun brew tap-new foo to create a new foo tap!\n") }
   end
 
   describe TapAlreadyTappedError do
-    subject(:error) { described_class.new("foo") }
+    subject(:error) { klass.new("foo") }
+
+    let(:klass) { TapAlreadyTappedError }
 
     it(:to_s) { expect(error.to_s).to eq("Tap foo already tapped.\n") }
   end
 
   describe BuildError do
-    subject(:error) { described_class.new(formula, "badprg", ["arg1", 2, Pathname.new("arg3"), :arg4], {}) }
+    subject(:error) { klass.new(formula, "badprg", ["arg1", 2, Pathname.new("arg3"), :arg4], {}) }
 
+    let(:klass) { BuildError }
     let(:formula) { instance_double(Formula, name: "foo") }
 
     it(:to_s) { expect(error.to_s).to eq("Failed executing: badprg arg1 2 arg3 arg4") }
   end
 
   describe OperationInProgressError do
-    subject(:error) { described_class.new(Pathname("foo")) }
+    subject(:error) { klass.new(Pathname("foo")) }
+
+    let(:klass) { OperationInProgressError }
 
     it(:to_s) { expect(error.to_s).to match(/has already locked foo/) }
   end
 
   describe FormulaInstallationAlreadyAttemptedError do
-    subject(:error) { described_class.new(formula) }
+    subject(:error) { klass.new(formula) }
 
+    let(:klass) { FormulaInstallationAlreadyAttemptedError }
     let(:formula) { instance_double(Formula, full_name: "foo/bar") }
 
     it(:to_s) { expect(error.to_s).to eq("Formula installation already attempted: foo/bar") }
   end
 
   describe FormulaConflictError do
-    subject(:error) { described_class.new(formula, [conflict]) }
+    subject(:error) { klass.new(formula, [conflict]) }
 
+    let(:klass) { FormulaConflictError }
     let(:formula) { instance_double(Formula, full_name: "foo/qux") }
     let(:conflict) { instance_double(Formula::FormulaConflict, name: "bar", reason: "I decided to") }
 
@@ -183,38 +204,43 @@ RSpec.describe "Exception" do
   end
 
   describe CompilerSelectionError do
-    subject(:error) { described_class.new(formula) }
+    subject(:error) { klass.new(formula) }
 
+    let(:klass) { CompilerSelectionError }
     let(:formula) { instance_double(Formula, full_name: "foo") }
 
     it(:to_s) { expect(error.to_s).to match(/foo cannot be built with any available compilers\./) }
   end
 
   describe CurlDownloadStrategyError do
+    let(:klass) { CurlDownloadStrategyError }
+
     context "when the file does not exist" do
-      subject(:error) { described_class.new("file:///tmp/foo") }
+      subject(:error) { klass.new("file:///tmp/foo") }
 
       it(:to_s) { expect(error.to_s).to eq("File cannot be read: /tmp/foo") }
     end
 
     context "when the download failed" do
-      subject(:error) { described_class.new("https://brew.sh") }
+      subject(:error) { klass.new("https://brew.sh") }
 
       it(:to_s) { expect(error.to_s).to eq("Download failed: https://brew.sh") }
     end
   end
 
   describe ErrorDuringExecution do
-    subject(:error) { described_class.new(["badprg", "arg1", "arg2"], status:) }
+    subject(:error) { klass.new(["badprg", "arg1", "arg2"], status:) }
 
+    let(:klass) { ErrorDuringExecution }
     let(:status) { instance_double(Process::Status, exitstatus: 17, termsig: nil) }
 
     it(:to_s) { expect(error.to_s).to eq("Failure while executing; `badprg arg1 arg2` exited with 17.") }
   end
 
   describe ChecksumMismatchError do
-    subject(:error) { described_class.new("/file.tar.gz", expected_checksum, actual_checksum) }
+    subject(:error) { klass.new("/file.tar.gz", expected_checksum, actual_checksum) }
 
+    let(:klass) { ChecksumMismatchError }
     let(:expected_checksum) { instance_double(Checksum, to_s: "deadbeef") }
     let(:actual_checksum) { instance_double(Checksum, to_s: "deadcafe") }
 
@@ -225,7 +251,7 @@ RSpec.describe "Exception" do
         file.binmode
         file.write("PK\x03\x04binary-content")
         file.flush
-        message = described_class.new(Pathname(file.path), expected_checksum, actual_checksum).to_s
+        message = klass.new(Pathname(file.path), expected_checksum, actual_checksum).to_s
         expect(message).not_to match(%r{HTML/XML})
       end
     end
@@ -235,15 +261,16 @@ RSpec.describe "Exception" do
         file.binmode
         file.write('<!doctype html><html lang="en"><head><title>Oh noes!</title>')
         file.flush
-        message = described_class.new(Pathname(file.path), expected_checksum, actual_checksum).to_s
+        message = klass.new(Pathname(file.path), expected_checksum, actual_checksum).to_s
         expect(message).to match(%r{HTML/XML, not a binary})
       end
     end
   end
 
   describe ResourceMissingError do
-    subject(:error) { described_class.new(formula, resource) }
+    subject(:error) { klass.new(formula, resource) }
 
+    let(:klass) { ResourceMissingError }
     let(:formula) { instance_double(Formula, full_name: "bar") }
     let(:resource) { instance_double(Resource, inspect: "<resource foo>") }
 
@@ -251,23 +278,27 @@ RSpec.describe "Exception" do
   end
 
   describe DuplicateResourceError do
-    subject(:error) { described_class.new(resource) }
+    subject(:error) { klass.new(resource) }
 
+    let(:klass) { DuplicateResourceError }
     let(:resource) { instance_double(Resource, inspect: "<resource foo>") }
 
     it(:to_s) { expect(error.to_s).to eq("Resource <resource foo> is defined more than once") }
   end
 
   describe BottleFormulaUnavailableError do
-    subject(:error) { described_class.new("/foo.bottle.tar.gz", "foo/1.0/.brew/foo.rb") }
+    subject(:error) { klass.new("/foo.bottle.tar.gz", "foo/1.0/.brew/foo.rb") }
 
+    let(:klass) { BottleFormulaUnavailableError }
     let(:formula) { instance_double(Formula, full_name: "foo") }
 
     it(:to_s) { expect(error.to_s).to match(/This bottle does not contain the formula file/) }
   end
 
   describe BuildFlagsError do
-    subject(:error) { described_class.new(["-s"]) }
+    subject(:error) { klass.new(["-s"]) }
+
+    let(:klass) { BuildFlagsError }
 
     it(:to_s) { expect(error.to_s).to match(/flag:\s+-s\nrequires building tools/) }
   end

--- a/Library/Homebrew/test/extend/blank_spec.rb
+++ b/Library/Homebrew/test/extend/blank_spec.rb
@@ -4,8 +4,10 @@
 require "extend/blank"
 
 RSpec.describe Object do
+  let(:klass) { Object }
+
   let(:empty_true) do
-    Class.new(described_class) do
+    Class.new(klass) do
       # This API is intentionally non-ideal for testing.
       # rubocop:disable Naming/PredicateMethod
       def empty?
@@ -15,14 +17,14 @@ RSpec.describe Object do
     end
   end
   let(:empty_false) do
-    Class.new(described_class) do
+    Class.new(klass) do
       def empty?
         false
       end
     end
   end
   let(:blank) { [empty_true.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", [], {}] }
-  let(:present) { [empty_false.new, described_class.new, true, 0, 1, "a", [nil], { nil => 0 }, Time.now] }
+  let(:present) { [empty_false.new, klass.new, true, 0, 1, "a", [nil], { nil => 0 }, Time.now] }
 
   describe ".blank?" do
     it "checks if an object is blank" do

--- a/Library/Homebrew/test/formatter_spec.rb
+++ b/Library/Homebrew/test/formatter_spec.rb
@@ -5,8 +5,10 @@ require "utils/formatter"
 require "utils/tty"
 
 RSpec.describe Formatter do
+  let(:klass) { Formatter }
+
   describe "::columns" do
-    subject(:columns) { described_class.columns(input) }
+    subject(:columns) { klass.columns(input) }
 
     let(:input) do
       %w[
@@ -108,88 +110,88 @@ RSpec.describe Formatter do
           -h, --help                       Show this message.
       HELP
 
-      expect(described_class.format_help_text(text, width: 80)).to eq expected
+      expect(klass.format_help_text(text, width: 80)).to eq expected
     end
   end
 
   describe "::truncate" do
     it "returns the original string if it's shorter than max length" do
-      expect(described_class.truncate("short", max: 10)).to eq("short")
+      expect(klass.truncate("short", max: 10)).to eq("short")
     end
 
     it "truncates strings longer than max length" do
-      expect(described_class.truncate("this is a long string", max: 10)).to eq("this is...")
+      expect(klass.truncate("this is a long string", max: 10)).to eq("this is...")
     end
 
     it "uses custom omission string" do
-      expect(described_class.truncate("this is a long string", max: 10, omission: " [...]")).to eq("this [...]")
+      expect(klass.truncate("this is a long string", max: 10, omission: " [...]")).to eq("this [...]")
     end
   end
 
   describe ".disk_usage_readable_size_unit" do
     it "returns size and unit for bytes" do
-      expect(described_class.disk_usage_readable_size_unit(500)).to eq([500, "B"])
+      expect(klass.disk_usage_readable_size_unit(500)).to eq([500, "B"])
     end
 
     it "converts to KB for sizes >= 1000" do
-      size, unit = described_class.disk_usage_readable_size_unit(1500)
+      size, unit = klass.disk_usage_readable_size_unit(1500)
       expect(unit).to eq("KB")
       expect(size).to eq(1.5)
     end
 
     it "converts to MB for sizes >= 1000000" do
-      size, unit = described_class.disk_usage_readable_size_unit(2_500_000)
+      size, unit = klass.disk_usage_readable_size_unit(2_500_000)
       expect(unit).to eq("MB")
       expect(size).to eq(2.5)
     end
 
     it "converts to GB for sizes >= 1000000000" do
-      size, unit = described_class.disk_usage_readable_size_unit(3_500_000_000)
+      size, unit = klass.disk_usage_readable_size_unit(3_500_000_000)
       expect(unit).to eq("GB")
       expect(size).to eq(3.5)
     end
 
     it "respects precision parameter" do
-      _, unit = described_class.disk_usage_readable_size_unit(999.5, precision: 0)
+      _, unit = klass.disk_usage_readable_size_unit(999.5, precision: 0)
       expect(unit).to eq("KB")
     end
   end
 
   describe ".disk_usage_readable" do
     it "formats bytes as human-readable sizes" do
-      expect(described_class.disk_usage_readable(1)).to eq("1B")
-      expect(described_class.disk_usage_readable(999)).to eq("999B")
-      expect(described_class.disk_usage_readable(1000)).to eq("1KB")
-      expect(described_class.disk_usage_readable(1025)).to eq("1KB")
-      expect(described_class.disk_usage_readable(4_404_020)).to eq("4.4MB")
-      expect(described_class.disk_usage_readable(4_509_715_660)).to eq("4.5GB")
+      expect(klass.disk_usage_readable(1)).to eq("1B")
+      expect(klass.disk_usage_readable(999)).to eq("999B")
+      expect(klass.disk_usage_readable(1000)).to eq("1KB")
+      expect(klass.disk_usage_readable(1025)).to eq("1KB")
+      expect(klass.disk_usage_readable(4_404_020)).to eq("4.4MB")
+      expect(klass.disk_usage_readable(4_509_715_660)).to eq("4.5GB")
     end
   end
 
   describe ".number_readable" do
     it "returns a string with thousands separators" do
-      expect(described_class.number_readable(1)).to eq("1")
-      expect(described_class.number_readable(1_000)).to eq("1,000")
-      expect(described_class.number_readable(1_000_000)).to eq("1,000,000")
+      expect(klass.number_readable(1)).to eq("1")
+      expect(klass.number_readable(1_000)).to eq("1,000")
+      expect(klass.number_readable(1_000_000)).to eq("1,000,000")
     end
   end
 
   describe ".redact_secrets" do
     it "replaces secrets with asterisks" do
-      expect(described_class.redact_secrets("password123", ["password123"])).to eq("******")
+      expect(klass.redact_secrets("password123", ["password123"])).to eq("******")
     end
 
     it "replaces multiple secrets" do
       input = "user: admin, pass: secret"
-      expect(described_class.redact_secrets(input, ["admin", "secret"])).to eq("user: ******, pass: ******")
+      expect(klass.redact_secrets(input, ["admin", "secret"])).to eq("user: ******, pass: ******")
     end
 
     it "handles empty secrets array" do
-      expect(described_class.redact_secrets("keep this", [])).to eq("keep this")
+      expect(klass.redact_secrets("keep this", [])).to eq("keep this")
     end
 
     it "returns frozen string" do
-      result = described_class.redact_secrets("test", ["foo"])
+      result = klass.redact_secrets("test", ["foo"])
       expect(result).to be_frozen
     end
   end

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -6,9 +6,7 @@ require "git_repository"
 require "securerandom"
 
 RSpec.describe Homebrew::FormulaAuditor do
-  include FileUtils
-  include Test::Helper::Formula
-
+  let(:klass) { Homebrew::FormulaAuditor }
   let(:dir) { mktmpdir }
   let(:foo_version) do
     @count ||= 0
@@ -19,6 +17,9 @@ RSpec.describe Homebrew::FormulaAuditor do
   let(:origin_formula_path) { origin_tap_path/formula_subpath }
   let(:tap_path) { HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-bar" }
   let(:formula_path) { tap_path/formula_subpath }
+
+  include FileUtils
+  include Test::Helper::Formula
 
   def formula_auditor(name, text, options = {})
     path = Pathname.new "#{dir}/#{name}.rb"
@@ -35,7 +36,7 @@ RSpec.describe Homebrew::FormulaAuditor do
       options.delete :tap_audit_exceptions
     end
 
-    described_class.new(formula, **options)
+    klass.new(formula, **options)
   end
 
   def formula_gsub(before, after = "")
@@ -1182,7 +1183,7 @@ RSpec.describe Homebrew::FormulaAuditor do
 
   describe "#audit_stable_version" do
     subject do
-      fa = described_class.new(Formulary.factory(formula_path), git: true)
+      fa = klass.new(Formulary.factory(formula_path), git: true)
       fa.audit_stable_version
       fa.problems.first&.fetch(:message)
     end
@@ -1242,7 +1243,7 @@ RSpec.describe Homebrew::FormulaAuditor do
 
   describe "#audit_revision dependency relationships" do
     subject do
-      fa = described_class.new(Formulary.factory(formula_path), git: true)
+      fa = klass.new(Formulary.factory(formula_path), git: true)
       fa.audit_revision
       fa.problems.first&.fetch(:message)
     end
@@ -1421,7 +1422,7 @@ RSpec.describe Homebrew::FormulaAuditor do
         name:     "bar",
       )
     end
-    let(:auditor) { described_class.new(target_formula, git: true) }
+    let(:auditor) { klass.new(target_formula, git: true) }
     let(:foo_path) { tap_path/"Formula/f/foo.rb" }
 
     it "resolves sharded formula paths when filtering by names" do
@@ -1474,7 +1475,7 @@ RSpec.describe Homebrew::FormulaAuditor do
         name:     "foo",
       )
     end
-    let(:auditor) { described_class.new(target_formula, git: true) }
+    let(:auditor) { klass.new(target_formula, git: true) }
     let(:formula_versions) { instance_double(FormulaVersions) }
 
     it "walks history from the merge-base with origin/HEAD" do
@@ -1512,7 +1513,7 @@ RSpec.describe Homebrew::FormulaAuditor do
         compatibility_version: current_compatibility_version,
       )
     end
-    let(:auditor) { described_class.new(target_formula, git: true) }
+    let(:auditor) { klass.new(target_formula, git: true) }
     let(:foo_path) { tap_path/"Formula/foo.rb" }
     let(:bar_path) { tap_path/"Formula/bar.rb" }
 
@@ -1667,7 +1668,7 @@ RSpec.describe Homebrew::FormulaAuditor do
         depends_on: dependency_names,
       )
     end
-    let(:auditor) { described_class.new(target_formula, git: true) }
+    let(:auditor) { klass.new(target_formula, git: true) }
     let(:bar_path) { tap_path/"Formula/bar.rb" }
     let(:foo_path) { tap_path/"Formula/foo.rb" }
     let(:current_dependency_compatibility) { 1 }
@@ -1838,7 +1839,7 @@ RSpec.describe Homebrew::FormulaAuditor do
         conflicts_with "bar"
       end
 
-      fa = described_class.new foo
+      fa = klass.new foo
       fa.audit_conflicts
 
       expect(fa.problems.first[:message])
@@ -1853,7 +1854,7 @@ RSpec.describe Homebrew::FormulaAuditor do
       end
       stub_formula_loader foo
 
-      fa = described_class.new foo
+      fa = klass.new foo
       fa.audit_conflicts
 
       expect(fa.problems.first[:message])
@@ -1875,7 +1876,7 @@ RSpec.describe Homebrew::FormulaAuditor do
         conflicts_with "foo"
       end
 
-      fa = described_class.new bar
+      fa = klass.new bar
       fa.audit_conflicts
 
       expect(fa.problems.first[:message])

--- a/Library/Homebrew/test/formula_creator_spec.rb
+++ b/Library/Homebrew/test/formula_creator_spec.rb
@@ -4,6 +4,8 @@
 require "formula_creator"
 
 RSpec.describe Homebrew::FormulaCreator do
+  let(:klass) { Homebrew::FormulaCreator }
+
   describe ".new" do
     tests = {
       "generic tarball URL":             {
@@ -63,7 +65,7 @@ RSpec.describe Homebrew::FormulaCreator do
           end
         end
 
-        formula_creator = described_class.new(url: test.fetch(:url), name: test[:name], fetch:)
+        formula_creator = klass.new(url: test.fetch(:url), name: test[:name], fetch:)
 
         expect(formula_creator.name).to eq(test.fetch(:expected_name))
         if (expected_version = test[:expected_version])

--- a/Library/Homebrew/test/formula_info_spec.rb
+++ b/Library/Homebrew/test/formula_info_spec.rb
@@ -4,9 +4,11 @@
 require "formula_info"
 
 RSpec.describe FormulaInfo, :integration_test do
+  let(:klass) { FormulaInfo }
+
   it "tests the FormulaInfo class" do
     formula_path = setup_test_formula "testball"
-    info = described_class.lookup(formula_path)
+    info = klass.lookup(formula_path)
     expect(info).not_to be_nil
     expect(info.revision).to eq(0)
     expect(info.bottle_tags).to eq([])

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -11,6 +11,8 @@ require "test/support/fixtures/testball_bottle"
 require "test/support/fixtures/testball_bottle_cellar"
 
 RSpec.describe FormulaInstaller do
+  let(:klass) { FormulaInstaller }
+
   alias_matcher :pour_bottle, :be_pour_bottle
 
   matcher :be_poured_from_bottle do
@@ -102,7 +104,7 @@ RSpec.describe FormulaInstaller do
     expect(formula).not_to be_bottled
 
     expect do
-      described_class.new(formula).install
+      klass.new(formula).install
     end.to raise_error(UnbottledError)
 
     expect(formula).not_to be_latest_version_installed

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -13,6 +13,8 @@ require "test/support/fixtures/failball"
 require "test/support/fixtures/failball_offline_install"
 
 RSpec.describe FormulaInstaller do
+  let(:klass) { FormulaInstaller }
+
   matcher :be_poured_from_bottle do
     match(&:poured_from_bottle)
   end
@@ -20,7 +22,7 @@ RSpec.describe FormulaInstaller do
   def temporary_install(formula, **options)
     expect(formula).not_to be_latest_version_installed
 
-    installer = described_class.new(formula, **options)
+    installer = klass.new(formula, **options)
 
     installer.fetch
     installer.install
@@ -105,7 +107,7 @@ RSpec.describe FormulaInstaller do
     end
 
     it "stores new prefix config where install_etc_var restores it from" do
-      installer = described_class.new(f)
+      installer = klass.new(f)
       installer.build_bottle_preinstall
       config_file.dirname.mkpath
       config_file.write "new\n"
@@ -119,7 +121,7 @@ RSpec.describe FormulaInstaller do
   describe "#verify_deps_exist" do
     it "does not install an untapped dependency tap" do
       formula = Testball.new
-      installer = described_class.new(formula)
+      installer = klass.new(formula)
       tap = instance_double(Tap, user: "user", repository: "repo", to_s: "user/repo", installed?: false)
 
       allow(installer).to receive(:compute_dependencies).and_raise(TapFormulaUnavailableError.new(tap, "foo"))
@@ -144,7 +146,7 @@ RSpec.describe FormulaInstaller do
                  Utils::Bottles.tag.to_sym => "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97"
         end
       end
-      installer = described_class.new(formula)
+      installer = FormulaInstaller.new(formula)
       installer.download_queue = instance_double(Homebrew::DownloadQueue)
       manifest_resource = formula.bottle&.github_packages_manifest_resource
       cached_download = manifest_resource&.cached_download
@@ -169,7 +171,7 @@ RSpec.describe FormulaInstaller do
                  Utils::Bottles.tag.to_sym => "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97"
         end
       end
-      installer = described_class.new(formula)
+      installer = FormulaInstaller.new(formula)
       installer.download_queue = instance_double(Homebrew::DownloadQueue)
       manifest_resource = formula.bottle&.github_packages_manifest_resource
 
@@ -193,7 +195,7 @@ RSpec.describe FormulaInstaller do
         url "foo-1.0"
       end
 
-      expect(described_class.new(ordinary_formula, link_keg: false).link_keg).to be true
+      expect(klass.new(ordinary_formula, link_keg: false).link_keg).to be true
     end
 
     it "links non-keg-only dependencies even when they were not previously linked" do
@@ -202,7 +204,7 @@ RSpec.describe FormulaInstaller do
       end
       dependency = instance_double(Dependency, to_formula: dependency_formula, name: dependency_formula.name,
                                                options: Options.new)
-      installer = described_class.new(Testball.new)
+      installer = klass.new(Testball.new)
       child_installer = nil
 
       allow(dependency_formula).to receive_messages(
@@ -212,7 +214,7 @@ RSpec.describe FormulaInstaller do
         any_version_installed?:    false,
       )
       allow(installer).to receive(:oh1)
-      allow(described_class).to receive(:new).and_wrap_original do |original, formula, **kwargs|
+      allow(klass).to receive(:new).and_wrap_original do |original, formula, **kwargs|
         instance = original.call(formula, **kwargs)
         next instance if formula != dependency_formula
 
@@ -244,13 +246,13 @@ RSpec.describe FormulaInstaller do
     end
 
     it "does not link by default when it is not installed on request" do
-      fi = described_class.new(keg_only_formula)
+      fi = klass.new(keg_only_formula)
 
       expect(fi.link_keg).to be false
     end
 
     it "links by default when no sibling variants are installed" do
-      fi = described_class.new(keg_only_formula, installed_on_request: true)
+      fi = klass.new(keg_only_formula, installed_on_request: true)
 
       expect(fi.link_keg).to be true
     end
@@ -258,7 +260,7 @@ RSpec.describe FormulaInstaller do
     it "does not link by default when any version is already installed" do
       allow(keg_only_formula).to receive(:any_version_installed?).and_return(true)
 
-      fi = described_class.new(keg_only_formula)
+      fi = klass.new(keg_only_formula)
 
       expect(fi.link_keg).to be false
     end
@@ -266,7 +268,7 @@ RSpec.describe FormulaInstaller do
     it "links when explicitly requested" do
       allow(keg_only_formula).to receive(:any_version_installed?).and_return(true)
 
-      fi = described_class.new(keg_only_formula, link_keg: true)
+      fi = klass.new(keg_only_formula, link_keg: true)
 
       expect(fi.link_keg).to be true
     end
@@ -279,7 +281,7 @@ RSpec.describe FormulaInstaller do
       allow(other_version).to receive(:any_version_installed?).and_return(true)
       allow(keg_only_formula).to receive(:link_overwrite_formulae).and_return([other_version])
 
-      fi = described_class.new(keg_only_formula)
+      fi = klass.new(keg_only_formula)
 
       expect(fi.link_keg).to be false
     end
@@ -291,7 +293,7 @@ RSpec.describe FormulaInstaller do
       allow(unversioned_formula).to receive(:any_version_installed?).and_return(true)
       allow(keg_only_formula).to receive(:link_overwrite_formulae).and_return([unversioned_formula])
 
-      fi = described_class.new(keg_only_formula)
+      fi = klass.new(keg_only_formula)
 
       expect(fi.link_keg).to be false
     end
@@ -303,7 +305,7 @@ RSpec.describe FormulaInstaller do
       end
       allow(keg_only_formula).to receive(:link_overwrite_formulae).and_return([unversioned_formula])
 
-      fi = described_class.new(keg_only_formula)
+      fi = klass.new(keg_only_formula)
 
       expect(fi.link_keg).to be false
     end
@@ -316,7 +318,7 @@ RSpec.describe FormulaInstaller do
       allow(full_variant).to receive(:any_version_installed?).and_return(true)
       allow(keg_only_formula).to receive(:link_overwrite_formulae).and_return([full_variant])
 
-      fi = described_class.new(keg_only_formula)
+      fi = klass.new(keg_only_formula)
 
       expect(fi.link_keg).to be false
     end
@@ -334,7 +336,7 @@ RSpec.describe FormulaInstaller do
       allow(full_formula).to receive_messages(any_version_installed?:  false,
                                               link_overwrite_formulae: [non_full_variant])
 
-      fi = described_class.new(full_formula)
+      fi = klass.new(full_formula)
 
       expect(fi.link_keg).to be false
     end
@@ -366,7 +368,7 @@ RSpec.describe FormulaInstaller do
     end
 
     it "only optlinks when default linking is disabled by an installed sibling" do
-      installer = described_class.new(versioned_formula)
+      installer = klass.new(versioned_formula)
 
       expect(installer.link_keg).to be false
       expect(Homebrew::Unlink).not_to receive(:unlink_link_overwrite_formulae)
@@ -377,7 +379,7 @@ RSpec.describe FormulaInstaller do
     end
 
     it "unlinks siblings before linking when explicitly requested" do
-      installer = described_class.new(versioned_formula, link_keg: true)
+      installer = klass.new(versioned_formula, link_keg: true)
 
       expect(installer.link_keg).to be true
       expect(Homebrew::Unlink).to receive(:unlink_link_overwrite_formulae).with(versioned_formula,
@@ -406,7 +408,7 @@ RSpec.describe FormulaInstaller do
       allow(keg_only_formula).to receive_messages(any_version_installed?: false, linked?: false,
                                                   link_overwrite_formulae: [unversioned_formula])
 
-      installer = described_class.new(keg_only_formula, installed_on_request: true)
+      installer = klass.new(keg_only_formula, installed_on_request: true)
 
       expect(installer.send(:link_manual_command_warning)).to eq <<~EOS
         #{formula_name} was installed but not linked because #{base_name} is already linked.
@@ -432,7 +434,7 @@ RSpec.describe FormulaInstaller do
       Formulary.cache.delete(dep_path)
       f = Formulary.factory(dep_name)
 
-      fi = described_class.new(f)
+      fi = klass.new(f)
 
       expect do
         fi.check_install_sanity
@@ -465,7 +467,7 @@ RSpec.describe FormulaInstaller do
       RUBY
       Formulary.cache.delete(formula2_path)
 
-      fi = described_class.new(formula1)
+      fi = klass.new(formula1)
 
       expect do
         fi.check_install_sanity
@@ -501,7 +503,7 @@ RSpec.describe FormulaInstaller do
       expect(dependency_keg).to be_linked
       expect(dependency).to be_pinned
 
-      fi = described_class.new(dependent)
+      fi = klass.new(dependent)
 
       expect do
         fi.check_install_sanity
@@ -525,7 +527,7 @@ RSpec.describe FormulaInstaller do
       Formulary.cache.delete(f_path)
 
       f = Formulary.factory(f_name)
-      fi = described_class.new(f)
+      fi = klass.new(f)
 
       expect do
         fi.forbidden_license_check
@@ -549,7 +551,7 @@ RSpec.describe FormulaInstaller do
       Formulary.cache.delete(f_path)
 
       f = Formulary.factory(f_name)
-      fi = described_class.new(f)
+      fi = klass.new(f)
 
       expect do
         fi.forbidden_license_check
@@ -582,7 +584,7 @@ RSpec.describe FormulaInstaller do
       Formulary.cache.delete(f_path)
 
       f = Formulary.factory(f_name)
-      fi = described_class.new(f)
+      fi = klass.new(f)
 
       expect do
         fi.forbidden_license_check
@@ -604,7 +606,7 @@ RSpec.describe FormulaInstaller do
       Formulary.cache.delete(f_path)
 
       f = Formulary.factory(f_name)
-      fi = described_class.new(f)
+      fi = klass.new(f)
 
       expect do
         fi.forbidden_license_check
@@ -637,7 +639,7 @@ RSpec.describe FormulaInstaller do
       Formulary.cache.delete(f_path)
 
       f = Formulary.factory("#{f_tap}/#{f_name}")
-      fi = described_class.new(f)
+      fi = klass.new(f)
 
       expect do
         fi.forbidden_tap_check
@@ -660,7 +662,7 @@ RSpec.describe FormulaInstaller do
       Formulary.cache.delete(f_path)
 
       f = Formulary.factory("#{f_tap}/#{f_name}")
-      fi = described_class.new(f)
+      fi = klass.new(f)
 
       expect do
         fi.forbidden_tap_check
@@ -683,7 +685,7 @@ RSpec.describe FormulaInstaller do
       Formulary.cache.delete(f_path)
 
       f = Formulary.factory("#{f_tap}/#{f_name}")
-      fi = described_class.new(f)
+      fi = klass.new(f)
 
       expect { fi.forbidden_tap_check }.not_to raise_error
     ensure
@@ -715,7 +717,7 @@ RSpec.describe FormulaInstaller do
       Formulary.cache.delete(f_path)
 
       f = Formulary.factory(f_name)
-      fi = described_class.new(f)
+      fi = klass.new(f)
 
       expect do
         fi.forbidden_tap_check
@@ -738,7 +740,7 @@ RSpec.describe FormulaInstaller do
       Formulary.cache.delete(f_path)
 
       f = Formulary.factory(f_name)
-      fi = described_class.new(f)
+      fi = klass.new(f)
 
       expect do
         fi.forbidden_formula_check
@@ -768,7 +770,7 @@ RSpec.describe FormulaInstaller do
       Formulary.cache.delete(f_path)
 
       f = Formulary.factory(f_name)
-      fi = described_class.new(f)
+      fi = klass.new(f)
 
       expect do
         fi.forbidden_formula_check
@@ -793,7 +795,7 @@ RSpec.describe FormulaInstaller do
 
       f = Formulary.factory("#{homebrew_forbidden}/#{f_name}")
       allow(f).to receive(:loaded_from_api?).and_return(true)
-      fi = described_class.new(f)
+      fi = klass.new(f)
 
       expect(Homebrew::API::Formula).not_to receive(:source_download)
 
@@ -815,7 +817,7 @@ RSpec.describe FormulaInstaller do
 
       f = Formulary.factory(f_name)
       allow(f).to receive(:loaded_from_api?).and_return(true)
-      fi = described_class.new(f)
+      fi = klass.new(f)
 
       expect(Homebrew::API::Formula).not_to receive(:source_download)
 
@@ -841,7 +843,7 @@ RSpec.describe FormulaInstaller do
   end
 
   describe "#caveats" do
-    subject(:formula_installer) { described_class.new(Testball.new) }
+    subject(:formula_installer) { klass.new(Testball.new) }
 
     it "shows audit problems if HOMEBREW_DEVELOPER is set" do
       ENV["HOMEBREW_DEVELOPER"] = "1"
@@ -870,7 +872,7 @@ RSpec.describe FormulaInstaller do
       expect(service).to receive(:to_plist).and_return("plist")
       expect(service).to receive(:to_systemd_unit).and_return("unit")
 
-      installer = described_class.new(formula)
+      installer = klass.new(formula)
       expect do
         installer.install_service
       end.not_to output(/Error: Failed to install service files/).to_stderr
@@ -899,7 +901,7 @@ RSpec.describe FormulaInstaller do
       expect(service).to receive(:to_systemd_unit).and_return("unit")
       expect(service).to receive(:to_systemd_timer).and_return("timer")
 
-      installer = described_class.new(formula)
+      installer = klass.new(formula)
       expect do
         installer.install_service
       end.not_to output(/Error: Failed to install service files/).to_stderr
@@ -917,7 +919,7 @@ RSpec.describe FormulaInstaller do
       expect(formula).to receive(:service?).and_return(nil)
       expect(formula).not_to receive(:launchd_service_path)
 
-      installer = described_class.new(formula)
+      installer = klass.new(formula)
       expect do
         installer.install_service
       end.not_to output(/Error: Failed to install service files/).to_stderr
@@ -938,7 +940,7 @@ RSpec.describe FormulaInstaller do
         .with(formula)
         .and_return(source_formula)
 
-      installer = described_class.new(formula)
+      installer = klass.new(formula)
 
       # Stub out the actual build subprocess since we only care about the guard
       allow(installer).to receive(:build_argv).and_return([])
@@ -960,7 +962,7 @@ RSpec.describe FormulaInstaller do
         .with(formula)
         .and_raise(CannotInstallFormulaError, "source code not found")
 
-      installer = described_class.new(formula)
+      installer = klass.new(formula)
 
       expect do
         installer.build
@@ -974,7 +976,7 @@ RSpec.describe FormulaInstaller do
         url "foo"
         version "1.0"
       end
-      installer = described_class.new(formula)
+      installer = klass.new(formula)
       sandbox = instance_double(Sandbox)
 
       allow(installer).to receive(:build_argv).and_return([])

--- a/Library/Homebrew/test/formula_pin_spec.rb
+++ b/Library/Homebrew/test/formula_pin_spec.rb
@@ -4,8 +4,9 @@
 require "formula_pin"
 
 RSpec.describe FormulaPin do
-  subject(:formula_pin) { described_class.new(formula) }
+  subject(:formula_pin) { klass.new(formula) }
 
+  let(:klass) { FormulaPin }
   let(:name) { "double" }
   let(:formula) { instance_double(Formula, name:, rack: HOMEBREW_CELLAR/name) }
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Formula do
 
   describe "::new" do
     let(:klass) do
-      Class.new(described_class) do
+      Class.new(Formula) do
         url "https://brew.sh/foo-1.0.tar.gz"
       end
     end
@@ -65,7 +65,7 @@ RSpec.describe Formula do
     end
 
     specify "formula instantiation without a subclass" do
-      expect { described_class.new(name, path, spec) }
+      expect { Formula.new(name, path, spec) }
         .to raise_error(RuntimeError, "Do not call `Formula.new' directly without a subclass.")
     end
 
@@ -839,7 +839,7 @@ RSpec.describe Formula do
 
   describe "::installed_with_alias_path" do
     specify "with alias path with nil" do
-      expect(described_class.installed_with_alias_path(nil)).to be_empty
+      expect(Formula.installed_with_alias_path(nil)).to be_empty
     end
 
     specify "with alias path with a path" do
@@ -870,12 +870,12 @@ RSpec.describe Formula do
         formula_with_different_alias,
       ]
 
-      allow(described_class).to receive(:installed).and_return(formulae)
+      allow(Formula).to receive(:installed).and_return(formulae)
 
       CoreTap.instance.alias_dir.mkpath
       FileUtils.ln_sf formula_with_alias.path, alias_path
 
-      expect(described_class.installed_with_alias_path(alias_path))
+      expect(Formula.installed_with_alias_path(alias_path))
         .to eq([formula_with_alias])
     end
   end
@@ -1318,7 +1318,7 @@ RSpec.describe Formula do
 
       expect(f3.runtime_dependencies.map(&:name)).to eq(["baz/qux/f2"])
 
-      described_class.clear_cache
+      Formula.clear_cache
 
       f1_path = Tap.fetch("foo", "bar").path/"Formula/f1.rb"
       stub_formula_loader(formula("f1", path: f1_path) { url("f1-1.0") }, "foo/bar/f1")
@@ -1758,7 +1758,7 @@ RSpec.describe Formula do
     before do
       stub_formula_loader(f)
       stub_formula_loader(new_formula)
-      allow(described_class).to receive(:installed).and_return([f])
+      allow(Formula).to receive(:installed).and_return([f])
 
       f.build = tab
       new_formula.build = tab
@@ -1952,7 +1952,7 @@ RSpec.describe Formula do
 
       tab = setup_tab_for_prefix(old_alias_target_prefix, path: alias_path)
       old_formula.build = tab
-      allow(described_class).to receive(:installed).and_return([old_formula])
+      allow(Formula).to receive(:installed).and_return([old_formula])
 
       CoreTap.instance.alias_dir.mkpath
       FileUtils.ln_sf f.path, alias_path
@@ -1967,7 +1967,7 @@ RSpec.describe Formula do
 
       tab = setup_tab_for_prefix(old_alias_target_prefix, path: old_formula.path)
       old_formula.build = tab
-      allow(described_class).to receive(:installed).and_return([old_formula])
+      allow(Formula).to receive(:installed).and_return([old_formula])
       expect(f.outdated_kegs).to be_empty
     end
 
@@ -1991,7 +1991,7 @@ RSpec.describe Formula do
       expect(f.outdated_kegs).to be_empty
 
       setup_tab_for_prefix(greater_prefix, tap: "homebrew/core")
-      described_class.clear_cache
+      Formula.clear_cache
 
       expect(f.outdated_kegs).to be_empty
     end
@@ -2003,12 +2003,12 @@ RSpec.describe Formula do
 
       setup_tab_for_prefix(outdated_prefix)
       setup_tab_for_prefix(extra_outdated_prefix, tap: "homebrew/core")
-      described_class.clear_cache
+      Formula.clear_cache
 
       expect(f.outdated_kegs).not_to be_empty
 
       setup_tab_for_prefix(outdated_prefix, tap: "user/repo")
-      described_class.clear_cache
+      Formula.clear_cache
 
       expect(f.outdated_kegs).not_to be_empty
     end
@@ -2020,7 +2020,7 @@ RSpec.describe Formula do
       expect(f.outdated_kegs).to be_empty
 
       setup_tab_for_prefix(same_prefix, tap: "user/repo")
-      described_class.clear_cache
+      Formula.clear_cache
 
       expect(f.outdated_kegs).to be_empty
     end
@@ -2032,7 +2032,7 @@ RSpec.describe Formula do
 
       tab.source["versions"] = { "stable" => f.version.to_s }
       tab.write
-      described_class.clear_cache
+      Formula.clear_cache
 
       expect(f.outdated_kegs).to be_empty
     end
@@ -2071,15 +2071,15 @@ RSpec.describe Formula do
 
         tab_a.source["versions"] = { "stable" => f.version.to_s }
         tab_a.write
-        described_class.clear_cache
+        Formula.clear_cache
         expect(f.outdated_kegs(fetch_head: true)).not_to be_empty
 
         FileUtils.rm_r(head_prefix_a)
-        described_class.clear_cache
+        Formula.clear_cache
         expect(f.outdated_kegs(fetch_head: true)).not_to be_empty
 
         setup_tab_for_prefix(head_prefix_c, source_modified_time: 1)
-        described_class.clear_cache
+        Formula.clear_cache
         expect(f.outdated_kegs(fetch_head: true)).to be_empty
       ensure
         FileUtils.rm_r(testball_repo) if testball_repo.exist?
@@ -2131,13 +2131,13 @@ RSpec.describe Formula do
         setup_tab_for_prefix(prefix_b, versions: { "stable" => "2.14", "version_scheme" => 2 })
 
         expect(f.outdated_kegs).not_to be_empty
-        described_class.clear_cache
+        Formula.clear_cache
 
         prefix_c = HOMEBREW_CELLAR/"testball/20141009"
         setup_tab_for_prefix(prefix_c, versions: { "stable" => "20141009", "version_scheme" => 3 })
 
         expect(f.outdated_kegs).not_to be_empty
-        described_class.clear_cache
+        Formula.clear_cache
 
         prefix_d = HOMEBREW_CELLAR/"testball/20141011"
         setup_tab_for_prefix(prefix_d, versions: { "stable" => "20141009", "version_scheme" => 3 })
@@ -2160,7 +2160,7 @@ RSpec.describe Formula do
         setup_tab_for_prefix(head_prefix, versions: { "stable" => "1.0", "version_scheme" => 1 })
         expect(f.outdated_kegs).not_to be_empty
 
-        described_class.clear_cache
+        Formula.clear_cache
         FileUtils.rm_r(head_prefix)
 
         setup_tab_for_prefix(head_prefix, versions: { "stable" => "1.0", "version_scheme" => 2 })
@@ -2552,7 +2552,7 @@ RSpec.describe Formula do
 
   describe "#specified_path" do
     let(:klass) do
-      Class.new(described_class) do
+      Class.new(Formula) do
         url "https://brew.sh/foo-1.0.tar.gz"
       end
     end
@@ -2729,13 +2729,13 @@ RSpec.describe Formula do
 
   describe ".all" do
     it "skips formulas that raise FormulaSpecificationError" do
-      allow(described_class).to receive_messages(core_names: ["testball"], tap_files: [])
+      allow(Formula).to receive_messages(core_names: ["testball"], tap_files: [])
       allow(Formulary).to receive(:factory).with("testball").and_raise(
         FormulaSpecificationError, "testball: formula requires at least a URL"
       )
 
-      expect { described_class.all(eval_all: true) }.not_to raise_error
-      expect(described_class.all(eval_all: true)).to eq([])
+      expect { Formula.all(eval_all: true) }.not_to raise_error
+      expect(Formula.all(eval_all: true)).to eq([])
     end
   end
 

--- a/Library/Homebrew/test/formula_validation_spec.rb
+++ b/Library/Homebrew/test/formula_validation_spec.rb
@@ -4,6 +4,8 @@
 require "formula"
 
 RSpec.describe Formula do
+  let(:klass) { Formula }
+
   describe "::new" do
     matcher :fail_with_invalid do |attr|
       match do |actual|
@@ -25,7 +27,7 @@ RSpec.describe Formula do
         formula do
           def brew; end
         end
-      end.to raise_error(RuntimeError, /\AThe method `brew` on #{described_class} was declared as final/)
+      end.to raise_error(RuntimeError, /\AThe method `brew` on #{klass} was declared as final/)
     end
 
     it "validates the `name`" do

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -6,11 +6,13 @@ require "formula_installer"
 require "utils/bottles"
 
 RSpec.describe Formulary do
+  let(:klass) { Formulary }
+
   let(:formula_name) { "testball_bottle" }
   let(:formula_path) { CoreTap.instance.new_formula_path(formula_name) }
   let(:formula_content) do
     <<~RUBY
-      class #{described_class.class_s(formula_name)} < Formula
+      class #{klass.class_s(formula_name)} < Formula
         url "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
         sha256 TESTBALL_SHA256
 
@@ -31,27 +33,27 @@ RSpec.describe Formulary do
 
   describe "::class_s" do
     it "replaces '+' with 'x'" do
-      expect(described_class.class_s("foo++")).to eq("Fooxx")
+      expect(klass.class_s("foo++")).to eq("Fooxx")
     end
 
     it "converts a string with dots to PascalCase" do
-      expect(described_class.class_s("shell.fm")).to eq("ShellFm")
+      expect(klass.class_s("shell.fm")).to eq("ShellFm")
     end
 
     it "converts a string with hyphens to PascalCase" do
-      expect(described_class.class_s("pkg-config")).to eq("PkgConfig")
+      expect(klass.class_s("pkg-config")).to eq("PkgConfig")
     end
 
     it "converts a string with a single letter separated by a hyphen to PascalCase" do
-      expect(described_class.class_s("s-lang")).to eq("SLang")
+      expect(klass.class_s("s-lang")).to eq("SLang")
     end
 
     it "converts a string with underscores to PascalCase" do
-      expect(described_class.class_s("foo_bar")).to eq("FooBar")
+      expect(klass.class_s("foo_bar")).to eq("FooBar")
     end
 
     it "replaces '@' with 'AT'" do
-      expect(described_class.class_s("openssl@1.1")).to eq("OpensslAT11")
+      expect(klass.class_s("openssl@1.1")).to eq("OpensslAT11")
     end
   end
 
@@ -63,22 +65,22 @@ RSpec.describe Formulary do
       end
 
       it "returns a Formula" do
-        expect(described_class.factory(formula_name)).to be_a(Formula)
+        expect(klass.factory(formula_name)).to be_a(Formula)
       end
 
       it "returns a Formula when given a fully qualified name" do
-        expect(described_class.factory("homebrew/core/#{formula_name}")).to be_a(Formula)
+        expect(klass.factory("homebrew/core/#{formula_name}")).to be_a(Formula)
       end
 
       it "raises an error if the Formula cannot be found" do
         expect do
-          described_class.factory("not_existed_formula")
+          klass.factory("not_existed_formula")
         end.to raise_error(FormulaUnavailableError)
       end
 
       it "raises an error if ref is nil" do
         expect do
-          described_class.factory(nil)
+          klass.factory(nil)
         end.to raise_error(TypeError)
       end
 
@@ -91,11 +93,11 @@ RSpec.describe Formulary do
         end
 
         it "returns a Formula" do
-          expect(described_class.factory(formula_name)).to be_a(Formula)
+          expect(klass.factory(formula_name)).to be_a(Formula)
         end
 
         it "returns a Formula when given a fully qualified name" do
-          expect(described_class.factory("homebrew/core/#{formula_name}")).to be_a(Formula)
+          expect(klass.factory("homebrew/core/#{formula_name}")).to be_a(Formula)
         end
       end
 
@@ -103,20 +105,20 @@ RSpec.describe Formulary do
         let(:formula_name) { "giraffe" }
         let(:formula_content) do
           <<~RUBY
-            class Wrong#{described_class.class_s(formula_name)} < Formula
+            class Wrong#{klass.class_s(formula_name)} < Formula
             end
           RUBY
         end
 
         it "raises an error" do
           expect do
-            described_class.factory(formula_name)
+            klass.factory(formula_name)
           end.to raise_error(TapFormulaClassUnavailableError)
         end
       end
 
       it "returns a Formula when given a path" do
-        expect(described_class.factory(formula_path)).to be_a(Formula)
+        expect(klass.factory(formula_path)).to be_a(Formula)
       end
 
       it "errors when given a path but paths are disabled" do
@@ -124,21 +126,21 @@ RSpec.describe Formulary do
         FileUtils.cp formula_path, HOMEBREW_TEMP
         temp_formula_path = HOMEBREW_TEMP/formula_path.basename
         expect do
-          described_class.factory(temp_formula_path)
+          klass.factory(temp_formula_path)
         ensure
           temp_formula_path.unlink
         end.to raise_error(RuntimeError, /requires formulae to be in a tap, rejecting/)
       end
 
       it "returns a Formula when given a URL", :needs_utils_curl do
-        formula = described_class.factory("file://#{formula_path}")
+        formula = klass.factory("file://#{formula_path}")
         expect(formula).to be_a(Formula)
       end
 
       it "errors when given a URL but paths are disabled" do
         ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = "1"
         expect do
-          described_class.factory("file://#{formula_path}")
+          klass.factory("file://#{formula_path}")
         end.to raise_error(FormulaUnavailableError)
       end
 
@@ -159,13 +161,13 @@ RSpec.describe Formulary do
         it "disallows cache paths when paths are explicitly disabled" do
           ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = "1"
           expect do
-            described_class.factory(cache_formula_path)
+            klass.factory(cache_formula_path)
           end.to raise_error(/requires formulae to be in a tap/)
         end
       end
 
       context "when given a bottle" do
-        subject(:formula) { described_class.factory(bottle) }
+        subject(:formula) { klass.factory(bottle) }
 
         specify do
           expect(formula).to be_a(Formula)
@@ -174,7 +176,7 @@ RSpec.describe Formulary do
       end
 
       context "when given an alias" do
-        subject(:formula) { described_class.factory("foo") }
+        subject(:formula) { klass.factory("foo") }
 
         let(:alias_dir) { CoreTap.instance.alias_dir }
         let(:alias_path) { alias_dir/"foo" }
@@ -196,14 +198,14 @@ RSpec.describe Formulary do
           allow(DevelopmentTools).to receive_messages(needs_libc_formula?: false, needs_compiler_formula?: false)
         end
 
-        let(:installed_formula) { described_class.factory(formula_path) }
+        let(:installed_formula) { klass.factory(formula_path) }
         let(:installer) { FormulaInstaller.new(installed_formula) }
 
         it "returns a Formula when given a rack" do
           installer.fetch
           installer.install
 
-          f = described_class.from_rack(installed_formula.rack)
+          f = klass.from_rack(installed_formula.rack)
           expect(f).to be_a(Formula)
         end
 
@@ -212,7 +214,7 @@ RSpec.describe Formulary do
           installer.install
 
           keg = Keg.new(installed_formula.prefix)
-          f = described_class.from_keg(keg)
+          f = klass.from_keg(keg)
           expect(f).to be_a(Formula)
         end
       end
@@ -240,7 +242,7 @@ RSpec.describe Formulary do
               "#{formula_name}": "homebrew/core"
             }
           EOS
-          formula = described_class.factory("#{tap}/#{formula_name}")
+          formula = klass.factory("#{tap}/#{formula_name}")
           expect(formula).to be_a(Formula)
           expect(formula.tap).to eq(CoreTap.instance)
           expect(formula.path).to eq(formula_path)
@@ -252,7 +254,7 @@ RSpec.describe Formulary do
               "#{formula_name}": "#{another_tap}"
             }
           EOS
-          formula = described_class.factory("#{tap}/#{formula_name}")
+          formula = klass.factory("#{tap}/#{formula_name}")
           expect(formula).to be_a(Formula)
           expect(formula.tap).to eq(another_tap)
           expect(formula.path).to eq(another_tap_formula_path)
@@ -268,7 +270,7 @@ RSpec.describe Formulary do
 
           expect(another_tap).not_to receive(:ensure_installed!)
 
-          expect { described_class.factory("#{tap}/#{formula_name}") }
+          expect { klass.factory("#{tap}/#{formula_name}") }
             .to raise_error(TapFormulaUnavailableError, /If you trust this tap/)
         end
       end
@@ -287,25 +289,25 @@ RSpec.describe Formulary do
         end
 
         it "returns a Formula when given a name" do
-          expect(described_class.factory(formula_name)).to be_a(Formula)
+          expect(klass.factory(formula_name)).to be_a(Formula)
         end
 
         it "returns a Formula from an Alias path" do
-          expect(described_class.factory(alias_name)).to be_a(Formula)
+          expect(klass.factory(alias_name)).to be_a(Formula)
         end
 
         it "returns a Formula from a fully qualified Alias path" do
-          expect(described_class.factory("#{tap.name}/#{alias_name}")).to be_a(Formula)
+          expect(klass.factory("#{tap.name}/#{alias_name}")).to be_a(Formula)
         end
 
         it "raises an error when the Formula cannot be found" do
           expect do
-            described_class.factory("#{tap}/not_existed_formula")
+            klass.factory("#{tap}/not_existed_formula")
           end.to raise_error(TapFormulaUnavailableError)
         end
 
         it "returns a Formula when given a fully qualified name" do
-          expect(described_class.factory("#{tap}/#{formula_name}")).to be_a(Formula)
+          expect(klass.factory("#{tap}/#{formula_name}")).to be_a(Formula)
         end
 
         it "raises an error if a Formula is in multiple Taps" do
@@ -313,7 +315,7 @@ RSpec.describe Formulary do
           (another_tap.path/"Formula/#{formula_name}.rb").write formula_content
 
           expect do
-            described_class.factory(formula_name)
+            klass.factory(formula_name)
           end.to raise_error(TapFormulaAmbiguityError)
         end
       end
@@ -494,7 +496,7 @@ RSpec.describe Formulary do
       it "returns a Formula when given a name" do
         allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents
 
-        formula = described_class.factory(formula_name)
+        formula = klass.factory(formula_name)
         expect(formula).to be_a(Formula)
 
         expect(formula.keg_only_reason.reason).to eq :provided_by_macos
@@ -534,7 +536,7 @@ RSpec.describe Formulary do
       it "returns a Formula that can regenerate its JSON API" do
         allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents
 
-        formula = described_class.factory(formula_name)
+        formula = klass.factory(formula_name)
         expect(formula).to be_a(Formula)
         expect(formula.loaded_from_api?).to be true
         expect(formula.loaded_from_internal_api?).to be false
@@ -546,7 +548,7 @@ RSpec.describe Formulary do
       it "returns a deprecated Formula when given a name" do
         allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents(deprecate_json)
 
-        formula = described_class.factory(formula_name)
+        formula = klass.factory(formula_name)
         expect(formula).to be_a(Formula)
         expect(formula.deprecated?).to be true
         expect(formula.deprecation_date).to eq(Date.parse("2022-06-15"))
@@ -559,7 +561,7 @@ RSpec.describe Formulary do
       it "returns a disabled Formula when given a name" do
         allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents(disable_json)
 
-        formula = described_class.factory(formula_name)
+        formula = klass.factory(formula_name)
         expect(formula).to be_a(Formula)
         expect(formula.disabled?).to be true
         expect(formula.disable_date).to eq(Date.parse("2022-06-15"))
@@ -573,7 +575,7 @@ RSpec.describe Formulary do
         contents = formula_json_contents(deprecate_future_json)
         allow(Homebrew::API::Formula).to receive(:all_formulae).and_return contents
 
-        formula = described_class.factory(formula_name)
+        formula = klass.factory(formula_name)
         expect(formula).to be_a(Formula)
         expect(formula.deprecated?).to be false
         expect(formula.deprecation_date).to eq(future_date)
@@ -588,7 +590,7 @@ RSpec.describe Formulary do
       it "returns a future-disabled Formula when given a name" do
         allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents(disable_future_json)
 
-        formula = described_class.factory(formula_name)
+        formula = klass.factory(formula_name)
         expect(formula).to be_a(Formula)
         expect(formula.deprecated?).to be true
         expect(formula.deprecation_date).to be_nil
@@ -608,7 +610,7 @@ RSpec.describe Formulary do
       it "returns a Formula with variations when given a name", :needs_macos do
         allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents(variations_json)
 
-        formula = described_class.factory(formula_name)
+        formula = klass.factory(formula_name)
         expect(formula).to be_a(Formula)
         expect(formula.declared_deps.count).to eq 7
         expect(formula.deps.count).to eq 6
@@ -620,7 +622,7 @@ RSpec.describe Formulary do
         allow(Homebrew::API::Formula)
           .to receive(:all_formulae).and_return formula_json_contents(linux_variations_json)
 
-        formula = described_class.factory(formula_name)
+        formula = klass.factory(formula_name)
         expect(formula).to be_a(Formula)
         expect(formula.declared_deps.count).to eq 6
         expect(formula.deps.count).to eq 6
@@ -631,7 +633,7 @@ RSpec.describe Formulary do
         allow(Homebrew::API::Formula)
           .to receive(:all_formulae).and_return formula_json_contents(older_macos_variations_json)
 
-        formula = described_class.factory(formula_name)
+        formula = klass.factory(formula_name)
         expect(formula).to be_a(Formula)
         expect(formula.declared_deps.count).to eq 6
         expect(formula.deps.count).to eq 5
@@ -656,8 +658,8 @@ RSpec.describe Formulary do
             { "#{old_formula_name}": "homebrew/core/#{formula_name}" }
           JSON
 
-          loader = described_class::FromNameLoader.try_new(old_formula_name)
-          expect(loader).to be_a(described_class::FromAPILoader)
+          loader = klass::FromNameLoader.try_new(old_formula_name)
+          expect(loader).to be_a(klass::FromAPILoader)
           expect(loader.name).to eq formula_name
           expect(loader.path).not_to exist
         end
@@ -668,8 +670,8 @@ RSpec.describe Formulary do
             { "#{old_formula_name}": "homebrew/core/#{formula_name}" }
           JSON
 
-          loader = described_class::FromTapLoader.try_new("#{foo_tap}/#{old_formula_name}")
-          expect(loader).to be_a(described_class::FromAPILoader)
+          loader = klass::FromTapLoader.try_new("#{foo_tap}/#{old_formula_name}")
+          expect(loader).to be_a(klass::FromAPILoader)
           expect(loader.name).to eq formula_name
           expect(loader.path).not_to exist
         end
@@ -679,31 +681,31 @@ RSpec.describe Formulary do
     context "when passed a URL" do
       it "raises an error when given an https URL" do
         expect do
-          described_class.factory("https://brew.sh/foo.rb")
+          klass.factory("https://brew.sh/foo.rb")
         end.to raise_error(UnsupportedInstallationMethod)
       end
 
       it "raises an error when given a bottle URL" do
         expect do
-          described_class.factory("https://brew.sh/foo-1.0.arm64_catalina.bottle.tar.gz")
+          klass.factory("https://brew.sh/foo-1.0.arm64_catalina.bottle.tar.gz")
         end.to raise_error(UnsupportedInstallationMethod)
       end
 
       it "raises an error when given an ftp URL" do
         expect do
-          described_class.factory("ftp://brew.sh/foo.rb")
+          klass.factory("ftp://brew.sh/foo.rb")
         end.to raise_error(UnsupportedInstallationMethod)
       end
 
       it "raises an error when given an sftp URL" do
         expect do
-          described_class.factory("sftp://brew.sh/foo.rb")
+          klass.factory("sftp://brew.sh/foo.rb")
         end.to raise_error(UnsupportedInstallationMethod)
       end
 
       it "does not raise an error when given a file URL", :needs_utils_curl do
         expect do
-          described_class.factory("file://#{TEST_FIXTURE_DIR}/testball.rb")
+          klass.factory("file://#{TEST_FIXTURE_DIR}/testball.rb")
         end.not_to raise_error
       end
     end
@@ -711,14 +713,14 @@ RSpec.describe Formulary do
     context "when passed ref with spaces" do
       it "raises a FormulaUnavailableError error" do
         expect do
-          described_class.factory("foo bar")
+          klass.factory("foo bar")
         end.to raise_error(FormulaUnavailableError)
       end
     end
   end
 
   specify "::from_contents" do
-    expect(described_class.from_contents(formula_name, formula_path, formula_content)).to be_a(Formula)
+    expect(klass.from_contents(formula_name, formula_path, formula_content)).to be_a(Formula)
   end
 
   describe "::to_rack" do
@@ -728,7 +730,7 @@ RSpec.describe Formulary do
 
     context "when the Rack does not exist" do
       it "returns the Rack" do
-        expect(described_class.to_rack(formula_name)).to eq(rack_path)
+        expect(klass.to_rack(formula_name)).to eq(rack_path)
       end
     end
 
@@ -738,13 +740,13 @@ RSpec.describe Formulary do
       end
 
       it "returns the Rack" do
-        expect(described_class.to_rack(formula_name)).to eq(rack_path)
+        expect(klass.to_rack(formula_name)).to eq(rack_path)
       end
     end
 
     it "raises an error if the Formula is not available" do
       expect do
-        described_class.to_rack("a/b/#{formula_name}")
+        klass.to_rack("a/b/#{formula_name}")
       end.to raise_error(TapFormulaUnavailableError)
     end
   end
@@ -752,7 +754,7 @@ RSpec.describe Formulary do
   describe "::core_path" do
     it "returns the path to a Formula in the core tap" do
       name = "foo-bar"
-      expect(described_class.core_path(name))
+      expect(klass.core_path(name))
         .to eq(Pathname.new("#{HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core/Formula/#{name}.rb"))
     end
   end
@@ -763,14 +765,14 @@ RSpec.describe Formulary do
         mktmpdir.cd do
           FileUtils.mkdir "Formula"
           FileUtils.touch "Formula/gcc.rb"
-          expect(described_class.loader_for("./Formula/gcc.rb")).to be_a Formulary::FromPathLoader
+          expect(klass.loader_for("./Formula/gcc.rb")).to be_a Formulary::FromPathLoader
         end
       end
     end
 
     context "when given a tapped name" do
       it "returns a `FromTapLoader`", :no_api do
-        expect(described_class.loader_for("homebrew/core/gcc")).to be_a Formulary::FromTapLoader
+        expect(klass.loader_for("homebrew/core/gcc")).to be_a Formulary::FromTapLoader
       end
     end
 
@@ -806,7 +808,7 @@ RSpec.describe Formulary do
 
           it "does not warn when loading the short token" do
             expect do
-              described_class.loader_for(token)
+              klass.loader_for(token)
             end.not_to output.to_stderr
           end
         end
@@ -824,19 +826,19 @@ RSpec.describe Formulary do
 
           it "does not warn when loading the short token" do
             expect do
-              described_class.loader_for(token)
+              klass.loader_for(token)
             end.not_to output.to_stderr
           end
 
           it "does not warn when loading the full token in the default tap" do
             expect do
-              described_class.loader_for("#{new_tap}/#{token}")
+              klass.loader_for("#{new_tap}/#{token}")
             end.not_to output.to_stderr
           end
 
           it "warns when loading the full token in the old tap" do
             expect do
-              described_class.loader_for("#{old_tap}/#{token}")
+              klass.loader_for("#{old_tap}/#{token}")
             end.to output(
               a_string_including("Formula #{old_tap}/#{token} was renamed to #{token}.").once,
             ).to_stderr
@@ -852,7 +854,7 @@ RSpec.describe Formulary do
           #
           #   it "stops recursing" do
           #     expect do
-          #       described_class.loader_for("#{new_tap}/#{token}")
+          #       klass.loader_for("#{new_tap}/#{token}")
           #     end.not_to output.to_stderr
           #   end
           # end
@@ -876,7 +878,7 @@ RSpec.describe Formulary do
           # It would be preferable not to print a warning when installing with the short token
           it "warns when loading the short token" do
             expect do
-              described_class.loader_for(token)
+              klass.loader_for(token)
             end.to output(
               a_string_including("Formula #{old_tap}/#{token} was renamed to #{new_tap}/#{token}.").once,
             ).to_stderr
@@ -884,7 +886,7 @@ RSpec.describe Formulary do
 
           it "warns with the canonical token when loading an uppercase short token" do
             expect do
-              described_class.loader_for(token.upcase)
+              klass.loader_for(token.upcase)
             end.to output(
               a_string_including("Formula #{old_tap}/#{token} was renamed to #{new_tap}/#{token}.").once,
             ).to_stderr
@@ -892,13 +894,13 @@ RSpec.describe Formulary do
 
           it "does not warn when loading the full token in the new tap" do
             expect do
-              described_class.loader_for("#{new_tap}/#{token}")
+              klass.loader_for("#{new_tap}/#{token}")
             end.not_to output.to_stderr
           end
 
           it "warns when loading the full token in the old tap" do
             expect do
-              described_class.loader_for("#{old_tap}/#{token}")
+              klass.loader_for("#{old_tap}/#{token}")
             end.to output(
               a_string_including("Formula #{old_tap}/#{token} was renamed to #{new_tap}/#{token}.").once,
             ).to_stderr

--- a/Library/Homebrew/test/free_port_spec.rb
+++ b/Library/Homebrew/test/free_port_spec.rb
@@ -5,7 +5,9 @@ require "socket"
 require "formula_free_port"
 
 RSpec.describe Homebrew::FreePort do
-  subject(:instance) { Object.new.extend(described_class) }
+  subject(:instance) { Object.new.extend(klass) }
+
+  let(:klass) { Homebrew::FreePort }
 
   describe "#free_port" do
     it "returns a free TCP/IP port" do

--- a/Library/Homebrew/test/git_repository_spec.rb
+++ b/Library/Homebrew/test/git_repository_spec.rb
@@ -4,8 +4,9 @@
 require "git_repository"
 
 RSpec.describe GitRepository do
-  subject(:git_repo) { described_class.new(clone_path) }
+  subject(:git_repo) { klass.new(clone_path) }
 
+  let(:klass) { GitRepository }
   let(:branch_name) { "main" }
   let(:tag_name) { branch_name }
   let(:repo_root) { mktmpdir }

--- a/Library/Homebrew/test/github_packages_spec.rb
+++ b/Library/Homebrew/test/github_packages_spec.rb
@@ -4,13 +4,15 @@
 require "github_packages"
 
 RSpec.describe GitHubPackages do
+  let(:klass) { GitHubPackages }
+
   describe "#upload_bottle" do
     it "omits platform metadata from image index descriptors for all bottles" do
       mktmpdir.cd do
         bottle = Pathname("testball--1.0.all.bottle.tar.gz")
         Zlib::GzipWriter.open(bottle) { |gz| gz.write("test") }
 
-        github_packages = Class.new(described_class) do
+        github_packages = Class.new(klass) do
           private
 
           def validate_schema!(_schema_uri, _json); end

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -5,23 +5,10 @@ require "github_runner_matrix"
 require "test/support/fixtures/testball"
 
 RSpec.describe GitHubRunnerMatrix, :no_api do
-  before do
-    allow(ENV).to receive(:fetch).and_call_original
-    allow(ENV).to receive(:fetch).with("HOMEBREW_LINUX_RUNNER").and_return("ubuntu-latest")
-    allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_LONG_TIMEOUT", "false").and_return("false")
-    allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER", "false").and_return("false")
-    allow(ENV).to receive(:fetch).with("GITHUB_RUN_ID").and_return("12345")
-    allow(ENV).to receive(:fetch).with("HOMEBREW_EVAL_ALL", nil).and_call_original
-    allow(ENV).to receive(:fetch).with("HOMEBREW_SIMULATE_MACOS_ON_LINUX", nil).and_call_original
-    allow(ENV).to receive(:fetch).with("HOMEBREW_FORBID_PACKAGES_FROM_PATHS", nil).and_call_original
-    allow(ENV).to receive(:fetch).with("HOMEBREW_DEVELOPER", nil).and_call_original
-    allow(ENV).to receive(:fetch).with("HOMEBREW_NO_INSTALL_FROM_API", nil).and_call_original
-  end
-
+  let(:klass) { GitHubRunnerMatrix }
   let(:newest_supported_macos) do
-    MacOSVersion::SYMBOLS.find { |k, _| k == described_class::NEWEST_HOMEBREW_CORE_MACOS_RUNNER }
+    MacOSVersion::SYMBOLS.find { |k, _| k == klass::NEWEST_HOMEBREW_CORE_MACOS_RUNNER }
   end
-
   let(:testball) { setup_test_runner_formula("testball") }
   let(:testball_depender) { setup_test_runner_formula("testball-depender", ["testball"]) }
   let(:testball_depender_linux) { setup_test_runner_formula("testball-depender-linux", ["testball", :linux]) }
@@ -35,9 +22,22 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
     setup_test_runner_formula("testball-depender-newest", ["testball", { macos: symbol }])
   end
 
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with("HOMEBREW_LINUX_RUNNER").and_return("ubuntu-latest")
+    allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_LONG_TIMEOUT", "false").and_return("false")
+    allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER", "false").and_return("false")
+    allow(ENV).to receive(:fetch).with("GITHUB_RUN_ID").and_return("12345")
+    allow(ENV).to receive(:fetch).with("HOMEBREW_EVAL_ALL", nil).and_call_original
+    allow(ENV).to receive(:fetch).with("HOMEBREW_SIMULATE_MACOS_ON_LINUX", nil).and_call_original
+    allow(ENV).to receive(:fetch).with("HOMEBREW_FORBID_PACKAGES_FROM_PATHS", nil).and_call_original
+    allow(ENV).to receive(:fetch).with("HOMEBREW_DEVELOPER", nil).and_call_original
+    allow(ENV).to receive(:fetch).with("HOMEBREW_NO_INSTALL_FROM_API", nil).and_call_original
+  end
+
   describe "OLDEST_HOMEBREW_CORE_MACOS_RUNNER" do
     it "is not newer than HOMEBREW_MACOS_OLDEST_SUPPORTED" do
-      oldest_macos_runner = MacOSVersion.from_symbol(described_class::OLDEST_HOMEBREW_CORE_MACOS_RUNNER)
+      oldest_macos_runner = MacOSVersion.from_symbol(klass::OLDEST_HOMEBREW_CORE_MACOS_RUNNER)
       expect(oldest_macos_runner).to be <= HOMEBREW_MACOS_OLDEST_SUPPORTED
     end
   end
@@ -45,7 +45,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
   describe "#active_runner_specs_hash" do
     it "returns an object that responds to `#to_json`" do
       expect(
-        described_class.new([], ["deleted"], all_supported: false, dependent_matrix: false)
+        klass.new([], ["deleted"], all_supported: false, dependent_matrix: false)
                        .active_runner_specs_hash
                        .respond_to?(:to_json),
       ).to be(true)
@@ -54,7 +54,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
 
   describe "#generate_runners!" do
     it "is idempotent" do
-      matrix = described_class.new([], [], all_supported: false, dependent_matrix: false)
+      matrix = klass.new([], [], all_supported: false, dependent_matrix: false)
       runners = matrix.runners.dup
       matrix.send(:generate_runners!)
 
@@ -64,19 +64,19 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
 
   context "when there are no testing formulae and no deleted formulae" do
     it "activates no test runners" do
-      expect(described_class.new([], [], all_supported: false, dependent_matrix: false).runners.any?(&:active))
+      expect(klass.new([], [], all_supported: false, dependent_matrix: false).runners.any?(&:active))
         .to be(false)
     end
 
     it "activates no dependent runners" do
-      expect(described_class.new([], [], all_supported: false, dependent_matrix: true).runners.any?(&:active))
+      expect(klass.new([], [], all_supported: false, dependent_matrix: true).runners.any?(&:active))
         .to be(false)
     end
   end
 
   context "when passed `--all-supported`" do
     it "activates all runners" do
-      expect(described_class.new([], [], all_supported: true, dependent_matrix: false).runners.all?(&:active))
+      expect(klass.new([], [], all_supported: true, dependent_matrix: false).runners.all?(&:active))
         .to be(true)
     end
   end
@@ -85,7 +85,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
     context "when it is a matrix for the `tests` job" do
       context "when testing formulae have no requirements" do
         it "activates all runners" do
-          expect(described_class.new([testball], [], all_supported: false, dependent_matrix: false)
+          expect(klass.new([testball], [], all_supported: false, dependent_matrix: false)
                                 .runners
                                 .all?(&:active))
             .to be(true)
@@ -94,9 +94,9 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
 
       context "when testing formulae require Linux" do
         it "activates only the Linux runners" do
-          runner_matrix = described_class.new([testball_depender_linux], [],
-                                              all_supported:    false,
-                                              dependent_matrix: false)
+          runner_matrix = klass.new([testball_depender_linux], [],
+                                    all_supported:    false,
+                                    dependent_matrix: false)
 
           expect(runner_matrix.runners.all?(&:active)).to be(false)
           expect(runner_matrix.runners.any?(&:active)).to be(true)
@@ -106,9 +106,9 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
 
       context "when testing formulae require macOS" do
         it "activates only the macOS runners" do
-          runner_matrix = described_class.new([testball_depender_macos], [],
-                                              all_supported:    false,
-                                              dependent_matrix: false)
+          runner_matrix = klass.new([testball_depender_macos], [],
+                                    all_supported:    false,
+                                    dependent_matrix: false)
 
           expect(runner_matrix.runners.all?(&:active)).to be(false)
           expect(runner_matrix.runners.any?(&:active)).to be(true)
@@ -118,9 +118,9 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
 
       context "when testing formulae require Intel" do
         it "activates only the Intel runners" do
-          runner_matrix = described_class.new([testball_depender_intel], [],
-                                              all_supported:    false,
-                                              dependent_matrix: false)
+          runner_matrix = klass.new([testball_depender_intel], [],
+                                    all_supported:    false,
+                                    dependent_matrix: false)
 
           expect(runner_matrix.runners.all?(&:active)).to be(false)
           expect(runner_matrix.runners.any?(&:active)).to be(true)
@@ -130,9 +130,9 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
 
       context "when testing formulae require ARM" do
         it "activates only the ARM runners" do
-          runner_matrix = described_class.new([testball_depender_arm], [],
-                                              all_supported:    false,
-                                              dependent_matrix: false)
+          runner_matrix = klass.new([testball_depender_arm], [],
+                                    all_supported:    false,
+                                    dependent_matrix: false)
 
           expect(runner_matrix.runners.all?(&:active)).to be(false)
           expect(runner_matrix.runners.any?(&:active)).to be(true)
@@ -143,9 +143,9 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
       context "when testing formulae require a macOS version" do
         it "activates the Linux runners and suitable macOS runners" do
           _, v = newest_supported_macos
-          runner_matrix = described_class.new([testball_depender_newest], [],
-                                              all_supported:    false,
-                                              dependent_matrix: false)
+          runner_matrix = klass.new([testball_depender_newest], [],
+                                    all_supported:    false,
+                                    dependent_matrix: false)
 
           expect(runner_matrix.runners.all?(&:active)).to be(false)
           expect(runner_matrix.runners.any?(&:active)).to be(true)
@@ -160,7 +160,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
           allow(Homebrew::EnvConfig).to receive(:eval_all?).and_return(true)
           allow(Formula).to receive(:all).and_return([testball].map(&:formula))
 
-          expect(described_class.new([testball], [], all_supported: false, dependent_matrix: true)
+          expect(klass.new([testball], [], all_supported: false, dependent_matrix: true)
                                 .runners
                                 .any?(&:active))
             .to be(false)
@@ -173,7 +173,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
             allow(Homebrew::EnvConfig).to receive(:eval_all?).and_return(true)
             allow(Formula).to receive(:all).and_return([testball, testball_depender].map(&:formula))
 
-            expect(described_class.new([testball], [], all_supported: false, dependent_matrix: true)
+            expect(klass.new([testball], [], all_supported: false, dependent_matrix: true)
                                   .runners
                                   .all?(&:active))
               .to be(true)
@@ -183,11 +183,11 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
             allow(Homebrew::EnvConfig).to receive(:eval_all?).and_return(true)
             allow(Formula).to receive(:all).and_return([testball, testball_depender].map(&:formula))
 
-            runners = described_class.new([testball], [],
-                                          all_supported:    false,
-                                          dependent_matrix: true,
-                                          dependent_shards: 2)
-                                     .active_runner_specs_hash
+            runners = klass.new([testball], [],
+                                all_supported:    false,
+                                dependent_matrix: true,
+                                dependent_shards: 2)
+                           .active_runner_specs_hash
 
             expect(runners).to all(include(:formulae_dependents_shard))
             expect(runners.map { |runner| runner.fetch(:formulae_dependents_shard) }.uniq).to eq(["1/2", "2/2"])
@@ -200,7 +200,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
             allow(Homebrew::EnvConfig).to receive(:eval_all?).and_return(true)
             allow(Formula).to receive(:all).and_return([testball, testball_depender_linux].map(&:formula))
 
-            runner_matrix = described_class.new([testball], [], all_supported: false, dependent_matrix: true)
+            runner_matrix = klass.new([testball], [], all_supported: false, dependent_matrix: true)
             expect(runner_matrix.runners.all?(&:active)).to be(false)
             expect(runner_matrix.runners.any?(&:active)).to be(true)
             expect(get_runner_names(runner_matrix)).to eq(get_runner_names(runner_matrix, :linux?))
@@ -212,7 +212,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
             allow(Homebrew::EnvConfig).to receive(:eval_all?).and_return(true)
             allow(Formula).to receive(:all).and_return([testball, testball_depender_macos].map(&:formula))
 
-            runner_matrix = described_class.new([testball], [], all_supported: false, dependent_matrix: true)
+            runner_matrix = klass.new([testball], [], all_supported: false, dependent_matrix: true)
             expect(runner_matrix.runners.all?(&:active)).to be(false)
             expect(runner_matrix.runners.any?(&:active)).to be(true)
             expect(get_runner_names(runner_matrix)).to eq(get_runner_names(runner_matrix, :macos?))
@@ -224,7 +224,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
             allow(Homebrew::EnvConfig).to receive(:eval_all?).and_return(true)
             allow(Formula).to receive(:all).and_return([testball, testball_depender_intel].map(&:formula))
 
-            runner_matrix = described_class.new([testball], [], all_supported: false, dependent_matrix: true)
+            runner_matrix = klass.new([testball], [], all_supported: false, dependent_matrix: true)
             expect(runner_matrix.runners.all?(&:active)).to be(false)
             expect(runner_matrix.runners.any?(&:active)).to be(true)
             expect(get_runner_names(runner_matrix)).to eq(get_runner_names(runner_matrix, :x86_64?))
@@ -236,7 +236,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
             allow(Homebrew::EnvConfig).to receive(:eval_all?).and_return(true)
             allow(Formula).to receive(:all).and_return([testball, testball_depender_arm].map(&:formula))
 
-            runner_matrix = described_class.new([testball], [], all_supported: false, dependent_matrix: true)
+            runner_matrix = klass.new([testball], [], all_supported: false, dependent_matrix: true)
             expect(runner_matrix.runners.all?(&:active)).to be(false)
             expect(runner_matrix.runners.any?(&:active)).to be(true)
             expect(get_runner_names(runner_matrix)).to eq(get_runner_names(runner_matrix, :arm64?))
@@ -249,7 +249,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
   context "when there are deleted formulae" do
     context "when it is a matrix for the `tests` job" do
       it "activates all runners" do
-        expect(described_class.new([], ["deleted"], all_supported: false, dependent_matrix: false)
+        expect(klass.new([], ["deleted"], all_supported: false, dependent_matrix: false)
                               .runners
                               .all?(&:active))
           .to be(true)
@@ -259,7 +259,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
     context "when it is a matrix for the `test_deps` job" do
       context "when there are no testing formulae" do
         it "activates no runners" do
-          expect(described_class.new([], ["deleted"], all_supported: false, dependent_matrix: true)
+          expect(klass.new([], ["deleted"], all_supported: false, dependent_matrix: true)
                                 .runners
                                 .any?(&:active))
             .to be(false)
@@ -269,9 +269,9 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
       context "when there are testing formulae with no dependents" do
         it "activates no runners" do
           testing_formulae = [testball]
-          runner_matrix = described_class.new(testing_formulae, ["deleted"],
-                                              all_supported:    false,
-                                              dependent_matrix: true)
+          runner_matrix = klass.new(testing_formulae, ["deleted"],
+                                    all_supported:    false,
+                                    dependent_matrix: true)
 
           allow(Homebrew::EnvConfig).to receive(:eval_all?).and_return(true)
           allow(Formula).to receive(:all).and_return(testing_formulae.map(&:formula))
@@ -287,7 +287,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
             allow(Formula).to receive(:all).and_return([testball, testball_depender].map(&:formula))
 
             testing_formulae = [testball]
-            expect(described_class.new(testing_formulae, ["deleted"], all_supported: false, dependent_matrix: true)
+            expect(klass.new(testing_formulae, ["deleted"], all_supported: false, dependent_matrix: true)
                                   .runners
                                   .all?(&:active))
               .to be(true)
@@ -300,11 +300,11 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
               allow(Homebrew::EnvConfig).to receive(:eval_all?).and_return(true)
               allow(Formula).to receive(:all).and_return([testball, testball_depender_linux].map(&:formula))
 
-              matrix = described_class.new([testball], ["deleted"], all_supported: false, dependent_matrix: true)
+              matrix = klass.new([testball], ["deleted"], all_supported: false, dependent_matrix: true)
               expect(get_runner_names(matrix)).to eq(["Linux x86_64", "Linux arm64"])
 
               allow(ENV).to receive(:[]).with("HOMEBREW_LINUX_RUNNER").and_return("linux-self-hosted-1")
-              matrix = described_class.new([testball], ["deleted"], all_supported: false, dependent_matrix: true)
+              matrix = klass.new([testball], ["deleted"], all_supported: false, dependent_matrix: true)
               expect(get_runner_names(matrix)).to eq(["Linux x86_64"])
             end
           end
@@ -314,7 +314,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
               allow(Homebrew::EnvConfig).to receive(:eval_all?).and_return(true)
               allow(Formula).to receive(:all).and_return([testball, testball_depender_macos].map(&:formula))
 
-              matrix = described_class.new([testball], ["deleted"], all_supported: false, dependent_matrix: true)
+              matrix = klass.new([testball], ["deleted"], all_supported: false, dependent_matrix: true)
               expect(get_runner_names(matrix)).to eq(get_runner_names(matrix, :macos?))
             end
           end

--- a/Library/Homebrew/test/github_runner_spec.rb
+++ b/Library/Homebrew/test/github_runner_spec.rb
@@ -4,10 +4,12 @@
 require "github_runner"
 
 RSpec.describe GitHubRunner do
+  let(:klass) { GitHubRunner }
+
   let(:runner) do
     spec = MacOSRunnerSpec.new(name: "macOS 11-arm64", runner: "11-arm64", timeout: 90, cleanup: true)
     version = MacOSVersion.new("11")
-    described_class.new(platform: :macos, arch: :arm64, spec:, macos_version: version)
+    klass.new(platform: :macos, arch: :arm64, spec:, macos_version: version)
   end
 
   it "has immutable attributes" do

--- a/Library/Homebrew/test/hardware/cpu_spec.rb
+++ b/Library/Homebrew/test/hardware/cpu_spec.rb
@@ -4,6 +4,8 @@
 require "hardware"
 
 RSpec.describe Hardware::CPU do
+  let(:klass) { Hardware::CPU }
+
   describe "::type" do
     let(:cpu_types) do
       [
@@ -15,7 +17,7 @@ RSpec.describe Hardware::CPU do
     end
 
     it "returns the current CPU's type as a symbol, or :dunno if it cannot be detected" do
-      expect(cpu_types).to include(described_class.type)
+      expect(cpu_types).to include(klass.type)
     end
   end
 
@@ -83,27 +85,27 @@ RSpec.describe Hardware::CPU do
     end
 
     it "returns the current CPU's family name as a symbol, or :dunno if it cannot be detected" do
-      expect(cpu_families).to include described_class.family
+      expect(cpu_families).to include klass.family
     end
 
     context "when hw.cpufamily is 0x573b5eec on a Mac", :needs_macos do
       before do
-        allow(described_class)
+        allow(klass)
           .to receive(:sysctl_int)
           .with("hw.cpufamily")
           .and_return(0x573b5eec)
       end
 
       it "returns :arm_firestorm_icestorm on ARM" do
-        allow(described_class).to receive_messages(arm?: true, intel?: false)
+        allow(klass).to receive_messages(arm?: true, intel?: false)
 
-        expect(described_class.family).to eq(:arm_firestorm_icestorm)
+        expect(klass.family).to eq(:arm_firestorm_icestorm)
       end
 
       it "returns :westmere on Intel" do
-        allow(described_class).to receive_messages(arm?: false, intel?: true)
+        allow(klass).to receive_messages(arm?: false, intel?: true)
 
-        expect(described_class.family).to eq(:westmere)
+        expect(klass.family).to eq(:westmere)
       end
     end
   end

--- a/Library/Homebrew/test/head_software_spec_spec.rb
+++ b/Library/Homebrew/test/head_software_spec_spec.rb
@@ -4,7 +4,9 @@
 require "head_software_spec"
 
 RSpec.describe HeadSoftwareSpec do
-  subject(:head_spec) { described_class.new }
+  subject(:head_spec) { klass.new }
+
+  let(:klass) { HeadSoftwareSpec }
 
   specify "#version" do
     expect(head_spec.version).to eq(Version.new("HEAD"))

--- a/Library/Homebrew/test/homebrew_spec.rb
+++ b/Library/Homebrew/test/homebrew_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Homebrew do
         end
       end
 
-      described_class.inject_dump_stats!(klass, /^check_/)
+      Homebrew.inject_dump_stats!(klass, /^check_/)
 
       expect(klass.new.check_something).to eq("result")
       expect($times).to have_key(:check_something)
@@ -42,7 +42,7 @@ RSpec.describe Homebrew do
       end
 
       klass.prepend(mod)
-      described_class.inject_dump_stats!(klass, /^check_/)
+      Homebrew.inject_dump_stats!(klass, /^check_/)
 
       expect(klass.new.check_example).to eq("base_extended")
       expect($times).to have_key(:check_example)
@@ -59,7 +59,7 @@ RSpec.describe Homebrew do
         end
       end
 
-      described_class.inject_dump_stats!(klass, /^check_/)
+      Homebrew.inject_dump_stats!(klass, /^check_/)
 
       instance = klass.new
       instance.check_matched

--- a/Library/Homebrew/test/installed_dependents_spec.rb
+++ b/Library/Homebrew/test/installed_dependents_spec.rb
@@ -4,6 +4,14 @@
 require "installed_dependents"
 
 RSpec.describe InstalledDependents do
+  let(:klass) { InstalledDependents }
+  let!(:keg) { setup_test_keg("foo", "1.0") }
+  let!(:keg_only_keg) do
+    setup_test_keg("foo-keg-only", "1.0") do
+      keg_only "a good reason"
+    end
+  end
+
   include FileUtils
 
   def stub_formula(name, version = "1.0", &block)
@@ -30,13 +38,6 @@ RSpec.describe InstalledDependents do
     end
 
     Keg.new(path)
-  end
-
-  let!(:keg) { setup_test_keg("foo", "1.0") }
-  let!(:keg_only_keg) do
-    setup_test_keg("foo-keg-only", "1.0") do
-      keg_only "a good reason"
-    end
   end
 
   describe "::find_some_installed_dependents" do
@@ -89,14 +90,14 @@ RSpec.describe InstalledDependents do
       # nil tab means no known dependencies — don't fall back to formula definitions
       tab_dependencies dependent, nil
 
-      result = described_class.find_some_installed_dependents([keg, tap_dep])
+      result = klass.find_some_installed_dependents([keg, tap_dep])
       expect(result).to be_nil
     end
 
     specify "no dependencies anywhere" do
       dependent = setup_test_keg("bar", "1.0")
       tab_dependencies dependent, nil
-      expect(described_class.find_some_installed_dependents([keg])).to be_nil
+      expect(klass.find_some_installed_dependents([keg])).to be_nil
     end
 
     specify "nil tab does not fall back to formula definitions" do
@@ -106,7 +107,7 @@ RSpec.describe InstalledDependents do
       # Tab has nil runtime_dependencies — should not fall back to the
       # formula definition's depends_on, so uninstalling foo is allowed.
       tab_dependencies dependent, nil
-      expect(described_class.find_some_installed_dependents([keg])).to be_nil
+      expect(klass.find_some_installed_dependents([keg])).to be_nil
     end
 
     specify "uninstalling dependent and dependency" do
@@ -114,7 +115,7 @@ RSpec.describe InstalledDependents do
         depends_on "foo"
       end
       tab_dependencies dependent, nil
-      expect(described_class.find_some_installed_dependents([keg, dependent])).to be_nil
+      expect(klass.find_some_installed_dependents([keg, dependent])).to be_nil
     end
 
     specify "renamed dependency with nil tab" do
@@ -129,7 +130,7 @@ RSpec.describe InstalledDependents do
       (HOMEBREW_CELLAR/"foo").rename(renamed_path)
       renamed_keg = Keg.new(renamed_path/keg.version.to_s)
 
-      result = described_class.find_some_installed_dependents([renamed_keg])
+      result = klass.find_some_installed_dependents([renamed_keg])
       expect(result).to be_nil
     end
 
@@ -144,33 +145,33 @@ RSpec.describe InstalledDependents do
       (HOMEBREW_CELLAR/"foo").rename(renamed_path)
       renamed_keg = Keg.new(renamed_path/keg.version.to_s)
 
-      result = described_class.find_some_installed_dependents([renamed_keg])
+      result = klass.find_some_installed_dependents([renamed_keg])
       expect(result).to eq([[renamed_keg], ["bar"]])
     end
 
     specify "empty dependencies in Tab" do
       dependent = setup_test_keg("bar", "1.0")
       tab_dependencies dependent, []
-      expect(described_class.find_some_installed_dependents([keg])).to be_nil
+      expect(klass.find_some_installed_dependents([keg])).to be_nil
     end
 
     specify "same name but different version in Tab" do
       dependent = setup_test_keg("bar", "1.0")
       tab_dependencies dependent, [{ "full_name" => keg.name, "version" => "1.1" }]
-      expect(described_class.find_some_installed_dependents([keg])).to eq([[keg], ["bar"]])
+      expect(klass.find_some_installed_dependents([keg])).to eq([[keg], ["bar"]])
     end
 
     specify "different name and same version in Tab" do
       stub_formula("baz")
       dependent = setup_test_keg("bar", "1.0")
       tab_dependencies dependent, [{ "full_name" => "baz", "version" => keg.version.to_s }]
-      expect(described_class.find_some_installed_dependents([keg])).to be_nil
+      expect(klass.find_some_installed_dependents([keg])).to be_nil
     end
 
     specify "same name and version in Tab" do
       dependent = setup_test_keg("bar", "1.0")
       tab_dependencies dependent, [{ "full_name" => keg.name, "version" => keg.version.to_s }]
-      expect(described_class.find_some_installed_dependents([keg])).to eq([[keg], ["bar"]])
+      expect(klass.find_some_installed_dependents([keg])).to eq([[keg], ["bar"]])
     end
 
     specify "old tab version returns nil dependencies and does not block" do
@@ -180,20 +181,20 @@ RSpec.describe InstalledDependents do
       # Tab from Homebrew < 1.1.6 is unreliable; runtime_dependencies returns nil.
       # With tab-only trust, nil means no known deps — uninstall is allowed.
       unreliable_tab_dependencies dependent, [{ "full_name" => "baz", "version" => "1.0" }]
-      expect(described_class.find_some_installed_dependents([keg])).to be_nil
+      expect(klass.find_some_installed_dependents([keg])).to be_nil
     end
 
     specify "non-opt-linked" do
       keg.remove_opt_record
       dependent = setup_test_keg("bar", "1.0")
       tab_dependencies dependent, [{ "full_name" => keg.name, "version" => keg.version.to_s }]
-      expect(described_class.find_some_installed_dependents([keg])).to be_nil
+      expect(klass.find_some_installed_dependents([keg])).to be_nil
     end
 
     specify "keg-only" do
       dependent = setup_test_keg("bar", "1.0")
       tab_dependencies dependent, [{ "full_name" => keg_only_keg.name, "version" => "1.1" }] # different version
-      expect(described_class.find_some_installed_dependents([keg_only_keg])).to eq([[keg_only_keg], ["bar"]])
+      expect(klass.find_some_installed_dependents([keg_only_keg])).to eq([[keg_only_keg], ["bar"]])
     end
 
     def stub_cask_name(name, version, dependency)
@@ -233,7 +234,7 @@ RSpec.describe InstalledDependents do
         depends_on "foo"
       end
       tab_dependencies dependent, [{ "full_name" => "baz", "version" => "1.0" }]
-      expect(described_class.find_some_installed_dependents([keg])).to be_nil
+      expect(klass.find_some_installed_dependents([keg])).to be_nil
     end
 
     specify "tab with dependency blocks uninstall" do
@@ -242,12 +243,12 @@ RSpec.describe InstalledDependents do
         depends_on "foo"
       end
       tab_dependencies dependent, [{ "full_name" => "foo", "version" => "1.0" }]
-      expect(described_class.find_some_installed_dependents([keg])).to eq([[keg], ["bar"]])
+      expect(klass.find_some_installed_dependents([keg])).to eq([[keg], ["bar"]])
     end
 
     specify "identify dependent casks" do
       setup_test_cask("qux", "1.0.0", "foo")
-      dependents = described_class.find_some_installed_dependents([keg]).last
+      dependents = klass.find_some_installed_dependents([keg]).last
       expect(dependents.include?("qux")).to be(true)
     end
   end

--- a/Library/Homebrew/test/keg_only_reason_spec.rb
+++ b/Library/Homebrew/test/keg_only_reason_spec.rb
@@ -4,14 +4,17 @@
 require "keg_only_reason"
 
 RSpec.describe KegOnlyReason do
+  sig { returns(T.class_of(KegOnlyReason)) }
+  let(:klass) { KegOnlyReason }
+
   describe "#to_s" do
     it "returns the reason provided" do
-      r = described_class.new :provided_by_macos, "test"
+      r = klass.new :provided_by_macos, "test"
       expect(r.to_s).to eq("test")
     end
 
     it "returns a default message when no reason is provided" do
-      r = described_class.new :provided_by_macos, ""
+      r = klass.new :provided_by_macos, ""
       expect(r.to_s).to match(/^macOS already provides/)
     end
   end

--- a/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
@@ -4,8 +4,9 @@
 require "keg_relocate"
 
 RSpec.describe Keg do
-  subject(:keg) { described_class.new(HOMEBREW_CELLAR/"foo/1.0.0") }
+  subject(:keg) { klass.new(HOMEBREW_CELLAR/"foo/1.0.0") }
 
+  let(:klass) { Keg }
   let(:dir) { HOMEBREW_CELLAR/"foo/1.0.0" }
   let(:newdir) { HOMEBREW_CELLAR/"foo" }
   let(:binary_file) { dir/"file.bin" }

--- a/Library/Homebrew/test/keg_relocate/grep_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/grep_spec.rb
@@ -4,8 +4,9 @@
 require "keg_relocate"
 
 RSpec.describe Keg do
-  subject(:keg) { described_class.new(HOMEBREW_CELLAR/"foo/1.0.0") }
+  subject(:keg) { klass.new(HOMEBREW_CELLAR/"foo/1.0.0") }
 
+  let(:klass) { Keg }
   let(:dir) { HOMEBREW_CELLAR/"foo/1.0.0" }
   let(:text_file) { dir/"file.txt" }
   let(:binary_file) { dir/"file.bin" }

--- a/Library/Homebrew/test/keg_relocate/relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/relocation_spec.rb
@@ -4,6 +4,8 @@
 require "keg_relocate"
 
 RSpec.describe Keg::Relocation do
+  let(:klass) { Keg::Relocation }
+
   let(:prefix) { HOMEBREW_PREFIX.to_s }
   let(:cellar) { HOMEBREW_CELLAR.to_s }
   let(:repository) { HOMEBREW_REPOSITORY.to_s }
@@ -16,7 +18,7 @@ RSpec.describe Keg::Relocation do
   let(:escaped_cellar) { /(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))#{HOMEBREW_CELLAR}/o }
 
   def setup_relocation
-    relocation = described_class.new
+    relocation = klass.new
     relocation.add_replacement_pair :prefix, prefix, prefix_placeholder, path: true
     relocation.add_replacement_pair :cellar, /#{cellar}/o, cellar_placeholder, path: true
     relocation.add_replacement_pair :repository_placeholder, repository_placeholder, repository
@@ -60,9 +62,9 @@ RSpec.describe Keg::Relocation do
   end
 
   specify "::path_to_regex" do
-    expect(described_class.path_to_regex(prefix)).to eq escaped_prefix
-    expect(described_class.path_to_regex("foo.bar")).to eq(/(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))foo\.bar/)
-    expect(described_class.path_to_regex(/#{cellar}/o)).to eq escaped_cellar
-    expect(described_class.path_to_regex(/foo.bar/)).to eq(/(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))foo.bar/)
+    expect(klass.path_to_regex(prefix)).to eq escaped_prefix
+    expect(klass.path_to_regex("foo.bar")).to eq(/(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))foo\.bar/)
+    expect(klass.path_to_regex(/#{cellar}/o)).to eq escaped_cellar
+    expect(klass.path_to_regex(/foo.bar/)).to eq(/(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))foo.bar/)
   end
 end

--- a/Library/Homebrew/test/keg_relocate/text_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/text_spec.rb
@@ -4,8 +4,9 @@
 require "keg_relocate"
 
 RSpec.describe Keg do
-  subject(:keg) { described_class.new(HOMEBREW_CELLAR/"foo/1.0.0") }
+  subject(:keg) { klass.new(HOMEBREW_CELLAR/"foo/1.0.0") }
 
+  let(:klass) { Keg }
   let(:dir) { mktmpdir }
   let(:file) { dir/"file.txt" }
   let(:placeholder) { "@@PLACEHOLDER@@" }
@@ -26,7 +27,7 @@ RSpec.describe Keg do
   end
 
   def setup_relocation(placeholders: false)
-    relocation = described_class::Relocation.new
+    relocation = klass::Relocation.new
 
     if placeholders
       relocation.add_replacement_pair :dir, placeholder, dir.to_s
@@ -40,10 +41,10 @@ RSpec.describe Keg do
   specify "::text_matches_in_file" do
     setup_file
 
-    result = described_class.text_matches_in_file(file, placeholder, [], [], nil)
+    result = klass.text_matches_in_file(file, placeholder, [], [], nil)
     expect(result.count).to eq 0
 
-    result = described_class.text_matches_in_file(file, dir.to_s, [], [], nil)
+    result = klass.text_matches_in_file(file, dir.to_s, [], [], nil)
     expect(result.count).to eq 2
   end
 

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -5,6 +5,12 @@ require "keg"
 require "stringio"
 
 RSpec.describe Keg do
+  let(:klass) { Keg }
+  let(:dst) { HOMEBREW_PREFIX/"bin"/"helloworld" }
+  let(:nonexistent) { Pathname.new("/some/nonexistent/path") }
+  let!(:keg) { setup_test_keg("foo", "1.0") }
+  let(:kegs) { [] }
+
   include FileUtils
 
   def setup_test_keg(name, version)
@@ -15,15 +21,10 @@ RSpec.describe Keg do
       touch path/"bin"/file
     end
 
-    keg = described_class.new(path)
+    keg = klass.new(path)
     kegs << keg
     keg
   end
-
-  let(:dst) { HOMEBREW_PREFIX/"bin"/"helloworld" }
-  let(:nonexistent) { Pathname.new("/some/nonexistent/path") }
-  let!(:keg) { setup_test_keg("foo", "1.0") }
-  let(:kegs) { [] }
 
   before do
     (HOMEBREW_PREFIX/"bin").mkpath
@@ -36,7 +37,7 @@ RSpec.describe Keg do
   end
 
   specify "::all" do
-    expect(described_class.all).to eq([keg])
+    expect(klass.all).to eq([keg])
   end
 
   specify "#empty_installation?" do
@@ -274,8 +275,8 @@ RSpec.describe Keg do
       (a/"lib"/"example2").make_symlink "example"
       (b/"lib"/"example2").mkpath
 
-      a = described_class.new(a)
-      b = described_class.new(b)
+      a = klass.new(a)
+      b = klass.new(b)
       a.link
 
       lib = HOMEBREW_PREFIX/"lib"
@@ -288,7 +289,7 @@ RSpec.describe Keg do
       a = HOMEBREW_CELLAR/"a"/"1.0"
       (a/"lib"/"foo").mkpath
 
-      keg = described_class.new(a)
+      keg = klass.new(a)
 
       link = HOMEBREW_PREFIX/"lib"/"foo"
       link.parent.mkpath
@@ -306,7 +307,7 @@ RSpec.describe Keg do
       oldname_opt_record.make_relative_symlink(HOMEBREW_CELLAR/"foo/1.0")
       keg_record = HOMEBREW_CELLAR/"foo"/"2.0"
       (keg_record/"bin").mkpath
-      keg = described_class.new(keg_record)
+      keg = klass.new(keg_record)
       keg.optlink
       expect(keg_record).to eq(oldname_opt_record.resolved_path)
       keg.uninstall

--- a/Library/Homebrew/test/language/java_spec.rb
+++ b/Library/Homebrew/test/language/java_spec.rb
@@ -4,6 +4,8 @@
 require "language/java"
 
 RSpec.describe Language::Java do
+  let(:klass) { Language::Java }
+
   let(:f) do
     formula("openjdk") do
       url "openjdk"
@@ -26,36 +28,36 @@ RSpec.describe Language::Java do
 
   describe "::java_home" do
     it "returns valid JAVA_HOME if version is specified" do
-      java_home = described_class.java_home("1.8+")
+      java_home = klass.java_home("1.8+")
       expect(java_home).to eql(expected_home)
     end
 
     it "returns valid JAVA_HOME if version is not specified" do
-      java_home = described_class.java_home
+      java_home = klass.java_home
       expect(java_home).to eql(expected_home)
     end
   end
 
   describe "::java_home_env" do
     it "returns java_home path if version specified" do
-      java_home_env = described_class.java_home_env("1.8+")
+      java_home_env = klass.java_home_env("1.8+")
       expect(java_home_env[:JAVA_HOME]).to eql(expected_home.to_s)
     end
 
     it "returns java_home path if version is not specified" do
-      java_home_env = described_class.java_home_env
+      java_home_env = klass.java_home_env
       expect(java_home_env[:JAVA_HOME]).to eql(expected_home.to_s)
     end
   end
 
   describe "::overridable_java_home_env" do
     it "returns java_home path if version specified" do
-      overridable_java_home_env = described_class.overridable_java_home_env("1.8+")
+      overridable_java_home_env = klass.overridable_java_home_env("1.8+")
       expect(overridable_java_home_env[:JAVA_HOME]).to eql("${JAVA_HOME:-#{expected_home}}")
     end
 
     it "returns java_home path if version is not specified" do
-      overridable_java_home_env = described_class.overridable_java_home_env
+      overridable_java_home_env = klass.overridable_java_home_env
       expect(overridable_java_home_env[:JAVA_HOME]).to eql("${JAVA_HOME:-#{expected_home}}")
     end
   end

--- a/Library/Homebrew/test/language/node/shebang_spec.rb
+++ b/Library/Homebrew/test/language/node/shebang_spec.rb
@@ -5,6 +5,8 @@ require "language/node"
 require "utils/shebang"
 
 RSpec.describe Language::Node::Shebang do
+  let(:klass) { Language::Node::Shebang }
+
   let(:file) { Tempfile.new("node-shebang") }
   let(:broken_file) { Tempfile.new("node-shebang") }
   let(:f) do
@@ -56,7 +58,7 @@ RSpec.describe Language::Node::Shebang do
   describe "#detected_node_shebang" do
     it "can be used to replace Node shebangs" do
       allow(Formulary).to receive(:factory).with(f[:node18].name).and_return(f[:node18])
-      Utils::Shebang.rewrite_shebang described_class.detected_node_shebang(f[:versioned_node_dep]), file.path
+      Utils::Shebang.rewrite_shebang klass.detected_node_shebang(f[:versioned_node_dep]), file.path
 
       expect(File.read(file)).to eq <<~EOS
         #!#{HOMEBREW_PREFIX/"opt/node@18/bin/node"}
@@ -68,7 +70,7 @@ RSpec.describe Language::Node::Shebang do
 
     it "can fix broken shebang like `#!node`" do
       allow(Formulary).to receive(:factory).with(f[:node18].name).and_return(f[:node18])
-      Utils::Shebang.rewrite_shebang described_class.detected_node_shebang(f[:versioned_node_dep]), broken_file.path
+      Utils::Shebang.rewrite_shebang klass.detected_node_shebang(f[:versioned_node_dep]), broken_file.path
 
       expect(File.read(broken_file)).to eq <<~EOS
         #!#{HOMEBREW_PREFIX/"opt/node@18/bin/node"}
@@ -79,12 +81,12 @@ RSpec.describe Language::Node::Shebang do
     end
 
     it "errors if formula doesn't depend on node" do
-      expect { Utils::Shebang.rewrite_shebang described_class.detected_node_shebang(f[:no_deps]), file.path }
+      expect { Utils::Shebang.rewrite_shebang klass.detected_node_shebang(f[:no_deps]), file.path }
         .to raise_error(ShebangDetectionError, "Cannot detect Node shebang: formula does not depend on Node.")
     end
 
     it "errors if formula depends on more than one node" do
-      expect { Utils::Shebang.rewrite_shebang described_class.detected_node_shebang(f[:multiple_deps]), file.path }
+      expect { Utils::Shebang.rewrite_shebang klass.detected_node_shebang(f[:multiple_deps]), file.path }
         .to raise_error(ShebangDetectionError, "Cannot detect Node shebang: formula has multiple Node dependencies.")
     end
   end

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -4,11 +4,13 @@
 require "language/node"
 
 RSpec.describe Language::Node do
+  let(:klass) { Language::Node }
+
   let(:npm_pack_cmd) { ["npm", "pack", "--ignore-scripts"] }
 
   describe "#setup_npm_environment" do
     before do
-      described_class.instance_variable_set(:@env_set, false)
+      klass.instance_variable_set(:@env_set, false)
     end
 
     it "calls prepend_path when node formula exists only during the first call" do
@@ -19,13 +21,13 @@ RSpec.describe Language::Node do
       without_partial_double_verification do
         expect(ENV).to receive(:prepend_path)
       end
-      described_class.setup_npm_environment
+      klass.setup_npm_environment
 
-      expect(described_class.instance_variable_get(:@env_set)).to be(true)
+      expect(klass.instance_variable_get(:@env_set)).to be(true)
       without_partial_double_verification do
         expect(ENV).not_to receive(:prepend_path)
       end
-      described_class.setup_npm_environment
+      klass.setup_npm_environment
     end
 
     it "does not call prepend_path when node formula does not exist" do
@@ -33,7 +35,7 @@ RSpec.describe Language::Node do
       without_partial_double_verification do
         expect(ENV).not_to receive(:prepend_path)
       end
-      described_class.setup_npm_environment
+      klass.setup_npm_environment
     end
   end
 
@@ -43,7 +45,7 @@ RSpec.describe Language::Node do
         path = Pathname("package.json")
         path.atomic_write("{\"scripts\":{\"prepare\": \"ls\", \"prepack\": \"ls\", \"test\": \"ls\"}}")
         allow(Utils).to receive(:popen_read).with(*npm_pack_cmd).and_return(`echo pack.tgz`)
-        described_class.pack_for_installation
+        klass.pack_for_installation
         expect(path.read).not_to include("prepare")
         expect(path.read).not_to include("prepack")
         expect(path.read).to include("test")
@@ -55,33 +57,33 @@ RSpec.describe Language::Node do
     let(:npm_install_arg) { Pathname("libexec") }
 
     before do
-      allow(described_class).to receive(:setup_npm_environment)
+      allow(klass).to receive(:setup_npm_environment)
     end
 
     it "raises error with non zero exitstatus" do
       allow(Utils).to receive(:popen_read).with(*npm_pack_cmd).and_return(`false`)
-      expect { described_class.std_npm_install_args(npm_install_arg) }.to raise_error("npm failed to pack #{Dir.pwd}")
+      expect { klass.std_npm_install_args(npm_install_arg) }.to raise_error("npm failed to pack #{Dir.pwd}")
     end
 
     it "raises error with empty npm pack output" do
       allow(Utils).to receive(:popen_read).with(*npm_pack_cmd).and_return(`true`)
-      expect { described_class.std_npm_install_args(npm_install_arg) }.to raise_error("npm failed to pack #{Dir.pwd}")
+      expect { klass.std_npm_install_args(npm_install_arg) }.to raise_error("npm failed to pack #{Dir.pwd}")
     end
 
     it "does not raise error with a zero exitstatus" do
       allow(Utils).to receive(:popen_read).with(*npm_pack_cmd).and_return(`echo pack.tgz`)
-      resp = described_class.std_npm_install_args(npm_install_arg)
+      resp = klass.std_npm_install_args(npm_install_arg)
       expect(resp).to include("--min-release-age=1", "--prefix=#{npm_install_arg}", "#{Dir.pwd}/pack.tgz")
     end
   end
 
   describe "#local_npm_install_args" do
     before do
-      allow(described_class).to receive(:setup_npm_environment)
+      allow(klass).to receive(:setup_npm_environment)
     end
 
     it "includes the default npm install arguments" do
-      resp = described_class.local_npm_install_args
+      resp = klass.local_npm_install_args
       expect(resp).to include("--loglevel=silly", "--build-from-source", "--cache=#{HOMEBREW_CACHE}/npm_cache",
                               "--min-release-age=1")
     end

--- a/Library/Homebrew/test/language/perl/shebang_spec.rb
+++ b/Library/Homebrew/test/language/perl/shebang_spec.rb
@@ -5,6 +5,8 @@ require "language/perl"
 require "utils/shebang"
 
 RSpec.describe Language::Perl::Shebang do
+  let(:klass) { Language::Perl::Shebang }
+
   let(:file) { Tempfile.new("perl-shebang") }
   let(:broken_file) { Tempfile.new("perl-shebang") }
   let(:f) do
@@ -55,7 +57,7 @@ RSpec.describe Language::Perl::Shebang do
   describe "#detected_perl_shebang" do
     it "can be used to replace Perl shebangs when depends_on \"perl\" is used" do
       allow(Formulary).to receive(:factory).with(f[:perl].name).and_return(f[:perl])
-      Utils::Shebang.rewrite_shebang described_class.detected_perl_shebang(f[:depends_on]), file.path
+      Utils::Shebang.rewrite_shebang klass.detected_perl_shebang(f[:depends_on]), file.path
 
       expect(File.read(file)).to eq <<~EOS
         #!#{HOMEBREW_PREFIX}/opt/perl/bin/perl
@@ -67,7 +69,7 @@ RSpec.describe Language::Perl::Shebang do
 
     it "can be used to replace Perl shebangs when uses_from_macos \"perl\" is used" do
       allow(Formulary).to receive(:factory).with(f[:perl].name).and_return(f[:perl])
-      Utils::Shebang.rewrite_shebang described_class.detected_perl_shebang(f[:uses_from_macos]), file.path
+      Utils::Shebang.rewrite_shebang klass.detected_perl_shebang(f[:uses_from_macos]), file.path
 
       expected_shebang = if OS.mac?
         "/usr/bin/perl#{MacOS.preferred_perl_version}"
@@ -85,7 +87,7 @@ RSpec.describe Language::Perl::Shebang do
 
     it "can fix broken shebang like `#!perl`" do
       allow(Formulary).to receive(:factory).with(f[:perl].name).and_return(f[:perl])
-      Utils::Shebang.rewrite_shebang described_class.detected_perl_shebang(f[:uses_from_macos]), broken_file.path
+      Utils::Shebang.rewrite_shebang klass.detected_perl_shebang(f[:uses_from_macos]), broken_file.path
 
       expected_shebang = if OS.mac?
         "/usr/bin/perl#{MacOS.preferred_perl_version}"
@@ -102,7 +104,7 @@ RSpec.describe Language::Perl::Shebang do
     end
 
     it "errors if formula doesn't depend on perl" do
-      expect { Utils::Shebang.rewrite_shebang described_class.detected_perl_shebang(f[:no_deps]), file.path }
+      expect { Utils::Shebang.rewrite_shebang klass.detected_perl_shebang(f[:no_deps]), file.path }
         .to raise_error(ShebangDetectionError, "Cannot detect Perl shebang: formula does not depend on Perl.")
     end
   end

--- a/Library/Homebrew/test/language/php/shebang_spec.rb
+++ b/Library/Homebrew/test/language/php/shebang_spec.rb
@@ -5,6 +5,8 @@ require "language/php"
 require "utils/shebang"
 
 RSpec.describe Language::PHP::Shebang do
+  let(:klass) { Language::PHP::Shebang }
+
   let(:file) { Tempfile.new("php-shebang") }
   let(:broken_file) { Tempfile.new("php-shebang") }
   let(:f) do
@@ -57,7 +59,7 @@ RSpec.describe Language::PHP::Shebang do
   describe "#detected_php_shebang" do
     it "can be used to replace PHP shebangs" do
       allow(Formulary).to receive(:factory).with(f[:php81].name).and_return(f[:php81])
-      Utils::Shebang.rewrite_shebang described_class.detected_php_shebang(f[:versioned_php_dep]), file.path
+      Utils::Shebang.rewrite_shebang klass.detected_php_shebang(f[:versioned_php_dep]), file.path
 
       expect(File.read(file)).to eq <<~EOS
         #!#{HOMEBREW_PREFIX/"opt/php@8.1/bin/php"}
@@ -69,7 +71,7 @@ RSpec.describe Language::PHP::Shebang do
 
     it "can fix broken shebang like `#!php`" do
       allow(Formulary).to receive(:factory).with(f[:php81].name).and_return(f[:php81])
-      Utils::Shebang.rewrite_shebang described_class.detected_php_shebang(f[:versioned_php_dep]), broken_file.path
+      Utils::Shebang.rewrite_shebang klass.detected_php_shebang(f[:versioned_php_dep]), broken_file.path
 
       expect(File.read(broken_file)).to eq <<~EOS
         #!#{HOMEBREW_PREFIX/"opt/php@8.1/bin/php"}
@@ -80,12 +82,12 @@ RSpec.describe Language::PHP::Shebang do
     end
 
     it "errors if formula doesn't depend on PHP" do
-      expect { Utils::Shebang.rewrite_shebang described_class.detected_php_shebang(f[:no_deps]), file.path }
+      expect { Utils::Shebang.rewrite_shebang klass.detected_php_shebang(f[:no_deps]), file.path }
         .to raise_error(ShebangDetectionError, "Cannot detect PHP shebang: formula does not depend on PHP.")
     end
 
     it "errors if formula depends on more than one php" do
-      expect { Utils::Shebang.rewrite_shebang described_class.detected_php_shebang(f[:multiple_deps]), file.path }
+      expect { Utils::Shebang.rewrite_shebang klass.detected_php_shebang(f[:multiple_deps]), file.path }
         .to raise_error(ShebangDetectionError, "Cannot detect PHP shebang: formula has multiple PHP dependencies.")
     end
   end

--- a/Library/Homebrew/test/language/python/shebang_spec.rb
+++ b/Library/Homebrew/test/language/python/shebang_spec.rb
@@ -5,6 +5,8 @@ require "language/python"
 require "utils/shebang"
 
 RSpec.describe Language::Python::Shebang do
+  let(:klass) { Language::Python::Shebang }
+
   let(:file) { Tempfile.new("python-shebang") }
   let(:broken_file) { Tempfile.new("python-shebang") }
   let(:f) do
@@ -57,7 +59,7 @@ RSpec.describe Language::Python::Shebang do
     it "can be used to replace Python shebangs" do
       allow(Formulary).to receive(:factory).with(f[:python311].name).and_return(f[:python311])
       Utils::Shebang.rewrite_shebang(
-        described_class.detected_python_shebang(f[:versioned_python_dep], use_python_from_path: false), file.path
+        klass.detected_python_shebang(f[:versioned_python_dep], use_python_from_path: false), file.path
       )
 
       expect(File.read(file)).to eq <<~EOS
@@ -70,7 +72,7 @@ RSpec.describe Language::Python::Shebang do
 
     it "can be pointed to a `python3` in PATH" do
       Utils::Shebang.rewrite_shebang(
-        described_class.detected_python_shebang(f[:versioned_python_dep], use_python_from_path: true), file.path
+        klass.detected_python_shebang(f[:versioned_python_dep], use_python_from_path: true), file.path
       )
 
       expect(File.read(file)).to eq <<~EOS
@@ -83,8 +85,8 @@ RSpec.describe Language::Python::Shebang do
 
     it "can fix broken shebang line `#!python`" do
       Utils::Shebang.rewrite_shebang(
-        described_class.detected_python_shebang(f[:versioned_python_dep],
-                                                use_python_from_path: true), broken_file.path
+        klass.detected_python_shebang(f[:versioned_python_dep],
+                                      use_python_from_path: true), broken_file.path
       )
 
       expect(File.read(broken_file)).to eq <<~EOS
@@ -98,7 +100,7 @@ RSpec.describe Language::Python::Shebang do
     it "errors if formula doesn't depend on python" do
       expect do
         Utils::Shebang.rewrite_shebang(
-          described_class.detected_python_shebang(f[:no_deps], use_python_from_path: false),
+          klass.detected_python_shebang(f[:no_deps], use_python_from_path: false),
           file.path,
         )
       end.to raise_error(ShebangDetectionError, "Cannot detect Python shebang: formula does not depend on Python.")
@@ -107,7 +109,7 @@ RSpec.describe Language::Python::Shebang do
     it "errors if formula depends on more than one python" do
       expect do
         Utils::Shebang.rewrite_shebang(
-          described_class.detected_python_shebang(f[:multiple_deps], use_python_from_path: false),
+          klass.detected_python_shebang(f[:multiple_deps], use_python_from_path: false),
           file.path,
         )
       end.to raise_error(

--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -5,10 +5,12 @@ require "language/python"
 require "resource"
 
 RSpec.describe Language::Python::Virtualenv, :needs_python do
+  let(:klass) { Language::Python::Virtualenv }
+
   describe "#virtualenv_install_with_resources" do
     let(:venv) { instance_double(Language::Python::Virtualenv::Virtualenv) }
     let(:f) do
-      virtualenv_module = described_class
+      virtualenv_module = klass
       formula "foo" do
         include virtualenv_module
 
@@ -149,10 +151,10 @@ RSpec.describe Language::Python::Virtualenv, :needs_python do
   end
 
   describe Language::Python::Virtualenv::Virtualenv do
-    subject(:virtualenv) { described_class.new(formula, dir, "python") }
+    subject(:virtualenv) { klass.new(formula, dir, "python") }
 
+    let(:klass) { Language::Python::Virtualenv::Virtualenv }
     let(:dir) { mktmpdir }
-
     let(:resource) { instance_double(Resource, "resource", stage: true) }
     let(:formula_bin) { dir/"formula_bin" }
     let(:formula_man) { dir/"formula_man" }

--- a/Library/Homebrew/test/language/python_spec.rb
+++ b/Library/Homebrew/test/language/python_spec.rb
@@ -4,30 +4,33 @@
 require "language/python"
 
 RSpec.describe Language::Python, :needs_python do
+  sig { returns(T.class_of(Language::Python)) }
+  let(:klass) { Language::Python }
+
   describe "#major_minor_version" do
     it "returns a Version for Python 2" do
-      expect(described_class).to receive(:major_minor_version).and_return(Version)
-      described_class.major_minor_version("python")
+      expect(klass).to receive(:major_minor_version).and_return(Version)
+      klass.major_minor_version("python")
     end
   end
 
   describe "#site_packages" do
     it "gives a different location between PyPy and Python 2" do
-      expect(described_class.site_packages("python")).not_to eql(described_class.site_packages("pypy"))
+      expect(klass.site_packages("python")).not_to eql(klass.site_packages("pypy"))
     end
   end
 
   describe "#homebrew_site_packages" do
     it "returns the Homebrew site packages location" do
-      expect(described_class).to receive(:site_packages).and_return(Pathname)
-      described_class.site_packages("python")
+      expect(klass).to receive(:site_packages).and_return(Pathname)
+      klass.site_packages("python")
     end
   end
 
   describe "#user_site_packages" do
     it "can determine user site packages location" do
-      expect(described_class).to receive(:user_site_packages).and_return(Pathname)
-      described_class.user_site_packages("python")
+      expect(klass).to receive(:user_site_packages).and_return(Pathname)
+      klass.user_site_packages("python")
     end
   end
 end

--- a/Library/Homebrew/test/lazy_object_spec.rb
+++ b/Library/Homebrew/test/lazy_object_spec.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
 
 require "lazy_object"

--- a/Library/Homebrew/test/lazy_object_spec.rb
+++ b/Library/Homebrew/test/lazy_object_spec.rb
@@ -4,35 +4,37 @@
 require "lazy_object"
 
 RSpec.describe LazyObject do
+  let(:klass) { LazyObject }
+
   describe "#initialize" do
     it "does not evaluate the block" do
       expect do |block|
-        described_class.new(&block)
+        klass.new(&block)
       end.not_to yield_control
     end
   end
 
   describe "when receiving a message" do
     it "evaluates the block" do
-      expect(described_class.new { 42 }.to_s).to eq "42"
+      expect(klass.new { 42 }.to_s).to eq "42"
     end
   end
 
   describe "#!" do
     it "delegates to the underlying object" do
-      expect(!described_class.new { false }).to be true
+      expect(!klass.new { false }).to be true
     end
   end
 
   describe "#!=" do
     it "delegates to the underlying object" do
-      expect(described_class.new { 42 }).not_to eq 13
+      expect(klass.new { 42 }).not_to eq 13
     end
   end
 
   describe "#==" do
     it "delegates to the underlying object" do
-      expect(described_class.new { 42 }).to eq 42
+      expect(klass.new { 42 }).to eq 42
     end
   end
 end

--- a/Library/Homebrew/test/linkage_cache_store_spec.rb
+++ b/Library/Homebrew/test/linkage_cache_store_spec.rb
@@ -4,8 +4,9 @@
 require "linkage_cache_store"
 
 RSpec.describe LinkageCacheStore do
-  subject(:linkage_cache) { described_class.new(keg_name, database) }
+  subject(:linkage_cache) { klass.new(keg_name, database) }
 
+  let(:klass) { LinkageCacheStore }
   let(:keg_name) { "keg_name" }
   let(:database) { instance_double(CacheStoreDatabase, "database") }
 

--- a/Library/Homebrew/test/linux_runner_spec_spec.rb
+++ b/Library/Homebrew/test/linux_runner_spec_spec.rb
@@ -4,8 +4,10 @@
 require "linux_runner_spec"
 
 RSpec.describe LinuxRunnerSpec do
+  let(:klass) { LinuxRunnerSpec }
+
   let(:spec) do
-    described_class.new(
+    klass.new(
       name:      "Linux",
       runner:    "ubuntu-latest",
       container: { image: "ghcr.io/homebrew/brew:main", options: "--user=linuxbrew" },

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -4,8 +4,9 @@
 require "livecheck/livecheck"
 
 RSpec.describe Homebrew::Livecheck do
-  subject(:livecheck) { described_class }
+  subject(:livecheck) { klass }
 
+  let(:klass) { Homebrew::Livecheck }
   let(:cask_url) { "https://brew.sh/test-0.0.1.dmg" }
   let(:head_url) { "https://github.com/Homebrew/brew.git" }
   let(:homepage_url) { "https://brew.sh" }
@@ -13,7 +14,6 @@ RSpec.describe Homebrew::Livecheck do
   let(:stable_url) { "https://brew.sh/test-0.0.1.tgz" }
   let(:resource_url) { "https://brew.sh/foo-1.0.tar.gz" }
   let(:brew_regex) { /href=.*?test[._-]v?(\d+(?:\.\d+)+)\.(?:t|dmg)/i }
-
   let(:f) do
     formula("test") do
       desc "Test formula"
@@ -37,7 +37,6 @@ RSpec.describe Homebrew::Livecheck do
       end
     end
   end
-
   let(:f_stable_url_only) do
     stable_url_s = stable_url
 
@@ -46,9 +45,7 @@ RSpec.describe Homebrew::Livecheck do
       url stable_url_s
     end
   end
-
   let(:r) { f.resources.first }
-
   let(:c) do
     Cask::CaskLoader.load(+<<-RUBY)
       cask "test" do
@@ -66,7 +63,6 @@ RSpec.describe Homebrew::Livecheck do
       end
     RUBY
   end
-
   let(:c_no_checkable_urls) do
     Cask::CaskLoader.load(+<<-RUBY)
       cask "test_no_checkable_urls" do

--- a/Library/Homebrew/test/livecheck/livecheck_version_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_version_spec.rb
@@ -4,6 +4,8 @@
 require "livecheck/livecheck_version"
 
 RSpec.describe Homebrew::Livecheck::LivecheckVersion do
+  let(:klass) { Homebrew::Livecheck::LivecheckVersion }
+
   let(:formula) { instance_double(Formula) }
   let(:cask) { instance_double(Cask::Cask) }
   let(:resource) { instance_double(Resource) }
@@ -19,19 +21,19 @@ RSpec.describe Homebrew::Livecheck::LivecheckVersion do
   end
 
   specify "::create" do
-    expect(described_class.create(formula, Version.new("1.1.6")).versions).to eq ["1.1.6"]
-    expect(described_class.create(formula, Version.new("2.19.0,1.8.0")).versions).to eq ["2.19.0,1.8.0"]
-    expect(described_class.create(formula, Version.new("0.17.0,20210111183933,226")).versions)
+    expect(klass.create(formula, Version.new("1.1.6")).versions).to eq ["1.1.6"]
+    expect(klass.create(formula, Version.new("2.19.0,1.8.0")).versions).to eq ["2.19.0,1.8.0"]
+    expect(klass.create(formula, Version.new("0.17.0,20210111183933,226")).versions)
       .to eq ["0.17.0,20210111183933,226"]
 
-    expect(described_class.create(cask, Version.new("1.1.6")).versions).to eq ["1.1.6"]
-    expect(described_class.create(cask, Version.new("2.19.0,1.8.0")).versions).to eq ["2.19.0", "1.8.0"]
-    expect(described_class.create(cask, Version.new("0.17.0,20210111183933,226")).versions)
+    expect(klass.create(cask, Version.new("1.1.6")).versions).to eq ["1.1.6"]
+    expect(klass.create(cask, Version.new("2.19.0,1.8.0")).versions).to eq ["2.19.0", "1.8.0"]
+    expect(klass.create(cask, Version.new("0.17.0,20210111183933,226")).versions)
       .to eq ["0.17.0", "20210111183933", "226"]
 
-    expect(described_class.create(resource, Version.new("1.1.6")).versions).to eq ["1.1.6"]
-    expect(described_class.create(resource, Version.new("2.19.0,1.8.0")).versions).to eq ["2.19.0,1.8.0"]
-    expect(described_class.create(resource, Version.new("0.17.0,20210111183933,226")).versions)
+    expect(klass.create(resource, Version.new("1.1.6")).versions).to eq ["1.1.6"]
+    expect(klass.create(resource, Version.new("2.19.0,1.8.0")).versions).to eq ["2.19.0,1.8.0"]
+    expect(klass.create(resource, Version.new("0.17.0,20210111183933,226")).versions)
       .to eq ["0.17.0,20210111183933,226"]
   end
 end

--- a/Library/Homebrew/test/livecheck/options_spec.rb
+++ b/Library/Homebrew/test/livecheck/options_spec.rb
@@ -4,8 +4,9 @@
 require "livecheck/options"
 
 RSpec.describe Homebrew::Livecheck::Options do
-  subject(:options) { described_class }
+  subject(:options) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Options }
   let(:cookies) { { "cookie_key" => "cookie_value" } }
   let(:header_string) { "Accept: */*" }
   let(:referer_url) { "https://example.com/referer" }
@@ -17,7 +18,6 @@ RSpec.describe Homebrew::Livecheck::Options do
       string:  "a + b = c",
     }
   end
-
   let(:args) do
     {
       cookies:       cookies,
@@ -35,7 +35,6 @@ RSpec.describe Homebrew::Livecheck::Options do
     }
   end
   let(:merged_hash) { args.merge(other_args) }
-
   let(:base_options) { options.new(**args) }
   let(:other_options) { options.new(**other_args) }
   let(:merged_options) { options.new(**merged_hash) }

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -5,8 +5,9 @@ require "livecheck/livecheck"
 require "livecheck/skip_conditions"
 
 RSpec.describe Homebrew::Livecheck::SkipConditions do
-  subject(:skip_conditions) { described_class }
+  subject(:skip_conditions) { klass }
 
+  let(:klass) { Homebrew::Livecheck::SkipConditions }
   let(:formulae) do
     {
       basic:               formula("test") do
@@ -77,7 +78,6 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       end,
     }
   end
-
   let(:casks) do
     {
       basic:                                 Cask::Cask.new("test") do
@@ -181,7 +181,6 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       end,
     }
   end
-
   let(:status_hashes) do
     {
       formula: {

--- a/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
@@ -4,8 +4,9 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Apache do
-  subject(:apache) { described_class }
+  subject(:apache) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Apache }
   let(:apache_urls) do
     {
       version_dir:                    "https://www.apache.org/dyn/closer.lua?path=abc/1.2.3/def-1.2.3.tar.gz",
@@ -29,7 +30,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Apache do
     }
   end
   let(:non_apache_url) { "https://brew.sh/test" }
-
   let(:generated) do
     values = {
       version_dir:            {
@@ -66,7 +66,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Apache do
 
     values
   end
-
   let(:content) do
     start_html = <<~EOS
       <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
@@ -123,7 +122,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Apache do
       files:       start_html + files + end_html,
     }
   end
-
   let(:matches) do
     {
       directories: ["1.2.0", "1.2.1", "1.2.2"],

--- a/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
@@ -4,8 +4,9 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Bitbucket do
-  subject(:bitbucket) { described_class }
+  subject(:bitbucket) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Bitbucket }
   let(:bitbucket_urls) do
     {
       get:       "https://bitbucket.org/abc/def/get/1.2.3.tar.gz",
@@ -13,7 +14,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Bitbucket do
     }
   end
   let(:non_bitbucket_url) { "https://brew.sh/test" }
-
   let(:generated) do
     {
       get:       {
@@ -26,7 +26,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Bitbucket do
       },
     }
   end
-
   # This example HTML omits table columns for the sake of brevity.
   let(:content) do
     <<~EOS
@@ -83,7 +82,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Bitbucket do
       </html>
     EOS
   end
-
   let(:matches) { ["1.2.3", "1.2.2", "1.2.1"] }
 
   describe "::match?" do

--- a/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
@@ -4,8 +4,9 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Cpan do
-  subject(:cpan) { described_class }
+  subject(:cpan) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Cpan }
   let(:cpan_urls) do
     {
       no_subdirectory:       "https://cpan.metacpan.org/authors/id/H/HO/HOMEBREW/Brew-v1.2.3.tar.gz",
@@ -15,7 +16,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Cpan do
     }
   end
   let(:non_cpan_url) { "https://brew.sh/test" }
-
   let(:generated) do
     {
       no_subdirectory:   {
@@ -28,7 +28,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Cpan do
       },
     }
   end
-
   # CPAN doesn't specify a DOCTYPE, so it's also omitted here.
   let(:content) do
     <<~EOS
@@ -58,7 +57,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Cpan do
 
     EOS
   end
-
   let(:matches) { ["1.2.3", "1.2.2", "1.2.1"] }
 
   describe "::match?" do

--- a/Library/Homebrew/test/livecheck/strategy/crate_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/crate_spec.rb
@@ -4,19 +4,17 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Crate do
-  subject(:crate) { described_class }
+  subject(:crate) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Crate }
   let(:crate_url) { "https://static.crates.io/crates/example/example-0.1.0.crate" }
   let(:non_crate_url) { "https://brew.sh/test" }
-
   # This only differs from the `DEFAULT_REGEX` so we can distinguish between a
   # provided regex and the default strategy regex in testing.
   let(:regex) { /v?(\d+(?:\.\d+)+)/i }
-
   let(:generated) do
     { url: "https://crates.io/api/v1/crates/example/versions" }
   end
-
   # This is a limited subset of a `versions` response object, for the sake of
   # testing.
   let(:content) do
@@ -48,9 +46,7 @@ RSpec.describe Homebrew::Livecheck::Strategy::Crate do
       }
     EOS
   end
-
   let(:matches) { ["1.0.0", "1.0.1"] }
-
   let(:find_versions_return_hash) do
     {
       matches: {
@@ -61,7 +57,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Crate do
       url:     generated[:url],
     }
   end
-
   let(:find_versions_cached_return_hash) do
     find_versions_return_hash.merge({ cached: true })
   end

--- a/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
@@ -4,13 +4,12 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::ElectronBuilder do
-  subject(:electron_builder) { described_class }
+  subject(:electron_builder) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::ElectronBuilder }
   let(:http_url) { "https://www.example.com/example/latest-mac.yml" }
   let(:non_http_url) { "ftp://brew.sh/" }
-
   let(:regex) { /Example[._-]v?(\d+(?:\.\d+)+)[._-]mac\.zip/i }
-
   let(:content) do
     <<~EOS
       version: 1.2.3
@@ -27,7 +26,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::ElectronBuilder do
       releaseDate: '2000-01-01T00:00:00.000Z'
     EOS
   end
-
   let(:content_timestamp) do
     # An electron-builder YAML file may use a timestamp instead of an explicit
     # string value (with quotes) for `releaseDate`, so we need to make sure that
@@ -35,7 +33,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::ElectronBuilder do
     # scenario (e.g. `Tried to load unspecified class: Time`).
     content.sub(/releaseDate:\s*'([^']+)'/, 'releaseDate: \1')
   end
-
   let(:matches) { ["1.2.3"] }
 
   describe "::match?" do

--- a/Library/Homebrew/test/livecheck/strategy/extract_plist_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/extract_plist_spec.rb
@@ -5,11 +5,11 @@ require "livecheck/strategy"
 require "bundle_version"
 
 RSpec.describe Homebrew::Livecheck::Strategy::ExtractPlist do
-  subject(:extract_plist) { described_class }
+  subject(:extract_plist) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::ExtractPlist }
   let(:http_url) { "https://brew.sh/blog/" }
   let(:non_http_url) { "ftp://brew.sh/" }
-
   let(:items) do
     {
       "first"  => extract_plist::Item.new(
@@ -20,7 +20,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::ExtractPlist do
       ),
     }
   end
-
   let(:multipart_items) do
     {
       "first"  => extract_plist::Item.new(
@@ -32,7 +31,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::ExtractPlist do
     }
   end
   let(:multipart_regex) { /^v?(\d+(?:\.\d+)+)(?:[._-](\d+))?(?:[._-]([0-9a-f]+))?$/i }
-
   let(:versions) { ["1.2", "1.2.3"] }
   let(:multipart_versions) { ["1.2.3,45", "1.2.3,45,abcdef"] }
 

--- a/Library/Homebrew/test/livecheck/strategy/git_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/git_spec.rb
@@ -4,11 +4,11 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Git do
-  subject(:git) { described_class }
+  subject(:git) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Git }
   let(:git_url) { "https://github.com/Homebrew/brew.git" }
   let(:non_git_url) { "https://brew.sh/test" }
-
   let(:regexes) do
     {
       standard: /^v?(\d+(?:\.\d+)+)$/i,
@@ -16,7 +16,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Git do
       brew:     %r{^brew/v?(\d+(?:\.\d+)+)$}i,
     }
   end
-
   let(:content) do
     normal = <<~EOS
       e0f1758045b8194f77a43050ca433cbe928f27fb\trefs/tags/brew/1.2
@@ -33,14 +32,12 @@ RSpec.describe Homebrew::Livecheck::Strategy::Git do
       hyphens:,
     }
   end
-
   let(:tags) do
     {
       normal:  ["brew/1.2", "brew/1.2.1", "brew/1.2.2", "brew/1.2.3", "brew/1.2.4", "1.2.5"],
       hyphens: ["brew/1-2", "brew/1-2-1", "brew/1-2-2", "brew/1-2-3", "brew/1-2-4", "1-2-5"],
     }
   end
-
   let(:matches) do
     {
       default:        ["1.2", "1.2.1", "1.2.2", "1.2.3", "1.2.4", "1.2.5"],
@@ -48,7 +45,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Git do
       brew_regex:     ["1.2", "1.2.1", "1.2.2", "1.2.3", "1.2.4"],
     }
   end
-
   let(:messages) do
     [
       "remote: Support for password authentication was removed on August 13, 2021.",

--- a/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
@@ -4,8 +4,9 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::GithubLatest do
-  subject(:github_latest) { described_class }
+  subject(:github_latest) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::GithubLatest }
   let(:github_urls) do
     {
       release_asset:     "https://github.com/abc/def/releases/download/1.2.3/ghi-1.2.3.tar.gz",
@@ -16,7 +17,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::GithubLatest do
     }
   end
   let(:non_github_url) { "https://brew.sh/test" }
-
   let(:generated) do
     {
       def:  {
@@ -31,7 +31,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::GithubLatest do
       },
     }
   end
-
   # For the sake of brevity, this is a limited subset of the information found
   # in release objects in a response from the GitHub API.
   let(:content) do
@@ -45,7 +44,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::GithubLatest do
     EOS
   end
   let(:json) { JSON.parse(content) }
-
   let(:matches) { ["1.2.3"] }
 
   describe "::match?" do

--- a/Library/Homebrew/test/livecheck/strategy/github_releases_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/github_releases_spec.rb
@@ -4,8 +4,9 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::GithubReleases do
-  subject(:github_releases) { described_class }
+  subject(:github_releases) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::GithubReleases }
   let(:github_urls) do
     {
       release_asset:     "https://github.com/abc/def/releases/download/1.2.3/ghi-1.2.3.tar.gz",
@@ -16,9 +17,7 @@ RSpec.describe Homebrew::Livecheck::Strategy::GithubReleases do
     }
   end
   let(:non_github_url) { "https://brew.sh/test" }
-
   let(:regex) { github_releases::DEFAULT_REGEX }
-
   let(:generated) do
     {
       def:  {
@@ -33,7 +32,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::GithubReleases do
       },
     }
   end
-
   # For the sake of brevity, this is a limited subset of the information found
   # in release objects in a response from the GitHub API. Some of these objects
   # are somewhat representative of real world scenarios but others are
@@ -84,7 +82,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::GithubReleases do
     EOS
   end
   let(:json) { JSON.parse(content) }
-
   let(:matches) { ["1.2.3", "1.2.2"] }
 
   describe "::match?" do

--- a/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
@@ -4,25 +4,23 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Gnome do
-  subject(:gnome) { described_class }
+  subject(:gnome) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Gnome }
   let(:gnome_url) { "https://download.gnome.org/sources/abc/1.2/abc-1.2.3.tar.xz" }
   let(:non_gnome_url) { "https://brew.sh/test" }
-
   let(:generated) do
     {
       url:   "https://download.gnome.org/sources/abc/cache.json",
       regex: /abc-(\d+(?:\.\d+)*)\.t/i,
     }
   end
-
   let(:content) do
     <<~EOS
       [4, {"abc": {"40.1.0": {"news": "40.1/abc-40.1.0.news", "changes": "40.1/abc-40.1.0.changes", "tar.xz": "40.1/abc-40.1.0.tar.xz", "sha256sum": "40.1/abc-40.1.0.sha256sum"}, "1.2.90": {"news": "1.2/abc-1.2.90.news", "changes": "1.2/abc-1.2.90.changes", "tar.xz": "1.2/abc-1.2.90.tar.xz", "sha256sum": "1.2/abc-1.2.90.sha256sum"}, "1.2.4": {"news": "1.2/abc-1.2.4.news", "changes": "1.2/abc-1.2.4.changes", "tar.xz": "1.2/abc-1.2.4.tar.xz", "sha256sum": "1.2/abc-1.2.4.sha256sum"}, "1.2.3": {"news": "1.2/abc-1.2.3.news", "changes": "1.2/abc-1.2.3.changes", "tar.xz": "1.2/abc-1.2.3.tar.xz", "sha256sum": "1.2/abc-1.2.3.sha256sum"}, "1.1.0": {"news": "1.1/abc-1.1.0.news", "changes": "1.1/abc-1.1.0.changes", "tar.xz": "1.1/abc-1.1.0.tar.xz", "sha256sum": "1.1/abc-1.1.0.sha256sum"}, "1": {"news": "1/abc-1.news", "changes": "1/abc-1.changes", "tar.xz": "1/abc-1.tar.xz", "sha256sum": "1/abc-1.sha256sum"}}}, {"abc": ["1", "1.1.0", "1.2.3", "1.2.4", "1.2.90", "40.1.0"]}, {"1": ["LATEST-IS-1"], "1.1": ["LATEST-IS-1.1.0"], "1.2": ["LATEST-IS-1.2.4"], "40": ["LATEST-IS-40.1.0"], ".": ["cache.json"]}]
 
     EOS
   end
-
   let(:matches) do
     {
       all:     ["40.1.0", "1.2.90", "1.2.4", "1.2.3", "1.1.0", "1"],

--- a/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
@@ -4,8 +4,9 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Gnu do
-  subject(:gnu) { described_class }
+  subject(:gnu) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Gnu }
   let(:gnu_urls) do
     {
       no_version_dir: "https://ftpmirror.gnu.org/gnu/abc/abc-1.2.3.tar.gz",
@@ -15,7 +16,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Gnu do
     }
   end
   let(:non_gnu_url) { "https://brew.sh/test" }
-
   let(:generated) do
     {
       no_version_dir: {
@@ -33,7 +33,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Gnu do
       savannah:       {},
     }
   end
-
   # The whitespace in a real response is a bit looser and this has been
   # reformatted for the sake of brevity.
   let(:content) do
@@ -101,7 +100,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Gnu do
 
     EOS
   end
-
   let(:matches) { ["1.2.2", "1.2.3"] }
 
   describe "::match?" do

--- a/Library/Homebrew/test/livecheck/strategy/hackage_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/hackage_spec.rb
@@ -4,8 +4,9 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Hackage do
-  subject(:hackage) { described_class }
+  subject(:hackage) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Hackage }
   let(:hackage_urls) do
     {
       package:   "https://hackage.haskell.org/package/abc-1.2.3/abc-1.2.3.tar.gz",
@@ -13,14 +14,12 @@ RSpec.describe Homebrew::Livecheck::Strategy::Hackage do
     }
   end
   let(:non_hackage_url) { "https://brew.sh/test" }
-
   let(:generated) do
     {
       url:   "https://hackage.haskell.org/package/abc/src/",
       regex: %r{<h3>abc-(.*?)/?</h3>}i,
     }
   end
-
   let(:content) do
     <<~EOS
       <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
@@ -50,7 +49,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Hackage do
       </html>
     EOS
   end
-
   let(:matches) { ["1.2.3"] }
 
   describe "::match?" do

--- a/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
@@ -4,11 +4,11 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::HeaderMatch do
-  subject(:header_match) { described_class }
+  subject(:header_match) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::HeaderMatch }
   let(:http_url) { "https://brew.sh/blog/" }
   let(:non_http_url) { "ftp://brew.sh/" }
-
   let(:regexes) do
     {
       archive: /filename=brew[._-]v?(\d+(?:\.\d+)+)\.t/i,
@@ -16,7 +16,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::HeaderMatch do
       loose:   /v?(\d+(?:\.\d+)+)/i,
     }
   end
-
   let(:headers) do
     headers = {
       content_disposition: {
@@ -40,7 +39,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::HeaderMatch do
 
     headers
   end
-
   let(:matches) do
     matches = {
       content_disposition: ["1.2.3"],

--- a/Library/Homebrew/test/livecheck/strategy/json_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/json_spec.rb
@@ -4,13 +4,12 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Json do
-  subject(:json) { described_class }
+  subject(:json) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Json }
   let(:http_url) { "https://brew.sh/blog/" }
   let(:non_http_url) { "ftp://brew.sh/" }
-
   let(:regex) { /^v?(\d+(?:\.\d+)+)$/i }
-
   let(:content) do
     <<~EOS
       {
@@ -40,7 +39,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Json do
     EOS
   end
   let(:content_simple) { '{"version":"1.2.3"}' }
-
   let(:matches) do
     {
       content: ["1.1.2", "1.1.1", "1.1.0", "1.0.3", "1.0.2", "1.0.1", "1.0.0"],

--- a/Library/Homebrew/test/livecheck/strategy/launchpad_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/launchpad_spec.rb
@@ -4,8 +4,9 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Launchpad do
-  subject(:launchpad) { described_class }
+  subject(:launchpad) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Launchpad }
   let(:launchpad_urls) do
     {
       version_dir:    "https://launchpad.net/abc/1.2/1.2.3/+download/abc-1.2.3.tar.gz",
@@ -14,13 +15,11 @@ RSpec.describe Homebrew::Livecheck::Strategy::Launchpad do
     }
   end
   let(:non_launchpad_url) { "https://brew.sh/test" }
-
   let(:generated) do
     {
       url: "https://launchpad.net/abc/",
     }
   end
-
   # The whitespace in a real response is a bit looser and this has been
   # reformatted for the sake of brevity.
   let(:content) do
@@ -54,7 +53,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Launchpad do
       </html>
     EOS
   end
-
   let(:matches) { ["1.2.3"] }
 
   describe "::match?" do

--- a/Library/Homebrew/test/livecheck/strategy/npm_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/npm_spec.rb
@@ -4,8 +4,9 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Npm do
-  subject(:npm) { described_class }
+  subject(:npm) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Npm }
   let(:npm_urls) do
     {
       typical:    "https://registry.npmjs.org/abc/-/def-1.2.3.tgz",
@@ -13,7 +14,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Npm do
     }
   end
   let(:non_npm_url) { "https://brew.sh/test" }
-
   let(:generated) do
     {
       typical:    {
@@ -24,7 +24,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Npm do
       },
     }
   end
-
   # This is a limited subset of a `latest` response object, for the sake of
   # testing.
   let(:content) do
@@ -35,7 +34,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Npm do
       }
     EOS
   end
-
   let(:matches) { ["1.2.3"] }
 
   describe "::match?" do

--- a/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
@@ -4,13 +4,12 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::PageMatch do
-  subject(:page_match) { described_class }
+  subject(:page_match) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::PageMatch }
   let(:http_url) { "https://brew.sh/blog/" }
   let(:non_http_url) { "ftp://brew.sh/" }
-
   let(:regex) { %r{href=.*?/homebrew[._-]v?(\d+(?:\.\d+)+)/?["' >]}i }
-
   let(:content) do
     <<~EOS
       <!DOCTYPE html>
@@ -36,7 +35,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::PageMatch do
       </html>
     EOS
   end
-
   let(:matches) { ["2.6.0", "2.5.0", "2.4.0", "2.3.0", "2.2.0", "2.1.0", "2.0.0", "1.9.0"] }
 
   describe "::match?" do

--- a/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
@@ -4,19 +4,17 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Pypi do
-  subject(:pypi) { described_class }
+  subject(:pypi) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Pypi }
   let(:pypi_url) { "https://files.pythonhosted.org/packages/ab/cd/efg/example-package-1.2.3.tar.gz" }
   let(:non_pypi_url) { "https://brew.sh/test" }
-
   let(:regex) { /^v?(\d+(?:\.\d+)+)/i }
-
   let(:generated) do
     {
       url: "https://pypi.org/pypi/example-package/json",
     }
   end
-
   # This is a limited subset of a PyPI JSON API response object, for the sake
   # of testing. Typical versions use a `1.2.3` format but this adds a suffix,
   # so we can test regex matching.
@@ -29,9 +27,7 @@ RSpec.describe Homebrew::Livecheck::Strategy::Pypi do
       }
     JSON
   end
-
   let(:matches) { ["1.2.3-456"] }
-
   let(:find_versions_return_hash) do
     {
       matches: {
@@ -41,7 +37,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Pypi do
       url:     generated[:url],
     }
   end
-
   let(:find_versions_cached_return_hash) do
     find_versions_return_hash.merge({ cached: true })
   end

--- a/Library/Homebrew/test/livecheck/strategy/ruby_gems_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/ruby_gems_spec.rb
@@ -4,18 +4,17 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::RubyGems do
-  subject(:ruby_gems) { described_class }
+  subject(:ruby_gems) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::RubyGems }
   let(:ruby_gems_url) { "https://rubygems.org/downloads/example-package-1.2.3.gem" }
   let(:platform_ruby_gems_url) { "https://rubygems.org/downloads/example-package-1.2.3-arm64-darwin.gem" }
   let(:non_ruby_gems_url) { "https://brew.sh/test" }
-
   let(:generated) do
     {
       url: "https://rubygems.org/api/v1/versions/example-package/latest.json",
     }
   end
-
   let(:content) do
     <<~JSON
       {

--- a/Library/Homebrew/test/livecheck/strategy/sourceforge_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sourceforge_spec.rb
@@ -4,8 +4,9 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Sourceforge do
-  subject(:sourceforge) { described_class }
+  subject(:sourceforge) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Sourceforge }
   let(:sourceforge_urls) do
     {
       typical:       "https://downloads.sourceforge.net/project/abc/def-1.2.3.tar.gz",
@@ -14,7 +15,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Sourceforge do
     }
   end
   let(:non_sourceforge_url) { "https://brew.sh/test" }
-
   let(:generated) do
     {
       typical: {
@@ -26,7 +26,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Sourceforge do
       },
     }
   end
-
   let(:content) do
     <<~EOS
       <?xml version="1.0" encoding="utf-8"?>
@@ -52,7 +51,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Sourceforge do
       </rss>
     EOS
   end
-
   let(:matches) { ["1.2.3"] }
 
   describe "::match?" do

--- a/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
@@ -5,28 +5,12 @@ require "livecheck/strategy"
 require "bundle_version"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Sparkle do
-  subject(:sparkle) { described_class }
+  subject(:sparkle) { klass }
 
-  def create_appcast_xml(items_str = "")
-    <<~EOS
-      <?xml version="1.0" encoding="utf-8"?>
-      <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
-        <channel>
-          <title>Example Changelog</title>
-          <link>#{appcast_url}</link>
-          <description>Most recent changes with links to updates.</description>
-          <language>en</language>
-          #{items_str}
-        </channel>
-      </rss>
-    EOS
-  end
-
+  let(:klass) { Homebrew::Livecheck::Strategy::Sparkle }
   let(:appcast_url) { "https://www.example.com/example/appcast.xml" }
   let(:non_http_url) { "ftp://brew.sh/" }
-
   let(:title_regex) { /Version\s+v?(\d+(?:\.\d+)+)\s*$/i }
-
   # The `item_hashes` data is used to create test appcast XML and expected
   # `Sparkle::Item` objects.
   let(:item_hashes) do
@@ -82,7 +66,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Sparkle do
       },
     }
   end
-
   let(:xml) do
     v123_item = <<~EOS
       <item>
@@ -188,7 +171,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Sparkle do
       undefined_namespace:,
     }
   end
-
   let(:items) do
     {
       v124: Homebrew::Livecheck::Strategy::Sparkle::Item.new(
@@ -253,7 +235,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Sparkle do
       ),
     }
   end
-
   let(:item_arrays) do
     item_arrays = {
       appcast:        [
@@ -295,8 +276,22 @@ RSpec.describe Homebrew::Livecheck::Strategy::Sparkle do
 
     item_arrays
   end
-
   let(:matches) { ["1.2.3,123"] }
+
+  def create_appcast_xml(items_str = "")
+    <<~EOS
+      <?xml version="1.0" encoding="utf-8"?>
+      <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+        <channel>
+          <title>Example Changelog</title>
+          <link>#{appcast_url}</link>
+          <description>Most recent changes with links to updates.</description>
+          <language>en</language>
+          #{items_str}
+        </channel>
+      </rss>
+    EOS
+  end
 
   describe "::match?" do
     it "returns true for an HTTP URL" do

--- a/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
@@ -6,13 +6,12 @@ require "rexml/document"
 require "rexml/undefinednamespaceexception"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Xml do
-  subject(:xml) { described_class }
+  subject(:xml) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Xml }
   let(:http_url) { "https://brew.sh/blog/" }
   let(:non_http_url) { "ftp://brew.sh/" }
-
   let(:regex) { /^v?(\d+(?:\.\d+)+)$/i }
-
   let(:content_version_text) do
     <<~EOS
       <?xml version="1.0" encoding="utf-8"?>
@@ -39,7 +38,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Xml do
       </versions>
     EOS
   end
-
   let(:content_version_attr) do
     <<~EOS
       <?xml version="1.0" encoding="utf-8"?>
@@ -66,21 +64,18 @@ RSpec.describe Homebrew::Livecheck::Strategy::Xml do
       </items>
     EOS
   end
-
   let(:content_simple) do
     <<~EOS
       <?xml version="1.0" encoding="utf-8"?>
       <version>1.2.3</version>
     EOS
   end
-
   let(:content_undefined_namespace) do
     <<~EOS
       <?xml version="1.0" encoding="utf-8"?>
       <something:version>1.2.3</something:version>
     EOS
   end
-
   let(:parent_child_text) { { parent: "1.2.3", child: "4.5.6" } }
   let(:content_parent_child) do
     # This XML deliberately includes unnecessary whitespace, to ensure that
@@ -98,7 +93,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Xml do
       </elements>
     EOS
   end
-
   let(:matches) do
     {
       content: ["1.1.2", "1.1.1", "1.1.0", "1.0.3", "1.0.2", "1.0.1", "1.0.0"],

--- a/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
@@ -4,8 +4,9 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Xorg do
-  subject(:xorg) { described_class }
+  subject(:xorg) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Xorg }
   let(:xorg_urls) do
     {
       app:         "https://www.x.org/archive/individual/app/abc-1.2.3.tar.bz2",
@@ -18,7 +19,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Xorg do
     }
   end
   let(:non_xorg_url) { "https://brew.sh/test" }
-
   let(:generated) do
     {
       app:         {
@@ -51,7 +51,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Xorg do
       },
     }
   end
-
   let(:content) do
     <<~EOS
       <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
@@ -116,7 +115,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Xorg do
       </html>
     EOS
   end
-
   let(:matches) { ["1.2.2", "1.2.3"] }
 
   describe "::match?" do

--- a/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
@@ -4,13 +4,12 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy::Yaml do
-  subject(:yaml) { described_class }
+  subject(:yaml) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy::Yaml }
   let(:http_url) { "https://brew.sh/blog/" }
   let(:non_http_url) { "ftp://brew.sh/" }
-
   let(:regex) { /^v?(\d+(?:\.\d+)+)$/i }
-
   let(:content) do
     <<~EOS
       versions:
@@ -37,11 +36,9 @@ RSpec.describe Homebrew::Livecheck::Strategy::Yaml do
     EOS
   end
   let(:content_simple) { "version: 1.2.3" }
-
   # This should produce a `Psych::SyntaxError` (`did not find expected comment
   # or line break while scanning a block scalar`)
   let(:content_invalid) { ">~" }
-
   let(:matches) do
     {
       content: ["1.1.2", "1.1.1", "1.1.0", "1.0.3", "1.0.2", "1.0.1", "1.0.0"],

--- a/Library/Homebrew/test/livecheck/strategy_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy_spec.rb
@@ -4,11 +4,11 @@
 require "livecheck/strategy"
 
 RSpec.describe Homebrew::Livecheck::Strategy do
-  subject(:strategy) { described_class }
+  subject(:strategy) { klass }
 
+  let(:klass) { Homebrew::Livecheck::Strategy }
   let(:url) { "https://brew.sh/" }
   let(:redirection_url) { "https://brew.sh/redirection" }
-
   let(:post_hash) do
     {
       empty:   "",
@@ -19,7 +19,6 @@ RSpec.describe Homebrew::Livecheck::Strategy do
   end
   let(:form_string) { "empty=&boolean=true&number=1&string=a+%2B+b+%3D+c" }
   let(:json_string) { '{"empty":"","boolean":"true","number":"1","string":"a + b = c"}' }
-
   let(:response_hash) do
     response_hash = {}
 
@@ -52,7 +51,6 @@ RSpec.describe Homebrew::Livecheck::Strategy do
 
     response_hash
   end
-
   let(:body) do
     <<~HTML
       <!DOCTYPE html>
@@ -69,7 +67,6 @@ RSpec.describe Homebrew::Livecheck::Strategy do
       </html>
     HTML
   end
-
   let(:response_text) do
     response_text = {}
 

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -5,6 +5,8 @@ require "formula"
 require "livecheck"
 
 RSpec.describe Livecheck do
+  let(:klass) { Livecheck }
+
   let(:f) do
     formula do
       homepage "https://brew.sh"
@@ -12,7 +14,7 @@ RSpec.describe Livecheck do
       head "https://github.com/Homebrew/brew.git", branch: "main"
     end
   end
-  let(:livecheck_f) { described_class.new(f.class) }
+  let(:livecheck_f) { klass.new(f.class) }
 
   let(:c) do
     Cask::CaskLoader.load(+<<-RUBY)
@@ -26,7 +28,7 @@ RSpec.describe Livecheck do
       end
     RUBY
   end
-  let(:livecheck_c) { described_class.new(c) }
+  let(:livecheck_c) { klass.new(c) }
 
   let(:post_hash) do
     {

--- a/Library/Homebrew/test/locale_spec.rb
+++ b/Library/Homebrew/test/locale_spec.rb
@@ -4,51 +4,53 @@
 require "locale"
 
 RSpec.describe Locale do
+  let(:klass) { Locale }
+
   describe "::parse" do
     it "parses a string in the correct format" do
-      expect(described_class.parse("zh")).to eql(described_class.new("zh", nil, nil))
-      expect(described_class.parse("zh-CN")).to eql(described_class.new("zh", nil, "CN"))
-      expect(described_class.parse("zh-Hans")).to eql(described_class.new("zh", "Hans", nil))
-      expect(described_class.parse("zh-Hans-CN")).to eql(described_class.new("zh", "Hans", "CN"))
+      expect(klass.parse("zh")).to eql(klass.new("zh", nil, nil))
+      expect(klass.parse("zh-CN")).to eql(klass.new("zh", nil, "CN"))
+      expect(klass.parse("zh-Hans")).to eql(klass.new("zh", "Hans", nil))
+      expect(klass.parse("zh-Hans-CN")).to eql(klass.new("zh", "Hans", "CN"))
     end
 
     it "correctly parses a string with a UN M.49 region code" do
-      expect(described_class.parse("es-419")).to eql(described_class.new("es", nil, "419"))
+      expect(klass.parse("es-419")).to eql(klass.new("es", nil, "419"))
     end
 
     describe "raises a ParserError when given" do
       it "an empty string" do
-        expect { described_class.parse("") }.to raise_error(Locale::ParserError)
+        expect { klass.parse("") }.to raise_error(Locale::ParserError)
       end
 
       it "a string in a wrong format" do
-        expect { described_class.parse("zh-CN-Hans") }.to raise_error(Locale::ParserError)
-        expect { described_class.parse("zh_CN_Hans") }.to raise_error(Locale::ParserError)
-        expect { described_class.parse("zhCNHans") }.to raise_error(Locale::ParserError)
-        expect { described_class.parse("zh-CN_Hans") }.to raise_error(Locale::ParserError)
-        expect { described_class.parse("zhCN") }.to raise_error(Locale::ParserError)
-        expect { described_class.parse("zh_Hans") }.to raise_error(Locale::ParserError)
-        expect { described_class.parse("zh-") }.to raise_error(Locale::ParserError)
-        expect { described_class.parse("ZH-CN") }.to raise_error(Locale::ParserError)
-        expect { described_class.parse("zh-cn") }.to raise_error(Locale::ParserError)
+        expect { klass.parse("zh-CN-Hans") }.to raise_error(Locale::ParserError)
+        expect { klass.parse("zh_CN_Hans") }.to raise_error(Locale::ParserError)
+        expect { klass.parse("zhCNHans") }.to raise_error(Locale::ParserError)
+        expect { klass.parse("zh-CN_Hans") }.to raise_error(Locale::ParserError)
+        expect { klass.parse("zhCN") }.to raise_error(Locale::ParserError)
+        expect { klass.parse("zh_Hans") }.to raise_error(Locale::ParserError)
+        expect { klass.parse("zh-") }.to raise_error(Locale::ParserError)
+        expect { klass.parse("ZH-CN") }.to raise_error(Locale::ParserError)
+        expect { klass.parse("zh-cn") }.to raise_error(Locale::ParserError)
       end
     end
   end
 
   describe "::new" do
     it "raises an ArgumentError when all arguments are nil" do
-      expect { described_class.new(nil, nil, nil) }.to raise_error(ArgumentError)
+      expect { klass.new(nil, nil, nil) }.to raise_error(ArgumentError)
     end
 
     it "raises a ParserError when one of the arguments does not match the locale format" do
-      expect { described_class.new("ZH", nil, nil) }.to raise_error(Locale::ParserError)
-      expect { described_class.new(nil, "hans", nil) }.to raise_error(Locale::ParserError)
-      expect { described_class.new(nil, nil, "cn") }.to raise_error(Locale::ParserError)
+      expect { klass.new("ZH", nil, nil) }.to raise_error(Locale::ParserError)
+      expect { klass.new(nil, "hans", nil) }.to raise_error(Locale::ParserError)
+      expect { klass.new(nil, nil, "cn") }.to raise_error(Locale::ParserError)
     end
   end
 
   describe "#include?" do
-    subject(:locale) { described_class.new("zh", "Hans", "CN") }
+    subject(:locale) { klass.new("zh", "Hans", "CN") }
 
     specify(:aggregate_failures) do
       expect(locale).to include("zh")
@@ -61,12 +63,12 @@ RSpec.describe Locale do
   end
 
   describe "#eql?" do
-    subject(:locale) { described_class.new("zh", "Hans", "CN") }
+    subject(:locale) { klass.new("zh", "Hans", "CN") }
 
     context "when all parts match" do
       specify(:aggregate_failures) do
         expect(locale).to eql("zh-Hans-CN")
-        expect(locale).to eql(described_class.new("zh", "Hans", "CN"))
+        expect(locale).to eql(klass.new("zh", "Hans", "CN"))
       end
     end
 
@@ -90,9 +92,9 @@ RSpec.describe Locale do
     let(:locale_groups) { [["zh"], ["zh-TW"]] }
 
     it "finds best matching language code, independent of order" do
-      expect(described_class.new("zh", nil, "TW").detect(locale_groups)).to eql(["zh-TW"])
-      expect(described_class.new("zh", nil, "TW").detect(locale_groups.reverse)).to eql(["zh-TW"])
-      expect(described_class.new("zh", "Hans", "CN").detect(locale_groups)).to eql(["zh"])
+      expect(klass.new("zh", nil, "TW").detect(locale_groups)).to eql(["zh-TW"])
+      expect(klass.new("zh", nil, "TW").detect(locale_groups.reverse)).to eql(["zh-TW"])
+      expect(klass.new("zh", "Hans", "CN").detect(locale_groups)).to eql(["zh"])
     end
   end
 end

--- a/Library/Homebrew/test/lock_file_spec.rb
+++ b/Library/Homebrew/test/lock_file_spec.rb
@@ -4,9 +4,10 @@
 require "lock_file"
 
 RSpec.describe LockFile do
-  subject(:lock_file) { described_class.new(:lock, Pathname("foo")) }
+  subject(:lock_file) { klass.new(:lock, Pathname("foo")) }
 
-  let(:lock_file_copy) { described_class.new(:lock, Pathname("foo")) }
+  let(:klass) { LockFile }
+  let(:lock_file_copy) { klass.new(:lock, Pathname("foo")) }
 
   describe "#lock" do
     it "ensures the lock file is created" do

--- a/Library/Homebrew/test/macos_runner_spec_spec.rb
+++ b/Library/Homebrew/test/macos_runner_spec_spec.rb
@@ -4,7 +4,9 @@
 require "macos_runner_spec"
 
 RSpec.describe MacOSRunnerSpec do
-  let(:spec) { described_class.new(name: "macOS 11-arm64", runner: "11-arm64", timeout: 90, cleanup: true) }
+  let(:klass) { MacOSRunnerSpec }
+
+  let(:spec) { klass.new(name: "macOS 11-arm64", runner: "11-arm64", timeout: 90, cleanup: true) }
 
   it "has immutable attributes" do
     [:name, :runner, :timeout, :cleanup].each do |attribute|

--- a/Library/Homebrew/test/macos_version_spec.rb
+++ b/Library/Homebrew/test/macos_version_spec.rb
@@ -4,34 +4,36 @@
 require "macos_version"
 
 RSpec.describe MacOSVersion do
-  let(:version) { described_class.new("10.15") }
-  let(:tahoe_major) { described_class.new("26.0") }
-  let(:big_sur_major) { described_class.new("11.0") }
-  let(:big_sur_update) { described_class.new("11.1") }
-  let(:frozen_version) { described_class.new("10.15").freeze }
+  let(:klass) { MacOSVersion }
+
+  let(:version) { klass.new("10.15") }
+  let(:tahoe_major) { klass.new("26.0") }
+  let(:big_sur_major) { klass.new("11.0") }
+  let(:big_sur_update) { klass.new("11.1") }
+  let(:frozen_version) { klass.new("10.15").freeze }
 
   describe "::kernel_major_version" do
     it "returns the kernel major version" do
-      expect(described_class.kernel_major_version(version)).to eq "19"
-      expect(described_class.kernel_major_version(tahoe_major)).to eq "25"
-      expect(described_class.kernel_major_version(big_sur_major)).to eq "20"
-      expect(described_class.kernel_major_version(big_sur_update)).to eq "20"
+      expect(klass.kernel_major_version(version)).to eq "19"
+      expect(klass.kernel_major_version(tahoe_major)).to eq "25"
+      expect(klass.kernel_major_version(big_sur_major)).to eq "20"
+      expect(klass.kernel_major_version(big_sur_update)).to eq "20"
     end
 
     it "matches the major version returned by OS.kernel_version", :needs_macos do
-      expect(described_class.kernel_major_version(OS::Mac.version)).to eq OS.kernel_version.major
+      expect(klass.kernel_major_version(OS::Mac.version)).to eq OS.kernel_version.major
     end
   end
 
   describe "::from_symbol" do
     it "raises an error if the symbol is not a valid macOS version" do
       expect do
-        described_class.from_symbol(:foo)
+        klass.from_symbol(:foo)
       end.to raise_error(MacOSVersion::Error, "unknown or unsupported macOS version: :foo")
     end
 
     it "creates a new version from a valid macOS version" do
-      symbol_version = described_class.from_symbol(:catalina)
+      symbol_version = klass.from_symbol(:catalina)
       expect(symbol_version).to eq(version)
     end
   end
@@ -39,12 +41,12 @@ RSpec.describe MacOSVersion do
   describe "#new" do
     it "raises an error if the version is not a valid macOS version" do
       expect do
-        described_class.new("1.2")
+        klass.new("1.2")
       end.to raise_error(MacOSVersion::Error, 'unknown or unsupported macOS version: "1.2"')
     end
 
     it "creates a new version from a valid macOS version" do
-      string_version = described_class.new("11")
+      string_version = klass.new("11")
       expect(string_version).to eq(:big_sur)
     end
   end
@@ -75,12 +77,12 @@ RSpec.describe MacOSVersion do
     # We're explicitly testing the `===` operator results here.
     expect(version).to be === Version.new("10.15") # rubocop:disable Style/CaseEquality
     expect(version).to be < Version.new("11")
-    expect(described_class.new("11").inspect).to eq("#<MacOSVersion: \"11\">")
-    expect(described_class.new(described_class::SYMBOLS.values.first).outdated_release?).to be false
-    expect(described_class.new("10.0").outdated_release?).to be true
-    expect(described_class.new("1000").prerelease?).to be true
-    expect(described_class.new("10.0").unsupported_release?).to be true
-    expect(described_class.new("1000").unsupported_release?).to be true
+    expect(klass.new("11").inspect).to eq("#<MacOSVersion: \"11\">")
+    expect(klass.new(klass::SYMBOLS.values.first).outdated_release?).to be false
+    expect(klass.new("10.0").outdated_release?).to be true
+    expect(klass.new("1000").prerelease?).to be true
+    expect(klass.new("10.0").unsupported_release?).to be true
+    expect(klass.new("1000").unsupported_release?).to be true
   end
 
   describe "after Big Sur" do
@@ -100,12 +102,12 @@ RSpec.describe MacOSVersion do
   end
 
   describe "#strip_patch" do
-    let(:catalina_update) { described_class.new("10.15.1") }
+    let(:catalina_update) { klass.new("10.15.1") }
 
     specify do
-      expect(big_sur_update.strip_patch).to eq(described_class.new("11"))
-      expect(catalina_update.strip_patch).to eq(described_class.new("10.15"))
-      expect(described_class::NULL.strip_patch).to be described_class::NULL
+      expect(big_sur_update.strip_patch).to eq(klass.new("11"))
+      expect(catalina_update.strip_patch).to eq(klass.new("10.15"))
+      expect(klass::NULL.strip_patch).to be klass::NULL
     end
   end
 
@@ -121,13 +123,13 @@ RSpec.describe MacOSVersion do
     expect(frozen_version.to_sym).to eq(version_symbol)
     expect(frozen_version.instance_variable_get(:@sym)).to be_nil
 
-    expect(described_class::NULL.to_sym).to eq(:dunno)
+    expect(klass::NULL.to_sym).to eq(:dunno)
   end
 
   specify "#pretty_name" do
     version_pretty_name = "Catalina"
 
-    expect(described_class.new("11").pretty_name).to eq("Big Sur")
+    expect(klass.new("11").pretty_name).to eq("Big Sur")
 
     # We call this more than once to exercise the caching logic
     expect(version.pretty_name).to eq(version_pretty_name)
@@ -143,20 +145,20 @@ RSpec.describe MacOSVersion do
     context "when CPU is Intel" do
       it "returns true if version requires a Nehalem CPU" do
         allow(Hardware::CPU).to receive(:type).and_return(:intel)
-        expect(described_class.new("10.15").requires_nehalem_cpu?).to be true
+        expect(klass.new("10.15").requires_nehalem_cpu?).to be true
       end
     end
 
     context "when CPU is not Intel" do
       it "raises an error" do
         allow(Hardware::CPU).to receive(:type).and_return(:arm)
-        expect { described_class.new("10.15").requires_nehalem_cpu? }
+        expect { klass.new("10.15").requires_nehalem_cpu? }
           .to raise_error(ArgumentError)
       end
     end
 
     it "returns false when version is null" do
-      expect(described_class::NULL.requires_nehalem_cpu?).to be false
+      expect(klass::NULL.requires_nehalem_cpu?).to be false
     end
   end
 end

--- a/Library/Homebrew/test/manpages_spec.rb
+++ b/Library/Homebrew/test/manpages_spec.rb
@@ -33,8 +33,10 @@ RSpec.describe Homebrew::Manpages do
   end
 
   it "lists options under the root command and matching subcommands", :aggregate_failures do
-    root_section, install_and_info_sections = described_class.cmd_parser_manpage_lines(subcommand_parser).join
-                                                             .split("`test install`:")
+    root_section, install_and_info_sections = Homebrew::Manpages
+                                              .cmd_parser_manpage_lines(subcommand_parser)
+                                              .join
+                                              .split("`test install`:")
     install_section, info_section = install_and_info_sections.split("`test info` <service>:")
 
     expect(root_section).to include("`--global`")

--- a/Library/Homebrew/test/mcp_server_spec.rb
+++ b/Library/Homebrew/test/mcp_server_spec.rb
@@ -6,10 +6,12 @@ require "stringio"
 require "timeout"
 
 RSpec.describe Homebrew::McpServer do
+  let(:klass) { Homebrew::McpServer }
+
   let(:stdin) { StringIO.new }
   let(:stdout) { StringIO.new }
   let(:stderr) { StringIO.new }
-  let(:server) { described_class.new(stdin:, stdout:, stderr:) }
+  let(:server) { klass.new(stdin:, stdout:, stderr:) }
   let(:jsonrpc) { Homebrew::McpServer::JSON_RPC_VERSION }
   let(:id) { Random.rand(1000) }
   let(:code) { Homebrew::McpServer::ERROR_CODE }

--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -5,7 +5,9 @@ require "messages"
 require "spec_helper"
 
 RSpec.describe Messages do
-  let(:messages) { described_class.new }
+  let(:klass) { Messages }
+
+  let(:messages) { klass.new }
   let(:test_formula) { formula("foo") { url("https://brew.sh/foo-0.1.tgz") } }
   let(:elapsed_time) { 1.1 }
 

--- a/Library/Homebrew/test/migrator_spec.rb
+++ b/Library/Homebrew/test/migrator_spec.rb
@@ -7,16 +7,14 @@ require "tab"
 require "keg"
 
 RSpec.describe Migrator do
-  subject(:migrator) { described_class.new(new_formula, old_formula.name) }
+  subject(:migrator) { klass.new(new_formula, old_formula.name) }
 
+  let(:klass) { Migrator }
   let(:new_formula) { Testball.new("newname") }
   let(:old_formula) { Testball.new("oldname") }
-
   let(:new_keg_record) { HOMEBREW_CELLAR/"newname/0.1" }
   let(:old_keg_record) { HOMEBREW_CELLAR/"oldname/0.1" }
-
   let(:old_tab) { Tab.empty }
-
   let(:keg) { Keg.new(old_keg_record) }
   let(:old_pin) { HOMEBREW_PINNED_KEGS/"oldname" }
 
@@ -61,7 +59,7 @@ RSpec.describe Migrator do
   describe "::new" do
     it "raises an error if there is no old path" do
       expect do
-        described_class.new(new_formula, "oldname")
+        klass.new(new_formula, "oldname")
       end.to raise_error(Migrator::MigratorNoOldpathError)
     end
 
@@ -74,7 +72,7 @@ RSpec.describe Migrator do
       tab.write
 
       expect do
-        described_class.new(new_formula, "oldname")
+        klass.new(new_formula, "oldname")
       end.to raise_error(Migrator::MigratorDifferentTapsError)
     end
   end
@@ -210,7 +208,7 @@ RSpec.describe Migrator do
     tab.tabfile = HOMEBREW_CELLAR/"oldname/0.1/INSTALL_RECEIPT.json"
     tab.source["path"] = "/should/be/the/same"
     tab.write
-    migrator = described_class.new(new_formula, "oldname")
+    migrator = klass.new(new_formula, "oldname")
     tab.tabfile.delete
     migrator.backup_old_tabs
     expect(Tab.for_keg(old_keg_record).source["path"]).to eq("/should/be/the/same")

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -4,8 +4,10 @@
 require "missing_formula"
 
 RSpec.describe Homebrew::MissingFormula do
+  let(:klass) { Homebrew::MissingFormula }
+
   describe "::reason" do
-    subject { described_class.reason("gem") }
+    subject { klass.reason("gem") }
 
     it { is_expected.not_to be_nil }
   end
@@ -18,24 +20,24 @@ RSpec.describe Homebrew::MissingFormula do
     end
 
     specify(:aggregate_failures) do
-      expect(described_class).to disallow("gem")
-      expect(described_class).to disallow("pip")
-      expect(described_class).to disallow("pil")
-      expect(described_class).to disallow("macruby")
-      expect(described_class).to disallow("lzma")
-      expect(described_class).to disallow("gsutil")
-      expect(described_class).to disallow("gfortran")
-      expect(described_class).to disallow("play")
-      expect(described_class).to disallow("haskell-platform")
-      expect(described_class).to disallow("mysqldump-secure")
-      expect(described_class).to disallow("ngrok")
+      expect(klass).to disallow("gem")
+      expect(klass).to disallow("pip")
+      expect(klass).to disallow("pil")
+      expect(klass).to disallow("macruby")
+      expect(klass).to disallow("lzma")
+      expect(klass).to disallow("gsutil")
+      expect(klass).to disallow("gfortran")
+      expect(klass).to disallow("play")
+      expect(klass).to disallow("haskell-platform")
+      expect(klass).to disallow("mysqldump-secure")
+      expect(klass).to disallow("ngrok")
     end
 
     it("disallows Xcode", :needs_macos) { is_expected.to disallow("xcode") }
   end
 
   describe "::tap_migration_reason" do
-    subject(:reason) { described_class.tap_migration_reason(formula) }
+    subject(:reason) { klass.tap_migration_reason(formula) }
 
     let(:migration_target) { "homebrew/bar" }
 
@@ -71,7 +73,7 @@ RSpec.describe Homebrew::MissingFormula do
   end
 
   describe "::deleted_reason" do
-    subject { described_class.deleted_reason(formula, silent: true) }
+    subject { klass.deleted_reason(formula, silent: true) }
 
     before do
       tap_path = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo"
@@ -115,7 +117,7 @@ RSpec.describe Homebrew::MissingFormula do
   end
 
   describe "::cask_reason", :cask do
-    subject(:reason) { described_class.cask_reason(formula, show_info:) }
+    subject(:reason) { klass.cask_reason(formula, show_info:) }
 
     context "with a formula name that is a cask and show_info: false" do
       let(:formula) { "local-caffeine" }
@@ -143,7 +145,7 @@ RSpec.describe Homebrew::MissingFormula do
   end
 
   describe "::suggest_command", :cask do
-    subject(:reason) { described_class.suggest_command(name, command) }
+    subject(:reason) { klass.suggest_command(name, command) }
 
     context "when installing" do
       let(:name) { "local-caffeine" }

--- a/Library/Homebrew/test/options/deprecated_option_spec.rb
+++ b/Library/Homebrew/test/options/deprecated_option_spec.rb
@@ -4,7 +4,9 @@
 require "options"
 
 RSpec.describe DeprecatedOption do
-  subject(:option) { described_class.new("foo", "bar") }
+  subject(:option) { klass.new("foo", "bar") }
+
+  let(:klass) { DeprecatedOption }
 
   specify do
     expect(option.old).to eq("foo")
@@ -14,8 +16,8 @@ RSpec.describe DeprecatedOption do
   end
 
   specify "equality" do
-    foobar = described_class.new("foo", "bar")
-    boofar = described_class.new("boo", "far")
+    foobar = klass.new("foo", "bar")
+    boofar = klass.new("boo", "far")
     expect(foobar).to eq(option)
     expect(option).to eq(foobar)
     expect(boofar).not_to eq(option)

--- a/Library/Homebrew/test/options/option_spec.rb
+++ b/Library/Homebrew/test/options/option_spec.rb
@@ -4,18 +4,20 @@
 require "options"
 
 RSpec.describe Option do
-  subject(:option) { described_class.new("foo") }
+  subject(:option) { klass.new("foo") }
+
+  let(:klass) { Option }
 
   specify do
     expect(option.to_s).to eq("--foo")
     expect(option.description).to be_empty
-    expect(described_class.new("foo", "foo").description).to eq("foo")
+    expect(klass.new("foo", "foo").description).to eq("foo")
     expect(option.inspect).to eq("#<Option: \"--foo\">")
   end
 
   specify "equality" do
-    foo = described_class.new("foo")
-    bar = described_class.new("bar")
+    foo = klass.new("foo")
+    bar = klass.new("bar")
     expect(option).to eq(foo)
     expect(option).not_to eq(bar)
     expect(option).to eql(foo)

--- a/Library/Homebrew/test/options_spec.rb
+++ b/Library/Homebrew/test/options_spec.rb
@@ -4,7 +4,9 @@
 require "options"
 
 RSpec.describe Options do
-  subject(:options) { described_class.new }
+  subject(:options) { klass.new }
+
+  let(:klass) { Options }
 
   it "removes duplicate options" do
     options << Option.new("foo")
@@ -31,26 +33,26 @@ RSpec.describe Options do
 
   describe "#+" do
     it "returns options" do
-      expect(options + described_class.new).to be_an_instance_of(described_class)
+      expect(options + klass.new).to be_an_instance_of(klass)
     end
   end
 
   describe "#-" do
     it "returns options" do
-      expect(options - described_class.new).to be_an_instance_of(described_class)
+      expect(options - klass.new).to be_an_instance_of(klass)
     end
   end
 
   specify "#&" do
     foo, bar, baz = %w[foo bar baz].map { |o| Option.new(o) }
-    other_options = described_class.new << foo << bar
+    other_options = klass.new << foo << bar
     options << foo << baz
     expect((options & other_options).to_a).to eq([foo])
   end
 
   specify "#|" do
     foo, bar, baz = %w[foo bar baz].map { |o| Option.new(o) }
-    other_options = described_class.new << foo << bar
+    other_options = klass.new << foo << bar
     options << foo << baz
     expect((options | other_options).sort).to eq([foo, bar, baz].sort)
   end
@@ -87,7 +89,7 @@ RSpec.describe Options do
     array = %w[--foo --bar]
     option1 = Option.new("foo")
     option2 = Option.new("bar")
-    expect(described_class.create(array).sort).to eq([option1, option2].sort)
+    expect(klass.create(array).sort).to eq([option1, option2].sort)
   end
 
   specify "#to_s" do

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -4,9 +4,11 @@
 require "dependency_collector"
 
 RSpec.describe DependencyCollector do
-  alias_matcher :be_a_build_requirement, :be_build
+  subject(:collector) { klass.new }
 
-  subject(:collector) { described_class.new }
+  let(:klass) { DependencyCollector }
+
+  alias_matcher :be_a_build_requirement, :be_build
 
   describe "#add" do
     let(:resource) { Resource.new }

--- a/Library/Homebrew/test/os/linux/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/linux/diagnostic_spec.rb
@@ -5,7 +5,9 @@ require "diagnostic"
 require "sandbox"
 
 RSpec.describe Homebrew::Diagnostic::Checks do
-  subject(:checks) { described_class.new }
+  subject(:checks) { klass.new }
+
+  let(:klass) { Homebrew::Diagnostic::Checks }
 
   specify "#check_supported_architecture" do
     allow(Hardware::CPU).to receive(:type).and_return(:arm64)

--- a/Library/Homebrew/test/os/linux/elf_spec.rb
+++ b/Library/Homebrew/test/os/linux/elf_spec.rb
@@ -2,13 +2,16 @@
 # frozen_string_literal: true
 
 RSpec.describe OS::Linux::Elf do
+  sig { returns(T.class_of(OS::Linux::Elf)) }
+  let(:klass) { OS::Linux::Elf }
+
   describe "::expand_elf_dst" do
     it "expands tokens that are not wrapped in curly braces" do
       str = "$ORIGIN/../lib"
       ref = "ORIGIN"
       repl = "/opt/homebrew/bin"
       expected = "/opt/homebrew/bin/../lib"
-      expect(described_class.expand_elf_dst(str, ref, repl)).to eq(expected)
+      expect(klass.expand_elf_dst(str, ref, repl)).to eq(expected)
     end
 
     it "expands tokens that are wrapped in curly braces" do
@@ -16,13 +19,13 @@ RSpec.describe OS::Linux::Elf do
       ref = "ORIGIN"
       repl = "/opt/homebrew/bin"
       expected = "/opt/homebrew/bin/../lib"
-      expect(described_class.expand_elf_dst(str, ref, repl)).to eq(expected)
+      expect(klass.expand_elf_dst(str, ref, repl)).to eq(expected)
 
       str = "${ORIGIN}new/../lib"
       ref = "ORIGIN"
       repl = "/opt/homebrew/bin"
       expected = "/opt/homebrew/binnew/../lib"
-      expect(described_class.expand_elf_dst(str, ref, repl)).to eq(expected)
+      expect(klass.expand_elf_dst(str, ref, repl)).to eq(expected)
     end
 
     it "expands multiple occurrences of token" do
@@ -30,7 +33,7 @@ RSpec.describe OS::Linux::Elf do
       ref = "ORIGIN"
       repl = "/opt/homebrew/bin"
       expected = "/opt/homebrew/bin/../../opt/homebrew/bin/../lib"
-      expect(described_class.expand_elf_dst(str, ref, repl)).to eq(expected)
+      expect(klass.expand_elf_dst(str, ref, repl)).to eq(expected)
     end
 
     it "rejects and passes through tokens containing additional characters" do
@@ -38,37 +41,37 @@ RSpec.describe OS::Linux::Elf do
       ref = "ORIGIN"
       repl = "/opt/homebrew/bin"
       expected = "$ORIGINAL/../lib"
-      expect(described_class.expand_elf_dst(str, ref, repl)).to eq(expected)
+      expect(klass.expand_elf_dst(str, ref, repl)).to eq(expected)
 
       str = "$ORIGIN_/../lib"
       ref = "ORIGIN"
       repl = "/opt/homebrew/bin"
       expected = "$ORIGIN_/../lib"
-      expect(described_class.expand_elf_dst(str, ref, repl)).to eq(expected)
+      expect(klass.expand_elf_dst(str, ref, repl)).to eq(expected)
 
       str = "$ORIGIN_STORY/../lib"
       ref = "ORIGIN"
       repl = "/opt/homebrew/bin"
       expected = "$ORIGIN_STORY/../lib"
-      expect(described_class.expand_elf_dst(str, ref, repl)).to eq(expected)
+      expect(klass.expand_elf_dst(str, ref, repl)).to eq(expected)
 
       str = "${ORIGINAL}/../lib"
       ref = "ORIGIN"
       repl = "/opt/homebrew/bin"
       expected = "${ORIGINAL}/../lib"
-      expect(described_class.expand_elf_dst(str, ref, repl)).to eq(expected)
+      expect(klass.expand_elf_dst(str, ref, repl)).to eq(expected)
 
       str = "${ORIGIN_}/../lib"
       ref = "ORIGIN"
       repl = "/opt/homebrew/bin"
       expected = "${ORIGIN_}/../lib"
-      expect(described_class.expand_elf_dst(str, ref, repl)).to eq(expected)
+      expect(klass.expand_elf_dst(str, ref, repl)).to eq(expected)
 
       str = "${ORIGIN_STORY}/../lib"
       ref = "ORIGIN"
       repl = "/opt/homebrew/bin"
       expected = "${ORIGIN_STORY}/../lib"
-      expect(described_class.expand_elf_dst(str, ref, repl)).to eq(expected)
+      expect(klass.expand_elf_dst(str, ref, repl)).to eq(expected)
     end
 
     it "rejects and passes through tokens with mismatched curly braces" do
@@ -76,13 +79,13 @@ RSpec.describe OS::Linux::Elf do
       ref = "ORIGIN"
       repl = "/opt/homebrew/bin"
       expected = "${ORIGIN/../lib"
-      expect(described_class.expand_elf_dst(str, ref, repl)).to eq(expected)
+      expect(klass.expand_elf_dst(str, ref, repl)).to eq(expected)
 
       str = "$ORIGIN}/../lib"
       ref = "ORIGIN"
       repl = "/opt/homebrew/bin"
       expected = "$ORIGIN}/../lib"
-      expect(described_class.expand_elf_dst(str, ref, repl)).to eq(expected)
+      expect(klass.expand_elf_dst(str, ref, repl)).to eq(expected)
     end
   end
 end

--- a/Library/Homebrew/test/os/linux/formula_installer_spec.rb
+++ b/Library/Homebrew/test/os/linux/formula_installer_spec.rb
@@ -5,12 +5,14 @@ require "formula_installer"
 require "test/support/fixtures/testball"
 
 RSpec.describe FormulaInstaller do
+  subject(:keg) { klass.new(keg_path) }
+
+  let(:klass) { FormulaInstaller }
+
   include FileUtils
 
-  subject(:keg) { described_class.new(keg_path) }
-
   describe "#fresh_install" do
-    subject(:formula_installer) { described_class.new(Testball.new) }
+    subject(:formula_installer) { klass.new(Testball.new) }
 
     it "is true by default" do
       formula = Testball.new

--- a/Library/Homebrew/test/os/linux/ld_spec.rb
+++ b/Library/Homebrew/test/os/linux/ld_spec.rb
@@ -5,6 +5,8 @@ require "os/linux/ld"
 require "tmpdir"
 
 RSpec.describe OS::Linux::Ld do
+  let(:klass) { OS::Linux::Ld }
+
   let(:diagnostics) do
     <<~EOS
       path.prefix="/usr"
@@ -19,44 +21,44 @@ RSpec.describe OS::Linux::Ld do
 
     before do
       allow(File).to receive(:executable?).and_return(false)
-      described_class.instance_variable_set(:@system_ld_so, nil)
+      klass.instance_variable_set(:@system_ld_so, nil)
     end
 
     it "returns the path to a known dynamic linker" do
       allow(File).to receive(:executable?).with(ld_so).and_return(true)
-      expect(described_class.system_ld_so).to eq(Pathname(ld_so))
+      expect(klass.system_ld_so).to eq(Pathname(ld_so))
     end
 
     it "returns nil when there is no known dynamic linker" do
-      expect(described_class.system_ld_so).to be_nil
+      expect(klass.system_ld_so).to be_nil
     end
   end
 
   describe "::sysconfdir" do
     it "returns path.sysconfdir" do
-      allow(described_class).to receive(:ld_so_diagnostics).and_return(diagnostics)
-      expect(described_class.sysconfdir).to eq("/usr/local/etc")
-      expect(described_class.sysconfdir(brewed: false)).to eq("/usr/local/etc")
+      allow(klass).to receive(:ld_so_diagnostics).and_return(diagnostics)
+      expect(klass.sysconfdir).to eq("/usr/local/etc")
+      expect(klass.sysconfdir(brewed: false)).to eq("/usr/local/etc")
     end
 
     it "returns fallback on blank diagnostics" do
-      allow(described_class).to receive(:ld_so_diagnostics).and_return("")
-      expect(described_class.sysconfdir).to eq("/etc")
-      expect(described_class.sysconfdir(brewed: false)).to eq("/etc")
+      allow(klass).to receive(:ld_so_diagnostics).and_return("")
+      expect(klass.sysconfdir).to eq("/etc")
+      expect(klass.sysconfdir(brewed: false)).to eq("/etc")
     end
   end
 
   describe "::system_dirs" do
     it "returns all path.system_dirs" do
-      allow(described_class).to receive(:ld_so_diagnostics).and_return(diagnostics)
-      expect(described_class.system_dirs).to eq(["/lib64", "/var/lib"])
-      expect(described_class.system_dirs(brewed: false)).to eq(["/lib64", "/var/lib"])
+      allow(klass).to receive(:ld_so_diagnostics).and_return(diagnostics)
+      expect(klass.system_dirs).to eq(["/lib64", "/var/lib"])
+      expect(klass.system_dirs(brewed: false)).to eq(["/lib64", "/var/lib"])
     end
 
     it "returns an empty array on blank diagnostics" do
-      allow(described_class).to receive(:ld_so_diagnostics).and_return("")
-      expect(described_class.system_dirs).to eq([])
-      expect(described_class.system_dirs(brewed: false)).to eq([])
+      allow(klass).to receive(:ld_so_diagnostics).and_return("")
+      expect(klass.system_dirs).to eq([])
+      expect(klass.system_dirs(brewed: false)).to eq([])
     end
   end
 
@@ -97,7 +99,7 @@ RSpec.describe OS::Linux::Ld do
     end
 
     it "parses library paths successfully" do
-      expect(described_class.library_paths(ld_etc/"ld.so.conf")).to eq(%w[/foo/bar /baz/qux /g/h/i /a/b/c /d/e/f])
+      expect(klass.library_paths(ld_etc/"ld.so.conf")).to eq(%w[/foo/bar /baz/qux /g/h/i /a/b/c /d/e/f])
     end
   end
 end

--- a/Library/Homebrew/test/os/linux/libstdcxx_spec.rb
+++ b/Library/Homebrew/test/os/linux/libstdcxx_spec.rb
@@ -4,27 +4,29 @@
 require "os/linux/libstdcxx"
 
 RSpec.describe OS::Linux::Libstdcxx do
+  let(:klass) { OS::Linux::Libstdcxx }
+
   describe "::below_ci_version?" do
     it "returns false when system version matches CI version" do
-      allow(described_class).to receive(:system_version).and_return(Version.new(OS::LINUX_LIBSTDCXX_CI_VERSION))
-      expect(described_class.below_ci_version?).to be false
+      allow(klass).to receive(:system_version).and_return(Version.new(OS::LINUX_LIBSTDCXX_CI_VERSION))
+      expect(klass.below_ci_version?).to be false
     end
 
     it "returns true when system version cannot be detected" do
-      allow(described_class).to receive(:system_version).and_return(Version::NULL)
-      expect(described_class.below_ci_version?).to be true
+      allow(klass).to receive(:system_version).and_return(Version::NULL)
+      expect(klass.below_ci_version?).to be true
     end
   end
 
   describe "::system_version" do
     let(:tmpdir) { mktmpdir }
-    let(:libstdcxx) { tmpdir/described_class::SONAME }
-    let(:soversion) { Version.new(described_class::SOVERSION.to_s) }
+    let(:libstdcxx) { tmpdir/klass::SONAME }
+    let(:soversion) { Version.new(klass::SOVERSION.to_s) }
 
     before do
       tmpdir.mkpath
-      described_class.instance_variable_set(:@system_version, nil)
-      allow(described_class).to receive(:system_path).and_return(libstdcxx)
+      klass.instance_variable_set(:@system_version, nil)
+      allow(klass).to receive(:system_path).and_return(libstdcxx)
     end
 
     after do
@@ -32,8 +34,8 @@ RSpec.describe OS::Linux::Libstdcxx do
     end
 
     it "returns NULL when unable to find system path" do
-      allow(described_class).to receive(:system_path).and_return(nil)
-      expect(described_class.system_version).to be Version::NULL
+      allow(klass).to receive(:system_path).and_return(nil)
+      expect(klass.system_version).to be Version::NULL
     end
 
     it "returns full version from filename" do
@@ -41,19 +43,19 @@ RSpec.describe OS::Linux::Libstdcxx do
       libstdcxx_real = libstdcxx.sub_ext(".#{full_version}")
       FileUtils.touch libstdcxx_real
       FileUtils.ln_s libstdcxx_real, libstdcxx
-      expect(described_class.system_version).to eq full_version
+      expect(klass.system_version).to eq full_version
     end
 
     it "returns major version when non-standard libstdc++ filename without full version" do
       FileUtils.touch libstdcxx
-      expect(described_class.system_version).to eq soversion
+      expect(klass.system_version).to eq soversion
     end
 
     it "returns major version when non-standard libstdc++ filename with unexpected realpath" do
       libstdcxx_real = tmpdir/"libstdc++.so.real"
       FileUtils.touch libstdcxx_real
       FileUtils.ln_s libstdcxx_real, libstdcxx
-      expect(described_class.system_version).to eq soversion
+      expect(klass.system_version).to eq soversion
     end
   end
 end

--- a/Library/Homebrew/test/os/linux_spec.rb
+++ b/Library/Homebrew/test/os/linux_spec.rb
@@ -5,33 +5,35 @@ require "locale"
 require "os/linux"
 
 RSpec.describe OS::Linux do
+  let(:klass) { OS::Linux }
+
   describe "::languages", :needs_linux do
     it "returns a list of all languages" do
-      expect(described_class.languages).not_to be_empty
+      expect(klass.languages).not_to be_empty
     end
   end
 
   describe "::language", :needs_linux do
     it "returns the first item from #languages" do
-      expect(described_class.language).to eq(described_class.languages.first)
+      expect(klass.language).to eq(klass.languages.first)
     end
   end
 
   describe "::'os_version'", :needs_linux do
     it "returns the OS version" do
-      expect(described_class.os_version).not_to be_empty
+      expect(klass.os_version).not_to be_empty
     end
   end
 
   describe "::'wsl?'" do
     it "returns the WSL state" do
-      expect(described_class.wsl?).to be(false)
+      expect(klass.wsl?).to be(false)
     end
   end
 
   describe "::'wsl_version'", :needs_linux do
     it "returns the WSL version" do
-      expect(described_class.wsl_version).to match(Version::NULL)
+      expect(klass.wsl_version).to match(Version::NULL)
     end
   end
 end

--- a/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
@@ -4,9 +4,11 @@
 require "dependency_collector"
 
 RSpec.describe DependencyCollector do
-  alias_matcher :need_tar_xz_dependency, :be_tar_needs_xz_dependency
+  subject(:collector) { klass.new }
 
-  subject(:collector) { described_class.new }
+  let(:klass) { DependencyCollector }
+
+  alias_matcher :need_tar_xz_dependency, :be_tar_needs_xz_dependency
 
   specify "Resource dependency from a '.xz' URL" do
     resource = Resource.new

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -4,7 +4,9 @@
 require "diagnostic"
 
 RSpec.describe Homebrew::Diagnostic::Checks do
-  subject(:checks) { described_class.new }
+  subject(:checks) { klass.new }
+
+  let(:klass) { Homebrew::Diagnostic::Checks }
 
   specify "#check_for_unsupported_macos" do
     ENV.delete("HOMEBREW_DEVELOPER")

--- a/Library/Homebrew/test/os/mac/formula_installer_spec.rb
+++ b/Library/Homebrew/test/os/mac/formula_installer_spec.rb
@@ -5,12 +5,14 @@ require "formula_installer"
 require "test/support/fixtures/testball"
 
 RSpec.describe FormulaInstaller do
+  subject(:keg) { klass.new(keg_path) }
+
+  let(:klass) { FormulaInstaller }
+
   include FileUtils
 
-  subject(:keg) { described_class.new(keg_path) }
-
   describe "#fresh_install" do
-    subject(:formula_installer) { described_class.new(Testball.new) }
+    subject(:formula_installer) { klass.new(Testball.new) }
 
     it "is true by default" do
       formula = Testball.new

--- a/Library/Homebrew/test/os/mac/keg_spec.rb
+++ b/Library/Homebrew/test/os/mac/keg_spec.rb
@@ -4,9 +4,11 @@
 require "keg"
 
 RSpec.describe Keg do
-  include FileUtils
+  subject(:keg) { klass.new(keg_path) }
 
-  subject(:keg) { described_class.new(keg_path) }
+  let(:klass) { Keg }
+
+  include FileUtils
 
   describe "#mach_o_files" do
     let(:keg_path) { HOMEBREW_CELLAR/"a/1.0" }

--- a/Library/Homebrew/test/os/mac/reinstall_spec.rb
+++ b/Library/Homebrew/test/os/mac/reinstall_spec.rb
@@ -5,25 +5,27 @@ require "reinstall"
 require "extend/os/mac/pkgconf"
 
 RSpec.describe Homebrew::Reinstall do
+  let(:klass) { Homebrew::Reinstall }
+
   describe ".reinstall_pkgconf_if_needed!" do
     let(:formula) { instance_double(Formula) }
     let(:formula_installer) do
       instance_double(FormulaInstaller, formula:, prelude_fetch: true, prelude: true, fetch: true)
     end
-    let(:context) { instance_double(described_class::InstallationContext, formula_installer:) }
+    let(:context) { instance_double(klass::InstallationContext, formula_installer:) }
 
     before do
       allow(Formula).to receive(:[]).with("pkgconf").and_return(formula)
       allow(Homebrew::Install).to receive(:fetch_formulae).with([formula_installer])
-      allow(described_class).to receive(:build_install_context).and_return(context)
+      allow(klass).to receive(:build_install_context).and_return(context)
     end
 
     context "when there is no macOS SDK mismatch" do
       it "does nothing" do
         allow(Homebrew::Pkgconf).to receive(:macos_sdk_mismatch).and_return(nil)
-        expect(described_class).not_to receive(:reinstall_formula)
+        expect(klass).not_to receive(:reinstall_formula)
 
-        described_class.reinstall_pkgconf_if_needed!
+        klass.reinstall_pkgconf_if_needed!
       end
     end
 
@@ -33,20 +35,20 @@ RSpec.describe Homebrew::Reinstall do
           macos_sdk_mismatch:       :mismatch,
           mismatch_warning_message: "warning",
         )
-        expect(described_class).not_to receive(:reinstall_formula)
-        expect(described_class).to receive(:opoo).with(/would be reinstalled/)
+        expect(klass).not_to receive(:reinstall_formula)
+        expect(klass).to receive(:opoo).with(/would be reinstalled/)
 
-        described_class.reinstall_pkgconf_if_needed!(dry_run: true)
+        klass.reinstall_pkgconf_if_needed!(dry_run: true)
       end
     end
 
     context "when there is a mismatch and reinstall succeeds" do
       it "reinstalls pkgconf and prints success" do
         allow(Homebrew::Pkgconf).to receive(:macos_sdk_mismatch).and_return(:mismatch)
-        expect(described_class).to receive(:reinstall_formula).with(context)
-        expect(described_class).to receive(:ohai).with(/Reinstalled pkgconf/)
+        expect(klass).to receive(:reinstall_formula).with(context)
+        expect(klass).to receive(:ohai).with(/Reinstalled pkgconf/)
 
-        described_class.reinstall_pkgconf_if_needed!
+        klass.reinstall_pkgconf_if_needed!
       end
     end
 
@@ -56,11 +58,11 @@ RSpec.describe Homebrew::Reinstall do
           macos_sdk_mismatch:       :mismatch,
           mismatch_warning_message: "warning",
         )
-        allow(described_class).to receive(:reinstall_formula).and_raise(RuntimeError)
+        allow(klass).to receive(:reinstall_formula).and_raise(RuntimeError)
 
-        expect(described_class).to receive(:ofail).with("warning")
+        expect(klass).to receive(:ofail).with("warning")
 
-        described_class.reinstall_pkgconf_if_needed!
+        klass.reinstall_pkgconf_if_needed!
       end
     end
   end

--- a/Library/Homebrew/test/os/mac/sdk_spec.rb
+++ b/Library/Homebrew/test/os/mac/sdk_spec.rb
@@ -2,8 +2,9 @@
 # frozen_string_literal: true
 
 RSpec.describe OS::Mac::CLTSDKLocator do
-  subject(:locator) { described_class.new }
+  subject(:locator) { klass.new }
 
+  let(:klass) { OS::Mac::CLTSDKLocator }
   let(:big_sur_sdk) { OS::Mac::SDK.new(MacOSVersion.new("11"), "/some/path/MacOSX.sdk", :clt) }
   let(:catalina_sdk) { OS::Mac::SDK.new(MacOSVersion.new("10.15"), "/some/path/MacOSX10.15.sdk", :clt) }
 
@@ -12,7 +13,7 @@ RSpec.describe OS::Mac::CLTSDKLocator do
 
     expect(locator.sdk_for(MacOSVersion.new("11"))).to eq(big_sur_sdk)
     expect(locator.sdk_for(MacOSVersion.new("10.15"))).to eq(catalina_sdk)
-    expect { locator.sdk_for(MacOSVersion.new("10.14")) }.to raise_error(described_class::NoSDKError)
+    expect { locator.sdk_for(MacOSVersion.new("10.14")) }.to raise_error(klass::NoSDKError)
   end
 
   describe "#sdk_if_applicable" do

--- a/Library/Homebrew/test/os/mac_spec.rb
+++ b/Library/Homebrew/test/os/mac_spec.rb
@@ -5,15 +5,17 @@ require "locale"
 require "os/mac"
 
 RSpec.describe OS::Mac do
+  let(:klass) { OS::Mac }
+
   describe "::languages" do
     it "returns a list of all languages" do
-      expect(described_class.languages).not_to be_empty
+      expect(klass.languages).not_to be_empty
     end
   end
 
   describe "::language" do
     it "returns the first item from #languages" do
-      expect(described_class.language).to eq(described_class.languages.first)
+      expect(klass.language).to eq(klass.languages.first)
     end
   end
 
@@ -31,13 +33,13 @@ RSpec.describe OS::Mac do
     it "returns the Xcode SDK path on Xcode-only systems" do
       allow(OS::Mac::Xcode).to receive(:installed?).and_return(true)
       allow(OS::Mac::CLT).to receive(:installed?).and_return(false)
-      expect(described_class.sdk_path).to eq(xcode_sdk_path)
+      expect(klass.sdk_path).to eq(xcode_sdk_path)
     end
 
     it "returns the CLT SDK path on CLT-only systems" do
       allow(OS::Mac::Xcode).to receive(:installed?).and_return(false)
       allow(OS::Mac::CLT).to receive(:installed?).and_return(true)
-      expect(described_class.sdk_path).to eq(clt_sdk_path)
+      expect(klass.sdk_path).to eq(clt_sdk_path)
     end
   end
 end

--- a/Library/Homebrew/test/os/os_spec.rb
+++ b/Library/Homebrew/test/os/os_spec.rb
@@ -2,19 +2,21 @@
 # frozen_string_literal: true
 
 RSpec.describe OS do
+  let(:klass) { OS }
+
   describe "::kernel_version" do
     it "is not NULL" do
-      expect(described_class.kernel_version).not_to be_null
+      expect(klass.kernel_version).not_to be_null
     end
   end
 
   describe "::kernel_name" do
     it "returns Linux on Linux", :needs_linux do
-      expect(described_class.kernel_name).to eq "Linux"
+      expect(klass.kernel_name).to eq "Linux"
     end
 
     it "returns Darwin on macOS", :needs_macos do
-      expect(described_class.kernel_name).to eq "Darwin"
+      expect(klass.kernel_name).to eq "Darwin"
     end
   end
 end

--- a/Library/Homebrew/test/os_spec.rb
+++ b/Library/Homebrew/test/os_spec.rb
@@ -4,11 +4,13 @@
 require "os"
 
 RSpec.describe OS do
+  let(:klass) { OS }
+
   it "detects nix-homebrew from its repository" do
     stub_const("HOMEBREW_REPOSITORY", HOMEBREW_PREFIX/"Library/.homebrew-is-managed-by-nix")
 
-    expect(described_class.nix_managed_homebrew?).to be(true)
-    expect(described_class.nix_managed_homebrew_issues_url)
+    expect(klass.nix_managed_homebrew?).to be(true)
+    expect(klass.nix_managed_homebrew_issues_url)
       .to eq("https://github.com/zhaofengli/nix-homebrew/issues")
   end
 
@@ -19,7 +21,7 @@ RSpec.describe OS do
 
       (prefix/".managed_by_nix_darwin").write("")
 
-      expect(described_class.nix_managed_homebrew?).to be(true)
+      expect(klass.nix_managed_homebrew?).to be(true)
     end
   end
 
@@ -32,7 +34,7 @@ RSpec.describe OS do
       ENV["HOMEBREW_UPDATE_BEFORE"] = "nix"
       ENV["HOMEBREW_UPDATE_AFTER"] = "nix"
 
-      expect(described_class.nix_managed_homebrew?).to be(true)
+      expect(klass.nix_managed_homebrew?).to be(true)
     end
   ensure
     ENV["HOMEBREW_UPDATE_BEFORE"] = old_update_before
@@ -45,8 +47,8 @@ RSpec.describe OS do
       stub_const("HOMEBREW_REPOSITORY", prefix/"Library/Homebrew")
       stub_const("ARGV", ["bundle", "--file=/nix/store/example-Brewfile"])
 
-      expect(described_class.nix_managed_homebrew?).to be(true)
-      expect(described_class.nix_managed_homebrew_issues_url)
+      expect(klass.nix_managed_homebrew?).to be(true)
+      expect(klass.nix_managed_homebrew_issues_url)
         .to eq("https://github.com/nix-darwin/nix-darwin/issues")
     end
   end

--- a/Library/Homebrew/test/patch_spec.rb
+++ b/Library/Homebrew/test/patch_spec.rb
@@ -4,9 +4,11 @@
 require "patch"
 
 RSpec.describe Patch do
+  let(:klass) { Patch }
+
   describe "#create" do
     context "with a simple patch" do
-      subject(:patch) { described_class.create(:p2, nil) }
+      subject(:patch) { klass.create(:p2, nil) }
 
       specify(:aggregate_failures) do
         expect(patch).to be_a ExternalPatch
@@ -17,35 +19,35 @@ RSpec.describe Patch do
     end
 
     context "with a string patch" do
-      subject(:patch) { described_class.create(:p0, "foo") }
+      subject(:patch) { klass.create(:p0, "foo") }
 
       it { is_expected.to be_a StringPatch }
       it(:strip) { expect(patch.strip).to eq(:p0) }
     end
 
     context "with a string patch without strip" do
-      subject(:patch) { described_class.create("foo", nil) }
+      subject(:patch) { klass.create("foo", nil) }
 
       it { is_expected.to be_a StringPatch }
       it(:strip) { expect(patch.strip).to eq(:p1) }
     end
 
     context "with a data patch" do
-      subject(:patch) { described_class.create(:p0, :DATA) }
+      subject(:patch) { klass.create(:p0, :DATA) }
 
       it { is_expected.to be_a DATAPatch }
       it(:strip) { expect(patch.strip).to eq(:p0) }
     end
 
     context "with a data patch without strip" do
-      subject(:patch) { described_class.create(:DATA, nil) }
+      subject(:patch) { klass.create(:DATA, nil) }
 
       it { is_expected.to be_a DATAPatch }
       it(:strip) { expect(patch.strip).to eq(:p1) }
     end
 
     context "with a local file patch" do
-      subject(:patch) { described_class.create(:p0, nil) { file "Patches/foo.diff" } }
+      subject(:patch) { klass.create(:p0, nil) { file "Patches/foo.diff" } }
 
       specify(:aggregate_failures) do
         expect(patch).to be_a LocalPatch
@@ -58,43 +60,43 @@ RSpec.describe Patch do
 
     it "rejects blank local file patch paths" do
       expect do
-        described_class.create(:p1, nil) { file "" }
+        klass.create(:p1, nil) { file "" }
       end.to raise_error(ArgumentError, "Patch file must be a relative path within the repository.")
     end
 
     it "rejects current directory local file patch paths" do
       expect do
-        described_class.create(:p1, nil) { file "." }
+        klass.create(:p1, nil) { file "." }
       end.to raise_error(ArgumentError, "Patch file must be a relative path within the repository.")
     end
 
     it "rejects parent directory local file patch paths" do
       expect do
-        described_class.create(:p1, nil) { file ".." }
+        klass.create(:p1, nil) { file ".." }
       end.to raise_error(ArgumentError, "Patch file must be a relative path within the repository.")
     end
 
     it "rejects local file patch paths ending in a slash" do
       expect do
-        described_class.create(:p1, nil) { file "Patches/" }
+        klass.create(:p1, nil) { file "Patches/" }
       end.to raise_error(ArgumentError, "Patch file must be a relative path within the repository.")
     end
 
     it "rejects local file patches outside the repository" do
       expect do
-        described_class.create(:p1, nil) { file "../foo.diff" }
+        klass.create(:p1, nil) { file "../foo.diff" }
       end.to raise_error(ArgumentError, "Patch file must be a relative path within the repository.")
     end
 
     it "rejects absolute local file patches" do
       expect do
-        described_class.create(:p1, nil) { file "/tmp/foo.diff" }
+        klass.create(:p1, nil) { file "/tmp/foo.diff" }
       end.to raise_error(ArgumentError, "Patch file must be a relative path within the repository.")
     end
 
     it "rejects local file patches with URLs" do
       expect do
-        described_class.create(:p1, nil) do
+        klass.create(:p1, nil) do
           file "Patches/foo.diff"
           url "https://brew.sh/foo.diff"
         end
@@ -103,7 +105,7 @@ RSpec.describe Patch do
 
     it "rejects local file patches with sha256" do
       expect do
-        described_class.create(:p1, nil) do
+        klass.create(:p1, nil) do
           file "Patches/foo.diff"
           sha256 "63376b8fdd6613a91976106d9376069274191860cd58f039b29ff16de1925621"
         end
@@ -112,7 +114,7 @@ RSpec.describe Patch do
 
     it "rejects local file patches with directory" do
       expect do
-        described_class.create(:p1, nil) do
+        klass.create(:p1, nil) do
           file "Patches/foo.diff"
           directory "subdir"
         end
@@ -121,7 +123,7 @@ RSpec.describe Patch do
 
     it "rejects local file patches with apply" do
       expect do
-        described_class.create(:p1, nil) do
+        klass.create(:p1, nil) do
           file "Patches/foo.diff"
           apply "foo.diff"
         end
@@ -130,7 +132,7 @@ RSpec.describe Patch do
   end
 
   describe "#patch_files" do
-    subject(:patch) { described_class.create(:p2, nil) }
+    subject(:patch) { klass.create(:p2, nil) }
 
     context "when the patch is empty" do
       it(:resource) { expect(patch.resource).to be_a Resource::Patch }
@@ -157,7 +159,9 @@ RSpec.describe Patch do
   end
 
   describe ExternalPatch do
-    subject(:patch) { described_class.new(:p1) { url "file:///my.patch" } }
+    subject(:patch) { klass.new(:p1) { url "file:///my.patch" } }
+
+    let(:klass) { ExternalPatch }
 
     describe "#url" do
       it(:url) { expect(patch.url).to eq("file:///my.patch") }

--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -5,12 +5,13 @@ require "extend/pathname"
 require "install_renamed"
 
 RSpec.describe Pathname do
-  include FileUtils
-
+  let(:klass) { Pathname }
   let(:src) { mktmpdir }
   let(:dst) { mktmpdir }
   let(:file) { src/"foo" }
   let(:dir) { src/"bar" }
+
+  include FileUtils
 
   describe EagerInitializeExtension do
     it "defines the lazy memoised ivars on every new Pathname" do
@@ -133,12 +134,12 @@ RSpec.describe Pathname do
 
   describe "#extname" do
     specify do
-      expect(described_class.new("foo-0.1.tar.gz").extname).to eq(".tar.gz")
-      expect(described_class.new("foo-0.1.cpio.gz").extname).to eq(".cpio.gz")
-      expect(described_class.new("foo-0.1").extname).to eq("")
-      expect(described_class.new("foo-1.0-rc1").extname).to eq("")
-      expect(described_class.new("foo-1.2.3").extname).to eq ""
-      expect(described_class.new("snap7-full-1.4.2.7z").extname).to eq ".7z"
+      expect(klass.new("foo-0.1.tar.gz").extname).to eq(".tar.gz")
+      expect(klass.new("foo-0.1.cpio.gz").extname).to eq(".cpio.gz")
+      expect(klass.new("foo-0.1").extname).to eq("")
+      expect(klass.new("foo-1.0-rc1").extname).to eq("")
+      expect(klass.new("foo-1.2.3").extname).to eq ""
+      expect(klass.new("snap7-full-1.4.2.7z").extname).to eq ".7z"
     end
   end
 
@@ -239,21 +240,23 @@ RSpec.describe Pathname do
 
     it "can install relative paths as symlinks" do
       dst.install_symlink "foo" => "bar"
-      expect((dst/"bar").readlink).to eq(described_class.new("foo"))
+      expect((dst/"bar").readlink).to eq(klass.new("foo"))
     end
 
     it "can install relative symlinks in a symlinked directory" do
       mkdir_p dst/"1/2"
       dst.install_symlink "1/2" => "12"
-      expect((dst/"12").readlink).to eq(described_class.new("1/2"))
+      expect((dst/"12").readlink).to eq(klass.new("1/2"))
       (dst/"12").install_symlink dst/"foo"
-      expect((dst/"12/foo").readlink).to eq(described_class.new("../../foo"))
+      expect((dst/"12/foo").readlink).to eq(klass.new("../../foo"))
     end
   end
 
   describe InstallRenamed do
+    let(:klass) { InstallRenamed }
+
     before do
-      dst.extend(described_class)
+      dst.extend(klass)
     end
 
     it "renames the installed file if it already exists" do

--- a/Library/Homebrew/test/pkg_version_spec.rb
+++ b/Library/Homebrew/test/pkg_version_spec.rb
@@ -4,80 +4,82 @@
 require "pkg_version"
 
 RSpec.describe PkgVersion do
+  let(:klass) { PkgVersion }
+
   describe "::parse" do
     it "parses versions from a string" do
-      expect(described_class.parse("1.0_1")).to eq(described_class.new(Version.new("1.0"), 1))
-      expect(described_class.parse("1.0_1")).to eq(described_class.new(Version.new("1.0"), 1))
-      expect(described_class.parse("1.0")).to eq(described_class.new(Version.new("1.0"), 0))
-      expect(described_class.parse("1.0_0")).to eq(described_class.new(Version.new("1.0"), 0))
-      expect(described_class.parse("2.1.4_0")).to eq(described_class.new(Version.new("2.1.4"), 0))
-      expect(described_class.parse("1.0.1e_1")).to eq(described_class.new(Version.new("1.0.1e"), 1))
+      expect(klass.parse("1.0_1")).to eq(klass.new(Version.new("1.0"), 1))
+      expect(klass.parse("1.0_1")).to eq(klass.new(Version.new("1.0"), 1))
+      expect(klass.parse("1.0")).to eq(klass.new(Version.new("1.0"), 0))
+      expect(klass.parse("1.0_0")).to eq(klass.new(Version.new("1.0"), 0))
+      expect(klass.parse("2.1.4_0")).to eq(klass.new(Version.new("2.1.4"), 0))
+      expect(klass.parse("1.0.1e_1")).to eq(klass.new(Version.new("1.0.1e"), 1))
     end
   end
 
   specify "#==" do
-    expect(described_class.parse("1.0_0")).to eq described_class.parse("1.0")
-    version_to_compare = described_class.parse("1.0_1")
-    expect(version_to_compare == described_class.parse("1.0_1")).to be true
-    expect(version_to_compare == described_class.parse("1.0_2")).to be false
+    expect(klass.parse("1.0_0")).to eq klass.parse("1.0")
+    version_to_compare = klass.parse("1.0_1")
+    expect(version_to_compare == klass.parse("1.0_1")).to be true
+    expect(version_to_compare == klass.parse("1.0_2")).to be false
   end
 
   describe "#>" do
     it "returns true if the left version is bigger than the right" do
-      expect(described_class.parse("1.1")).to be > described_class.parse("1.0_1")
+      expect(klass.parse("1.1")).to be > klass.parse("1.0_1")
     end
 
     it "returns true if the left version is HEAD" do
-      expect(described_class.parse("HEAD")).to be > described_class.parse("1.0")
+      expect(klass.parse("HEAD")).to be > klass.parse("1.0")
     end
 
     it "raises an error if the other side isn't of the same class" do
       expect do
-        described_class.new(Version.new("1.0"), 0) > Object.new
+        klass.new(Version.new("1.0"), 0) > Object.new
       end.to raise_error(TypeError)
     end
 
     it "is not compatible with Version" do
       expect do
-        described_class.new(Version.new("1.0"), 0) > Version.new("1.0")
+        klass.new(Version.new("1.0"), 0) > Version.new("1.0")
       end.to raise_error(TypeError)
     end
   end
 
   describe "#<" do
     it "returns true if the left version is smaller than the right" do
-      expect(described_class.parse("1.0_1")).to be < described_class.parse("2.0_1")
+      expect(klass.parse("1.0_1")).to be < klass.parse("2.0_1")
     end
 
     it "returns true if the right version is HEAD" do
-      expect(described_class.parse("1.0")).to be < described_class.parse("HEAD")
+      expect(klass.parse("1.0")).to be < klass.parse("HEAD")
     end
   end
 
   describe "#<=>" do
     it "returns nil if the comparison fails" do
-      expect(Object.new <=> described_class.new(Version.new("1.0"), 0)).to be_nil
+      expect(Object.new <=> klass.new(Version.new("1.0"), 0)).to be_nil
     end
   end
 
   describe "#to_s" do
     it "returns a string of the form 'version_revision'" do
-      expect(described_class.new(Version.new("1.0"), 0).to_s).to eq("1.0")
-      expect(described_class.new(Version.new("1.0"), 1).to_s).to eq("1.0_1")
-      expect(described_class.new(Version.new("1.0"), 0).to_s).to eq("1.0")
-      expect(described_class.new(Version.new("1.0"), 0).to_s).to eq("1.0")
-      expect(described_class.new(Version.new("HEAD"), 1).to_s).to eq("HEAD_1")
-      expect(described_class.new(Version.new("HEAD-ffffff"), 1).to_s).to eq("HEAD-ffffff_1")
+      expect(klass.new(Version.new("1.0"), 0).to_s).to eq("1.0")
+      expect(klass.new(Version.new("1.0"), 1).to_s).to eq("1.0_1")
+      expect(klass.new(Version.new("1.0"), 0).to_s).to eq("1.0")
+      expect(klass.new(Version.new("1.0"), 0).to_s).to eq("1.0")
+      expect(klass.new(Version.new("HEAD"), 1).to_s).to eq("HEAD_1")
+      expect(klass.new(Version.new("HEAD-ffffff"), 1).to_s).to eq("HEAD-ffffff_1")
     end
   end
 
   describe "#hash" do
-    let(:version_one_revision_one) { described_class.new(Version.new("1.0"), 1) }
-    let(:version_one_dot_one_revision_one) { described_class.new(Version.new("1.1"), 1) }
-    let(:version_one_revision_zero) { described_class.new(Version.new("1.0"), 0) }
+    let(:version_one_revision_one) { klass.new(Version.new("1.0"), 1) }
+    let(:version_one_dot_one_revision_one) { klass.new(Version.new("1.1"), 1) }
+    let(:version_one_revision_zero) { klass.new(Version.new("1.0"), 0) }
 
     it "returns a hash based on the version and revision" do
-      expect(version_one_revision_one.hash).to eq(described_class.new(Version.new("1.0"), 1).hash)
+      expect(version_one_revision_one.hash).to eq(klass.new(Version.new("1.0"), 1).hash)
       expect(version_one_revision_one.hash).not_to eq(version_one_dot_one_revision_one.hash)
       expect(version_one_revision_one.hash).not_to eq(version_one_revision_zero.hash)
     end
@@ -85,43 +87,43 @@ RSpec.describe PkgVersion do
 
   describe "#version" do
     it "returns package version" do
-      expect(described_class.parse("1.2.3_4").version).to eq Version.new("1.2.3")
+      expect(klass.parse("1.2.3_4").version).to eq Version.new("1.2.3")
     end
   end
 
   describe "#revision" do
     it "returns package revision" do
-      expect(described_class.parse("1.2.3_4").revision).to eq 4
+      expect(klass.parse("1.2.3_4").revision).to eq 4
     end
   end
 
   describe "#major" do
     it "returns major version token" do
-      expect(described_class.parse("1.2.3_4").major).to eq Version::Token.create("1")
+      expect(klass.parse("1.2.3_4").major).to eq Version::Token.create("1")
     end
   end
 
   describe "#minor" do
     it "returns minor version token" do
-      expect(described_class.parse("1.2.3_4").minor).to eq Version::Token.create("2")
+      expect(klass.parse("1.2.3_4").minor).to eq Version::Token.create("2")
     end
   end
 
   describe "#patch" do
     it "returns patch version token" do
-      expect(described_class.parse("1.2.3_4").patch).to eq Version::Token.create("3")
+      expect(klass.parse("1.2.3_4").patch).to eq Version::Token.create("3")
     end
   end
 
   describe "#major_minor" do
     it "returns major.minor version" do
-      expect(described_class.parse("1.2.3_4").major_minor).to eq Version.new("1.2")
+      expect(klass.parse("1.2.3_4").major_minor).to eq Version.new("1.2")
     end
   end
 
   describe "#major_minor_patch" do
     it "returns major.minor.patch version" do
-      expect(described_class.parse("1.2.3_4").major_minor_patch).to eq Version.new("1.2.3")
+      expect(klass.parse("1.2.3_4").major_minor_patch).to eq Version.new("1.2.3")
     end
   end
 end

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe Requirement do
 
   subject(:requirement) { klass.new }
 
-  let(:klass) { Class.new(described_class) }
+  let(:klass) { Class.new(Requirement) }
 
   describe "base class" do
     it "raises an error when instantiated" do
-      expect { described_class.new }
+      expect { Requirement.new }
         .to raise_error(RuntimeError, "Requirement is declared as abstract; it cannot be instantiated")
     end
   end
@@ -49,7 +49,7 @@ RSpec.describe Requirement do
   describe "#fatal?" do
     describe "#fatal true is specified" do
       let(:klass) do
-        Class.new(described_class) do
+        Class.new(Requirement) do
           fatal true
         end
       end
@@ -65,7 +65,7 @@ RSpec.describe Requirement do
   describe "#satisfied?" do
     describe "#satisfy with block and build_env returns true" do
       let(:klass) do
-        Class.new(described_class) do
+        Class.new(Requirement) do
           satisfy(build_env: false) do
             true
           end
@@ -77,7 +77,7 @@ RSpec.describe Requirement do
 
     describe "#satisfy with block and build_env returns false" do
       let(:klass) do
-        Class.new(described_class) do
+        Class.new(Requirement) do
           satisfy(build_env: false) do
             false
           end
@@ -89,7 +89,7 @@ RSpec.describe Requirement do
 
     describe "#satisfy returns true" do
       let(:klass) do
-        Class.new(described_class) do
+        Class.new(Requirement) do
           satisfy true
         end
       end
@@ -99,7 +99,7 @@ RSpec.describe Requirement do
 
     describe "#satisfy returns false" do
       let(:klass) do
-        Class.new(described_class) do
+        Class.new(Requirement) do
           satisfy false
         end
       end
@@ -109,7 +109,7 @@ RSpec.describe Requirement do
 
     describe "#satisfy with block returning true and without :build_env" do
       let(:klass) do
-        Class.new(described_class) do
+        Class.new(Requirement) do
           satisfy do
             true
           end
@@ -124,7 +124,7 @@ RSpec.describe Requirement do
 
     describe "#satisfy with block returning true and :build_env set to false" do
       let(:klass) do
-        Class.new(described_class) do
+        Class.new(Requirement) do
           satisfy(build_env: false) do
             true
           end
@@ -139,7 +139,7 @@ RSpec.describe Requirement do
 
     describe "#satisfy with block returning path and without :build_env" do
       let(:klass) do
-        Class.new(described_class) do
+        Class.new(Requirement) do
           satisfy do
             Pathname.new("/foo/bar/baz")
           end
@@ -157,7 +157,7 @@ RSpec.describe Requirement do
 
     describe "#satisfy with block returning path under HOMEBREW_PREFIX/bin" do
       let(:klass) do
-        Class.new(described_class) do
+        Class.new(Requirement) do
           satisfy do
             HOMEBREW_PREFIX/"bin/foo"
           end
@@ -175,7 +175,7 @@ RSpec.describe Requirement do
 
     describe "#satisfy with block returning path under HOMEBREW_PREFIX/sbin" do
       let(:klass) do
-        Class.new(described_class) do
+        Class.new(Requirement) do
           satisfy do
             HOMEBREW_PREFIX/"sbin/foo"
           end
@@ -193,7 +193,7 @@ RSpec.describe Requirement do
 
     describe "#satisfy with block calling #which and :build_env set to false" do
       let(:klass) do
-        Class.new(described_class) do
+        Class.new(Requirement) do
           satisfy(build_env: false) do
             which("sh")
           end
@@ -223,7 +223,7 @@ RSpec.describe Requirement do
     let(:klass) { self.class.const_get(const) }
 
     before do
-      stub_const const.to_s, Class.new(described_class)
+      stub_const const.to_s, Class.new(Requirement)
     end
 
     it(:name) { expect(requirement.name).to eq("foo") }
@@ -232,7 +232,7 @@ RSpec.describe Requirement do
 
   describe "#modify_build_environment" do
     context "without env proc" do
-      let(:klass) { Class.new(described_class) }
+      let(:klass) { Class.new(Requirement) }
 
       it "returns nil" do
         expect { requirement.modify_build_environment }.not_to raise_error

--- a/Library/Homebrew/test/requirements/arch_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/arch_requirement_spec.rb
@@ -4,7 +4,9 @@
 require "requirements/arch_requirement"
 
 RSpec.describe ArchRequirement do
-  subject(:requirement) { described_class.new([Hardware::CPU.type]) }
+  subject(:requirement) { klass.new([Hardware::CPU.type]) }
+
+  let(:klass) { ArchRequirement }
 
   describe "#satisfied?" do
     it "supports architecture symbols" do

--- a/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
@@ -5,9 +5,10 @@ require "requirements/codesign_requirement"
 
 RSpec.describe CodesignRequirement do
   subject(:requirement) do
-    described_class.new([{ identity:, with:, url: }])
+    klass.new([{ identity:, with:, url: }])
   end
 
+  let(:klass) { CodesignRequirement }
   let(:identity) { "lldb_codesign" }
   let(:with) { "LLDB" }
   let(:url) do

--- a/Library/Homebrew/test/requirements/linux_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/linux_requirement_spec.rb
@@ -4,7 +4,9 @@
 require "requirements/linux_requirement"
 
 RSpec.describe LinuxRequirement do
-  subject(:requirement) { described_class.new }
+  subject(:requirement) { klass.new }
+
+  let(:klass) { LinuxRequirement }
 
   describe "#satisfied?" do
     it "returns true on Linux" do

--- a/Library/Homebrew/test/requirements/macos_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/macos_requirement_spec.rb
@@ -4,8 +4,9 @@
 require "requirements/macos_requirement"
 
 RSpec.describe MacOSRequirement do
-  subject(:requirement) { described_class.new }
+  subject(:requirement) { klass.new }
 
+  let(:klass) { MacOSRequirement }
   let(:macos_oldest_allowed) { MacOSVersion.new(HOMEBREW_MACOS_OLDEST_ALLOWED) }
   let(:macos_newest_allowed) { MacOSVersion.new(HOMEBREW_MACOS_NEWEST_UNSUPPORTED) }
   let(:tahoe_major) { MacOSVersion.new("26.0") }
@@ -16,22 +17,22 @@ RSpec.describe MacOSRequirement do
     end
 
     it "supports version symbols", :needs_macos do
-      requirement = described_class.new([MacOS.version.to_sym])
+      requirement = klass.new([MacOS.version.to_sym])
       expect(requirement).to be_satisfied
     end
 
     it "supports maximum versions", :needs_macos do
-      requirement = described_class.new([:catalina], comparator: "<=")
+      requirement = klass.new([:catalina], comparator: "<=")
       expect(requirement.satisfied?).to eq MacOS.version <= :catalina
     end
   end
 
   specify "#minimum_version" do
-    no_requirement = described_class.new
-    max_requirement = described_class.new([:tahoe], comparator: "<=")
-    min_requirement = described_class.new([:tahoe], comparator: ">=")
-    exact_requirement = described_class.new([:tahoe], comparator: "==")
-    range_requirement = described_class.new([[:sonoma, :tahoe]], comparator: "==")
+    no_requirement = klass.new
+    max_requirement = klass.new([:tahoe], comparator: "<=")
+    min_requirement = klass.new([:tahoe], comparator: ">=")
+    exact_requirement = klass.new([:tahoe], comparator: "==")
+    range_requirement = klass.new([[:sonoma, :tahoe]], comparator: "==")
     expect(no_requirement.minimum_version).to eq macos_oldest_allowed
     expect(max_requirement.minimum_version).to eq macos_oldest_allowed
     expect(min_requirement.minimum_version).to eq tahoe_major
@@ -40,11 +41,11 @@ RSpec.describe MacOSRequirement do
   end
 
   specify "#maximum_version" do
-    no_requirement = described_class.new
-    max_requirement = described_class.new([:tahoe], comparator: "<=")
-    min_requirement = described_class.new([:tahoe], comparator: ">=")
-    exact_requirement = described_class.new([:tahoe], comparator: "==")
-    range_requirement = described_class.new([[:sonoma, :tahoe]], comparator: "==")
+    no_requirement = klass.new
+    max_requirement = klass.new([:tahoe], comparator: "<=")
+    min_requirement = klass.new([:tahoe], comparator: ">=")
+    exact_requirement = klass.new([:tahoe], comparator: "==")
+    range_requirement = klass.new([[:sonoma, :tahoe]], comparator: "==")
     expect(no_requirement.maximum_version).to eq macos_newest_allowed
     expect(max_requirement.maximum_version).to eq tahoe_major
     expect(min_requirement.maximum_version).to eq macos_newest_allowed
@@ -53,11 +54,11 @@ RSpec.describe MacOSRequirement do
   end
 
   specify "#allows?" do
-    no_requirement = described_class.new
-    max_requirement = described_class.new([:sequoia], comparator: "<=")
-    min_requirement = described_class.new([:ventura], comparator: ">=")
-    exact_requirement = described_class.new([:tahoe], comparator: "==")
-    range_requirement = described_class.new([[:sonoma, :tahoe]], comparator: "==")
+    no_requirement = klass.new
+    max_requirement = klass.new([:sequoia], comparator: "<=")
+    min_requirement = klass.new([:ventura], comparator: ">=")
+    exact_requirement = klass.new([:tahoe], comparator: "==")
+    range_requirement = klass.new([[:sonoma, :tahoe]], comparator: "==")
     expect(no_requirement.allows?(tahoe_major)).to be true
     expect(max_requirement.allows?(tahoe_major)).to be false
     expect(min_requirement.allows?(tahoe_major)).to be true

--- a/Library/Homebrew/test/requirements_spec.rb
+++ b/Library/Homebrew/test/requirements_spec.rb
@@ -4,7 +4,7 @@
 require "requirements"
 
 RSpec.describe Requirements do
-  subject(:requirements) { described_class.new }
+  subject(:requirements) { Requirements.new }
 
   describe "#<<" do
     it "returns itself" do

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -5,10 +5,10 @@ require "resource"
 require "livecheck"
 
 RSpec.describe Resource do
-  subject(:resource) { described_class.new("test") }
+  subject(:resource) { Resource.new("test") }
 
   let(:livecheck_resource) do
-    described_class.new do
+    Resource.new do
       url "https://brew.sh/foo-1.0.tar.gz"
       sha256 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
@@ -175,7 +175,7 @@ RSpec.describe Resource do
   end
 
   describe "#owner" do
-    let(:owner) { described_class.new("test-owner") }
+    let(:owner) { Resource.new("test-owner") }
 
     it "sets the owner" do
       resource.owner = owner

--- a/Library/Homebrew/test/rubocops/bottle/bottle_digest_indentation_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_digest_indentation_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/bottle"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::BottleDigestIndentation do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::BottleDigestIndentation }
 
   it "reports no offenses for `bottle :unneeded`" do
     expect_no_offenses(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/bottle/bottle_format_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_format_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/bottle"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::BottleFormat do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::BottleFormat }
 
   it "reports no offenses for `bottle :unneeded`" do
     expect_no_offenses(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/bottle/bottle_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_order_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/bottle"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::BottleOrder do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::BottleOrder }
 
   it "reports no offenses for `bottle :unneeded`" do
     expect_no_offenses(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/bottle/bottle_tag_indentation_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_tag_indentation_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/bottle"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::BottleTagIndentation do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::BottleTagIndentation }
 
   it "reports no offenses for `bottle :unneeded`" do
     expect_no_offenses(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/caveats_spec.rb
+++ b/Library/Homebrew/test/rubocops/caveats_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/caveats"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Caveats do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Caveats }
 
   context "when auditing `caveats`" do
     it "reports an offense if `setuid` is mentioned" do

--- a/Library/Homebrew/test/rubocops/checksum/checksum_case_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum/checksum_case_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/checksum"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::ChecksumCase do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::ChecksumCase }
 
   context "when auditing spec checksums" do
     it "reports an offense if a checksum contains uppercase letters" do

--- a/Library/Homebrew/test/rubocops/checksum/checksum_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum/checksum_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/checksum"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Checksum do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Checksum }
 
   context "when auditing spec checksums" do
     it "reports an offense if a checksum is empty" do

--- a/Library/Homebrew/test/rubocops/class/class_name_spec.rb
+++ b/Library/Homebrew/test/rubocops/class/class_name_spec.rb
@@ -4,8 +4,9 @@
 require "rubocops/class"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::ClassName do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
 
+  let(:klass) { RuboCop::Cop::FormulaAudit::ClassName }
   let(:corrected_source) do
     <<~RUBY
       class Foo < Formula

--- a/Library/Homebrew/test/rubocops/class/test_present.rb
+++ b/Library/Homebrew/test/rubocops/class/test_present.rb
@@ -4,7 +4,7 @@
 require "rubocops/class"
 
 RSpec.describe RuboCop::Cop::FormulaAuditStrict::TestPresent do
-  subject(:cop) { described_class.new }
+  subject(:cop) { RuboCop::Cop::FormulaAuditStrict::TestPresent.new }
 
   it "reports an offense when there is no test block" do
     expect_offense(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/class/test_spec.rb
+++ b/Library/Homebrew/test/rubocops/class/test_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/class"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Test do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Test }
 
   it "reports and corrects an offense when /usr/local/bin is found in test calls" do
     expect_offense(<<~'RUBY')

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/components_order"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::ComponentsOrder }
 
   context "when auditing formula components order" do
     it "reports and corrects an offense when `uses_from_macos` precedes `depends_on`" do

--- a/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/components_redundancy"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::ComponentsRedundancy }
 
   context "when auditing formula components" do
     it "reports an offense if `url` is outside `stable` block" do

--- a/Library/Homebrew/test/rubocops/conflicts_spec.rb
+++ b/Library/Homebrew/test/rubocops/conflicts_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/conflicts"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Conflicts do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Conflicts }
 
   context "when auditing `conflicts_with`" do
     it "reports and corrects an offense if reason is capitalized" do

--- a/Library/Homebrew/test/rubocops/dependency_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/dependency_order_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/dependency_order"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::DependencyOrder do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::DependencyOrder }
 
   context "when auditing `uses_from_macos`" do
     it "reports and corrects incorrectly ordered conditional dependencies" do

--- a/Library/Homebrew/test/rubocops/deprecate_disable/date_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_disable/date_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/deprecate_disable"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::DeprecateDisableDate }
 
   context "when auditing `deprecate!`" do
     it "reports and corrects an offense if `date` is not ISO 8601 compliant" do

--- a/Library/Homebrew/test/rubocops/deprecate_disable/reason_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_disable/reason_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/deprecate_disable"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::DeprecateDisableReason }
 
   context "when auditing `deprecate!`" do
     it "reports no offenses if `reason` is acceptable" do

--- a/Library/Homebrew/test/rubocops/desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/desc_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/desc"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Desc do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Desc }
 
   context "when auditing formula `desc` methods" do
     it "reports an offense when there is no `desc`" do

--- a/Library/Homebrew/test/rubocops/exec_shell_metacharacters_spec.rb
+++ b/Library/Homebrew/test/rubocops/exec_shell_metacharacters_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/shell_commands"
 
 RSpec.describe RuboCop::Cop::Homebrew::ExecShellMetacharacters do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::Homebrew::ExecShellMetacharacters }
 
   context "when auditing exec calls" do
     it "reports aan offense when output piping is used" do

--- a/Library/Homebrew/test/rubocops/files_spec.rb
+++ b/Library/Homebrew/test/rubocops/files_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/files"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Files do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Files }
 
   context "when auditing files" do
     it "reports an offense when the permissions are invalid" do

--- a/Library/Homebrew/test/rubocops/homepage_spec.rb
+++ b/Library/Homebrew/test/rubocops/homepage_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/homepage"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Homepage do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Homepage }
 
   context "when auditing homepage" do
     it "reports an offense when there is no homepage" do

--- a/Library/Homebrew/test/rubocops/io_read_spec.rb
+++ b/Library/Homebrew/test/rubocops/io_read_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/io_read"
 
 RSpec.describe RuboCop::Cop::Homebrew::IORead do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::Homebrew::IORead }
 
   it "reports an offense when `IO.read` is used with a pipe character" do
     expect_offense(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/keg_only_spec.rb
+++ b/Library/Homebrew/test/rubocops/keg_only_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/keg_only"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::KegOnly do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::KegOnly }
 
   it "reports and corrects an offense when the `keg_only` reason is capitalized" do
     expect_offense(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/lines/class_inheritance_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/class_inheritance_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::ClassInheritance do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::ClassInheritance }
 
   context "when auditing formula class inheritance" do
     it "reports an offense when not using spaces for class inheritance" do

--- a/Library/Homebrew/test/rubocops/lines/full_dependency_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/full_dependency_check_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::FullDependencyCheck do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::FullDependencyCheck }
 
   context "when auditing -full dependencies in homebrew/core" do
     it "reports an offense when a formula depends on a -full formula" do

--- a/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
@@ -4,8 +4,12 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit do
+  let(:klass) { RuboCop::Cop::FormulaAudit }
+
   describe RuboCop::Cop::FormulaAudit::GenerateCompletionsDSL do
-    subject(:cop) { described_class.new }
+    subject(:cop) { klass.new }
+
+    let(:klass) { RuboCop::Cop::FormulaAudit::GenerateCompletionsDSL }
 
     it "reports an offense when writing to a shell completions file directly" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
@@ -115,7 +119,9 @@ RSpec.describe RuboCop::Cop::FormulaAudit do
   end
 
   describe RuboCop::Cop::FormulaAudit::SingleGenerateCompletionsDSLCall do
-    subject(:cop) { described_class.new }
+    subject(:cop) { klass.new }
+
+    let(:klass) { RuboCop::Cop::FormulaAudit::SingleGenerateCompletionsDSLCall }
 
     it "reports an offense when using multiple #generate_completions_from_executable calls for different shells" do
       expect_offense(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/lines/libiconv_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/libiconv_check_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::LibiconvCheck do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::LibiconvCheck }
 
   context "when auditing libiconv dependencies in homebrew/core" do
     it "reports an offense when a formula depends on `libiconv`" do

--- a/Library/Homebrew/test/rubocops/lines/quictls_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/quictls_check_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::QuicTLSCheck do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::QuicTLSCheck }
 
   context "when auditing formula dependencies" do
     it "reports an offense when a formula depends on `quictls`" do

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Lines do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Lines }
 
   context "when auditing deprecated special dependencies" do
     it "reports an offense when using depends_on :automake" do

--- a/Library/Homebrew/test/rubocops/livecheck/regex_case_insensitive_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_case_insensitive_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/livecheck"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckRegexCaseInsensitive do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::LivecheckRegexCaseInsensitive }
 
   it "reports an offense when the `regex` is not case-insensitive" do
     expect_offense(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/livecheck/regex_extension_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_extension_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/livecheck"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckRegexExtension do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::LivecheckRegexExtension }
 
   it "reports an offense when the `regex` does not use `\\.t` for archive file extensions" do
     expect_offense(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/livecheck/regex_if_page_match_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_if_page_match_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/livecheck"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckRegexIfPageMatch do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::LivecheckRegexIfPageMatch }
 
   it "reports an offense when there is no `regex` for `strategy :page_match`" do
     expect_offense(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/livecheck/regex_parentheses_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_parentheses_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/livecheck"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckRegexParentheses do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::LivecheckRegexParentheses }
 
   it "reports an offense when the `regex` call in the `livecheck` block does not use parentheses" do
     expect_offense(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/livecheck/skip_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/skip_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/livecheck"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckSkip do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::LivecheckSkip }
 
   it "reports an offense when a skipped formula's `livecheck` block contains other information" do
     expect_offense(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/livecheck"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckUrlProvided do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::LivecheckUrlProvided }
 
   it "reports an offense when a `url` is not specified in a `livecheck` block" do
     expect_offense(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/livecheck/url_symbol_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/url_symbol_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/livecheck"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckUrlSymbol do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::LivecheckUrlSymbol }
 
   it "reports an offense when the `url` specified in the `livecheck` block is identical to a formula URL" do
     expect_offense(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/move_to_extend_os_spec.rb
+++ b/Library/Homebrew/test/rubocops/move_to_extend_os_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/move_to_extend_os"
 
 RSpec.describe RuboCop::Cop::Homebrew::MoveToExtendOS do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::Homebrew::MoveToExtendOS }
 
   it "registers an offense when using `OS.linux?`" do
     expect_offense(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/no_autobump.rb
+++ b/Library/Homebrew/test/rubocops/no_autobump.rb
@@ -4,7 +4,7 @@
 require "rubocops/no_autobump"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::NoAutobump do
-  subject(:cop) { described_class.new }
+  subject(:cop) { RuboCop::Cop::FormulaAudit::NoAutobump.new }
 
   it "reports no offenses if `reason` is acceptable" do
     expect_no_offenses(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/no_fileutils_rmrf_spec.rb
+++ b/Library/Homebrew/test/rubocops/no_fileutils_rmrf_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/no_fileutils_rmrf"
 
 RSpec.describe RuboCop::Cop::Homebrew::NoFileutilsRmrf do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::Homebrew::NoFileutilsRmrf }
 
   describe "rm_rf" do
     it "registers an offense" do

--- a/Library/Homebrew/test/rubocops/non_public_api_usage_spec.rb
+++ b/Library/Homebrew/test/rubocops/non_public_api_usage_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/non_public_api_usage"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::NonPublicApiUsage do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::NonPublicApiUsage }
 
   before do
     allow(RuboCop::Cop::ApiAnnotationHelper).to receive(:methods_with_api_level).and_return(Set.new)

--- a/Library/Homebrew/test/rubocops/options_spec.rb
+++ b/Library/Homebrew/test/rubocops/options_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/options"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Options do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Options }
 
   context "when auditing options" do
     it "reports an offense when using bad option names" do

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/patches"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Patches do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Patches }
 
   def expect_offense_hash(message:, severity:, line:, column:, source:)
     [{ message:, severity:, line:, column:, source: }]

--- a/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/uses_from_macos"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::ProvidedByMacos do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::ProvidedByMacos }
 
   it "fails for formulae not in PROVIDED_BY_MACOS_FORMULAE list" do
     expect_offense(<<~RUBY)
@@ -40,5 +42,5 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ProvidedByMacos do
     RUBY
   end
 
-  include_examples "formulae exist", described_class::PROVIDED_BY_MACOS_FORMULAE
+  include_examples "formulae exist", RuboCop::Cop::FormulaAudit::ProvidedByMacos::PROVIDED_BY_MACOS_FORMULAE
 end

--- a/Library/Homebrew/test/rubocops/public_api_cookbook_spec.rb
+++ b/Library/Homebrew/test/rubocops/public_api_cookbook_spec.rb
@@ -4,8 +4,9 @@
 require "rubocops/public_api_cookbook"
 
 RSpec.describe RuboCop::Cop::Homebrew::PublicApiCookbook do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
 
+  let(:klass) { RuboCop::Cop::Homebrew::PublicApiCookbook }
   let(:formula_path) { "formula.rb" }
   let(:cask_dsl_path) { "cask/dsl.rb" }
   let(:helper_path) { "rubocops/shared/api_annotation_helper.rb" }

--- a/Library/Homebrew/test/rubocops/public_api_documentation_spec.rb
+++ b/Library/Homebrew/test/rubocops/public_api_documentation_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/public_api_documentation"
 
 RSpec.describe RuboCop::Cop::Homebrew::PublicApiDocumentation do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::Homebrew::PublicApiDocumentation }
 
   context "when a method has a bare `@api public` with no description" do
     it "reports an offense" do
@@ -96,7 +98,7 @@ RSpec.describe RuboCop::Cop::Homebrew::PublicApiDocumentation do
 
   context "when a public API file is missing from `Style/Documentation.Include`" do
     subject(:cop) do
-      described_class.new(RuboCop::Config.new("Style/Documentation" => { "Include" => [] }))
+      klass.new(RuboCop::Config.new("Style/Documentation" => { "Include" => [] }))
     end
 
     it "reports an offense" do
@@ -112,7 +114,7 @@ RSpec.describe RuboCop::Cop::Homebrew::PublicApiDocumentation do
 
   context "when a documented API file has no public API annotations" do
     subject(:cop) do
-      described_class.new(RuboCop::Config.new("Style/Documentation" => { "Include" => ["stale.rb"] }))
+      klass.new(RuboCop::Config.new("Style/Documentation" => { "Include" => ["stale.rb"] }))
     end
 
     it "reports an offense" do

--- a/Library/Homebrew/test/rubocops/resource_requires_dependencies_spec.rb
+++ b/Library/Homebrew/test/rubocops/resource_requires_dependencies_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/resource_requires_dependencies"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::ResourceRequiresDependencies do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::ResourceRequiresDependencies }
 
   context "when a formula does not have any resources" do
     it "does not report offenses" do

--- a/Library/Homebrew/test/rubocops/service_spec.rb
+++ b/Library/Homebrew/test/rubocops/service_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/service"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Service do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Service }
 
   it "reports offenses when a service block is missing a required command" do
     expect_offense(<<~RUBY)

--- a/Library/Homebrew/test/rubocops/shell_commands_spec.rb
+++ b/Library/Homebrew/test/rubocops/shell_commands_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/shell_commands"
 
 RSpec.describe RuboCop::Cop::Homebrew::ShellCommands do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::Homebrew::ShellCommands }
 
   context "when auditing shell commands" do
     it "reports and corrects an offense when `system` arguments should be separated" do

--- a/Library/Homebrew/test/rubocops/text/assert_statements_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/assert_statements_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::AssertStatements do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::AssertStatements }
 
   context "when auditing formula assertions" do
     it "reports an offense when assert ... include is used" do

--- a/Library/Homebrew/test/rubocops/text/comments_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/comments_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Comments do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Comments }
 
   context "when auditing comment text" do
     it "reports an offense when commented cmake calls exist" do

--- a/Library/Homebrew/test/rubocops/text/license_arrays_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/license_arrays_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::LicenseArrays do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::LicenseArrays }
 
   context "when auditing license arrays" do
     it "reports no offenses for license strings" do

--- a/Library/Homebrew/test/rubocops/text/licenses_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/licenses_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Licenses do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Licenses }
 
   context "when auditing licenses" do
     it "reports no offenses for license strings" do

--- a/Library/Homebrew/test/rubocops/text/macos_on_linux_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/macos_on_linux_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::MacOSOnLinux do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::MacOSOnLinux }
 
   it "reports an offense when `MacOS` is used in the `Formula` class" do
     expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")

--- a/Library/Homebrew/test/rubocops/text/make_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/make_check_spec.rb
@@ -4,8 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAuditStrict::MakeCheck do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
 
+  let(:klass) { RuboCop::Cop::FormulaAuditStrict::MakeCheck }
   let(:path) { HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-core" }
 
   before do

--- a/Library/Homebrew/test/rubocops/text/miscellaneous_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/miscellaneous_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Miscellaneous }
 
   context "when auditing formula miscellany" do
     it "reports an offense for unneeded `FileUtils` usage" do

--- a/Library/Homebrew/test/rubocops/text/mpi_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/mpi_check_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::MpiCheck do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::MpiCheck }
 
   context "when auditing MPI dependencies" do
     it "reports and corrects an offense when using depends_on \"mpich\" in homebrew/core" do

--- a/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::OnSystemConditionals }
 
   context "when auditing OS conditionals" do
     it "reports an offense when `OS.linux?` is used on Formula class" do

--- a/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::OptionDeclarations }
 
   context "when auditing options" do
     it "reports an offense when `build.without?` is used in homebrew/core" do

--- a/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::PythonVersions do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::PythonVersions }
 
   context "when auditing Python versions" do
     it "reports no offenses for Python with no dependency" do

--- a/Library/Homebrew/test/rubocops/text/safe_popen_commands_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/safe_popen_commands_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::SafePopenCommands do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::SafePopenCommands }
 
   context "when auditing popen commands" do
     it "reports and corrects `Utils.popen_read` usage" do

--- a/Library/Homebrew/test/rubocops/text/shell_variables_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/shell_variables_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::ShellVariables do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::ShellVariables }
 
   context "when auditing shell variables" do
     it "reports and corrects unexpanded shell variables in `Utils.popen`" do

--- a/Library/Homebrew/test/rubocops/text/std_npm_args_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/std_npm_args_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/lines"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::StdNpmArgs do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::StdNpmArgs }
 
   context "when auditing node formulae" do
     it "reports an offense when `npm install` is called without std_npm_args arguments" do

--- a/Library/Homebrew/test/rubocops/text/strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/strict_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/text"
 
 RSpec.describe RuboCop::Cop::FormulaAuditStrict::Text do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAuditStrict::Text }
 
   context "when auditing formula text in homebrew/core" do
     it "reports an offense if `env :userpaths` is present" do

--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/text"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Text do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Text }
 
   context "when auditing formula text" do
     it 'reports an offense if `require "formula"` is present' do

--- a/Library/Homebrew/test/rubocops/urls/git_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/git_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/urls"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::GitUrls do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::GitUrls }
 
   context "when a git URL is used" do
     it "reports no offenses with a non-git URL" do

--- a/Library/Homebrew/test/rubocops/urls/git_strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/git_strict_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/urls"
 
 RSpec.describe RuboCop::Cop::FormulaAuditStrict::GitUrls do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAuditStrict::GitUrls }
 
   context "when a git URL is used" do
     it "reports no offenses with both a tag and a revision" do

--- a/Library/Homebrew/test/rubocops/urls/http_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/http_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/urls"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::HttpUrls do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::HttpUrls }
 
   context "when auditing HTTP URLs" do
     it "reports an offense for http:// URLs in homebrew-core" do

--- a/Library/Homebrew/test/rubocops/urls/pypi_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/pypi_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/urls"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::PyPiUrls do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::PyPiUrls }
 
   context "when a pypi URL is used" do
     it "reports an offense for pypi.python.org urls" do

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -4,8 +4,9 @@
 require "rubocops/urls"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
 
+  let(:klass) { RuboCop::Cop::FormulaAudit::Urls }
   let(:offense_list) do
     [{
       "url" => "https://ftp.gnu.org/lightning/lightning-2.1.0.tar.gz",

--- a/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/uses_from_macos"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::UsesFromMacos do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::UsesFromMacos }
 
   context "when auditing `uses_from_macos` dependencies" do
     it "reports an offense when used on non-macOS dependency" do
@@ -49,5 +51,5 @@ RSpec.describe RuboCop::Cop::FormulaAudit::UsesFromMacos do
     end
   end
 
-  include_examples "formulae exist", described_class::ALLOWED_USES_FROM_MACOS_DEPS
+  include_examples "formulae exist", RuboCop::Cop::FormulaAudit::UsesFromMacos::ALLOWED_USES_FROM_MACOS_DEPS
 end

--- a/Library/Homebrew/test/rubocops/version_spec.rb
+++ b/Library/Homebrew/test/rubocops/version_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/version"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::Version do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::Version }
 
   context "when auditing version" do
     it "reports an offense if `version` is an empty string" do

--- a/Library/Homebrew/test/rubocops/zero_zero_zero_zero_spec.rb
+++ b/Library/Homebrew/test/rubocops/zero_zero_zero_zero_spec.rb
@@ -4,7 +4,9 @@
 require "rubocops/zero_zero_zero_zero"
 
 RSpec.describe RuboCop::Cop::FormulaAudit::ZeroZeroZeroZero do
-  subject(:cop) { described_class.new }
+  subject(:cop) { klass.new }
+
+  let(:klass) { RuboCop::Cop::FormulaAudit::ZeroZeroZeroZero }
 
   it "reports no offenses when 0.0.0.0 is used inside test do blocks" do
     expect_no_offenses(<<~RUBY, "/homebrew-core/")

--- a/Library/Homebrew/test/sandbox_linux_spec.rb
+++ b/Library/Homebrew/test/sandbox_linux_spec.rb
@@ -5,7 +5,9 @@ require "sandbox"
 require "extend/os/linux/sandbox" if OS.linux?
 
 RSpec.describe Sandbox, :needs_linux do
-  subject(:sandbox) { described_class.new }
+  subject(:sandbox) { klass.new }
+
+  let(:klass) { Sandbox }
 
   around do |example|
     with_env(HOMEBREW_SANDBOX_LINUX: "1") { example.run }
@@ -13,7 +15,7 @@ RSpec.describe Sandbox, :needs_linux do
 
   describe "::bubblewrap_executable" do
     let(:sandbox_class) do
-      Class.new(described_class) do
+      Class.new(klass) do
         class << self
           attr_accessor :test_executable_candidate_paths
 
@@ -50,7 +52,7 @@ RSpec.describe Sandbox, :needs_linux do
 
   describe "::available?" do
     let(:sandbox_class) do
-      Class.new(described_class) do
+      Class.new(klass) do
         class << self
           attr_accessor :test_executable_candidate_paths
 
@@ -120,7 +122,7 @@ RSpec.describe Sandbox, :needs_linux do
   end
 
   describe "::configuration_commands" do
-    let(:sandbox_class) { Class.new(described_class) }
+    let(:sandbox_class) { Class.new(klass) }
 
     def expect_sandbox_configuration_command(sandbox_class, assignment, result:)
       command = ["sudo", "sysctl", "-w", assignment]
@@ -235,7 +237,7 @@ RSpec.describe Sandbox, :needs_linux do
 
   describe "#run" do
     before do
-      skip "Sandbox not implemented." if !ENV["CI"] && !described_class.available?
+      skip "Sandbox not implemented." if !ENV["CI"] && !klass.available?
     end
 
     it "allows writing to an allowed path" do

--- a/Library/Homebrew/test/sandbox_shared_spec.rb
+++ b/Library/Homebrew/test/sandbox_shared_spec.rb
@@ -4,10 +4,12 @@
 require "sandbox"
 
 RSpec.describe Sandbox do
-  subject(:sandbox) { described_class.new }
+  subject(:sandbox) { klass.new }
+
+  let(:klass) { Sandbox }
 
   describe "::failure_reason" do
-    let(:sandbox_class) { Class.new(described_class) }
+    let(:sandbox_class) { Class.new(klass) }
 
     it "returns nil if the sandbox is available" do
       allow(sandbox_class).to receive(:state).and_return(:available)
@@ -24,7 +26,7 @@ RSpec.describe Sandbox do
 
   describe "::executable" do
     let(:sandbox_class) do
-      Class.new(described_class) do
+      Class.new(klass) do
         class << self
           attr_accessor :test_executable_name, :unsuitable_executables
 

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -4,15 +4,16 @@
 require "sandbox"
 
 RSpec.describe Sandbox, :needs_macos do
-  define_negated_matcher :not_matching, :matching
+  subject(:sandbox) { klass.new }
 
-  subject(:sandbox) { described_class.new }
-
+  let(:klass) { Sandbox }
   let(:dir) { mktmpdir }
   let(:file) { dir/"foo" }
 
+  define_negated_matcher :not_matching, :matching
+
   before do
-    skip "Sandbox not implemented." unless described_class.available?
+    skip "Sandbox not implemented." unless klass.available?
   end
 
   specify "#allow_write" do

--- a/Library/Homebrew/test/sbom_spec.rb
+++ b/Library/Homebrew/test/sbom_spec.rb
@@ -4,8 +4,10 @@
 require "sbom"
 
 RSpec.describe SBOM do
+  let(:klass) { SBOM }
+
   describe "#schema_validation_errors" do
-    subject(:sbom) { described_class.create(f, tab) }
+    subject(:sbom) { klass.create(f, tab) }
 
     before { ENV.delete("HOMEBREW_ENFORCE_SBOM") }
 

--- a/Library/Homebrew/test/search_spec.rb
+++ b/Library/Homebrew/test/search_spec.rb
@@ -6,17 +6,19 @@ require "descriptions"
 require "cmd/desc"
 
 RSpec.describe Homebrew::Search do
+  let(:klass) { Homebrew::Search }
+
   describe "#query_regexp" do
     it "correctly parses a regex query" do
-      expect(described_class.query_regexp("/^query$/")).to eq(/^query$/)
+      expect(klass.query_regexp("/^query$/")).to eq(/^query$/)
     end
 
     it "returns the original string if it is not a regex query" do
-      expect(described_class.query_regexp("query")).to eq("query")
+      expect(klass.query_regexp("query")).to eq("query")
     end
 
     it "raises an error if the query is an invalid regex" do
-      expect { described_class.query_regexp("/+/") }.to raise_error(/not a valid regex/)
+      expect { klass.query_regexp("/+/") }.to raise_error(/not a valid regex/)
     end
   end
 
@@ -27,25 +29,25 @@ RSpec.describe Homebrew::Search do
       let(:collection) { [["with-dashes", "withdashes"]] }
 
       it "searches by the selected argument" do
-        expect(described_class.search(collection, /withdashes/) { |_, short_name| short_name }).not_to be_empty
-        expect(described_class.search(collection, /withdashes/) { |long_name, _| long_name }).to be_empty
+        expect(klass.search(collection, /withdashes/) { |_, short_name| short_name }).not_to be_empty
+        expect(klass.search(collection, /withdashes/) { |long_name, _| long_name }).to be_empty
       end
     end
 
     context "when given a regex" do
       it "does not simplify strings" do
-        expect(described_class.search(collection, /with-dashes/)).to eq ["with-dashes"]
+        expect(klass.search(collection, /with-dashes/)).to eq ["with-dashes"]
       end
     end
 
     context "when given a string" do
       it "simplifies both the query and searched strings" do
-        expect(described_class.search(collection, "with dashes")).to eq ["with-dashes"]
+        expect(klass.search(collection, "with dashes")).to eq ["with-dashes"]
       end
 
       it "does not simplify strings with @ and + characters" do
-        expect(described_class.search(collection, "with@alpha")).to eq ["with@alpha"]
-        expect(described_class.search(collection, "with+plus")).to eq ["with+plus"]
+        expect(klass.search(collection, "with@alpha")).to eq ["with@alpha"]
+        expect(klass.search(collection, "with+plus")).to eq ["with+plus"]
       end
     end
 
@@ -53,14 +55,14 @@ RSpec.describe Homebrew::Search do
       let(:collection) { { "foo" => "bar" } }
 
       it "returns a Hash" do
-        expect(described_class.search(collection, "foo")).to eq "foo" => "bar"
+        expect(klass.search(collection, "foo")).to eq "foo" => "bar"
       end
 
       context "with a nil value" do
         let(:collection) { { "foo" => nil } }
 
         it "does not raise an error" do
-          expect(described_class.search(collection, "foo")).to eq "foo" => nil
+          expect(klass.search(collection, "foo")).to eq "foo" => nil
         end
       end
     end
@@ -84,23 +86,23 @@ RSpec.describe Homebrew::Search do
 
     it "annotates deprecated formulae" do
       allow(formula).to receive(:deprecated?).and_return(true)
-      expect(described_class.search_formulae(/testball/)).to contain_exactly(match(/\(deprecated\)/))
+      expect(klass.search_formulae(/testball/)).to contain_exactly(match(/\(deprecated\)/))
     end
 
     it "annotates disabled formulae" do
       allow(formula).to receive(:disabled?).and_return(true)
-      expect(described_class.search_formulae(/testball/)).to contain_exactly(match(/\(disabled\)/))
+      expect(klass.search_formulae(/testball/)).to contain_exactly(match(/\(disabled\)/))
     end
 
     it "does not annotate normal formulae" do
-      expect(described_class.search_formulae(/testball/)).to eq(["testball"])
+      expect(klass.search_formulae(/testball/)).to eq(["testball"])
     end
 
     it "shows only the installed icon for installed formulae" do
       allow(formula).to receive_messages(any_version_installed?: true, pinned?: true)
 
-      expect(described_class.search_formulae(/testball/))
-        .to eq([described_class.pretty_installed("testball")])
+      expect(klass.search_formulae(/testball/))
+        .to eq([klass.pretty_installed("testball")])
     end
   end
 
@@ -121,29 +123,29 @@ RSpec.describe Homebrew::Search do
 
     it "annotates deprecated casks", :needs_macos do
       allow(cask).to receive(:deprecated?).and_return(true)
-      expect(described_class.search_casks(/testball/)).to contain_exactly(match(/\(deprecated\)/))
+      expect(klass.search_casks(/testball/)).to contain_exactly(match(/\(deprecated\)/))
     end
 
     it "annotates disabled casks", :needs_macos do
       allow(cask).to receive(:disabled?).and_return(true)
-      expect(described_class.search_casks(/testball/)).to contain_exactly(match(/\(disabled\)/))
+      expect(klass.search_casks(/testball/)).to contain_exactly(match(/\(disabled\)/))
     end
 
     it "does not annotate normal casks", :needs_macos do
-      expect(described_class.search_casks(/testball/)).to eq(["testball"])
+      expect(klass.search_casks(/testball/)).to eq(["testball"])
     end
 
     it "hides macOS-only casks on Linux", :needs_linux do
       allow(cask).to receive(:supports_linux?).and_return(false)
 
-      expect(described_class.search_casks(/testball/)).to eq([])
+      expect(klass.search_casks(/testball/)).to eq([])
     end
 
     it "shows only the installed icon for installed casks", :needs_macos do
       allow(cask).to receive(:installed?).and_return(true)
 
-      expect(described_class.search_casks(/testball/))
-        .to eq([described_class.pretty_installed("testball")])
+      expect(klass.search_casks(/testball/))
+        .to eq([klass.pretty_installed("testball")])
     end
   end
 
@@ -165,12 +167,12 @@ RSpec.describe Homebrew::Search do
       end
 
       it "searches formula descriptions" do
-        expect { described_class.search_descriptions(described_class.query_regexp("some"), args) }
+        expect { klass.search_descriptions(klass.query_regexp("some"), args) }
           .to output(/testball: Some test/).to_stdout
       end
 
       it "searches cask descriptions", :needs_macos do
-        expect { described_class.search_descriptions(described_class.query_regexp("ball"), args) }
+        expect { klass.search_descriptions(klass.query_regexp("ball"), args) }
           .to output(/testball: \(Test Ball\) Some test/).to_stdout
           .and not_to_output(/testball: Some test/).to_stdout
       end

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -5,6 +5,8 @@ require "formula"
 require "service"
 
 RSpec.describe Homebrew::Service do
+  let(:klass) { Homebrew::Service }
+
   let(:name) { "formula_name" }
 
   def stub_formula(&block)
@@ -1391,12 +1393,12 @@ RSpec.describe Homebrew::Service do
     end
 
     it "replaces placeholders with local paths" do
-      expect(described_class.from_hash(serialized_hash)).to eq(deserialized_hash)
+      expect(klass.from_hash(serialized_hash)).to eq(deserialized_hash)
     end
 
     describe "run command" do
       it "handles String argument correctly" do
-        expect(described_class.from_hash({
+        expect(klass.from_hash({
           "run" => "$HOMEBREW_PREFIX/opt/formula_name/bin/beanstalkd",
         })).to eq({
           run: "#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd",
@@ -1404,7 +1406,7 @@ RSpec.describe Homebrew::Service do
       end
 
       it "handles Array argument correctly" do
-        expect(described_class.from_hash({
+        expect(klass.from_hash({
           "run" => ["$HOMEBREW_PREFIX/opt/formula_name/bin/beanstalkd", "--option"],
         })).to eq({
           run: ["#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd", "--option"],
@@ -1412,7 +1414,7 @@ RSpec.describe Homebrew::Service do
       end
 
       it "handles Hash argument correctly" do
-        expect(described_class.from_hash({
+        expect(klass.from_hash({
           "run" => {
             "linux" => "$HOMEBREW_PREFIX/opt/formula_name/bin/beanstalkd",
             "macos" => ["$HOMEBREW_PREFIX/opt/formula_name/bin/beanstalkd", "--option"],

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -6,8 +6,9 @@ require "services/system"
 require "services/formula_wrapper"
 
 RSpec.describe Homebrew::Services::Cli do
-  subject(:services_cli) { described_class }
+  subject(:services_cli) { klass }
 
+  let(:klass) { Homebrew::Services::Cli }
   let(:service_string) { "service" }
 
   describe "#bin" do
@@ -427,7 +428,7 @@ RSpec.describe Homebrew::Services::Cli do
       expect(Homebrew::Services::System).to receive(:launchctl?).once.and_return(true)
       expect(Homebrew::Services::System).not_to receive(:systemctl?)
       expect(Homebrew::Services::System).to receive(:root?).twice.and_return(false)
-      expect(described_class).to receive(:launchctl_load).once.and_return(true)
+      expect(klass).to receive(:launchctl_load).once.and_return(true)
       expect do
         services_cli.service_load(
           instance_double(

--- a/Library/Homebrew/test/services/formula_wrapper_spec.rb
+++ b/Library/Homebrew/test/services/formula_wrapper_spec.rb
@@ -6,8 +6,9 @@ require "services/formula_wrapper"
 require "tempfile"
 
 RSpec.describe Homebrew::Services::FormulaWrapper do
-  subject(:service) { described_class.new(formula) }
+  subject(:service) { klass.new(formula) }
 
+  let(:klass) { Homebrew::Services::FormulaWrapper }
   let(:formula) do
     instance_double(Formula,
                     name:                   "mysql",
@@ -20,7 +21,6 @@ RSpec.describe Homebrew::Services::FormulaWrapper do
                     any_version_installed?: true,
                     service?:               false)
   end
-
   let(:service_object) do
     instance_double(Homebrew::Service,
                     requires_root?: false,
@@ -384,7 +384,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper do
   describe "#to_hash" do
     it "represents non-service values" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: true, systemctl?: false)
-      allow_any_instance_of(described_class).to receive_messages(service?: false, service_file_present?: false)
+      allow_any_instance_of(klass).to receive_messages(service?: false, service_file_present?: false)
       expected = {
         exit_code:    nil,
         file:         Pathname.new("/usr/local/opt/mysql/homebrew.mysql.plist"),

--- a/Library/Homebrew/test/services/formulae_spec.rb
+++ b/Library/Homebrew/test/services/formulae_spec.rb
@@ -4,10 +4,13 @@
 require "services/formulae"
 
 RSpec.describe Homebrew::Services::Formulae do
+  sig { returns(T.class_of(Homebrew::Services::Formulae)) }
+  let(:klass) { Homebrew::Services::Formulae }
+
   describe "#services_list" do
     it "empty list without available formulae" do
-      allow(described_class).to receive(:available_services).and_return({})
-      expect(described_class.services_list).to eq([])
+      allow(klass).to receive(:available_services).and_return({})
+      expect(klass.services_list).to eq([])
     end
 
     it "list with available formulae" do
@@ -22,8 +25,8 @@ RSpec.describe Homebrew::Services::Formulae do
       ]
 
       expect(formula).to receive(:to_hash).and_return(expected[0])
-      allow(described_class).to receive(:available_services).and_return([formula])
-      expect(described_class.services_list).to eq(expected)
+      allow(klass).to receive(:available_services).and_return([formula])
+      expect(klass.services_list).to eq(expected)
     end
   end
 end

--- a/Library/Homebrew/test/services/system/systemctl_spec.rb
+++ b/Library/Homebrew/test/services/system/systemctl_spec.rb
@@ -5,17 +5,19 @@ require "services/system"
 require "services/system/systemctl"
 
 RSpec.describe Homebrew::Services::System::Systemctl do
+  let(:klass) { Homebrew::Services::System::Systemctl }
+
   let(:bindir) { mktmpdir }
 
   describe ".scope" do
     it "outputs systemctl scope for user" do
       allow(Homebrew::Services::System).to receive(:root?).and_return(false)
-      expect(described_class.scope).to eq("--user")
+      expect(klass.scope).to eq("--user")
     end
 
     it "outputs systemctl scope for root" do
       allow(Homebrew::Services::System).to receive(:root?).and_return(true)
-      expect(described_class.scope).to eq("--system")
+      expect(klass.scope).to eq("--system")
     end
   end
 
@@ -27,10 +29,10 @@ RSpec.describe Homebrew::Services::System::Systemctl do
         exit 0
       SH
       systemctl.chmod 0755
-      described_class.reset_executable!
+      klass.reset_executable!
 
       with_env(PATH: bindir.to_s) do
-        expect(described_class.executable).to eq(systemctl)
+        expect(klass.executable).to eq(systemctl)
       end
     end
   end

--- a/Library/Homebrew/test/services/system_spec.rb
+++ b/Library/Homebrew/test/services/system_spec.rb
@@ -4,10 +4,12 @@
 require "services/system"
 
 RSpec.describe Homebrew::Services::System do
+  let(:klass) { Homebrew::Services::System }
+
   let(:bindir) { mktmpdir }
 
   before do
-    described_class.reset_launchctl!
+    klass.reset_launchctl!
     Homebrew::Services::System::Systemctl.reset_executable!
   end
 
@@ -21,14 +23,14 @@ RSpec.describe Homebrew::Services::System do
       launchctl.chmod 0755
 
       with_env(PATH: bindir.to_s) do
-        expect(described_class.launchctl).to eq(launchctl)
+        expect(klass.launchctl).to eq(launchctl)
       end
 
-      described_class.reset_launchctl!
+      klass.reset_launchctl!
       launchctl.unlink
 
       with_env(PATH: bindir.to_s) do
-        expect(described_class.launchctl).to be_nil
+        expect(klass.launchctl).to be_nil
       end
     end
   end
@@ -43,14 +45,14 @@ RSpec.describe Homebrew::Services::System do
       launchctl.chmod 0755
 
       with_env(PATH: bindir.to_s) do
-        expect(described_class.launchctl?).to be(true)
+        expect(klass.launchctl?).to be(true)
       end
 
-      described_class.reset_launchctl!
+      klass.reset_launchctl!
       launchctl.unlink
 
       with_env(PATH: bindir.to_s) do
-        expect(described_class.launchctl?).to be(false)
+        expect(klass.launchctl?).to be(false)
       end
     end
   end
@@ -65,33 +67,33 @@ RSpec.describe Homebrew::Services::System do
       systemctl.chmod 0755
 
       with_env(PATH: bindir.to_s) do
-        expect(described_class.systemctl?).to be(true)
+        expect(klass.systemctl?).to be(true)
       end
 
       Homebrew::Services::System::Systemctl.reset_executable!
       systemctl.unlink
 
       with_env(PATH: bindir.to_s) do
-        expect(described_class.systemctl?).to be(false)
+        expect(klass.systemctl?).to be(false)
       end
     end
   end
 
   describe "#root?" do
     it "checks if the command is ran as root" do
-      expect(described_class.root?).to be(false)
+      expect(klass.root?).to be(false)
     end
   end
 
   describe "#user" do
     it "returns the current username" do
-      expect(described_class.user).to eq(ENV.fetch("USER"))
+      expect(klass.user).to eq(ENV.fetch("USER"))
     end
   end
 
   describe "#user_of_process" do
     it "returns the username for empty PID" do
-      expect(described_class.user_of_process(nil)).to eq(ENV.fetch("USER"))
+      expect(klass.user_of_process(nil)).to eq(ENV.fetch("USER"))
     end
 
     it "returns the PID username" do
@@ -99,44 +101,44 @@ RSpec.describe Homebrew::Services::System do
         USER
         user
       EOS
-      expect(described_class.user_of_process(50)).to eq("user")
+      expect(klass.user_of_process(50)).to eq("user")
     end
 
     it "returns nil if unavailable" do
       allow(Utils).to receive(:safe_popen_read).and_return <<~EOS
         USER
       EOS
-      expect(described_class.user_of_process(50)).to be_nil
+      expect(klass.user_of_process(50)).to be_nil
     end
   end
 
   describe "#domain_target" do
     it "returns the current domain target" do
-      allow(described_class).to receive(:root?).and_return(false)
-      expect(described_class.domain_target).to match(%r{gui/(\d+)})
+      allow(klass).to receive(:root?).and_return(false)
+      expect(klass.domain_target).to match(%r{gui/(\d+)})
     end
 
     it "returns the root domain target" do
-      allow(described_class).to receive(:root?).and_return(true)
-      expect(described_class.domain_target).to match("system")
+      allow(klass).to receive(:root?).and_return(true)
+      expect(klass.domain_target).to match("system")
     end
   end
 
   describe "#boot_path" do
     it "macOS - returns the boot path" do
-      allow(described_class).to receive(:launchctl?).and_return(true)
-      expect(described_class.boot_path.to_s).to eq("/Library/LaunchDaemons")
+      allow(klass).to receive(:launchctl?).and_return(true)
+      expect(klass.boot_path.to_s).to eq("/Library/LaunchDaemons")
     end
 
     it "SystemD - returns the boot path" do
-      allow(described_class).to receive_messages(launchctl?: false, systemctl?: true)
-      expect(described_class.boot_path.to_s).to eq("/usr/lib/systemd/system")
+      allow(klass).to receive_messages(launchctl?: false, systemctl?: true)
+      expect(klass.boot_path.to_s).to eq("/usr/lib/systemd/system")
     end
 
     it "Unknown - raises an error" do
-      allow(described_class).to receive_messages(launchctl?: false, systemctl?: false)
+      allow(klass).to receive_messages(launchctl?: false, systemctl?: false)
       expect do
-        described_class.boot_path.to_s
+        klass.boot_path.to_s
       end.to raise_error(UsageError,
                          "Invalid usage: `brew services` is supported only on macOS or Linux (with systemd)!")
     end
@@ -145,21 +147,21 @@ RSpec.describe Homebrew::Services::System do
   describe "#user_path" do
     it "macOS - returns the user path" do
       ENV["HOME"] = "/tmp_home"
-      allow(described_class).to receive_messages(launchctl?: true, systemctl?: false)
-      expect(described_class.user_path.to_s).to eq("/tmp_home/Library/LaunchAgents")
+      allow(klass).to receive_messages(launchctl?: true, systemctl?: false)
+      expect(klass.user_path.to_s).to eq("/tmp_home/Library/LaunchAgents")
     end
 
     it "systemD - returns the user path" do
       ENV["HOME"] = "/tmp_home"
-      allow(described_class).to receive_messages(launchctl?: false, systemctl?: true)
-      expect(described_class.user_path.to_s).to eq("/tmp_home/.config/systemd/user")
+      allow(klass).to receive_messages(launchctl?: false, systemctl?: true)
+      expect(klass.user_path.to_s).to eq("/tmp_home/.config/systemd/user")
     end
 
     it "Unknown - raises an error" do
       ENV["HOME"] = "/tmp_home"
-      allow(described_class).to receive_messages(launchctl?: false, systemctl?: false)
+      allow(klass).to receive_messages(launchctl?: false, systemctl?: false)
       expect do
-        described_class.user_path.to_s
+        klass.user_path.to_s
       end.to raise_error(UsageError,
                          "Invalid usage: `brew services` is supported only on macOS or Linux (with systemd)!")
     end
@@ -168,26 +170,26 @@ RSpec.describe Homebrew::Services::System do
   describe "#path" do
     it "macOS - user - returns the current relevant path" do
       ENV["HOME"] = "/tmp_home"
-      allow(described_class).to receive_messages(root?: false, launchctl?: true, systemctl?: false)
-      expect(described_class.path.to_s).to eq("/tmp_home/Library/LaunchAgents")
+      allow(klass).to receive_messages(root?: false, launchctl?: true, systemctl?: false)
+      expect(klass.path.to_s).to eq("/tmp_home/Library/LaunchAgents")
     end
 
     it "macOS - root- returns the current relevant path" do
       ENV["HOME"] = "/tmp_home"
-      allow(described_class).to receive_messages(root?: true, launchctl?: true, systemctl?: false)
-      expect(described_class.path.to_s).to eq("/Library/LaunchDaemons")
+      allow(klass).to receive_messages(root?: true, launchctl?: true, systemctl?: false)
+      expect(klass.path.to_s).to eq("/Library/LaunchDaemons")
     end
 
     it "systemD - user - returns the current relevant path" do
       ENV["HOME"] = "/tmp_home"
-      allow(described_class).to receive_messages(root?: false, launchctl?: false, systemctl?: true)
-      expect(described_class.path.to_s).to eq("/tmp_home/.config/systemd/user")
+      allow(klass).to receive_messages(root?: false, launchctl?: false, systemctl?: true)
+      expect(klass.path.to_s).to eq("/tmp_home/.config/systemd/user")
     end
 
     it "systemD - root- returns the current relevant path" do
       ENV["HOME"] = "/tmp_home"
-      allow(described_class).to receive_messages(root?: true, launchctl?: false, systemctl?: true)
-      expect(described_class.path.to_s).to eq("/usr/lib/systemd/system")
+      allow(klass).to receive_messages(root?: true, launchctl?: false, systemctl?: true)
+      expect(klass.path.to_s).to eq("/usr/lib/systemd/system")
     end
   end
 end

--- a/Library/Homebrew/test/settings_spec.rb
+++ b/Library/Homebrew/test/settings_spec.rb
@@ -4,6 +4,8 @@
 require "settings"
 
 RSpec.describe Homebrew::Settings do
+  let(:klass) { Homebrew::Settings }
+
   before do
     HOMEBREW_REPOSITORY.cd do
       system "git", "init"
@@ -19,56 +21,56 @@ RSpec.describe Homebrew::Settings do
   describe ".read" do
     it "returns the correct value for a setting" do
       setup_setting
-      expect(described_class.read("foo")).to eq "true"
+      expect(klass.read("foo")).to eq "true"
     end
 
     it "returns the correct value for a setting as a symbol" do
       setup_setting
-      expect(described_class.read(:foo)).to eq "true"
+      expect(klass.read(:foo)).to eq "true"
     end
 
     it "returns nil when setting is not set" do
       setup_setting
-      expect(described_class.read("bar")).to be_nil
+      expect(klass.read("bar")).to be_nil
     end
 
     it "runs on a repo without a configuration file" do
-      expect { described_class.read("foo", repo: HOMEBREW_REPOSITORY/"bar") }.not_to raise_error
+      expect { klass.read("foo", repo: HOMEBREW_REPOSITORY/"bar") }.not_to raise_error
     end
   end
 
   describe ".write" do
     it "writes over an existing value" do
       setup_setting
-      described_class.write :foo, false
-      expect(described_class.read("foo")).to eq "false"
+      klass.write :foo, false
+      expect(klass.read("foo")).to eq "false"
     end
 
     it "writes a new value" do
       setup_setting
-      described_class.write :bar, "abcde"
-      expect(described_class.read("bar")).to eq "abcde"
+      klass.write :bar, "abcde"
+      expect(klass.read("bar")).to eq "abcde"
     end
 
     it "returns if the repo doesn't have a configuration file" do
-      expect { described_class.write("foo", false, repo: HOMEBREW_REPOSITORY/"bar") }.not_to raise_error
+      expect { klass.write("foo", false, repo: HOMEBREW_REPOSITORY/"bar") }.not_to raise_error
     end
   end
 
   describe ".delete" do
     it "deletes an existing setting" do
       setup_setting
-      described_class.delete(:foo)
-      expect(described_class.read("foo")).to be_nil
+      klass.delete(:foo)
+      expect(klass.read("foo")).to be_nil
     end
 
     it "deletes a non-existing setting" do
       setup_setting
-      expect { described_class.delete(:bar) }.not_to raise_error
+      expect { klass.delete(:bar) }.not_to raise_error
     end
 
     it "returns if the repo doesn't have a configuration file" do
-      expect { described_class.delete("foo", repo: HOMEBREW_REPOSITORY/"bar") }.not_to raise_error
+      expect { klass.delete("foo", repo: HOMEBREW_REPOSITORY/"bar") }.not_to raise_error
     end
   end
 end

--- a/Library/Homebrew/test/simulate_system_spec.rb
+++ b/Library/Homebrew/test/simulate_system_spec.rb
@@ -4,139 +4,142 @@
 require "settings"
 
 RSpec.describe Homebrew::SimulateSystem do
+  sig { returns(T.class_of(Homebrew::SimulateSystem)) }
+  let(:klass) { Homebrew::SimulateSystem }
+
   after do
-    described_class.clear
+    klass.clear
   end
 
   describe "::simulating_or_running_on_macos?" do
     it "returns true on macOS", :needs_macos do
-      described_class.clear
-      expect(described_class.simulating_or_running_on_macos?).to be true
+      klass.clear
+      expect(klass.simulating_or_running_on_macos?).to be true
     end
 
     it "returns false on Linux", :needs_linux do
-      described_class.clear
-      expect(described_class.simulating_or_running_on_macos?).to be false
+      klass.clear
+      expect(klass.simulating_or_running_on_macos?).to be false
     end
 
     it "returns false on macOS when simulating Linux", :needs_macos do
-      described_class.clear
-      described_class.os = :linux
-      expect(described_class.simulating_or_running_on_macos?).to be false
+      klass.clear
+      klass.os = :linux
+      expect(klass.simulating_or_running_on_macos?).to be false
     end
 
     it "returns true on Linux when simulating a generic macOS version", :needs_linux do
-      described_class.clear
-      described_class.os = :macos
-      expect(described_class.simulating_or_running_on_macos?).to be true
+      klass.clear
+      klass.os = :macos
+      expect(klass.simulating_or_running_on_macos?).to be true
     end
 
     it "returns true on Linux when simulating a specific macOS version", :needs_linux do
-      described_class.clear
-      described_class.os = :monterey
-      expect(described_class.simulating_or_running_on_macos?).to be true
+      klass.clear
+      klass.os = :monterey
+      expect(klass.simulating_or_running_on_macos?).to be true
     end
 
     it "returns true on Linux with HOMEBREW_SIMULATE_MACOS_ON_LINUX", :needs_linux do
-      described_class.clear
+      klass.clear
       ENV["HOMEBREW_SIMULATE_MACOS_ON_LINUX"] = "1"
-      expect(described_class.simulating_or_running_on_macos?).to be true
+      expect(klass.simulating_or_running_on_macos?).to be true
     end
   end
 
   describe "::simulating_or_running_on_linux?" do
     it "returns true on Linux", :needs_linux do
-      described_class.clear
-      expect(described_class.simulating_or_running_on_linux?).to be true
+      klass.clear
+      expect(klass.simulating_or_running_on_linux?).to be true
     end
 
     it "returns false on macOS", :needs_macos do
-      described_class.clear
-      expect(described_class.simulating_or_running_on_linux?).to be false
+      klass.clear
+      expect(klass.simulating_or_running_on_linux?).to be false
     end
 
     it "returns true on macOS when simulating Linux", :needs_macos do
-      described_class.clear
-      described_class.os = :linux
-      expect(described_class.simulating_or_running_on_linux?).to be true
+      klass.clear
+      klass.os = :linux
+      expect(klass.simulating_or_running_on_linux?).to be true
     end
 
     it "returns false on Linux when simulating a generic macOS version", :needs_linux do
-      described_class.clear
-      described_class.os = :macos
-      expect(described_class.simulating_or_running_on_linux?).to be false
+      klass.clear
+      klass.os = :macos
+      expect(klass.simulating_or_running_on_linux?).to be false
     end
 
     it "returns false on Linux when simulating a specific macOS version", :needs_linux do
-      described_class.clear
-      described_class.os = :monterey
-      expect(described_class.simulating_or_running_on_linux?).to be false
+      klass.clear
+      klass.os = :monterey
+      expect(klass.simulating_or_running_on_linux?).to be false
     end
 
     it "returns false on Linux with HOMEBREW_SIMULATE_MACOS_ON_LINUX", :needs_linux do
-      described_class.clear
+      klass.clear
       ENV["HOMEBREW_SIMULATE_MACOS_ON_LINUX"] = "1"
-      expect(described_class.simulating_or_running_on_linux?).to be false
+      expect(klass.simulating_or_running_on_linux?).to be false
     end
   end
 
   describe "::current_arch" do
     it "returns the current architecture" do
-      described_class.clear
-      expect(described_class.current_arch).to eq Hardware::CPU.type
+      klass.clear
+      expect(klass.current_arch).to eq Hardware::CPU.type
     end
 
     it "returns the simulated architecture" do
-      described_class.clear
+      klass.clear
       simulated_arch = if Hardware::CPU.arm?
         :intel
       else
         :arm
       end
-      described_class.arch = simulated_arch
-      expect(described_class.current_arch).to eq simulated_arch
+      klass.arch = simulated_arch
+      expect(klass.current_arch).to eq simulated_arch
     end
   end
 
   describe "::current_os" do
     it "returns the current macOS version on macOS", :needs_macos do
-      described_class.clear
-      expect(described_class.current_os).to eq MacOS.version.to_sym
+      klass.clear
+      expect(klass.current_os).to eq MacOS.version.to_sym
     end
 
     it "returns `:linux` on Linux", :needs_linux do
-      described_class.clear
-      expect(described_class.current_os).to eq :linux
+      klass.clear
+      expect(klass.current_os).to eq :linux
     end
 
     it "returns `:linux` when simulating Linux on macOS", :needs_macos do
-      described_class.clear
-      described_class.os = :linux
-      expect(described_class.current_os).to eq :linux
+      klass.clear
+      klass.os = :linux
+      expect(klass.current_os).to eq :linux
     end
 
     it "returns `:macos` when simulating a generic macOS version on Linux", :needs_linux do
-      described_class.clear
-      described_class.os = :macos
-      expect(described_class.current_os).to eq :macos
+      klass.clear
+      klass.os = :macos
+      expect(klass.current_os).to eq :macos
     end
 
     it "returns `:macos` when simulating a specific macOS version on Linux", :needs_linux do
-      described_class.clear
-      described_class.os = :monterey
-      expect(described_class.current_os).to eq :monterey
+      klass.clear
+      klass.os = :monterey
+      expect(klass.current_os).to eq :monterey
     end
 
     it "returns the current macOS version on macOS with HOMEBREW_SIMULATE_MACOS_ON_LINUX", :needs_macos do
-      described_class.clear
+      klass.clear
       ENV["HOMEBREW_SIMULATE_MACOS_ON_LINUX"] = "1"
-      expect(described_class.current_os).to eq MacOS.version.to_sym
+      expect(klass.current_os).to eq MacOS.version.to_sym
     end
 
     it "returns the newest supported macOS symbol on Linux with HOMEBREW_SIMULATE_MACOS_ON_LINUX", :needs_linux do
-      described_class.clear
+      klass.clear
       ENV["HOMEBREW_SIMULATE_MACOS_ON_LINUX"] = "1"
-      expect(described_class.current_os).to eq MacOSVersion.new(HOMEBREW_MACOS_NEWEST_SUPPORTED).to_sym
+      expect(klass.current_os).to eq MacOSVersion.new(HOMEBREW_MACOS_NEWEST_SUPPORTED).to_sym
     end
   end
 end

--- a/Library/Homebrew/test/software_spec_spec.rb
+++ b/Library/Homebrew/test/software_spec_spec.rb
@@ -4,12 +4,13 @@
 require "software_spec"
 
 RSpec.describe SoftwareSpec do
+  subject(:spec) { klass.new }
+
+  let(:klass) { SoftwareSpec }
+  let(:owner) { instance_double(Cask::Cask, name: "some_name", full_name: "some_name", tap: "homebrew/core") }
+
   alias_matcher :have_defined_resource, :be_resource_defined
   alias_matcher :have_defined_option, :be_option_defined
-
-  subject(:spec) { described_class.new }
-
-  let(:owner) { instance_double(Cask::Cask, name: "some_name", full_name: "some_name", tap: "homebrew/core") }
 
   describe "#resource" do
     it "defines a resource" do

--- a/Library/Homebrew/test/startup/bootsnap_spec.rb
+++ b/Library/Homebrew/test/startup/bootsnap_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Homebrew::Bootsnap do
   describe "::load!" do
     it "does not error when the configured gem path is unavailable" do
       with_env(HOMEBREW_BOOTSNAP_GEM_PATH: "#{TEST_TMPDIR}/missing-bootsnap", HOMEBREW_NO_BOOTSNAP: nil) do
-        expect { described_class.load! }.not_to raise_error
+        expect { Homebrew::Bootsnap.load! }.not_to raise_error
       end
     end
   end

--- a/Library/Homebrew/test/style_spec.rb
+++ b/Library/Homebrew/test/style_spec.rb
@@ -4,6 +4,8 @@
 require "style"
 
 RSpec.describe Homebrew::Style do
+  let(:klass) { Homebrew::Style }
+
   around do |example|
     FileUtils.ln_s HOMEBREW_LIBRARY_PATH, HOMEBREW_LIBRARY/"Homebrew"
     FileUtils.ln_s HOMEBREW_LIBRARY_PATH.parent/".rubocop.yml", HOMEBREW_LIBRARY/".rubocop.yml"
@@ -30,7 +32,7 @@ RSpec.describe Homebrew::Style do
         end
       EOS
 
-      style_offenses = described_class.check_style_json([formula])
+      style_offenses = klass.check_style_json([formula])
 
       expect(style_offenses.for_path(formula.realpath).map(&:message))
         .to include("Extra empty line detected at class body beginning.")
@@ -45,7 +47,7 @@ RSpec.describe Homebrew::Style do
       # but not regular, cop violations
       target_file = HOMEBREW_LIBRARY_PATH/"utils.rb"
 
-      style_result = described_class.check_style_and_print([target_file])
+      style_result = klass.check_style_and_print([target_file])
 
       expect(style_result).to be true
     end
@@ -53,10 +55,10 @@ RSpec.describe Homebrew::Style do
 
   describe ".run_actionlint!" do
     before do
-      allow(described_class).to receive_messages(actionlint: "actionlint", shellcheck: "shellcheck")
+      allow(klass).to receive_messages(actionlint: "actionlint", shellcheck: "shellcheck")
       # Run a trivial command so $CHILD_STATUS is non-nil after the stubbed `system` call.
       system("true")
-      allow(described_class).to receive(:system).and_return(true)
+      allow(klass).to receive(:system).and_return(true)
     end
 
     it "uses a tap's actionlint config when present" do
@@ -69,7 +71,7 @@ RSpec.describe Homebrew::Style do
       tap_config = tap_path/".github/actionlint.yaml"
       tap_config.write "self-hosted-runner:\n  labels: []\n"
 
-      expect(described_class).to receive(:system).with(
+      expect(klass).to receive(:system).with(
         "actionlint", "-shellcheck", "shellcheck",
         "-config-file", tap_config,
         "-ignore", "image: string; options: string",
@@ -77,7 +79,7 @@ RSpec.describe Homebrew::Style do
         workflow
       )
 
-      described_class.run_actionlint!([workflow])
+      klass.run_actionlint!([workflow])
     end
 
     it "falls back to HOMEBREW_REPOSITORY config when no tap config exists" do
@@ -87,7 +89,7 @@ RSpec.describe Homebrew::Style do
       workflow = workflows_dir/"ci.yml"
       workflow.write "name: CI"
 
-      expect(described_class).to receive(:system).with(
+      expect(klass).to receive(:system).with(
         "actionlint", "-shellcheck", "shellcheck",
         "-config-file", HOMEBREW_REPOSITORY/".github/actionlint.yaml",
         "-ignore", "image: string; options: string",
@@ -95,7 +97,7 @@ RSpec.describe Homebrew::Style do
         workflow
       )
 
-      described_class.run_actionlint!([workflow])
+      klass.run_actionlint!([workflow])
     end
 
     it "falls back to HOMEBREW_REPOSITORY config when files span multiple taps" do
@@ -111,7 +113,7 @@ RSpec.describe Homebrew::Style do
       workflow2 = tap2_path/".github/workflows/ci.yml"
       workflow2.write "name: CI"
 
-      expect(described_class).to receive(:system).with(
+      expect(klass).to receive(:system).with(
         "actionlint", "-shellcheck", "shellcheck",
         "-config-file", HOMEBREW_REPOSITORY/".github/actionlint.yaml",
         "-ignore", "image: string; options: string",
@@ -119,7 +121,7 @@ RSpec.describe Homebrew::Style do
         workflow1, workflow2
       )
 
-      described_class.run_actionlint!([workflow1, workflow2])
+      klass.run_actionlint!([workflow1, workflow2])
     end
   end
 
@@ -133,7 +135,7 @@ RSpec.describe Homebrew::Style do
                                                          executable: "shellcheck")
                                                    .and_return(Pathname.new("/usr/bin/shellcheck"))
 
-      expect(described_class.shellcheck).to eq(Pathname.new("/usr/bin/shellcheck"))
+      expect(klass.shellcheck).to eq(Pathname.new("/usr/bin/shellcheck"))
     end
   end
 
@@ -148,7 +150,7 @@ RSpec.describe Homebrew::Style do
                                                          version_args: ["-version"])
                                                    .and_return(Pathname.new("/usr/bin/actionlint"))
 
-      expect(described_class.actionlint).to eq(Pathname.new("/usr/bin/actionlint"))
+      expect(klass.actionlint).to eq(Pathname.new("/usr/bin/actionlint"))
     end
   end
 
@@ -164,13 +166,13 @@ RSpec.describe Homebrew::Style do
                                                    .and_return(Pathname.new("/usr/bin/shfmt"))
       system("true")
 
-      expect(described_class).to receive(:system).with(
+      expect(klass).to receive(:system).with(
         { "HOMEBREW_SHFMT" => "/usr/bin/shfmt" },
         HOMEBREW_LIBRARY/"Homebrew/utils/shfmt.sh",
         "--language-dialect", "bash", "--indent", "2", "--case-indent", "--", shell_file
       ).and_return(true)
 
-      described_class.run_shfmt!([shell_file])
+      klass.run_shfmt!([shell_file])
     end
   end
 
@@ -188,12 +190,12 @@ RSpec.describe Homebrew::Style do
     it "passes --disable-uncorrectable when --todo is enabled" do
       result = double(status: double(exitstatus: 0), stdout: '{"files":[]}')
 
-      expect(described_class).to receive(:system_command) do |_cmd, args:, **|
+      expect(klass).to receive(:system_command) do |_cmd, args:, **|
         expect(args).to include("--disable-uncorrectable")
         result
       end
 
-      described_class.run_rubocop([ruby_file], :json, fix: true, todo: true)
+      klass.run_rubocop([ruby_file], :json, fix: true, todo: true)
     end
   end
 end

--- a/Library/Homebrew/test/support/helper/subcommand_spec.rb
+++ b/Library/Homebrew/test/support/helper/subcommand_spec.rb
@@ -3,6 +3,6 @@
 
 RSpec.describe Test::Helper::Subcommand::Args do
   specify "unknown predicates raise" do
-    expect { described_class.new(named: []).formuale? }.to raise_error(NoMethodError)
+    expect { Test::Helper::Subcommand::Args.new(named: []).formuale? }.to raise_error(NoMethodError)
   end
 end

--- a/Library/Homebrew/test/support/helper/subcommand_spec.rb
+++ b/Library/Homebrew/test/support/helper/subcommand_spec.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: false
 # frozen_string_literal: true
 
 RSpec.describe Test::Helper::Subcommand::Args do

--- a/Library/Homebrew/test/system_command_result_spec.rb
+++ b/Library/Homebrew/test/system_command_result_spec.rb
@@ -4,19 +4,20 @@
 require "system_command"
 
 RSpec.describe SystemCommand::Result do
-  RSpec::Matchers.alias_matcher :a_string_containing, :include
-
   subject(:result) do
-    described_class.new([], output_array, instance_double(Process::Status, exitstatus: 0, success?: true),
-                        secrets: [])
+    klass.new([], output_array, instance_double(Process::Status, exitstatus: 0, success?: true),
+              secrets: [])
   end
 
+  let(:klass) { SystemCommand::Result }
   let(:output_array) do
     [
       [:stdout, "output\n"],
       [:stderr, "error\n"],
     ]
   end
+
+  RSpec::Matchers.alias_matcher :a_string_containing, :include
 
   describe "#to_ary" do
     it "can be destructed like `Open3.capture3`" do

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -4,9 +4,11 @@
 require "system_command"
 
 RSpec.describe SystemCommand do
+  let(:klass) { SystemCommand }
+
   describe "#initialize" do
     subject(:command) do
-      described_class.new(
+      klass.new(
         "env",
         args:         env_args,
         env:,
@@ -95,7 +97,7 @@ RSpec.describe SystemCommand do
 
   context "when the exit code is 0" do
     describe "its result" do
-      subject(:result) { described_class.run("true") }
+      subject(:result) { klass.run("true") }
 
       it { is_expected.to be_a_success }
       it(:exit_status) { expect(result.exit_status).to eq(0) }
@@ -108,14 +110,14 @@ RSpec.describe SystemCommand do
     context "with a command that must succeed" do
       it "throws an error" do
         expect do
-          described_class.run!(command)
+          klass.run!(command)
         end.to raise_error(ErrorDuringExecution)
       end
     end
 
     context "with a command that does not have to succeed" do
       describe "its result" do
-        subject(:result) { described_class.run(command) }
+        subject(:result) { klass.run(command) }
 
         it { is_expected.not_to be_a_success }
         it(:exit_status) { expect(result.exit_status).to eq(1) }
@@ -132,7 +134,7 @@ RSpec.describe SystemCommand do
     end
 
     describe "its result" do
-      subject(:result) { described_class.run(command, args: [path]) }
+      subject(:result) { klass.run(command, args: [path]) }
 
       it { is_expected.to be_a_success }
       it(:stdout) { expect(result.stdout).to eq("somefile\n") }
@@ -150,7 +152,7 @@ RSpec.describe SystemCommand do
 
     shared_examples "it returns '1 2 3 4 5 6'" do
       describe "its result" do
-        subject(:result) { described_class.run(command, **options) }
+        subject(:result) { klass.run(command, **options) }
 
         it { is_expected.to be_a_success }
         it(:stdout) { expect(result.stdout).to eq([1, 3, 5, nil].join("\n")) }
@@ -162,7 +164,7 @@ RSpec.describe SystemCommand do
       it "echoes only STDERR" do
         expected = [2, 4, 6].map { |i| "#{i}\n" }.join
         expect do
-          described_class.run(command, **options)
+          klass.run(command, **options)
         end.to output(expected).to_stderr
       end
 
@@ -175,7 +177,7 @@ RSpec.describe SystemCommand do
       end
 
       it "echoes both STDOUT and STDERR" do
-        expect { described_class.run(command, **options) }
+        expect { klass.run(command, **options) }
           .to output("1\n3\n5\n").to_stdout
           .and output("2\n4\n6\n").to_stderr
       end
@@ -189,7 +191,7 @@ RSpec.describe SystemCommand do
       end
 
       it "echoes only STDERR output" do
-        expect { described_class.run(command, **options) }
+        expect { klass.run(command, **options) }
           .to output("2\n4\n6\n").to_stderr
           .and not_to_output.to_stdout
       end
@@ -206,7 +208,7 @@ RSpec.describe SystemCommand do
 
         it "echoes the command and all output to STDERR" do
           with_context(verbose: true, debug: true) do
-            expect { described_class.run(command, **options) }
+            expect { klass.run(command, **options) }
               .to output(/\A.*#{Regexp.escape(command)}.*\n1\n2\n3\n4\n5\n6\n\Z/).to_stderr
               .and not_to_output.to_stdout
           end
@@ -223,7 +225,7 @@ RSpec.describe SystemCommand do
 
       it "echoes nothing" do
         expect do
-          described_class.run(command, **options)
+          klass.run(command, **options)
         end.not_to output.to_stdout
       end
 
@@ -238,7 +240,7 @@ RSpec.describe SystemCommand do
       it "echoes only STDOUT" do
         expected = [1, 3, 5].map { |i| "#{i}\n" }.join
         expect do
-          described_class.run(command, **options)
+          klass.run(command, **options)
         end.to output(expected).to_stdout
       end
 
@@ -256,13 +258,13 @@ RSpec.describe SystemCommand do
     end
 
     it "returns without deadlocking", timeout: 30 do
-      expect(described_class.run(command, **options)).to be_a_success
+      expect(klass.run(command, **options)).to be_a_success
     end
   end
 
   context "when given an invalid variable name" do
     it "raises an ArgumentError" do
-      expect { described_class.run("true", env: { "1ABC" => true }) }
+      expect { klass.run("true", env: { "1ABC" => true }) }
         .to raise_error(ArgumentError, /variable name/)
     end
   end
@@ -276,14 +278,14 @@ RSpec.describe SystemCommand do
 
       FileUtils.chmod "+x", path/"tool"
 
-      expect(described_class.run("tool", env: { "PATH" => path.to_s }).stdout).to include "Hello, world!"
+      expect(klass.run("tool", env: { "PATH" => path.to_s }).stdout).to include "Hello, world!"
     end
   end
 
   describe "#run" do
     it "does not raise a `SystemCallError` when the executable does not exist" do
       expect do
-        described_class.run("non_existent_executable")
+        klass.run("non_existent_executable")
       end.not_to raise_error
     end
 
@@ -321,11 +323,11 @@ RSpec.describe SystemCommand do
       it "does not leak the secrets" do
         redacted_msg = /#{Regexp.escape("username:******")}/
         expect do
-          described_class.run! "curl",
-                               args:    %w[--user username:hunter2],
-                               verbose: true,
-                               debug:   true,
-                               secrets: %w[hunter2]
+          klass.run! "curl",
+                     args:    %w[--user username:hunter2],
+                     verbose: true,
+                     debug:   true,
+                     secrets: %w[hunter2]
         end.to raise_error(ErrorDuringExecution, redacted_msg).and output(redacted_msg).to_stderr
       end
 
@@ -333,10 +335,10 @@ RSpec.describe SystemCommand do
         redacted_msg = /#{Regexp.escape("username:******")}/
         expect do
           ENV["PASSWORD"] = "hunter2"
-          described_class.run! "curl",
-                               args:    %w[--user username:hunter2],
-                               debug:   true,
-                               verbose: true
+          klass.run! "curl",
+                     args:    %w[--user username:hunter2],
+                     debug:   true,
+                     verbose: true
         end.to raise_error(ErrorDuringExecution, redacted_msg).and output(redacted_msg).to_stderr
       end
     end
@@ -345,11 +347,11 @@ RSpec.describe SystemCommand do
       it "does not leak the secrets" do
         redacted_msg = /#{Regexp.escape("username:******")}/
         expect do
-          described_class.run! "echo",
-                               args:         %w[username:hunter2],
-                               verbose:      true,
-                               print_stdout: true,
-                               secrets:      %w[hunter2]
+          klass.run! "echo",
+                     args:         %w[username:hunter2],
+                     verbose:      true,
+                     print_stdout: true,
+                     secrets:      %w[hunter2]
         end.to output(redacted_msg).to_stdout
       end
 
@@ -357,10 +359,10 @@ RSpec.describe SystemCommand do
         redacted_msg = /#{Regexp.escape("username:******")}/
         expect do
           ENV["PASSWORD"] = "hunter2"
-          described_class.run! "echo",
-                               args:         %w[username:hunter2],
-                               print_stdout: true,
-                               verbose:      true
+          klass.run! "echo",
+                     args:         %w[username:hunter2],
+                     print_stdout: true,
+                     verbose:      true
         end.to output(redacted_msg).to_stdout
       end
     end
@@ -374,7 +376,7 @@ RSpec.describe SystemCommand do
             # Ignore SIGINT.
           end
 
-          described_class.run! "sleep", args: [5]
+          klass.run! "sleep", args: [5]
 
           exit!
         end

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -5,6 +5,44 @@ require "tab"
 require "formula"
 
 RSpec.describe Tab do
+  subject(:tab) do
+    klass.new(
+      "homebrew_version"     => HOMEBREW_VERSION,
+      "used_options"         => used_options.as_flags,
+      "unused_options"       => unused_options.as_flags,
+      "built_as_bottle"      => false,
+      "poured_from_bottle"   => true,
+      "installed_on_request" => true,
+      "changed_files"        => [],
+      "time"                 => time,
+      "source_modified_time" => 0,
+      "compiler"             => "clang",
+      "stdlib"               => "libcxx",
+      "runtime_dependencies" => [],
+      "source"               => {
+        "tap"          => CoreTap.instance.to_s,
+        "path"         => CoreTap.instance.path.to_s,
+        "spec"         => "stable",
+        "scm_revision" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "versions"     => {
+          "stable" => "0.10",
+          "head"   => "HEAD-1111111",
+        },
+      },
+      "arch"                 => Hardware::CPU.arch,
+      "built_on"             => DevelopmentTools.build_system_info,
+    )
+  end
+
+  let(:klass) { Tab }
+  let(:time) { Time.now.to_i }
+  let(:unused_options) { Options.create(%w[--with-baz --without-qux]) }
+  let(:used_options) { Options.create(%w[--with-foo --without-bar]) }
+  let(:git_repo) { HOMEBREW_CACHE/"tab-spec-git-repo" }
+  let(:f) { formula { url "foo-1.0" } }
+  let(:f_tab_path) { f.prefix/"INSTALL_RECEIPT.json" }
+  let(:f_tab_content) { (TEST_FIXTURE_DIR/"receipt.json").read }
+
   alias_matcher :be_built_with, :be_with
 
   matcher :be_poured_from_bottle do
@@ -37,44 +75,6 @@ RSpec.describe Tab do
     end
   end
 
-  subject(:tab) do
-    described_class.new(
-      "homebrew_version"     => HOMEBREW_VERSION,
-      "used_options"         => used_options.as_flags,
-      "unused_options"       => unused_options.as_flags,
-      "built_as_bottle"      => false,
-      "poured_from_bottle"   => true,
-      "installed_on_request" => true,
-      "changed_files"        => [],
-      "time"                 => time,
-      "source_modified_time" => 0,
-      "compiler"             => "clang",
-      "stdlib"               => "libcxx",
-      "runtime_dependencies" => [],
-      "source"               => {
-        "tap"          => CoreTap.instance.to_s,
-        "path"         => CoreTap.instance.path.to_s,
-        "spec"         => "stable",
-        "scm_revision" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "versions"     => {
-          "stable" => "0.10",
-          "head"   => "HEAD-1111111",
-        },
-      },
-      "arch"                 => Hardware::CPU.arch,
-      "built_on"             => DevelopmentTools.build_system_info,
-    )
-  end
-
-  let(:time) { Time.now.to_i }
-  let(:unused_options) { Options.create(%w[--with-baz --without-qux]) }
-  let(:used_options) { Options.create(%w[--with-foo --without-bar]) }
-  let(:git_repo) { HOMEBREW_CACHE/"tab-spec-git-repo" }
-
-  let(:f) { formula { url "foo-1.0" } }
-  let(:f_tab_path) { f.prefix/"INSTALL_RECEIPT.json" }
-  let(:f_tab_content) { (TEST_FIXTURE_DIR/"receipt.json").read }
-
   after do
     FileUtils.rm_rf git_repo
   end
@@ -98,7 +98,7 @@ RSpec.describe Tab do
     # < 1.1.7 runtime_dependencies were wrong so are ignored
     stub_const("HOMEBREW_VERSION", "1.1.7")
 
-    tab = described_class.empty
+    tab = klass.empty
 
     expect(tab.homebrew_version).to eq(HOMEBREW_VERSION)
     expect(tab.unused_options).to be_empty
@@ -140,10 +140,10 @@ RSpec.describe Tab do
   end
 
   specify "#parsed_homebrew_version" do
-    tab = described_class.new
+    tab = klass.new
     expect(tab.parsed_homebrew_version).to be Version::NULL
 
-    tab = described_class.new(homebrew_version: "1.2.3")
+    tab = klass.new(homebrew_version: "1.2.3")
     expect(tab.parsed_homebrew_version).to eq("1.2.3")
     expect(tab.parsed_homebrew_version).to be < "1.2.3-1-g12789abdf"
     expect(tab.parsed_homebrew_version).to be_a(Version)
@@ -153,14 +153,14 @@ RSpec.describe Tab do
     expect(tab.parsed_homebrew_version).to be > "1.2.4-566-g21789abdf"
     expect(tab.parsed_homebrew_version).to be < "1.2.4-568-g01789abdf"
 
-    tab = described_class.new(homebrew_version: "2.0.0-134-gabcdefabc-dirty")
+    tab = klass.new(homebrew_version: "2.0.0-134-gabcdefabc-dirty")
     expect(tab.parsed_homebrew_version).to be > "2.0.0"
     expect(tab.parsed_homebrew_version).to be > "2.0.0-133-g21789abdf"
     expect(tab.parsed_homebrew_version).to be < "2.0.0-135-g01789abdf"
   end
 
   specify "#runtime_dependencies" do
-    tab = described_class.new
+    tab = klass.new
     expect(tab.runtime_dependencies).to be_nil
 
     tab.homebrew_version = "1.1.6"
@@ -187,8 +187,8 @@ RSpec.describe Tab do
       runtime_deps = [Dependency.new("foo")]
       foo = formula("foo") { url "foo-1.0" }
       stub_formula_loader foo
-      runtime_deps_hash = described_class.runtime_deps_hash(foo, runtime_deps)
-      tab = described_class.new
+      runtime_deps_hash = klass.runtime_deps_hash(foo, runtime_deps)
+      tab = klass.new
       tab.homebrew_version = "1.1.6"
       tab.runtime_dependencies = runtime_deps_hash
       expect(tab.runtime_dependencies).to eql(
@@ -213,7 +213,7 @@ RSpec.describe Tab do
           "declared_directly" => true,
         },
       ]
-      expect(described_class.runtime_deps_hash(formula, runtime_deps)).to eq(expected_output)
+      expect(klass.runtime_deps_hash(formula, runtime_deps)).to eq(expected_output)
     end
 
     it "includes recursive dependencies" do
@@ -243,7 +243,7 @@ RSpec.describe Tab do
           "declared_directly" => false,
         },
       ]
-      expect(described_class.runtime_deps_hash(formula, formula_recursive_deps)).to eq(expected_output)
+      expect(klass.runtime_deps_hash(formula, formula_recursive_deps)).to eq(expected_output)
     end
 
     it "includes compatibility_version when set" do
@@ -267,14 +267,14 @@ RSpec.describe Tab do
           "compatibility_version" => 1,
         },
       ]
-      expect(described_class.runtime_deps_hash(formula, formula_recursive_deps)).to eq(expected_output)
+      expect(klass.runtime_deps_hash(formula, formula_recursive_deps)).to eq(expected_output)
     end
   end
 
   describe "::from_file" do
     it "parses a formula Tab from a file" do
       path = Pathname.new("#{TEST_FIXTURE_DIR}/receipt.json")
-      tab = described_class.from_file(path)
+      tab = klass.from_file(path)
       source_path = "/usr/local/Library/Taps/homebrew/homebrew-core/Formula/foo.rb"
       runtime_dependencies = [{ "full_name" => "foo", "version" => "1.0" }]
       changed_files = %w[INSTALL_RECEIPT.json bin/foo].map { Pathname.new(it) }
@@ -304,7 +304,7 @@ RSpec.describe Tab do
   describe "::from_file_content" do
     it "parses a formula Tab from a file" do
       path = Pathname.new("#{TEST_FIXTURE_DIR}/receipt.json")
-      tab = described_class.from_file_content(path.read, path)
+      tab = klass.from_file_content(path.read, path)
       source_path = "/usr/local/Library/Taps/homebrew/homebrew-core/Formula/foo.rb"
       runtime_dependencies = [{ "full_name" => "foo", "version" => "1.0" }]
       changed_files = %w[INSTALL_RECEIPT.json bin/foo].map { Pathname.new(it) }
@@ -332,7 +332,7 @@ RSpec.describe Tab do
 
     it "can parse an old formula Tab file" do
       path = Pathname.new("#{TEST_FIXTURE_DIR}/receipt_old.json")
-      tab = described_class.from_file_content(path.read, path)
+      tab = klass.from_file_content(path.read, path)
 
       expect(tab.used_options.sort).to eq(used_options.sort)
       expect(tab.unused_options.sort).to eq(unused_options.sort)
@@ -352,7 +352,7 @@ RSpec.describe Tab do
     end
 
     it "raises a parse exception message including the Tab filename" do
-      expect { described_class.from_file_content("''", "receipt.json") }.to raise_error(
+      expect { klass.from_file_content("''", "receipt.json") }.to raise_error(
         JSON::ParserError,
         /receipt.json:/,
       )
@@ -386,7 +386,7 @@ RSpec.describe Tab do
 
       compiler = DevelopmentTools.default_compiler
       stdlib = :libcxx
-      tab = described_class.create(f, compiler, stdlib)
+      tab = klass.create(f, compiler, stdlib)
 
       runtime_dependencies = [
         { "full_name" => "bar", "version" => "2.0", "revision" => 0, "pkg_version" => "2.0",
@@ -405,7 +405,7 @@ RSpec.describe Tab do
       f = formula(alias_path:) { url "foo-1.0" }
       compiler = DevelopmentTools.default_compiler
       stdlib = :libcxx
-      tab = described_class.create(f, compiler, stdlib)
+      tab = klass.create(f, compiler, stdlib)
 
       expect(tab.source["path"]).to eq(f.alias_path.to_s)
     end
@@ -421,14 +421,14 @@ RSpec.describe Tab do
       end
       f.public_send(f.active_spec_sym).fetch
 
-      tab = described_class.create(f, DevelopmentTools.default_compiler, :libcxx)
+      tab = klass.create(f, DevelopmentTools.default_compiler, :libcxx)
 
       expect(tab.source["scm_revision"]).to eq(commit)
     end
   end
 
   describe "::for_keg" do
-    subject(:tab_for_keg) { described_class.for_keg(f.prefix) }
+    subject(:tab_for_keg) { klass.for_keg(f.prefix) }
 
     it "creates a Tab for a given Keg" do
       f.prefix.mkpath
@@ -446,7 +446,7 @@ RSpec.describe Tab do
 
   describe "::for_formula" do
     it "creates a Tab for a given Formula" do
-      tab = described_class.for_formula(f)
+      tab = klass.for_formula(f)
       expect(tab.source["path"]).to eq(f.path.to_s)
     end
 
@@ -454,7 +454,7 @@ RSpec.describe Tab do
       alias_path = CoreTap.instance.alias_dir/"bar"
       f = formula(alias_path:) { url "foo-1.0" }
 
-      tab = described_class.for_formula(f)
+      tab = klass.for_formula(f)
       expect(tab.source["path"]).to eq(alias_path.to_s)
     end
 
@@ -462,14 +462,14 @@ RSpec.describe Tab do
       f.prefix.mkpath
       f_tab_path.write f_tab_content
 
-      tab = described_class.for_formula(f)
+      tab = klass.for_formula(f)
       expect(tab.tabfile).to eq(f_tab_path)
     end
 
     it "can create a Tab for a non-existent Formula" do
       f.prefix.mkpath
 
-      tab = described_class.for_formula(f)
+      tab = klass.for_formula(f)
       expect(tab.tabfile).to be_nil
     end
 
@@ -483,7 +483,7 @@ RSpec.describe Tab do
       expect(f2.rack).to eq(f.rack)
       expect(f.installed_prefixes.length).to eq(2)
 
-      tab = described_class.for_formula(f)
+      tab = klass.for_formula(f)
       expect(tab.tabfile).to eq(f_tab_path)
     end
 
@@ -496,13 +496,13 @@ RSpec.describe Tab do
       expect(f2.rack).to eq(f.rack)
       expect(f.installed_prefixes.length).to eq(1)
 
-      tab = described_class.for_formula(f)
+      tab = klass.for_formula(f)
       expect(tab.tabfile).to eq(f_tab_path)
     end
   end
 
   specify "#to_json" do
-    json_tab = described_class.new(JSON.parse(tab.to_json))
+    json_tab = klass.new(JSON.parse(tab.to_json))
     expect(json_tab.homebrew_version).to eq(tab.homebrew_version)
     expect(json_tab.used_options.sort).to eq(tab.used_options.sort)
     expect(json_tab.unused_options.sort).to eq(tab.unused_options.sort)
@@ -524,7 +524,7 @@ RSpec.describe Tab do
   end
 
   specify "#to_bottle_hash" do
-    json_tab = described_class.new(JSON.parse(tab.to_bottle_hash.to_json))
+    json_tab = klass.new(JSON.parse(tab.to_bottle_hash.to_json))
     expect(json_tab.homebrew_version).to eq(tab.homebrew_version)
     expect(json_tab.changed_files).to eq(tab.changed_files)
     expect(json_tab.source_modified_time).to eq(tab.source_modified_time)
@@ -540,7 +540,7 @@ RSpec.describe Tab do
     let(:time_string) { Time.at(1_720_189_863).strftime("%Y-%m-%d at %H:%M:%S") }
 
     it "returns install information for the Tab" do
-      tab = described_class.new(
+      tab = klass.new(
         poured_from_bottle:       true,
         loaded_from_api:          true,
         loaded_from_internal_api: false,
@@ -553,59 +553,59 @@ RSpec.describe Tab do
     end
 
     it "includes 'Poured from bottle' if the formula was installed from a bottle" do
-      tab = described_class.new(poured_from_bottle: true)
+      tab = klass.new(poured_from_bottle: true)
       expect(tab.to_s).to include("Poured from bottle")
     end
 
     it "includes 'Built from source' if the formula was not installed from a bottle" do
-      tab = described_class.new(poured_from_bottle: false)
+      tab = klass.new(poured_from_bottle: false)
       expect(tab.to_s).to include("Built from source")
     end
 
     it "includes 'using the formulae.brew.sh API' if the formula was installed from the API" do
-      tab = described_class.new(loaded_from_api: true)
+      tab = klass.new(loaded_from_api: true)
       expect(tab.to_s).to include("using the formulae.brew.sh API")
     end
 
     it "includes 'using the internal formulae.brew.sh API' if the formula was installed from the internal API" do
-      tab = described_class.new(loaded_from_api: true, loaded_from_internal_api: true)
+      tab = klass.new(loaded_from_api: true, loaded_from_internal_api: true)
       expect(tab.to_s).to include("using the internal formulae.brew.sh API")
     end
 
     it "does not include 'using the formulae.brew.sh API' if the formula was not installed from the API" do
-      tab = described_class.new(loaded_from_api: false)
+      tab = klass.new(loaded_from_api: false)
       expect(tab.to_s).not_to include("using the formulae.brew.sh API")
     end
 
     it "doesn't include 'using the internal formulae.brew.sh API' if the formula wasn't installed via internal API" do
-      tab = described_class.new(loaded_from_api: true, loaded_from_internal_api: false)
+      tab = klass.new(loaded_from_api: true, loaded_from_internal_api: false)
       expect(tab.to_s).not_to include("using the internal formulae.brew.sh API")
     end
 
     it "includes the time value if specified" do
-      tab = described_class.new(time: 1_720_189_863)
+      tab = klass.new(time: 1_720_189_863)
       expect(tab.to_s).to include("on #{time_string}")
     end
 
     it "does not include the time value if not specified" do
-      tab = described_class.new(time: nil)
+      tab = klass.new(time: nil)
       expect(tab.to_s).not_to match(/on %d+-%d+-%d+ at %d+:%d+:%d+/)
     end
 
     it "includes options if specified" do
-      tab = described_class.new(used_options: %w[--with-foo --without-bar])
+      tab = klass.new(used_options: %w[--with-foo --without-bar])
       expect(tab.to_s).to include("with: --with-foo --without-bar")
     end
 
     it "not to include options if not specified" do
-      tab = described_class.new(used_options: [])
+      tab = klass.new(used_options: [])
       expect(tab.to_s).not_to include("with: ")
     end
   end
 
   specify "::remap_deprecated_options" do
     deprecated_options = [DeprecatedOption.new("with-foo", "with-foo-new")]
-    remapped_options = described_class.remap_deprecated_options(deprecated_options, tab.used_options)
+    remapped_options = klass.remap_deprecated_options(deprecated_options, tab.used_options)
     expect(remapped_options).to include(Option.new("without-bar"))
     expect(remapped_options).to include(Option.new("with-foo-new"))
   end

--- a/Library/Homebrew/test/tap_auditor_spec.rb
+++ b/Library/Homebrew/test/tap_auditor_spec.rb
@@ -4,9 +4,11 @@
 require "tap_auditor"
 
 RSpec.describe Homebrew::TapAuditor do
+  let(:klass) { Homebrew::TapAuditor }
+
   let(:tap) { Tap.fetch("homebrew", "foo") }
   let(:tap_path) { tap.path }
-  let(:auditor) { described_class.new(tap, strict: false) }
+  let(:auditor) { klass.new(tap, strict: false) }
 
   def write_cask(token, path = tap_path/"Casks"/"#{token}.rb")
     path.dirname.mkpath

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -2,14 +2,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Tap do
-  include FileUtils
+  subject(:homebrew_foo_tap) { klass.fetch("Homebrew", "foo") }
 
-  alias_matcher :have_cask_file, :be_cask_file
-  alias_matcher :have_formula_file, :be_formula_file
-  alias_matcher :have_custom_remote, :be_custom_remote
-
-  subject(:homebrew_foo_tap) { described_class.fetch("Homebrew", "foo") }
-
+  let(:klass) { Tap }
   let(:path) { HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo" }
   let(:formula_file) { path/"Formula/foo.rb" }
   let(:alias_file) { path/"Aliases/bar" }
@@ -18,6 +13,12 @@ RSpec.describe Tap do
   let(:bash_completion_file) { path/"completions/bash/brew-tap-cmd" }
   let(:zsh_completion_file) { path/"completions/zsh/_brew-tap-cmd" }
   let(:fish_completion_file) { path/"completions/fish/brew-tap-cmd.fish" }
+
+  include FileUtils
+
+  alias_matcher :have_cask_file, :be_cask_file
+  alias_matcher :have_formula_file, :be_formula_file
+  alias_matcher :have_custom_remote, :be_custom_remote
 
   before do
     path.mkpath
@@ -91,47 +92,47 @@ RSpec.describe Tap do
   end
 
   specify "::fetch" do
-    expect(described_class.fetch("Homebrew", "core")).to be_a(CoreTap)
-    expect(described_class.fetch("Homebrew", "homebrew")).to be_a(CoreTap)
-    tap = described_class.fetch("Homebrew", "foo")
-    expect(tap).to be_a(described_class)
+    expect(klass.fetch("Homebrew", "core")).to be_a(CoreTap)
+    expect(klass.fetch("Homebrew", "homebrew")).to be_a(CoreTap)
+    tap = klass.fetch("Homebrew", "foo")
+    expect(tap).to be_a(klass)
     expect(tap.name).to eq("homebrew/foo")
 
     expect do
-      described_class.fetch("foo")
+      klass.fetch("foo")
     end.to raise_error(Tap::InvalidNameError, /Invalid tap name/)
 
     expect do
-      described_class.fetch("homebrew/homebrew/bar")
+      klass.fetch("homebrew/homebrew/bar")
     end.to raise_error(Tap::InvalidNameError, /Invalid tap name/)
 
     expect do
-      described_class.fetch("homebrew", "homebrew/baz")
+      klass.fetch("homebrew", "homebrew/baz")
     end.to raise_error(Tap::InvalidNameError, /Invalid tap name/)
   end
 
   describe "::from_path" do
-    let(:tap) { described_class.fetch("Homebrew", "core") }
+    let(:tap) { klass.fetch("Homebrew", "core") }
     let(:path) { tap.path }
     let(:formula_path) { path/"Formula/formula.rb" }
 
     it "returns the Tap for a Formula path" do
-      expect(described_class.from_path(formula_path)).to eq tap
+      expect(klass.from_path(formula_path)).to eq tap
     end
 
     it "returns the Tap when given its exact path" do
-      expect(described_class.from_path(path)).to eq tap
+      expect(klass.from_path(path)).to eq tap
     end
 
     context "when path contains a dot" do
-      let(:tap) { described_class.fetch("str4d.xyz", "rage") }
+      let(:tap) { klass.fetch("str4d.xyz", "rage") }
 
       after do
         tap.uninstall
       end
 
       it "returns the Tap when given its exact path" do
-        expect(described_class.from_path(path)).to eq tap
+        expect(klass.from_path(path)).to eq tap
       end
     end
   end
@@ -140,8 +141,8 @@ RSpec.describe Tap do
     before { allow(Homebrew::EnvConfig).to receive(:allowed_taps).and_return("homebrew/allowed") }
 
     it "returns a set of allowed taps according to the environment" do
-      expect(described_class.allowed_taps)
-        .to contain_exactly(described_class.fetch("homebrew/allowed"))
+      expect(klass.allowed_taps)
+        .to contain_exactly(klass.fetch("homebrew/allowed"))
     end
   end
 
@@ -149,8 +150,8 @@ RSpec.describe Tap do
     before { allow(Homebrew::EnvConfig).to receive(:forbidden_taps).and_return("homebrew/forbidden") }
 
     it "returns a set of forbidden taps according to the environment" do
-      expect(described_class.forbidden_taps)
-        .to contain_exactly(described_class.fetch("homebrew/forbidden"))
+      expect(klass.forbidden_taps)
+        .to contain_exactly(klass.fetch("homebrew/forbidden"))
     end
   end
 
@@ -165,7 +166,7 @@ RSpec.describe Tap do
   end
 
   specify "#issues_url" do
-    t = described_class.fetch("someone", "foo")
+    t = klass.fetch("someone", "foo")
     path = HOMEBREW_TAP_DIRECTORY/"someone/homebrew-foo"
     path.mkpath
     cd path do
@@ -177,7 +178,7 @@ RSpec.describe Tap do
     expect(homebrew_foo_tap.issues_url).to eq("https://github.com/Homebrew/homebrew-foo/issues")
 
     (HOMEBREW_TAP_DIRECTORY/"someone/homebrew-no-git").mkpath
-    expect(described_class.fetch("someone", "no-git").issues_url).to be_nil
+    expect(klass.fetch("someone", "no-git").issues_url).to be_nil
   ensure
     FileUtils.rm_rf(path.parent)
   end
@@ -217,7 +218,7 @@ RSpec.describe Tap do
       expect(homebrew_foo_tap.remote).to eq("https://github.com/Homebrew/homebrew-foo")
       expect(homebrew_foo_tap).not_to have_custom_remote
 
-      services_tap = described_class.fetch("Homebrew", "test-bot")
+      services_tap = klass.fetch("Homebrew", "test-bot")
       services_tap.path.mkpath
       services_tap.path.cd do
         system "git", "init"
@@ -243,7 +244,7 @@ RSpec.describe Tap do
 
       expect(homebrew_foo_tap.remote_repository).to eq("Homebrew/homebrew-foo")
 
-      services_tap = described_class.fetch("Homebrew", "test-bot")
+      services_tap = klass.fetch("Homebrew", "test-bot")
       services_tap.path.mkpath
       services_tap.path.cd do
         system "git", "init"
@@ -257,7 +258,7 @@ RSpec.describe Tap do
 
       expect(homebrew_foo_tap.remote_repository).to eq("Homebrew/homebrew-foo")
 
-      services_tap = described_class.fetch("Homebrew", "test-bot")
+      services_tap = klass.fetch("Homebrew", "test-bot")
       services_tap.path.mkpath
       services_tap.path.cd do
         system "git", "init"
@@ -278,7 +279,7 @@ RSpec.describe Tap do
   end
 
   describe "#custom_remote?" do
-    subject(:tap) { described_class.fetch("Homebrew", "test-bot") }
+    subject(:tap) { klass.fetch("Homebrew", "test-bot") }
 
     let(:remote) { nil }
 
@@ -323,14 +324,14 @@ RSpec.describe Tap do
   describe "#install" do
     it "raises an error when the Tap is already tapped" do
       setup_git_repo
-      already_tapped_tap = described_class.fetch("Homebrew", "foo")
+      already_tapped_tap = klass.fetch("Homebrew", "foo")
       expect(already_tapped_tap).to be_installed
       expect { already_tapped_tap.install }.to raise_error(TapAlreadyTappedError)
     end
 
     it "raises an error when the Tap is already tapped with the right remote" do
       setup_git_repo
-      already_tapped_tap = described_class.fetch("Homebrew", "foo")
+      already_tapped_tap = klass.fetch("Homebrew", "foo")
       expect(already_tapped_tap).to be_installed
       right_remote = homebrew_foo_tap.remote
       expect { already_tapped_tap.install clone_target: right_remote }.to raise_error(TapAlreadyTappedError)
@@ -338,7 +339,7 @@ RSpec.describe Tap do
 
     it "raises an error when the remote doesn't match" do
       setup_git_repo
-      already_tapped_tap = described_class.fetch("Homebrew", "foo")
+      already_tapped_tap = klass.fetch("Homebrew", "foo")
       expect(already_tapped_tap).to be_installed
       wrong_remote = "#{homebrew_foo_tap.remote}-oops"
       expect do
@@ -347,7 +348,7 @@ RSpec.describe Tap do
     end
 
     it "raises an error when the remote for Homebrew/core doesn't match HOMEBREW_CORE_GIT_REMOTE" do
-      core_tap = described_class.fetch("Homebrew", "core")
+      core_tap = klass.fetch("Homebrew", "core")
       wrong_remote = "#{Homebrew::EnvConfig.core_git_remote}-oops"
       expect do
         core_tap.install clone_target: wrong_remote
@@ -356,7 +357,7 @@ RSpec.describe Tap do
 
     it "raises an error when run `brew tap --custom-remote` without a custom remote (already installed)" do
       setup_git_repo
-      already_tapped_tap = described_class.fetch("Homebrew", "foo")
+      already_tapped_tap = klass.fetch("Homebrew", "foo")
       expect(already_tapped_tap).to be_installed
 
       expect do
@@ -365,7 +366,7 @@ RSpec.describe Tap do
     end
 
     it "raises an error when run `brew tap --custom-remote` without a custom remote (not installed)" do
-      not_tapped_tap = described_class.fetch("Homebrew", "bar")
+      not_tapped_tap = klass.fetch("Homebrew", "bar")
       expect(not_tapped_tap).not_to be_installed
 
       expect do
@@ -374,7 +375,7 @@ RSpec.describe Tap do
     end
 
     specify "Git error" do
-      tap = described_class.fetch("user", "repo")
+      tap = klass.fetch("user", "repo")
 
       expect do
         tap.install clone_target: "file:///not/existed/remote/url"
@@ -387,7 +388,7 @@ RSpec.describe Tap do
 
   describe "#uninstall" do
     it "raises an error if the Tap is not available" do
-      tap = described_class.fetch("Homebrew", "bar")
+      tap = klass.fetch("Homebrew", "bar")
       expect { tap.uninstall }.to raise_error(TapUnavailableError)
     end
   end
@@ -397,7 +398,7 @@ RSpec.describe Tap do
     setup_git_repo
     setup_completion link: true
 
-    tap = described_class.fetch("Homebrew", "bar")
+    tap = klass.fetch("Homebrew", "bar")
 
     tap.install clone_target: homebrew_foo_tap.path/".git"
 
@@ -423,7 +424,7 @@ RSpec.describe Tap do
     setup_tap_files
     setup_git_repo
     setup_completion link: true
-    tap = described_class.fetch("NotHomebrew", "baz")
+    tap = klass.fetch("NotHomebrew", "baz")
     tap.install clone_target: homebrew_foo_tap.path/".git"
     (HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").delete
     (HOMEBREW_PREFIX/"etc/bash_completion.d/brew-tap-cmd").delete
@@ -444,7 +445,7 @@ RSpec.describe Tap do
     setup_tap_files
     setup_git_repo
     setup_completion link: false
-    tap = described_class.fetch("NotHomebrew", "baz")
+    tap = klass.fetch("NotHomebrew", "baz")
     tap.install clone_target: homebrew_foo_tap.path/".git"
     (HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").delete
     tap.link_completions_and_manpages
@@ -462,7 +463,7 @@ RSpec.describe Tap do
     setup_tap_files
     setup_git_repo
     setup_completion link: false
-    tap = described_class.fetch("Homebrew", "baz")
+    tap = klass.fetch("Homebrew", "baz")
     tap.install clone_target: homebrew_foo_tap.path/".git"
     (HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").delete
     (HOMEBREW_PREFIX/"etc/bash_completion.d/brew-tap-cmd").delete
@@ -491,7 +492,7 @@ RSpec.describe Tap do
 
   describe ".each" do
     it "returns an enumerator if no block is passed" do
-      expect(described_class.each).to be_an_instance_of(Enumerator)
+      expect(klass.each).to be_an_instance_of(Enumerator)
     end
 
     context "when the core tap is not installed" do
@@ -503,35 +504,35 @@ RSpec.describe Tap do
       end
 
       it "includes the core tap with the api" do
-        expect(described_class.to_a).to include(CoreTap.instance)
+        expect(klass.to_a).to include(CoreTap.instance)
       end
 
       it "omits the core tap without the api", :no_api do
-        expect(described_class.to_a).not_to include(CoreTap.instance)
+        expect(klass.to_a).not_to include(CoreTap.instance)
       end
     end
   end
 
   describe ".installed" do
     it "includes only installed taps" do
-      expect(described_class.installed)
-        .to contain_exactly(CoreTap.instance, described_class.fetch("homebrew/foo"))
+      expect(klass.installed)
+        .to contain_exactly(CoreTap.instance, klass.fetch("homebrew/foo"))
     end
   end
 
   describe ".all" do
     it "includes the core and cask taps by default", :needs_macos do
-      expect(described_class.all).to contain_exactly(
+      expect(klass.all).to contain_exactly(
         CoreTap.instance,
         CoreCaskTap.instance,
-        described_class.fetch("homebrew/foo"),
-        described_class.fetch("third-party/tap"),
+        klass.fetch("homebrew/foo"),
+        klass.fetch("third-party/tap"),
       )
     end
 
     it "includes the core tap and excludes the cask tap by default", :needs_linux do
-      expect(described_class.all)
-        .to contain_exactly(CoreTap.instance, described_class.fetch("homebrew/foo"))
+      expect(klass.all)
+        .to contain_exactly(CoreTap.instance, klass.fetch("homebrew/foo"))
     end
   end
 
@@ -589,7 +590,7 @@ RSpec.describe Tap do
             [cask_tap, "schism-tracker", %w[schismtracker]],
             [cask_tap, "google-cloud-sdk", %w[app-engine-go-32 app-engine-go-64]],
           ].each do |tap, name, result|
-            expect(described_class.tap_migration_oldnames(tap, name)).to eq(result)
+            expect(klass.tap_migration_oldnames(tap, name)).to eq(result)
           end
         end
       end
@@ -621,7 +622,7 @@ RSpec.describe Tap do
 
     describe "#formula_file?" do
       it "matches files from Formula/" do
-        tap = described_class.fetch("hard/core")
+        tap = klass.fetch("hard/core")
         FileUtils.mkdir_p(tap.path/"Formula")
 
         %w[
@@ -646,7 +647,7 @@ RSpec.describe Tap do
       end
 
       it "matches files from HomebrewFormula/" do
-        tap = described_class.fetch("hard/core")
+        tap = klass.fetch("hard/core")
         FileUtils.mkdir_p(tap.path/"HomebrewFormula")
 
         %w[
@@ -671,7 +672,7 @@ RSpec.describe Tap do
       end
 
       it "matches files from the top-level directory" do
-        tap = described_class.fetch("hard/core")
+        tap = klass.fetch("hard/core")
         FileUtils.mkdir_p(tap.path)
 
         %w[
@@ -694,7 +695,7 @@ RSpec.describe Tap do
 
     describe "#cask_file?" do
       it "matches files from Casks/" do
-        tap = described_class.fetch("hard/core")
+        tap = klass.fetch("hard/core")
 
         %w[
           kvazaar.rb
@@ -718,7 +719,9 @@ RSpec.describe Tap do
   end
 
   describe CoreTap do
-    subject(:core_tap) { described_class.instance }
+    subject(:core_tap) { klass.instance }
+
+    let(:klass) { CoreTap }
 
     specify "attributes" do
       expect(core_tap.user).to eq("Homebrew")
@@ -777,30 +780,30 @@ RSpec.describe Tap do
   describe "#repository_var_suffix" do
     specify do
       expect(CoreTap.instance.repository_var_suffix).to eq "_HOMEBREW_HOMEBREW_CORE"
-      expect(described_class.fetch("my",
-                                   "tap-with-dashes").repository_var_suffix).to eq "_MY_HOMEBREW_TAP_WITH_DASHES"
-      expect(described_class.fetch("my",
-                                   "tap-with-@-symbol").repository_var_suffix).to eq "_MY_HOMEBREW_TAP_WITH___SYMBOL"
+      expect(klass.fetch("my",
+                         "tap-with-dashes").repository_var_suffix).to eq "_MY_HOMEBREW_TAP_WITH_DASHES"
+      expect(klass.fetch("my",
+                         "tap-with-@-symbol").repository_var_suffix).to eq "_MY_HOMEBREW_TAP_WITH___SYMBOL"
     end
   end
 
   describe "::with_formula_name" do
     it "returns the tap and formula name when given a full name" do
-      expect(described_class.with_formula_name("homebrew/core/gcc")).to eq [CoreTap.instance, "gcc"]
+      expect(klass.with_formula_name("homebrew/core/gcc")).to eq [CoreTap.instance, "gcc"]
     end
 
     it "returns nil when given a relative path" do
-      expect(described_class.with_formula_name("./Formula/gcc.rb")).to be_nil
+      expect(klass.with_formula_name("./Formula/gcc.rb")).to be_nil
     end
   end
 
   describe "::with_cask_token" do
     it "returns the tap and cask token when given a full token" do
-      expect(described_class.with_cask_token("homebrew/cask/alfred")).to eq [CoreCaskTap.instance, "alfred"]
+      expect(klass.with_cask_token("homebrew/cask/alfred")).to eq [CoreCaskTap.instance, "alfred"]
     end
 
     it "returns nil when given a relative path" do
-      expect(described_class.with_cask_token("./Casks/alfred.rb")).to be_nil
+      expect(klass.with_cask_token("./Casks/alfred.rb")).to be_nil
     end
   end
 end

--- a/Library/Homebrew/test/test_bot/bottles_fetch_spec.rb
+++ b/Library/Homebrew/test/test_bot/bottles_fetch_spec.rb
@@ -5,11 +5,13 @@ require "test_bot"
 require "dev-cmd/test-bot"
 
 RSpec.describe Homebrew::TestBot::BottlesFetch do
+  let(:klass) { Homebrew::TestBot::BottlesFetch }
+
   describe "#run!" do
     it "accepts Utils::Bottles::Tag objects from the bottle collector" do
       # Regression test: bottle_specification.collector.tags returns Utils::Bottles::Tag objects,
       # not Symbols. The fetch_bottles! signature must accept Tag, not Symbol.
-      fetch = described_class.new(tap: nil, git: nil, dry_run: true, fail_fast: false, verbose: false)
+      fetch = klass.new(tap: nil, git: nil, dry_run: true, fail_fast: false, verbose: false)
       fetch.testing_formulae = ["some-formula"]
       tag = Utils::Bottles::Tag.new(system: :sequoia, arch: :arm64)
       allow(fetch).to receive(:formulae_by_tag).and_return({ tag => Set["some-formula"] })

--- a/Library/Homebrew/test/test_bot/formulae_dependents_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_dependents_spec.rb
@@ -5,8 +5,10 @@ require "test_bot"
 
 RSpec.describe Homebrew::TestBot::FormulaeDependents do
   subject(:formulae_dependents) do
-    described_class.new(tap: nil, git: nil, dry_run: false, fail_fast: false, verbose: false)
+    klass.new(tap: nil, git: nil, dry_run: false, fail_fast: false, verbose: false)
   end
+
+  let(:klass) { Homebrew::TestBot::FormulaeDependents }
 
   describe "#dependents_for_shard" do
     it "keeps dependent formulae that depend on each other in the same shard" do

--- a/Library/Homebrew/test/test_bot/formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_spec.rb
@@ -4,6 +4,9 @@
 require "test_bot"
 
 RSpec.describe Homebrew::TestBot::Formulae do
+  sig { returns(T.class_of(Homebrew::TestBot::Formulae)) }
+  let(:klass) { Homebrew::TestBot::Formulae }
+
   describe "#dependency_name_match?" do
     it "requires exact matches when either name is tap-qualified", :aggregate_failures do
       Dir.mktmpdir do |tmpdir|
@@ -12,7 +15,7 @@ RSpec.describe Homebrew::TestBot::Formulae do
           linkage:                    Pathname.new("#{tmpdir}/linkage.txt"),
           skipped_or_failed_formulae: Pathname.new("#{tmpdir}/skipped.txt"),
         }
-        formulae = described_class.new(
+        formulae = klass.new(
           tap: nil, git: "git", dry_run: true, fail_fast: false, verbose: false,
           output_paths:
         )
@@ -60,7 +63,7 @@ RSpec.describe Homebrew::TestBot::Formulae do
           linkage:                    Pathname.new("#{tmpdir}/linkage.txt"),
           skipped_or_failed_formulae: Pathname.new("#{tmpdir}/skipped.txt"),
         }
-        formulae = described_class.new(
+        formulae = klass.new(
           tap: nil, git: "git", dry_run: true, fail_fast: false, verbose: false,
           output_paths:
         )
@@ -87,7 +90,7 @@ RSpec.describe Homebrew::TestBot::Formulae do
           linkage:                    Pathname.new("#{tmpdir}/linkage.txt"),
           skipped_or_failed_formulae: Pathname.new("#{tmpdir}/skipped.txt"),
         }
-        formulae = described_class.new(
+        formulae = klass.new(
           tap: nil, git: "git", dry_run: true, fail_fast: false, verbose: false,
           output_paths:
         )
@@ -108,7 +111,7 @@ RSpec.describe Homebrew::TestBot::Formulae do
           linkage:                    Pathname.new("#{tmpdir}/linkage.txt"),
           skipped_or_failed_formulae: Pathname.new("#{tmpdir}/skipped.txt"),
         }
-        formulae = described_class.new(
+        formulae = klass.new(
           tap: CoreTap.instance, git: "git", dry_run: true, fail_fast: false, verbose: false,
           output_paths:
         )
@@ -144,7 +147,7 @@ RSpec.describe Homebrew::TestBot::Formulae do
           config_file.dirname.mkpath
           config_file.write "old\n"
 
-          described_class.new(
+          klass.new(
             tap: nil, git: "git", dry_run: true, fail_fast: false, verbose: false,
             output_paths: {
               bottle:                     Pathname.new("#{tmpdir}/bottle.txt"),

--- a/Library/Homebrew/test/test_bot/junit_spec.rb
+++ b/Library/Homebrew/test/test_bot/junit_spec.rb
@@ -4,6 +4,9 @@
 require "test_bot"
 
 RSpec.describe Homebrew::TestBot::Junit do
+  sig { returns(T.class_of(Homebrew::TestBot::Junit)) }
+  let(:klass) { Homebrew::TestBot::Junit }
+
   # Regression test: Junit requires REXML before use. Without the require calls in #initialize,
   # environments that don't load REXML elsewhere (e.g. Linux CI) raise
   # "uninitialized constant Homebrew::TestBot::Junit::REXML".
@@ -21,7 +24,7 @@ RSpec.describe Homebrew::TestBot::Junit do
       )
       test = instance_double(Homebrew::TestBot::Test, steps: [step])
 
-      junit = described_class.new([test])
+      junit = klass.new([test])
       junit.build(filters: ["audit"])
 
       Dir.mktmpdir do |tmpdir|
@@ -50,7 +53,7 @@ RSpec.describe Homebrew::TestBot::Junit do
       )
       test = instance_double(Homebrew::TestBot::Test, steps: [step])
 
-      junit = described_class.new([test])
+      junit = klass.new([test])
       junit.build(filters: ["test"])
 
       Dir.mktmpdir do |tmpdir|

--- a/Library/Homebrew/test/test_bot/setup_spec.rb
+++ b/Library/Homebrew/test/test_bot/setup_spec.rb
@@ -4,7 +4,9 @@
 require "dev-cmd/test-bot"
 
 RSpec.describe Homebrew::TestBot::Setup do
-  subject(:setup) { described_class.new }
+  subject(:setup) { klass.new }
+
+  let(:klass) { Homebrew::TestBot::Setup }
 
   describe "#run!" do
     it "is successful" do

--- a/Library/Homebrew/test/test_bot/step_spec.rb
+++ b/Library/Homebrew/test/test_bot/step_spec.rb
@@ -4,8 +4,9 @@
 require "test_bot"
 
 RSpec.describe Homebrew::TestBot::Step do
-  subject(:step) { described_class.new(command, env:, verbose:) }
+  subject(:step) { klass.new(command, env:, verbose:) }
 
+  let(:klass) { Homebrew::TestBot::Step }
   let(:command) { ["brew", "config"] }
   let(:env) { {} }
   let(:verbose) { false }

--- a/Library/Homebrew/test/test_bot/test_cleanup_spec.rb
+++ b/Library/Homebrew/test/test_bot/test_cleanup_spec.rb
@@ -4,12 +4,15 @@
 require "dev-cmd/test-bot"
 
 RSpec.describe Homebrew::TestBot::CleanupAfter do
+  sig { returns(T.class_of(Homebrew::TestBot::CleanupAfter)) }
+  let(:klass) { Homebrew::TestBot::CleanupAfter }
+
   # Regression test: checkout_branch_if_needed, reset_if_needed, and clean_if_needed
   # expect a String (repository path). Passing HOMEBREW_REPOSITORY (Pathname) would cause
   # "Parameter 'repository': Expected type String, got type Pathname" in strict typing.
   describe "#run!" do
     it "passes a String to checkout_branch_if_needed, reset_if_needed, and clean_if_needed when tap is set" do
-      cleanup = described_class.new(
+      cleanup = klass.new(
         tap:       CoreTap.instance,
         git:       "git",
         dry_run:   true,

--- a/Library/Homebrew/test/test_bot/test_formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/test_formulae_spec.rb
@@ -6,8 +6,10 @@ require "utils/github/artifacts"
 
 RSpec.describe Homebrew::TestBot::TestFormulae do
   subject(:test_formulae) do
-    described_class.new(tap: nil, git: nil, dry_run: false, fail_fast: false, verbose: false)
+    klass.new(tap: nil, git: nil, dry_run: false, fail_fast: false, verbose: false)
   end
+
+  let(:klass) { Homebrew::TestBot::TestFormulae }
 
   describe "#download_artifacts_from_previous_run!" do
     it "does not raise KeyError when accessing downloaded_artifacts for a new SHA" do

--- a/Library/Homebrew/test/test_bot/test_spec.rb
+++ b/Library/Homebrew/test/test_bot/test_spec.rb
@@ -4,12 +4,14 @@
 require "test_bot"
 
 RSpec.describe Homebrew::TestBot::Test do
+  let(:klass) { Homebrew::TestBot::Test }
+
   describe "#test" do
     it "converts Pathname arguments to strings" do
       # Regression test: callers like TestCleanup pass Pathname objects (e.g. repository)
       # as positional arguments. The `test` method must coerce them to String before
       # forwarding to Step.new, which expects T::Array[String].
-      test_instance = described_class.new(dry_run: true)
+      test_instance = klass.new(dry_run: true)
 
       step = test_instance.send(:test, "git", "-C", Pathname.new("/some/path"), "status")
 

--- a/Library/Homebrew/test/test_bot_spec.rb
+++ b/Library/Homebrew/test/test_bot_spec.rb
@@ -4,6 +4,8 @@
 require "dev-cmd/test-bot"
 
 RSpec.describe Homebrew::TestBot do
+  let(:klass) { Homebrew::TestBot }
+
   describe "::setup_github_actions_sandbox!" do
     around do |example|
       with_env(HOMEBREW_NO_SANDBOX_LINUX: nil) { example.run }
@@ -15,31 +17,31 @@ RSpec.describe Homebrew::TestBot do
     end
 
     it "configures the Linux sandbox for GitHub Actions" do
-      expect(described_class).to receive(:configure_sandbox!).and_return(true)
+      expect(klass).to receive(:configure_sandbox!).and_return(true)
 
-      described_class.setup_github_actions_sandbox!
+      klass.setup_github_actions_sandbox!
     end
 
     it "disables the Linux sandbox if GitHub Actions cannot configure it" do
-      allow(described_class).to receive(:configure_sandbox!).and_return(false)
+      allow(klass).to receive(:configure_sandbox!).and_return(false)
 
-      described_class.setup_github_actions_sandbox!
+      klass.setup_github_actions_sandbox!
 
       expect(ENV.fetch("HOMEBREW_NO_SANDBOX_LINUX")).to eq("1")
     end
 
     it "does nothing outside GitHub Actions" do
       allow(GitHub::Actions).to receive(:env_set?).and_return(false)
-      expect(described_class).not_to receive(:configure_sandbox!)
+      expect(klass).not_to receive(:configure_sandbox!)
 
-      described_class.setup_github_actions_sandbox!
+      klass.setup_github_actions_sandbox!
     end
 
     it "does nothing when the Linux sandbox is disabled" do
       allow(Homebrew::EnvConfig).to receive(:sandbox_linux?).and_return(false)
-      expect(described_class).not_to receive(:configure_sandbox!)
+      expect(klass).not_to receive(:configure_sandbox!)
 
-      described_class.setup_github_actions_sandbox!
+      klass.setup_github_actions_sandbox!
     end
   end
 end

--- a/Library/Homebrew/test/test_bot_spec.rb
+++ b/Library/Homebrew/test/test_bot_spec.rb
@@ -4,6 +4,7 @@
 require "dev-cmd/test-bot"
 
 RSpec.describe Homebrew::TestBot do
+  sig { returns(T.class_of(Homebrew::TestBot)) }
   let(:klass) { Homebrew::TestBot }
 
   describe "::setup_github_actions_sandbox!" do

--- a/Library/Homebrew/test/test_runner_formula_spec.rb
+++ b/Library/Homebrew/test/test_runner_formula_spec.rb
@@ -5,6 +5,8 @@ require "test_runner_formula"
 require "test/support/fixtures/testball"
 
 RSpec.describe TestRunnerFormula do
+  let(:klass) { TestRunnerFormula }
+
   let(:testball) { Testball.new }
   let(:xcode_helper) { setup_test_runner_formula("xcode-helper", [:macos]) }
   let(:linux_kernel_requirer) { setup_test_runner_formula("linux-kernel-requirer", [:linux]) }
@@ -14,57 +16,57 @@ RSpec.describe TestRunnerFormula do
 
   describe "#initialize" do
     it "enables the Formulary factory cache" do
-      described_class.new(testball)
+      klass.new(testball)
       expect(Formulary.factory_cached?).to be(true)
     end
   end
 
   describe "#name" do
     it "returns the wrapped Formula's name" do
-      expect(described_class.new(testball).name).to eq(testball.name)
+      expect(klass.new(testball).name).to eq(testball.name)
     end
   end
 
   describe "#eval_all" do
     specify do
-      expect(described_class.new(testball).eval_all).to be(false)
-      expect(described_class.new(testball, eval_all: true).eval_all).to be(true)
+      expect(klass.new(testball).eval_all).to be(false)
+      expect(klass.new(testball, eval_all: true).eval_all).to be(true)
     end
 
     it "takes the value of HOMEBREW_EVAL_ALL at instantiation time if not specified" do
       allow(Homebrew::EnvConfig).to receive(:eval_all?).and_return(true)
-      expect(described_class.new(testball).eval_all).to be(true)
+      expect(klass.new(testball).eval_all).to be(true)
 
       allow(Homebrew::EnvConfig).to receive(:eval_all?).and_return(false)
-      expect(described_class.new(testball).eval_all).to be(false)
+      expect(klass.new(testball).eval_all).to be(false)
     end
   end
 
   describe "#formula" do
     it "returns the wrapped Formula" do
-      expect(described_class.new(testball).formula).to eq(testball)
+      expect(klass.new(testball).formula).to eq(testball)
     end
   end
 
   describe "#macos_only?" do
     context "when a formula requires macOS" do
       it "returns true" do
-        expect(described_class.new(xcode_helper).macos_only?).to be(true)
+        expect(klass.new(xcode_helper).macos_only?).to be(true)
       end
     end
 
     context "when a formula does not require macOS" do
       it "returns false" do
-        expect(described_class.new(testball).macos_only?).to be(false)
-        expect(described_class.new(linux_kernel_requirer).macos_only?).to be(false)
-        expect(described_class.new(old_non_portable_software).macos_only?).to be(false)
-        expect(described_class.new(fancy_new_software).macos_only?).to be(false)
+        expect(klass.new(testball).macos_only?).to be(false)
+        expect(klass.new(linux_kernel_requirer).macos_only?).to be(false)
+        expect(klass.new(old_non_portable_software).macos_only?).to be(false)
+        expect(klass.new(fancy_new_software).macos_only?).to be(false)
       end
     end
 
     context "when a formula requires only a minimum version of macOS" do
       it "returns false" do
-        expect(described_class.new(needs_modern_compiler).macos_only?).to be(false)
+        expect(klass.new(needs_modern_compiler).macos_only?).to be(false)
       end
     end
   end
@@ -72,22 +74,22 @@ RSpec.describe TestRunnerFormula do
   describe "#macos_compatible?" do
     context "when a formula is compatible with macOS" do
       it "returns true" do
-        expect(described_class.new(testball).macos_compatible?).to be(true)
-        expect(described_class.new(xcode_helper).macos_compatible?).to be(true)
-        expect(described_class.new(old_non_portable_software).macos_compatible?).to be(true)
-        expect(described_class.new(fancy_new_software).macos_compatible?).to be(true)
+        expect(klass.new(testball).macos_compatible?).to be(true)
+        expect(klass.new(xcode_helper).macos_compatible?).to be(true)
+        expect(klass.new(old_non_portable_software).macos_compatible?).to be(true)
+        expect(klass.new(fancy_new_software).macos_compatible?).to be(true)
       end
     end
 
     context "when a formula requires only a minimum version of macOS" do
       it "returns false" do
-        expect(described_class.new(needs_modern_compiler).macos_compatible?).to be(true)
+        expect(klass.new(needs_modern_compiler).macos_compatible?).to be(true)
       end
     end
 
     context "when a formula is not compatible with macOS" do
       it "returns false" do
-        expect(described_class.new(linux_kernel_requirer).macos_compatible?).to be(false)
+        expect(klass.new(linux_kernel_requirer).macos_compatible?).to be(false)
       end
     end
   end
@@ -95,17 +97,17 @@ RSpec.describe TestRunnerFormula do
   describe "#linux_only?" do
     context "when a formula requires Linux" do
       it "returns true" do
-        expect(described_class.new(linux_kernel_requirer).linux_only?).to be(true)
+        expect(klass.new(linux_kernel_requirer).linux_only?).to be(true)
       end
     end
 
     context "when a formula does not require Linux" do
       it "returns false" do
-        expect(described_class.new(testball).linux_only?).to be(false)
-        expect(described_class.new(xcode_helper).linux_only?).to be(false)
-        expect(described_class.new(old_non_portable_software).linux_only?).to be(false)
-        expect(described_class.new(fancy_new_software).linux_only?).to be(false)
-        expect(described_class.new(needs_modern_compiler).linux_only?).to be(false)
+        expect(klass.new(testball).linux_only?).to be(false)
+        expect(klass.new(xcode_helper).linux_only?).to be(false)
+        expect(klass.new(old_non_portable_software).linux_only?).to be(false)
+        expect(klass.new(fancy_new_software).linux_only?).to be(false)
+        expect(klass.new(needs_modern_compiler).linux_only?).to be(false)
       end
     end
   end
@@ -113,17 +115,17 @@ RSpec.describe TestRunnerFormula do
   describe "#linux_compatible?" do
     context "when a formula is compatible with Linux" do
       it "returns true" do
-        expect(described_class.new(testball).linux_compatible?).to be(true)
-        expect(described_class.new(linux_kernel_requirer).linux_compatible?).to be(true)
-        expect(described_class.new(old_non_portable_software).linux_compatible?).to be(true)
-        expect(described_class.new(fancy_new_software).linux_compatible?).to be(true)
-        expect(described_class.new(needs_modern_compiler).linux_compatible?).to be(true)
+        expect(klass.new(testball).linux_compatible?).to be(true)
+        expect(klass.new(linux_kernel_requirer).linux_compatible?).to be(true)
+        expect(klass.new(old_non_portable_software).linux_compatible?).to be(true)
+        expect(klass.new(fancy_new_software).linux_compatible?).to be(true)
+        expect(klass.new(needs_modern_compiler).linux_compatible?).to be(true)
       end
     end
 
     context "when a formula is not compatible with Linux" do
       it "returns false" do
-        expect(described_class.new(xcode_helper).linux_compatible?).to be(false)
+        expect(klass.new(xcode_helper).linux_compatible?).to be(false)
       end
     end
   end
@@ -131,22 +133,22 @@ RSpec.describe TestRunnerFormula do
   describe "#x86_64_only?" do
     context "when a formula requires an Intel architecture" do
       it "returns true" do
-        expect(described_class.new(old_non_portable_software).x86_64_only?).to be(true)
+        expect(klass.new(old_non_portable_software).x86_64_only?).to be(true)
       end
     end
 
     context "when a formula requires a non-Intel architecture" do
       it "returns false" do
-        expect(described_class.new(fancy_new_software).x86_64_only?).to be(false)
+        expect(klass.new(fancy_new_software).x86_64_only?).to be(false)
       end
     end
 
     context "when a formula does not require a specific architecture" do
       it "returns false" do
-        expect(described_class.new(testball).x86_64_only?).to be(false)
-        expect(described_class.new(xcode_helper).x86_64_only?).to be(false)
-        expect(described_class.new(linux_kernel_requirer).x86_64_only?).to be(false)
-        expect(described_class.new(needs_modern_compiler).x86_64_only?).to be(false)
+        expect(klass.new(testball).x86_64_only?).to be(false)
+        expect(klass.new(xcode_helper).x86_64_only?).to be(false)
+        expect(klass.new(linux_kernel_requirer).x86_64_only?).to be(false)
+        expect(klass.new(needs_modern_compiler).x86_64_only?).to be(false)
       end
     end
   end
@@ -154,17 +156,17 @@ RSpec.describe TestRunnerFormula do
   describe "#x86_64_compatible?" do
     context "when a formula is compatible with the Intel architecture" do
       it "returns true" do
-        expect(described_class.new(testball).x86_64_compatible?).to be(true)
-        expect(described_class.new(xcode_helper).x86_64_compatible?).to be(true)
-        expect(described_class.new(linux_kernel_requirer).x86_64_compatible?).to be(true)
-        expect(described_class.new(old_non_portable_software).x86_64_compatible?).to be(true)
-        expect(described_class.new(needs_modern_compiler).x86_64_compatible?).to be(true)
+        expect(klass.new(testball).x86_64_compatible?).to be(true)
+        expect(klass.new(xcode_helper).x86_64_compatible?).to be(true)
+        expect(klass.new(linux_kernel_requirer).x86_64_compatible?).to be(true)
+        expect(klass.new(old_non_portable_software).x86_64_compatible?).to be(true)
+        expect(klass.new(needs_modern_compiler).x86_64_compatible?).to be(true)
       end
     end
 
     context "when a formula is not compatible with the Intel architecture" do
       it "returns false" do
-        expect(described_class.new(fancy_new_software).x86_64_compatible?).to be(false)
+        expect(klass.new(fancy_new_software).x86_64_compatible?).to be(false)
       end
     end
   end
@@ -172,22 +174,22 @@ RSpec.describe TestRunnerFormula do
   describe "#arm64_only?" do
     context "when a formula requires an ARM64 architecture" do
       it "returns true" do
-        expect(described_class.new(fancy_new_software).arm64_only?).to be(true)
+        expect(klass.new(fancy_new_software).arm64_only?).to be(true)
       end
     end
 
     context "when a formula requires a non-ARM64 architecture" do
       it "returns false" do
-        expect(described_class.new(old_non_portable_software).arm64_only?).to be(false)
+        expect(klass.new(old_non_portable_software).arm64_only?).to be(false)
       end
     end
 
     context "when a formula does not require a specific architecture" do
       it "returns false" do
-        expect(described_class.new(testball).arm64_only?).to be(false)
-        expect(described_class.new(xcode_helper).arm64_only?).to be(false)
-        expect(described_class.new(linux_kernel_requirer).arm64_only?).to be(false)
-        expect(described_class.new(needs_modern_compiler).arm64_only?).to be(false)
+        expect(klass.new(testball).arm64_only?).to be(false)
+        expect(klass.new(xcode_helper).arm64_only?).to be(false)
+        expect(klass.new(linux_kernel_requirer).arm64_only?).to be(false)
+        expect(klass.new(needs_modern_compiler).arm64_only?).to be(false)
       end
     end
   end
@@ -195,23 +197,23 @@ RSpec.describe TestRunnerFormula do
   describe "#arm64_compatible?" do
     context "when a formula is compatible with an ARM64 architecture" do
       it "returns true" do
-        expect(described_class.new(testball).arm64_compatible?).to be(true)
-        expect(described_class.new(xcode_helper).arm64_compatible?).to be(true)
-        expect(described_class.new(linux_kernel_requirer).arm64_compatible?).to be(true)
-        expect(described_class.new(fancy_new_software).arm64_compatible?).to be(true)
-        expect(described_class.new(needs_modern_compiler).arm64_compatible?).to be(true)
+        expect(klass.new(testball).arm64_compatible?).to be(true)
+        expect(klass.new(xcode_helper).arm64_compatible?).to be(true)
+        expect(klass.new(linux_kernel_requirer).arm64_compatible?).to be(true)
+        expect(klass.new(fancy_new_software).arm64_compatible?).to be(true)
+        expect(klass.new(needs_modern_compiler).arm64_compatible?).to be(true)
       end
     end
 
     context "when a formula is not compatible with an ARM64 architecture" do
       it "returns false" do
-        expect(described_class.new(old_non_portable_software).arm64_compatible?).to be(false)
+        expect(klass.new(old_non_portable_software).arm64_compatible?).to be(false)
       end
     end
   end
 
   describe "#versioned_macos_requirement" do
-    let(:requirement) { described_class.new(needs_modern_compiler).versioned_macos_requirement }
+    let(:requirement) { klass.new(needs_modern_compiler).versioned_macos_requirement }
 
     it "returns a MacOSRequirement with a specified version" do
       expect(requirement).to be_a(MacOSRequirement)
@@ -220,16 +222,16 @@ RSpec.describe TestRunnerFormula do
 
     context "when a formula has an unversioned MacOSRequirement" do
       it "returns nil" do
-        expect(described_class.new(xcode_helper).versioned_macos_requirement).to be_nil
+        expect(klass.new(xcode_helper).versioned_macos_requirement).to be_nil
       end
     end
 
     context "when a formula has no declared MacOSRequirement" do
       it "returns nil" do
-        expect(described_class.new(testball).versioned_macos_requirement).to be_nil
-        expect(described_class.new(linux_kernel_requirer).versioned_macos_requirement).to be_nil
-        expect(described_class.new(old_non_portable_software).versioned_macos_requirement).to be_nil
-        expect(described_class.new(fancy_new_software).versioned_macos_requirement).to be_nil
+        expect(klass.new(testball).versioned_macos_requirement).to be_nil
+        expect(klass.new(linux_kernel_requirer).versioned_macos_requirement).to be_nil
+        expect(klass.new(old_non_portable_software).versioned_macos_requirement).to be_nil
+        expect(klass.new(fancy_new_software).versioned_macos_requirement).to be_nil
       end
     end
   end
@@ -238,14 +240,14 @@ RSpec.describe TestRunnerFormula do
     context "when a formula has a versioned MacOSRequirement" do
       context "when passed a compatible macOS version" do
         it "returns true" do
-          expect(described_class.new(needs_modern_compiler).compatible_with?(MacOSVersion.new("13")))
+          expect(klass.new(needs_modern_compiler).compatible_with?(MacOSVersion.new("13")))
             .to be(true)
         end
       end
 
       context "when passed an incompatible macOS version" do
         it "returns false" do
-          expect(described_class.new(needs_modern_compiler).compatible_with?(MacOSVersion.new("11")))
+          expect(klass.new(needs_modern_compiler).compatible_with?(MacOSVersion.new("11")))
             .to be(false)
         end
       end
@@ -255,7 +257,7 @@ RSpec.describe TestRunnerFormula do
       it "returns true" do
         MacOSVersion::SYMBOLS.each_value do |v|
           version = MacOSVersion.new(v)
-          expect(described_class.new(xcode_helper).compatible_with?(version)).to be(true)
+          expect(klass.new(xcode_helper).compatible_with?(version)).to be(true)
         end
       end
     end
@@ -264,10 +266,10 @@ RSpec.describe TestRunnerFormula do
       it "returns true" do
         MacOSVersion::SYMBOLS.each_value do |v|
           version = MacOSVersion.new(v)
-          expect(described_class.new(testball).compatible_with?(version)).to be(true)
-          expect(described_class.new(linux_kernel_requirer).compatible_with?(version)).to be(true)
-          expect(described_class.new(old_non_portable_software).compatible_with?(version)).to be(true)
-          expect(described_class.new(fancy_new_software).compatible_with?(version)).to be(true)
+          expect(klass.new(testball).compatible_with?(version)).to be(true)
+          expect(klass.new(linux_kernel_requirer).compatible_with?(version)).to be(true)
+          expect(klass.new(old_non_portable_software).compatible_with?(version)).to be(true)
+          expect(klass.new(fancy_new_software).compatible_with?(version)).to be(true)
         end
       end
     end
@@ -294,12 +296,12 @@ RSpec.describe TestRunnerFormula do
 
     context "when a formula has no dependents" do
       it "returns an empty array" do
-        expect(described_class.new(testball).dependents(**current_system)).to eq([])
-        expect(described_class.new(xcode_helper).dependents(**current_system)).to eq([])
-        expect(described_class.new(linux_kernel_requirer).dependents(**current_system)).to eq([])
-        expect(described_class.new(old_non_portable_software).dependents(**current_system)).to eq([])
-        expect(described_class.new(fancy_new_software).dependents(**current_system)).to eq([])
-        expect(described_class.new(needs_modern_compiler).dependents(**current_system)).to eq([])
+        expect(klass.new(testball).dependents(**current_system)).to eq([])
+        expect(klass.new(xcode_helper).dependents(**current_system)).to eq([])
+        expect(klass.new(linux_kernel_requirer).dependents(**current_system)).to eq([])
+        expect(klass.new(old_non_portable_software).dependents(**current_system)).to eq([])
+        expect(klass.new(fancy_new_software).dependents(**current_system)).to eq([])
+        expect(klass.new(needs_modern_compiler).dependents(**current_system)).to eq([])
       end
     end
 
@@ -313,11 +315,11 @@ RSpec.describe TestRunnerFormula do
         allow(Formula).to receive(:all).and_return([testball_user, recursive_testball_dependent])
 
         expect(
-          described_class.new(testball, eval_all: true).dependents(**current_system).map(&:name),
+          klass.new(testball, eval_all: true).dependents(**current_system).map(&:name),
         ).to eq(["testball_user"])
 
         expect(
-          described_class.new(testball_user, eval_all: true).dependents(**current_system).map(&:name),
+          klass.new(testball_user, eval_all: true).dependents(**current_system).map(&:name),
         ).to eq(["recursive_testball_dependent"])
       end
 
@@ -345,7 +347,7 @@ RSpec.describe TestRunnerFormula do
             allow(Formula).to receive(:all).and_wrap_original { testball_and_dependents }
 
             expect(
-              described_class.new(testball, eval_all: true).dependents(
+              klass.new(testball, eval_all: true).dependents(
                 platform: :linux, arch: :x86_64, macos_version: nil,
               ).map(&:name).sort,
             ).to eq(["testball_user", "testball_user-intel", "testball_user-linux"].sort)
@@ -357,7 +359,7 @@ RSpec.describe TestRunnerFormula do
             allow(Formula).to receive(:all).and_wrap_original { testball_and_dependents }
 
             expect(
-              described_class.new(testball, eval_all: true).dependents(
+              klass.new(testball, eval_all: true).dependents(
                 platform: :macos, arch: :x86_64, macos_version: nil,
               ).map(&:name).sort,
             ).to eq(["testball_user", "testball_user-intel", "testball_user-macos"].sort)
@@ -369,7 +371,7 @@ RSpec.describe TestRunnerFormula do
             allow(Formula).to receive(:all).and_wrap_original { testball_and_dependents }
 
             expect(
-              described_class.new(testball, eval_all: true).dependents(
+              klass.new(testball, eval_all: true).dependents(
                 platform: :macos, arch: :arm64, macos_version: nil,
               ).map(&:name).sort,
             ).to eq(["testball_user", "testball_user-arm", "testball_user-macos"].sort)
@@ -381,7 +383,7 @@ RSpec.describe TestRunnerFormula do
             allow(Formula).to receive(:all).and_wrap_original { testball_and_dependents }
 
             expect(
-              described_class.new(testball, eval_all: true).dependents(
+              klass.new(testball, eval_all: true).dependents(
                 platform: :macos, arch: :x86_64, macos_version: :sonoma,
               ).map(&:name).sort,
             ).to eq(["testball_user", "testball_user-intel", "testball_user-macos"].sort)
@@ -393,7 +395,7 @@ RSpec.describe TestRunnerFormula do
             allow(Formula).to receive(:all).and_wrap_original { testball_and_dependents }
 
             expect(
-              described_class.new(testball, eval_all: true).dependents(
+              klass.new(testball, eval_all: true).dependents(
                 platform: :macos, arch: :arm64, macos_version: :ventura,
               ).map(&:name).sort,
             ).to eq(%w[testball_user testball_user-arm testball_user-macos testball_user-ventura].sort)

--- a/Library/Homebrew/test/uninstall_spec.rb
+++ b/Library/Homebrew/test/uninstall_spec.rb
@@ -4,6 +4,8 @@
 require "uninstall"
 
 RSpec.describe Homebrew::Uninstall do
+  let(:klass) { Homebrew::Uninstall }
+
   let(:dependency) { formula("dependency") { url "f-1" } }
 
   let(:dependent_formula) do
@@ -50,7 +52,7 @@ RSpec.describe Homebrew::Uninstall do
   describe "::handle_unsatisfied_dependents" do
     specify "when `ignore_dependencies` is false" do
       expect do
-        described_class.handle_unsatisfied_dependents(kegs_by_rack)
+        klass.handle_unsatisfied_dependents(kegs_by_rack)
       end.to output(/Error/).to_stderr
 
       expect(Homebrew).to have_failed
@@ -58,7 +60,7 @@ RSpec.describe Homebrew::Uninstall do
 
     specify "when `ignore_dependencies` is true" do
       expect do
-        described_class.handle_unsatisfied_dependents(kegs_by_rack, ignore_dependencies: true)
+        klass.handle_unsatisfied_dependents(kegs_by_rack, ignore_dependencies: true)
       end.not_to output.to_stderr
 
       expect(Homebrew).not_to have_failed

--- a/Library/Homebrew/test/unlink_spec.rb
+++ b/Library/Homebrew/test/unlink_spec.rb
@@ -4,6 +4,8 @@
 require "unlink"
 
 RSpec.describe Homebrew::Unlink do
+  let(:klass) { Homebrew::Unlink }
+
   describe ".unlink_link_overwrite_formulae" do
     let(:formula) { instance_double(Formula, keg_only?: false) }
     let(:linked_keg_only_keg) { instance_double(Keg, directory?: true) }
@@ -22,10 +24,10 @@ RSpec.describe Homebrew::Unlink do
     it "only unlinks linked keg-only sibling formulae for non-keg-only formulae" do
       allow(formula).to receive(:link_overwrite_formulae)
         .and_return([linked_keg_only_formula, linked_non_keg_only_formula, unlinked_formula])
-      expect(described_class).to receive(:unlink).with(linked_keg_only_keg, verbose: true).once
-      expect(described_class).not_to receive(:unlink).with(linked_non_keg_only_keg, verbose: true)
+      expect(klass).to receive(:unlink).with(linked_keg_only_keg, verbose: true).once
+      expect(klass).not_to receive(:unlink).with(linked_non_keg_only_keg, verbose: true)
 
-      described_class.unlink_link_overwrite_formulae(formula, verbose: true)
+      klass.unlink_link_overwrite_formulae(formula, verbose: true)
     end
 
     it "unlinks all linked sibling formulae for keg-only formulae" do
@@ -33,10 +35,10 @@ RSpec.describe Homebrew::Unlink do
                                          link_overwrite_formulae: [linked_keg_only_formula,
                                                                    linked_non_keg_only_formula,
                                                                    unlinked_formula])
-      expect(described_class).to receive(:unlink).with(linked_keg_only_keg, verbose: true).once
-      expect(described_class).to receive(:unlink).with(linked_non_keg_only_keg, verbose: true).once
+      expect(klass).to receive(:unlink).with(linked_keg_only_keg, verbose: true).once
+      expect(klass).to receive(:unlink).with(linked_non_keg_only_keg, verbose: true).once
 
-      described_class.unlink_link_overwrite_formulae(formula, verbose: true)
+      klass.unlink_link_overwrite_formulae(formula, verbose: true)
     end
   end
 end

--- a/Library/Homebrew/test/unpack_strategy/bzip2_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/bzip2_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe UnpackStrategy::Bzip2 do
   include_examples "#extract", children: ["container"]
 
   it "extracts with bzip2" do
-    strategy = described_class.new(path)
+    strategy = UnpackStrategy::Bzip2.new(path)
 
     Dir.mktmpdir do |dir|
       unpack_dir = Pathname(dir)

--- a/Library/Homebrew/test/unpack_strategy/directory_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/directory_spec.rb
@@ -4,6 +4,8 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Directory do
+  let(:klass) { UnpackStrategy::Directory }
+
   let(:path) do
     mktmpdir.tap do |path|
       FileUtils.touch path/"file"
@@ -17,7 +19,7 @@ RSpec.describe UnpackStrategy::Directory do
   let(:unpack_dir) { mktmpdir }
 
   shared_examples "extract directory" do |move:|
-    subject(:strategy) { described_class.new(path, move:) }
+    subject(:strategy) { klass.new(path, move:) }
 
     it "does not follow symlinks" do
       strategy.extract(to: unpack_dir)

--- a/Library/Homebrew/test/unpack_strategy/zstd_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/zstd_spec.rb
@@ -4,6 +4,8 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Zstd do
+  let(:klass) { UnpackStrategy::Zstd }
+
   let(:path) { TEST_FIXTURE_DIR/"cask/container.tar.zst" }
 
   it "is correctly detected" do
@@ -12,6 +14,6 @@ RSpec.describe UnpackStrategy::Zstd do
     # such as `UnpackStrategy::Zstd`. On macOS `UnpackStrategy.detect("container.tar.zst")`
     # returns `UnpackStrategy::Zstd` and on Ubuntu 22.04 it returns `UnpackStrategy::Tar`,
     # because the host's version of `tar` is recent enough and `zstd` is installed.
-    expect(UnpackStrategy.detect(path)).to(be_a(described_class).or(be_a(UnpackStrategy::Tar)))
+    expect(UnpackStrategy.detect(path)).to(be_a(klass).or(be_a(UnpackStrategy::Tar)))
   end
 end

--- a/Library/Homebrew/test/unpack_strategy_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy_spec.rb
@@ -2,8 +2,10 @@
 # frozen_string_literal: true
 
 RSpec.describe UnpackStrategy do
+  let(:klass) { UnpackStrategy }
+
   describe "#extract_nestedly" do
-    subject(:strategy) { described_class.detect(path) }
+    subject(:strategy) { klass.detect(path) }
 
     let(:unpack_dir) { mktmpdir }
 

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -5,43 +5,45 @@ require "utils/analytics"
 require "formula_installer"
 
 RSpec.describe Utils::Analytics do
+  let(:klass) { Utils::Analytics }
+
   describe "::default_package_tags" do
     let(:ci) { ", CI" if ENV["CI"] }
 
     it "returns OS_VERSION and prefix when HOMEBREW_PREFIX is a custom prefix on intel" do
       expect(Homebrew).to receive(:default_prefix?).and_return(false).at_least(:once)
-      expect(described_class.default_package_tags).to have_key(:prefix)
-      expect(described_class.default_package_tags[:prefix]).to eq "custom-prefix"
+      expect(klass.default_package_tags).to have_key(:prefix)
+      expect(klass.default_package_tags[:prefix]).to eq "custom-prefix"
     end
 
     it "returns OS_VERSION, ARM and prefix when HOMEBREW_PREFIX is a custom prefix on arm" do
       expect(Homebrew).to receive(:default_prefix?).and_return(false).at_least(:once)
-      expect(described_class.default_package_tags).to have_key(:arch)
-      expect(described_class.default_package_tags[:arch]).to eq HOMEBREW_PHYSICAL_PROCESSOR
-      expect(described_class.default_package_tags).to have_key(:prefix)
-      expect(described_class.default_package_tags[:prefix]).to eq "custom-prefix"
+      expect(klass.default_package_tags).to have_key(:arch)
+      expect(klass.default_package_tags[:arch]).to eq HOMEBREW_PHYSICAL_PROCESSOR
+      expect(klass.default_package_tags).to have_key(:prefix)
+      expect(klass.default_package_tags[:prefix]).to eq "custom-prefix"
     end
 
     it "returns OS_VERSION, Rosetta and prefix when HOMEBREW_PREFIX is a custom prefix on Rosetta", :needs_macos do
       expect(Homebrew).to receive(:default_prefix?).and_return(false).at_least(:once)
-      expect(described_class.default_package_tags).to have_key(:prefix)
-      expect(described_class.default_package_tags[:prefix]).to eq "custom-prefix"
+      expect(klass.default_package_tags).to have_key(:prefix)
+      expect(klass.default_package_tags[:prefix]).to eq "custom-prefix"
     end
 
     it "does not include prefix when HOMEBREW_PREFIX is the default prefix" do
       expect(Homebrew).to receive(:default_prefix?).and_return(true).at_least(:once)
-      expect(described_class.default_package_tags).to have_key(:prefix)
-      expect(described_class.default_package_tags[:prefix]).to eq HOMEBREW_PREFIX.to_s
+      expect(klass.default_package_tags).to have_key(:prefix)
+      expect(klass.default_package_tags[:prefix]).to eq HOMEBREW_PREFIX.to_s
     end
 
     it "includes CI when ENV['CI'] is set" do
       ENV["CI"] = "1"
-      expect(described_class.default_package_tags).to have_key(:ci)
+      expect(klass.default_package_tags).to have_key(:ci)
     end
 
     it "includes developer when ENV['HOMEBREW_DEVELOPER'] is set" do
       expect(Homebrew::EnvConfig).to receive(:developer?).and_return(true)
-      expect(described_class.default_package_tags).to have_key(:developer)
+      expect(klass.default_package_tags).to have_key(:developer)
     end
   end
 
@@ -55,15 +57,15 @@ RSpec.describe Utils::Analytics do
     context "when ENV vars is set" do
       it "returns nil when HOMEBREW_NO_ANALYTICS is true" do
         ENV["HOMEBREW_NO_ANALYTICS"] = "true"
-        expect(described_class).not_to receive(:report_influx)
-        described_class.report_package_event(:install, package_name:, tap_name:,
+        expect(klass).not_to receive(:report_influx)
+        klass.report_package_event(:install, package_name:, tap_name:,
           on_request:, options:)
       end
 
       it "returns nil when HOMEBREW_NO_ANALYTICS_THIS_RUN is true" do
         ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"] = "true"
-        expect(described_class).not_to receive(:report_influx)
-        described_class.report_package_event(:install, package_name:, tap_name:,
+        expect(klass).not_to receive(:report_influx)
+        klass.report_package_event(:install, package_name:, tap_name:,
           on_request:, options:)
       end
 
@@ -71,9 +73,9 @@ RSpec.describe Utils::Analytics do
         ENV.delete("HOMEBREW_NO_ANALYTICS_THIS_RUN")
         ENV.delete("HOMEBREW_NO_ANALYTICS")
         ENV["HOMEBREW_ANALYTICS_DEBUG"] = "true"
-        expect(described_class).to receive(:report_influx)
+        expect(klass).to receive(:report_influx)
 
-        described_class.report_package_event(:install, package_name:, tap_name:,
+        klass.report_package_event(:install, package_name:, tap_name:,
           on_request:, options:)
       end
     end
@@ -82,9 +84,9 @@ RSpec.describe Utils::Analytics do
       ENV.delete("HOMEBREW_NO_ANALYTICS_THIS_RUN")
       ENV.delete("HOMEBREW_NO_ANALYTICS")
       ENV["HOMEBREW_ANALYTICS_DEBUG"] = "true"
-      expect(described_class).to receive(:report_influx).with(:install, hash_including(on_request:),
-                                                              hash_including(package: package_name)).once
-      described_class.report_package_event(:install, package_name:, tap_name:,
+      expect(klass).to receive(:report_influx).with(:install, hash_including(on_request:),
+                                                    hash_including(package: package_name)).once
+      klass.report_package_event(:install, package_name:, tap_name:,
           on_request:, options:)
     end
   end
@@ -100,8 +102,8 @@ RSpec.describe Utils::Analytics do
       ENV.delete("HOMEBREW_NO_ANALYTICS_THIS_RUN")
       ENV.delete("HOMEBREW_NO_ANALYTICS")
       ENV["HOMEBREW_ANALYTICS_DEBUG"] = "true"
-      expect(described_class).to receive(:deferred_curl).once
-      described_class.report_influx(:install, { on_request: }, { package:, tap_name: })
+      expect(klass).to receive(:deferred_curl).once
+      klass.report_influx(:install, { on_request: }, { package:, tap_name: })
     end
   end
 
@@ -112,14 +114,14 @@ RSpec.describe Utils::Analytics do
 
       it "reports event if BuildError raised for a formula with a public remote repository" do
         allow_any_instance_of(Tap).to receive(:custom_remote?).and_return(false)
-        expect(described_class).to respond_to(:report_package_event)
-        described_class.report_build_error(err)
+        expect(klass).to respond_to(:report_package_event)
+        klass.report_build_error(err)
       end
 
       it "does not report event if BuildError raised for a formula with a private remote repository" do
         allow_any_instance_of(Tap).to receive(:private?).and_return(true)
-        expect(described_class).not_to receive(:report_package_event)
-        described_class.report_build_error(err)
+        expect(klass).not_to receive(:report_package_event)
+        klass.report_build_error(err)
       end
     end
 
@@ -128,8 +130,8 @@ RSpec.describe Utils::Analytics do
       let(:f) { instance_double(Formula, name: "foo", path: "blah", tap: nil) }
 
       it "does not report event if BuildError is raised" do
-        expect(described_class).not_to receive(:report_package_event)
-        described_class.report_build_error(err)
+        expect(klass).not_to receive(:report_package_event)
+        klass.report_build_error(err)
       end
     end
 
@@ -139,8 +141,8 @@ RSpec.describe Utils::Analytics do
 
       it "does not report event if BuildError is raised" do
         allow_any_instance_of(Pathname).to receive(:directory?).and_return(false)
-        expect(described_class).not_to receive(:report_package_event)
-        described_class.report_build_error(err)
+        expect(klass).not_to receive(:report_package_event)
+        klass.report_build_error(err)
       end
     end
   end
@@ -157,12 +159,12 @@ RSpec.describe Utils::Analytics do
       ENV.delete("HOMEBREW_NO_ANALYTICS_THIS_RUN")
       ENV.delete("HOMEBREW_NO_ANALYTICS")
       ENV["HOMEBREW_ANALYTICS_DEBUG"] = "true"
-      expect(described_class).to receive(:report_influx).with(
+      expect(klass).to receive(:report_influx).with(
         :command_run,
         hash_including(command:),
         hash_including(options:),
       ).once
-      described_class.report_command_run(command_instance)
+      klass.report_command_run(command_instance)
     end
   end
 
@@ -175,18 +177,18 @@ RSpec.describe Utils::Analytics do
       ENV.delete("HOMEBREW_NO_ANALYTICS")
       ENV["HOMEBREW_ANALYTICS_DEBUG"] = "true"
       ENV["HOMEBREW_TEST_BOT_ANALYTICS"] = "true"
-      expect(described_class).to receive(:report_influx).with(
+      expect(klass).to receive(:report_influx).with(
         :test_bot_test,
         hash_including(passed:),
         hash_including(command:),
       ).once
-      described_class.report_test_bot_test(command, passed)
+      klass.report_test_bot_test(command, passed)
     end
   end
 
   specify "::table_output" do
     results = { "ack" => 10, "wget" => 100 }
-    expect { described_class.table_output("install", "30", results) }
+    expect { klass.table_output("install", "30", results) }
       .to output(/110 |  100.00%/).to_stdout
       .and not_to_output.to_stderr
   end

--- a/Library/Homebrew/test/utils/ast/ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/ast_spec.rb
@@ -4,6 +4,8 @@
 require "utils/ast"
 
 RSpec.describe Utils::AST do
+  let(:klass) { Utils::AST }
+
   describe ".stanza_text" do
     let(:compound_license) do
       <<-RUBY
@@ -16,34 +18,34 @@ RSpec.describe Utils::AST do
     end
 
     it "accepts existing stanza text" do
-      expect(described_class.stanza_text(:revision, "revision 1")).to eq("revision 1")
-      expect(described_class.stanza_text(:license, "license :public_domain")).to eq("license :public_domain")
-      expect(described_class.stanza_text(:license, 'license "MIT"')).to eq('license "MIT"')
-      expect(described_class.stanza_text(:license, compound_license)).to eq(compound_license)
+      expect(klass.stanza_text(:revision, "revision 1")).to eq("revision 1")
+      expect(klass.stanza_text(:license, "license :public_domain")).to eq("license :public_domain")
+      expect(klass.stanza_text(:license, 'license "MIT"')).to eq('license "MIT"')
+      expect(klass.stanza_text(:license, compound_license)).to eq(compound_license)
     end
 
     it "accepts a number as the stanza value" do
-      expect(described_class.stanza_text(:revision, 1)).to eq("revision 1")
+      expect(klass.stanza_text(:revision, 1)).to eq("revision 1")
     end
 
     it "accepts a symbol as the stanza value" do
-      expect(described_class.stanza_text(:license, :public_domain)).to eq("license :public_domain")
+      expect(klass.stanza_text(:license, :public_domain)).to eq("license :public_domain")
     end
 
     it "accepts a string as the stanza value" do
-      expect(described_class.stanza_text(:license, "MIT")).to eq('license "MIT"')
+      expect(klass.stanza_text(:license, "MIT")).to eq('license "MIT"')
     end
 
     it "adds indent to stanza text if specified" do
-      expect(described_class.stanza_text(:revision, "revision 1", indent: 2)).to eq("  revision 1")
-      expect(described_class.stanza_text(:license, 'license "MIT"', indent: 2)).to eq('  license "MIT"')
-      expect(described_class.stanza_text(:license, compound_license, indent: 2)).to eq(compound_license)
+      expect(klass.stanza_text(:revision, "revision 1", indent: 2)).to eq("  revision 1")
+      expect(klass.stanza_text(:license, 'license "MIT"', indent: 2)).to eq('  license "MIT"')
+      expect(klass.stanza_text(:license, compound_license, indent: 2)).to eq(compound_license)
     end
 
     it "does not add indent if already indented" do
-      expect(described_class.stanza_text(:revision, "  revision 1", indent: 2)).to eq("  revision 1")
+      expect(klass.stanza_text(:revision, "  revision 1", indent: 2)).to eq("  revision 1")
       expect(
-        described_class.stanza_text(:license, compound_license, indent: 2),
+        klass.stanza_text(:license, compound_license, indent: 2),
       ).to eq(compound_license)
     end
   end

--- a/Library/Homebrew/test/utils/ast/cask_ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/cask_ast_spec.rb
@@ -5,7 +5,7 @@ require "utils/ast"
 
 RSpec.describe Utils::AST::CaskAST do
   subject(:cask_ast) do
-    described_class.new <<~RUBY
+    klass.new <<~RUBY
       cask "foo" do
         version "1.0"
         sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -20,6 +20,8 @@ RSpec.describe Utils::AST::CaskAST do
       end
     RUBY
   end
+
+  let(:klass) { Utils::AST::CaskAST }
 
   describe "#replace_first_stanza_value" do
     it "replaces the first matching stanza argument" do
@@ -54,7 +56,7 @@ RSpec.describe Utils::AST::CaskAST do
     end
 
     it "replaces matching hash argument values" do
-      cask_ast = described_class.new <<~RUBY
+      cask_ast = klass.new <<~RUBY
         cask "foo" do
           version "1.0"
           sha256 arm:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -80,7 +82,7 @@ RSpec.describe Utils::AST::CaskAST do
 
   describe "#depends_on_macos?" do
     it "detects casks with a macOS dependency" do
-      cask_ast = described_class.new <<~RUBY
+      cask_ast = klass.new <<~RUBY
         cask "foo" do
           version "1.0"
           sha256 :no_check

--- a/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
@@ -5,7 +5,7 @@ require "utils/ast"
 
 RSpec.describe Utils::AST::FormulaAST do
   subject(:formula_ast) do
-    described_class.new <<~RUBY
+    klass.new <<~RUBY
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tar.gz"
         license all_of: [
@@ -16,6 +16,8 @@ RSpec.describe Utils::AST::FormulaAST do
       end
     RUBY
   end
+
+  let(:klass) { Utils::AST::FormulaAST }
 
   describe "#replace_stanza" do
     it "replaces the specified stanza in a formula" do
@@ -65,7 +67,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
   describe "#replace_stable_stanza_hash_value" do
     subject(:formula_ast) do
-      described_class.new <<~RUBY
+      klass.new <<~RUBY
         class Foo < Formula
           url "https://brew.sh/foo.git",
               tag:      "v1.0",
@@ -90,7 +92,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
   describe "#remove_stanzas" do
     subject(:formula_ast) do
-      described_class.new <<~RUBY
+      klass.new <<~RUBY
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tar.gz"
           mirror "https://example.com/foo-1.0.tar.gz"
@@ -131,7 +133,7 @@ RSpec.describe Utils::AST::FormulaAST do
     end
 
     it "adds stanzas after comments following a multi-line stanza" do
-      formula_ast = described_class.new <<~RUBY
+      formula_ast = klass.new <<~RUBY
         class Foo < Formula
           url "https://brew.sh/foo.git",
               tag:      "v1.0",
@@ -158,7 +160,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
   describe "#replace_resource_stanza_value" do
     subject(:formula_ast) do
-      described_class.new <<~RUBY
+      klass.new <<~RUBY
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tar.gz"
 
@@ -194,7 +196,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
   describe "#replace_resource_stanzas" do
     it "inserts resource stanzas before the install method" do
-      formula_ast = described_class.new <<~RUBY
+      formula_ast = klass.new <<~RUBY
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tar.gz"
 
@@ -230,7 +232,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
     context "when resource stanzas already exist" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY
+        klass.new <<~RUBY
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz"
 
@@ -275,7 +277,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
     context "when resource stanzas are split into multiple groups" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY
+        klass.new <<~RUBY
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz"
 
@@ -303,7 +305,7 @@ RSpec.describe Utils::AST::FormulaAST do
   describe "#remove_stanza" do
     context "when stanza to be removed is a single line followed by a blank line" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY.chomp
+        klass.new <<~RUBY.chomp
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz"
             license :cannot_represent
@@ -335,7 +337,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
     context "when stanza to be removed is a multiline block followed by a blank line" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY.chomp
+        klass.new <<~RUBY.chomp
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz"
             license all_of: [
@@ -371,7 +373,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
     context "when stanza to be removed has a comment on the same line" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY.chomp
+        klass.new <<~RUBY.chomp
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz"
             license :cannot_represent # comment
@@ -404,7 +406,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
     context "when stanza to be removed has a comment on the next line" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY.chomp
+        klass.new <<~RUBY.chomp
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz"
             license :cannot_represent
@@ -438,7 +440,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
     context "when stanza to be removed has newlines before and after" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY.chomp
+        klass.new <<~RUBY.chomp
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz"
 
@@ -475,7 +477,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
     context "when stanza to be removed is at the end of the formula" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY.chomp
+        klass.new <<~RUBY.chomp
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz"
             license :cannot_represent
@@ -514,7 +516,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
     context "when `license` is a string" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY.chomp
+        klass.new <<~RUBY.chomp
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz"
             license "MIT"
@@ -543,7 +545,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
     context "when `license` is a symbol" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY.chomp
+        klass.new <<~RUBY.chomp
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz"
             license :cannot_represent
@@ -572,7 +574,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
     context "when `license` is multiline" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY.chomp
+        klass.new <<~RUBY.chomp
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz"
             license all_of: [
@@ -609,7 +611,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
     context "when `head` is a string" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY.chomp
+        klass.new <<~RUBY.chomp
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz"
             head "https://brew.sh/foo.git", branch: "develop"
@@ -638,7 +640,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
     context "when `head` is a block" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY.chomp
+        klass.new <<~RUBY.chomp
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz"
 
@@ -675,7 +677,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
     context "when there is a comment on the same line" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY.chomp
+        klass.new <<~RUBY.chomp
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz" # comment
           end
@@ -702,7 +704,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
     context "when the next line is a comment" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY.chomp
+        klass.new <<~RUBY.chomp
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz"
             # comment
@@ -731,7 +733,7 @@ RSpec.describe Utils::AST::FormulaAST do
 
     context "when the next line is blank and the one after it is a comment" do
       subject(:formula_ast) do
-        described_class.new <<~RUBY.chomp
+        klass.new <<~RUBY.chomp
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tar.gz"
 

--- a/Library/Homebrew/test/utils/autoremove_spec.rb
+++ b/Library/Homebrew/test/utils/autoremove_spec.rb
@@ -4,6 +4,8 @@
 require "utils/autoremove"
 
 RSpec.describe Utils::Autoremove do
+  let(:klass) { Utils::Autoremove }
+
   shared_context "with formulae for dependency testing" do
     let(:formula_with_deps) do
       formula "zero" do
@@ -75,7 +77,7 @@ RSpec.describe Utils::Autoremove do
       it "filters out runtime dependencies" do
         allow(tab_from_keg).to receive(:poured_from_bottle).and_return(true)
 
-        expect(described_class.send(:bottled_formulae_with_no_formula_dependents, formulae))
+        expect(klass.send(:bottled_formulae_with_no_formula_dependents, formulae))
           .to eq([formula_with_deps, formula_is_build_dep])
       end
     end
@@ -84,7 +86,7 @@ RSpec.describe Utils::Autoremove do
       it "filters out formulae" do
         allow(tab_from_keg).to receive(:poured_from_bottle).and_return(false)
 
-        expect(described_class.send(:bottled_formulae_with_no_formula_dependents, formulae))
+        expect(klass.send(:bottled_formulae_with_no_formula_dependents, formulae))
           .to eq([])
       end
     end
@@ -98,7 +100,7 @@ RSpec.describe Utils::Autoremove do
         expect(formula_with_deps).not_to receive(:installed_runtime_formula_dependencies)
         expect(first_formula_dep).not_to receive(:installed_runtime_formula_dependencies)
 
-        expect(described_class.send(:bottled_formulae_with_no_formula_dependents, formulae))
+        expect(klass.send(:bottled_formulae_with_no_formula_dependents, formulae))
           .to eq([formula_with_deps, formula_is_build_dep])
       end
     end
@@ -114,21 +116,21 @@ RSpec.describe Utils::Autoremove do
     specify "installed on request" do
       allow(tab_from_keg).to receive_messages(installed_on_request: true, installed_on_request_present?: true)
 
-      expect(described_class.send(:unused_formulae_with_no_formula_dependents, formulae))
+      expect(klass.send(:unused_formulae_with_no_formula_dependents, formulae))
         .to eq([])
     end
 
     specify "not installed on request" do
       allow(tab_from_keg).to receive_messages(installed_on_request: false, installed_on_request_present?: true)
 
-      expect(described_class.send(:unused_formulae_with_no_formula_dependents, formulae))
+      expect(klass.send(:unused_formulae_with_no_formula_dependents, formulae))
         .to match_array(formulae)
     end
 
     specify "installed on request is null" do
       allow(tab_from_keg).to receive_messages(installed_on_request: false, installed_on_request_present?: false)
 
-      expect(described_class.send(:unused_formulae_with_no_formula_dependents, formulae))
+      expect(klass.send(:unused_formulae_with_no_formula_dependents, formulae))
         .to eq([])
     end
   end
@@ -177,17 +179,17 @@ RSpec.describe Utils::Autoremove do
     include_context "with formulae and casks for dependency testing"
 
     specify "no dependents" do
-      expect(described_class.send(:cask_dependent_formula_names, casks_no_deps, formulae))
+      expect(klass.send(:cask_dependent_formula_names, casks_no_deps, formulae))
         .to eq(Set.new)
     end
 
     specify "one dependent" do
-      expect(described_class.send(:cask_dependent_formula_names, casks_one_dep, formulae))
+      expect(klass.send(:cask_dependent_formula_names, casks_one_dep, formulae))
         .to contain_exactly("two")
     end
 
     specify "multiple dependents" do
-      expect(described_class.send(:cask_dependent_formula_names, casks_multiple_deps, formulae))
+      expect(klass.send(:cask_dependent_formula_names, casks_multiple_deps, formulae))
         .to contain_exactly("zero", "one", "two")
     end
   end

--- a/Library/Homebrew/test/utils/backtrace_spec.rb
+++ b/Library/Homebrew/test/utils/backtrace_spec.rb
@@ -4,6 +4,8 @@
 require "utils/backtrace"
 
 RSpec.describe Utils::Backtrace do
+  let(:klass) { Utils::Backtrace }
+
   let(:backtrace_no_sorbet_paths) do
     [
       "/Library/Homebrew/downloadable.rb:75:in",
@@ -58,34 +60,34 @@ RSpec.describe Utils::Backtrace do
   end
 
   before do
-    allow(described_class).to receive(:sorbet_runtime_path)
+    allow(klass).to receive(:sorbet_runtime_path)
       .and_return("/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime")
     allow(Context).to receive(:current).and_return(Context::ContextStruct.new(verbose: false))
   end
 
   it "handles nil backtrace" do
     exception = exception_with backtrace: nil
-    expect(described_class.clean(exception)).to be_nil
+    expect(klass.clean(exception)).to be_nil
   end
 
   it "handles empty array backtrace" do
     exception = exception_with backtrace: []
-    expect(described_class.clean(exception)).to eq []
+    expect(klass.clean(exception)).to eq []
   end
 
   it "removes sorbet paths when top error is not from sorbet" do
     exception = exception_with backtrace: backtrace_with_sorbet_paths
-    expect(described_class.clean(exception)).to eq backtrace_no_sorbet_paths
+    expect(klass.clean(exception)).to eq backtrace_no_sorbet_paths
   end
 
   it "includes sorbet paths when top error is not from sorbet and verbose is set" do
     allow(Context).to receive(:current).and_return(Context::ContextStruct.new(verbose: true))
     exception = exception_with backtrace: backtrace_with_sorbet_paths
-    expect(described_class.clean(exception)).to eq backtrace_with_sorbet_paths
+    expect(klass.clean(exception)).to eq backtrace_with_sorbet_paths
   end
 
   it "doesn't change backtrace when error is from sorbet" do
     exception = exception_with backtrace: backtrace_with_sorbet_error
-    expect(described_class.clean(exception)).to eq backtrace_with_sorbet_error
+    expect(klass.clean(exception)).to eq backtrace_with_sorbet_error
   end
 end

--- a/Library/Homebrew/test/utils/bottles/bottles_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/bottles_spec.rb
@@ -4,13 +4,15 @@
 require "utils/bottles"
 
 RSpec.describe Utils::Bottles do
+  let(:klass) { Utils::Bottles }
+
   describe "#tag", :needs_macos do
     it "returns :big_sur or :arm64_big_sur on Big Sur" do
       allow(MacOS).to receive(:version).and_return(MacOSVersion.new("11.0"))
       if Hardware::CPU.intel?
-        expect(described_class.tag).to eq(:big_sur)
+        expect(klass.tag).to eq(:big_sur)
       else
-        expect(described_class.tag).to eq(:arm64_big_sur)
+        expect(klass.tag).to eq(:arm64_big_sur)
       end
     end
   end
@@ -46,7 +48,7 @@ RSpec.describe Utils::Bottles do
         formula = Formula["testball2"]
         formula.prefix.mkpath
 
-        runtime_dependencies = described_class.load_tab(formula).runtime_dependencies
+        runtime_dependencies = klass.load_tab(formula).runtime_dependencies
 
         expect(runtime_dependencies).not_to be_nil
         expect(runtime_dependencies.size).to eq(1)

--- a/Library/Homebrew/test/utils/bottles/collector_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/collector_spec.rb
@@ -4,8 +4,9 @@
 require "utils/bottles"
 
 RSpec.describe Utils::Bottles::Collector do
-  subject(:collector) { described_class.new }
+  subject(:collector) { klass.new }
 
+  let(:klass) { Utils::Bottles::Collector }
   let(:tahoe) { Utils::Bottles::Tag.from_symbol(:tahoe) }
   let(:sequoia) { Utils::Bottles::Tag.from_symbol(:sequoia) }
   let(:sonoma) { Utils::Bottles::Tag.from_symbol(:sonoma) }

--- a/Library/Homebrew/test/utils/bottles/tag_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/tag_spec.rb
@@ -4,9 +4,11 @@
 require "utils/bottles"
 
 RSpec.describe Utils::Bottles::Tag do
+  let(:klass) { Utils::Bottles::Tag }
+
   it "can parse macOS symbols with archs" do
     symbol = :arm64_big_sur
-    tag = described_class.from_symbol(symbol)
+    tag = klass.from_symbol(symbol)
     expect(tag.system).to eq(:big_sur)
     expect(tag.arch).to eq(:arm64)
     expect(tag.to_macos_version).to eq(MacOSVersion.from_symbol(:big_sur))
@@ -17,7 +19,7 @@ RSpec.describe Utils::Bottles::Tag do
 
   it "can parse macOS symbols without archs" do
     symbol = :big_sur
-    tag = described_class.from_symbol(symbol)
+    tag = klass.from_symbol(symbol)
     expect(tag.system).to eq(:big_sur)
     expect(tag.arch).to eq(:x86_64)
     expect(tag.to_macos_version).to eq(MacOSVersion.from_symbol(:big_sur))
@@ -28,7 +30,7 @@ RSpec.describe Utils::Bottles::Tag do
 
   it "can parse Linux symbols" do
     symbol = :x86_64_linux
-    tag = described_class.from_symbol(symbol)
+    tag = klass.from_symbol(symbol)
     expect(tag.system).to eq(:linux)
     expect(tag.arch).to eq(:x86_64)
     expect { tag.to_macos_version }.to raise_error(MacOSVersion::Error)
@@ -39,8 +41,8 @@ RSpec.describe Utils::Bottles::Tag do
 
   describe "#==" do
     it "compares using the standardized arch" do
-      monterey_intel = described_class.new(system: :monterey, arch: :intel)
-      monterex_x86_64 = described_class.new(system: :monterey, arch: :x86_64)
+      monterey_intel = klass.new(system: :monterey, arch: :intel)
+      monterex_x86_64 = klass.new(system: :monterey, arch: :x86_64)
 
       expect(monterey_intel).to eq monterex_x86_64
     end
@@ -48,37 +50,37 @@ RSpec.describe Utils::Bottles::Tag do
 
   describe "#standardized_arch" do
     specify do
-      expect(described_class.new(system: :all, arch: :intel).standardized_arch).to eq(:x86_64)
-      expect(described_class.new(system: :all, arch: :arm).standardized_arch).to eq(:arm64)
+      expect(klass.new(system: :all, arch: :intel).standardized_arch).to eq(:x86_64)
+      expect(klass.new(system: :all, arch: :arm).standardized_arch).to eq(:arm64)
     end
   end
 
   describe "#valid_combination?" do
     it "returns true for Intel" do
-      tag = described_class.new(system: :big_sur, arch: :intel)
+      tag = klass.new(system: :big_sur, arch: :intel)
       expect(tag.valid_combination?).to be true
-      tag = described_class.new(system: :linux, arch: :x86_64)
+      tag = klass.new(system: :linux, arch: :x86_64)
       expect(tag.valid_combination?).to be true
     end
 
     it "returns false for ARM on macOS Catalina" do
-      tag = described_class.new(system: :catalina, arch: :arm64)
+      tag = klass.new(system: :catalina, arch: :arm64)
       expect(tag.valid_combination?).to be false
     end
 
     it "returns true for ARM on macOS Big Sur or newer" do
-      tag = described_class.new(system: :big_sur, arch: :arm64)
+      tag = klass.new(system: :big_sur, arch: :arm64)
       expect(tag.valid_combination?).to be true
-      tag = described_class.new(system: :monterey, arch: :arm)
+      tag = klass.new(system: :monterey, arch: :arm)
       expect(tag.valid_combination?).to be true
-      tag = described_class.new(system: :ventura, arch: :arm)
+      tag = klass.new(system: :ventura, arch: :arm)
       expect(tag.valid_combination?).to be true
     end
 
     it "returns true for ARM on Linux" do
-      tag = described_class.new(system: :linux, arch: :arm64)
+      tag = klass.new(system: :linux, arch: :arm64)
       expect(tag.valid_combination?).to be true
-      tag = described_class.new(system: :linux, arch: :arm)
+      tag = klass.new(system: :linux, arch: :arm)
       expect(tag.valid_combination?).to be true
     end
   end

--- a/Library/Homebrew/test/utils/bottles/tag_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/tag_spec.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
 
 require "utils/bottles"

--- a/Library/Homebrew/test/utils/cpan_spec.rb
+++ b/Library/Homebrew/test/utils/cpan_spec.rb
@@ -4,6 +4,8 @@
 require "utils/cpan"
 
 RSpec.describe CPAN do
+  let(:klass) { CPAN }
+
   let(:cpan_package_url) do
     "https://cpan.metacpan.org/authors/id/P/PE/PEVANS/Scalar-List-Utils-1.68.tar.gz"
   end
@@ -15,9 +17,11 @@ RSpec.describe CPAN do
   end
 
   describe CPAN::Package do
-    let(:package_from_cpan_url) { described_class.new("Scalar::Util", cpan_package_url) }
-    let(:package_from_tgz_url) { described_class.new("Example::Module", cpan_tgz_url) }
-    let(:package_from_non_cpan_url) { described_class.new("SomePackage", non_cpan_package_url) }
+    let(:klass) { CPAN::Package }
+
+    let(:package_from_cpan_url) { klass.new("Scalar::Util", cpan_package_url) }
+    let(:package_from_tgz_url) { klass.new("Example::Module", cpan_tgz_url) }
+    let(:package_from_non_cpan_url) { klass.new("SomePackage", non_cpan_package_url) }
 
     describe "initialize" do
       specify do

--- a/Library/Homebrew/test/utils/fork_spec.rb
+++ b/Library/Homebrew/test/utils/fork_spec.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
 
 require "utils/fork"

--- a/Library/Homebrew/test/utils/fork_spec.rb
+++ b/Library/Homebrew/test/utils/fork_spec.rb
@@ -4,10 +4,12 @@
 require "utils/fork"
 
 RSpec.describe Utils do
+  let(:klass) { Utils }
+
   describe "#safe_fork" do
     it "raises a RuntimeError on an error that isn't ErrorDuringExecution" do
       expect do
-        described_class.safe_fork do
+        klass.safe_fork do
           raise "this is an exception in the child"
         end
       end.to raise_error(RuntimeError)
@@ -15,7 +17,7 @@ RSpec.describe Utils do
 
     it "raises an ErrorDuringExecution on one in the child" do
       expect do
-        described_class.safe_fork do
+        klass.safe_fork do
           safe_system "/usr/bin/false"
         end
       end.to raise_error(ErrorDuringExecution)

--- a/Library/Homebrew/test/utils/formatter_spec.rb
+++ b/Library/Homebrew/test/utils/formatter_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Formatter do
     end
 
     it "stretches few short items into wide columns that fill the terminal" do
-      first_row = described_class.columns(%w[aa bb cc dd]).lines.first.chomp
+      first_row = Formatter.columns(%w[aa bb cc dd]).lines.first.chomp
 
       expect(first_row.index("bb")).to be > 2
     end
 
     it "uses tighter columns when min_width fits more columns than the item count" do
-      default_first_row = described_class.columns(%w[aa bb cc dd]).lines.first.chomp
-      pinned_first_row = described_class.columns(%w[aa bb cc dd], min_width: 4).lines.first.chomp
+      default_first_row = Formatter.columns(%w[aa bb cc dd]).lines.first.chomp
+      pinned_first_row = Formatter.columns(%w[aa bb cc dd], min_width: 4).lines.first.chomp
 
       expect(pinned_first_row.index("bb")).to be < default_first_row.index("bb")
     end
@@ -29,8 +29,8 @@ RSpec.describe Formatter do
       few = %w[a b c]
       shared_min_width = (many + few).map(&:length).max
 
-      many_first_row = described_class.columns(many, min_width: shared_min_width).lines.first.chomp
-      few_first_row = described_class.columns(few, min_width: shared_min_width).lines.first.chomp
+      many_first_row = Formatter.columns(many, min_width: shared_min_width).lines.first.chomp
+      few_first_row = Formatter.columns(few, min_width: shared_min_width).lines.first.chomp
 
       expect(many_first_row.index("item3")).to eq(few_first_row.index("b"))
     end

--- a/Library/Homebrew/test/utils/formatter_spec.rb
+++ b/Library/Homebrew/test/utils/formatter_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Formatter do
     end
 
     it "stretches few short items into wide columns that fill the terminal" do
-      first_row = Formatter.columns(%w[aa bb cc dd]).lines.first.chomp
+      first_row = Formatter.columns(%w[aa bb cc dd]).lines.fetch(0).chomp
 
       expect(first_row.index("bb")).to be > 2
     end
 
     it "uses tighter columns when min_width fits more columns than the item count" do
-      default_first_row = Formatter.columns(%w[aa bb cc dd]).lines.first.chomp
-      pinned_first_row = Formatter.columns(%w[aa bb cc dd], min_width: 4).lines.first.chomp
+      default_first_row = Formatter.columns(%w[aa bb cc dd]).lines.fetch(0).chomp
+      pinned_first_row = Formatter.columns(%w[aa bb cc dd], min_width: 4).lines.fetch(0).chomp
 
       expect(pinned_first_row.index("bb")).to be < default_first_row.index("bb")
     end
@@ -27,10 +27,10 @@ RSpec.describe Formatter do
     it "produces matching column widths for two calls sharing the same min_width" do
       many = (1..20).map { |i| "item#{i}" }
       few = %w[a b c]
-      shared_min_width = (many + few).map(&:length).max
+      shared_min_width = (many + few).map(&:length).max || 0
 
-      many_first_row = Formatter.columns(many, min_width: shared_min_width).lines.first.chomp
-      few_first_row = Formatter.columns(few, min_width: shared_min_width).lines.first.chomp
+      many_first_row = Formatter.columns(many, min_width: shared_min_width).lines.fetch(0).chomp
+      few_first_row = Formatter.columns(few, min_width: shared_min_width).lines.fetch(0).chomp
 
       expect(many_first_row.index("item3")).to eq(few_first_row.index("b"))
     end

--- a/Library/Homebrew/test/utils/git_repository_spec.rb
+++ b/Library/Homebrew/test/utils/git_repository_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Utils do
   shared_examples "git_repository helper function" do |method_name|
     context "when directory is not a Git repository" do
       it "returns nil if `safe` parameter is `false`" do
-        expect(klass.public_send(method_name, TEST_TMPDIR, safe: false)).to be_nil
+        expect(Utils.public_send(method_name, TEST_TMPDIR, safe: false)).to be_nil
       end
 
       it "raises an error if `safe` parameter is `true`" do
-        expect { klass.public_send(method_name, TEST_TMPDIR, safe: true) }
+        expect { Utils.public_send(method_name, TEST_TMPDIR, safe: true) }
           .to raise_error("Not a Git repository: #{TEST_TMPDIR}")
       end
     end
@@ -28,11 +28,11 @@ RSpec.describe Utils do
       end
 
       it "returns nil if `safe` parameter is `false`" do
-        expect(klass.public_send(method_name, HOMEBREW_CACHE, safe: false)).to be_nil
+        expect(Utils.public_send(method_name, HOMEBREW_CACHE, safe: false)).to be_nil
       end
 
       it "raises an error if `safe` parameter is `true`" do
-        expect { klass.public_send(method_name, HOMEBREW_CACHE, safe: true) }
+        expect { Utils.public_send(method_name, HOMEBREW_CACHE, safe: true) }
           .to raise_error("Git is unavailable")
       end
     end

--- a/Library/Homebrew/test/utils/git_repository_spec.rb
+++ b/Library/Homebrew/test/utils/git_repository_spec.rb
@@ -4,14 +4,20 @@
 require "utils/git_repository"
 
 RSpec.describe Utils do
+  let(:klass) { Utils }
+  let(:commit_message) { "File added" }
+  let(:branch_name) { "test-branch" }
+  let(:head_revision) { HOMEBREW_CACHE.cd { `git rev-parse HEAD`.chomp } }
+  let(:short_head_revision) { HOMEBREW_CACHE.cd { `git rev-parse --short HEAD`.chomp } }
+
   shared_examples "git_repository helper function" do |method_name|
     context "when directory is not a Git repository" do
       it "returns nil if `safe` parameter is `false`" do
-        expect(described_class.public_send(method_name, TEST_TMPDIR, safe: false)).to be_nil
+        expect(klass.public_send(method_name, TEST_TMPDIR, safe: false)).to be_nil
       end
 
       it "raises an error if `safe` parameter is `true`" do
-        expect { described_class.public_send(method_name, TEST_TMPDIR, safe: true) }
+        expect { klass.public_send(method_name, TEST_TMPDIR, safe: true) }
           .to raise_error("Not a Git repository: #{TEST_TMPDIR}")
       end
     end
@@ -22,11 +28,11 @@ RSpec.describe Utils do
       end
 
       it "returns nil if `safe` parameter is `false`" do
-        expect(described_class.public_send(method_name, HOMEBREW_CACHE, safe: false)).to be_nil
+        expect(klass.public_send(method_name, HOMEBREW_CACHE, safe: false)).to be_nil
       end
 
       it "raises an error if `safe` parameter is `true`" do
-        expect { described_class.public_send(method_name, HOMEBREW_CACHE, safe: true) }
+        expect { klass.public_send(method_name, HOMEBREW_CACHE, safe: true) }
           .to raise_error("Git is unavailable")
       end
     end
@@ -42,19 +48,13 @@ RSpec.describe Utils do
     end
   end
 
-  let(:commit_message) { "File added" }
-  let(:branch_name) { "test-branch" }
-
-  let(:head_revision) { HOMEBREW_CACHE.cd { `git rev-parse HEAD`.chomp } }
-  let(:short_head_revision) { HOMEBREW_CACHE.cd { `git rev-parse --short HEAD`.chomp } }
-
   describe "::git_head" do
     it "returns the revision at HEAD" do
-      expect(described_class.git_head(HOMEBREW_CACHE)).to eq(head_revision)
-      expect(described_class.git_head(HOMEBREW_CACHE, length: 5)).to eq(head_revision[0...5])
+      expect(klass.git_head(HOMEBREW_CACHE)).to eq(head_revision)
+      expect(klass.git_head(HOMEBREW_CACHE, length: 5)).to eq(head_revision[0...5])
       HOMEBREW_CACHE.cd do
-        expect(described_class.git_head).to eq(head_revision)
-        expect(described_class.git_head(length: 5)).to eq(head_revision[0...5])
+        expect(klass.git_head).to eq(head_revision)
+        expect(klass.git_head(length: 5)).to eq(head_revision[0...5])
       end
     end
 
@@ -63,11 +63,11 @@ RSpec.describe Utils do
 
   describe "::git_short_head" do
     it "returns the short revision at HEAD" do
-      expect(described_class.git_short_head(HOMEBREW_CACHE)).to eq(short_head_revision)
-      expect(described_class.git_short_head(HOMEBREW_CACHE, length: 5)).to eq(head_revision[0...5])
+      expect(klass.git_short_head(HOMEBREW_CACHE)).to eq(short_head_revision)
+      expect(klass.git_short_head(HOMEBREW_CACHE, length: 5)).to eq(head_revision[0...5])
       HOMEBREW_CACHE.cd do
-        expect(described_class.git_short_head).to eq(short_head_revision)
-        expect(described_class.git_short_head(length: 5)).to eq(head_revision[0...5])
+        expect(klass.git_short_head).to eq(short_head_revision)
+        expect(klass.git_short_head(length: 5)).to eq(head_revision[0...5])
       end
     end
 
@@ -78,9 +78,9 @@ RSpec.describe Utils do
     include_examples "git_repository helper function", :git_branch
 
     it "returns the current Git branch" do
-      expect(described_class.git_branch(HOMEBREW_CACHE)).to eq(branch_name)
+      expect(klass.git_branch(HOMEBREW_CACHE)).to eq(branch_name)
       HOMEBREW_CACHE.cd do
-        expect(described_class.git_branch).to eq(branch_name)
+        expect(klass.git_branch).to eq(branch_name)
       end
     end
   end
@@ -89,11 +89,11 @@ RSpec.describe Utils do
     include_examples "git_repository helper function", :git_commit_message
 
     it "returns the commit message of HEAD" do
-      expect(described_class.git_commit_message(HOMEBREW_CACHE)).to eq(commit_message)
-      expect(described_class.git_commit_message(HOMEBREW_CACHE, commit: head_revision)).to eq(commit_message)
+      expect(klass.git_commit_message(HOMEBREW_CACHE)).to eq(commit_message)
+      expect(klass.git_commit_message(HOMEBREW_CACHE, commit: head_revision)).to eq(commit_message)
       HOMEBREW_CACHE.cd do
-        expect(described_class.git_commit_message).to eq(commit_message)
-        expect(described_class.git_commit_message(commit: head_revision)).to eq(commit_message)
+        expect(klass.git_commit_message).to eq(commit_message)
+        expect(klass.git_commit_message(commit: head_revision)).to eq(commit_message)
       end
     end
   end

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -4,11 +4,22 @@
 require "utils/git"
 
 RSpec.describe Utils::Git do
+  let(:klass) { Utils::Git }
+  let(:file) { "README.md" }
+  # Allow instance variables here for a simpler `before do` block.
+  # rubocop:disable RSpec/InstanceVariable
+  let(:file_hash_one) { @h1[0..6] }
+  let(:file_hash_two) { @h2[0..6] }
+  let(:files) { ["README.md", "LICENSE.txt"] }
+  let(:files_hash_one) { [@h3[0..6], ["LICENSE.txt"]] }
+  let(:files_hash_two) { [@h2[0..6], ["README.md"]] }
+  let(:cherry_pick_commit) { @cherry_pick_commit[0..6] }
+
   around do |example|
-    described_class.clear_available_cache
+    klass.clear_available_cache
     example.run
   ensure
-    described_class.clear_available_cache
+    klass.clear_available_cache
   end
 
   before do
@@ -44,26 +55,17 @@ RSpec.describe Utils::Git do
     end
   end
 
-  let(:file) { "README.md" }
-  # Allow instance variables here for a simpler `before do` block.
-  # rubocop:disable RSpec/InstanceVariable
-  let(:file_hash_one) { @h1[0..6] }
-  let(:file_hash_two) { @h2[0..6] }
-  let(:files) { ["README.md", "LICENSE.txt"] }
-  let(:files_hash_one) { [@h3[0..6], ["LICENSE.txt"]] }
-  let(:files_hash_two) { [@h2[0..6], ["README.md"]] }
-  let(:cherry_pick_commit) { @cherry_pick_commit[0..6] }
   # rubocop:enable RSpec/InstanceVariable
 
   describe "#cherry_pick!" do
     it "can cherry pick a commit" do
-      expect(described_class.cherry_pick!(HOMEBREW_CACHE, cherry_pick_commit)).to be_truthy
+      expect(klass.cherry_pick!(HOMEBREW_CACHE, cherry_pick_commit)).to be_truthy
     end
 
     it "aborts when cherry picking an existing hash" do
       ENV["GIT_MERGE_VERBOSITY"] = "5" # Consistent output across git versions
       expect do
-        described_class.cherry_pick!(HOMEBREW_CACHE, file_hash_one)
+        klass.cherry_pick!(HOMEBREW_CACHE, file_hash_one)
       end.to raise_error(ErrorDuringExecution, /Merge conflict in README.md/)
     end
   end
@@ -71,27 +73,27 @@ RSpec.describe Utils::Git do
   describe "#last_revision_commit_of_file" do
     it "gives last revision commit when before_commit is nil" do
       expect(
-        described_class.last_revision_commit_of_file(HOMEBREW_CACHE, file),
+        klass.last_revision_commit_of_file(HOMEBREW_CACHE, file),
       ).to eq(file_hash_one)
     end
 
     it "gives revision commit based on before_commit when it is not nil" do
       expect(
-        described_class.last_revision_commit_of_file(HOMEBREW_CACHE,
-                                                     file,
-                                                     before_commit: file_hash_two),
+        klass.last_revision_commit_of_file(HOMEBREW_CACHE,
+                                           file,
+                                           before_commit: file_hash_two),
       ).to eq(file_hash_two)
     end
   end
 
   describe "#file_at_commit" do
     it "returns file contents when file exists" do
-      expect(described_class.file_at_commit(HOMEBREW_CACHE, file, file_hash_one)).to eq("README")
+      expect(klass.file_at_commit(HOMEBREW_CACHE, file, file_hash_one)).to eq("README")
     end
 
     it "returns empty when file doesn't exist" do
-      expect(described_class.file_at_commit(HOMEBREW_CACHE, "foo.txt", file_hash_one)).to eq("")
-      expect(described_class.file_at_commit(HOMEBREW_CACHE, "LICENSE.txt", file_hash_one)).to eq("")
+      expect(klass.file_at_commit(HOMEBREW_CACHE, "foo.txt", file_hash_one)).to eq("")
+      expect(klass.file_at_commit(HOMEBREW_CACHE, "LICENSE.txt", file_hash_one)).to eq("")
     end
   end
 
@@ -99,7 +101,7 @@ RSpec.describe Utils::Git do
     context "when before_commit is nil" do
       it "gives last revision commit" do
         expect(
-          described_class.last_revision_commit_of_files(HOMEBREW_CACHE, files),
+          klass.last_revision_commit_of_files(HOMEBREW_CACHE, files),
         ).to eq(files_hash_one)
       end
     end
@@ -107,9 +109,9 @@ RSpec.describe Utils::Git do
     context "when before_commit is not nil" do
       it "gives last revision commit" do
         expect(
-          described_class.last_revision_commit_of_files(HOMEBREW_CACHE,
-                                                        files,
-                                                        before_commit: file_hash_two),
+          klass.last_revision_commit_of_files(HOMEBREW_CACHE,
+                                              files,
+                                              before_commit: file_hash_two),
         ).to eq(files_hash_two)
       end
     end
@@ -118,55 +120,55 @@ RSpec.describe Utils::Git do
   describe "#last_revision_of_file" do
     it "returns last revision of file" do
       expect(
-        described_class.last_revision_of_file(HOMEBREW_CACHE,
-                                              HOMEBREW_CACHE/file),
+        klass.last_revision_of_file(HOMEBREW_CACHE,
+                                    HOMEBREW_CACHE/file),
       ).to eq("README")
     end
 
     it "returns last revision of file based on before_commit" do
       expect(
-        described_class.last_revision_of_file(HOMEBREW_CACHE, HOMEBREW_CACHE/file,
-                                              before_commit: "0..3"),
+        klass.last_revision_of_file(HOMEBREW_CACHE, HOMEBREW_CACHE/file,
+                                    before_commit: "0..3"),
       ).to eq("# README")
     end
   end
 
   describe "::available?" do
     it "returns true if git --version command succeeds" do
-      expect(described_class).to be_available
+      expect(klass).to be_available
     end
 
     it "returns false if git --version command does not succeed" do
       stub_const("HOMEBREW_SHIMS_PATH", HOMEBREW_PREFIX/"bin/shim")
-      expect(described_class).not_to be_available
+      expect(klass).not_to be_available
     end
   end
 
   describe "::path" do
     it "returns nil when git is not available" do
       stub_const("HOMEBREW_SHIMS_PATH", HOMEBREW_PREFIX/"bin/shim")
-      expect(described_class.path).to be_nil
+      expect(klass.path).to be_nil
     end
 
     it "returns path of git when git is available" do
-      expect(described_class.path).to end_with("git")
+      expect(klass.path).to end_with("git")
     end
   end
 
   describe "::version" do
     it "returns null when git is not available" do
       stub_const("HOMEBREW_SHIMS_PATH", HOMEBREW_PREFIX/"bin/shim")
-      expect(described_class.version).to be Version::NULL
+      expect(klass.version).to be Version::NULL
     end
 
     it "returns version of git when git is available" do
-      expect(described_class.version).to be > Version::NULL
+      expect(klass.version).to be > Version::NULL
     end
   end
 
   describe "::ensure_installed!" do
     it "doesn't fail if git already available" do
-      expect { described_class.ensure_installed! }.not_to raise_error
+      expect { klass.ensure_installed! }.not_to raise_error
     end
 
     context "when git is not already available" do
@@ -176,7 +178,7 @@ RSpec.describe Utils::Git do
 
       it "can't install brewed git if homebrew/core is unavailable" do
         allow_any_instance_of(Pathname).to receive(:directory?).and_return(false)
-        expect { described_class.ensure_installed! }.to raise_error("Git is unavailable")
+        expect { klass.ensure_installed! }.to raise_error("Git is unavailable")
       end
 
       it "raises error if can't install git" do
@@ -185,22 +187,22 @@ RSpec.describe Utils::Git do
         allow(Formula).to receive(:[]).with("git").and_return(formula_double)
         allow(formula_double).to receive(:ensure_installed!).with(executable: "git").and_raise(RuntimeError)
 
-        expect { described_class.ensure_installed! }.to raise_error("Git is unavailable")
+        expect { klass.ensure_installed! }.to raise_error("Git is unavailable")
       end
 
       unless ENV["HOMEBREW_TEST_GENERIC_OS"]
         it "keeps using the git shim after the formula install helper" do
-          expect(described_class).to receive(:available?).and_return(false)
+          expect(klass).to receive(:available?).and_return(false)
           allow(CoreTap.instance).to receive(:installed?).and_return(true)
           formula_double = instance_double(Formula)
           allow(Formula).to receive(:[]).with("git").and_return(formula_double)
           allow(formula_double).to receive(:ensure_installed!).with(executable: "git")
                                                               .and_return(Pathname.new("/usr/bin/git"))
-          expect(described_class).to receive(:available?).and_return(true)
+          expect(klass).to receive(:available?).and_return(true)
 
-          described_class.ensure_installed!
+          klass.ensure_installed!
 
-          expect(described_class.git).to eq(HOMEBREW_SHIMS_PATH/"shared/git")
+          expect(klass.git).to eq(HOMEBREW_SHIMS_PATH/"shared/git")
         end
       end
     end
@@ -209,7 +211,7 @@ RSpec.describe Utils::Git do
   describe "::remote_exists?" do
     it "returns true when git is not available" do
       stub_const("HOMEBREW_SHIMS_PATH", HOMEBREW_PREFIX/"bin/shim")
-      expect(described_class).to be_remote_exists("blah")
+      expect(klass).to be_remote_exists("blah")
     end
 
     context "when git is available" do
@@ -224,11 +226,11 @@ RSpec.describe Utils::Git do
           system git, "remote", "add", "origin", url
         end
 
-        expect(described_class).to be_remote_exists(url)
+        expect(klass).to be_remote_exists(url)
       end
 
       it "returns false when git remote does not exist" do
-        expect(described_class).not_to be_remote_exists("blah")
+        expect(klass).not_to be_remote_exists("blah")
       end
     end
   end

--- a/Library/Homebrew/test/utils/github/actions_spec.rb
+++ b/Library/Homebrew/test/utils/github/actions_spec.rb
@@ -4,19 +4,21 @@
 require "utils/github/actions"
 
 RSpec.describe GitHub::Actions::Annotation do
+  let(:klass) { GitHub::Actions::Annotation }
+
   let(:message) { "lorem ipsum" }
 
   describe "#new" do
     it "fails when the type is wrong" do
       expect do
-        described_class.new(:fatal, message, file: "file.txt")
+        klass.new(:fatal, message, file: "file.txt")
       end.to raise_error(ArgumentError)
     end
   end
 
   describe "#to_s" do
     it "escapes newlines" do
-      annotation = described_class.new(:warning, <<~EOS, file: "file.txt")
+      annotation = klass.new(:warning, <<~EOS, file: "file.txt")
         lorem
         ipsum
       EOS
@@ -25,25 +27,25 @@ RSpec.describe GitHub::Actions::Annotation do
     end
 
     it "allows specifying the file" do
-      annotation = described_class.new(:warning, "lorem ipsum", file: "file.txt")
+      annotation = klass.new(:warning, "lorem ipsum", file: "file.txt")
 
       expect(annotation.to_s).to eq "::warning file=file.txt::lorem ipsum"
     end
 
     it "allows specifying the title" do
-      annotation = described_class.new(:warning, "lorem ipsum", file: "file.txt", title: "foo")
+      annotation = klass.new(:warning, "lorem ipsum", file: "file.txt", title: "foo")
 
       expect(annotation.to_s).to eq "::warning file=file.txt,title=foo::lorem ipsum"
     end
 
     it "allows specifying the file and line" do
-      annotation = described_class.new(:error, "lorem ipsum", file: "file.txt", line: 3)
+      annotation = klass.new(:error, "lorem ipsum", file: "file.txt", line: 3)
 
       expect(annotation.to_s).to eq "::error file=file.txt,line=3::lorem ipsum"
     end
 
     it "allows specifying the file, line and column" do
-      annotation = described_class.new(:error, "lorem ipsum", file: "file.txt", line: 3, column: 18)
+      annotation = klass.new(:error, "lorem ipsum", file: "file.txt", line: 3, column: 18)
 
       expect(annotation.to_s).to eq "::error file=file.txt,line=3,col=18::lorem ipsum"
     end

--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -4,30 +4,32 @@
 require "utils/github"
 
 RSpec.describe GitHub do
+  let(:klass) { GitHub }
+
   describe "::search_query_string" do
     it "builds a query with the given hash parameters formatted as key:value" do
-      query = described_class.search_query_string(user: "Homebrew", repo: "brew")
+      query = klass.search_query_string(user: "Homebrew", repo: "brew")
       expect(query).to eq("q=user%3AHomebrew+repo%3Abrew&per_page=100")
     end
 
     it "adds a variable number of top-level string parameters to the query when provided" do
-      query = described_class.search_query_string("value1", "value2", user: "Homebrew")
+      query = klass.search_query_string("value1", "value2", user: "Homebrew")
       expect(query).to eq("q=value1+value2+user%3AHomebrew&per_page=100")
     end
 
     it "turns array values into multiple key:value parameters" do
-      query = described_class.search_query_string(user: ["Homebrew", "caskroom"])
+      query = klass.search_query_string(user: ["Homebrew", "caskroom"])
       expect(query).to eq("q=user%3AHomebrew+user%3Acaskroom&per_page=100")
     end
   end
 
   describe "::search_issues", :needs_network do
     it "queries GitHub issues with the passed parameters" do
-      results = described_class.search_issues("brew search",
-                                              repo:   "Homebrew/legacy-homebrew",
-                                              author: "MikeMcQuaid",
-                                              is:     "issue",
-                                              no:     "milestone")
+      results = klass.search_issues("brew search",
+                                    repo:   "Homebrew/legacy-homebrew",
+                                    author: "MikeMcQuaid",
+                                    is:     "issue",
+                                    no:     "milestone")
       expect(results).not_to be_empty
       expect(results.first["title"]).to eq("Shall we move more things to taps?")
     end
@@ -35,14 +37,14 @@ RSpec.describe GitHub do
 
   describe "::repository_approved_reviews", :needs_network do
     it "can get reviews for a pull request" do
-      reviews = described_class.repository_approved_reviews("Homebrew", "homebrew-core", 1, commit: "deadbeef")
+      reviews = klass.repository_approved_reviews("Homebrew", "homebrew-core", 1, commit: "deadbeef")
       expect(reviews).to eq([])
     end
   end
 
   describe "::public_member_usernames", :needs_network do
     it "gets the usernames of all publicly visible members of the organisation" do
-      response = described_class.public_member_usernames("Homebrew")
+      response = klass.public_member_usernames("Homebrew")
       expect(response).to be_a(Array)
     end
   end
@@ -50,25 +52,25 @@ RSpec.describe GitHub do
   describe "::get_artifact_urls", :needs_network do
     it "fails to find a nonexistent workflow" do
       expect do
-        described_class.get_artifact_urls(
-          described_class.get_workflow_run("Homebrew", "homebrew-core", "1"),
+        klass.get_artifact_urls(
+          klass.get_workflow_run("Homebrew", "homebrew-core", "1"),
         )
       end.to raise_error(/No matching check suite found/)
     end
 
     it "fails to find artifacts that don't exist" do
       expect do
-        described_class.get_artifact_urls(
-          described_class.get_workflow_run("Homebrew", "homebrew-core", "252626",
-                                           workflow_id: "triage.yml", artifact_pattern: "false_artifact"),
+        klass.get_artifact_urls(
+          klass.get_workflow_run("Homebrew", "homebrew-core", "252626",
+                                 workflow_id: "triage.yml", artifact_pattern: "false_artifact"),
         )
       end.to raise_error(/No artifacts with the pattern .+ were found/)
     end
 
     it "gets artifact URLs" do
-      urls = described_class.get_artifact_urls(
-        described_class.get_workflow_run("Homebrew", "homebrew-core", "252626",
-                                         workflow_id: "triage.yml", artifact_pattern: "event_payload"),
+      urls = klass.get_artifact_urls(
+        klass.get_workflow_run("Homebrew", "homebrew-core", "252626",
+                               workflow_id: "triage.yml", artifact_pattern: "event_payload"),
       )
       expect(urls).to eq(["https://api.github.com/repos/Homebrew/homebrew-core/actions/artifacts/4457761305/zip"])
     end
@@ -83,11 +85,11 @@ RSpec.describe GitHub do
     end
 
     it "gets commit hashes for a pull request" do
-      expect(described_class.pull_request_commits("Homebrew", "legacy-homebrew", 50678)).to eq(hashes)
+      expect(klass.pull_request_commits("Homebrew", "legacy-homebrew", 50678)).to eq(hashes)
     end
 
     it "gets commit hashes for a paginated pull request API response" do
-      expect(described_class.pull_request_commits("Homebrew", "legacy-homebrew", 50678, per_page: 1)).to eq(hashes)
+      expect(klass.pull_request_commits("Homebrew", "legacy-homebrew", 50678, per_page: 1)).to eq(hashes)
     end
   end
 
@@ -100,53 +102,53 @@ RSpec.describe GitHub do
     let(:to) { nil }
 
     it "counts commits authored by a user" do
-      allow(described_class).to receive(:repo_commits_for_user)
+      allow(klass).to receive(:repo_commits_for_user)
         .with("homebrew/cask", "user1", "author", nil, nil, max, verbose).and_return(five_shas)
-      allow(described_class).to receive(:repo_commits_for_user)
+      allow(klass).to receive(:repo_commits_for_user)
         .with("homebrew/cask", "user1", "committer", nil, nil, max, verbose).and_return([])
 
-      expect(described_class.count_repository_commits("homebrew/cask", "user1", max:, verbose:, from:,
+      expect(klass.count_repository_commits("homebrew/cask", "user1", max:, verbose:, from:,
 to:)).to eq(5)
     end
 
     it "counts commits committed by a user" do
-      allow(described_class).to receive(:repo_commits_for_user)
+      allow(klass).to receive(:repo_commits_for_user)
         .with("homebrew/core", "user1", "author", nil, nil, max, verbose).and_return([])
-      allow(described_class).to receive(:repo_commits_for_user)
+      allow(klass).to receive(:repo_commits_for_user)
         .with("homebrew/core", "user1", "committer", nil, nil, max, verbose).and_return(five_shas)
 
-      expect(described_class.count_repository_commits("homebrew/core", "user1", max:, verbose:, from:,
+      expect(klass.count_repository_commits("homebrew/core", "user1", max:, verbose:, from:,
 to:)).to eq(5)
     end
 
     it "calculates correctly when authored > committed with different shas" do
-      allow(described_class).to receive(:repo_commits_for_user)
+      allow(klass).to receive(:repo_commits_for_user)
         .with("homebrew/cask", "user1", "author", nil, nil, max, verbose).and_return(ten_shas)
-      allow(described_class).to receive(:repo_commits_for_user)
+      allow(klass).to receive(:repo_commits_for_user)
         .with("homebrew/cask", "user1", "committer", nil, nil, max, verbose).and_return(%w[1 2 3 4 5])
 
-      expect(described_class.count_repository_commits("homebrew/cask", "user1", max:, verbose:, from:,
+      expect(klass.count_repository_commits("homebrew/cask", "user1", max:, verbose:, from:,
 to:)).to eq(15)
     end
 
     it "calculates correctly when committed > authored" do
-      allow(described_class).to receive(:repo_commits_for_user)
+      allow(klass).to receive(:repo_commits_for_user)
         .with("homebrew/cask", "user1", "author", nil, nil, max, verbose).and_return(five_shas)
-      allow(described_class).to receive(:repo_commits_for_user)
+      allow(klass).to receive(:repo_commits_for_user)
         .with("homebrew/cask", "user1", "committer", nil, nil, max, verbose).and_return(ten_shas)
 
-      expect(described_class.count_repository_commits("homebrew/cask", "user1", max:, verbose:, from:,
+      expect(klass.count_repository_commits("homebrew/cask", "user1", max:, verbose:, from:,
 to:)).to eq(10)
     end
 
     it "deduplicates commits authored and committed by the same user" do
-      allow(described_class).to receive(:repo_commits_for_user)
+      allow(klass).to receive(:repo_commits_for_user)
         .with("homebrew/core", "user1", "author", nil, nil, max, verbose).and_return(five_shas)
-      allow(described_class).to receive(:repo_commits_for_user)
+      allow(klass).to receive(:repo_commits_for_user)
         .with("homebrew/core", "user1", "committer", nil, nil, max, verbose).and_return(five_shas)
 
       # Because user1 authored and committed the same 5 commits.
-      expect(described_class.count_repository_commits("homebrew/core", "user1", max:, verbose:, from:,
+      expect(klass.count_repository_commits("homebrew/core", "user1", max:, verbose:, from:,
 to:)).to eq(5)
     end
   end

--- a/Library/Homebrew/test/utils/gzip_spec.rb
+++ b/Library/Homebrew/test/utils/gzip_spec.rb
@@ -4,6 +4,8 @@
 require "utils/gzip"
 
 RSpec.describe Utils::Gzip do
+  let(:klass) { Utils::Gzip }
+
   include FileUtils
 
   describe "compress_with_options" do
@@ -19,7 +21,7 @@ RSpec.describe Utils::Gzip do
         File.write(somefile, file_content)
         mkdir path/"subdir"
 
-        expect(described_class.compress_with_options(somefile, mtime:, orig_name:,
+        expect(klass.compress_with_options(somefile, mtime:, orig_name:,
 output:)).to eq(output)
         expect(Digest::SHA256.hexdigest(File.read(output))).to eq(expected_checksum)
       end
@@ -34,7 +36,7 @@ output:)).to eq(output)
         somefile = path/"somefile"
         File.write(somefile, file_content)
 
-        expect(described_class.compress_with_options(somefile).to_s).to eq("#{somefile}.gz")
+        expect(klass.compress_with_options(somefile).to_s).to eq("#{somefile}.gz")
         expect(Digest::SHA256.hexdigest(File.read("#{somefile}.gz"))).to eq(expected_checksum)
       end
     end
@@ -46,7 +48,7 @@ output:)).to eq(output)
         files = (0..2).map { |n| path/"somefile#{n}" }
         FileUtils.touch files
 
-        results = described_class.compress(*files, reproducible: false)
+        results = klass.compress(*files, reproducible: false)
         3.times do |n|
           expect(results[n].to_s).to eq("#{files[n]}.gz")
           expect(Pathname.new("#{files[n]}.gz")).to exist
@@ -66,7 +68,7 @@ output:)).to eq(output)
         files = (0..2).map { |n| path/"somefile#{n}" }
         files.each { |f| File.write(f, "Hello world") }
 
-        results = described_class.compress(*files, mtime:)
+        results = klass.compress(*files, mtime:)
         3.times do |n|
           expect(results[n].to_s).to eq("#{files[n]}.gz")
           expect(Digest::SHA256.hexdigest(File.read(results[n]))).to eq(expected_checksums[n])
@@ -86,7 +88,7 @@ output:)).to eq(output)
         files = (0..2).map { |n| path/"somefile#{n}" }
         files.each { |f| File.write(f, "Hello world") }
 
-        results = described_class.compress(*files)
+        results = klass.compress(*files)
         3.times do |n|
           expect(results[n].to_s).to eq("#{files[n]}.gz")
           expect(Digest::SHA256.hexdigest(File.read(results[n]))).to eq(expected_checksums[n])

--- a/Library/Homebrew/test/utils/inreplace_spec.rb
+++ b/Library/Homebrew/test/utils/inreplace_spec.rb
@@ -5,6 +5,8 @@ require "tempfile"
 require "utils/inreplace"
 
 RSpec.describe Utils::Inreplace do
+  let(:klass) { Utils::Inreplace }
+
   let(:file) { Tempfile.new("test") }
 
   before do
@@ -21,19 +23,19 @@ RSpec.describe Utils::Inreplace do
   describe ".inreplace" do
     it "raises error if there are no files given to replace" do
       expect do
-        described_class.inreplace [], "d", "f"
+        klass.inreplace [], "d", "f"
       end.to raise_error(Utils::Inreplace::Error)
     end
 
     it "raises error if there is nothing to replace" do
       expect do
-        described_class.inreplace file.path, "d", "f"
+        klass.inreplace file.path, "d", "f"
       end.to raise_error(Utils::Inreplace::Error)
     end
 
     it "raises error if there is nothing to replace in block form" do
       expect do
-        described_class.inreplace(file.path) do |s|
+        klass.inreplace(file.path) do |s|
           # Using `gsub!` here is what we want, and it's only a test.
           s.gsub!("d", "f") # rubocop:disable Performance/StringReplacement
         end
@@ -42,7 +44,7 @@ RSpec.describe Utils::Inreplace do
 
     it "raises error if there is no make variables to replace" do
       expect do
-        described_class.inreplace(file.path) do |s|
+        klass.inreplace(file.path) do |s|
           s.change_make_var! "VAR", "value"
           s.remove_make_var! "VAR2"
         end
@@ -51,7 +53,7 @@ RSpec.describe Utils::Inreplace do
 
     it "substitutes pathname within file" do
       # For a specific instance of this, see https://github.com/Homebrew/homebrew-core/blob/a8b0b10/Formula/loki.rb#L48
-      described_class.inreplace(file.path) do |s|
+      klass.inreplace(file.path) do |s|
         s.gsub!(Pathname("b"), Pathname("f"))
       end
       expect(File.binread(file)).to eq <<~EOS
@@ -63,7 +65,7 @@ RSpec.describe Utils::Inreplace do
     end
 
     it "substitutes all occurrences within file when `global: true`" do
-      described_class.inreplace(file.path, "a", "foo")
+      klass.inreplace(file.path, "a", "foo")
       expect(File.binread(file)).to eq <<~EOS
         foo
         b
@@ -73,7 +75,7 @@ RSpec.describe Utils::Inreplace do
     end
 
     it "substitutes only the first occurrence when `global: false`" do
-      described_class.inreplace(file.path, "a", "foo", global: false)
+      klass.inreplace(file.path, "a", "foo", global: false)
       expect(File.binread(file)).to eq <<~EOS
         foo
         b
@@ -86,12 +88,12 @@ RSpec.describe Utils::Inreplace do
   describe ".inreplace_pairs" do
     it "raises error if there is no old value" do
       expect do
-        described_class.inreplace_pairs(file.path, [[nil, "f"]])
+        klass.inreplace_pairs(file.path, [[nil, "f"]])
       end.to raise_error(TypeError)
     end
 
     it "substitutes returned string but not file when `read_only_run: true`" do
-      expect(described_class.inreplace_pairs(file.path, [["a", "foo"]], read_only_run: true)).to eq <<~EOS
+      expect(klass.inreplace_pairs(file.path, [["a", "foo"]], read_only_run: true)).to eq <<~EOS
         foo
         b
         c
@@ -112,7 +114,7 @@ RSpec.describe Utils::Inreplace do
         c
         foofoo
       TEXT
-      expect(described_class.inreplace_pairs(file.path, [["a", "foo"]])).to eq replace_result
+      expect(klass.inreplace_pairs(file.path, [["a", "foo"]])).to eq replace_result
       expect(File.binread(file)).to eq replace_result
     end
 
@@ -124,7 +126,7 @@ RSpec.describe Utils::Inreplace do
         c
         test
       TEXT
-      expect(described_class.inreplace_pairs(file.path, pairs)).to eq replace_result
+      expect(klass.inreplace_pairs(file.path, pairs)).to eq replace_result
       expect(File.binread(file)).to eq replace_result
     end
   end

--- a/Library/Homebrew/test/utils/linkage_spec.rb
+++ b/Library/Homebrew/test/utils/linkage_spec.rb
@@ -4,6 +4,8 @@
 require "utils/linkage"
 
 RSpec.describe Utils do
+  let(:klass) { Utils }
+
   [:needs_macos, :needs_linux].each do |needs_os|
     describe "::binary_linked_to_library?", needs_os do
       let(:suffix) { OS.mac? ? ".dylib" : ".so" }
@@ -38,14 +40,14 @@ RSpec.describe Utils do
       end
 
       it "returns true if the binary is linked to the library" do
-        result = described_class.binary_linked_to_library?(HOMEBREW_PREFIX/"bin/brewtest",
-                                                           HOMEBREW_PREFIX/"lib/libbrewfoo#{suffix}")
+        result = klass.binary_linked_to_library?(HOMEBREW_PREFIX/"bin/brewtest",
+                                                 HOMEBREW_PREFIX/"lib/libbrewfoo#{suffix}")
         expect(result).to be true
       end
 
       it "returns false if the binary is not linked to the library" do
-        result = described_class.binary_linked_to_library?(HOMEBREW_PREFIX/"bin/brewtest",
-                                                           HOMEBREW_PREFIX/"lib/libbrewbar#{suffix}")
+        result = klass.binary_linked_to_library?(HOMEBREW_PREFIX/"bin/brewtest",
+                                                 HOMEBREW_PREFIX/"lib/libbrewbar#{suffix}")
         expect(result).to be false
       end
 
@@ -53,7 +55,7 @@ RSpec.describe Utils do
         non_brew_library = "/usr/lib/libtest#{suffix}"
         shim = OS.mac? ? MachOShim : ELFShim
         allow_any_instance_of(shim).to receive(:dynamically_linked_libraries).and_return([non_brew_library])
-        result = described_class.binary_linked_to_library?(HOMEBREW_PREFIX/"bin/brewtest", non_brew_library)
+        result = klass.binary_linked_to_library?(HOMEBREW_PREFIX/"bin/brewtest", non_brew_library)
         expect(result).to be true
       end
     end

--- a/Library/Homebrew/test/utils/output_spec.rb
+++ b/Library/Homebrew/test/utils/output_spec.rb
@@ -4,12 +4,14 @@
 require "utils/output"
 
 RSpec.describe Utils::Output do
+  let(:klass) { Utils::Output }
+
   def esc(code)
     /(\e\[\d+m)*\e\[#{code}m/
   end
 
   describe "#pretty_installed" do
-    subject(:pretty_installed_output) { described_class.pretty_installed("foo") }
+    subject(:pretty_installed_output) { klass.pretty_installed("foo") }
 
     context "when $stdout is a TTY" do
       before { allow($stdout).to receive(:tty?).and_return(true) }
@@ -41,7 +43,7 @@ RSpec.describe Utils::Output do
   end
 
   describe "#pretty_uninstalled" do
-    subject(:pretty_uninstalled_output) { described_class.pretty_uninstalled("foo") }
+    subject(:pretty_uninstalled_output) { klass.pretty_uninstalled("foo") }
 
     context "when $stdout is a TTY" do
       before { allow($stdout).to receive(:tty?).and_return(true) }
@@ -73,7 +75,7 @@ RSpec.describe Utils::Output do
   end
 
   describe "#pretty_deprecated" do
-    subject(:pretty_deprecated_output) { described_class.pretty_deprecated("foo") }
+    subject(:pretty_deprecated_output) { klass.pretty_deprecated("foo") }
 
     context "when $stdout is a TTY" do
       before { allow($stdout).to receive(:tty?).and_return(true) }
@@ -94,7 +96,7 @@ RSpec.describe Utils::Output do
   end
 
   describe "#pretty_disabled" do
-    subject(:pretty_disabled_output) { described_class.pretty_disabled("foo") }
+    subject(:pretty_disabled_output) { klass.pretty_disabled("foo") }
 
     context "when $stdout is a TTY" do
       before { allow($stdout).to receive(:tty?).and_return(true) }
@@ -116,18 +118,18 @@ RSpec.describe Utils::Output do
 
   describe "#pretty_duration" do
     it "converts seconds to a human-readable string" do
-      expect(described_class.pretty_duration(1)).to eq("1 second")
-      expect(described_class.pretty_duration(2.5)).to eq("2 seconds")
-      expect(described_class.pretty_duration(42)).to eq("42 seconds")
-      expect(described_class.pretty_duration(240)).to eq("4 minutes")
-      expect(described_class.pretty_duration(252.45)).to eq("4 minutes 12 seconds")
+      expect(klass.pretty_duration(1)).to eq("1 second")
+      expect(klass.pretty_duration(2.5)).to eq("2 seconds")
+      expect(klass.pretty_duration(42)).to eq("42 seconds")
+      expect(klass.pretty_duration(240)).to eq("4 minutes")
+      expect(klass.pretty_duration(252.45)).to eq("4 minutes 12 seconds")
     end
   end
 
   describe "#ofail" do
     it "sets Homebrew.failed to true" do
       expect do
-        described_class.ofail "foo"
+        klass.ofail "foo"
       end.to output("Error: foo\n").to_stderr
 
       expect(Homebrew).to have_failed
@@ -137,7 +139,7 @@ RSpec.describe Utils::Output do
   describe "#odie" do
     it "exits with 1" do
       expect do
-        described_class.odie "foo"
+        klass.odie "foo"
       end.to output("Error: foo\n").to_stderr.and raise_error SystemExit
     end
   end
@@ -146,7 +148,7 @@ RSpec.describe Utils::Output do
     it "raises a MethodDeprecatedError when `disable` is true" do
       ENV.delete("HOMEBREW_DEVELOPER")
       expect do
-        described_class.odeprecated(
+        klass.odeprecated(
           "method", "replacement",
           caller:  ["#{HOMEBREW_LIBRARY}/Taps/playbrew/homebrew-play/"],
           disable: true

--- a/Library/Homebrew/test/utils/path_spec.rb
+++ b/Library/Homebrew/test/utils/path_spec.rb
@@ -4,31 +4,34 @@
 require "utils/path"
 
 RSpec.describe Utils::Path do
+  sig { returns(T.class_of(Utils::Path)) }
+  let(:klass) { Utils::Path }
+
   describe "::child_of?" do
     it "recognizes a path as its own child" do
-      expect(described_class.child_of?("/foo/bar", "/foo/bar")).to be(true)
+      expect(klass.child_of?("/foo/bar", "/foo/bar")).to be(true)
     end
 
     it "recognizes a path that is a child of the parent" do
-      expect(described_class.child_of?("/foo", "/foo/bar")).to be(true)
+      expect(klass.child_of?("/foo", "/foo/bar")).to be(true)
     end
 
     it "recognizes a path that is a grandchild of the parent" do
-      expect(described_class.child_of?("/foo", "/foo/bar/baz")).to be(true)
+      expect(klass.child_of?("/foo", "/foo/bar/baz")).to be(true)
     end
 
     it "does not recognize a path that is not a child" do
-      expect(described_class.child_of?("/foo", "/bar/baz")).to be(false)
+      expect(klass.child_of?("/foo", "/bar/baz")).to be(false)
     end
 
     it "handles . and .. in paths correctly" do
-      expect(described_class.child_of?("/foo", "/foo/./bar")).to be(true)
-      expect(described_class.child_of?("/foo/bar", "/foo/../foo/bar/baz")).to be(true)
+      expect(klass.child_of?("/foo", "/foo/./bar")).to be(true)
+      expect(klass.child_of?("/foo/bar", "/foo/../foo/bar/baz")).to be(true)
     end
 
     it "handles relative paths correctly" do
-      expect(described_class.child_of?("foo", "./bar/baz")).to be(false)
-      expect(described_class.child_of?("../foo", "./bar/baz/../../../foo/bar/baz")).to be(true)
+      expect(klass.child_of?("foo", "./bar/baz")).to be(false)
+      expect(klass.child_of?("../foo", "./bar/baz/../../../foo/bar/baz")).to be(true)
     end
   end
 end

--- a/Library/Homebrew/test/utils/popen_spec.rb
+++ b/Library/Homebrew/test/utils/popen_spec.rb
@@ -4,15 +4,17 @@
 require "utils/popen"
 
 RSpec.describe Utils do
+  let(:klass) { Utils }
+
   describe "::popen_read" do
     it "reads the standard output of a given command" do
-      expect(described_class.popen_read("sh", "-c", "echo success").chomp).to eq("success")
+      expect(klass.popen_read("sh", "-c", "echo success").chomp).to eq("success")
       expect($CHILD_STATUS).to be_a_success
     end
 
     it "can be given a block to manually read from the pipe" do
       expect(
-        described_class.popen_read("sh", "-c", "echo success") do |pipe|
+        klass.popen_read("sh", "-c", "echo success") do |pipe|
           pipe.read.chomp
         end,
       ).to eq("success")
@@ -20,7 +22,7 @@ RSpec.describe Utils do
     end
 
     it "fails when the command does not exist" do
-      expect(described_class.popen_read("./nonexistent", err: :out))
+      expect(klass.popen_read("./nonexistent", err: :out))
         .to eq("brew: command not found: ./nonexistent\n")
       expect($CHILD_STATUS).to be_a_failure
     end
@@ -32,14 +34,14 @@ RSpec.describe Utils do
     before { foo.write "Foo\n" }
 
     it "supports writing to a command's standard input" do
-      described_class.popen_write("grep", "-q", "success") do |pipe|
+      klass.popen_write("grep", "-q", "success") do |pipe|
         pipe.write "success\n"
       end
       expect($CHILD_STATUS).to be_a_success
     end
 
     it "returns the command's standard output before writing" do
-      child_stdout = described_class.popen_write("cat", foo, "-") do |pipe|
+      child_stdout = klass.popen_write("cat", foo, "-") do |pipe|
         pipe.write "Bar\n"
       end
       expect($CHILD_STATUS).to be_a_success
@@ -50,7 +52,7 @@ RSpec.describe Utils do
     end
 
     it "returns the command's standard output after writing" do
-      child_stdout = described_class.popen_write("cat", "-", foo) do |pipe|
+      child_stdout = klass.popen_write("cat", "-", foo) do |pipe|
         pipe.write "Bar\n"
       end
       expect($CHILD_STATUS).to be_a_success
@@ -61,7 +63,7 @@ RSpec.describe Utils do
     end
 
     it "supports interleaved writing between two reads" do
-      child_stdout = described_class.popen_write("cat", foo, "-", foo) do |pipe|
+      child_stdout = klass.popen_write("cat", foo, "-", foo) do |pipe|
         pipe.write "Bar\n"
       end
       expect($CHILD_STATUS).to be_a_success
@@ -75,12 +77,12 @@ RSpec.describe Utils do
 
   describe "::safe_popen_read" do
     it "does not raise an error if the command succeeds" do
-      expect(described_class.safe_popen_read("sh", "-c", "true")).to eq("")
+      expect(klass.safe_popen_read("sh", "-c", "true")).to eq("")
       expect($CHILD_STATUS).to be_a_success
     end
 
     it "raises an error if the command fails" do
-      expect { described_class.safe_popen_read("sh", "-c", "false") }.to raise_error(ErrorDuringExecution)
+      expect { klass.safe_popen_read("sh", "-c", "false") }.to raise_error(ErrorDuringExecution)
       expect($CHILD_STATUS).to be_a_failure
     end
   end
@@ -88,14 +90,14 @@ RSpec.describe Utils do
   describe "::safe_popen_write" do
     it "does not raise an error if the command succeeds" do
       expect(
-        described_class.safe_popen_write("grep", "success") { |pipe| pipe.write "success\n" }.chomp,
+        klass.safe_popen_write("grep", "success") { |pipe| pipe.write "success\n" }.chomp,
       ).to eq("success")
       expect($CHILD_STATUS).to be_a_success
     end
 
     it "raises an error if the command fails" do
       expect do
-        described_class.safe_popen_write("grep", "success") { |pipe| pipe.write "failure\n" }
+        klass.safe_popen_write("grep", "success") { |pipe| pipe.write "failure\n" }
       end.to raise_error(ErrorDuringExecution)
       expect($CHILD_STATUS).to be_a_failure
     end

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -5,6 +5,8 @@ require "utils/pypi"
 require "formulary"
 
 RSpec.describe PyPI do
+  let(:klass) { PyPI }
+
   let(:pypi_package_url) do
     "https://files.pythonhosted.org/packages/b0/3f/2e1dad67eb172b6443b5eb37eb885a054a55cfd733393071499514140282/" \
       "snakemake-5.29.0.tar.gz"
@@ -18,39 +20,41 @@ RSpec.describe PyPI do
   end
 
   describe PyPI::Package do
+    let(:klass) { PyPI::Package }
+
     let(:package_checksum) { "47417307d08ecb0707b3b29effc933bd63d8c8e3ab15509c62b685b7614c6568" }
     let(:old_package_checksum) { "2367ce91baf7f8fa7738d33aff9670ffdf5410bbac49aeb209f73b45a3425046" }
 
-    let(:package) { described_class.new("snakemake") }
-    let(:package_with_version) { described_class.new("snakemake==5.28.0") }
-    let(:package_with_different_version) { described_class.new("snakemake==5.29.0") }
-    let(:package_with_extra) { described_class.new("snakemake[foo]") }
-    let(:package_with_extra_and_version) { described_class.new("snakemake[foo]==5.28.0") }
-    let(:package_with_different_capitalization) { described_class.new("SNAKEMAKE") }
-    let(:package_from_pypi_url) { described_class.new(pypi_package_url, is_url: true) }
-    let(:package_from_non_pypi_url) { described_class.new(non_pypi_package_url, is_url: true) }
-    let(:other_package) { described_class.new("virtualenv==20.2.0") }
+    let(:package) { klass.new("snakemake") }
+    let(:package_with_version) { klass.new("snakemake==5.28.0") }
+    let(:package_with_different_version) { klass.new("snakemake==5.29.0") }
+    let(:package_with_extra) { klass.new("snakemake[foo]") }
+    let(:package_with_extra_and_version) { klass.new("snakemake[foo]==5.28.0") }
+    let(:package_with_different_capitalization) { klass.new("SNAKEMAKE") }
+    let(:package_from_pypi_url) { klass.new(pypi_package_url, is_url: true) }
+    let(:package_from_non_pypi_url) { klass.new(non_pypi_package_url, is_url: true) }
+    let(:other_package) { klass.new("virtualenv==20.2.0") }
 
     describe "initialize" do
       specify do
-        expect(described_class.new("foo").name).to eq "foo"
-        expect(described_class.new("foo[bar]").name).to eq "foo"
-        expect(described_class.new("foo[bar]").extras).to eq ["bar"]
-        expect(described_class.new("foo[bar,baz]").extras).to eq ["bar", "baz"]
-        expect(described_class.new("foo==1.2.3").name).to eq "foo"
-        expect(described_class.new("foo==1.2.3").version).to eq "1.2.3"
-        expect(described_class.new("foo[bar]==1.2.3").extras).to eq ["bar"]
-        expect(described_class.new("foo[bar,baz]==1.2.3").extras).to eq ["bar", "baz"]
-        expect(described_class.new("foo[bar]==1.2.3").version).to eq "1.2.3"
-        expect(described_class.new("foo[bar,baz]==1.2.3").version).to eq "1.2.3"
-        expect(described_class.new(pypi_package_url, is_url: true).name).to eq "snakemake"
-        expect(described_class.new(pypi_package_url, is_url: true).version).to eq "5.29.0"
+        expect(klass.new("foo").name).to eq "foo"
+        expect(klass.new("foo[bar]").name).to eq "foo"
+        expect(klass.new("foo[bar]").extras).to eq ["bar"]
+        expect(klass.new("foo[bar,baz]").extras).to eq ["bar", "baz"]
+        expect(klass.new("foo==1.2.3").name).to eq "foo"
+        expect(klass.new("foo==1.2.3").version).to eq "1.2.3"
+        expect(klass.new("foo[bar]==1.2.3").extras).to eq ["bar"]
+        expect(klass.new("foo[bar,baz]==1.2.3").extras).to eq ["bar", "baz"]
+        expect(klass.new("foo[bar]==1.2.3").version).to eq "1.2.3"
+        expect(klass.new("foo[bar,baz]==1.2.3").version).to eq "1.2.3"
+        expect(klass.new(pypi_package_url, is_url: true).name).to eq "snakemake"
+        expect(klass.new(pypi_package_url, is_url: true).version).to eq "5.29.0"
       end
     end
 
     describe ".version=" do
       it "sets for package names" do
-        package = described_class.new("snakemake==5.28.0")
+        package = klass.new("snakemake==5.28.0")
         expect(package.version).to eq "5.28.0"
 
         package.version = "5.29.0"
@@ -58,7 +62,7 @@ RSpec.describe PyPI do
       end
 
       it "sets for PyPI package URLs" do
-        package = described_class.new(old_pypi_package_url, is_url: true)
+        package = klass.new(old_pypi_package_url, is_url: true)
         expect(package.version).to eq "5.28.0"
 
         package.version = "5.29.0"
@@ -66,7 +70,7 @@ RSpec.describe PyPI do
       end
 
       it "fails for non-PYPI package URLs" do
-        package = described_class.new(non_pypi_package_url, is_url: true)
+        package = klass.new(non_pypi_package_url, is_url: true)
 
         expect { package.version = "1.2.3" }.to raise_error(ArgumentError)
       end
@@ -168,7 +172,7 @@ RSpec.describe PyPI do
         "--uploaded-prior-to=2026-04-03T12:00:00Z", "--report=/dev/stdout", "snakemake"
       ).and_return('{"install":[]}')
 
-      expect(described_class.pip_report([PyPI::Package.new("snakemake")])).to eq([])
+      expect(klass.pip_report([PyPI::Package.new("snakemake")])).to eq([])
     end
   end
 
@@ -208,15 +212,15 @@ RSpec.describe PyPI do
       livecheck_package = PyPI::Package.new("aws-lambda-rie==1.0")
 
       allow(Formula).to receive(:[]).with("python").and_return(instance_double(Formula, ensure_installed!: true))
-      allow(described_class).to receive(:pip_report)
+      allow(klass).to receive(:pip_report)
         .and_return([PyPI::Package.new("foo==1.0"), package, livecheck_package])
       allow(package).to receive(:pypi_info).and_return(
         ["bar", "https://files.pythonhosted.org/packages/bar-1.0.tar.gz", "d" * 64, "1.0", nil],
       )
       expect(livecheck_package).not_to receive(:pypi_info)
 
-      described_class.update_python_resources!(Formulary.from_contents("foo", path, contents),
-                                               package_name: "foo", silent: true)
+      klass.update_python_resources!(Formulary.from_contents("foo", path, contents),
+                                     package_name: "foo", silent: true)
 
       expect(path.read).to eq <<~RUBY
         class Foo < Formula
@@ -240,15 +244,15 @@ RSpec.describe PyPI do
 
   describe "update_pypi_url", :needs_network do
     it "updates url to new version" do
-      expect(described_class.update_pypi_url(old_pypi_package_url, "5.29.0")).to eq pypi_package_url
+      expect(klass.update_pypi_url(old_pypi_package_url, "5.29.0")).to eq pypi_package_url
     end
 
     it "returns nil for invalid versions" do
-      expect(described_class.update_pypi_url(old_pypi_package_url, "0.0.0")).to be_nil
+      expect(klass.update_pypi_url(old_pypi_package_url, "0.0.0")).to be_nil
     end
 
     it "returns nil for non-pypi urls" do
-      expect(described_class.update_pypi_url(non_pypi_package_url, "1.1")).to be_nil
+      expect(klass.update_pypi_url(non_pypi_package_url, "1.1")).to be_nil
     end
   end
 end

--- a/Library/Homebrew/test/utils/service_spec.rb
+++ b/Library/Homebrew/test/utils/service_spec.rb
@@ -4,21 +4,24 @@
 require "utils/service"
 
 RSpec.describe Utils::Service do
+  sig { returns(T.class_of(Utils::Service)) }
+  let(:klass) { Utils::Service }
+
   describe "::systemd_quote" do
     it "quotes empty strings correctly" do
-      expect(described_class.systemd_quote("")).to eq '""'
+      expect(klass.systemd_quote("")).to eq '""'
     end
 
     it "quotes strings with special characters escaped correctly" do
-      expect(described_class.systemd_quote("\a\b\f\n\r\t\v\\"))
+      expect(klass.systemd_quote("\a\b\f\n\r\t\v\\"))
         .to eq '"\\a\\b\\f\\n\\r\\t\\v\\\\"'
-      expect(described_class.systemd_quote("\"' ")).to eq "\"\\\"' \""
+      expect(klass.systemd_quote("\"' ")).to eq "\"\\\"' \""
     end
 
     it "does not escape characters that do not need escaping" do
-      expect(described_class.systemd_quote("daemon off;")).to eq '"daemon off;"'
-      expect(described_class.systemd_quote("--timeout=3")).to eq '"--timeout=3"'
-      expect(described_class.systemd_quote("--answer=foo bar"))
+      expect(klass.systemd_quote("daemon off;")).to eq '"daemon off;"'
+      expect(klass.systemd_quote("--timeout=3")).to eq '"--timeout=3"'
+      expect(klass.systemd_quote("--answer=foo bar"))
         .to eq '"--answer=foo bar"'
     end
   end

--- a/Library/Homebrew/test/utils/shared_audits_spec.rb
+++ b/Library/Homebrew/test/utils/shared_audits_spec.rb
@@ -5,6 +5,8 @@ require "utils/shared_audits"
 require "utils/curl"
 
 RSpec.describe SharedAudits do
+  let(:klass) { SharedAudits }
+
   let(:eol_json_text) do
     <<~JSON
       {
@@ -39,79 +41,79 @@ RSpec.describe SharedAudits do
   describe "::eol_data" do
     it "returns a parsed JSON object if the product is found" do
       mock_curl_output stdout: eol_json_text
-      expect(described_class.eol_data("product", "cycle")&.dig("result", "isEol")).to be(true)
-      expect(described_class.eol_data("product", "cycle")&.dig("result", "eolFrom")).to eq("2025-01-01")
+      expect(klass.eol_data("product", "cycle")&.dig("result", "isEol")).to be(true)
+      expect(klass.eol_data("product", "cycle")&.dig("result", "eolFrom")).to eq("2025-01-01")
     end
 
     it "returns nil if the product is not found" do
       mock_curl_output stdout: "<html></html>"
-      expect(described_class.eol_data("none", "cycle")).to be_nil
+      expect(klass.eol_data("none", "cycle")).to be_nil
     end
 
     it "returns nil if api call fails" do
       mock_curl_output success: false
-      expect(described_class.eol_data("", "")).to be_nil
+      expect(klass.eol_data("", "")).to be_nil
     end
   end
 
   describe "::github_tag_from_url" do
     it "finds tags in archive urls" do
       url = "https://github.com/a/b/archive/refs/tags/v1.2.3.tar.gz"
-      expect(described_class.github_tag_from_url(url)).to eq("v1.2.3")
+      expect(klass.github_tag_from_url(url)).to eq("v1.2.3")
     end
 
     it "finds tags in release urls" do
       url = "https://github.com/a/b/releases/download/1.2.3/b-1.2.3.tar.bz2"
-      expect(described_class.github_tag_from_url(url)).to eq("1.2.3")
+      expect(klass.github_tag_from_url(url)).to eq("1.2.3")
     end
 
     it "finds tags with slashes" do
       url = "https://github.com/a/b/archive/refs/tags/c/d/e/f/g-v1.2.3.tar.gz"
-      expect(described_class.github_tag_from_url(url)).to eq("c/d/e/f/g-v1.2.3")
+      expect(klass.github_tag_from_url(url)).to eq("c/d/e/f/g-v1.2.3")
     end
 
     it "finds tags in orgs/repos with special characters" do
       url = "https://github.com/a-b/c-d_e.f/archive/refs/tags/2.5.tar.gz"
-      expect(described_class.github_tag_from_url(url)).to eq("2.5")
+      expect(klass.github_tag_from_url(url)).to eq("2.5")
     end
   end
 
   describe "::gitlab_tag_from_url" do
     it "doesn't find tags in invalid urls" do
       url = "https://gitlab.com/a/-/archive/v1.2.3/a-v1.2.3.tar.gz"
-      expect(described_class.gitlab_tag_from_url(url)).to be_nil
+      expect(klass.gitlab_tag_from_url(url)).to be_nil
     end
 
     it "finds tags in basic urls" do
       url = "https://gitlab.com/a/b/-/archive/v1.2.3/b-1.2.3.tar.gz"
-      expect(described_class.gitlab_tag_from_url(url)).to eq("v1.2.3")
+      expect(klass.gitlab_tag_from_url(url)).to eq("v1.2.3")
     end
 
     it "finds tags in urls with subgroups" do
       url = "https://gitlab.com/a/b/c/d/e/f/g/-/archive/2.5/g-2.5.tar.gz"
-      expect(described_class.gitlab_tag_from_url(url)).to eq("2.5")
+      expect(klass.gitlab_tag_from_url(url)).to eq("2.5")
     end
 
     it "finds tags in urls with special characters" do
       url = "https://gitlab.com/a.b/c-d_e/-/archive/2.5/c-d_e-2.5.tar.gz"
-      expect(described_class.gitlab_tag_from_url(url)).to eq("2.5")
+      expect(klass.gitlab_tag_from_url(url)).to eq("2.5")
     end
   end
 
   describe "::forgejo_tag_from_url" do
     it "finds tags in basic urls" do
       url = "https://codeberg.org/Aviac/codeberg-cli/archive/v0.4.11.tar.gz"
-      expect(described_class.forgejo_tag_from_url(url)).to eq("v0.4.11")
+      expect(klass.forgejo_tag_from_url(url)).to eq("v0.4.11")
     end
 
     it "finds tags in urls with subgroups" do
       url = "https://codeberg.org/Aviac/codeberg-cli/archive/some/test/1.2.3.tar.gz"
-      expect(described_class.forgejo_tag_from_url(url)).to eq("some/test/1.2.3")
+      expect(klass.forgejo_tag_from_url(url)).to eq("some/test/1.2.3")
     end
 
     it "finds tags in orgs/repos with special characters" do
       url = "https://codeberg.org/Aviaca-b_cv/codeberg-cli/archive/v0.4.11.tar.gz"
-      expect(described_class.forgejo_tag_from_url(url)).to eq("v0.4.11")
+      expect(klass.forgejo_tag_from_url(url)).to eq("v0.4.11")
     end
   end
 end

--- a/Library/Homebrew/test/utils/shell_completion_spec.rb
+++ b/Library/Homebrew/test/utils/shell_completion_spec.rb
@@ -4,21 +4,23 @@
 require "utils/shell_completion"
 
 RSpec.describe Utils::ShellCompletion do
+  let(:klass) { Utils::ShellCompletion }
+
   describe ".default_completion_shells" do
     it "returns bash, zsh, and fish for nil format" do
-      expect(described_class.default_completion_shells(nil)).to eq([:bash, :zsh, :fish])
+      expect(klass.default_completion_shells(nil)).to eq([:bash, :zsh, :fish])
     end
 
     it "returns bash, zsh, and fish for unrecognized format" do
-      expect(described_class.default_completion_shells(:unknown)).to eq([:bash, :zsh, :fish])
+      expect(klass.default_completion_shells(:unknown)).to eq([:bash, :zsh, :fish])
     end
 
     it "includes pwsh for cobra format" do
-      expect(described_class.default_completion_shells(:cobra)).to eq([:bash, :zsh, :fish, :pwsh])
+      expect(klass.default_completion_shells(:cobra)).to eq([:bash, :zsh, :fish, :pwsh])
     end
 
     it "includes pwsh for typer format" do
-      expect(described_class.default_completion_shells(:typer)).to eq([:bash, :zsh, :fish, :pwsh])
+      expect(klass.default_completion_shells(:typer)).to eq([:bash, :zsh, :fish, :pwsh])
     end
   end
 
@@ -26,50 +28,50 @@ RSpec.describe Utils::ShellCompletion do
     let(:env) { {} }
 
     it "returns shell name for nil format" do
-      expect(described_class.completion_shell_parameter(nil, :bash, "/usr/bin/foo", env)).to eq("bash")
+      expect(klass.completion_shell_parameter(nil, :bash, "/usr/bin/foo", env)).to eq("bash")
     end
 
     it "returns --shell=<name> for :arg format" do
-      expect(described_class.completion_shell_parameter(:arg, :zsh, "/usr/bin/foo", env)).to eq("--shell=zsh")
+      expect(klass.completion_shell_parameter(:arg, :zsh, "/usr/bin/foo", env)).to eq("--shell=zsh")
     end
 
     it "sets env and returns nil for :clap format" do
-      result = described_class.completion_shell_parameter(:clap, :fish, "/usr/bin/foo", env)
+      result = klass.completion_shell_parameter(:clap, :fish, "/usr/bin/foo", env)
       expect(result).to be_nil
       expect(env["COMPLETE"]).to eq("fish")
     end
 
     it "sets env with uppercased program name for :click format" do
-      result = described_class.completion_shell_parameter(:click, :bash, "/usr/local/bin/my-tool", env)
+      result = klass.completion_shell_parameter(:click, :bash, "/usr/local/bin/my-tool", env)
       expect(result).to be_nil
       expect(env["_MY_TOOL_COMPLETE"]).to eq("bash_source")
     end
 
     it "returns subcommand array for :cobra format" do
-      result = described_class.completion_shell_parameter(:cobra, :zsh, "/usr/bin/foo", env)
+      result = klass.completion_shell_parameter(:cobra, :zsh, "/usr/bin/foo", env)
       expect(result).to eq(["completion", "zsh"])
     end
 
     it "returns --<shell> for :flag format" do
-      expect(described_class.completion_shell_parameter(:flag, :fish, "/usr/bin/foo", env)).to eq("--fish")
+      expect(klass.completion_shell_parameter(:flag, :fish, "/usr/bin/foo", env)).to eq("--fish")
     end
 
     it "returns nil for :none format" do
-      expect(described_class.completion_shell_parameter(:none, :bash, "/usr/bin/foo", env)).to be_nil
+      expect(klass.completion_shell_parameter(:none, :bash, "/usr/bin/foo", env)).to be_nil
     end
 
     it "returns subcommand array for :typer format and sets env" do
-      result = described_class.completion_shell_parameter(:typer, :bash, "/usr/bin/foo", env)
+      result = klass.completion_shell_parameter(:typer, :bash, "/usr/bin/foo", env)
       expect(result).to eq(["--show-completion", "bash"])
       expect(env["_TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION"]).to eq("1")
     end
 
     it "maps :pwsh to 'powershell'" do
-      expect(described_class.completion_shell_parameter(nil, :pwsh, "/usr/bin/foo", env)).to eq("powershell")
+      expect(klass.completion_shell_parameter(nil, :pwsh, "/usr/bin/foo", env)).to eq("powershell")
     end
 
     it "interpolates custom format string" do
-      expect(described_class.completion_shell_parameter("--complete-", :zsh, "/usr/bin/foo", env))
+      expect(klass.completion_shell_parameter("--complete-", :zsh, "/usr/bin/foo", env))
         .to eq("--complete-zsh")
     end
   end
@@ -80,7 +82,7 @@ RSpec.describe Utils::ShellCompletion do
         {}, "/usr/bin/foo", "completions", "bash", err: :err
       ).and_return("completion output")
 
-      result = described_class.generate_completion_output(
+      result = klass.generate_completion_output(
         ["/usr/bin/foo", "completions"], "bash", {}
       )
 
@@ -92,7 +94,7 @@ RSpec.describe Utils::ShellCompletion do
         {}, "/usr/bin/foo", "completion", "zsh", err: :err
       ).and_return("output")
 
-      described_class.generate_completion_output(
+      klass.generate_completion_output(
         ["/usr/bin/foo"], ["completion", "zsh"], {}
       )
     end
@@ -102,7 +104,7 @@ RSpec.describe Utils::ShellCompletion do
         {}, "/usr/bin/foo", err: :err
       ).and_return("output")
 
-      described_class.generate_completion_output(["/usr/bin/foo"], nil, {})
+      klass.generate_completion_output(["/usr/bin/foo"], nil, {})
     end
   end
 end

--- a/Library/Homebrew/test/utils/shell_spec.rb
+++ b/Library/Homebrew/test/utils/shell_spec.rb
@@ -4,84 +4,86 @@
 require "utils/shell"
 
 RSpec.describe Utils::Shell do
+  let(:klass) { Utils::Shell }
+
   describe "::profile" do
     it "returns ~/.profile by default" do
       ENV["SHELL"] = "/bin/another_shell"
-      expect(described_class.profile).to eq("~/.profile")
+      expect(klass.profile).to eq("~/.profile")
     end
 
     it "returns ~/.profile for sh" do
       ENV["SHELL"] = "/bin/sh"
-      expect(described_class.profile).to eq("~/.profile")
+      expect(klass.profile).to eq("~/.profile")
     end
 
     it "returns ~/.profile for Bash" do
       ENV["SHELL"] = "/bin/bash"
-      expect(described_class.profile).to eq("~/.profile")
+      expect(klass.profile).to eq("~/.profile")
     end
 
     it "returns /tmp/.zshrc for Zsh if ZDOTDIR is /tmp" do
       ENV["SHELL"] = "/bin/zsh"
       ENV["HOMEBREW_ZDOTDIR"] = "/tmp"
-      expect(described_class.profile).to eq("/tmp/.zshrc")
+      expect(klass.profile).to eq("/tmp/.zshrc")
     end
 
     it "returns ~/.zshrc for Zsh" do
       ENV["SHELL"] = "/bin/zsh"
       ENV["HOMEBREW_ZDOTDIR"] = nil
-      expect(described_class.profile).to eq("~/.zshrc")
+      expect(klass.profile).to eq("~/.zshrc")
     end
 
     it "returns ~/.kshrc for Ksh" do
       ENV["SHELL"] = "/bin/ksh"
-      expect(described_class.profile).to eq("~/.kshrc")
+      expect(klass.profile).to eq("~/.kshrc")
     end
 
     it "returns ~/.config/powershell/Microsoft.PowerShell_profile.ps1 for PowerShell" do
       ENV["SHELL"] = "/usr/bin/pwsh"
-      expect(described_class.profile).to eq("~/.config/powershell/Microsoft.PowerShell_profile.ps1")
+      expect(klass.profile).to eq("~/.config/powershell/Microsoft.PowerShell_profile.ps1")
     end
   end
 
   describe "::from_path" do
     it "supports a raw command name" do
-      expect(described_class.from_path("bash")).to eq(:bash)
+      expect(klass.from_path("bash")).to eq(:bash)
     end
 
     it "supports full paths" do
-      expect(described_class.from_path("/bin/bash")).to eq(:bash)
+      expect(klass.from_path("/bin/bash")).to eq(:bash)
     end
 
     it "supports versions" do
-      expect(described_class.from_path("zsh-5.2")).to eq(:zsh)
+      expect(klass.from_path("zsh-5.2")).to eq(:zsh)
     end
 
     it "strips newlines" do
-      expect(described_class.from_path("zsh-5.2\n")).to eq(:zsh)
+      expect(klass.from_path("zsh-5.2\n")).to eq(:zsh)
     end
 
     it "returns nil when input is invalid" do
-      expect(described_class.from_path("")).to be_nil
-      expect(described_class.from_path("@@@@@@")).to be_nil
-      expect(described_class.from_path("invalid_shell-4.2")).to be_nil
+      expect(klass.from_path("")).to be_nil
+      expect(klass.from_path("@@@@@@")).to be_nil
+      expect(klass.from_path("invalid_shell-4.2")).to be_nil
     end
   end
 
   specify "::sh_quote" do
-    expect(described_class.send(:sh_quote, "")).to eq("''")
-    expect(described_class.send(:sh_quote, "\\")).to eq("\\\\")
-    expect(described_class.send(:sh_quote, "\n")).to eq("'\n'")
-    expect(described_class.send(:sh_quote, "$")).to eq("\\$")
-    expect(described_class.send(:sh_quote, "word")).to eq("word")
+    expect(klass.send(:sh_quote, "")).to eq("''")
+    expect(klass.send(:sh_quote, "\\")).to eq("\\\\")
+    expect(klass.send(:sh_quote, "\n")).to eq("'\n'")
+    expect(klass.send(:sh_quote, "$")).to eq("\\$")
+    expect(klass.send(:sh_quote, "word")).to eq("word")
   end
 
   specify "::csh_quote" do
-    expect(described_class.send(:csh_quote, "")).to eq("''")
-    expect(described_class.send(:csh_quote, "\\")).to eq("\\\\")
+    expect(klass.send(:csh_quote, "")).to eq("''")
+    expect(klass.send(:csh_quote, "\\")).to eq("\\\\")
     # NOTE: This test is different than for `sh`.
-    expect(described_class.send(:csh_quote, "\n")).to eq("'\\\n'")
-    expect(described_class.send(:csh_quote, "$")).to eq("\\$")
-    expect(described_class.send(:csh_quote, "word")).to eq("word")
+    expect(klass.send(:csh_quote, "\n")).to eq("'\\\n'")
+    expect(klass.send(:csh_quote, "$")).to eq("\\$")
+    expect(klass.send(:csh_quote, "word")).to eq("word")
   end
 
   describe "::prepend_path_in_profile" do
@@ -89,20 +91,20 @@ RSpec.describe Utils::Shell do
 
     it "supports tcsh" do
       ENV["SHELL"] = "/bin/tcsh"
-      expect(described_class.prepend_path_in_profile(path))
-        .to eq("echo 'setenv PATH #{path}:$PATH' >> #{described_class.profile}")
+      expect(klass.prepend_path_in_profile(path))
+        .to eq("echo 'setenv PATH #{path}:$PATH' >> #{klass.profile}")
     end
 
     it "supports Bash" do
       ENV["SHELL"] = "/bin/bash"
-      expect(described_class.prepend_path_in_profile(path))
-        .to eq("echo 'export PATH=\"#{path}:$PATH\"' >> #{described_class.profile}")
+      expect(klass.prepend_path_in_profile(path))
+        .to eq("echo 'export PATH=\"#{path}:$PATH\"' >> #{klass.profile}")
     end
 
     it "supports fish" do
       ENV["SHELL"] = "/usr/local/bin/fish"
       ENV["fish_user_paths"] = "/some/path"
-      expect(described_class.prepend_path_in_profile(path))
+      expect(klass.prepend_path_in_profile(path))
         .to eq("fish_add_path #{path}")
     end
   end
@@ -118,7 +120,7 @@ RSpec.describe Utils::Shell do
       ENV["SHELL"] = preferred_path
       ENV["PATH"] = path
       zdotdir = "#{HOMEBREW_TEMP}/brew-zsh-prompt-#{Process.euid}"
-      expect(described_class.shell_with_prompt(prompt, preferred_path:, notice:, home:)).to eq \
+      expect(klass.shell_with_prompt(prompt, preferred_path:, notice:, home:)).to eq \
         "BREW_PROMPT_PATH=\"#{path}\" BREW_PROMPT_TYPE=\"#{prompt}\" ZDOTDIR=\"#{zdotdir}\" #{preferred_path}"
     end
 
@@ -127,20 +129,20 @@ RSpec.describe Utils::Shell do
       ENV["SHELL"] = "/bin/bash"
       ENV["PATH"] = path
       rcfile = "#{HOMEBREW_LIBRARY_PATH}/utils/bash/brew-sh-prompt-bashrc.bash"
-      expect(described_class.shell_with_prompt(prompt, preferred_path:, notice:, home:)).to eq \
+      expect(klass.shell_with_prompt(prompt, preferred_path:, notice:, home:)).to eq \
         "BREW_PROMPT_PATH=\"#{path}\" BREW_PROMPT_TYPE=\"#{prompt}\" #{preferred_path} --rcfile \"#{rcfile}\""
     end
 
     it "returns generic shell prompt configuration" do
       preferred_path = "/bin/dash"
       ENV["SHELL"] = preferred_path
-      expect(described_class.shell_with_prompt(prompt, preferred_path:, notice:, home:)).to eq \
+      expect(klass.shell_with_prompt(prompt, preferred_path:, notice:, home:)).to eq \
         "PS1=\"\\[\\033[1;32m\\]#{prompt} \\[\\033[1;31m\\]\\w \\[\\033[1;34m\\]$\\[\\033[0m\\] \" #{preferred_path}"
     end
 
     it "outputs notice when provided" do
       notice = "Test Notice"
-      expect { described_class.shell_with_prompt("test", preferred_path: "/bin/bash", notice: notice) }
+      expect { klass.shell_with_prompt("test", preferred_path: "/bin/bash", notice: notice) }
         .to output("#{notice}\n").to_stdout
     end
   end

--- a/Library/Homebrew/test/utils/spdx_spec.rb
+++ b/Library/Homebrew/test/utils/spdx_spec.rb
@@ -4,31 +4,33 @@
 require "utils/spdx"
 
 RSpec.describe SPDX do
+  let(:klass) { SPDX }
+
   describe ".license_data" do
     it "has the license list version" do
-      expect(described_class.license_data["licenseListVersion"]).not_to be_nil
+      expect(klass.license_data["licenseListVersion"]).not_to be_nil
     end
 
     it "has the release date" do
-      expect(described_class.license_data["releaseDate"]).not_to be_nil
+      expect(klass.license_data["releaseDate"]).not_to be_nil
     end
 
     it "has licenses" do
-      expect(described_class.license_data["licenses"].length).not_to eq(0)
+      expect(klass.license_data["licenses"].length).not_to eq(0)
     end
   end
 
   describe ".exception_data" do
     it "has the license list version" do
-      expect(described_class.exception_data["licenseListVersion"]).not_to be_nil
+      expect(klass.exception_data["licenseListVersion"]).not_to be_nil
     end
 
     it "has the release date" do
-      expect(described_class.exception_data["releaseDate"]).not_to be_nil
+      expect(klass.exception_data["releaseDate"]).not_to be_nil
     end
 
     it "has exceptions" do
-      expect(described_class.exception_data["exceptions"].length).not_to eq(0)
+      expect(klass.exception_data["exceptions"].length).not_to eq(0)
     end
   end
 
@@ -36,7 +38,7 @@ RSpec.describe SPDX do
     let(:download_dir) { mktmpdir }
 
     it "downloads latest license data" do
-      described_class.download_latest_license_data! to: download_dir
+      klass.download_latest_license_data! to: download_dir
       expect(download_dir/"spdx_licenses.json").to exist
       expect(download_dir/"spdx_exceptions.json").to exist
     end
@@ -44,19 +46,19 @@ RSpec.describe SPDX do
 
   describe ".parse_license_expression" do
     specify do
-      expect(described_class.parse_license_expression("MIT").first).to eq ["MIT"]
-      expect(described_class.parse_license_expression("Apache-2.0+").first).to eq ["Apache-2.0+"]
-      expect(described_class.parse_license_expression(any_of: ["MIT", "0BSD"]).first).to eq ["MIT", "0BSD"]
-      expect(described_class.parse_license_expression(all_of: ["MIT", "0BSD"]).first).to eq ["MIT", "0BSD"]
-      expect(described_class.parse_license_expression(any_of: ["MIT", "EPL-1.0+"]).first).to eq ["MIT", "EPL-1.0+"]
-      expect(described_class.parse_license_expression(["MIT", "EPL-1.0+"]).first).to eq ["MIT", "EPL-1.0+"]
-      expect(described_class.parse_license_expression(:public_domain).first).to eq [:public_domain]
-      expect(described_class.parse_license_expression(:cannot_represent).first).to eq [:cannot_represent]
+      expect(klass.parse_license_expression("MIT").first).to eq ["MIT"]
+      expect(klass.parse_license_expression("Apache-2.0+").first).to eq ["Apache-2.0+"]
+      expect(klass.parse_license_expression(any_of: ["MIT", "0BSD"]).first).to eq ["MIT", "0BSD"]
+      expect(klass.parse_license_expression(all_of: ["MIT", "0BSD"]).first).to eq ["MIT", "0BSD"]
+      expect(klass.parse_license_expression(any_of: ["MIT", "EPL-1.0+"]).first).to eq ["MIT", "EPL-1.0+"]
+      expect(klass.parse_license_expression(["MIT", "EPL-1.0+"]).first).to eq ["MIT", "EPL-1.0+"]
+      expect(klass.parse_license_expression(:public_domain).first).to eq [:public_domain]
+      expect(klass.parse_license_expression(:cannot_represent).first).to eq [:cannot_represent]
     end
 
     it "returns license and exception" do
       license_expression = { "MIT" => { with: "LLVM-exception" } }
-      expect(described_class.parse_license_expression(license_expression)).to eq [["MIT"], ["LLVM-exception"]]
+      expect(klass.parse_license_expression(license_expression)).to eq [["MIT"], ["LLVM-exception"]]
     end
 
     it "returns licenses and exceptions for complex license expressions" do
@@ -70,108 +72,108 @@ RSpec.describe SPDX do
         },
       ] }
       result = [["MIT", :public_domain, "curl", "0BSD", "Zlib"], ["LLVM-exception"]]
-      expect(described_class.parse_license_expression(license_expression)).to eq result
+      expect(klass.parse_license_expression(license_expression)).to eq result
     end
   end
 
   describe ".valid_license?" do
     it "returns true for valid license identifier" do
-      expect(described_class.valid_license?("MIT")).to be true
+      expect(klass.valid_license?("MIT")).to be true
     end
 
     it "returns false for invalid license identifier" do
-      expect(described_class.valid_license?("foo")).to be false
+      expect(klass.valid_license?("foo")).to be false
     end
 
     it "returns true for deprecated license identifier" do
-      expect(described_class.valid_license?("GPL-1.0")).to be true
+      expect(klass.valid_license?("GPL-1.0")).to be true
     end
 
     it "returns true for license identifier with plus" do
-      expect(described_class.valid_license?("Apache-2.0+")).to be true
+      expect(klass.valid_license?("Apache-2.0+")).to be true
     end
 
     it "returns true for :public_domain" do
-      expect(described_class.valid_license?(:public_domain)).to be true
+      expect(klass.valid_license?(:public_domain)).to be true
     end
 
     it "returns true for :cannot_represent" do
-      expect(described_class.valid_license?(:cannot_represent)).to be true
+      expect(klass.valid_license?(:cannot_represent)).to be true
     end
 
     it "returns false for invalid symbol" do
-      expect(described_class.valid_license?(:invalid_symbol)).to be false
+      expect(klass.valid_license?(:invalid_symbol)).to be false
     end
   end
 
   describe ".deprecated_license?" do
     it "returns true for deprecated license identifier" do
-      expect(described_class.deprecated_license?("GPL-1.0")).to be true
+      expect(klass.deprecated_license?("GPL-1.0")).to be true
     end
 
     it "returns true for deprecated license identifier with plus" do
-      expect(described_class.deprecated_license?("GPL-1.0+")).to be true
+      expect(klass.deprecated_license?("GPL-1.0+")).to be true
     end
 
     it "returns false for non-deprecated license identifier" do
-      expect(described_class.deprecated_license?("MIT")).to be false
+      expect(klass.deprecated_license?("MIT")).to be false
     end
 
     it "returns false for non-deprecated license identifier with plus" do
-      expect(described_class.deprecated_license?("EPL-1.0+")).to be false
+      expect(klass.deprecated_license?("EPL-1.0+")).to be false
     end
 
     it "returns false for invalid license identifier" do
-      expect(described_class.deprecated_license?("foo")).to be false
+      expect(klass.deprecated_license?("foo")).to be false
     end
 
     it "returns false for :public_domain" do
-      expect(described_class.deprecated_license?(:public_domain)).to be false
+      expect(klass.deprecated_license?(:public_domain)).to be false
     end
 
     it "returns false for :cannot_represent" do
-      expect(described_class.deprecated_license?(:cannot_represent)).to be false
+      expect(klass.deprecated_license?(:cannot_represent)).to be false
     end
   end
 
   describe ".valid_license_exception?" do
     it "returns true for valid license exception identifier" do
-      expect(described_class.valid_license_exception?("LLVM-exception")).to be true
+      expect(klass.valid_license_exception?("LLVM-exception")).to be true
     end
 
     it "returns false for invalid license exception identifier" do
-      expect(described_class.valid_license_exception?("foo")).to be false
+      expect(klass.valid_license_exception?("foo")).to be false
     end
 
     it "returns false for deprecated license exception identifier" do
-      expect(described_class.valid_license_exception?("Nokia-Qt-exception-1.1")).to be false
+      expect(klass.valid_license_exception?("Nokia-Qt-exception-1.1")).to be false
     end
   end
 
   describe ".license_expression_to_string" do
     it "returns a single license" do
-      expect(described_class.license_expression_to_string("MIT")).to eq "MIT"
+      expect(klass.license_expression_to_string("MIT")).to eq "MIT"
     end
 
     it "returns a single license with plus" do
-      expect(described_class.license_expression_to_string("Apache-2.0+")).to eq "Apache-2.0+"
+      expect(klass.license_expression_to_string("Apache-2.0+")).to eq "Apache-2.0+"
     end
 
     it "returns multiple licenses with :any" do
-      expect(described_class.license_expression_to_string({ any_of: ["MIT", "0BSD"] })).to eq "MIT OR 0BSD"
+      expect(klass.license_expression_to_string({ any_of: ["MIT", "0BSD"] })).to eq "MIT OR 0BSD"
     end
 
     it "returns multiple licenses with :all" do
-      expect(described_class.license_expression_to_string({ all_of: ["MIT", "0BSD"] })).to eq "MIT AND 0BSD"
+      expect(klass.license_expression_to_string({ all_of: ["MIT", "0BSD"] })).to eq "MIT AND 0BSD"
     end
 
     it "returns multiple licenses with plus" do
-      expect(described_class.license_expression_to_string({ any_of: ["MIT", "EPL-1.0+"] })).to eq "MIT OR EPL-1.0+"
+      expect(klass.license_expression_to_string({ any_of: ["MIT", "EPL-1.0+"] })).to eq "MIT OR EPL-1.0+"
     end
 
     it "returns license and exception" do
       license_expression = { "MIT" => { with: "LLVM-exception" } }
-      expect(described_class.license_expression_to_string(license_expression)).to eq "MIT WITH LLVM-exception"
+      expect(klass.license_expression_to_string(license_expression)).to eq "MIT WITH LLVM-exception"
     end
 
     it "returns licenses and exceptions for complex license expressions" do
@@ -185,23 +187,23 @@ RSpec.describe SPDX do
         },
       ] }
       result = "MIT OR LicenseRef-Homebrew-public-domain OR (0BSD AND Zlib) OR (curl WITH LLVM-exception)"
-      expect(described_class.license_expression_to_string(license_expression)).to eq result
+      expect(klass.license_expression_to_string(license_expression)).to eq result
     end
 
     it "returns :public_domain" do
-      expect(described_class.license_expression_to_string(:public_domain)).to eq "LicenseRef-Homebrew-public-domain"
+      expect(klass.license_expression_to_string(:public_domain)).to eq "LicenseRef-Homebrew-public-domain"
     end
 
     it "returns :cannot_represent" do
       result = "LicenseRef-Homebrew-cannot-represent"
-      expect(described_class.license_expression_to_string(:cannot_represent)).to eq result
+      expect(klass.license_expression_to_string(:cannot_represent)).to eq result
     end
   end
 
   describe ".string_to_license_expression" do
     it "returns the correct result for 'and', 'or' and 'with'" do
       expr_string = "Apache-2.0 and (Apache-2.0 with LLVM-exception) and (MIT or NCSA)"
-      expect(described_class.string_to_license_expression(expr_string)).to eq({
+      expect(klass.string_to_license_expression(expr_string)).to eq({
         all_of: [
           "Apache-2.0",
           { "Apache-2.0" => { with: "LLVM-exception" } },
@@ -212,7 +214,7 @@ RSpec.describe SPDX do
 
     it "returns the correct result for 'AND', 'OR' and 'WITH'" do
       expr_string = "Apache-2.0 AND (Apache-2.0 WITH LLVM-exception) AND (MIT OR NCSA)"
-      expect(described_class.string_to_license_expression(expr_string)).to eq({
+      expect(klass.string_to_license_expression(expr_string)).to eq({
         all_of: [
           "Apache-2.0",
           { "Apache-2.0" => { with: "LLVM-exception" } },
@@ -223,7 +225,7 @@ RSpec.describe SPDX do
 
     # The final array item is legitimately a hash in the case of license expressions.
     it "handles nested brackets" do
-      expect(described_class.string_to_license_expression("A AND (B OR (C AND D))")).to eq({
+      expect(klass.string_to_license_expression("A AND (B OR (C AND D))")).to eq({
         all_of: [
           "A",
           { any_of: [
@@ -235,57 +237,57 @@ RSpec.describe SPDX do
     end
 
     it "returns :public_domain" do
-      expect(described_class.string_to_license_expression("LicenseRef-Homebrew-public-domain")).to eq :public_domain
+      expect(klass.string_to_license_expression("LicenseRef-Homebrew-public-domain")).to eq :public_domain
     end
 
     it "returns :cannot_represent" do
       expr_string = "LicenseRef-Homebrew-cannot-represent"
-      expect(described_class.string_to_license_expression(expr_string)).to eq :cannot_represent
+      expect(klass.string_to_license_expression(expr_string)).to eq :cannot_represent
     end
   end
 
   describe ".license_version_info" do
     it "returns license without version" do
-      expect(described_class.license_version_info("MIT")).to eq ["MIT"]
+      expect(klass.license_version_info("MIT")).to eq ["MIT"]
     end
 
     it "returns :public_domain without version" do
-      expect(described_class.license_version_info(:public_domain)).to eq [:public_domain]
+      expect(klass.license_version_info(:public_domain)).to eq [:public_domain]
     end
 
     it "returns license with version" do
-      expect(described_class.license_version_info("Apache-2.0")).to eq ["Apache", "2.0", false]
+      expect(klass.license_version_info("Apache-2.0")).to eq ["Apache", "2.0", false]
     end
 
     it "returns license with version and plus" do
-      expect(described_class.license_version_info("Apache-2.0+")).to eq ["Apache", "2.0", true]
+      expect(klass.license_version_info("Apache-2.0+")).to eq ["Apache", "2.0", true]
     end
 
     it "returns more complicated license with version" do
-      expect(described_class.license_version_info("CC-BY-3.0-AT")).to eq ["CC-BY", "3.0", false]
+      expect(klass.license_version_info("CC-BY-3.0-AT")).to eq ["CC-BY", "3.0", false]
     end
 
     it "returns more complicated license with version and plus" do
-      expect(described_class.license_version_info("CC-BY-3.0-AT+")).to eq ["CC-BY", "3.0", true]
+      expect(klass.license_version_info("CC-BY-3.0-AT+")).to eq ["CC-BY", "3.0", true]
     end
 
     it "returns license with -only" do
-      expect(described_class.license_version_info("GPL-3.0-only")).to eq ["GPL", "3.0", false]
+      expect(klass.license_version_info("GPL-3.0-only")).to eq ["GPL", "3.0", false]
     end
 
     it "returns license with -or-later" do
-      expect(described_class.license_version_info("GPL-3.0-or-later")).to eq ["GPL", "3.0", true]
+      expect(klass.license_version_info("GPL-3.0-or-later")).to eq ["GPL", "3.0", true]
     end
   end
 
   describe ".licenses_forbid_installation?" do
-    let(:mit_forbidden) { { "MIT" => described_class.license_version_info("MIT") } }
-    let(:epl_1_forbidden) { { "EPL-1.0" => described_class.license_version_info("EPL-1.0") } }
-    let(:epl_1_plus_forbidden) { { "EPL-1.0+" => described_class.license_version_info("EPL-1.0+") } }
+    let(:mit_forbidden) { { "MIT" => klass.license_version_info("MIT") } }
+    let(:epl_1_forbidden) { { "EPL-1.0" => klass.license_version_info("EPL-1.0") } }
+    let(:epl_1_plus_forbidden) { { "EPL-1.0+" => klass.license_version_info("EPL-1.0+") } }
     let(:multiple_forbidden) do
       {
-        "MIT"  => described_class.license_version_info("MIT"),
-        "0BSD" => described_class.license_version_info("0BSD"),
+        "MIT"  => klass.license_version_info("MIT"),
+        "0BSD" => klass.license_version_info("0BSD"),
       }
     end
     let(:any_of_license) { { any_of: ["MIT", "0BSD"] } }
@@ -302,81 +304,81 @@ RSpec.describe SPDX do
     let(:license_exception) { { "MIT" => { with: "LLVM-exception" } } }
 
     it "allows installation with no forbidden licenses" do
-      expect(described_class.licenses_forbid_installation?("MIT", {})).to be false
+      expect(klass.licenses_forbid_installation?("MIT", {})).to be false
     end
 
     it "allows installation with non-forbidden license" do
-      expect(described_class.licenses_forbid_installation?("0BSD", mit_forbidden)).to be false
+      expect(klass.licenses_forbid_installation?("0BSD", mit_forbidden)).to be false
     end
 
     it "forbids installation with forbidden license" do
-      expect(described_class.licenses_forbid_installation?("MIT", mit_forbidden)).to be true
+      expect(klass.licenses_forbid_installation?("MIT", mit_forbidden)).to be true
     end
 
     it "allows installation of later license version" do
-      expect(described_class.licenses_forbid_installation?("EPL-2.0", epl_1_forbidden)).to be false
+      expect(klass.licenses_forbid_installation?("EPL-2.0", epl_1_forbidden)).to be false
     end
 
     it "forbids installation of later license version with plus in forbidden license list" do
-      expect(described_class.licenses_forbid_installation?("EPL-2.0", epl_1_plus_forbidden)).to be true
+      expect(klass.licenses_forbid_installation?("EPL-2.0", epl_1_plus_forbidden)).to be true
     end
 
     it "allows installation when one of the any_of licenses is allowed" do
-      expect(described_class.licenses_forbid_installation?(any_of_license, mit_forbidden)).to be false
+      expect(klass.licenses_forbid_installation?(any_of_license, mit_forbidden)).to be false
     end
 
     it "forbids installation when none of the any_of licenses are allowed" do
-      expect(described_class.licenses_forbid_installation?(any_of_license, multiple_forbidden)).to be true
+      expect(klass.licenses_forbid_installation?(any_of_license, multiple_forbidden)).to be true
     end
 
     it "forbids installation when one of the all_of licenses is allowed" do
-      expect(described_class.licenses_forbid_installation?(all_of_license, mit_forbidden)).to be true
+      expect(klass.licenses_forbid_installation?(all_of_license, mit_forbidden)).to be true
     end
 
     it "allows installation with license + exception that aren't forbidden" do
-      expect(described_class.licenses_forbid_installation?(license_exception, epl_1_forbidden)).to be false
+      expect(klass.licenses_forbid_installation?(license_exception, epl_1_forbidden)).to be false
     end
 
     it "forbids installation with license + exception that are't forbidden" do
-      expect(described_class.licenses_forbid_installation?(license_exception, mit_forbidden)).to be true
+      expect(klass.licenses_forbid_installation?(license_exception, mit_forbidden)).to be true
     end
 
     it "allows installation with nested licenses with no forbidden licenses" do
-      expect(described_class.licenses_forbid_installation?(nested_licenses, epl_1_forbidden)).to be false
+      expect(klass.licenses_forbid_installation?(nested_licenses, epl_1_forbidden)).to be false
     end
 
     it "allows installation with nested licenses when second hash item matches" do
-      expect(described_class.licenses_forbid_installation?(nested_licenses, mit_forbidden)).to be false
+      expect(klass.licenses_forbid_installation?(nested_licenses, mit_forbidden)).to be false
     end
 
     it "forbids installation with nested licenses when all licenses are forbidden" do
-      expect(described_class.licenses_forbid_installation?(nested_licenses, multiple_forbidden)).to be true
+      expect(klass.licenses_forbid_installation?(nested_licenses, multiple_forbidden)).to be true
     end
   end
 
   describe ".forbidden_licenses_include?" do
-    let(:mit_forbidden) { { "MIT" => described_class.license_version_info("MIT") } }
-    let(:epl_1_forbidden) { { "EPL-1.0" => described_class.license_version_info("EPL-1.0") } }
-    let(:epl_1_plus_forbidden) { { "EPL-1.0+" => described_class.license_version_info("EPL-1.0+") } }
+    let(:mit_forbidden) { { "MIT" => klass.license_version_info("MIT") } }
+    let(:epl_1_forbidden) { { "EPL-1.0" => klass.license_version_info("EPL-1.0") } }
+    let(:epl_1_plus_forbidden) { { "EPL-1.0+" => klass.license_version_info("EPL-1.0+") } }
 
     it "returns false with no forbidden licenses" do
-      expect(described_class.forbidden_licenses_include?("MIT", {})).to be false
+      expect(klass.forbidden_licenses_include?("MIT", {})).to be false
     end
 
     it "returns false with no matching forbidden licenses" do
-      expect(described_class.forbidden_licenses_include?("MIT", epl_1_forbidden)).to be false
+      expect(klass.forbidden_licenses_include?("MIT", epl_1_forbidden)).to be false
     end
 
     it "returns true with matching license" do
-      expect(described_class.forbidden_licenses_include?("MIT", mit_forbidden)).to be true
+      expect(klass.forbidden_licenses_include?("MIT", mit_forbidden)).to be true
     end
 
     it "returns false with later version of forbidden license" do
-      expect(described_class.forbidden_licenses_include?("EPL-2.0", epl_1_forbidden)).to be false
+      expect(klass.forbidden_licenses_include?("EPL-2.0", epl_1_forbidden)).to be false
     end
 
     it "returns true with later version of forbidden license with later versions forbidden" do
-      expect(described_class.forbidden_licenses_include?("EPL-2.0", epl_1_plus_forbidden)).to be true
+      expect(klass.forbidden_licenses_include?("EPL-2.0", epl_1_plus_forbidden)).to be true
     end
   end
 end

--- a/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
+++ b/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
@@ -4,7 +4,9 @@
 require "utils/string_inreplace_extension"
 
 RSpec.describe StringInreplaceExtension do
-  subject(:string_extension) { described_class.new(string.dup) }
+  subject(:string_extension) { klass.new(string.dup) }
+
+  let(:klass) { StringInreplaceExtension }
 
   describe "#change_make_var!" do
     context "with a flag" do

--- a/Library/Homebrew/test/utils/svn_spec.rb
+++ b/Library/Homebrew/test/utils/svn_spec.rb
@@ -4,16 +4,18 @@
 require "utils/svn"
 
 RSpec.describe Utils::Svn do
+  let(:klass) { Utils::Svn }
+
   before do
-    described_class.clear_version_cache
+    klass.clear_version_cache
   end
 
   describe "::available?" do
     it "returns svn version if svn available" do
       if quiet_system "#{HOMEBREW_SHIMS_PATH}/shared/svn", "--version"
-        expect(described_class).to be_available
+        expect(klass).to be_available
       else
-        expect(described_class).not_to be_available
+        expect(klass).not_to be_available
       end
     end
   end
@@ -21,34 +23,34 @@ RSpec.describe Utils::Svn do
   describe "::version" do
     it "returns svn version if svn available" do
       if quiet_system "#{HOMEBREW_SHIMS_PATH}/shared/svn", "--version"
-        expect(described_class.version).to match(/^\d+\.\d+\.\d+$/)
+        expect(klass.version).to match(/^\d+\.\d+\.\d+$/)
       else
-        expect(described_class.version).to be_nil
+        expect(klass.version).to be_nil
       end
     end
 
     it "returns version of svn when svn is available", :needs_svn do
-      expect(described_class.version).not_to be_nil
+      expect(klass.version).not_to be_nil
     end
   end
 
   describe "::remote_exists?" do
     it "returns true when svn is not available" do
-      allow(described_class).to receive(:available?).and_return(false)
-      expect(described_class).to be_remote_exists("blah")
+      allow(klass).to receive(:available?).and_return(false)
+      expect(klass).to be_remote_exists("blah")
     end
 
     context "when svn is available" do
       before do
-        allow(described_class).to receive(:available?).and_return(true)
+        allow(klass).to receive(:available?).and_return(true)
       end
 
       it "returns false when remote does not exist" do
-        expect(described_class).not_to be_remote_exists("blah")
+        expect(klass).not_to be_remote_exists("blah")
       end
 
       it "returns true when remote exists", :needs_network, :needs_svn do
-        expect(described_class).to be_remote_exists("https://svn.code.sf.net/p/ctags/code/trunk")
+        expect(klass).to be_remote_exists("https://svn.code.sf.net/p/ctags/code/trunk")
       end
     end
   end

--- a/Library/Homebrew/test/utils/tar_spec.rb
+++ b/Library/Homebrew/test/utils/tar_spec.rb
@@ -4,24 +4,26 @@
 require "utils/tar"
 
 RSpec.describe Utils::Tar do
+  let(:klass) { Utils::Tar }
+
   before do
-    described_class.clear_executable_cache
+    klass.clear_executable_cache
   end
 
   describe ".available?" do
     it "returns true if tar or gnu-tar is available" do
-      if described_class.executable.present?
-        expect(described_class).to be_available
+      if klass.executable.present?
+        expect(klass).to be_available
       else
-        expect(described_class).not_to be_available
+        expect(klass).not_to be_available
       end
     end
   end
 
   describe ".validate_file" do
     it "does not raise an error when tar and gnu-tar are unavailable" do
-      allow(described_class).to receive(:available?).and_return false
-      expect { described_class.validate_file "blah" }.not_to raise_error
+      allow(klass).to receive(:available?).and_return false
+      expect { klass.validate_file "blah" }.not_to raise_error
     end
 
     context "when tar or gnu-tar is available" do
@@ -29,20 +31,20 @@ RSpec.describe Utils::Tar do
       let(:invalid_resource) { "#{TEST_TMPDIR}/invalid.tgz" }
 
       before do
-        allow(described_class).to receive(:available?).and_return true
+        allow(klass).to receive(:available?).and_return true
       end
 
       it "does not raise an error if file is not a tar file" do
-        expect { described_class.validate_file "blah" }.not_to raise_error
+        expect { klass.validate_file "blah" }.not_to raise_error
       end
 
       it "does not raise an error if file is valid tar file" do
-        expect { described_class.validate_file testball_resource }.not_to raise_error
+        expect { klass.validate_file testball_resource }.not_to raise_error
       end
 
       it "raises an error if file is an invalid tar file" do
         FileUtils.touch invalid_resource
-        expect { described_class.validate_file invalid_resource }.to raise_error SystemExit
+        expect { klass.validate_file invalid_resource }.to raise_error SystemExit
         FileUtils.rm_f invalid_resource
       end
     end

--- a/Library/Homebrew/test/utils/timer_spec.rb
+++ b/Library/Homebrew/test/utils/timer_spec.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
 
 require "utils/timer"

--- a/Library/Homebrew/test/utils/timer_spec.rb
+++ b/Library/Homebrew/test/utils/timer_spec.rb
@@ -4,31 +4,33 @@
 require "utils/timer"
 
 RSpec.describe Utils::Timer do
+  let(:klass) { Utils::Timer }
+
   describe "#remaining" do
     it "returns nil when nil" do
-      expect(described_class.remaining(nil)).to be_nil
+      expect(klass.remaining(nil)).to be_nil
     end
 
     it "returns time remaining when there is time remaining" do
-      expect(described_class.remaining(Time.now + 10)).to be > 1
+      expect(klass.remaining(Time.now + 10)).to be > 1
     end
 
     it "returns 0 when there is no time remaining" do
-      expect(described_class.remaining(Time.now - 10)).to be 0
+      expect(klass.remaining(Time.now - 10)).to be 0
     end
   end
 
   describe "#remaining!" do
     it "returns nil when nil" do
-      expect(described_class.remaining!(nil)).to be_nil
+      expect(klass.remaining!(nil)).to be_nil
     end
 
     it "returns time remaining when there is time remaining" do
-      expect(described_class.remaining!(Time.now + 10)).to be > 1
+      expect(klass.remaining!(Time.now + 10)).to be > 1
     end
 
     it "returns 0 when there is no time remaining" do
-      expect { described_class.remaining!(Time.now - 10) }.to raise_error(Timeout::Error)
+      expect { klass.remaining!(Time.now - 10) }.to raise_error(Timeout::Error)
     end
   end
 end

--- a/Library/Homebrew/test/utils/topological_hash_spec.rb
+++ b/Library/Homebrew/test/utils/topological_hash_spec.rb
@@ -4,9 +4,11 @@
 require "utils/topological_hash"
 
 RSpec.describe Utils::TopologicalHash do
+  let(:klass) { Utils::TopologicalHash }
+
   describe "#tsort" do
     it "returns a topologically sorted array" do
-      hash = described_class.new
+      hash = klass.new
       hash[1] = [2, 3]
       hash[2] = [3]
       hash[3] = []
@@ -17,7 +19,7 @@ RSpec.describe Utils::TopologicalHash do
 
   describe "#strongly_connected_components" do
     it "returns an array of arrays" do
-      hash = described_class.new
+      hash = klass.new
       hash[1] = [2]
       hash[2] = [3, 4]
       hash[3] = [2]
@@ -79,7 +81,7 @@ RSpec.describe Utils::TopologicalHash do
       stub_cask_loader cask3
 
       packages = [formula1, formula2, formula3, formula4, cask1, cask2, cask3]
-      expect(described_class.graph_package_dependencies(packages)).to eq({
+      expect(klass.graph_package_dependencies(packages)).to eq({
         formula1 => [],
         formula2 => [formula1],
         formula3 => [formula4],
@@ -90,10 +92,10 @@ RSpec.describe Utils::TopologicalHash do
       })
 
       sorted = [formula1, cask1, cask2, cask3, formula2]
-      expect(described_class.graph_package_dependencies([cask3, cask2, cask1, formula2, formula1]).tsort).to eq sorted
-      expect(described_class.graph_package_dependencies([cask3, formula2]).tsort).to eq sorted
+      expect(klass.graph_package_dependencies([cask3, cask2, cask1, formula2, formula1]).tsort).to eq sorted
+      expect(klass.graph_package_dependencies([cask3, formula2]).tsort).to eq sorted
 
-      expect { described_class.graph_package_dependencies([formula3, formula4]).tsort }.to raise_error TSort::Cyclic
+      expect { klass.graph_package_dependencies([formula3, formula4]).tsort }.to raise_error TSort::Cyclic
     end
   end
 end

--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -2,30 +2,33 @@
 # frozen_string_literal: true
 
 RSpec.describe Tty do
+  sig { returns(T.class_of(Tty)) }
+  let(:klass) { Tty }
+
   describe "::strip_ansi" do
     it "removes ANSI escape codes from a string" do
-      expect(described_class.strip_ansi("\033[36;7mhello\033[0m")).to eq("hello")
+      expect(klass.strip_ansi("\033[36;7mhello\033[0m")).to eq("hello")
     end
   end
 
   describe "::width" do
     specify do
-      expect(described_class.width).to be_a(Integer)
-      expect(described_class.width).to be >= 0
+      expect(klass.width).to be_a(Integer)
+      expect(klass.width).to be >= 0
     end
   end
 
   describe "::truncate" do
     it "truncates the text to the terminal width, minus 4, to account for '==> '" do
-      allow(described_class).to receive(:width).and_return(15)
+      allow(klass).to receive(:width).and_return(15)
 
-      expect(described_class.truncate("foobar something very long")).to eq("foobar some")
-      expect(described_class.truncate("truncate")).to eq("truncate")
+      expect(klass.truncate("foobar something very long")).to eq("foobar some")
+      expect(klass.truncate("truncate")).to eq("truncate")
     end
 
     it "doesn't truncate the text if the terminal is unsupported, i.e. the width is 0" do
-      allow(described_class).to receive(:width).and_return(0)
-      expect(described_class.truncate("foobar something very long")).to eq("foobar something very long")
+      allow(klass).to receive(:width).and_return(0)
+      expect(klass.truncate("foobar something very long")).to eq("foobar something very long")
     end
   end
 
@@ -35,14 +38,14 @@ RSpec.describe Tty do
     end
 
     it "returns an empty string for all colors" do
-      expect(described_class.to_s).to eq("")
-      expect(described_class.red.to_s).to eq("")
-      expect(described_class.green.to_s).to eq("")
-      expect(described_class.yellow.to_s).to eq("")
-      expect(described_class.blue.to_s).to eq("")
-      expect(described_class.magenta.to_s).to eq("")
-      expect(described_class.cyan.to_s).to eq("")
-      expect(described_class.default.to_s).to eq("")
+      expect(klass.to_s).to eq("")
+      expect(klass.red.to_s).to eq("")
+      expect(klass.green.to_s).to eq("")
+      expect(klass.yellow.to_s).to eq("")
+      expect(klass.blue.to_s).to eq("")
+      expect(klass.magenta.to_s).to eq("")
+      expect(klass.cyan.to_s).to eq("")
+      expect(klass.default.to_s).to eq("")
     end
   end
 
@@ -52,26 +55,26 @@ RSpec.describe Tty do
     end
 
     it "returns ANSI escape codes for colors" do
-      expect(described_class.to_s).to eq("")
-      expect(described_class.red.to_s).to eq("\033[31m")
-      expect(described_class.green.to_s).to eq("\033[32m")
-      expect(described_class.yellow.to_s).to eq("\033[33m")
-      expect(described_class.blue.to_s).to eq("\033[34m")
-      expect(described_class.magenta.to_s).to eq("\033[35m")
-      expect(described_class.cyan.to_s).to eq("\033[36m")
-      expect(described_class.default.to_s).to eq("\033[39m")
+      expect(klass.to_s).to eq("")
+      expect(klass.red.to_s).to eq("\033[31m")
+      expect(klass.green.to_s).to eq("\033[32m")
+      expect(klass.yellow.to_s).to eq("\033[33m")
+      expect(klass.blue.to_s).to eq("\033[34m")
+      expect(klass.magenta.to_s).to eq("\033[35m")
+      expect(klass.cyan.to_s).to eq("\033[36m")
+      expect(klass.default.to_s).to eq("\033[39m")
     end
 
     it "returns an empty string for all colors when HOMEBREW_NO_COLOR is set" do
       ENV["HOMEBREW_NO_COLOR"] = "1"
-      expect(described_class.to_s).to eq("")
-      expect(described_class.red.to_s).to eq("")
-      expect(described_class.green.to_s).to eq("")
-      expect(described_class.yellow.to_s).to eq("")
-      expect(described_class.blue.to_s).to eq("")
-      expect(described_class.magenta.to_s).to eq("")
-      expect(described_class.cyan.to_s).to eq("")
-      expect(described_class.default.to_s).to eq("")
+      expect(klass.to_s).to eq("")
+      expect(klass.red.to_s).to eq("")
+      expect(klass.green.to_s).to eq("")
+      expect(klass.yellow.to_s).to eq("")
+      expect(klass.blue.to_s).to eq("")
+      expect(klass.magenta.to_s).to eq("")
+      expect(klass.cyan.to_s).to eq("")
+      expect(klass.default.to_s).to eq("")
     end
   end
 end

--- a/Library/Homebrew/test/utils/user_spec.rb
+++ b/Library/Homebrew/test/utils/user_spec.rb
@@ -4,7 +4,9 @@
 require "utils/user"
 
 RSpec.describe User do
-  subject(:user) { described_class.current }
+  subject(:user) { klass.current }
+
+  let(:klass) { User }
 
   it { is_expected.to eq ENV.fetch("USER") }
 

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -4,109 +4,111 @@
 require "utils"
 
 RSpec.describe Utils do
+  let(:klass) { Utils }
+
   describe ".deconstantize" do
     it "removes the rightmost segment from the constant expression in the string" do
-      expect(described_class.deconstantize("Net::HTTP")).to eq("Net")
-      expect(described_class.deconstantize("::Net::HTTP")).to eq("::Net")
-      expect(described_class.deconstantize("String")).to eq("")
-      expect(described_class.deconstantize("::String")).to eq("")
+      expect(klass.deconstantize("Net::HTTP")).to eq("Net")
+      expect(klass.deconstantize("::Net::HTTP")).to eq("::Net")
+      expect(klass.deconstantize("String")).to eq("")
+      expect(klass.deconstantize("::String")).to eq("")
     end
 
     it "returns an empty string if the namespace is empty" do
-      expect(described_class.deconstantize("")).to eq("")
-      expect(described_class.deconstantize("::")).to eq("")
+      expect(klass.deconstantize("")).to eq("")
+      expect(klass.deconstantize("::")).to eq("")
     end
   end
 
   describe ".demodulize" do
     it "removes the module part from the expression in the string" do
-      expect(described_class.demodulize("Foo::Bar")).to eq("Bar")
+      expect(klass.demodulize("Foo::Bar")).to eq("Bar")
     end
 
     it "returns the string if it does not contain a module expression" do
-      expect(described_class.demodulize("FooBar")).to eq("FooBar")
+      expect(klass.demodulize("FooBar")).to eq("FooBar")
     end
 
     it "returns an empty string if the namespace is empty" do
-      expect(described_class.demodulize("")).to eq("")
-      expect(described_class.demodulize("::")).to eq("")
+      expect(klass.demodulize("")).to eq("")
+      expect(klass.demodulize("::")).to eq("")
     end
 
     it "raise an ArgumentError when passed nil" do
-      expect { described_class.demodulize(nil) }.to raise_error(ArgumentError)
+      expect { klass.demodulize(nil) }.to raise_error(ArgumentError)
     end
   end
 
   describe ".name_from_full_name" do
     it "returns the package name for a full name" do
-      expect(described_class.name_from_full_name("homebrew/core/wget")).to eq("wget")
+      expect(klass.name_from_full_name("homebrew/core/wget")).to eq("wget")
     end
 
     it "returns untapped names unchanged" do
-      expect(described_class.name_from_full_name("wget")).to eq("wget")
+      expect(klass.name_from_full_name("wget")).to eq("wget")
     end
 
     it "does not treat taps as full names" do
-      expect(described_class.name_from_full_name("homebrew/core")).to eq("homebrew/core")
+      expect(klass.name_from_full_name("homebrew/core")).to eq("homebrew/core")
     end
   end
 
   describe ".tap_from_full_name" do
     it "returns the tap for a full name" do
-      expect(described_class.tap_from_full_name("homebrew/core/wget")).to eq("homebrew/core")
+      expect(klass.tap_from_full_name("homebrew/core/wget")).to eq("homebrew/core")
     end
 
     it "returns nil for untapped names" do
-      expect(described_class.tap_from_full_name("wget")).to be_nil
+      expect(klass.tap_from_full_name("wget")).to be_nil
     end
 
     it "returns nil for tap names" do
-      expect(described_class.tap_from_full_name("homebrew/core")).to be_nil
+      expect(klass.tap_from_full_name("homebrew/core")).to be_nil
     end
   end
 
   specify ".parse_author!" do
     parse_error_msg = /Unable to parse name and email/
 
-    expect(described_class.parse_author!("John Doe <john.doe@example.com>"))
+    expect(klass.parse_author!("John Doe <john.doe@example.com>"))
       .to eq({ name: "John Doe", email: "john.doe@example.com" })
-    expect { described_class.parse_author!("") }
+    expect { klass.parse_author!("") }
       .to raise_error(parse_error_msg)
-    expect { described_class.parse_author!("John Doe") }
+    expect { klass.parse_author!("John Doe") }
       .to raise_error(parse_error_msg)
-    expect { described_class.parse_author!("<john.doe@example.com>") }
+    expect { klass.parse_author!("<john.doe@example.com>") }
       .to raise_error(parse_error_msg)
   end
 
   describe ".pluralize" do
     it "combines the stem with the default suffix based on the count" do
-      expect(described_class.pluralize("foo", 0)).to eq("foos")
-      expect(described_class.pluralize("foo", 1)).to eq("foo")
-      expect(described_class.pluralize("foo", 2)).to eq("foos")
+      expect(klass.pluralize("foo", 0)).to eq("foos")
+      expect(klass.pluralize("foo", 1)).to eq("foo")
+      expect(klass.pluralize("foo", 2)).to eq("foos")
     end
 
     it "combines the stem with the singular suffix based on the count" do
-      expect(described_class.pluralize("foo", 0, singular: "o")).to eq("foos")
-      expect(described_class.pluralize("foo", 1, singular: "o")).to eq("fooo")
-      expect(described_class.pluralize("foo", 2, singular: "o")).to eq("foos")
+      expect(klass.pluralize("foo", 0, singular: "o")).to eq("foos")
+      expect(klass.pluralize("foo", 1, singular: "o")).to eq("fooo")
+      expect(klass.pluralize("foo", 2, singular: "o")).to eq("foos")
     end
 
     it "combines the stem with the plural suffix based on the count" do
-      expect(described_class.pluralize("foo", 0, plural: "es")).to eq("fooes")
-      expect(described_class.pluralize("foo", 1, plural: "es")).to eq("foo")
-      expect(described_class.pluralize("foo", 2, plural: "es")).to eq("fooes")
+      expect(klass.pluralize("foo", 0, plural: "es")).to eq("fooes")
+      expect(klass.pluralize("foo", 1, plural: "es")).to eq("foo")
+      expect(klass.pluralize("foo", 2, plural: "es")).to eq("fooes")
     end
 
     it "combines the stem with the singular and plural suffix based on the count" do
-      expect(described_class.pluralize("foo", 0, singular: "o", plural: "es")).to eq("fooes")
-      expect(described_class.pluralize("foo", 1, singular: "o", plural: "es")).to eq("fooo")
-      expect(described_class.pluralize("foo", 2, singular: "o", plural: "es")).to eq("fooes")
+      expect(klass.pluralize("foo", 0, singular: "o", plural: "es")).to eq("fooes")
+      expect(klass.pluralize("foo", 1, singular: "o", plural: "es")).to eq("fooo")
+      expect(klass.pluralize("foo", 2, singular: "o", plural: "es")).to eq("fooes")
     end
 
     it "includes the count when requested" do
-      expect(described_class.pluralize("foo", 0, include_count: true)).to eq("0 foos")
-      expect(described_class.pluralize("foo", 1, include_count: true)).to eq("1 foo")
-      expect(described_class.pluralize("foo", 2, include_count: true)).to eq("2 foos")
+      expect(klass.pluralize("foo", 0, include_count: true)).to eq("0 foos")
+      expect(klass.pluralize("foo", 1, include_count: true)).to eq("1 foo")
+      expect(klass.pluralize("foo", 2, include_count: true)).to eq("2 foos")
     end
   end
 
@@ -141,16 +143,16 @@ RSpec.describe Utils do
 
     it "converts strings to underscore case" do
       words.each do |camel, under|
-        expect(described_class.underscore(camel)).to eq(under)
-        expect(described_class.underscore(under)).to eq(under)
+        expect(klass.underscore(camel)).to eq(under)
+        expect(klass.underscore(under)).to eq(under)
       end
     end
   end
 
   describe ".convert_to_string_or_symbol" do
     specify(:aggregate_failures) do
-      expect(described_class.convert_to_string_or_symbol(":example")).to eq(:example)
-      expect(described_class.convert_to_string_or_symbol("example")).to eq("example")
+      expect(klass.convert_to_string_or_symbol(":example")).to eq(:example)
+      expect(klass.convert_to_string_or_symbol("example")).to eq("example")
     end
   end
 
@@ -180,8 +182,8 @@ RSpec.describe Utils do
         ":i" => "\\\\also not a symbol", # literal: "\\also not a symbol"
       }
 
-      expect(described_class.deep_stringify_symbols(with_symbols)).to eq(without_symbols)
-      expect(described_class.deep_unstringify_symbols(without_symbols)).to eq(with_symbols)
+      expect(klass.deep_stringify_symbols(with_symbols)).to eq(without_symbols)
+      expect(klass.deep_unstringify_symbols(without_symbols)).to eq(with_symbols)
     end
   end
 
@@ -220,7 +222,7 @@ RSpec.describe Utils do
         n: [2],
       }
 
-      expect(described_class.deep_compact_blank(input)).to eq(expected_output)
+      expect(klass.deep_compact_blank(input)).to eq(expected_output)
     end
   end
 end

--- a/Library/Homebrew/test/version/parser_spec.rb
+++ b/Library/Homebrew/test/version/parser_spec.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
 
 require "version/parser"

--- a/Library/Homebrew/test/version/parser_spec.rb
+++ b/Library/Homebrew/test/version/parser_spec.rb
@@ -4,75 +4,83 @@
 require "version/parser"
 
 RSpec.describe Version::Parser do
+  let(:klass) { Version::Parser }
+
   specify "::new" do
-    expect { described_class.new }
+    expect { klass.new }
       .to raise_error("Version::Parser is declared as abstract; it cannot be instantiated")
   end
 
   describe Version::RegexParser do
+    let(:klass) { Version::RegexParser }
+
     specify "::new" do
-      expect { described_class.new(/[._-](\d+(?:\.\d+)+)/) }
+      expect { klass.new(/[._-](\d+(?:\.\d+)+)/) }
         .to raise_error("Version::RegexParser is declared as abstract; it cannot be instantiated")
     end
 
     specify "::process_spec" do
-      expect { described_class.process_spec(Pathname(TEST_TMPDIR)) }
+      expect { klass.process_spec(Pathname(TEST_TMPDIR)) }
         .to raise_error("The method `process_spec` on #<Class:Version::RegexParser> is declared as `abstract`. " \
                         "It does not have an implementation.")
     end
   end
 
   describe Version::UrlParser do
+    let(:klass) { Version::UrlParser }
+
     specify "::new" do
-      expect { described_class.new(/[._-](\d+(?:\.\d+)+)/) }.not_to raise_error
+      expect { klass.new(/[._-](\d+(?:\.\d+)+)/) }.not_to raise_error
     end
 
     specify "::process_spec" do
-      expect(described_class.process_spec(Pathname("#{TEST_TMPDIR}/testdir-0.1.test")))
+      expect(klass.process_spec(Pathname("#{TEST_TMPDIR}/testdir-0.1.test")))
         .to eq("#{TEST_TMPDIR}/testdir-0.1.test")
 
-      expect(described_class.process_spec(Pathname("https://sourceforge.net/foo_bar-1.21.tar.gz/download")))
+      expect(klass.process_spec(Pathname("https://sourceforge.net/foo_bar-1.21.tar.gz/download")))
         .to eq("https://sourceforge.net/foo_bar-1.21.tar.gz/download")
 
-      expect(described_class.process_spec(Pathname("https://sf.net/foo_bar-1.21.tar.gz/download")))
+      expect(klass.process_spec(Pathname("https://sf.net/foo_bar-1.21.tar.gz/download")))
         .to eq("https://sf.net/foo_bar-1.21.tar.gz/download")
 
-      expect(described_class.process_spec(Pathname("https://brew.sh/testball-0.1")))
+      expect(klass.process_spec(Pathname("https://brew.sh/testball-0.1")))
         .to eq("https://brew.sh/testball-0.1")
 
-      expect(described_class.process_spec(Pathname("https://brew.sh/testball-0.1.tgz")))
+      expect(klass.process_spec(Pathname("https://brew.sh/testball-0.1.tgz")))
         .to eq("https://brew.sh/testball-0.1.tgz")
     end
   end
 
   describe Version::StemParser do
+    let(:klass) { Version::StemParser }
+
     before { Pathname("#{TEST_TMPDIR}/testdir-0.1.test").mkpath }
 
     after { Pathname("#{TEST_TMPDIR}/testdir-0.1.test").unlink }
 
     specify "::new" do
-      expect { described_class.new(/[._-](\d+(?:\.\d+)+)/) }.not_to raise_error
+      expect { klass.new(/[._-](\d+(?:\.\d+)+)/) }.not_to raise_error
     end
 
     describe "::process_spec" do
       it "works with directories" do
-        expect(described_class.process_spec(Pathname("#{TEST_TMPDIR}/testdir-0.1.test"))).to eq("testdir-0.1.test")
+        expect(klass.process_spec(Pathname("#{TEST_TMPDIR}/testdir-0.1.test"))).to eq("testdir-0.1.test")
       end
 
       it "works with SourceForge URLs with /download suffix" do
-        expect(described_class.process_spec(Pathname("https://sourceforge.net/foo_bar-1.21.tar.gz/download")))
+        expect(klass.process_spec(Pathname("https://sourceforge.net/foo_bar-1.21.tar.gz/download")))
           .to eq("foo_bar-1.21")
 
-        expect(described_class.process_spec(Pathname("https://sf.net/foo_bar-1.21.tar.gz/download")))
+        expect(klass.process_spec(Pathname("https://sf.net/foo_bar-1.21.tar.gz/download")))
           .to eq("foo_bar-1.21")
       end
 
       it "works with URLs without file extension" do
-        expect(described_class.process_spec(Pathname("https://brew.sh/testball-0.1"))).to eq("testball-0.1")
+        expect(klass.process_spec(Pathname("https://brew.sh/testball-0.1"))).to eq("testball-0.1")
       end
 
       it "works with URLs with file extension" do
-        expect(described_class.process_spec(Pathname("https://brew.sh/testball-0.1.tgz"))).to eq("testball-0.1")
+        expect(klass.process_spec(Pathname("https://brew.sh/testball-0.1.tgz"))).to eq("testball-0.1")
       end
     end
   end

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -4,43 +4,47 @@
 require "version"
 
 RSpec.describe Version do
-  subject(:version) { described_class.new("1.2.3") }
+  subject(:version) { klass.new("1.2.3") }
+
+  let(:klass) { Version }
 
   specify ".formula_optionally_versioned_regex" do
-    expect(described_class.formula_optionally_versioned_regex("foo")).to match("foo@1.2")
+    expect(klass.formula_optionally_versioned_regex("foo")).to match("foo@1.2")
   end
 
   describe Version::Token do
+    let(:klass) { Version::Token }
+
     specify do
-      expect(described_class.create("foo").inspect).to eq('#<Version::StringToken "foo">')
-      expect(described_class.create("foo").to_s).to eq("foo")
+      expect(klass.create("foo").inspect).to eq('#<Version::StringToken "foo">')
+      expect(klass.create("foo").to_s).to eq("foo")
     end
 
     it "can be compared against nil" do
-      expect(described_class.create("2")).to be > nil
-      expect(described_class.create("p194")).to be > nil
+      expect(klass.create("2")).to be > nil
+      expect(klass.create("p194")).to be > nil
     end
 
     it "can be compared against `Version::NULL_TOKEN`" do
-      expect(described_class.create("2")).to be > Version::NULL_TOKEN
-      expect(described_class.create("p194")).to be > Version::NULL_TOKEN
+      expect(klass.create("2")).to be > Version::NULL_TOKEN
+      expect(klass.create("p194")).to be > Version::NULL_TOKEN
     end
 
     it "can be compared against strings" do
-      expect(described_class.create("2")).to eq "2"
-      expect(described_class.create("p194")).to eq "p194"
-      expect(described_class.create("1")).to eq 1
+      expect(klass.create("2")).to eq "2"
+      expect(klass.create("p194")).to eq "p194"
+      expect(klass.create("1")).to eq 1
     end
 
     specify "comparison returns nil for non-token" do
-      v = described_class.create("1")
+      v = klass.create("1")
       expect(v <=> Object.new).to be_nil
       expect { v > Object.new }.to raise_error(ArgumentError)
     end
 
     describe "#to_str" do
       it "implicitly converts token to string" do
-        expect(String.try_convert(described_class.create("foo"))).not_to be_nil
+        expect(String.try_convert(klass.create("foo"))).not_to be_nil
       end
     end
   end
@@ -77,8 +81,8 @@ RSpec.describe Version do
     subject(:null_version) { Version::NULL }
 
     specify do
-      expect(null_version).to be < described_class.new("1")
-      expect(null_version).not_to be > described_class.new("0")
+      expect(null_version).to be < klass.new("1")
+      expect(null_version).not_to be > klass.new("0")
       expect(null_version).not_to eql(null_version)
     end
 
@@ -118,164 +122,164 @@ RSpec.describe Version do
   end
 
   describe "::NULL_TOKEN" do
-    subject(:null_version) { described_class::NULL_TOKEN }
+    subject(:null_version) { klass::NULL_TOKEN }
 
     specify do
       expect(null_version.inspect).to eq("#<Version::NullToken>")
-      expect(null_version).to eq described_class::NULL_TOKEN
+      expect(null_version).to eq klass::NULL_TOKEN
     end
   end
 
   specify "comparison" do
-    expect(described_class.new("0.1")).to eq described_class.new("0.1.0")
-    expect(described_class.new("0.1")).to be < described_class.new("0.2")
-    expect(described_class.new("1.2.3")).to be > described_class.new("1.2.2")
-    expect(described_class.new("1.2.4")).to be < described_class.new("1.2.4.1")
+    expect(klass.new("0.1")).to eq klass.new("0.1.0")
+    expect(klass.new("0.1")).to be < klass.new("0.2")
+    expect(klass.new("1.2.3")).to be > klass.new("1.2.2")
+    expect(klass.new("1.2.4")).to be < klass.new("1.2.4.1")
 
-    expect(described_class.new("1.2.3")).to be > described_class.new("1.2.3alpha4")
-    expect(described_class.new("1.2.3")).to be > described_class.new("1.2.3beta2")
-    expect(described_class.new("1.2.3")).to be > described_class.new("1.2.3rc3")
-    expect(described_class.new("1.2.3")).to be < described_class.new("1.2.3-p34")
+    expect(klass.new("1.2.3")).to be > klass.new("1.2.3alpha4")
+    expect(klass.new("1.2.3")).to be > klass.new("1.2.3beta2")
+    expect(klass.new("1.2.3")).to be > klass.new("1.2.3rc3")
+    expect(klass.new("1.2.3")).to be < klass.new("1.2.3-p34")
   end
 
   specify "compare" do
-    expect(described_class.new("0.1").compare("==", described_class.new("0.1.0"))).to be true
-    expect(described_class.new("0.1").compare("<", described_class.new("0.2"))).to be true
-    expect(described_class.new("1.2.3").compare(">", described_class.new("1.2.2"))).to be true
-    expect(described_class.new("1.2.4").compare("<", described_class.new("1.2.4.1"))).to be true
-    expect(described_class.new("0.1").compare("!=", described_class.new("0.1.0"))).to be false
-    expect(described_class.new("0.1").compare(">=", described_class.new("0.2"))).to be false
-    expect(described_class.new("1.2.3").compare("<=", described_class.new("1.2.2"))).to be false
-    expect(described_class.new("1.2.4").compare(">=", described_class.new("1.2.4.1"))).to be false
+    expect(klass.new("0.1").compare("==", klass.new("0.1.0"))).to be true
+    expect(klass.new("0.1").compare("<", klass.new("0.2"))).to be true
+    expect(klass.new("1.2.3").compare(">", klass.new("1.2.2"))).to be true
+    expect(klass.new("1.2.4").compare("<", klass.new("1.2.4.1"))).to be true
+    expect(klass.new("0.1").compare("!=", klass.new("0.1.0"))).to be false
+    expect(klass.new("0.1").compare(">=", klass.new("0.2"))).to be false
+    expect(klass.new("1.2.3").compare("<=", klass.new("1.2.2"))).to be false
+    expect(klass.new("1.2.4").compare(">=", klass.new("1.2.4.1"))).to be false
 
-    expect(described_class.new("1.2.3").compare(">", described_class.new("1.2.3alpha4"))).to be true
-    expect(described_class.new("1.2.3").compare(">", described_class.new("1.2.3beta2"))).to be true
-    expect(described_class.new("1.2.3").compare(">", described_class.new("1.2.3rc3"))).to be true
-    expect(described_class.new("1.2.3").compare("<", described_class.new("1.2.3-p34"))).to be true
-    expect(described_class.new("1.2.3").compare("<=", described_class.new("1.2.3alpha4"))).to be false
-    expect(described_class.new("1.2.3").compare("<=", described_class.new("1.2.3beta2"))).to be false
-    expect(described_class.new("1.2.3").compare("<=", described_class.new("1.2.3rc3"))).to be false
-    expect(described_class.new("1.2.3").compare(">=", described_class.new("1.2.3-p34"))).to be false
+    expect(klass.new("1.2.3").compare(">", klass.new("1.2.3alpha4"))).to be true
+    expect(klass.new("1.2.3").compare(">", klass.new("1.2.3beta2"))).to be true
+    expect(klass.new("1.2.3").compare(">", klass.new("1.2.3rc3"))).to be true
+    expect(klass.new("1.2.3").compare("<", klass.new("1.2.3-p34"))).to be true
+    expect(klass.new("1.2.3").compare("<=", klass.new("1.2.3alpha4"))).to be false
+    expect(klass.new("1.2.3").compare("<=", klass.new("1.2.3beta2"))).to be false
+    expect(klass.new("1.2.3").compare("<=", klass.new("1.2.3rc3"))).to be false
+    expect(klass.new("1.2.3").compare(">=", klass.new("1.2.3-p34"))).to be false
   end
 
   specify "HEAD" do
-    expect(described_class.new("HEAD")).to be > described_class.new("1.2.3")
-    expect(described_class.new("HEAD-abcdef")).to be > described_class.new("1.2.3")
-    expect(described_class.new("1.2.3")).to be < described_class.new("HEAD")
-    expect(described_class.new("1.2.3")).to be < described_class.new("HEAD-fedcba")
-    expect(described_class.new("HEAD-abcdef")).to eq described_class.new("HEAD-fedcba")
-    expect(described_class.new("HEAD")).to eq described_class.new("HEAD-fedcba")
+    expect(klass.new("HEAD")).to be > klass.new("1.2.3")
+    expect(klass.new("HEAD-abcdef")).to be > klass.new("1.2.3")
+    expect(klass.new("1.2.3")).to be < klass.new("HEAD")
+    expect(klass.new("1.2.3")).to be < klass.new("HEAD-fedcba")
+    expect(klass.new("HEAD-abcdef")).to eq klass.new("HEAD-fedcba")
+    expect(klass.new("HEAD")).to eq klass.new("HEAD-fedcba")
   end
 
   specify "comparing alpha versions" do
-    expect(described_class.new("1.2.3alpha")).to be < described_class.new("1.2.3")
-    expect(described_class.new("1.2.3")).to be < described_class.new("1.2.3a")
-    expect(described_class.new("1.2.3alpha4")).to eq described_class.new("1.2.3a4")
-    expect(described_class.new("1.2.3alpha4")).to eq described_class.new("1.2.3A4")
-    expect(described_class.new("1.2.3alpha4")).to be > described_class.new("1.2.3alpha3")
-    expect(described_class.new("1.2.3alpha4")).to be < described_class.new("1.2.3alpha5")
-    expect(described_class.new("1.2.3alpha4")).to be < described_class.new("1.2.3alpha10")
+    expect(klass.new("1.2.3alpha")).to be < klass.new("1.2.3")
+    expect(klass.new("1.2.3")).to be < klass.new("1.2.3a")
+    expect(klass.new("1.2.3alpha4")).to eq klass.new("1.2.3a4")
+    expect(klass.new("1.2.3alpha4")).to eq klass.new("1.2.3A4")
+    expect(klass.new("1.2.3alpha4")).to be > klass.new("1.2.3alpha3")
+    expect(klass.new("1.2.3alpha4")).to be < klass.new("1.2.3alpha5")
+    expect(klass.new("1.2.3alpha4")).to be < klass.new("1.2.3alpha10")
 
-    expect(described_class.new("1.2.3alpha4")).to be < described_class.new("1.2.3beta2")
-    expect(described_class.new("1.2.3alpha4")).to be < described_class.new("1.2.3rc3")
-    expect(described_class.new("1.2.3alpha4")).to be < described_class.new("1.2.3")
-    expect(described_class.new("1.2.3alpha4")).to be < described_class.new("1.2.3-p34")
+    expect(klass.new("1.2.3alpha4")).to be < klass.new("1.2.3beta2")
+    expect(klass.new("1.2.3alpha4")).to be < klass.new("1.2.3rc3")
+    expect(klass.new("1.2.3alpha4")).to be < klass.new("1.2.3")
+    expect(klass.new("1.2.3alpha4")).to be < klass.new("1.2.3-p34")
   end
 
   specify "comparing beta versions" do
-    expect(described_class.new("1.2.3beta2")).to eq described_class.new("1.2.3b2")
-    expect(described_class.new("1.2.3beta2")).to eq described_class.new("1.2.3B2")
-    expect(described_class.new("1.2.3beta2")).to be > described_class.new("1.2.3beta1")
-    expect(described_class.new("1.2.3beta2")).to be < described_class.new("1.2.3beta3")
-    expect(described_class.new("1.2.3beta2")).to be < described_class.new("1.2.3beta10")
+    expect(klass.new("1.2.3beta2")).to eq klass.new("1.2.3b2")
+    expect(klass.new("1.2.3beta2")).to eq klass.new("1.2.3B2")
+    expect(klass.new("1.2.3beta2")).to be > klass.new("1.2.3beta1")
+    expect(klass.new("1.2.3beta2")).to be < klass.new("1.2.3beta3")
+    expect(klass.new("1.2.3beta2")).to be < klass.new("1.2.3beta10")
 
-    expect(described_class.new("1.2.3beta2")).to be > described_class.new("1.2.3alpha4")
-    expect(described_class.new("1.2.3beta2")).to be < described_class.new("1.2.3rc3")
-    expect(described_class.new("1.2.3beta2")).to be < described_class.new("1.2.3")
-    expect(described_class.new("1.2.3beta2")).to be < described_class.new("1.2.3-p34")
+    expect(klass.new("1.2.3beta2")).to be > klass.new("1.2.3alpha4")
+    expect(klass.new("1.2.3beta2")).to be < klass.new("1.2.3rc3")
+    expect(klass.new("1.2.3beta2")).to be < klass.new("1.2.3")
+    expect(klass.new("1.2.3beta2")).to be < klass.new("1.2.3-p34")
   end
 
   specify "comparing pre versions" do
-    expect(described_class.new("1.2.3pre9")).to eq described_class.new("1.2.3PRE9")
-    expect(described_class.new("1.2.3pre9")).to be > described_class.new("1.2.3pre8")
-    expect(described_class.new("1.2.3pre8")).to be < described_class.new("1.2.3pre9")
-    expect(described_class.new("1.2.3pre9")).to be < described_class.new("1.2.3pre10")
+    expect(klass.new("1.2.3pre9")).to eq klass.new("1.2.3PRE9")
+    expect(klass.new("1.2.3pre9")).to be > klass.new("1.2.3pre8")
+    expect(klass.new("1.2.3pre8")).to be < klass.new("1.2.3pre9")
+    expect(klass.new("1.2.3pre9")).to be < klass.new("1.2.3pre10")
 
-    expect(described_class.new("1.2.3pre3")).to be > described_class.new("1.2.3alpha2")
-    expect(described_class.new("1.2.3pre3")).to be > described_class.new("1.2.3alpha4")
-    expect(described_class.new("1.2.3pre3")).to be > described_class.new("1.2.3beta3")
-    expect(described_class.new("1.2.3pre3")).to be > described_class.new("1.2.3beta5")
-    expect(described_class.new("1.2.3pre3")).to be < described_class.new("1.2.3rc2")
-    expect(described_class.new("1.2.3pre3")).to be < described_class.new("1.2.3")
-    expect(described_class.new("1.2.3pre3")).to be < described_class.new("1.2.3-p2")
+    expect(klass.new("1.2.3pre3")).to be > klass.new("1.2.3alpha2")
+    expect(klass.new("1.2.3pre3")).to be > klass.new("1.2.3alpha4")
+    expect(klass.new("1.2.3pre3")).to be > klass.new("1.2.3beta3")
+    expect(klass.new("1.2.3pre3")).to be > klass.new("1.2.3beta5")
+    expect(klass.new("1.2.3pre3")).to be < klass.new("1.2.3rc2")
+    expect(klass.new("1.2.3pre3")).to be < klass.new("1.2.3")
+    expect(klass.new("1.2.3pre3")).to be < klass.new("1.2.3-p2")
   end
 
   specify "comparing RC versions" do
-    expect(described_class.new("1.2.3rc3")).to eq described_class.new("1.2.3RC3")
-    expect(described_class.new("1.2.3rc3")).to be > described_class.new("1.2.3rc2")
-    expect(described_class.new("1.2.3rc3")).to be < described_class.new("1.2.3rc4")
-    expect(described_class.new("1.2.3rc3")).to be < described_class.new("1.2.3rc10")
+    expect(klass.new("1.2.3rc3")).to eq klass.new("1.2.3RC3")
+    expect(klass.new("1.2.3rc3")).to be > klass.new("1.2.3rc2")
+    expect(klass.new("1.2.3rc3")).to be < klass.new("1.2.3rc4")
+    expect(klass.new("1.2.3rc3")).to be < klass.new("1.2.3rc10")
 
-    expect(described_class.new("1.2.3rc3")).to be > described_class.new("1.2.3alpha4")
-    expect(described_class.new("1.2.3rc3")).to be > described_class.new("1.2.3beta2")
-    expect(described_class.new("1.2.3rc3")).to be < described_class.new("1.2.3")
-    expect(described_class.new("1.2.3rc3")).to be < described_class.new("1.2.3-p34")
+    expect(klass.new("1.2.3rc3")).to be > klass.new("1.2.3alpha4")
+    expect(klass.new("1.2.3rc3")).to be > klass.new("1.2.3beta2")
+    expect(klass.new("1.2.3rc3")).to be < klass.new("1.2.3")
+    expect(klass.new("1.2.3rc3")).to be < klass.new("1.2.3-p34")
   end
 
   specify "comparing patch-level versions" do
-    expect(described_class.new("1.2.3-p34")).to eq described_class.new("1.2.3-P34")
-    expect(described_class.new("1.2.3-p34")).to be > described_class.new("1.2.3-p33")
-    expect(described_class.new("1.2.3-p34")).to be < described_class.new("1.2.3-p35")
-    expect(described_class.new("1.2.3-p34")).to be > described_class.new("1.2.3-p9")
+    expect(klass.new("1.2.3-p34")).to eq klass.new("1.2.3-P34")
+    expect(klass.new("1.2.3-p34")).to be > klass.new("1.2.3-p33")
+    expect(klass.new("1.2.3-p34")).to be < klass.new("1.2.3-p35")
+    expect(klass.new("1.2.3-p34")).to be > klass.new("1.2.3-p9")
 
-    expect(described_class.new("1.2.3-p34")).to be > described_class.new("1.2.3alpha4")
-    expect(described_class.new("1.2.3-p34")).to be > described_class.new("1.2.3beta2")
-    expect(described_class.new("1.2.3-p34")).to be > described_class.new("1.2.3rc3")
-    expect(described_class.new("1.2.3-p34")).to be > described_class.new("1.2.3")
+    expect(klass.new("1.2.3-p34")).to be > klass.new("1.2.3alpha4")
+    expect(klass.new("1.2.3-p34")).to be > klass.new("1.2.3beta2")
+    expect(klass.new("1.2.3-p34")).to be > klass.new("1.2.3rc3")
+    expect(klass.new("1.2.3-p34")).to be > klass.new("1.2.3")
   end
 
   specify "comparing post-level versions" do
-    expect(described_class.new("1.2.3.post34")).to be > described_class.new("1.2.3.post33")
-    expect(described_class.new("1.2.3.post34")).to be < described_class.new("1.2.3.post35")
+    expect(klass.new("1.2.3.post34")).to be > klass.new("1.2.3.post33")
+    expect(klass.new("1.2.3.post34")).to be < klass.new("1.2.3.post35")
 
-    expect(described_class.new("1.2.3.post34")).to be > described_class.new("1.2.3rc35")
-    expect(described_class.new("1.2.3.post34")).to be > described_class.new("1.2.3alpha35")
-    expect(described_class.new("1.2.3.post34")).to be > described_class.new("1.2.3beta35")
-    expect(described_class.new("1.2.3.post34")).to be > described_class.new("1.2.3")
+    expect(klass.new("1.2.3.post34")).to be > klass.new("1.2.3rc35")
+    expect(klass.new("1.2.3.post34")).to be > klass.new("1.2.3alpha35")
+    expect(klass.new("1.2.3.post34")).to be > klass.new("1.2.3beta35")
+    expect(klass.new("1.2.3.post34")).to be > klass.new("1.2.3")
   end
 
   specify "comparing unevenly-padded versions" do
-    expect(described_class.new("2.1.0-p194")).to be < described_class.new("2.1-p195")
-    expect(described_class.new("2.1-p195")).to be > described_class.new("2.1.0-p194")
-    expect(described_class.new("2.1-p194")).to be < described_class.new("2.1.0-p195")
-    expect(described_class.new("2.1.0-p195")).to be > described_class.new("2.1-p194")
-    expect(described_class.new("2-p194")).to be < described_class.new("2.1-p195")
+    expect(klass.new("2.1.0-p194")).to be < klass.new("2.1-p195")
+    expect(klass.new("2.1-p195")).to be > klass.new("2.1.0-p194")
+    expect(klass.new("2.1-p194")).to be < klass.new("2.1.0-p195")
+    expect(klass.new("2.1.0-p195")).to be > klass.new("2.1-p194")
+    expect(klass.new("2-p194")).to be < klass.new("2.1-p195")
   end
 
   it "can be compared against nil" do
-    expect(described_class.new("2.1.0-p194")).to be > nil
+    expect(klass.new("2.1.0-p194")).to be > nil
   end
 
   it "can be compared against Version::NULL" do
-    expect(described_class.new("2.1.0-p194")).to be > Version::NULL
+    expect(klass.new("2.1.0-p194")).to be > Version::NULL
   end
 
   it "can be compared against strings" do
-    expect(described_class.new("2.1.0-p194")).to eq "2.1.0-p194"
-    expect(described_class.new("1")).to eq 1
+    expect(klass.new("2.1.0-p194")).to eq "2.1.0-p194"
+    expect(klass.new("1")).to eq 1
   end
 
   it "can be compared against tokens" do
-    expect(described_class.new("2.1.0-p194")).to be > Version::Token.create("2")
-    expect(described_class.new("1")).to eq Version::Token.create("1")
+    expect(klass.new("2.1.0-p194")).to be > Version::Token.create("2")
+    expect(klass.new("1")).to eq Version::Token.create("1")
   end
 
   it "can be compared against Version::NULL_TOKEN" do
-    expect(described_class.new("2.1.0-p194")).to be > Version::NULL_TOKEN
+    expect(klass.new("2.1.0-p194")).to be > Version::NULL_TOKEN
   end
 
   specify "comparison returns nil for non-version" do
-    v = described_class.new("1.0")
+    v = klass.new("1.0")
     expect(v <=> Object.new).to be_nil
     expect { v > Object.new }.to raise_error(ArgumentError)
   end
@@ -283,13 +287,13 @@ RSpec.describe Version do
   specify "erlang versions" do
     versions = %w[R16B R15B03-1 R15B03 R15B02 R15B01 R14B04 R14B03
                   R14B02 R14B01 R14B R13B04 R13B03 R13B02-1].reverse
-    expect(versions.sort_by { |v| described_class.new(v) }).to eq(versions)
+    expect(versions.sort_by { |v| klass.new(v) }).to eq(versions)
   end
 
   specify "hash equality" do
-    v1 = described_class.new("0.1.0")
-    v2 = described_class.new("0.1.0")
-    v3 = described_class.new("0.1.1")
+    v1 = klass.new("0.1.0")
+    v2 = klass.new("0.1.0")
+    v3 = klass.new("0.1.1")
 
     expect(v1).to eql(v2)
     expect(v1).not_to eql(v3)
@@ -302,25 +306,25 @@ RSpec.describe Version do
 
   describe "::new" do
     it "raises a TypeError for non-string objects" do
-      expect { described_class.new(1.1) }.to raise_error(TypeError)
-      expect { described_class.new(1) }.to raise_error(TypeError)
-      expect { described_class.new(:symbol) }.to raise_error(TypeError)
+      expect { klass.new(1.1) }.to raise_error(TypeError)
+      expect { klass.new(1) }.to raise_error(TypeError)
+      expect { klass.new(:symbol) }.to raise_error(TypeError)
     end
 
     it "parses a version from a string" do
-      v = described_class.new("1.20")
+      v = klass.new("1.20")
       expect(v).not_to be_head
       expect(v.to_str).to eq("1.20")
     end
 
     specify "HEAD with commit" do
-      v = described_class.new("HEAD-abcdef")
+      v = klass.new("HEAD-abcdef")
       expect(v.commit).to eq("abcdef")
       expect(v.to_str).to eq("HEAD-abcdef")
     end
 
     specify "HEAD without commit" do
-      v = described_class.new("HEAD")
+      v = klass.new("HEAD")
       expect(v.commit).to be_nil
       expect(v.to_str).to eq("HEAD")
     end
@@ -328,11 +332,11 @@ RSpec.describe Version do
 
   describe "#detected_from_url?" do
     it "is false if created explicitly" do
-      expect(described_class.new("1.0.0")).not_to be_detected_from_url
+      expect(klass.new("1.0.0")).not_to be_detected_from_url
     end
 
     it "is true if the version was detected from a URL" do
-      version = described_class.detect("https://example.org/archive-1.0.0.tar.gz")
+      version = klass.detect("https://example.org/archive-1.0.0.tar.gz")
 
       expect(version).to eq "1.0.0"
       expect(version).to be_detected_from_url
@@ -340,16 +344,16 @@ RSpec.describe Version do
   end
 
   specify "#head?" do
-    v1 = described_class.new("HEAD-abcdef")
-    v2 = described_class.new("HEAD")
+    v1 = klass.new("HEAD-abcdef")
+    v2 = klass.new("HEAD")
 
     expect(v1).to be_head
     expect(v2).to be_head
   end
 
   specify "#update_commit" do
-    v1 = described_class.new("HEAD-abcdef")
-    v2 = described_class.new("HEAD")
+    v1 = klass.new("HEAD-abcdef")
+    v2 = klass.new("HEAD")
 
     v1.update_commit("ffffff")
     expect(v1.commit).to eq("ffffff")
@@ -362,85 +366,85 @@ RSpec.describe Version do
 
   describe "#major" do
     it "returns major version token" do
-      expect(described_class.new("1").major).to eq Version::Token.create("1")
-      expect(described_class.new("1.2").major).to eq Version::Token.create("1")
-      expect(described_class.new("1.2.3").major).to eq Version::Token.create("1")
-      expect(described_class.new("1.2.3alpha").major).to eq Version::Token.create("1")
-      expect(described_class.new("1.2.3alpha4").major).to eq Version::Token.create("1")
-      expect(described_class.new("1.2.3beta4").major).to eq Version::Token.create("1")
-      expect(described_class.new("1.2.3pre4").major).to eq Version::Token.create("1")
-      expect(described_class.new("1.2.3rc4").major).to eq Version::Token.create("1")
-      expect(described_class.new("1.2.3-p4").major).to eq Version::Token.create("1")
+      expect(klass.new("1").major).to eq Version::Token.create("1")
+      expect(klass.new("1.2").major).to eq Version::Token.create("1")
+      expect(klass.new("1.2.3").major).to eq Version::Token.create("1")
+      expect(klass.new("1.2.3alpha").major).to eq Version::Token.create("1")
+      expect(klass.new("1.2.3alpha4").major).to eq Version::Token.create("1")
+      expect(klass.new("1.2.3beta4").major).to eq Version::Token.create("1")
+      expect(klass.new("1.2.3pre4").major).to eq Version::Token.create("1")
+      expect(klass.new("1.2.3rc4").major).to eq Version::Token.create("1")
+      expect(klass.new("1.2.3-p4").major).to eq Version::Token.create("1")
     end
   end
 
   describe "#minor" do
     it "returns minor version token" do
-      expect(described_class.new("1").minor).to be_nil
-      expect(described_class.new("1.2").minor).to eq Version::Token.create("2")
-      expect(described_class.new("1.2.3").minor).to eq Version::Token.create("2")
-      expect(described_class.new("1.2.3alpha").minor).to eq Version::Token.create("2")
-      expect(described_class.new("1.2.3alpha4").minor).to eq Version::Token.create("2")
-      expect(described_class.new("1.2.3beta4").minor).to eq Version::Token.create("2")
-      expect(described_class.new("1.2.3pre4").minor).to eq Version::Token.create("2")
-      expect(described_class.new("1.2.3rc4").minor).to eq Version::Token.create("2")
-      expect(described_class.new("1.2.3-p4").minor).to eq Version::Token.create("2")
+      expect(klass.new("1").minor).to be_nil
+      expect(klass.new("1.2").minor).to eq Version::Token.create("2")
+      expect(klass.new("1.2.3").minor).to eq Version::Token.create("2")
+      expect(klass.new("1.2.3alpha").minor).to eq Version::Token.create("2")
+      expect(klass.new("1.2.3alpha4").minor).to eq Version::Token.create("2")
+      expect(klass.new("1.2.3beta4").minor).to eq Version::Token.create("2")
+      expect(klass.new("1.2.3pre4").minor).to eq Version::Token.create("2")
+      expect(klass.new("1.2.3rc4").minor).to eq Version::Token.create("2")
+      expect(klass.new("1.2.3-p4").minor).to eq Version::Token.create("2")
     end
   end
 
   describe "#patch" do
     it "returns patch version token" do
-      expect(described_class.new("1").patch).to be_nil
-      expect(described_class.new("1.2").patch).to be_nil
-      expect(described_class.new("1.2.3").patch).to eq Version::Token.create("3")
-      expect(described_class.new("1.2.3alpha").patch).to eq Version::Token.create("3")
-      expect(described_class.new("1.2.3alpha4").patch).to eq Version::Token.create("3")
-      expect(described_class.new("1.2.3beta4").patch).to eq Version::Token.create("3")
-      expect(described_class.new("1.2.3pre4").patch).to eq Version::Token.create("3")
-      expect(described_class.new("1.2.3rc4").patch).to eq Version::Token.create("3")
-      expect(described_class.new("1.2.3-p4").patch).to eq Version::Token.create("3")
+      expect(klass.new("1").patch).to be_nil
+      expect(klass.new("1.2").patch).to be_nil
+      expect(klass.new("1.2.3").patch).to eq Version::Token.create("3")
+      expect(klass.new("1.2.3alpha").patch).to eq Version::Token.create("3")
+      expect(klass.new("1.2.3alpha4").patch).to eq Version::Token.create("3")
+      expect(klass.new("1.2.3beta4").patch).to eq Version::Token.create("3")
+      expect(klass.new("1.2.3pre4").patch).to eq Version::Token.create("3")
+      expect(klass.new("1.2.3rc4").patch).to eq Version::Token.create("3")
+      expect(klass.new("1.2.3-p4").patch).to eq Version::Token.create("3")
     end
   end
 
   describe "#major_minor" do
     it "returns major.minor version" do
-      expect(described_class.new("1").major_minor).to eq described_class.new("1")
-      expect(described_class.new("1.2").major_minor).to eq described_class.new("1.2")
-      expect(described_class.new("1.2.3").major_minor).to eq described_class.new("1.2")
-      expect(described_class.new("1.2.3alpha").major_minor).to eq described_class.new("1.2")
-      expect(described_class.new("1.2.3alpha4").major_minor).to eq described_class.new("1.2")
-      expect(described_class.new("1.2.3beta4").major_minor).to eq described_class.new("1.2")
-      expect(described_class.new("1.2.3pre4").major_minor).to eq described_class.new("1.2")
-      expect(described_class.new("1.2.3rc4").major_minor).to eq described_class.new("1.2")
-      expect(described_class.new("1.2.3-p4").major_minor).to eq described_class.new("1.2")
+      expect(klass.new("1").major_minor).to eq klass.new("1")
+      expect(klass.new("1.2").major_minor).to eq klass.new("1.2")
+      expect(klass.new("1.2.3").major_minor).to eq klass.new("1.2")
+      expect(klass.new("1.2.3alpha").major_minor).to eq klass.new("1.2")
+      expect(klass.new("1.2.3alpha4").major_minor).to eq klass.new("1.2")
+      expect(klass.new("1.2.3beta4").major_minor).to eq klass.new("1.2")
+      expect(klass.new("1.2.3pre4").major_minor).to eq klass.new("1.2")
+      expect(klass.new("1.2.3rc4").major_minor).to eq klass.new("1.2")
+      expect(klass.new("1.2.3-p4").major_minor).to eq klass.new("1.2")
     end
   end
 
   describe "#major_minor_patch" do
     it "returns major.minor.patch version" do
-      expect(described_class.new("1").major_minor_patch).to eq described_class.new("1")
-      expect(described_class.new("1.2").major_minor_patch).to eq described_class.new("1.2")
-      expect(described_class.new("1.2.3").major_minor_patch).to eq described_class.new("1.2.3")
-      expect(described_class.new("1.2.3alpha").major_minor_patch).to eq described_class.new("1.2.3")
-      expect(described_class.new("1.2.3alpha4").major_minor_patch).to eq described_class.new("1.2.3")
-      expect(described_class.new("1.2.3beta4").major_minor_patch).to eq described_class.new("1.2.3")
-      expect(described_class.new("1.2.3pre4").major_minor_patch).to eq described_class.new("1.2.3")
-      expect(described_class.new("1.2.3rc4").major_minor_patch).to eq described_class.new("1.2.3")
-      expect(described_class.new("1.2.3-p4").major_minor_patch).to eq described_class.new("1.2.3")
+      expect(klass.new("1").major_minor_patch).to eq klass.new("1")
+      expect(klass.new("1.2").major_minor_patch).to eq klass.new("1.2")
+      expect(klass.new("1.2.3").major_minor_patch).to eq klass.new("1.2.3")
+      expect(klass.new("1.2.3alpha").major_minor_patch).to eq klass.new("1.2.3")
+      expect(klass.new("1.2.3alpha4").major_minor_patch).to eq klass.new("1.2.3")
+      expect(klass.new("1.2.3beta4").major_minor_patch).to eq klass.new("1.2.3")
+      expect(klass.new("1.2.3pre4").major_minor_patch).to eq klass.new("1.2.3")
+      expect(klass.new("1.2.3rc4").major_minor_patch).to eq klass.new("1.2.3")
+      expect(klass.new("1.2.3-p4").major_minor_patch).to eq klass.new("1.2.3")
     end
   end
 
   describe "::parse" do
     it "returns a NULL version when the URL cannot be parsed" do
-      expect(described_class.parse("https://brew.sh/blah.tar")).to be_null
-      expect(described_class.parse("foo")).to be_null
+      expect(klass.parse("https://brew.sh/blah.tar")).to be_null
+      expect(klass.parse("foo")).to be_null
     end
   end
 
   describe "::detect" do
     matcher :be_detected_from do |url, **specs|
       match do |expected|
-        @detected = described_class.detect(url, **specs)
+        @detected = klass.detect(url, **specs)
         @detected == expected
       end
 
@@ -454,364 +458,364 @@ RSpec.describe Version do
     end
 
     specify "version all dots" do
-      expect(described_class.new("1.14"))
+      expect(klass.new("1.14"))
         .to be_detected_from("https://brew.sh/foo.bar.la.1.14.zip")
     end
 
     specify "version underscore separator" do
-      expect(described_class.new("1.1"))
+      expect(klass.new("1.1"))
         .to be_detected_from("https://brew.sh/grc_1.1.tar.gz")
     end
 
     specify "boost version style" do
-      expect(described_class.new("1.39.0"))
+      expect(klass.new("1.39.0"))
         .to be_detected_from("https://brew.sh/boost_1_39_0.tar.bz2")
     end
 
     specify "erlang version style" do
-      expect(described_class.new("R13B"))
+      expect(klass.new("R13B"))
         .to be_detected_from("https://erlang.org/download/otp_src_R13B.tar.gz")
     end
 
     specify "another erlang version style" do
-      expect(described_class.new("R15B01"))
+      expect(klass.new("R15B01"))
         .to be_detected_from("https://github.com/erlang/otp/tarball/OTP_R15B01")
     end
 
     specify "yet another erlang version style" do
-      expect(described_class.new("R15B03-1"))
+      expect(klass.new("R15B03-1"))
         .to be_detected_from("https://github.com/erlang/otp/tarball/OTP_R15B03-1")
     end
 
     specify "p7zip version style" do
-      expect(described_class.new("9.04"))
+      expect(klass.new("9.04"))
         .to be_detected_from("https://kent.dl.sourceforge.net/sourceforge/p7zip/p7zip_9.04_src_all.tar.bz2")
     end
 
     specify "new github style" do
-      expect(described_class.new("1.1.4"))
+      expect(klass.new("1.1.4"))
         .to be_detected_from("https://github.com/sam-github/libnet/tarball/libnet-1.1.4")
     end
 
     specify "codeload style" do
-      expect(described_class.new("0.7.1"))
+      expect(klass.new("0.7.1"))
         .to be_detected_from("https://codeload.github.com/gsamokovarov/jump/tar.gz/v0.7.1")
     end
 
     specify "gloox beta style" do
-      expect(described_class.new("1.0-beta7"))
+      expect(klass.new("1.0-beta7"))
         .to be_detected_from("https://camaya.net/download/gloox-1.0-beta7.tar.bz2")
     end
 
     specify "sphinx beta style" do
-      expect(described_class.new("1.10-beta"))
+      expect(klass.new("1.10-beta"))
         .to be_detected_from("http://sphinxsearch.com/downloads/sphinx-1.10-beta.tar.gz")
     end
 
     specify "astyle version style" do
-      expect(described_class.new("1.23"))
+      expect(klass.new("1.23"))
         .to be_detected_from("https://kent.dl.sourceforge.net/sourceforge/astyle/astyle_1.23_macosx.tar.gz")
     end
 
     specify "version dos2unix" do
-      expect(described_class.new("3.1"))
+      expect(klass.new("3.1"))
         .to be_detected_from("http://www.sfr-fresh.com/linux/misc/dos2unix-3.1.tar.gz")
     end
 
     specify "version internal dash" do
-      expect(described_class.new("1.1-2"))
+      expect(klass.new("1.1-2"))
         .to be_detected_from("https://brew.sh/foo-arse-1.1-2.tar.gz")
-      expect(described_class.new("3.3.04-1"))
+      expect(klass.new("3.3.04-1"))
         .to be_detected_from("https://brew.sh/3.3.04-1.tar.gz")
-      expect(described_class.new("1.2-20200102"))
+      expect(klass.new("1.2-20200102"))
         .to be_detected_from("https://brew.sh/v1.2-20200102.tar.gz")
-      expect(described_class.new("3.6.6-0.2"))
+      expect(klass.new("3.6.6-0.2"))
         .to be_detected_from("https://brew.sh/v3.6.6-0.2.tar.gz")
     end
 
     specify "version single digit" do
-      expect(described_class.new("45"))
+      expect(klass.new("45"))
         .to be_detected_from("https://brew.sh/foo_bar.45.tar.gz")
     end
 
     specify "noseparator single digit" do
-      expect(described_class.new("45"))
+      expect(klass.new("45"))
         .to be_detected_from("https://brew.sh/foo_bar45.tar.gz")
     end
 
     specify "version developer that hates us format" do
-      expect(described_class.new("1.2.3"))
+      expect(klass.new("1.2.3"))
         .to be_detected_from("https://brew.sh/foo-bar-la.1.2.3.tar.gz")
     end
 
     specify "version regular" do
-      expect(described_class.new("1.21"))
+      expect(klass.new("1.21"))
         .to be_detected_from("https://brew.sh/foo_bar-1.21.tar.gz")
     end
 
     specify "version sourceforge download" do
-      expect(described_class.new("1.21"))
+      expect(klass.new("1.21"))
         .to be_detected_from("https://sourceforge.net/foo_bar-1.21.tar.gz/download")
-      expect(described_class.new("1.21"))
+      expect(klass.new("1.21"))
         .to be_detected_from("https://sf.net/foo_bar-1.21.tar.gz/download")
     end
 
     specify "version github" do
-      expect(described_class.new("1.0.5"))
+      expect(klass.new("1.0.5"))
         .to be_detected_from("https://github.com/lloyd/yajl/tarball/1.0.5")
     end
 
     specify "version github with high patch number" do
-      expect(described_class.new("1.2.34"))
+      expect(klass.new("1.2.34"))
         .to be_detected_from("https://github.com/lloyd/yajl/tarball/v1.2.34")
     end
 
     specify "yet another version" do
-      expect(described_class.new("0.15.1b"))
+      expect(klass.new("0.15.1b"))
         .to be_detected_from("https://brew.sh/mad-0.15.1b.tar.gz")
     end
 
     specify "lame version style" do
-      expect(described_class.new("398-2"))
+      expect(klass.new("398-2"))
         .to be_detected_from("https://kent.dl.sourceforge.net/sourceforge/lame/lame-398-2.tar.gz")
     end
 
     specify "ruby version style" do
-      expect(described_class.new("1.9.1-p243"))
+      expect(klass.new("1.9.1-p243"))
         .to be_detected_from("ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p243.tar.gz")
     end
 
     specify "omega version style" do
-      expect(described_class.new("0.80.2"))
+      expect(klass.new("0.80.2"))
         .to be_detected_from("http://www.alcyone.com/binaries/omega/omega-0.80.2-src.tar.gz")
     end
 
     specify "rc style" do
-      expect(described_class.new("1.2.2rc1"))
+      expect(klass.new("1.2.2rc1"))
         .to be_detected_from("https://downloads.xiph.org/releases/vorbis/libvorbis-1.2.2rc1.tar.bz2")
     end
 
     specify "dash rc style" do
-      expect(described_class.new("1.8.0-rc1"))
+      expect(klass.new("1.8.0-rc1"))
         .to be_detected_from("https://ftp.mozilla.org/pub/mozilla.org/js/js-1.8.0-rc1.tar.gz")
     end
 
     specify "angband version style" do
-      expect(described_class.new("3.0.9b"))
+      expect(klass.new("3.0.9b"))
         .to be_detected_from("http://rephial.org/downloads/3.0/angband-3.0.9b-src.tar.gz")
     end
 
     specify "stable suffix" do
-      expect(described_class.new("1.4.14b"))
+      expect(klass.new("1.4.14b"))
         .to be_detected_from("https://www.monkey.org/~provos/libevent-1.4.14b-stable.tar.gz")
     end
 
     specify "debian style" do
-      expect(described_class.new("3.03"))
+      expect(klass.new("3.03"))
         .to be_detected_from("https://ftp.de.debian.org/debian/pool/main/s/sl/sl_3.03.orig.tar.gz")
     end
 
     specify "debian style with letter suffix" do
-      expect(described_class.new("1.01b"))
+      expect(klass.new("1.01b"))
         .to be_detected_from("https://ftp.de.debian.org/debian/pool/main/m/mmv/mmv_1.01b.orig.tar.gz")
     end
 
     specify "debian style dotless" do
-      expect(described_class.new("1"))
+      expect(klass.new("1"))
         .to be_detected_from("https://deb.debian.org/debian/pool/main/e/example/example_1.orig.tar.gz")
-      expect(described_class.new("20040914"))
+      expect(klass.new("20040914"))
         .to be_detected_from("https://deb.debian.org/debian/pool/main/e/example/example_20040914.orig.tar.gz")
     end
 
     specify "bottle style" do
-      expect(described_class.new("4.8.0"))
+      expect(klass.new("4.8.0"))
         .to be_detected_from("https://homebrew.bintray.com/bottles/qt-4.8.0.lion.bottle.tar.gz")
     end
 
     specify "versioned bottle style" do
-      expect(described_class.new("4.8.1"))
+      expect(klass.new("4.8.1"))
         .to be_detected_from("https://homebrew.bintray.com/bottles/qt-4.8.1.lion.bottle.1.tar.gz")
     end
 
     specify "erlang bottle style" do
-      expect(described_class.new("R15B"))
+      expect(klass.new("R15B"))
         .to be_detected_from("https://homebrew.bintray.com/bottles/erlang-R15B.lion.bottle.tar.gz")
     end
 
     specify "another erlang bottle style" do
-      expect(described_class.new("R15B01"))
+      expect(klass.new("R15B01"))
         .to be_detected_from("https://homebrew.bintray.com/bottles/erlang-R15B01.mountain_lion.bottle.tar.gz")
     end
 
     specify "yet another erlang bottle style" do
-      expect(described_class.new("R15B03-1"))
+      expect(klass.new("R15B03-1"))
         .to be_detected_from("https://homebrew.bintray.com/bottles/erlang-R15B03-1.mountainlion.bottle.tar.gz")
     end
 
     specify "imagemagick style" do
-      expect(described_class.new("6.7.5-7"))
+      expect(klass.new("6.7.5-7"))
         .to be_detected_from("https://downloads.sf.net/project/machomebrew/mirror/ImageMagick-6.7.5-7.tar.bz2")
     end
 
     specify "imagemagick bottle style" do
-      expect(described_class.new("6.7.5-7"))
+      expect(klass.new("6.7.5-7"))
         .to be_detected_from("https://homebrew.bintray.com/bottles/imagemagick-6.7.5-7.lion.bottle.tar.gz")
     end
 
     specify "imagemagick versioned bottle style" do
-      expect(described_class.new("6.7.5-7"))
+      expect(klass.new("6.7.5-7"))
         .to be_detected_from("https://homebrew.bintray.com/bottles/imagemagick-6.7.5-7.lion.bottle.1.tar.gz")
     end
 
     specify "date-based version style" do
-      expect(described_class.new("2017-04-17"))
+      expect(klass.new("2017-04-17"))
         .to be_detected_from("https://brew.sh/dada-v2017-04-17.tar.gz")
     end
 
     specify "unstable version style" do
-      expect(described_class.new("1.3.0-beta.1"))
+      expect(klass.new("1.3.0-beta.1"))
         .to be_detected_from("https://registry.npmjs.org/@angular/cli/-/cli-1.3.0-beta.1.tgz")
-      expect(described_class.new("2.074.0-beta1"))
+      expect(klass.new("2.074.0-beta1"))
         .to be_detected_from("https://github.com/dlang/dmd/archive/v2.074.0-beta1.tar.gz")
-      expect(described_class.new("2.074.0-rc1"))
+      expect(klass.new("2.074.0-rc1"))
         .to be_detected_from("https://github.com/dlang/dmd/archive/v2.074.0-rc1.tar.gz")
-      expect(described_class.new("5.0.0-alpha10"))
+      expect(klass.new("5.0.0-alpha10"))
         .to be_detected_from(
           "https://github.com/premake/premake-core/releases/download/v5.0.0-alpha10/premake-5.0.0-alpha10-src.zip",
         )
     end
 
     specify "jenkins version style" do
-      expect(described_class.new("1.486"))
+      expect(klass.new("1.486"))
         .to be_detected_from("https://mirrors.jenkins-ci.org/war/1.486/jenkins.war")
-      expect(described_class.new("0.10.11"))
+      expect(klass.new("0.10.11"))
         .to be_detected_from("https://github.com/hechoendrupal/DrupalConsole/releases/download/0.10.11/drupal.phar")
     end
 
     specify "char prefixed, url-only version style" do
-      expect(described_class.new("1.9.293"))
+      expect(klass.new("1.9.293"))
         .to be_detected_from("https://github.com/clojure/clojurescript/releases/download/r1.9.293/cljs.jar")
-      expect(described_class.new("0.6.1"))
+      expect(klass.new("0.6.1"))
         .to be_detected_from("https://github.com/fibjs/fibjs/releases/download/v0.6.1/fullsrc.zip")
-      expect(described_class.new("1.9"))
+      expect(klass.new("1.9"))
         .to be_detected_from("https://wwwlehre.dhbw-stuttgart.de/~sschulz/WORK/E_DOWNLOAD/V_1.9/E.tgz")
     end
 
     specify "w.x.y.z url-only version style" do
-      expect(described_class.new("2.3.2.0"))
+      expect(klass.new("2.3.2.0"))
         .to be_detected_from("https://github.com/JustArchi/ArchiSteamFarm/releases/download/2.3.2.0/ASF.zip")
-      expect(described_class.new("1.7.5.2"))
+      expect(klass.new("1.7.5.2"))
         .to be_detected_from("https://people.gnome.org/~newren/eg/download/1.7.5.2/eg")
     end
 
     specify "dash version style" do
-      expect(described_class.new("3.4"))
+      expect(klass.new("3.4"))
         .to be_detected_from("https://www.antlr.org/download/antlr-3.4-complete.jar")
-      expect(described_class.new("9.2"))
+      expect(klass.new("9.2"))
         .to be_detected_from("https://cdn.nuxeo.com/nuxeo-9.2/nuxeo-server-9.2-tomcat.zip")
-      expect(described_class.new("0.181"))
+      expect(klass.new("0.181"))
         .to be_detected_from(
           "https://search.maven.org/remotecontent?filepath=" \
           "com/facebook/presto/presto-cli/0.181/presto-cli-0.181-executable.jar",
         )
-      expect(described_class.new("1.2.3"))
+      expect(klass.new("1.2.3"))
         .to be_detected_from(
           "https://search.maven.org/remotecontent?filepath=org/apache/orc/orc-tools/1.2.3/orc-tools-1.2.3-uber.jar",
         )
     end
 
     specify "apache version style" do
-      expect(described_class.new("1.2.0-rc2"))
+      expect(klass.new("1.2.0-rc2"))
         .to be_detected_from(
           "https://www.apache.org/dyn/closer.cgi?path=/cassandra/1.2.0/apache-cassandra-1.2.0-rc2-bin.tar.gz",
         )
     end
 
     specify "jpeg version style" do
-      expect(described_class.new("8d"))
+      expect(klass.new("8d"))
         .to be_detected_from("https://www.ijg.org/files/jpegsrc.v8d.tar.gz")
     end
 
     specify "ghc version style" do
-      expect(described_class.new("7.0.4"))
+      expect(klass.new("7.0.4"))
         .to be_detected_from("https://www.haskell.org/ghc/dist/7.0.4/ghc-7.0.4-x86_64-apple-darwin.tar.bz2")
-      expect(described_class.new("7.0.4"))
+      expect(klass.new("7.0.4"))
         .to be_detected_from("https://www.haskell.org/ghc/dist/7.0.4/ghc-7.0.4-i386-apple-darwin.tar.bz2")
     end
 
     specify "pypy version style" do
-      expect(described_class.new("1.4.1"))
+      expect(klass.new("1.4.1"))
         .to be_detected_from("https://pypy.org/download/pypy-1.4.1-osx.tar.bz2")
     end
 
     specify "openssl version style" do
-      expect(described_class.new("0.9.8s"))
+      expect(klass.new("0.9.8s"))
         .to be_detected_from("https://www.openssl.org/source/openssl-0.9.8s.tar.gz")
     end
 
     specify "xaw3d version style" do
-      expect(described_class.new("1.5E"))
+      expect(klass.new("1.5E"))
         .to be_detected_from("ftp://ftp.visi.com/users/hawkeyd/X/Xaw3d-1.5E.tar.gz")
     end
 
     specify "assimp version style" do
-      expect(described_class.new("2.0.863"))
+      expect(klass.new("2.0.863"))
         .to be_detected_from("https://downloads.sourceforge.net/project/assimp/assimp-2.0/assimp--2.0.863-sdk.zip")
     end
 
     specify "cmucl version style" do
-      expect(described_class.new("20c"))
+      expect(klass.new("20c"))
         .to be_detected_from(
           "https://common-lisp.net/project/cmucl/downloads/release/20c/cmucl-20c-x86-darwin.tar.bz2",
         )
     end
 
     specify "fann version style" do
-      expect(described_class.new("2.1.0beta"))
+      expect(klass.new("2.1.0beta"))
         .to be_detected_from("https://downloads.sourceforge.net/project/fann/fann/2.1.0beta/fann-2.1.0beta.zip")
     end
 
     specify "grads version style" do
-      expect(described_class.new("2.0.1"))
+      expect(klass.new("2.0.1"))
         .to be_detected_from("ftp://iges.org/grads/2.0/grads-2.0.1-bin-darwin9.8-intel.tar.gz")
     end
 
     specify "haxe version style" do
-      expect(described_class.new("2.08"))
+      expect(klass.new("2.08"))
         .to be_detected_from("https://haxe.org/file/haxe-2.08-osx.tar.gz")
     end
 
     specify "imap version style" do
-      expect(described_class.new("2007f"))
+      expect(klass.new("2007f"))
         .to be_detected_from("ftp://ftp.cac.washington.edu/imap/imap-2007f.tar.gz")
     end
 
     specify "suite3270 version style" do
-      expect(described_class.new("3.3.12ga7"))
+      expect(klass.new("3.3.12ga7"))
         .to be_detected_from(
           "https://downloads.sourceforge.net/project/x3270/x3270/3.3.12ga7/suite3270-3.3.12ga7-src.tgz",
         )
     end
 
     specify "wwwoffle version style" do
-      expect(described_class.new("2.9h"))
+      expect(klass.new("2.9h"))
         .to be_detected_from("http://www.gedanken.demon.co.uk/download-wwwoffle/wwwoffle-2.9h.tgz")
     end
 
     specify "synergy version style" do
-      expect(described_class.new("1.3.6p2"))
+      expect(klass.new("1.3.6p2"))
         .to be_detected_from("http://synergy.googlecode.com/files/synergy-1.3.6p2-MacOSX-Universal.zip")
     end
 
     specify "fontforge version style" do
-      expect(described_class.new("20120731"))
+      expect(klass.new("20120731"))
         .to be_detected_from(
           "https://downloads.sourceforge.net/project/fontforge/fontforge-source/fontforge_full-20120731-b.tar.bz2",
         )
     end
 
     specify "ezlupdate version style" do
-      expect(described_class.new("2011.10"))
+      expect(klass.new("2011.10"))
         .to be_detected_from(
           "https://github.com/downloads/ezsystems" \
           "/ezpublish-legacy/ezpublish_community_project-2011.10-with_ezc.tar.bz2",
@@ -819,19 +823,19 @@ RSpec.describe Version do
     end
 
     specify "aespipe version style" do
-      expect(described_class.new("2.4c"))
+      expect(klass.new("2.4c"))
         .to be_detected_from("http://loop-aes.sourceforge.net/aespipe/aespipe-v2.4c.tar.bz2")
     end
 
     specify "win version style" do
-      expect(described_class.new("0.9.17"))
+      expect(klass.new("0.9.17"))
         .to be_detected_from("https://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-0.9.17-w32.zip")
-      expect(described_class.new("1.29"))
+      expect(klass.new("1.29"))
         .to be_detected_from("https://ftpmirror.gnu.org/libidn/libidn-1.29-win64.zip")
     end
 
     specify "breseq version style" do
-      expect(described_class.new("0.35.1"))
+      expect(klass.new("0.35.1"))
         .to be_detected_from(
           "https://github.com/barricklab/breseq" \
           "/releases/download/v0.35.1/breseq-0.35.1.Source.tar.gz",
@@ -839,12 +843,12 @@ RSpec.describe Version do
     end
 
     specify "wildfly version style" do
-      expect(described_class.new("20.0.1"))
+      expect(klass.new("20.0.1"))
         .to be_detected_from("https://download.jboss.org/wildfly/20.0.1.Final/wildfly-20.0.1.Final.tar.gz")
     end
 
     specify "trinity version style" do
-      expect(described_class.new("2.10.0"))
+      expect(klass.new("2.10.0"))
         .to be_detected_from(
           "https://github.com/trinityrnaseq/trinityrnaseq" \
           "/releases/download/v2.10.0/trinityrnaseq-v2.10.0.FULL.tar.gz",
@@ -852,57 +856,57 @@ RSpec.describe Version do
     end
 
     specify "with arch" do
-      expect(described_class.new("4.0.18-1"))
+      expect(klass.new("4.0.18-1"))
         .to be_detected_from("https://ftpmirror.gnu.org/mtools/mtools-4.0.18-1.i686.rpm")
-      expect(described_class.new("5.5.7-5"))
+      expect(klass.new("5.5.7-5"))
         .to be_detected_from("https://ftpmirror.gnu.org/autogen/autogen-5.5.7-5.i386.rpm")
-      expect(described_class.new("2.8"))
+      expect(klass.new("2.8"))
         .to be_detected_from("https://ftpmirror.gnu.org/libtasn1/libtasn1-2.8-x86.zip")
-      expect(described_class.new("2.8"))
+      expect(klass.new("2.8"))
         .to be_detected_from("https://ftpmirror.gnu.org/libtasn1/libtasn1-2.8-x64.zip")
-      expect(described_class.new("4.0.18"))
+      expect(klass.new("4.0.18"))
         .to be_detected_from("https://ftpmirror.gnu.org/mtools/mtools_4.0.18_i386.deb")
     end
 
     specify "opam version" do
-      expect(described_class.new("2.18.3"))
+      expect(klass.new("2.18.3"))
         .to be_detected_from("https://opam.ocaml.org/archives/lablgtk.2.18.3+opam.tar.gz")
-      expect(described_class.new("1.9"))
+      expect(klass.new("1.9"))
         .to be_detected_from("https://opam.ocaml.org/archives/sha.1.9+opam.tar.gz")
-      expect(described_class.new("0.99.2"))
+      expect(klass.new("0.99.2"))
         .to be_detected_from("https://opam.ocaml.org/archives/ppx_tools.0.99.2+opam.tar.gz")
-      expect(described_class.new("1.0.2"))
+      expect(klass.new("1.0.2"))
         .to be_detected_from("https://opam.ocaml.org/archives/easy-format.1.0.2+opam.tar.gz")
     end
 
     specify "no extension version" do
-      expect(described_class.new("1.8.12"))
+      expect(klass.new("1.8.12"))
         .to be_detected_from("https://waf.io/waf-1.8.12")
-      expect(described_class.new("0.7.1"))
+      expect(klass.new("0.7.1"))
         .to be_detected_from("https://codeload.github.com/gsamokovarov/jump/tar.gz/v0.7.1")
-      expect(described_class.new("0.9.1234"))
+      expect(klass.new("0.9.1234"))
         .to be_detected_from("https://my.datomic.com/downloads/free/0.9.1234")
-      expect(described_class.new("1.2.3"))
+      expect(klass.new("1.2.3"))
         .to be_detected_from("https://my.datomic.com/downloads/free/1.2.3")
     end
 
     specify "dash separated version" do
-      expect(described_class.new("6-20151227"))
+      expect(klass.new("6-20151227"))
         .to be_detected_from("ftp://gcc.gnu.org/pub/gcc/snapshots/6-20151227/gcc-6-20151227.tar.bz2")
     end
 
     specify "semver in middle of URL" do
-      expect(described_class.new("7.1.10"))
+      expect(klass.new("7.1.10"))
         .to be_detected_from("https://php.net/get/php-7.1.10.tar.gz/from/this/mirror")
     end
 
     specify "from tag" do
-      expect(described_class.new("1.2.3"))
+      expect(klass.new("1.2.3"))
         .to be_detected_from("https://github.com/foo/bar.git", tag: "v1.2.3-stable")
     end
 
     specify "beta from tag" do
-      expect(described_class.new("1.2.3-beta1"))
+      expect(klass.new("1.2.3-beta1"))
         .to be_detected_from("https://github.com/foo/bar.git", tag: "v1.2.3-beta1")
     end
   end

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -322,7 +322,7 @@ module GitHub
         args += ["--dump-header", T.must(headers_tmpfile.path)]
 
         require "utils/curl"
-        result = Utils::Curl.curl_output("--location", url.to_s, *args, secrets: [token])
+        result = Utils::Curl.curl_output("--location", url.to_s, *args, secrets: token ? [token] : [])
         output, _, http_code = result.stdout.rpartition("\n")
         output, _, http_code = output.rpartition("\n") if http_code == "000"
         headers = headers_tmpfile.read


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

When we [moved away from using the RuboCop autocorrections for `described_class` replacements with class names everywhere](https://github.com/Homebrew/brew/pull/22307#pullrequestreview-4305032522), I used Copilot with Claude Opus 4.7 in Agent mode to make the changes in commit [adf7123](https://github.com/Homebrew/brew/pull/22307/commits/adf71232352b1edba7963c98fccd0b61b162d544) to add `let(:klass) { Foo }` and replace `described_class` with `klass` in all the places.

-----

- A follow-up from https://github.com/Homebrew/brew/pull/22205#issuecomment-4414826092, so that Sorbet typechecking of tests can be more thorough.