### PR TITLE
Sorbet now understands RSpec's `expect` block form

### DIFF
--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -5,3 +5,12 @@ class RSpec::Core::ExampleGroup
   include RSpec::Matchers
   include RSpec::Mocks::ExampleMethods
 end
+
+# The rspec-mocks RBI defines `ExpectHost#expect(target)` with a required
+# argument and no block, which conflicts with the block form `expect { ... }`
+# required by matchers like `raise_error`, `output`, `change`, etc.
+# Override it to match the rspec-expectations signature.
+module RSpec::Mocks::ExampleMethods::ExpectHost
+  sig { params(value: T.untyped, block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def expect(value = T.unsafe(nil), &block); end
+end

--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "extend/ENV"

--- a/Library/Homebrew/test/bump_version_parser_spec.rb
+++ b/Library/Homebrew/test/bump_version_parser_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "bump_version_parser"

--- a/Library/Homebrew/test/bundle/brewfile_spec.rb
+++ b/Library/Homebrew/test/bundle/brewfile_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/dsl_spec.rb
+++ b/Library/Homebrew/test/bundle/dsl_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/remover_spec.rb
+++ b/Library/Homebrew/test/bundle/remover_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromTapLoader do

--- a/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromURILoader do

--- a/Library/Homebrew/test/cmd/shared_examples/reinstall_pkgconf_if_needed.rb
+++ b/Library/Homebrew/test/cmd/shared_examples/reinstall_pkgconf_if_needed.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "reinstall"

--- a/Library/Homebrew/test/descriptions_spec.rb
+++ b/Library/Homebrew/test/descriptions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "descriptions"

--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/download_strategies/abstract_file_spec.rb
+++ b/Library/Homebrew/test/download_strategies/abstract_file_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/detector_spec.rb
+++ b/Library/Homebrew/test/download_strategies/detector_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/error_during_execution_spec.rb
+++ b/Library/Homebrew/test/error_during_execution_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe ErrorDuringExecution do

--- a/Library/Homebrew/test/free_port_spec.rb
+++ b/Library/Homebrew/test/free_port_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "socket"

--- a/Library/Homebrew/test/lazy_object_spec.rb
+++ b/Library/Homebrew/test/lazy_object_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "lazy_object"

--- a/Library/Homebrew/test/linkage_cache_store_spec.rb
+++ b/Library/Homebrew/test/linkage_cache_store_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "linkage_cache_store"

--- a/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/json_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/json_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/locale_spec.rb
+++ b/Library/Homebrew/test/locale_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "locale"

--- a/Library/Homebrew/test/lock_file_spec.rb
+++ b/Library/Homebrew/test/lock_file_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "lock_file"

--- a/Library/Homebrew/test/pkg_version_spec.rb
+++ b/Library/Homebrew/test/pkg_version_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "pkg_version"

--- a/Library/Homebrew/test/settings_spec.rb
+++ b/Library/Homebrew/test/settings_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "settings"

--- a/Library/Homebrew/test/startup/bootsnap_spec.rb
+++ b/Library/Homebrew/test/startup/bootsnap_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 RSpec.describe Homebrew::Bootsnap do

--- a/Library/Homebrew/test/support/helper/subcommand_spec.rb
+++ b/Library/Homebrew/test/support/helper/subcommand_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 RSpec.describe Test::Helper::Subcommand::Args do

--- a/Library/Homebrew/test/test_bot_spec.rb
+++ b/Library/Homebrew/test/test_bot_spec.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "dev-cmd/test-bot"

--- a/Library/Homebrew/test/utils/bottles/tag_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/tag_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "utils/bottles"

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/curl"

--- a/Library/Homebrew/test/utils/fork_spec.rb
+++ b/Library/Homebrew/test/utils/fork_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "utils/fork"

--- a/Library/Homebrew/test/utils/formatter_spec.rb
+++ b/Library/Homebrew/test/utils/formatter_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "utils/formatter"

--- a/Library/Homebrew/test/utils/git_repository_spec.rb
+++ b/Library/Homebrew/test/utils/git_repository_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/git_repository"

--- a/Library/Homebrew/test/utils/github/actions_spec.rb
+++ b/Library/Homebrew/test/utils/github/actions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/github/actions"

--- a/Library/Homebrew/test/utils/inreplace_spec.rb
+++ b/Library/Homebrew/test/utils/inreplace_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "tempfile"

--- a/Library/Homebrew/test/utils/shell_spec.rb
+++ b/Library/Homebrew/test/utils/shell_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/shell"

--- a/Library/Homebrew/test/utils/timer_spec.rb
+++ b/Library/Homebrew/test/utils/timer_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "utils/timer"

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils"

--- a/Library/Homebrew/test/version/parser_spec.rb
+++ b/Library/Homebrew/test/version/parser_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "version/parser"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Code changes made and commit message drafted with assistance from Copilot CLI, agent mode, model Claude Opus 4.7.

-----

- The rspec-mocks gem RBI defines `ExpectHost#expect(target)` with a required positional argument and no block, which wins over the rspec-expectations signature via `RSpec::Core::ExampleGroup`'s include chain. Hence, the block form `expect { ... }` — required by matchers like `raise_error`, `output`, `change` and `yield_*` — fails Sorbet typechecking at `# typed: true` or stricter with "Not enough arguments provided for method `RSpec::Mocks::ExampleMethods::ExpectHost#expect"`.

- So, add a shim that overrides `ExpectHost#expect` with the optional-value, block-accepting signature so both `expect(value)` and `expect { ... }` typecheck cleanly.

- With this shim, `brew tc --update --suggest-typed` bumps 41 additional test files to have at least basic typechecking.