### PR TITLE
info: mark deprecated/disabled pkg in install status

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -606,7 +606,13 @@ module Homebrew
           specs[0] = "#{installed_version} → #{upgrade_version}"
         end
         title_name = shadowed_by ? formula.name : formula.full_name
-        name_with_status = pretty_install_status(title_name, installed:, outdated:)
+        name_with_status = pretty_install_status(
+          title_name,
+          installed:,
+          outdated:,
+          deprecated: formula.deprecated?,
+          disabled:   formula.disabled?,
+        )
 
         puts "#{oh1_title(name_with_status)}: #{specs * ", "}#{" [#{attrs * ", "}]" unless attrs.empty?}"
         if shadowed_by

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -150,18 +150,30 @@ module Homebrew
 
       sig { params(tap: Tap, name: String, installed: T::Boolean).returns(String) }
       def decorate_formula(tap, name, installed:)
-        outdated = installed && Formulary.factory("#{tap.name}/#{name}").outdated?
-        pretty_install_status(name, installed:, outdated:)
+        formula = Formulary.factory("#{tap.name}/#{name}")
+        pretty_install_status(
+          name,
+          installed:,
+          outdated:   installed && formula.outdated?,
+          deprecated: formula.deprecated?,
+          disabled:   formula.disabled?,
+        )
       rescue
-        pretty_installed(name)
+        pretty_install_status(name, installed:)
       end
 
       sig { params(tap: Tap, token: String, installed: T::Boolean).returns(String) }
       def decorate_cask(tap, token, installed:)
-        outdated = installed && Cask::CaskLoader.load("#{tap.name}/#{token}").outdated?
-        pretty_install_status(token, installed:, outdated:)
+        cask = Cask::CaskLoader.load("#{tap.name}/#{token}")
+        pretty_install_status(
+          token,
+          installed:,
+          outdated:   installed && cask.outdated?,
+          deprecated: cask.deprecated?,
+          disabled:   cask.disabled?,
+        )
       rescue
-        pretty_installed(token)
+        pretty_install_status(token, installed:)
       end
 
       sig { params(taps: T::Array[Tap]).void }

--- a/Library/Homebrew/search.rb
+++ b/Library/Homebrew/search.rb
@@ -140,21 +140,16 @@ module Homebrew
         # Ignore aliases from results when the full name was also found
         next if aliases.include?(name) && results.include?(canonical_full_name)
 
-        display_name = if formula&.any_version_installed?
-          pretty_installed(name)
-        elsif formula.nil? || formula.valid_platform?
-          name
-        end
+        installed = formula&.any_version_installed? == true
+        next if formula && !formula.valid_platform? && !installed
 
-        next if display_name.nil?
-
-        if formula&.deprecated?
-          pretty_deprecated(display_name)
-        elsif formula&.disabled?
-          pretty_disabled(display_name)
-        else
-          display_name
-        end
+        pretty_install_status(
+          name,
+          installed:,
+          deprecated:       formula&.deprecated? == true,
+          disabled:         formula&.disabled? == true,
+          mark_uninstalled: false,
+        )
       end
     end
 
@@ -188,18 +183,13 @@ module Homebrew
         cask = Cask::CaskLoader.load(name.to_s)
         next if ignore_cask?(cask)
 
-        display_name = if cask.installed?
-          pretty_installed(cask.full_name)
-        else
-          cask.full_name
-        end
-        if cask.deprecated?
-          pretty_deprecated(display_name)
-        elsif cask.disabled?
-          pretty_disabled(display_name)
-        else
-          display_name
-        end
+        pretty_install_status(
+          cask.full_name,
+          installed:        cask.installed?,
+          deprecated:       cask.deprecated?,
+          disabled:         cask.disabled?,
+          mark_uninstalled: false,
+        )
       end.uniq
     end
 

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -241,6 +241,40 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
+  it "marks a deprecated formula with `(deprecated)` in the title" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      desc "Some test"
+      deprecate! date: "2024-01-01", because: :versioned_formula
+    end
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/==> .*testball.*\(deprecated\):/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "marks a disabled formula with `(disabled)` in the title" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      desc "Some test"
+      disable! date: "2024-01-01", because: :unmaintained
+    end
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive(:core_formula?).and_return(false)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(/==> .*testball.*\(disabled\):/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
   it "reloads the formula from the install receipt's tap and reports the shadowing tap" do
     info = described_class.new([])
     formula = installed_info_formula

--- a/Library/Homebrew/test/cmd/tap-info_spec.rb
+++ b/Library/Homebrew/test/cmd/tap-info_spec.rb
@@ -37,17 +37,31 @@ RSpec.describe Homebrew::Cmd::TapInfo do
     end
 
     it "marks an installed formula as satisfied" do
-      formula = instance_double(Formula, outdated?: false)
+      formula = instance_double(Formula, outdated?: false, deprecated?: false, disabled?: false)
       allow(Formulary).to receive(:factory).with("homebrew/foo/installed").and_return(formula)
 
       expect(tap_info.send(:decorate_formula, tap, "installed", installed: true)).to match(/installed.*✔/)
     end
 
     it "marks an outdated installed formula as upgradable" do
-      formula = instance_double(Formula, outdated?: true)
+      formula = instance_double(Formula, outdated?: true, deprecated?: false, disabled?: false)
       allow(Formulary).to receive(:factory).with("homebrew/foo/outdated").and_return(formula)
 
       expect(tap_info.send(:decorate_formula, tap, "outdated", installed: true)).to match(/outdated.*↑/)
+    end
+
+    it "marks a deprecated formula with `(deprecated)`" do
+      formula = instance_double(Formula, outdated?: false, deprecated?: true, disabled?: false)
+      allow(Formulary).to receive(:factory).with("homebrew/foo/old").and_return(formula)
+
+      expect(tap_info.send(:decorate_formula, tap, "old", installed: false)).to match(/old.*\(deprecated\)/)
+    end
+
+    it "marks a disabled formula with `(disabled)`" do
+      formula = instance_double(Formula, outdated?: false, deprecated?: false, disabled?: true)
+      allow(Formulary).to receive(:factory).with("homebrew/foo/gone").and_return(formula)
+
+      expect(tap_info.send(:decorate_formula, tap, "gone", installed: false)).to match(/gone.*\(disabled\)/)
     end
   end
 
@@ -65,17 +79,31 @@ RSpec.describe Homebrew::Cmd::TapInfo do
     end
 
     it "marks an installed cask as satisfied" do
-      cask = instance_double(Cask::Cask, outdated?: false)
+      cask = instance_double(Cask::Cask, outdated?: false, deprecated?: false, disabled?: false)
       allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/installed").and_return(cask)
 
       expect(tap_info.send(:decorate_cask, tap, "installed", installed: true)).to match(/installed.*✔/)
     end
 
     it "marks an outdated installed cask as upgradable" do
-      cask = instance_double(Cask::Cask, outdated?: true)
+      cask = instance_double(Cask::Cask, outdated?: true, deprecated?: false, disabled?: false)
       allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/outdated").and_return(cask)
 
       expect(tap_info.send(:decorate_cask, tap, "outdated", installed: true)).to match(/outdated.*↑/)
+    end
+
+    it "marks a deprecated cask with `(deprecated)`" do
+      cask = instance_double(Cask::Cask, outdated?: false, deprecated?: true, disabled?: false)
+      allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/old").and_return(cask)
+
+      expect(tap_info.send(:decorate_cask, tap, "old", installed: false)).to match(/old.*\(deprecated\)/)
+    end
+
+    it "marks a disabled cask with `(disabled)`" do
+      cask = instance_double(Cask::Cask, outdated?: false, deprecated?: false, disabled?: true)
+      allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/gone").and_return(cask)
+
+      expect(tap_info.send(:decorate_cask, tap, "gone", installed: false)).to match(/gone.*\(disabled\)/)
     end
   end
 
@@ -102,9 +130,21 @@ RSpec.describe Homebrew::Cmd::TapInfo do
         allow(Formula).to receive(:installed_formula_names).and_return(["foo"])
         allow(Cask::Caskroom).to receive(:tokens).and_return(["bar"])
         allow(Formulary).to receive(:factory).with("homebrew/foo/foo")
-                                             .and_return(instance_double(Formula, outdated?: false))
+                                             .and_return(instance_double(Formula, outdated?:   false,
+                                                                                  deprecated?: false,
+                                                                                  disabled?:   false))
+        allow(Formulary).to receive(:factory).with("homebrew/foo/uninstalled-formula")
+                                             .and_return(instance_double(Formula, outdated?:   false,
+                                                                                  deprecated?: false,
+                                                                                  disabled?:   false))
         allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/bar")
-                                                 .and_return(instance_double(Cask::Cask, outdated?: false))
+                                                 .and_return(instance_double(Cask::Cask, outdated?:   false,
+                                                                                         deprecated?: false,
+                                                                                         disabled?:   false))
+        allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/uninstalled-cask")
+                                                 .and_return(instance_double(Cask::Cask, outdated?:   false,
+                                                                                         deprecated?: false,
+                                                                                         disabled?:   false))
       end
 
       it "lists every formula and cask with mixed install markers under their headers" do
@@ -132,7 +172,9 @@ RSpec.describe Homebrew::Cmd::TapInfo do
         allow(Formula).to receive(:installed_formula_names).and_return(["formula7"])
         allow(Cask::Caskroom).to receive(:tokens).and_return([])
         allow(Formulary).to receive(:factory).with("homebrew/foo/formula7")
-                                             .and_return(instance_double(Formula, outdated?: false))
+                                             .and_return(instance_double(Formula, outdated?:   false,
+                                                                                  deprecated?: false,
+                                                                                  disabled?:   false))
       end
 
       it "warns about truncation and shows only installed entries under the standard header" do

--- a/Library/Homebrew/utils/output.rb
+++ b/Library/Homebrew/utils/output.rb
@@ -303,11 +303,28 @@ module Utils
         end
       end
 
-      sig { params(string: String, installed: T::Boolean, outdated: T::Boolean).returns(String) }
-      def pretty_install_status(string, installed:, outdated: false)
-        return pretty_uninstalled(string) unless installed
-
-        outdated ? pretty_upgradable(string) : pretty_installed(string)
+      sig {
+        params(string: String, installed: T::Boolean, outdated: T::Boolean, deprecated: T::Boolean,
+               disabled: T::Boolean, mark_uninstalled: T::Boolean).returns(String)
+      }
+      def pretty_install_status(string, installed:, outdated: false, deprecated: false, disabled: false,
+                                mark_uninstalled: true)
+        status = if installed && outdated
+          pretty_upgradable(string)
+        elsif installed
+          pretty_installed(string)
+        elsif mark_uninstalled
+          pretty_uninstalled(string)
+        else
+          string
+        end
+        if disabled
+          pretty_disabled(status)
+        elsif deprecated
+          pretty_deprecated(status)
+        else
+          status
+        end
       end
 
       sig { params(seconds: T.nilable(T.any(Integer, Float))).returns(String) }


### PR DESCRIPTION
Mark deprecated formula and deprecated siblings in `brew info`:

```
❯ brew info ffmpeg@2.8 ffmpeg
==> ffmpeg@2.8 ✔ (deprecated): stable 2.8.22 (bottled) [keg-only]
Play, record, convert, and stream audio and video
https://ffmpeg.org/
Old Names: ffmpeg28
Deprecated because it is a versioned formula! It will be disabled on 2027-01-17.
Installed (on request)
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/f/ffmpeg@2.8.rb
License: GPL-3.0-or-later
==> Installed Kegs and Versions
ffmpeg ↑                  7.1.1 → 8.1.1 (287 files, 54.7MB) [Linked]
ffmpeg@2.8 ✔ (deprecated) 2.8.22_8      (266 files, 46.0MB)

==> ffmpeg ↑: 7.1.1 → stable 8.1.1 (bottled), HEAD
Play, record, convert, and stream select audio and video codecs
https://ffmpeg.org/
Aliases: ffmpeg@8
Installed (on request)
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/f/ffmpeg.rb
License: GPL-3.0-or-later
==> Installed Kegs and Versions
ffmpeg ↑                  7.1.1 → 8.1.1 (287 files, 54.7MB) [Linked]
ffmpeg@2.8 ✔ (deprecated) 2.8.22_8      (266 files, 46.0MB)
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claud Code, Extra High

-----
