### PR TITLE
Remove executables fallback

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -214,13 +214,13 @@ module Homebrew
       end
     end
 
-    sig { params(legacy_executables_fallback: T::Boolean).void }
-    def self.write_names_and_aliases(legacy_executables_fallback: false)
+    sig { void }
+    def self.write_names_and_aliases
       if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.write_formula_names_and_aliases(legacy_executables_fallback:)
+        Homebrew::API::Internal.write_formula_names_and_aliases
         Homebrew::API::Internal.write_cask_names
       else
-        Homebrew::API::Formula.write_names_and_aliases(legacy_executables_fallback:)
+        Homebrew::API::Formula.write_names_and_aliases
         Homebrew::API::Cask.write_names
       end
     end
@@ -254,12 +254,11 @@ module Homebrew
 
     sig {
       params(
-        formulae:                    T::Hash[String, T::Hash[String, T.untyped]],
-        regenerate:                  T::Boolean,
-        legacy_executables_fallback: T::Boolean,
+        formulae:   T::Hash[String, T::Hash[String, T.untyped]],
+        regenerate: T::Boolean,
       ).returns(T::Boolean)
     }
-    def self.write_executables_file!(formulae, regenerate:, legacy_executables_fallback: false)
+    def self.write_executables_file!(formulae, regenerate:)
       executables_path = HOMEBREW_CACHE_API/"internal/executables.txt"
       executables_lines = formulae.filter_map do |name, hash|
         executables = T.cast(hash["executables"], T.nilable(T::Array[String]))
@@ -268,17 +267,22 @@ module Homebrew
         "#{name}:#{executables.join(" ")}"
       end
       if executables_lines.empty?
-        return false if executables_path.exist? && !executables_path.empty?
-        return false unless legacy_executables_fallback
-
-        # TODO: Remove this fallback once formula JSON always includes executables.
-        return download_executables_file_from_github_packages!(executables_path)
+        begin
+          executables_path.unlink
+          return true
+        rescue Errno::ENOENT
+          return false
+        end
       end
 
       contents = "#{executables_lines.sort.join("\n")}\n"
-      if !executables_path.exist? || regenerate || executables_path.read != contents
+      cached_contents = begin
+        executables_path.read unless regenerate
+      rescue Errno::ENOENT
+        nil
+      end
+      if regenerate || cached_contents != contents
         executables_path.dirname.mkpath
-        executables_path.unlink if executables_path.exist?
         executables_path.write(contents)
         return true
       end

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -201,13 +201,13 @@ module Homebrew
         cache.fetch("tap_migrations")
       end
 
-      sig { params(regenerate: T::Boolean, legacy_executables_fallback: T::Boolean).void }
-      def self.write_names_and_aliases(regenerate: false, legacy_executables_fallback: false)
+      sig { params(regenerate: T::Boolean).void }
+      def self.write_names_and_aliases(regenerate: false)
         download_and_cache_data! unless cache.key?("formulae")
 
         Homebrew::API.write_names_file!(all_formulae.keys, "formula", regenerate:)
         Homebrew::API.write_aliases_file!(all_aliases, "formula", regenerate:)
-        Homebrew::API.write_executables_file!(all_formulae, regenerate:, legacy_executables_fallback:)
+        Homebrew::API.write_executables_file!(all_formulae, regenerate:)
       end
     end
   end

--- a/Library/Homebrew/api/internal.rb
+++ b/Library/Homebrew/api/internal.rb
@@ -90,13 +90,13 @@ module Homebrew
       end
       private_class_method :download_and_cache_data!
 
-      sig { params(regenerate: T::Boolean, legacy_executables_fallback: T::Boolean).void }
-      def self.write_formula_names_and_aliases(regenerate: false, legacy_executables_fallback: false)
+      sig { params(regenerate: T::Boolean).void }
+      def self.write_formula_names_and_aliases(regenerate: false)
         download_and_cache_data! unless cache.key?("formula_hashes")
 
         Homebrew::API.write_names_file!(formula_hashes.keys, "formula", regenerate:)
         Homebrew::API.write_aliases_file!(formula_aliases, "formula", regenerate:)
-        Homebrew::API.write_executables_file!(formula_hashes, regenerate:, legacy_executables_fallback:)
+        Homebrew::API.write_executables_file!(formula_hashes, regenerate:)
       end
 
       sig { params(regenerate: T::Boolean).void }

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -101,9 +101,7 @@ module Homebrew
         end
 
         # Check if we can parse the JSON and do any Ruby-side follow-up.
-        unless Homebrew::EnvConfig.no_install_from_api?
-          Homebrew::API.write_names_and_aliases(legacy_executables_fallback: true)
-        end
+        Homebrew::API.write_names_and_aliases unless Homebrew::EnvConfig.no_install_from_api?
 
         Homebrew.failed = true if ENV["HOMEBREW_UPDATE_FAILED"]
         return if Homebrew::EnvConfig.disable_load_formula?

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Homebrew::API::Formula do
       expect((cache_dir/"internal/executables.txt").read).to eq("foo:foo-bin food\n")
     end
 
-    it "downloads the executables database if formula JSON has no executable entries" do
+    it "removes the executables database if formula JSON has no executable entries" do
       allow(Utils::Curl).to receive(:curl_download) do |*args, **kwargs|
         raise "unexpected download URL: #{args.last}" unless args.last.end_with?("formula.jws.json")
 
@@ -92,18 +92,16 @@ RSpec.describe Homebrew::API::Formula do
           }]
         JSON
       end
-      allow(Homebrew::API).to receive(:download_executables_file_from_github_packages!) do |target|
-        target.dirname.mkpath
-        target.write "foo:foo-bin\n"
-        true
-      end
+      expect(Homebrew::API).not_to receive(:download_executables_file_from_github_packages!)
       allow(Homebrew::API).to receive(:verify_and_parse_jws) do |json_data|
         [true, json_data]
       end
+      (cache_dir/"internal").mkpath
+      (cache_dir/"internal/executables.txt").write "foo:foo-bin\n"
 
-      described_class.write_names_and_aliases(legacy_executables_fallback: true)
+      described_class.write_names_and_aliases
 
-      expect((cache_dir/"internal/executables.txt").read).to eq("foo:foo-bin\n")
+      expect(cache_dir/"internal/executables.txt").not_to exist
     end
 
     it "does not download the executables database while reading formula JSON" do

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -146,6 +146,33 @@ RSpec.describe Homebrew::API do
     end
   end
 
+  describe "::write_executables_file!" do
+    it "handles the executables database being removed before comparison" do
+      cache_dir = mktmpdir
+      target = cache_dir/"internal/executables.txt"
+      target.dirname.mkpath
+      target.write "stale:stale-bin\n"
+      stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
+
+      removed = false
+      allow_any_instance_of(Pathname).to receive(:read).and_wrap_original do |method, *args|
+        if !removed && method.receiver == target
+          removed = true
+          target.unlink
+          raise Errno::ENOENT
+        end
+
+        method.call(*args)
+      end
+
+      expect(described_class.write_executables_file!(
+               { "foo" => { "executables" => ["foo-bin"] } },
+               regenerate: false,
+             )).to be true
+      expect(target.read).to eq("foo:foo-bin\n")
+    end
+  end
+
   describe "::tap_from_source_download" do
     let(:api_cache_root) { Homebrew::API::HOMEBREW_CACHE_API_SOURCE }
     let(:cache_path) do


### PR DESCRIPTION
Won't be merged until we've got a successful live API generation after https://github.com/Homebrew/brew/pull/22301 was merged.

- Stop downloading `executables.txt` when JSON has no entries.
- Require generated API JSON to carry executable data.
- Keep GitHub Packages as the API generation input only.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
