### PR TITLE
completion: update SHELL for ngrok

### DIFF
--- a/Library/Homebrew/cask/artifact/generated_completion.rb
+++ b/Library/Homebrew/cask/artifact/generated_completion.rb
@@ -93,7 +93,7 @@ module Cask
         executable = staged_path_join_executable(T.must(commands.first))
 
         shells.each do |shell|
-          popen_read_env = { "SHELL" => shell.to_s }
+          popen_read_env = { "SHELL" => "/bin/#{shell}" }
           shell_parameter = ::Utils::ShellCompletion.completion_shell_parameter(
             shell_parameter_format, shell, executable.to_s, popen_read_env
           )

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2457,7 +2457,7 @@ class Formula
     }
 
     shells.each do |shell|
-      popen_read_env = { "SHELL" => shell.to_s }
+      popen_read_env = { "SHELL" => "/bin/#{shell}" }
       script_path = completion_script_path_map[shell]
 
       shell_parameter = Utils::ShellCompletion.completion_shell_parameter(

--- a/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
@@ -40,11 +40,11 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
       artifact.install_phase
 
       expect(bash_dir/"foo").to be_a_file
-      expect((bash_dir/"foo").read).to eq("bash completion output")
+      expect((bash_dir/"foo").read).to eq("/bin/bash completion output")
       expect(zsh_dir/"_foo").to be_a_file
-      expect((zsh_dir/"_foo").read).to eq("zsh completion output")
+      expect((zsh_dir/"_foo").read).to eq("/bin/zsh completion output")
       expect(fish_dir/"foo.fish").to be_a_file
-      expect((fish_dir/"foo.fish").read).to eq("fish completion output")
+      expect((fish_dir/"foo.fish").read).to eq("/bin/fish completion output")
     end
 
     context "when generation fails for one shell" do
@@ -52,7 +52,7 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
         artifact = cask.artifacts.grep(described_class).first
 
         allow(Utils).to receive(:safe_popen_read) do |env, *_args, **_opts|
-          raise "boom" if env.fetch("SHELL") == "bash"
+          raise "boom" if env.fetch("SHELL").end_with?("bash")
 
           "zsh completion"
         end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

`ngrok` cask appears to ignore $SHELL unless it looks like a path

```console
$ SHELL=zsh ngrok completion | head -1
# bash completion for ngrok                                -*- shell-script -*-
$ SHELL=/zsh ngrok completion | head -1
#compdef ngrok
```

I would send ngrok a PR instead, but it's closed source and is simple enough to support on our side