### PR TITLE
Fix npm bundle dump PATH

### DIFF
--- a/Library/Homebrew/bundle/extensions/npm.rb
+++ b/Library/Homebrew/bundle/extensions/npm.rb
@@ -39,7 +39,9 @@ module Homebrew
 
           @packages = if (npm = package_manager_executable) &&
                          (!npm.to_s.start_with?("/") || npm.exist?)
-            parse_package_list(`#{npm} list -g --depth=0 --json 2>/dev/null`)
+            with_env(package_manager_env(npm)) do
+              parse_package_list(`#{npm} list -g --depth=0 --json 2>/dev/null`)
+            end
           end
           return [] if @packages.nil?
 

--- a/Library/Homebrew/test/bundle/npm_spec.rb
+++ b/Library/Homebrew/test/bundle/npm_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe Homebrew::Bundle::Npm do
         expect(dumper.packages).to eql(%w[vercel typescript])
       end
 
+      it "adds npm's directory to PATH when listing packages" do
+        npm = mktmpdir/"bin/npm"
+        npm.dirname.mkpath
+        npm.write("")
+
+        allow(described_class).to receive(:package_manager_executable).and_return(npm)
+        expect(described_class).to receive(:`).with("#{npm} list -g --depth=0 --json 2>/dev/null") do
+          expect(ENV.fetch("PATH", "")).to start_with("#{npm.dirname}:")
+          '{"dependencies":{"eslint":{"version":"10.4.0"}}}'
+        end
+
+        expect(dumper.packages).to eql(["eslint"])
+      end
+
       it "excludes npm itself from the package list" do
         allow(described_class).to receive(:`).with("npm list -g --depth=0 --json 2>/dev/null").and_return(<<~JSON)
           {


### PR DESCRIPTION
- Ensure `npm list` runs with npm's directory on `PATH`.
- This lets `/usr/bin/env node` resolve Homebrew's `node`.
- Add a regression for absolute npm shims.

Fixes https://github.com/Homebrew/brew/issues/22331

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with manual review and testing.

-----
