### PR TITLE
parse_basename: fix local test failures

### DIFF
--- a/Library/Homebrew/download_strategy/abstract_file_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/abstract_file_download_strategy.rb
@@ -82,8 +82,10 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
   def parse_basename(url, search_query: true)
     components = { path: T.let([], T::Array[String]), query: T.let([], T::Array[String]) }
 
+    file_url = T.let(false, T::Boolean)
     if url.match?(URI::RFC2396_PARSER.make_regexp)
       uri = URI(url)
+      file_url = uri.scheme == "file"
 
       if (uri_query = uri.query.presence)
         URI.decode_www_form(uri_query).each do |key, param|
@@ -109,9 +111,13 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
     # extensions (e.g. tar.gz).
     # Given a URL like https://example.com/download.php?file=foo-1.0.tar.gz
     # the basename we want is "foo-1.0.tar.gz", not "download.php".
-    [*components[:path], *components[:query]].reverse_each do |path|
-      path = Pathname(path)
-      return path.basename.to_s if path.extname.present?
+    # Skipped for file:// URLs since their paths can contain ancestor
+    # directories with dots (e.g. "github.com") that aren't real extensions.
+    unless file_url
+      [*components[:path], *components[:query]].reverse_each do |path|
+        path = Pathname(path)
+        return path.basename.to_s if path.extname.present?
+      end
     end
 
     filename = components[:path].last

--- a/Library/Homebrew/test/download_strategies/abstract_file_spec.rb
+++ b/Library/Homebrew/test/download_strategies/abstract_file_spec.rb
@@ -1,0 +1,39 @@
+# typed: false
+# frozen_string_literal: true
+
+require "download_strategy"
+
+RSpec.describe AbstractFileDownloadStrategy do
+  subject(:strategy) { Class.new(described_class).new(url, "foo", "1.2.3") }
+
+  let(:url) { "https://example.com/foo.tar.gz" }
+
+  describe "#parse_basename" do
+    it "returns the final path segment for simple URLs" do
+      expect(strategy.send(:parse_basename, "https://example.com/foo.tar.gz")).to eq("foo.tar.gz")
+    end
+
+    it "prefers a path segment with an extension over later extensionless segments" do
+      expect(strategy.send(:parse_basename, "https://example.com/foo-1.0.tar.gz/download")).to eq("foo-1.0.tar.gz")
+    end
+
+    it "extracts the basename from a response-content-disposition query parameter" do
+      url = "https://example.com/download.php?file=ignored&response-content-disposition=attachment;filename=\"real.tar.gz\""
+      expect(strategy.send(:parse_basename, url)).to eq("real.tar.gz")
+    end
+
+    it "uses the query value when the path has no extension" do
+      url = "https://example.com/download.php?file=foo-1.0.tar.gz"
+      expect(strategy.send(:parse_basename, url)).to eq("foo-1.0.tar.gz")
+    end
+
+    it "returns the final segment for file:// URLs even when an ancestor directory contains a dot" do
+      expect(strategy.send(:parse_basename, "file:///Users/me/git-repos/github.com/Homebrew/brew/naked_executable"))
+        .to eq("naked_executable")
+    end
+
+    it "returns the final segment for file:// URLs with an extension" do
+      expect(strategy.send(:parse_basename, "file:///tmp/foo.tar.gz")).to eq("foo.tar.gz")
+    end
+  end
+end


### PR DESCRIPTION
Trying to fix this issue that I see often when running `brew lgtm` locally:

```
❯ ./bin/brew tests --only=cask/artifact
Randomized with seed 6833
8 processes for 22 specs, ~ 2 specs per process
...............................................................
...
................
.........F.........

Failures:

  1) Cask::Artifact::Binary when the binary is not executable makes the binary executable
     Failure/Error: artifact.install_phase(command: NeverSudoSystemCommand, force: false)

     Cask::CaskError:
       It seems the symlink source '/private/tmp/homebrew-tests-20260517-67891-lfu5ba/prefix/Caskroom/with-non-executable-binary/1.2.3/naked_non_executable' is not there.
     # ./cask/artifact/symlinked.rb:69:in 'Cask::Artifact::Symlinked#link'
     # ./cask/artifact/binary.rb:19:in 'Cask::Artifact::Binary#link'
     # ./cask/artifact/symlinked.rb:29:in 'Cask::Artifact::Symlinked#install_phase'
     # ./test/cask/artifact/binary_spec.rb:57:in 'block (4 levels) in <main>'
     # ./test/cask/artifact/binary_spec.rb:56:in 'Array#each'
     # ./test/cask/artifact/binary_spec.rb:56:in 'block (3 levels) in <main>'
     # ./test/cask/artifact/binary_spec.rb:17:in 'block (2 levels) in <main>'
     # ./test/support/helper/spec/shared_context/homebrew_cask.rb:66:in 'block (2 levels) in <main>'
.
......................
.
..



Took 21 seconds
Tests Failed
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claud Code, Extra High

-----
