### PR TITLE
Skip empty upgrade ask prompt

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -207,7 +207,7 @@ module Homebrew
           end
 
           show_final_upgrade_summary(dry_run: true)
-          Install.ask(action: "upgrade")
+          Install.ask(action: "upgrade") if final_upgrade_summary.version_changes.present?
           @final_upgrade_summary = FinalUpgradeSummary.new
         end
 

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -100,8 +100,10 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
     expect(cmd).to receive(:upgrade_outdated_formulae!)
       .with([], dry_run: true, show_upgrade_summary: false)
-      .ordered
-      .and_return(true)
+      .ordered do
+        cmd.send(:final_upgrade_summary).version_changes << "testball 0.1 -> 0.2"
+        true
+      end
     expect(cmd).to receive(:upgrade_outdated_casks!)
       .with([], dry_run: true, skip_prefetch: false, show_upgrade_summary: false, download_queue: nil)
       .ordered
@@ -118,6 +120,33 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       .with([], skip_prefetch: false, show_upgrade_summary: false, download_queue: nil)
       .ordered
       .and_return(true)
+    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
+    allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
+    allow(Homebrew.messages).to receive(:display_messages)
+
+    cmd.run
+  end
+
+  it "does not ask before upgrading when nothing would upgrade" do
+    cmd = described_class.new(["--ask"])
+
+    expect(cmd).to receive(:upgrade_outdated_formulae!)
+      .with([], dry_run: true, show_upgrade_summary: false)
+      .ordered
+      .and_return(false)
+    expect(cmd).to receive(:upgrade_outdated_casks!)
+      .with([], dry_run: true, skip_prefetch: false, show_upgrade_summary: false, download_queue: nil)
+      .ordered
+      .and_return(false)
+    expect(Homebrew::Install).not_to receive(:ask)
+    expect(cmd).to receive(:upgrade_outdated_formulae!)
+      .with([], use_prefetched: false, show_upgrade_summary: false)
+      .ordered
+      .and_return(false)
+    expect(cmd).to receive(:upgrade_outdated_casks!)
+      .with([], skip_prefetch: false, show_upgrade_summary: false, download_queue: nil)
+      .ordered
+      .and_return(false)
     allow(Homebrew::Cleanup).to receive(:periodic_clean!)
     allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
     allow(Homebrew.messages).to receive(:display_messages)


### PR DESCRIPTION
- Avoid prompting for `brew upgrade --ask` when the dry-run plan has no version changes.
- Keep the ask-flow regression explicit so the prompt still appears when there are upgrades.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with manual review and testing.

-----
