### PR TITLE
info: indicate upgrade target for outdated @-versioned formulae

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -780,12 +780,15 @@ module Homebrew
             *heads.sort_by { |keg| -keg.tab.time.to_i },
             *versioned.sort_by(&:scheme_and_version).reverse,
           ]
-          ordered_kegs.map { |keg| [other, keg] }
+          ordered_kegs.each_with_index.map { |keg, index| [other, keg, index.zero?] }
         end
-        rows = with_kegs.map do |other, keg|
+        rows = with_kegs.map do |other, keg, newest|
           name_status = pretty_install_status(other.full_name, installed: true, outdated: other.outdated?)
+          version = keg.version.to_s
+          latest = other.pkg_version.to_s
+          version = "#{version} → #{latest}" if newest && other.outdated? && latest != version
           linked_marker = keg.linked? ? "[Linked]" : ""
-          [name_status, keg.version.to_s, "(#{keg.abv})", linked_marker, keg]
+          [name_status, version, "(#{keg.abv})", linked_marker, keg]
         end
         name_width = rows.map { |r| Tty.strip_ansi(r[0]).length }.max || 0
         version_width = rows.map { |r| r[1].length }.max || 0

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -1115,6 +1115,34 @@ RSpec.describe Homebrew::Cmd::Info do
         .and not_to_output.to_stderr
     end
 
+    it "shows installed → latest only on the newest installed keg of an outdated formula" do
+      info = described_class.new([])
+      main_formula = formula("testball") do
+        url "https://brew.sh/testball-2.0.tar.gz"
+        version "2.0"
+      end
+
+      ["1.0", "0.9"].each do |version|
+        keg_path = HOMEBREW_CELLAR/"testball/#{version}"
+        keg_path.mkpath
+        tab = Tab.empty
+        tab.tabfile = keg_path/AbstractTab::FILENAME
+        tab.write
+      end
+
+      allow(main_formula).to receive_messages(versioned_formulae: [], outdated?: true)
+      allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
+
+      expect { info.send(:info_formula, main_formula) }
+        .to output(Regexp.new(
+                     "==> Installed Kegs and Versions\n" \
+                     ".*testball\\b.*\\s+1\\.0 → 2\\.0\\s+\\(.*\\)\n" \
+                     ".*testball\\b.*\\s+0\\.9\\s+\\(",
+                   )).to_stdout
+        .and not_to_output(/0\.9 →/).to_stdout
+        .and not_to_output.to_stderr
+    end
+
     it "marks the currently linked version with `*`" do
       info = described_class.new([])
       main_formula = formula("testball") do
@@ -1249,7 +1277,7 @@ RSpec.describe Homebrew::Cmd::Info do
       expect { info.send(:info_formula, main_formula) }
         .to output(Regexp.new(
                      "==> Installed Kegs and Versions\n" \
-                     ".*testball\\b.*\\s+1\\.0\\s+\\(.*\\)\n" \
+                     ".*testball\\b.*\\s+1\\.0\\b.*\\(.*\\)\n" \
                      ".*testball\\b.*\\s+0\\.10\\s+\\(.*\\)\n" \
                      ".*testball\\b.*\\s+0\\.9\\s+\\(",
                    )).to_stdout


### PR DESCRIPTION
Make it easier to understand what is going on when you are on a un-upgraded latest formula like ffmpeg (on version 7) and how it's not the same as ffmpeg@7.

For the Python example, only show the upgadable version for the old version that are actually linkable. Some are lying around and can't be linked (if I understand there was a `brew switch` command, that was deprecated).

```
❯ brew info ffmpeg@7 ffmpeg@8 python
==> ffmpeg@7 ✘: stable 7.1.4 (bottled) [keg-only]
Play, record, convert, and stream audio and video
https://ffmpeg.org/
Not installed
Bottle Size: 20.8MB
Installed Size: 53.6MB
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/f/ffmpeg@7.rb
License: GPL-3.0-or-later
==> Installed Kegs and Versions
ffmpeg ↑ 7.1.1 → 8.1.1 (287 files, 54.7MB) [Linked]

==> ffmpeg ↑: 7.1.1 → stable 8.1.1 (bottled), HEAD
Play, record, convert, and stream select audio and video codecs
https://ffmpeg.org/
Aliases: ffmpeg@8
Installed (on request)
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/f/ffmpeg.rb
License: GPL-3.0-or-later
==> Installed Kegs and Versions
ffmpeg ↑ 7.1.1 → 8.1.1 (287 files, 54.7MB) [Linked]

==> python@3.14 ✔: stable 3.14.5 (bottled)
Interpreted, interactive, object-oriented programming language
https://www.python.org/
Aliases: python, python3, python@3
Installed (as dependency)
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/p/python@3.14.rb
License: Python-2.0
==> Installed Kegs and Versions
python@3.14 ✔ 3.14.5             (3,767 files, 76MB)   [Linked]
python@3.14 ✔ 3.14.4             (3,993 files, 79.8MB)
python@3.14 ✔ 3.14.3_1           (3,995 files, 80.8MB)
python@3.13 ↑ 3.13.2 → 3.13.13_1 (3,387 files, 70.8MB) [Linked]
python@3.13 ↑ 3.13.1             (3,278 files, 68.5MB)
python@3.12 ↑ 3.12.8 → 3.12.13_2 (3,372 files, 70.7MB) [Linked]
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claud Code, Extra High

-----
