### PR TITLE
cask: include resolved artifact targets in JSON output

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -629,7 +629,10 @@ module Cask
           uninstall_artifact = artifact.respond_to?(:uninstall_phase) || artifact.respond_to?(:post_uninstall_phase)
           next if uninstall_only && !zap_artifact && !uninstall_artifact
 
-          entry = T.let({ artifact.class.dsl_key => artifact.to_args }, T::Hash[Symbol, T.untyped])
+          entry = T.let(
+            { artifact.class.dsl_key => artifact.to_args },
+            T::Hash[Symbol, T.any(String, T::Array[T.anything])],
+          )
           entry[:target] = artifact.target.to_s if !uninstall_only && artifact.is_a?(Artifact::Relocated)
           entry
         end

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -629,7 +629,9 @@ module Cask
           uninstall_artifact = artifact.respond_to?(:uninstall_phase) || artifact.respond_to?(:post_uninstall_phase)
           next if uninstall_only && !zap_artifact && !uninstall_artifact
 
-          { artifact.class.dsl_key => artifact.to_args }
+          entry = T.let({ artifact.class.dsl_key => artifact.to_args }, T::Hash[Symbol, T.untyped])
+          entry[:target] = artifact.target.to_s if !uninstall_only && artifact.is_a?(Artifact::Relocated)
+          entry
         end
       end
     end

--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -81,7 +81,8 @@ module Cask
       )
     end
 
-    sig { params(config: ConfigHash).returns(ConfigHash) }
+    # runtime recursive evaluation forces the LazyObject to be evaluated
+    T::Sig::WithoutRuntime.sig { params(config: ConfigHash).returns(ConfigHash) }
     def self.canonicalize(config)
       config.to_h do |k, v|
         if DEFAULT_DIRS.key?(k)
@@ -136,7 +137,8 @@ module Cask
       @explicit.assert_valid_keys(*self.class.defaults.keys)
     end
 
-    sig { returns(ConfigHash) }
+    # runtime recursive evaluation forces the LazyObject to be evaluated
+    T::Sig::WithoutRuntime.sig { returns(ConfigHash) }
     def default
       @default ||= self.class.canonicalize(self.class.defaults)
     end

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -454,7 +454,7 @@ RSpec.describe Cask::Cask, :cask do
           trash: ["#{TEST_TMPDIR}/foo", "#{TEST_TMPDIR}/bar"],
         }] },
         { pkg: ["ManyArtifacts/ManyArtifacts.pkg"] },
-        { app: ["ManyArtifacts/ManyArtifacts.app"] },
+        { app: ["ManyArtifacts/ManyArtifacts.app"], target: "#{TEST_TMPDIR}/cask-appdir/ManyArtifacts.app" },
         { uninstall_postflight: nil },
         { postflight: nil },
         { zap: [{
@@ -563,7 +563,9 @@ RSpec.describe Cask::Cask, :cask do
   end
 
   describe "#to_h" do
-    let(:expected_json) { (TEST_FIXTURE_DIR/"cask/everything.json").read.strip }
+    let(:expected_json) do
+      (TEST_FIXTURE_DIR/"cask/everything.json").read.strip.gsub("$APPDIR", "#{TEST_TMPDIR}/cask-appdir")
+    end
 
     context "when loaded from cask file" do
       it "returns expected hash" do
@@ -757,7 +759,10 @@ RSpec.describe Cask::Cask, :cask do
     end
 
     context "when loaded from json file" do
-      let(:expected_json) { (TEST_FIXTURE_DIR/"cask/everything-with-variations.json").read.strip }
+      let(:expected_json) do
+        (TEST_FIXTURE_DIR/"cask/everything-with-variations.json").read.strip
+          .gsub("$APPDIR", "#{TEST_TMPDIR}/cask-appdir")
+      end
 
       it "returns expected hash with variations" do
         expect(Homebrew::API::Cask).not_to receive(:source_download)

--- a/Library/Homebrew/test/support/fixtures/cask/everything-with-variations.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything-with-variations.json
@@ -64,7 +64,8 @@
     {
       "app": [
         "Everything.app"
-      ]
+      ],
+      "target": "$APPDIR/Everything.app"
     },
     {
       "zap": [

--- a/Library/Homebrew/test/support/fixtures/cask/everything.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything.json
@@ -64,7 +64,8 @@
     {
       "app": [
         "Everything.app"
-      ]
+      ],
+      "target": "$APPDIR/Everything.app"
     },
     {
       "zap": [


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

Add a `target` sibling field per artifact entry in `Cask#artifacts_list`
(and therefore in `brew info --json=v2 --cask <name>`) containing the
absolute install path for `Relocated` artifacts (apps, fonts, plugins,
binaries, completions, etc.). Skipped for artifact types without a
target (pkg, installer, preflight blocks, zap) and in `uninstall_only:`
mode.

This lets external tooling — MDM agents, security scanners, packagers —
enumerate where a cask lands on disk without re-implementing Homebrew's
path-resolution logic (`Config` defaults, `HOMEBREW_CASK_OPTS`
overrides, `~` expansion, the `target:` DSL kwarg, etc.).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

-----

This PR was created with Claude Opus 4.7 with manual review.
