### PR TITLE
Move the 'wsl?' bool from the OS::Linux module up to the OS module

### DIFF
--- a/Library/Homebrew/extend/os/linux/system_config.rb
+++ b/Library/Homebrew/extend/os/linux/system_config.rb
@@ -61,7 +61,7 @@ module OS
           super
           out.puts "Kernel: #{kernel}"
           out.puts "OS: #{OS::Linux.os_version}"
-          out.puts "WSL: #{OS::Linux.wsl_version}" if OS::Linux.wsl?
+          out.puts "WSL: #{OS::Linux.wsl_version}" if OS.wsl?
           out.puts "Host glibc: #{host_glibc_version}"
           out.puts "Host libstdc++: #{host_libstdcxx_version}"
           out.puts "#{::DevelopmentTools.host_gcc_path}: #{host_gcc_version}"

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -25,6 +25,16 @@ module OS
     RbConfig::CONFIG["host_os"].include? "linux"
   end
 
+  # Check whether the operating system is Linux on windows (WSL).
+  #
+  # @api public
+  sig { returns(T::Boolean) }
+  def self.wsl?
+    return false if ENV["HOMEBREW_TEST_GENERIC_OS"]
+
+    /-microsoft/i.match?(kernel_version.to_s)
+  end
+
   # Get the kernel version.
   #
   # @api public
@@ -114,7 +124,7 @@ module OS
     else
       "https://docs.brew.sh/Troubleshooting"
     end.freeze
-    PATH_OPEN = if OS::Linux.wsl? && (wslview = which("wslview").presence)
+    PATH_OPEN = if wsl? && (wslview = which("wslview").presence)
       wslview.to_s
     else
       "xdg-open"

--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -43,7 +43,7 @@ module OS
 
     sig { returns(T::Boolean) }
     def self.wsl?
-      /-microsoft/i.match?(OS.kernel_version.to_s)
+      OS.wsl?
     end
 
     sig { returns(Version) }


### PR DESCRIPTION
This PR moves the makes the internal [`wsl?` boolean member of Homebrew's `OS::Linux`](https://github.com/Homebrew/brew/blob/fb60c879bac6e441c1e71468c0d0887d4c430558/Library/Homebrew/os/linux.rb#L45) available directly in as a public member of `OS` in  [`os.rb`](https://github.com/Homebrew/brew/blob/main/Library/Homebrew/os.rb) alongside `OS.mac?` and `OS.linux?`
While I've modified the handful of references in the code to point to this new location, I've maintained backwards compatibility by having leaving the definition of `wsl?` in `OS::Linux` but changing it to return the value of `OS.wsl?` instead which should prevent any breakage for users that happened to be using `OS::Linux.wsl?` in, for instance, brewfiles.

## Why this change?

I ran into some issues with Brewfiles, which I only have one of however, one that covers 10+ machines and depends on conditionals. The [Brew, brew Bundle and Brewfile "**Advanced brewfiles**"](https://docs.brew.sh/Brew-Bundle-and-Brewfile#advanced-brewfiles) section seems to encourage this usage of brewfiles, and explicitly provides examples of conditionals using `OS.mac?` and `OS.linux?`.

It's however not possible to safely check `OS::Linux.wsl?` to see if we are on a WSL machine since the `OS::Linux` module is only loaded by `brew` if we are currently on a Linux machine ([here](https://github.com/Homebrew/brew/blob/fb60c879bac6e441c1e71468c0d0887d4c430558/Library/Homebrew/os.rb#L110-L111)), thus, if we happen to be on a Mac (or run with `HOMEBREW_TEST_GENERIC_OS=true`), we get:

```
# Brewfile excerpt
...
brew "mypackage" unless OS::Linux.wsl?
...

# shell prompt, on a macOS machine
❯ brew bundle 
Error: Invalid Brewfile: undefined method 'wsl?' for module OS::Linux
```

Of course, we could get around this by using compounded conditional statements/checking we are on Linux first and THEN checking for WSL which would prevent the exception being raised, but IMO that leads to a more complicated to read/understand brewfile.

Hope you'll consider this change or propose an alternative if this isn't adequate, I'm happy to adjust the PR. thanks.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
   + There did not seem to be existing tests for `mac?` and `linux?` and the existing test for `OS::Linux.wsl?` tests this change by virtual of the fact that _that_ reference has been changed to refer to this new `wsl?` method. I can add an additional test however if you feel it warrants the duplication.
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----
