### PR TITLE
Fix package API cache install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,24 @@ jobs:
 
           echo "version=${homebrew_version}" >> "${GITHUB_OUTPUT}"
 
-      - name: Copy Homebrew API cache to brew subdirectory
-        run: cp -vR ~/Library/Caches/Homebrew/api brew/cache_api
+      - name: Prepare Homebrew API cache for package
+        run: |
+          package_api_cache="${RUNNER_TEMP}/homebrew-api-cache"
+          rm -rvf ~/Library/Caches/Homebrew/api "${package_api_cache}"
+
+          # TODO: Remove this forced regular API refresh when the internal API is default.
+          # Developer mode currently downloads the internal API cache, but the package
+          # should keep shipping the regular API files until all installs use internal API.
+          unset HOMEBREW_DEVELOPER HOMEBREW_DEV_CMD_RUN HOMEBREW_USE_INTERNAL_API HOMEBREW_NO_INSTALL_FROM_API
+          HOMEBREW_UPDATE_SKIP_BREW=1 brew update --auto-update --verbose
+          mkdir -vp "${package_api_cache}"
+          cp -vR ~/Library/Caches/Homebrew/api/. "${package_api_cache}/"
+
+          # Run developer mode too so the package cache works with both current
+          # developer behaviour and the future internal API default.
+          HOMEBREW_DEVELOPER=1 HOMEBREW_UPDATE_SKIP_BREW=1 brew update --auto-update --verbose
+          cp -vR "${package_api_cache}/." ~/Library/Caches/Homebrew/api
+          cp -vR ~/Library/Caches/Homebrew/api brew/cache_api
 
       - name: Check installer Git safety
         run: |

--- a/package/scripts/postinstall
+++ b/package/scripts/postinstall
@@ -97,7 +97,7 @@ user_home_dir=$(dscl . read /Users/"${homebrew_pkg_user}" NFSHomeDirectory | awk
 user_cache_dir="${user_home_dir}/Library/Caches/Homebrew"
 user_api_cache_dir="${user_cache_dir}/api"
 mkdir -vp "${user_api_cache_dir}"
-mv -v "${homebrew_directory}/cache_api/"* "${user_api_cache_dir}"
+cp -vpR "${homebrew_directory}/cache_api/." "${user_api_cache_dir}"
 chown -R "${homebrew_pkg_user}:staff" "${user_cache_dir}"
 rm -vrf "${homebrew_directory}/cache_api"
 


### PR DESCRIPTION
- Restore regular API cache files during package builds until `internal` API installs are the default.
- Merge packaged API cache contents so existing `api/internal` directories do not break package reinstalls.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and tweaking.

-----
