### PR TITLE
Scope subcommand option constraints

### DIFF
--- a/Library/Homebrew/bundle/subcommand/install.rb
+++ b/Library/Homebrew/bundle/subcommand/install.rb
@@ -46,6 +46,9 @@ module Homebrew
           switch "--cleanup",
                  description: "`install` performs cleanup operation, same as running `cleanup --force`.",
                  env:         [:bundle_install_cleanup, "--global"]
+          switch "--zap",
+                 description: "`cleanup` casks using the `zap` command instead of `uninstall`.",
+                 depends_on:  "--cleanup"
         end
 
         sig { override.void }

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -178,7 +178,7 @@ module Homebrew
         @command_name = T.let(cmd.command_name, String)
         @is_dev_cmd = T.let(cmd.dev_cmd?, T::Boolean)
 
-        @constraints = T.let([], T::Array[[String, String]])
+        @constraints = T.let([], T::Array[[String, String, T.nilable(T::Array[String])]])
         @conflicts = T.let([], T::Array[T::Array[String]])
         @switch_sources = T.let({}, T::Hash[String, Symbol])
         @option_sources = T.let({}, T::Hash[String, Symbol])
@@ -260,7 +260,7 @@ module Homebrew
         end
 
         names.each do |name|
-          set_constraints(name, depends_on:)
+          set_constraints(name, depends_on:, subcommands:)
         end
 
         env_value = value_for_env(env)
@@ -359,7 +359,7 @@ module Homebrew
         end
 
         names.each do |name|
-          set_constraints(name, depends_on:)
+          set_constraints(name, depends_on:, subcommands:)
         end
       end
 
@@ -487,7 +487,7 @@ module Homebrew
             set_default_options
             validate_options
           end
-          check_constraint_violations
+          check_constraint_violations(named_args)
           check_named_args(named_args)
           check_subcommand_violations(named_args)
         end
@@ -786,18 +786,24 @@ module Homebrew
         Formatter.format_help_text(desc, width: Formatter::OPTION_DESC_WIDTH).split("\n")
       end
 
-      sig { params(name: String, depends_on: T.nilable(String)).returns(T.nilable(T::Array[[String, String]])) }
-      def set_constraints(name, depends_on:)
+      sig {
+        params(name: String, depends_on: T.nilable(String),
+               subcommands: T.nilable(T.any(String, T::Array[String]))).void
+      }
+      def set_constraints(name, depends_on:, subcommands:)
         return if depends_on.nil?
 
         primary = option_to_name(depends_on)
         secondary = option_to_name(name)
-        @constraints << [primary, secondary]
+        @constraints << [primary, secondary, effective_subcommands(subcommands)]
       end
 
-      sig { void }
-      def check_constraints
-        @constraints.each do |primary, secondary|
+      sig { params(args: T::Array[String]).void }
+      def check_constraints(args)
+        subcommand = subcommand_name(args)
+        @constraints.each do |primary, secondary, subcommands|
+          next if subcommands.present? && (subcommand.nil? || subcommands.exclude?(subcommand))
+
           primary_passed = option_passed?(primary)
           secondary_passed = option_passed?(secondary)
 
@@ -833,7 +839,7 @@ module Homebrew
       sig { void }
       def check_invalid_constraints
         @conflicts.each do |mutually_exclusive_options_group|
-          @constraints.each do |p, s|
+          @constraints.each do |p, s, _subcommands|
             next unless Set[p, s].subset?(Set[*mutually_exclusive_options_group])
 
             raise InvalidConstraintError.new(p, s)
@@ -841,11 +847,11 @@ module Homebrew
         end
       end
 
-      sig { void }
-      def check_constraint_violations
+      sig { params(args: T::Array[String]).void }
+      def check_constraint_violations(args)
         check_invalid_constraints
         check_conflicts
-        check_constraints
+        check_constraints(args)
       end
 
       sig { params(args: T::Array[String], type: ArgType, min: T.nilable(Integer), max: T.nilable(Integer)).void }

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -648,6 +648,28 @@ RSpec.describe Homebrew::CLI::Parser do
         .to raise_error(UsageError, /`info` subcommand does not accept the `--force` switch/)
     end
 
+    it "applies option constraints only for the matching subcommand", :aggregate_failures do
+      parser = lambda do
+        described_class.new(Cmd) do
+          subcommand "install", default: true do
+            switch "--cleanup"
+            switch "--zap", depends_on: "--cleanup"
+            named_args :none
+          end
+
+          subcommand "cleanup" do
+            switch "--zap"
+            named_args :none
+          end
+        end
+      end
+
+      expect { parser.call.parse(["--zap"]) }
+        .to raise_error(Homebrew::CLI::OptionConstraintError, /`--zap` cannot be passed without `--cleanup`/)
+      expect(parser.call.parse(%w[--cleanup --zap]).subcommand).to eq("install")
+      expect(parser.call.parse(%w[cleanup --zap]).subcommand).to eq("cleanup")
+    end
+
     it "allows global options on all subcommands" do
       args = subcommand_parser.parse(%w[info foo --global])
 

--- a/Library/Homebrew/test/cmd/bundle_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle_spec.rb
@@ -7,8 +7,13 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Bundle do
   it_behaves_like "parseable arguments"
 
-  it "uses install as the default subcommand" do
-    expect(described_class.new([]).args.subcommand).to eq("install")
+  it "handles default install subcommand options", :aggregate_failures do
+    with_env("HOMEBREW_BUNDLE_INSTALL_CLEANUP" => nil) do
+      expect(described_class.new([]).args.subcommand).to eq("install")
+      expect(described_class.new(%w[--cleanup --zap]).args.subcommand).to eq("install")
+      expect { described_class.new(%w[--zap]) }
+        .to raise_error(UsageError, /`--zap` cannot be passed without `--cleanup`/)
+    end
   end
 
   it "rejects install-only options for exec" do


### PR DESCRIPTION
- Keep subcommand-specific `depends_on:` rules from affecting sibling subcommands.
- Allow `brew bundle cleanup --zap` while requiring `--cleanup` for default `brew bundle --zap`.

Fixes https://github.com/Homebrew/brew/issues/22324

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review, tweaking and testing.

-----
