### PR TITLE
info, tap-info: skip uninstalled marker and bold when not a problem (align with search)

### DIFF
--- a/Library/Homebrew/cask/info.rb
+++ b/Library/Homebrew/cask/info.rb
@@ -27,9 +27,9 @@ module Cask
       output << "#{metadata.join("\n")}\n" if metadata.present?
       repo = repo_info(cask)
       output << "#{repo}\n" if repo
-      deps = deps_info(cask)
+      deps = deps_info(cask, mark_uninstalled: installed)
       output << deps if deps
-      requirements = requirements_info(cask)
+      requirements = requirements_info(cask, mark_uninstalled: installed)
       output << requirements if requirements
       language = language_info(cask)
       output << language if language
@@ -84,19 +84,27 @@ module Cask
       info.join("\n")
     end
 
-    sig { params(cask: Cask).returns(T.nilable(String)) }
-    def self.deps_info(cask)
+    sig { params(cask: Cask, mark_uninstalled: T::Boolean).returns(T.nilable(String)) }
+    def self.deps_info(cask, mark_uninstalled: true)
       depends_on = cask.depends_on
 
       formula_deps = Array(depends_on[:formula]).map do |dep|
         name = dep.to_s
         rack = HOMEBREW_CELLAR/::Utils.name_from_full_name(name)
-        decorate_dependency(name, installed: rack.directory? && !rack.subdirs.empty?)
+        decorate_dependency(
+          name,
+          installed:        rack.directory? && !rack.subdirs.empty?,
+          mark_uninstalled:,
+        )
       end
 
       cask_deps = Array(depends_on[:cask]).map do |dep|
         name = dep.to_s
-        decorate_dependency("#{name} (cask)", installed: (Caskroom.path/name).directory?)
+        decorate_dependency(
+          "#{name} (cask)",
+          installed:        (Caskroom.path/name).directory?,
+          mark_uninstalled:,
+        )
       end
 
       all_deps = formula_deps + cask_deps
@@ -125,13 +133,13 @@ module Cask
       "#{lines.join("\n")}\n"
     end
 
-    sig { params(dep: String, installed: T::Boolean).returns(String) }
-    def self.decorate_dependency(dep, installed:)
-      installed ? pretty_installed(dep) : pretty_uninstalled(dep)
+    sig { params(dep: String, installed: T::Boolean, mark_uninstalled: T::Boolean).returns(String) }
+    def self.decorate_dependency(dep, installed:, mark_uninstalled: true)
+      pretty_install_status(dep, installed:, mark_uninstalled:)
     end
 
-    sig { params(cask: Cask).returns(T.nilable(String)) }
-    def self.requirements_info(cask)
+    sig { params(cask: Cask, mark_uninstalled: T::Boolean).returns(T.nilable(String)) }
+    def self.requirements_info(cask, mark_uninstalled: true)
       require "cask_dependent"
 
       requirements = CaskDependent.new(cask).requirements.grep_v(CaskDependent::Requirement)
@@ -160,8 +168,11 @@ module Cask
           else
             requirement.display_s
           end
-          installed = requirement.satisfied?
-          installed ? pretty_installed(requirement_s) : pretty_uninstalled(requirement_s)
+          pretty_install_status(
+            requirement_s,
+            installed:        requirement.satisfied?,
+            mark_uninstalled:,
+          )
         end.join(", ")}\n"
       end
       output

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -696,7 +696,8 @@ module Homebrew
           next if deps.empty?
 
           tab_deps = (kegs.any? && type != "build") ? tab_runtime_deps : nil
-          "#{type.capitalize} (#{deps.count}): #{decorate_dependencies(deps, tab_runtime_deps: tab_deps)}"
+          "#{type.capitalize} (#{deps.count}): " \
+            "#{decorate_dependencies(deps, tab_runtime_deps: tab_deps, mark_uninstalled: kegs.any?)}"
         end
         if dependency_lines.present? || tab_runtime_deps.present? || installed_dependents.any?
           ohai "Dependencies"
@@ -727,7 +728,7 @@ module Homebrew
             reqs = formula.requirements.select(&:"#{type}?")
             next if reqs.to_a.empty?
 
-            puts "#{type.capitalize}: #{decorate_requirements(reqs)}"
+            puts "#{type.capitalize}: #{decorate_requirements(reqs, mark_uninstalled: kegs.any?)}"
           end
         end
 
@@ -813,9 +814,10 @@ module Homebrew
 
       sig {
         params(dependencies:     T::Array[Dependency],
-               tab_runtime_deps: T.nilable(T::Array[T::Hash[String, T.untyped]])).returns(String)
+               tab_runtime_deps: T.nilable(T::Array[T::Hash[String, T.untyped]]),
+               mark_uninstalled: T::Boolean).returns(String)
       }
-      def decorate_dependencies(dependencies, tab_runtime_deps: nil)
+      def decorate_dependencies(dependencies, tab_runtime_deps: nil, mark_uninstalled: true)
         dependencies.map do |dep|
           display = dep_display_s(dep)
           full_name = tab_runtime_deps&.find do |d|
@@ -831,15 +833,15 @@ module Homebrew
           end
           installed ||= formula.any_version_installed? if !installed && formula
           outdated = T.let(installed && formula&.outdated? == true, T::Boolean)
-          pretty_install_status(display, installed:, outdated:)
+          pretty_install_status(display, installed:, outdated:, mark_uninstalled:)
         end.join(", ")
       end
 
-      sig { params(requirements: T::Array[Requirement]).returns(String) }
-      def decorate_requirements(requirements)
+      sig { params(requirements: T::Array[Requirement], mark_uninstalled: T::Boolean).returns(String) }
+      def decorate_requirements(requirements, mark_uninstalled: true)
         req_status = requirements.map do |req|
           req_s = req.display_s
-          req.satisfied? ? pretty_installed(req_s) : pretty_uninstalled(req_s)
+          pretty_install_status(req_s, installed: req.satisfied?, mark_uninstalled:)
         end
         req_status.join(", ")
       end

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -154,12 +154,13 @@ module Homebrew
         pretty_install_status(
           name,
           installed:,
-          outdated:   installed && formula.outdated?,
-          deprecated: formula.deprecated?,
-          disabled:   formula.disabled?,
+          outdated:         installed && formula.outdated?,
+          deprecated:       formula.deprecated?,
+          disabled:         formula.disabled?,
+          mark_uninstalled: false,
         )
       rescue
-        pretty_install_status(name, installed:)
+        pretty_install_status(name, installed:, mark_uninstalled: false)
       end
 
       sig { params(tap: Tap, token: String, installed: T::Boolean).returns(String) }
@@ -168,12 +169,13 @@ module Homebrew
         pretty_install_status(
           token,
           installed:,
-          outdated:   installed && cask.outdated?,
-          deprecated: cask.deprecated?,
-          disabled:   cask.disabled?,
+          outdated:         installed && cask.outdated?,
+          deprecated:       cask.deprecated?,
+          disabled:         cask.disabled?,
+          mark_uninstalled: false,
         )
       rescue
-        pretty_install_status(token, installed:)
+        pretty_install_status(token, installed:, mark_uninstalled: false)
       end
 
       sig { params(taps: T::Array[Tap]).void }

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Cask::Info, :cask do
       Not installed
       From: #{Formatter.url("https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/w/with-depends-on-cask-multiple.rb")}
       #{ohai_title "Dependencies"}
-      Required (2): #{uninstalled("local-caffeine (cask)")}, #{uninstalled("local-transmission-zip (cask)")}
+      Required (2): local-caffeine (cask), local-transmission-zip (cask)
       Recursive Runtime (2): 0 installed #{Formatter.success("✔")}, 2 missing #{Formatter.error("✘")}
       #{requirements_section(installed("macOS >= 10.15"))}
       #{ohai_title "Artifacts"}
@@ -99,7 +99,7 @@ RSpec.describe Cask::Info, :cask do
       Not installed
       From: #{Formatter.url("https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/w/with-depends-on-cask-multiple.rb")}
       #{ohai_title "Dependencies"}
-      Required (2): #{uninstalled("local-caffeine (cask)")}, #{installed("local-transmission-zip (cask)")}
+      Required (2): local-caffeine (cask), #{installed("local-transmission-zip (cask)")}
       Recursive Runtime (2): 1 installed #{Formatter.success("✔")}, 1 missing #{Formatter.error("✘")}
       #{requirements_section(installed("macOS >= 10.15"))}
       #{ohai_title "Artifacts"}
@@ -119,9 +119,9 @@ RSpec.describe Cask::Info, :cask do
   it "prints cask and formulas dependencies if the Cask has both" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
     arch_requirements = if Hardware::CPU.arm?
-      "#{uninstalled("x86_64 architecture")}, #{installed("arm64 architecture")}"
+      "x86_64 architecture, #{installed("arm64 architecture")}"
     else
-      "#{installed("x86_64 architecture")}, #{uninstalled("arm64 architecture")}"
+      "#{installed("x86_64 architecture")}, arm64 architecture"
     end
 
     expect do
@@ -132,7 +132,7 @@ RSpec.describe Cask::Info, :cask do
       Not installed
       From: #{Formatter.url("https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/w/with-depends-on-everything.rb")}
       #{ohai_title "Dependencies"}
-      Required (3): #{uninstalled("unar")}, #{uninstalled("local-caffeine (cask)")}, #{uninstalled("with-depends-on-cask (cask)")}
+      Required (3): unar, local-caffeine (cask), with-depends-on-cask (cask)
       Recursive Runtime (4): 0 installed #{Formatter.success("✔")}, 4 missing #{Formatter.error("✘")}
       #{requirements_section("#{arch_requirements}, #{installed("macOS >= 10.15")}")}
       #{ohai_title "Artifacts"}

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -716,7 +716,7 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
-  it "marks a missing dep on an uninstalled formula as unsatisfied" do
+  it "does not mark a missing dep on an uninstalled formula" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
     info = described_class.new([])
@@ -731,7 +731,7 @@ RSpec.describe Homebrew::Cmd::Info do
     allow(formula).to receive(:core_formula?).and_return(false)
 
     expect { info.send(:info_formula, formula) }
-      .to output(/Required \(1\): .*bar.*✘/).to_stdout
+      .to output(/Required \(1\): bar\n/).to_stdout
       .and not_to_output.to_stderr
   end
 

--- a/Library/Homebrew/test/cmd/tap-info_spec.rb
+++ b/Library/Homebrew/test/cmd/tap-info_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Homebrew::Cmd::TapInfo do
       allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
     end
 
-    it "marks an uninstalled formula as unsatisfied" do
-      expect(tap_info.send(:decorate_formula, tap, "missing", installed: false)).to match(/missing.*✘/)
+    it "does not mark an uninstalled formula" do
+      expect(tap_info.send(:decorate_formula, tap, "missing", installed: false)).not_to match(/✘/)
     end
 
     it "marks an installed formula as satisfied" do
@@ -74,8 +74,8 @@ RSpec.describe Homebrew::Cmd::TapInfo do
       allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
     end
 
-    it "marks an uninstalled cask as unsatisfied" do
-      expect(tap_info.send(:decorate_cask, tap, "missing", installed: false)).to match(/missing.*✘/)
+    it "does not mark an uninstalled cask" do
+      expect(tap_info.send(:decorate_cask, tap, "missing", installed: false)).not_to match(/✘/)
     end
 
     it "marks an installed cask as satisfied" do
@@ -147,11 +147,12 @@ RSpec.describe Homebrew::Cmd::TapInfo do
                                                                                          disabled?:   false))
       end
 
-      it "lists every formula and cask with mixed install markers under their headers" do
+      it "lists every formula and cask, marking only the installed ones" do
         expect { tap_info.send(:print_tap_listings, tap) }
           .to output(
-            /Commands.*mycmd.*==> Formulae.*foo.*✔.*uninstalled-formula.*✘.*==> Casks.*bar.*✔.*uninstalled-cask.*✘/m,
+            /Commands.*mycmd.*==> Formulae.*foo.*✔.*uninstalled-formula.*==> Casks.*bar.*✔.*uninstalled-cask/m,
           ).to_stdout
+        expect { tap_info.send(:print_tap_listings, tap) }.not_to output(/✘/).to_stdout
       end
     end
 
@@ -201,9 +202,10 @@ RSpec.describe Homebrew::Cmd::TapInfo do
         allow(Cask::Caskroom).to receive(:tokens).and_return([])
       end
 
-      it "lists every formula and cask with uninstalled markers" do
+      it "lists every formula and cask without uninstalled markers" do
         expect { tap_info.send(:print_tap_listings, tap) }
-          .to output(/==> Formulae.*baz.*✘.*foo.*✘.*==> Casks.*bar.*✘/m).to_stdout
+          .to output(/==> Formulae.*baz.*foo.*==> Casks.*bar/m).to_stdout
+        expect { tap_info.send(:print_tap_listings, tap) }.not_to output(/✘/).to_stdout
       end
     end
 


### PR DESCRIPTION
Aligns uninstalled formulae with how `brew search` works.

- For `brew tap-info`: Uninstalled formulae won't be bolded and not have the red X.
- For `brew info`: A non-installed dependency is not a problem before the formula itself is installed so won't show the red X. When the formula is installed, then a missing dep is a problem, so that should be highlighted with bold and a red X.

```
❯ brew tap-info facebook/fb
...
==> Formulae
buck                 fbsimctl             fbthrift-compiler    idb-companion ✔      watchman             xar

❯ brew info pyside@2
==> pyside@2 ✘ (disabled): stable 5.15.17 (bottled) [keg-only]
...
==> Dependencies
Required (3): llvm ✔, python@3.10, qt@5
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claud Code, Extra High

-----
