### PR TITLE
bundle/krew: use kubectl-krew directly

### DIFF
--- a/Library/Homebrew/bundle/extensions/krew.rb
+++ b/Library/Homebrew/bundle/extensions/krew.rb
@@ -16,27 +16,11 @@ module Homebrew
           @packages = T.let(nil, T.nilable(T::Array[String]))
           @installed_packages = T.let(nil, T.nilable(T::Array[String]))
           @package_manager_executable = T.let(nil, T.nilable(Pathname))
-          @krew_installed = T.let(nil, T.nilable(T::Boolean))
         end
 
         sig { override.returns(T.nilable(Pathname)) }
         def package_manager_executable
-          @package_manager_executable ||= T.let(which("kubectl", ORIGINAL_PATHS), T.nilable(Pathname))
-        end
-
-        sig { override.returns(T::Boolean) }
-        def package_manager_installed?
-          return @krew_installed unless @krew_installed.nil?
-
-          kubectl = package_manager_executable
-          result = if kubectl.present?
-            Kernel.system(package_manager_env(kubectl), kubectl.to_s, "krew", "version",
-                          out: File::NULL, err: File::NULL) == true
-          else
-            false
-          end
-          @krew_installed = T.let(result, T.nilable(T::Boolean))
-          result
+          @package_manager_executable ||= T.let(which("kubectl-krew", ORIGINAL_PATHS), T.nilable(Pathname))
         end
 
         sig { override.returns(T::Array[String]) }
@@ -45,8 +29,8 @@ module Homebrew
           return packages if packages
 
           @packages = if package_manager_installed?
-            with_package_manager_env do |kubectl|
-              parse_plugin_list(`#{kubectl} krew list 2>/dev/null`)
+            with_package_manager_env do |krew|
+              parse_plugin_list(`#{krew} list 2>/dev/null`)
             end
           else
             []
@@ -63,8 +47,8 @@ module Homebrew
         def install_package!(name, with: nil, verbose: false)
           _ = with
 
-          with_package_manager_env do |kubectl|
-            Bundle.system(kubectl.to_s, "krew", "install", name, verbose:)
+          with_package_manager_env do |krew|
+            Bundle.system(krew.to_s, "install", name, verbose:)
           end
         end
 

--- a/Library/Homebrew/test/bundle/krew_spec.rb
+++ b/Library/Homebrew/test/bundle/krew_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Homebrew::Bundle::Krew do
       before do
         described_class.reset!
         allow(described_class).to receive_messages(package_manager_installed?: true,
-                                                   package_manager_executable: Pathname.new("kubectl"))
+                                                   package_manager_executable: Pathname.new("kubectl-krew"))
       end
 
       it "returns plugin list" do
@@ -48,7 +48,7 @@ RSpec.describe Homebrew::Bundle::Krew do
   end
 
   describe "installing" do
-    context "when kubectl is not found" do
+    context "when kubectl-krew is not found" do
       before do
         described_class.reset!
         allow(described_class).to receive_messages(package_manager_executable: nil, package_manager_installed?: false)
@@ -72,10 +72,10 @@ RSpec.describe Homebrew::Bundle::Krew do
       end
     end
 
-    context "when kubectl and krew are installed" do
+    context "when kubectl-krew is installed" do
       before do
         allow(described_class).to receive_messages(
-          package_manager_executable: Pathname.new("/usr/local/bin/kubectl"),
+          package_manager_executable: Pathname.new("/usr/local/bin/kubectl-krew"),
           package_manager_installed?: true,
         )
       end
@@ -95,7 +95,7 @@ RSpec.describe Homebrew::Bundle::Krew do
         before do
           described_class.reset!
           allow(described_class).to receive_messages(
-            package_manager_executable: Pathname.new("/usr/local/bin/kubectl"),
+            package_manager_executable: Pathname.new("/usr/local/bin/kubectl-krew"),
             package_manager_installed?: true,
             installed_packages:         [],
           )
@@ -104,7 +104,7 @@ RSpec.describe Homebrew::Bundle::Krew do
         it "installs plugin" do
           expect(Homebrew::Bundle).to receive(:system) do |*args, verbose:|
             expect(ENV.fetch("PATH", "")).to start_with("/usr/local/bin:")
-            expect(args).to eq(["/usr/local/bin/kubectl", "krew", "install", "ctx"])
+            expect(args).to eq(["/usr/local/bin/kubectl-krew", "install", "ctx"])
             expect(verbose).to be(false)
             true
           end
@@ -114,7 +114,7 @@ RSpec.describe Homebrew::Bundle::Krew do
 
         it "updates dump output after install" do
           expect(Homebrew::Bundle).to receive(:system) do |*args, verbose:|
-            expect(args).to eq(["/usr/local/bin/kubectl", "krew", "install", "ctx"])
+            expect(args).to eq(["/usr/local/bin/kubectl-krew", "install", "ctx"])
             expect(verbose).to be(false)
             true
           end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

A [kubectl extension](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/#installing-kubectl-plugins) is just a `kubectl-*` executable on PATH, so we can simplify a bit here and just invoke `kubectl-krew` directly
