### PR TITLE
Avoid cached manifest downloads

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -347,7 +347,9 @@ module Homebrew
 
         Install.perform_preinstall_checks_once
 
-        if formulae_to_install.any? { |formula| formula.bottle&.github_packages_manifest_resource }
+        if formulae_to_install.any? do |formula|
+          formula.bottle&.github_packages_manifest_resource&.downloaded_and_valid? == false
+        end
           oh1 "Downloading bottle manifests"
         end
 

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -385,6 +385,12 @@ module Homebrew
                      "For more information, see: <https://docs.brew.sh/Analytics>",
         boolean:     true,
       },
+      HOMEBREW_NO_ASK:                           {
+        description: "If set, do not ask for confirmation before downloading and installing, upgrading or " \
+                     "reinstalling formulae and casks. This is a no-op until ask mode becomes the default " \
+                     "behaviour in a later release.",
+        boolean:     true,
+      },
       HOMEBREW_NO_AUTOREMOVE:                    {
         description: "If set, calls to `brew cleanup` and `brew uninstall` will not automatically " \
                      "remove unused formula dependents.",

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1427,7 +1427,7 @@ on_request: installed_on_request?, options:)
     if (bottle = formula.bottle) &&
        (manifest_resource = bottle.github_packages_manifest_resource) &&
        enqueue
-      download_queue.enqueue(manifest_resource)
+      download_queue.enqueue(manifest_resource) unless manifest_resource.downloaded_and_valid?
     else
       begin
         formula.fetch_bottle_tab(quiet: quiet)

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -383,10 +383,27 @@ class Resource
       @manifest_annotations = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
     end
 
+    sig { override.void }
+    def clear_cache
+      super
+      @manifest_annotations = nil
+    end
+
     sig { override.params(_filename: Pathname).void }
     def verify_download_integrity(_filename)
       # We don't have a checksum, but we can at least try parsing it.
       tab
+    end
+
+    sig { returns(T::Boolean) }
+    def downloaded_and_valid?
+      return false unless downloaded?
+
+      with_context(quiet: true) { verify_download_integrity(cached_download) }
+      true
+    rescue Error
+      clear_cache
+      false
     end
 
     sig { returns(T::Hash[String, T.untyped]) }

--- a/Library/Homebrew/test/bundle/commands/dump_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/dump_spec.rb
@@ -55,14 +55,13 @@ RSpec.describe Homebrew::Bundle::Commands::Dump do
 
     before do
       ENV["HOMEBREW_BUNDLE_FILE"] = ""
+      stub_formula_loader formula("mas") { url "mas-1.0" }
       allow_any_instance_of(Pathname).to receive(:exist?).and_return(true)
       allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(true)
       allow(Cask::Caskroom).to receive(:casks).and_return([])
 
       # don't try to load gcc/glibc
       allow(DevelopmentTools).to receive_messages(needs_libc_formula?: false, needs_compiler_formula?: false)
-
-      stub_formula_loader formula("mas") { url "mas-1.0" }
     end
 
     it "doesn't raise error" do

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -280,6 +280,28 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     end.to output("==> Downloading bottle manifests\n").to_stdout
   end
 
+  it "omits the bottle manifest heading for cached formula manifests" do
+    cmd = described_class.new([])
+    formula = formula("deno") do
+      url "https://brew.sh/deno-2.7.11.tar.gz"
+
+      bottle do
+        root_url HOMEBREW_BOTTLE_DEFAULT_DOMAIN
+        sha256 cellar: :any_skip_relocation,
+               Utils::Bottles.tag.to_sym => "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97"
+      end
+    end
+
+    allow(formula).to receive_messages(outdated?: true, latest_formula: formula, latest_version_installed?: false)
+    allow(formula.bottle&.github_packages_manifest_resource).to receive(:downloaded_and_valid?).and_return(true)
+    allow(Homebrew::Install).to receive(:perform_preinstall_checks_once)
+    allow(Homebrew::Upgrade).to receive(:formula_installers).and_return([])
+
+    expect do
+      cmd.send(:formulae_upgrade_context, [formula], show_upgrade_summary: false)
+    end.not_to output(/Downloading bottle manifests/).to_stdout
+  end
+
   it "does not trust failed shared prefetches" do
     cmd = described_class.new([])
     download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, fetch_failed: true, shutdown: nil)

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -137,6 +137,60 @@ RSpec.describe FormulaInstaller do
     end
   end
 
+  describe "#fetch_bottle_tab" do
+    it "does not enqueue cached bottle manifests" do
+      formula = formula("deno") do
+        url "https://brew.sh/deno-2.7.11.tar.gz"
+
+        bottle do
+          root_url HOMEBREW_BOTTLE_DEFAULT_DOMAIN
+          sha256 cellar: :any_skip_relocation,
+                 Utils::Bottles.tag.to_sym => "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97"
+        end
+      end
+      installer = described_class.new(formula)
+      installer.download_queue = instance_double(Homebrew::DownloadQueue)
+      manifest_resource = formula.bottle&.github_packages_manifest_resource
+      cached_download = manifest_resource&.cached_download
+
+      allow(manifest_resource).to receive(:downloaded?).and_return(true)
+      expect(manifest_resource).to receive(:verify_download_integrity).with(cached_download) do
+        expect(Context.current.quiet?).to be(true)
+      end
+      expect(manifest_resource).not_to receive(:clear_cache)
+      expect(installer.download_queue).not_to receive(:enqueue)
+
+      installer.fetch_bottle_tab(enqueue: true)
+    end
+
+    it "enqueues invalid cached bottle manifests" do
+      formula = formula("deno") do
+        url "https://brew.sh/deno-2.7.11.tar.gz"
+
+        bottle do
+          root_url HOMEBREW_BOTTLE_DEFAULT_DOMAIN
+          sha256 cellar: :any_skip_relocation,
+                 Utils::Bottles.tag.to_sym => "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97"
+        end
+      end
+      installer = described_class.new(formula)
+      installer.download_queue = instance_double(Homebrew::DownloadQueue)
+      manifest_resource = formula.bottle&.github_packages_manifest_resource
+
+      allow(manifest_resource).to receive(:downloaded?).and_return(true)
+      manifest_resource&.instance_variable_set(:@manifest_annotations, {})
+      expect(manifest_resource).to receive(:verify_download_integrity) do
+        expect(Context.current.quiet?).to be(true)
+        raise Resource::BottleManifest::Error
+      end
+      expect(installer.download_queue).to receive(:enqueue).with(manifest_resource)
+
+      installer.fetch_bottle_tab(enqueue: true)
+
+      expect(manifest_resource&.instance_variable_get(:@manifest_annotations)).to be_nil
+    end
+  end
+
   describe "linking defaults" do
     it "links non-keg-only formulae when link_keg is false" do
       ordinary_formula = formula "homebrew-link-default" do


### PR DESCRIPTION
- Prevent `upgrade --ask` from repeating bottle manifest headings when the manifest was already downloaded for the prompt
- Skip enqueueing cached bottle manifests so confirmed upgrades reuse the prompt manifest state without duplicate fetch output
- Add `HOMEBREW_NO_ASK` as a documented no-op placeholder until ask mode becomes the default in a later release
- Cover cached manifest handling in `upgrade` and `FormulaInstaller`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with manual review and testing.

-----
