### PR TITLE
Remove obsolete --skip-update from command-not-found handlers

### DIFF
--- a/Library/Homebrew/command-not-found/handler.fish
+++ b/Library/Homebrew/command-not-found/handler.fish
@@ -7,7 +7,7 @@ function fish_command_not_found
     set -l txt
 
     if not contains -- "$cmd" "-h" "--help" "--usage" "-?"
-        set txt (brew which-formula --skip-update --explain $cmd 2> /dev/null)
+        set txt (brew which-formula --explain $cmd 2> /dev/null)
     end
 
     if test -z "$txt"

--- a/Library/Homebrew/command-not-found/handler.sh
+++ b/Library/Homebrew/command-not-found/handler.sh
@@ -37,7 +37,7 @@ homebrew_command_not_found_handle() {
   if [[ "${cmd}" != "-h" ]] && [[ "${cmd}" != "--help" ]] && [[ "${cmd}" != "--usage" ]] && [[ "${cmd}" != "-?" ]]
   then
     local txt
-    txt="$(brew which-formula --skip-update --explain "${cmd}" 2>/dev/null)"
+    txt="$(brew which-formula --explain "${cmd}" 2>/dev/null)"
   fi
 
   if [[ -z "${txt}" ]]


### PR DESCRIPTION
## What does this PR do?

This removes the obsolete `--skip-update` option from the Bash/Zsh and Fish command-not-found handlers.

`brew which-formula` no longer accepts `--skip-update`, but the command-not-found handlers still passed it through, causing command-not-found integrations to fail when trying to call `brew which-formula --skip-update --explain`.

Fixes #22338.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?

Testing: not run - change only removes an obsolete option from shell handler calls.


- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] GPT 5.5, GPT 3.3-Codex, and Gemini 3.1-Flash were all used to generate this PR.

I used AI to help identify the stale `--skip-update` usage and review the small change. I manually verified that this PR only removes the obsolete option from the command-not-found handlers and does not restore `--skip-update` support.