### PR TITLE
Share system executable fallback

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -357,6 +357,7 @@ module Homebrew
         return if gnu_tar_formula.blank?
 
         gnu_tar_formula.ensure_installed!(reason: "bottling")
+        gnu_tar_formula
       end
 
       sig { params(mtime: String, default_tar: T::Boolean).returns([String, T::Array[String]]) }

--- a/Library/Homebrew/dev-cmd/cat.rb
+++ b/Library/Homebrew/dev-cmd/cat.rb
@@ -30,12 +30,13 @@ module Homebrew
             ENV["BAT_CONFIG_PATH"] = Homebrew::EnvConfig.bat_config_path
             ENV["BAT_THEME"] = Homebrew::EnvConfig.bat_theme
             require "formula"
-            Formula["bat"].ensure_installed!(
-              reason:           "displaying <formula>/<cask> source",
-              # The user might want to capture the output of `brew cat ...`
-              # Redirect stdout to stderr
-              output_to_stderr: true,
-            ).opt_bin/"bat"
+            T.cast(Formula["bat"].ensure_installed!(
+                     reason:           "displaying <formula>/<cask> source",
+                     # The user might want to capture the output of `brew cat ...`
+                     # Redirect stdout to stderr
+                     output_to_stderr: true,
+                     executable:       "bat",
+                   ), Pathname)
           else
             "cat"
           end

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -196,7 +196,7 @@ module Kernel
     return executable if executable
 
     require "formula"
-    Formula[formula_name].ensure_installed!(reason:, latest:).opt_bin/name
+    T.cast(Formula[formula_name].ensure_installed!(reason:, latest:, executable: name), Pathname)
   end
 
   # Calls the given block with the passed environment variables

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -344,15 +344,22 @@ class Formula
 
   # Ensure the given formula is installed.
   # This is useful for installing a utility formula (e.g. `shellcheck` for `brew style`).
+  # When `executable` is provided, a matching system executable in `ORIGINAL_PATHS`
+  # can satisfy the request without installing the formula. When `latest` is true,
+  # the system executable's version is checked with `version_args` first.
+  # Returns the executable path if `executable` is provided, otherwise the formula.
   sig {
     params(
       reason:           String,
       latest:           T::Boolean,
       output_to_stderr: T::Boolean,
       quiet:            T::Boolean,
-    ).returns(T.self_type)
+      executable:       T.nilable(String),
+      version_args:     T::Array[String],
+    ).returns(T.any(T.self_type, Pathname))
   }
-  def ensure_installed!(reason: "", latest: false, output_to_stderr: true, quiet: false)
+  def ensure_installed!(reason: "", latest: false, output_to_stderr: true, quiet: false, executable: nil,
+                        version_args: ["--version"])
     if output_to_stderr || quiet
       file = if quiet
         File::NULL
@@ -361,8 +368,16 @@ class Formula
       end
       # Call this method itself with redirected stdout
       redirect_stdout(file) do
-        return ensure_installed!(latest:, reason:, output_to_stderr: false)
+        return ensure_installed!(latest:, reason:, output_to_stderr: false, executable:, version_args:)
       end
+    end
+
+    if executable && (system_executable = which(executable, ORIGINAL_PATHS))
+      return system_executable unless latest
+
+      require "system_command"
+      result = SystemCommand.run(system_executable, args: version_args, print_stderr: false)
+      return system_executable if result.success? && result.stdout[/\d+(?:\.\d+)+/] == version.to_s
     end
 
     reason = " for #{reason}" if reason.present?
@@ -377,7 +392,7 @@ class Formula
       safe_system HOMEBREW_BREW_FILE, "upgrade", "--formula", full_name
     end
 
-    self
+    executable ? opt_bin/executable : self
   end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -322,7 +322,18 @@ module Homebrew
       args = ["--language-dialect", "bash", "--indent", "2", "--case-indent", "--", *files]
       args.unshift("--write") if fix # need to add before "--"
 
-      system shfmt, *args
+      require "formula"
+      shfmt_executable = T.cast(
+        Formula["shfmt"].ensure_installed!(latest:     true,
+                                           reason:     "formatting shell scripts",
+                                           executable: "shfmt"),
+        Pathname,
+      )
+      system(
+        { "HOMEBREW_SHFMT" => shfmt_executable.to_s },
+        shfmt,
+        *args,
+      )
       $CHILD_STATUS.success?
     end
 
@@ -391,20 +402,23 @@ module Homebrew
     sig { returns(Pathname) }
     def self.shellcheck
       require "formula"
-      Formula["shellcheck"].ensure_installed!(latest: true, reason: "shell style checks").opt_bin/"shellcheck"
+      T.cast(Formula["shellcheck"].ensure_installed!(latest:     true,
+                                                     reason:     "shell style checks",
+                                                     executable: "shellcheck"), Pathname)
     end
 
     sig { returns(Pathname) }
     def self.shfmt
-      require "formula"
-      Formula["shfmt"].ensure_installed!(latest: true, reason: "formatting shell scripts")
       HOMEBREW_LIBRARY/"Homebrew/utils/shfmt.sh"
     end
 
     sig { returns(Pathname) }
     def self.actionlint
       require "formula"
-      Formula["actionlint"].ensure_installed!(latest: true, reason: "GitHub Actions checks").opt_bin/"actionlint"
+      T.cast(Formula["actionlint"].ensure_installed!(latest:       true,
+                                                     reason:       "GitHub Actions checks",
+                                                     executable:   "actionlint",
+                                                     version_args: ["-version"]), Pathname)
     end
 
     # Collection of style offenses.

--- a/Library/Homebrew/test/dev-cmd/cat_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/cat_spec.rb
@@ -7,6 +7,32 @@ require "dev-cmd/cat"
 RSpec.describe Homebrew::DevCmd::Cat do
   it_behaves_like "parseable arguments"
 
+  it "uses a system bat when configured" do
+    formula_file = Formulary.find_formula_in_tap("testball", CoreTap.instance)
+    formula_file.dirname.mkpath
+    formula_file.write <<~RUBY
+      class Testball < Formula
+        url "https://brew.sh/testball-1.0"
+      end
+    RUBY
+    CoreTap.instance.clear_cache
+
+    cat = described_class.new(["testball"])
+    formula = instance_double(Formula)
+
+    allow(Homebrew::EnvConfig).to receive_messages(bat?: true, bat_config_path: "/tmp/bat.conf", bat_theme: "ansi")
+    allow(Formula).to receive(:[]).with("bat").and_return(formula)
+    allow(formula).to receive(:ensure_installed!).with(
+      reason:           "displaying <formula>/<cask> source",
+      output_to_stderr: true,
+      executable:       "bat",
+    ).and_return(Pathname.new("/usr/bin/bat"))
+
+    expect(cat).to receive(:safe_system).with(Pathname.new("/usr/bin/bat"), formula_file)
+
+    cat.run
+  end
+
   it "prints the content of a given Formula", :integration_test do
     formula_file = setup_test_formula "testball"
     content = formula_file.read

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -946,6 +946,54 @@ RSpec.describe Formula do
     expect(f.head).to be_nil
   end
 
+  describe "#ensure_installed!" do
+    let(:f) do
+      formula do
+        url "foo-1.2.3"
+      end
+    end
+
+    let(:executable) { Pathname.new("/usr/bin/foo") }
+
+    it "uses a system executable without checking the version by default" do
+      allow(f).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(executable)
+
+      expect(SystemCommand).not_to receive(:run)
+      expect(f).not_to receive(:any_version_installed?)
+
+      expect(f.ensure_installed!(executable: "foo", output_to_stderr: false)).to eq(executable)
+    end
+
+    it "uses a matching system executable when latest is requested" do
+      allow(f).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(executable)
+      allow(SystemCommand).to receive(:run)
+        .with(executable, args: ["--version"], print_stderr: false)
+        .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "foo 1.2.3\n"))
+
+      expect(f.ensure_installed!(executable: "foo", latest: true, output_to_stderr: false)).to eq(executable)
+    end
+
+    it "passes custom version arguments to the version check" do
+      allow(f).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(executable)
+      allow(SystemCommand).to receive(:run)
+        .with(executable, args: ["-version"], print_stderr: false)
+        .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "1.2.3\n"))
+
+      expect(f.ensure_installed!(executable: "foo", latest: true, output_to_stderr: false,
+                                 version_args: ["-version"])).to eq(executable)
+    end
+
+    it "returns the brewed executable path when the system version does not match latest" do
+      allow(f).to receive(:which).with("foo", ORIGINAL_PATHS).and_return(executable)
+      allow(SystemCommand).to receive(:run)
+        .with(executable, args: ["--version"], print_stderr: false)
+        .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "foo 1.2.2\n"))
+      allow(f).to receive_messages(any_version_installed?: true, latest_version_installed?: true)
+
+      expect(f.ensure_installed!(executable: "foo", latest: true, output_to_stderr: false)).to eq(f.opt_bin/"foo")
+    end
+  end
+
   it "honors attributes declared before specs" do
     f = formula do
       url "foo-1.0"

--- a/Library/Homebrew/test/style_spec.rb
+++ b/Library/Homebrew/test/style_spec.rb
@@ -123,6 +123,57 @@ RSpec.describe Homebrew::Style do
     end
   end
 
+  describe ".shellcheck" do
+    it "uses a matching system shellcheck" do
+      formula = instance_double(Formula)
+
+      allow(Formula).to receive(:[]).with("shellcheck").and_return(formula)
+      allow(formula).to receive(:ensure_installed!).with(latest:     true,
+                                                         reason:     "shell style checks",
+                                                         executable: "shellcheck")
+                                                   .and_return(Pathname.new("/usr/bin/shellcheck"))
+
+      expect(described_class.shellcheck).to eq(Pathname.new("/usr/bin/shellcheck"))
+    end
+  end
+
+  describe ".actionlint" do
+    it "uses a matching system actionlint" do
+      formula = instance_double(Formula)
+
+      allow(Formula).to receive(:[]).with("actionlint").and_return(formula)
+      allow(formula).to receive(:ensure_installed!).with(latest:       true,
+                                                         reason:       "GitHub Actions checks",
+                                                         executable:   "actionlint",
+                                                         version_args: ["-version"])
+                                                   .and_return(Pathname.new("/usr/bin/actionlint"))
+
+      expect(described_class.actionlint).to eq(Pathname.new("/usr/bin/actionlint"))
+    end
+  end
+
+  describe ".run_shfmt!" do
+    it "passes a matching system shfmt to the shfmt wrapper" do
+      shell_file = Pathname.new("/tmp/test.sh")
+      formula = instance_double(Formula)
+
+      allow(Formula).to receive(:[]).with("shfmt").and_return(formula)
+      allow(formula).to receive(:ensure_installed!).with(latest:     true,
+                                                         reason:     "formatting shell scripts",
+                                                         executable: "shfmt")
+                                                   .and_return(Pathname.new("/usr/bin/shfmt"))
+      system("true")
+
+      expect(described_class).to receive(:system).with(
+        { "HOMEBREW_SHFMT" => "/usr/bin/shfmt" },
+        HOMEBREW_LIBRARY/"Homebrew/utils/shfmt.sh",
+        "--language-dialect", "bash", "--indent", "2", "--case-indent", "--", shell_file
+      ).and_return(true)
+
+      described_class.run_shfmt!([shell_file])
+    end
+  end
+
   describe ".run_rubocop" do
     let(:dir) { mktmpdir }
     let(:ruby_file) { dir/"test.rb" }

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -180,20 +180,27 @@ RSpec.describe Utils::Git do
       end
 
       it "raises error if can't install git" do
-        stub_const("HOMEBREW_BREW_FILE", HOMEBREW_PREFIX/"bin/brew")
+        allow(CoreTap.instance).to receive(:installed?).and_return(true)
+        formula_double = instance_double(Formula)
+        allow(Formula).to receive(:[]).with("git").and_return(formula_double)
+        allow(formula_double).to receive(:ensure_installed!).with(executable: "git").and_raise(RuntimeError)
+
         expect { described_class.ensure_installed! }.to raise_error("Git is unavailable")
       end
 
       unless ENV["HOMEBREW_TEST_GENERIC_OS"]
-        it "installs git" do
+        it "keeps using the git shim after the formula install helper" do
           expect(described_class).to receive(:available?).and_return(false)
           allow(CoreTap.instance).to receive(:installed?).and_return(true)
           formula_double = instance_double(Formula)
           allow(Formula).to receive(:[]).with("git").and_return(formula_double)
-          allow(formula_double).to receive(:ensure_installed!).and_return(formula_double)
+          allow(formula_double).to receive(:ensure_installed!).with(executable: "git")
+                                                              .and_return(Pathname.new("/usr/bin/git"))
           expect(described_class).to receive(:available?).and_return(true)
 
           described_class.ensure_installed!
+
+          expect(described_class.git).to eq(HOMEBREW_SHIMS_PATH/"shared/git")
         end
       end
     end

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -122,7 +122,7 @@ module Utils
           raise "Refusing to install Git on a generic OS." if ENV["HOMEBREW_TEST_GENERIC_OS"]
 
           require "formula"
-          Formula["git"].ensure_installed!
+          Formula["git"].ensure_installed!(executable: "git")
           clear_available_cache
         rescue
           raise "Git is unavailable"

--- a/Library/Homebrew/utils/shfmt.sh
+++ b/Library/Homebrew/utils/shfmt.sh
@@ -16,9 +16,10 @@ then
   odie "${0##*/}: This program is internal and must be run via brew."
 fi
 
+# HOMEBREW_SHFMT is set by style.rb to the selected shfmt executable.
 # HOMEBREW_PREFIX is set by extend/ENV/super.rb
 # shellcheck disable=SC2154
-SHFMT="${HOMEBREW_PREFIX}/opt/shfmt/bin/shfmt"
+SHFMT="${HOMEBREW_SHFMT:-${HOMEBREW_PREFIX}/opt/shfmt/bin/shfmt}"
 if [[ ! -x "${SHFMT}" ]]
 then
   odie "${0##*/}: Please install shfmt by running \`brew install shfmt\`."


### PR DESCRIPTION
- Let `ensure_installed!` reuse matching system executables for tools.
- Keep `latest: true` as the only path that validates executable versions.
- Avoid installing brewed `git`, `bat` and style tools when PATH is enough.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
