### PR TITLE
More tightly scope build API override

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -263,7 +263,8 @@ begin
   formula_path = ARGV.first
   # `build.rb` is handed a concrete formula file; keep reparsing from falling
   # back to the API inside the Linux sandbox.
-  ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1" if formula_path&.end_with?(".rb")
+  # TODO: remove this and fix the sandbox code instead.
+  ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1" if ENV["HOMEBREW_SANDBOX_LINUX"] && formula_path&.end_with?(".rb")
 
   args = Homebrew::Cmd::InstallCmd.new.args
   Context.current = args.context


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22305
Fixes https://github.com/Homebrew/brew/issues/22306 
Fixes https://github.com/Homebrew/brew/issues/22310

Regression from https://github.com/Homebrew/brew/pull/22240

Avoid forcing `HOMEBREW_NO_INSTALL_FROM_API` in `build.rb` so source builds keep the caller's API mode unless `HOMEBREW_SANDBOX_LINUX` is set.

Temporary workaround while I work on a better sandbox-friendly fix.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Implemented by ✋🏻 

-----
