### PR TITLE
Resolve src through realpath in install_renamed

### DIFF
--- a/Library/Homebrew/install_renamed.rb
+++ b/Library/Homebrew/install_renamed.rb
@@ -48,6 +48,8 @@ module InstallRenamed
     # helper. If the live config still matches an older bottled default, replace
     # it so untouched configs advance on upgrade. Modified configs still receive
     # the new default as `*.default`.
+    # Resolve via realpath so the ascend walks the Cellar path, not `opt_prefix.
+    src = src.realpath
     src.ascend do |path|
       next if path.basename.to_s != ".bottle" || path.parent.parent.parent != HOMEBREW_CELLAR
 

--- a/Library/Homebrew/install_renamed.rb
+++ b/Library/Homebrew/install_renamed.rb
@@ -49,7 +49,12 @@ module InstallRenamed
     # it so untouched configs advance on upgrade. Modified configs still receive
     # the new default as `*.default`.
     # Resolve via realpath so the ascend walks the Cellar path, not `opt_prefix`.
-    src = src.realpath
+    # For symlink sources, resolve only the parent directory so broken symlinks
+    src = if src.symlink?
+      src.dirname.realpath/src.basename
+    else
+      src.realpath
+    end
     src.ascend do |path|
       next if path.basename.to_s != ".bottle" || path.parent.parent.parent != HOMEBREW_CELLAR
 

--- a/Library/Homebrew/install_renamed.rb
+++ b/Library/Homebrew/install_renamed.rb
@@ -48,7 +48,7 @@ module InstallRenamed
     # helper. If the live config still matches an older bottled default, replace
     # it so untouched configs advance on upgrade. Modified configs still receive
     # the new default as `*.default`.
-    # Resolve via realpath so the ascend walks the Cellar path, not `opt_prefix.
+    # Resolve via realpath so the ascend walks the Cellar path, not `opt_prefix`.
     src = src.realpath
     src.ascend do |path|
       next if path.basename.to_s != ".bottle" || path.parent.parent.parent != HOMEBREW_CELLAR

--- a/Library/Homebrew/install_renamed.rb
+++ b/Library/Homebrew/install_renamed.rb
@@ -50,6 +50,7 @@ module InstallRenamed
     # the new default as `*.default`.
     # Resolve via realpath so the ascend walks the Cellar path, not `opt_prefix`.
     # For symlink sources, resolve only the parent directory so broken symlinks
+    # are still handled without requiring the target to exist.
     src = if src.symlink?
       src.dirname.realpath/src.basename
     else

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1121,6 +1121,15 @@ RSpec.describe Formula do
 
       expect([config_file.read, default_config_file.read]).to eq(["custom\n", "new\n"])
     end
+
+    it "replaces config that matches the previous default when the keg is opt-linked" do
+      config_file.write "old\n"
+      Keg.new(f.rack/"2.0").optlink
+
+      f.install_etc_var
+
+      expect([config_file.read, default_config_file.exist?]).to eq(["new\n", false])
+    end
   end
 
   specify "test fixtures" do


### PR DESCRIPTION
Fixing untouched etc configs being left stale on upgrade.
After the new keg is linked, `Formula#prefix` returns `opt_prefix`, so the ascend in `append_default_if_different` walks via the `opt/` symlink and the `HOMEBREW_CELLAR` guard rejects every level — the sibling-keg lookup never runs and `<file>.default` is always written. Resolving `src` through `realpath` first puts the walk back on the cellar path so the lookup fires and untouched configs can advance on upgrade.

Tested locally by adding a line to a conf in https://github.com/redis-developer/homebrew-core/blob/redis-add-line-to-conf/Formula/r/redis.rb, created a bottle and ran `brew upgrade redis`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.
Used claude, verified manually the fix
-----
