### PR TITLE
Omit aliases from completions

### DIFF
--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -190,7 +190,7 @@ module Commands
   def self.rebuild_internal_commands_completion_list
     require "completions"
 
-    cmds = internal_commands + internal_developer_commands + internal_commands_aliases
+    cmds = internal_commands + internal_developer_commands
     cmds.reject! { |cmd| Homebrew::Completions::COMPLETIONS_EXCLUSION_LIST.include? cmd }
 
     file = HOMEBREW_REPOSITORY/"completions/internal_commands_list.txt"
@@ -204,7 +204,7 @@ module Commands
     # Ensure that the cache exists so we can build the commands list
     HOMEBREW_CACHE.mkpath
 
-    cmds = commands(aliases: true) - Homebrew::Completions::COMPLETIONS_EXCLUSION_LIST
+    cmds = commands - Homebrew::Completions::COMPLETIONS_EXCLUSION_LIST
 
     all_commands_file = HOMEBREW_CACHE/"all_commands_list.txt"
     external_commands_file = HOMEBREW_CACHE/"external_commands_list.txt"

--- a/Library/Homebrew/completions.rb
+++ b/Library/Homebrew/completions.rb
@@ -124,7 +124,7 @@ module Homebrew
 
     sig { void }
     def self.update_shell_completions!
-      commands = Commands.commands(external: false, aliases: true).sort
+      commands = Commands.commands(external: false).sort
 
       puts "Writing completions to #{COMPLETIONS_DIR}"
 
@@ -283,7 +283,12 @@ module Homebrew
 
     sig { params(commands: T::Array[String]).returns(String) }
     def self.generate_bash_completion_file(commands)
+      commands -= Commands.internal_commands_aliases
+
       variables = Variables.new(
+        aliases:              Commands::HOMEBREW_INTERNAL_COMMAND_ALIASES.map do |alias_cmd, command|
+          "#{alias_cmd}) echo \"#{command}\" ;;"
+        end,
         completion_functions: commands.filter_map do |command|
           generate_bash_subcommand_completion command
         end,
@@ -449,6 +454,8 @@ module Homebrew
 
     sig { params(commands: T::Array[String]).returns(String) }
     def self.generate_zsh_completion_file(commands)
+      commands -= Commands.internal_commands_aliases
+
       variables = Variables.new(
         aliases:                      Commands::HOMEBREW_INTERNAL_COMMAND_ALIASES.filter_map do |alias_cmd, command|
           alias_cmd = "'#{alias_cmd}'" if alias_cmd.start_with? "-"
@@ -482,7 +489,8 @@ module Homebrew
       return generate_fish_nested_subcommand_completion(command, subcommands) if subcommands.present?
 
       command_description = format_description Commands.command_description(command, short: true).to_s, fish: true
-      lines = if COMPLETIONS_EXCLUSION_LIST.include?(command)
+      lines = if COMPLETIONS_EXCLUSION_LIST.include?(command) ||
+                 Commands::HOMEBREW_INTERNAL_COMMAND_ALIASES.key?(command)
         []
       else
         ["__fish_brew_complete_cmd '#{command}' '#{command_description}'"]
@@ -571,7 +579,8 @@ module Homebrew
     sig { params(command: String, subcommands: T::Array[Homebrew::CLI::Parser::Subcommand]).returns(String) }
     def self.generate_fish_nested_subcommand_completion(command, subcommands)
       command_description = format_description Commands.command_description(command, short: true).to_s, fish: true
-      lines = if COMPLETIONS_EXCLUSION_LIST.include?(command)
+      lines = if COMPLETIONS_EXCLUSION_LIST.include?(command) ||
+                 Commands::HOMEBREW_INTERNAL_COMMAND_ALIASES.key?(command)
         []
       else
         ["__fish_brew_complete_cmd '#{command}' '#{command_description}'"]
@@ -615,7 +624,12 @@ module Homebrew
 
     sig { params(commands: T::Array[String]).returns(String) }
     def self.generate_fish_completion_file(commands)
+      commands -= Commands.internal_commands_aliases
+
       variables = Variables.new(
+        aliases:              Commands::HOMEBREW_INTERNAL_COMMAND_ALIASES.map do |alias_cmd, command|
+          "        case '#{alias_cmd}'\n            echo '#{command}'"
+        end,
         completion_functions: commands.filter_map do |command|
           generate_fish_subcommand_completion command
         end,

--- a/Library/Homebrew/completions/bash.erb
+++ b/Library/Homebrew/completions/bash.erb
@@ -113,7 +113,6 @@ __brew_complete_commands() {
 
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local cmds
-  local -a cmd_aliases
 
   if [[ -n ${__HOMEBREW_COMMANDS} ]]
   then
@@ -125,15 +124,24 @@ __brew_complete_commands() {
   then
     cmds="$(< "${HOMEBREW_REPOSITORY}/completions/internal_commands_list.txt")"
   fi
-  while read -r alias; do cmd_aliases+=("${alias}"); done < <(compgen -W "$(__brew_list_aliases)")
-  [[ -n ${cmd_aliases[*]+"${cmd_aliases[*]}"} ]] && cmds+=" ${cmd_aliases[*]} alias unalias"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${cmds}" -- "${cur}")
+  while read -r line
+  do
+    [[ $(__brew_internal_command_alias "${line}") == "${line}" ]] || continue
+    COMPREPLY+=("${line}")
+  done < <(compgen -W "${cmds}" -- "${cur}")
   export __HOMEBREW_COMMANDS=${cmds}
 }
 
 # compopt is only available in newer versions of bash
 __brew_complete_files() {
   command -v compopt &> /dev/null && compopt -o default
+}
+
+__brew_internal_command_alias() {
+  case "$1" in
+    <%= aliases.join("\n    ") + "\n" %>
+    *) echo "$1" ;;
+  esac
 }
 
 # https://github.com/Homebrew/homebrew-aliases
@@ -185,6 +193,8 @@ _brew() {
     __brew_complete_commands
     return
   fi
+
+  cmd="$(__brew_internal_command_alias "${cmd}")"
 
   # subcommands have their own completion functions
   case "${cmd}" in

--- a/Library/Homebrew/completions/fish.erb
+++ b/Library/Homebrew/completions/fish.erb
@@ -38,6 +38,14 @@ function __fish_brew_args -d "Returns a list of all arguments given to brew"
     end
 end
 
+function __fish_brew_expand_alias -a cmd -d "Expands a Homebrew command alias"
+    switch $cmd
+<%= aliases.join("\n") + "\n" %>
+        case '*'
+            echo $cmd
+    end
+end
+
 function __fish_brew_opts -d "Only arguments starting with a dash (options)"
     string match --all -- '-*' (__fish_brew_args)
 end
@@ -52,11 +60,12 @@ end
 function __fish_brew_command -d "Helps matching the first argument of brew"
     set args (__fish_brew_args)
     set -q args[1]; or return 1
+    set -l cmd (__fish_brew_expand_alias $args[1])
 
     if count $argv
-        contains -- $args[1] $argv
+        contains -- $cmd $argv
     else
-        echo $args[1]
+        echo $cmd
     end
 end
 
@@ -147,11 +156,16 @@ function __fish_brew_suggest_taps_installed -d "List all available taps"
     | string replace (brew --repo)/Library/Taps/ ""
 end
 
-function __fish_brew_suggest_commands -d "Lists all commands names, including aliases"
+function __fish_brew_suggest_commands -d "Lists all command names"
+    set -l commands
     if test -f (brew --cache)/all_commands_list.txt
-        cat (brew --cache)/all_commands_list.txt
+        set commands (cat (brew --cache)/all_commands_list.txt)
     else
-        cat (brew --repo)/completions/internal_commands_list.txt
+        set commands (cat (brew --repo)/completions/internal_commands_list.txt)
+    end
+    for command in $commands
+        set -l expanded_command (__fish_brew_expand_alias $command)
+        test "$expanded_command" = "$command"; and echo $command
     end
 end
 

--- a/Library/Homebrew/test/commands_spec.rb
+++ b/Library/Homebrew/test/commands_spec.rb
@@ -77,6 +77,34 @@ RSpec.describe Commands do
     end
   end
 
+  describe "::rebuild_internal_commands_completion_list" do
+    it "omits internal command aliases" do
+      mktmpdir do |repository|
+        stub_const("HOMEBREW_REPOSITORY", repository)
+        (repository/"completions").mkpath
+
+        described_class.rebuild_internal_commands_completion_list
+
+        commands = (repository/"completions/internal_commands_list.txt").read.lines(chomp: true)
+        expect(commands & described_class.internal_commands_aliases).to be_empty
+      end
+    end
+  end
+
+  describe "::rebuild_commands_completion_list" do
+    it "omits internal command aliases from the cached command list" do
+      mktmpdir do |cache|
+        stub_const("HOMEBREW_CACHE", cache)
+        allow(described_class).to receive(:external_commands).and_return(["external"])
+
+        described_class.rebuild_commands_completion_list
+
+        commands = (cache/"all_commands_list.txt").read.lines(chomp: true)
+        expect(commands & described_class.internal_commands_aliases).to be_empty
+      end
+    end
+  end
+
   describe "::path" do
     specify "returns the path for an internal command" do
       expect(described_class.path("rbcmd")).to eq(Commands::HOMEBREW_CMD_PATH/"rbcmd.rb")

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -396,6 +396,17 @@ RSpec.describe Homebrew::Completions do
         expect(file).to match(/^ {4}update\) _brew_update ;;/)
         expect(file).to match(/^complete -o bashdefault -o default -F _brew brew$/)
       end
+
+      it "doesn't add aliases to command completions" do
+        file = described_class.generate_bash_completion_file(%w[install missing up update])
+        expect(file).not_to include("cmd_aliases")
+        expect(file).not_to match(/^_brew_up\(\) {$/)
+        expect(file).not_to match(/^ {4}up\) _brew_up ;;/)
+        expect(file).to include('[[ $(__brew_internal_command_alias "${line}") == "${line}" ]] || continue')
+        expect(file).to include('cmd="$(__brew_internal_command_alias "${cmd}")"')
+        expect(file).to match(/^ {4}up\) echo "update" ;;$/)
+        expect(file).to match(/^ {4}update\) _brew_update ;;$/)
+      end
     end
 
     describe ".generate_zsh_subcommand_completion" do
@@ -460,6 +471,15 @@ RSpec.describe Homebrew::Completions do
         expect(completion).to include("'i:Show service information'")
         expect(completion).to include("info|i)")
         expect(completion).to include("*:service:__brew_services")
+      end
+
+      it "doesn't generate alias completion functions" do
+        file = described_class.generate_zsh_completion_file(%w[up update])
+        expect(file).not_to match(/^# brew up$/)
+        expect(file).not_to match(/^_brew_up\(\) {$/)
+        expect(file).to match(/^    up update$/)
+        expect(file).to include('command="${aliases[$command_or_alias]:-$command_or_alias}"')
+        expect(file).to include('local completion_func="_brew_${command//-/_}"')
       end
     end
 
@@ -545,6 +565,16 @@ RSpec.describe Homebrew::Completions do
         expect(file).to match(/^__fish_brew_complete_cmd 'install' 'Install a formula or cask'$/)
         expect(file).to match(/^__fish_brew_complete_cmd 'missing' 'Check the given formula kegs for .*'$/)
         expect(file).to match(/^__fish_brew_complete_cmd 'update' 'Fetch the newest version of Homebrew .*'$/)
+      end
+
+      it "omits aliases from command completions" do
+        file = described_class.generate_fish_completion_file(%w[up update])
+        expect(file).not_to match(/^__fish_brew_complete_cmd 'up'/)
+        expect(file).not_to match(/^__fish_brew_complete_arg 'up'/)
+        expect(file).to match(/^        case 'up'$/)
+        expect(file).to match(/^            echo 'update'$/)
+        expect(file).to include("set -l cmd (__fish_brew_expand_alias $args[1])")
+        expect(file).to match(/^__fish_brew_complete_cmd 'update'/)
       end
     end
   end

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -98,7 +98,6 @@ __brew_complete_commands() {
 
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local cmds
-  local -a cmd_aliases
 
   if [[ -n ${__HOMEBREW_COMMANDS} ]]
   then
@@ -110,15 +109,42 @@ __brew_complete_commands() {
   then
     cmds="$(< "${HOMEBREW_REPOSITORY}/completions/internal_commands_list.txt")"
   fi
-  while read -r alias; do cmd_aliases+=("${alias}"); done < <(compgen -W "$(__brew_list_aliases)")
-  [[ -n ${cmd_aliases[*]+"${cmd_aliases[*]}"} ]] && cmds+=" ${cmd_aliases[*]} alias unalias"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${cmds}" -- "${cur}")
+  while read -r line
+  do
+    [[ $(__brew_internal_command_alias "${line}") == "${line}" ]] || continue
+    COMPREPLY+=("${line}")
+  done < <(compgen -W "${cmds}" -- "${cur}")
   export __HOMEBREW_COMMANDS=${cmds}
 }
 
 # compopt is only available in newer versions of bash
 __brew_complete_files() {
   command -v compopt &> /dev/null && compopt -o default
+}
+
+__brew_internal_command_alias() {
+  case "$1" in
+    ls) echo "list" ;;
+    homepage) echo "home" ;;
+    -S) echo "search" ;;
+    up) echo "update" ;;
+    ln) echo "link" ;;
+    instal) echo "install" ;;
+    uninstal) echo "uninstall" ;;
+    post_install) echo "postinstall" ;;
+    rm) echo "uninstall" ;;
+    remove) echo "uninstall" ;;
+    abv) echo "info" ;;
+    dr) echo "doctor" ;;
+    --repo) echo "--repository" ;;
+    environment) echo "--env" ;;
+    --config) echo "config" ;;
+    -v) echo "--version" ;;
+    lc) echo "livecheck" ;;
+    tc) echo "typecheck" ;;
+    x) echo "exec" ;;
+    *) echo "$1" ;;
+  esac
 }
 
 # https://github.com/Homebrew/homebrew-aliases
@@ -201,22 +227,6 @@ _brew___cellar() {
   __brew_complete_formulae
 }
 
-_brew___config() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --debug
-      --help
-      --quiet
-      --verbose
-      "
-      return
-      ;;
-    *) ;;
-  esac
-}
-
 _brew___env() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "${cur}" in
@@ -253,23 +263,6 @@ _brew___prefix() {
     *) ;;
   esac
   __brew_complete_formulae
-}
-
-_brew___repo() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --debug
-      --help
-      --quiet
-      --verbose
-      "
-      return
-      ;;
-    *) ;;
-  esac
-  __brew_complete_tapped
 }
 
 _brew___repository() {
@@ -319,84 +312,6 @@ _brew___version() {
       ;;
     *) ;;
   esac
-}
-
-_brew__s() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --alpine
-      --archlinux
-      --cask
-      --closed
-      --debian
-      --debug
-      --desc
-      --eval-all
-      --fedora
-      --fink
-      --formula
-      --help
-      --macports
-      --open
-      --opensuse
-      --pull-request
-      --quiet
-      --repology
-      --ubuntu
-      --verbose
-      "
-      return
-      ;;
-    *) ;;
-  esac
-}
-
-_brew__v() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --debug
-      --help
-      --quiet
-      --verbose
-      "
-      return
-      ;;
-    *) ;;
-  esac
-}
-
-_brew_abv() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --analytics
-      --cask
-      --category
-      --days
-      --debug
-      --eval-all
-      --fetch-manifest
-      --formula
-      --github
-      --help
-      --installed
-      --json
-      --quiet
-      --sizes
-      --variations
-      --verbose
-      "
-      return
-      ;;
-    *) ;;
-  esac
-  __brew_complete_formulae
-  __brew_complete_casks
 }
 
 _brew_alias() {
@@ -1463,25 +1378,6 @@ _brew_doctor() {
   __brewcomp "${__HOMEBREW_DOCTOR_CHECKS=$(brew doctor --list-checks)}"
 }
 
-_brew_dr() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --audit-debug
-      --debug
-      --help
-      --list-checks
-      --quiet
-      --verbose
-      "
-      return
-      ;;
-    *) ;;
-  esac
-  __brewcomp "${__HOMEBREW_DOCTOR_CHECKS=$(brew doctor --list-checks)}"
-}
-
 _brew_edit() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "${cur}" in
@@ -1502,25 +1398,6 @@ _brew_edit() {
   __brew_complete_formulae
   __brew_complete_casks
   __brew_complete_tapped
-}
-
-_brew_environment() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --debug
-      --help
-      --plain
-      --quiet
-      --shell
-      --verbose
-      "
-      return
-      ;;
-    *) ;;
-  esac
-  __brew_complete_formulae
 }
 
 _brew_exec() {
@@ -1797,26 +1674,6 @@ _brew_home() {
   __brew_complete_casks
 }
 
-_brew_homepage() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --cask
-      --debug
-      --formula
-      --help
-      --quiet
-      --verbose
-      "
-      return
-      ;;
-    *) ;;
-  esac
-  __brew_complete_formulae
-  __brew_complete_casks
-}
-
 _brew_info() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "${cur}" in
@@ -1838,71 +1695,6 @@ _brew_info() {
       --sizes
       --variations
       --verbose
-      "
-      return
-      ;;
-    *) ;;
-  esac
-  __brew_complete_formulae
-  __brew_complete_casks
-}
-
-_brew_instal() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --HEAD
-      --adopt
-      --appdir
-      --appimagedir
-      --as-dependency
-      --ask
-      --audio-unit-plugindir
-      --binaries
-      --bottle-arch
-      --build-bottle
-      --build-from-source
-      --cask
-      --cc
-      --colorpickerdir
-      --debug
-      --debug-symbols
-      --dictionarydir
-      --display-times
-      --dry-run
-      --fetch-HEAD
-      --fontdir
-      --force
-      --force-bottle
-      --formula
-      --git
-      --help
-      --ignore-dependencies
-      --include-test
-      --input-methoddir
-      --interactive
-      --internet-plugindir
-      --keep-tmp
-      --keyboard-layoutdir
-      --language
-      --mdimporterdir
-      --no-binaries
-      --only-dependencies
-      --overwrite
-      --prefpanedir
-      --qlplugindir
-      --quiet
-      --require-sha
-      --screen-saverdir
-      --servicedir
-      --skip-cask-deps
-      --skip-link
-      --skip-post-install
-      --verbose
-      --vst-plugindir
-      --vst3-plugindir
-      --zap
       "
       return
       ;;
@@ -2011,35 +1803,6 @@ _brew_irb() {
       ;;
     *) ;;
   esac
-}
-
-_brew_lc() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --autobump
-      --cask
-      --debug
-      --eval-all
-      --extract-plist
-      --formula
-      --full-name
-      --help
-      --installed
-      --json
-      --newer-only
-      --quiet
-      --resources
-      --tap
-      --verbose
-      "
-      return
-      ;;
-    *) ;;
-  esac
-  __brew_complete_formulae
-  __brew_complete_casks
 }
 
 _brew_leaves() {
@@ -2180,27 +1943,6 @@ _brew_livecheck() {
   __brew_complete_casks
 }
 
-_brew_ln() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --HEAD
-      --debug
-      --dry-run
-      --force
-      --help
-      --overwrite
-      --quiet
-      --verbose
-      "
-      return
-      ;;
-    *) ;;
-  esac
-  __brew_complete_installed_formulae
-}
-
 _brew_log() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "${cur}" in
@@ -2224,38 +1966,6 @@ _brew_log() {
   esac
   __brew_complete_formulae
   __brew_complete_casks
-}
-
-_brew_ls() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --built-from-source
-      --cask
-      --debug
-      --formula
-      --full-name
-      --help
-      --installed-as-dependency
-      --installed-on-request
-      --multiple
-      --pinned
-      --poured-from-bottle
-      --quiet
-      --verbose
-      --versions
-      -1
-      -l
-      -r
-      -t
-      "
-      return
-      ;;
-    *) ;;
-  esac
-  __brew_complete_installed_formulae
-  __brew_complete_installed_casks
 }
 
 _brew_mcp_server() {
@@ -2394,23 +2104,6 @@ _brew_pin() {
   esac
   __brew_complete_installed_formulae
   __brew_complete_installed_casks
-}
-
-_brew_post_install() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --debug
-      --help
-      --quiet
-      --verbose
-      "
-      return
-      ;;
-    *) ;;
-  esac
-  __brew_complete_installed_formulae
 }
 
 _brew_postinstall() {
@@ -2678,52 +2371,6 @@ _brew_release() {
       ;;
     *) ;;
   esac
-}
-
-_brew_remove() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --cask
-      --debug
-      --force
-      --formula
-      --help
-      --ignore-dependencies
-      --quiet
-      --verbose
-      --zap
-      "
-      return
-      ;;
-    *) ;;
-  esac
-  __brew_complete_installed_formulae
-  __brew_complete_installed_casks
-}
-
-_brew_rm() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --cask
-      --debug
-      --force
-      --formula
-      --help
-      --ignore-dependencies
-      --quiet
-      --verbose
-      --zap
-      "
-      return
-      ;;
-    *) ;;
-  esac
-  __brew_complete_installed_formulae
-  __brew_complete_installed_casks
 }
 
 _brew_rubocop() {
@@ -3148,31 +2795,6 @@ _brew_tap_new() {
   __brew_complete_tapped
 }
 
-_brew_tc() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --debug
-      --dir
-      --file
-      --fix
-      --help
-      --ignore
-      --lsp
-      --quiet
-      --suggest-typed
-      --update
-      --update-all
-      --verbose
-      "
-      return
-      ;;
-    *) ;;
-  esac
-  __brew_complete_tapped
-}
-
 _brew_test() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "${cur}" in
@@ -3341,29 +2963,6 @@ _brew_unbottled() {
   __brew_complete_formulae
 }
 
-_brew_uninstal() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --cask
-      --debug
-      --force
-      --formula
-      --help
-      --ignore-dependencies
-      --quiet
-      --verbose
-      --zap
-      "
-      return
-      ;;
-    *) ;;
-  esac
-  __brew_complete_installed_formulae
-  __brew_complete_installed_casks
-}
-
 _brew_uninstall() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "${cur}" in
@@ -3465,25 +3064,6 @@ _brew_untap() {
     *) ;;
   esac
   __brew_complete_tapped
-}
-
-_brew_up() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --auto-update
-      --debug
-      --force
-      --help
-      --merge
-      --quiet
-      --verbose
-      "
-      return
-      ;;
-    *) ;;
-  esac
 }
 
 _brew_update() {
@@ -3849,23 +3429,6 @@ _brew_which_update() {
   esac
 }
 
-_brew_x() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "${cur}" in
-    -*)
-      __brewcomp "
-      --debug
-      --formulae
-      --help
-      --quiet
-      --verbose
-      "
-      return
-      ;;
-    *) ;;
-  esac
-}
-
 _brew() {
   local i=1 cmd
 
@@ -3894,21 +3457,18 @@ _brew() {
     return
   fi
 
+  cmd="$(__brew_internal_command_alias "${cmd}")"
+
   # subcommands have their own completion functions
   case "${cmd}" in
     --cache) _brew___cache ;;
     --caskroom) _brew___caskroom ;;
     --cellar) _brew___cellar ;;
-    --config) _brew___config ;;
     --env) _brew___env ;;
     --prefix) _brew___prefix ;;
-    --repo) _brew___repo ;;
     --repository) _brew___repository ;;
     --taps) _brew___taps ;;
     --version) _brew___version ;;
-    -S) _brew__s ;;
-    -v) _brew__v ;;
-    abv) _brew_abv ;;
     alias) _brew_alias ;;
     analytics) _brew_analytics ;;
     audit) _brew_audit ;;
@@ -3937,9 +3497,7 @@ _brew() {
     dispatch-build-bottle) _brew_dispatch_build_bottle ;;
     docs) _brew_docs ;;
     doctor) _brew_doctor ;;
-    dr) _brew_dr ;;
     edit) _brew_edit ;;
-    environment) _brew_environment ;;
     exec) _brew_exec ;;
     extract) _brew_extract ;;
     fetch) _brew_fetch ;;
@@ -3954,22 +3512,17 @@ _brew() {
     generate-zap) _brew_generate_zap ;;
     gist-logs) _brew_gist_logs ;;
     home) _brew_home ;;
-    homepage) _brew_homepage ;;
     info) _brew_info ;;
-    instal) _brew_instal ;;
     install) _brew_install ;;
     install-bundler-gems) _brew_install_bundler_gems ;;
     irb) _brew_irb ;;
-    lc) _brew_lc ;;
     leaves) _brew_leaves ;;
     lgtm) _brew_lgtm ;;
     link) _brew_link ;;
     linkage) _brew_linkage ;;
     list) _brew_list ;;
     livecheck) _brew_livecheck ;;
-    ln) _brew_ln ;;
     log) _brew_log ;;
-    ls) _brew_ls ;;
     mcp-server) _brew_mcp_server ;;
     migrate) _brew_migrate ;;
     missing) _brew_missing ;;
@@ -3977,7 +3530,6 @@ _brew() {
     options) _brew_options ;;
     outdated) _brew_outdated ;;
     pin) _brew_pin ;;
-    post_install) _brew_post_install ;;
     postinstall) _brew_postinstall ;;
     pr-automerge) _brew_pr_automerge ;;
     pr-publish) _brew_pr_publish ;;
@@ -3989,8 +3541,6 @@ _brew() {
     readall) _brew_readall ;;
     reinstall) _brew_reinstall ;;
     release) _brew_release ;;
-    remove) _brew_remove ;;
-    rm) _brew_rm ;;
     rubocop) _brew_rubocop ;;
     ruby) _brew_ruby ;;
     rubydoc) _brew_rubydoc ;;
@@ -4005,20 +3555,17 @@ _brew() {
     tap) _brew_tap ;;
     tap-info) _brew_tap_info ;;
     tap-new) _brew_tap_new ;;
-    tc) _brew_tc ;;
     test) _brew_test ;;
     test-bot) _brew_test_bot ;;
     tests) _brew_tests ;;
     typecheck) _brew_typecheck ;;
     unalias) _brew_unalias ;;
     unbottled) _brew_unbottled ;;
-    uninstal) _brew_uninstal ;;
     uninstall) _brew_uninstall ;;
     unlink) _brew_unlink ;;
     unpack) _brew_unpack ;;
     unpin) _brew_unpin ;;
     untap) _brew_untap ;;
-    up) _brew_up ;;
     update) _brew_update ;;
     update-if-needed) _brew_update_if_needed ;;
     update-license-data) _brew_update_license_data ;;
@@ -4036,7 +3583,6 @@ _brew() {
     version-install) _brew_version_install ;;
     which-formula) _brew_which_formula ;;
     which-update) _brew_which_update ;;
-    x) _brew_x ;;
     *) ;;
   esac
 }

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -23,6 +23,51 @@ function __fish_brew_args -d "Returns a list of all arguments given to brew"
     end
 end
 
+function __fish_brew_expand_alias -a cmd -d "Expands a Homebrew command alias"
+    switch $cmd
+        case 'ls'
+            echo 'list'
+        case 'homepage'
+            echo 'home'
+        case '-S'
+            echo 'search'
+        case 'up'
+            echo 'update'
+        case 'ln'
+            echo 'link'
+        case 'instal'
+            echo 'install'
+        case 'uninstal'
+            echo 'uninstall'
+        case 'post_install'
+            echo 'postinstall'
+        case 'rm'
+            echo 'uninstall'
+        case 'remove'
+            echo 'uninstall'
+        case 'abv'
+            echo 'info'
+        case 'dr'
+            echo 'doctor'
+        case '--repo'
+            echo '--repository'
+        case 'environment'
+            echo '--env'
+        case '--config'
+            echo 'config'
+        case '-v'
+            echo '--version'
+        case 'lc'
+            echo 'livecheck'
+        case 'tc'
+            echo 'typecheck'
+        case 'x'
+            echo 'exec'
+        case '*'
+            echo $cmd
+    end
+end
+
 function __fish_brew_opts -d "Only arguments starting with a dash (options)"
     string match --all -- '-*' (__fish_brew_args)
 end
@@ -37,11 +82,12 @@ end
 function __fish_brew_command -d "Helps matching the first argument of brew"
     set args (__fish_brew_args)
     set -q args[1]; or return 1
+    set -l cmd (__fish_brew_expand_alias $args[1])
 
     if count $argv
-        contains -- $args[1] $argv
+        contains -- $cmd $argv
     else
-        echo $args[1]
+        echo $cmd
     end
 end
 
@@ -132,11 +178,16 @@ function __fish_brew_suggest_taps_installed -d "List all available taps"
     | string replace (brew --repo)/Library/Taps/ ""
 end
 
-function __fish_brew_suggest_commands -d "Lists all commands names, including aliases"
+function __fish_brew_suggest_commands -d "Lists all command names"
+    set -l commands
     if test -f (brew --cache)/all_commands_list.txt
-        cat (brew --cache)/all_commands_list.txt
+        set commands (cat (brew --cache)/all_commands_list.txt)
     else
-        cat (brew --repo)/completions/internal_commands_list.txt
+        set commands (cat (brew --repo)/completions/internal_commands_list.txt)
+    end
+    for command in $commands
+        set -l expanded_command (__fish_brew_expand_alias $command)
+        test "$expanded_command" = "$command"; and echo $command
     end
 end
 
@@ -220,13 +271,6 @@ __fish_brew_complete_arg '--cellar' -l verbose -d 'Make some output more verbose
 __fish_brew_complete_arg '--cellar' -a '(__fish_brew_suggest_formulae_all)'
 
 
-__fish_brew_complete_cmd '--config' 'Show Homebrew and system configuration info useful for debugging'
-__fish_brew_complete_arg '--config' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg '--config' -l help -d 'Show this message'
-__fish_brew_complete_arg '--config' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg '--config' -l verbose -d 'Make some output more verbose'
-
-
 __fish_brew_complete_cmd '--env' 'Summarise Homebrew\'s build environment as a plain list'
 __fish_brew_complete_arg '--env' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg '--env' -l help -d 'Show this message'
@@ -245,14 +289,6 @@ __fish_brew_complete_arg '--prefix' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg '--prefix' -l unbrewed -d 'List files in Homebrew\'s prefix not installed by Homebrew'
 __fish_brew_complete_arg '--prefix' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg '--prefix' -a '(__fish_brew_suggest_formulae_all)'
-
-
-__fish_brew_complete_cmd '--repo' 'Display where Homebrew\'s Git repository is located'
-__fish_brew_complete_arg '--repo' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg '--repo' -l help -d 'Show this message'
-__fish_brew_complete_arg '--repo' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg '--repo' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg '--repo' -a '(__fish_brew_suggest_taps_installed)'
 
 
 __fish_brew_complete_cmd '--repository' 'Display where Homebrew\'s Git repository is located'
@@ -275,57 +311,6 @@ __fish_brew_complete_arg '--version' -l debug -d 'Display any debugging informat
 __fish_brew_complete_arg '--version' -l help -d 'Show this message'
 __fish_brew_complete_arg '--version' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg '--version' -l verbose -d 'Make some output more verbose'
-
-
-__fish_brew_complete_cmd '-S' 'Perform a substring search of cask tokens and formula names for text'
-__fish_brew_complete_arg '-S' -l alpine -d 'Search for text in the given database'
-__fish_brew_complete_arg '-S' -l archlinux -d 'Search for text in the given database'
-__fish_brew_complete_arg '-S' -l cask -d 'Search for casks'
-__fish_brew_complete_arg '-S' -l closed -d 'Search for only closed GitHub pull requests'
-__fish_brew_complete_arg '-S' -l debian -d 'Search for text in the given database'
-__fish_brew_complete_arg '-S' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg '-S' -l desc -d 'Search for formulae with a description matching text and casks with a name or description matching text'
-__fish_brew_complete_arg '-S' -l eval-all -d 'Evaluate all available formulae and casks, whether installed or not, to search their descriptions. Enabled by default if `$HOMEBREW_EVAL_ALL` is set'
-__fish_brew_complete_arg '-S' -l fedora -d 'Search for text in the given database'
-__fish_brew_complete_arg '-S' -l fink -d 'Search for text in the given database'
-__fish_brew_complete_arg '-S' -l formula -d 'Search for formulae'
-__fish_brew_complete_arg '-S' -l help -d 'Show this message'
-__fish_brew_complete_arg '-S' -l macports -d 'Search for text in the given database'
-__fish_brew_complete_arg '-S' -l open -d 'Search for only open GitHub pull requests'
-__fish_brew_complete_arg '-S' -l opensuse -d 'Search for text in the given database'
-__fish_brew_complete_arg '-S' -l pull-request -d 'Search for GitHub pull requests containing text'
-__fish_brew_complete_arg '-S' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg '-S' -l repology -d 'Search for text in the given database'
-__fish_brew_complete_arg '-S' -l ubuntu -d 'Search for text in the given database'
-__fish_brew_complete_arg '-S' -l verbose -d 'Make some output more verbose'
-
-
-__fish_brew_complete_cmd '-v' 'Print the version numbers of Homebrew, Homebrew/homebrew-core and Homebrew/homebrew-cask (if tapped) to standard output'
-__fish_brew_complete_arg '-v' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg '-v' -l help -d 'Show this message'
-__fish_brew_complete_arg '-v' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg '-v' -l verbose -d 'Make some output more verbose'
-
-
-__fish_brew_complete_cmd 'abv' 'Display brief statistics for your Homebrew installation'
-__fish_brew_complete_arg 'abv' -l analytics -d 'List global Homebrew analytics data or, if specified, installation and build error data for formula (provided neither `$HOMEBREW_NO_ANALYTICS` nor `$HOMEBREW_NO_GITHUB_API` are set)'
-__fish_brew_complete_arg 'abv' -l cask -d 'Treat all named arguments as casks'
-__fish_brew_complete_arg 'abv' -l category -d 'Which type of analytics data to retrieve. The value for category must be `install`, `install-on-request` or `build-error`; `cask-install` or `os-version` may be specified if formula is not. The default is `install`'
-__fish_brew_complete_arg 'abv' -l days -d 'How many days of analytics data to retrieve. The value for days must be `30`, `90` or `365`. The default is `30`'
-__fish_brew_complete_arg 'abv' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg 'abv' -l eval-all -d 'Evaluate all available formulae and casks, whether installed or not, to print their JSON'
-__fish_brew_complete_arg 'abv' -l fetch-manifest -d 'Fetch GitHub Packages manifest for extra information when formula is not installed'
-__fish_brew_complete_arg 'abv' -l formula -d 'Treat all named arguments as formulae'
-__fish_brew_complete_arg 'abv' -l github -d 'Open the GitHub source page for formula and cask in a browser. To view the history locally: `brew log -p` formula or cask'
-__fish_brew_complete_arg 'abv' -l help -d 'Show this message'
-__fish_brew_complete_arg 'abv' -l installed -d 'Output a human-readable inventory of installed formulae and casks. If `--json` is passed, print JSON for installed formulae and, with `--json=v2`, installed casks'
-__fish_brew_complete_arg 'abv' -l json -d 'Print a JSON representation. Currently the default value for version is `v1` for formula. For formula and cask use `v2`. See the docs for examples of using the JSON output: https://docs.brew.sh/Querying-Brew'
-__fish_brew_complete_arg 'abv' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'abv' -l sizes -d 'Show the size of installed formulae and casks'
-__fish_brew_complete_arg 'abv' -l variations -d 'Include the variations hash in each formula\'s JSON output'
-__fish_brew_complete_arg 'abv' -l verbose -d 'Show more verbose data for formula, or full information with `--installed`'
-__fish_brew_complete_arg 'abv; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'abv; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'alias' 'Show an alias\'s command'
@@ -948,16 +933,6 @@ __fish_brew_complete_arg 'doctor' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'doctor' -a '(__fish_brew_suggest_diagnostic_checks)'
 
 
-__fish_brew_complete_cmd 'dr' 'Check your system for potential problems'
-__fish_brew_complete_arg 'dr' -l audit-debug -d 'Enable debugging and profiling of audit methods'
-__fish_brew_complete_arg 'dr' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg 'dr' -l help -d 'Show this message'
-__fish_brew_complete_arg 'dr' -l list-checks -d 'List all audit methods, which can be run individually if provided as arguments'
-__fish_brew_complete_arg 'dr' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'dr' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'dr' -a '(__fish_brew_suggest_diagnostic_checks)'
-
-
 __fish_brew_complete_cmd 'edit' 'Open a formula, cask or tap in the editor set by `$EDITOR` or `$HOMEBREW_EDITOR`, or open the Homebrew repository for editing if no argument is provided'
 __fish_brew_complete_arg 'edit' -l cask -d 'Treat all named arguments as casks'
 __fish_brew_complete_arg 'edit' -l debug -d 'Display any debugging information'
@@ -969,16 +944,6 @@ __fish_brew_complete_arg 'edit' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'edit; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
 __fish_brew_complete_arg 'edit; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 __fish_brew_complete_arg 'edit' -a '(__fish_brew_suggest_taps_installed)'
-
-
-__fish_brew_complete_cmd 'environment' 'Summarise Homebrew\'s build environment as a plain list'
-__fish_brew_complete_arg 'environment' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg 'environment' -l help -d 'Show this message'
-__fish_brew_complete_arg 'environment' -l plain -d 'Generate plain output even when piped'
-__fish_brew_complete_arg 'environment' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'environment' -l shell -d 'Generate a list of environment variables for the specified shell, or `--shell=auto` to detect the current shell'
-__fish_brew_complete_arg 'environment' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'environment' -a '(__fish_brew_suggest_formulae_all)'
 
 
 __fish_brew_complete_cmd 'exec' 'Run command in an environment populated by Homebrew formulae'
@@ -1129,17 +1094,6 @@ __fish_brew_complete_arg 'home; and not __fish_seen_argument -l cask -l casks' -
 __fish_brew_complete_arg 'home; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
-__fish_brew_complete_cmd 'homepage' 'Open a formula or cask\'s homepage in a browser, or open Homebrew\'s own homepage if no argument is provided'
-__fish_brew_complete_arg 'homepage' -l cask -d 'Treat all named arguments as casks'
-__fish_brew_complete_arg 'homepage' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg 'homepage' -l formula -d 'Treat all named arguments as formulae'
-__fish_brew_complete_arg 'homepage' -l help -d 'Show this message'
-__fish_brew_complete_arg 'homepage' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'homepage' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'homepage; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'homepage; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
-
-
 __fish_brew_complete_cmd 'info' 'Display brief statistics for your Homebrew installation'
 __fish_brew_complete_arg 'info' -l analytics -d 'List global Homebrew analytics data or, if specified, installation and build error data for formula (provided neither `$HOMEBREW_NO_ANALYTICS` nor `$HOMEBREW_NO_GITHUB_API` are set)'
 __fish_brew_complete_arg 'info' -l cask -d 'Treat all named arguments as casks'
@@ -1159,61 +1113,6 @@ __fish_brew_complete_arg 'info' -l variations -d 'Include the variations hash in
 __fish_brew_complete_arg 'info' -l verbose -d 'Show more verbose data for formula, or full information with `--installed`'
 __fish_brew_complete_arg 'info; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
 __fish_brew_complete_arg 'info; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
-
-
-__fish_brew_complete_arg 'instal' -l HEAD -d 'If formula defines it, install the HEAD version, aka. main, trunk, unstable, master'
-__fish_brew_complete_arg 'instal' -l adopt -d 'Adopt existing artifacts in the destination that are identical to those being installed. Cannot be combined with `--force`'
-__fish_brew_complete_arg 'instal' -l appdir -d 'Target location for Applications (default: `/Applications`)'
-__fish_brew_complete_arg 'instal' -l appimagedir -d 'Target location for AppImages (default: `~/Applications`)'
-__fish_brew_complete_arg 'instal' -l as-dependency -d 'Install but mark as installed as a dependency and not installed on request'
-__fish_brew_complete_arg 'instal' -l ask -d 'Ask for confirmation before downloading and installing. Print a dependency plan, including added, changed and removed packages and dependencies, with download and install sizes of formula bottles. Enabled by default if `$HOMEBREW_ASK` is set'
-__fish_brew_complete_arg 'instal' -l audio-unit-plugindir -d 'Target location for Audio Unit Plugins (default: `~/Library/Audio/Plug-Ins/Components`)'
-__fish_brew_complete_arg 'instal' -l binaries -d 'Disable/enable linking of helper executables (default: enabled)'
-__fish_brew_complete_arg 'instal' -l bottle-arch -d 'Optimise bottles for the specified architecture rather than the oldest architecture supported by the version of macOS the bottles are built on'
-__fish_brew_complete_arg 'instal' -l build-bottle -d 'Prepare the formula for eventual bottling during installation, skipping any post-install steps'
-__fish_brew_complete_arg 'instal' -l build-from-source -d 'Compile formula from source even if a bottle is provided. Dependencies will still be installed from bottles if they are available'
-__fish_brew_complete_arg 'instal' -l cask -d 'Treat all named arguments as casks'
-__fish_brew_complete_arg 'instal' -l cc -d 'Attempt to compile using the specified compiler, which should be the name of the compiler\'s executable, e.g. `gcc-9` for GCC 9. In order to use LLVM\'s clang, specify `llvm_clang`. To use the Apple-provided clang, specify `clang`. This option will only accept compilers that are provided by Homebrew or bundled with macOS. Please do not file issues if you encounter errors while using this option'
-__fish_brew_complete_arg 'instal' -l colorpickerdir -d 'Target location for Color Pickers (default: `~/Library/ColorPickers`)'
-__fish_brew_complete_arg 'instal' -l debug -d 'If brewing fails, open an interactive debugging session with access to IRB or a shell inside the temporary build directory'
-__fish_brew_complete_arg 'instal' -l debug-symbols -d 'Generate debug symbols on build. Source will be retained in a cache directory'
-__fish_brew_complete_arg 'instal' -l dictionarydir -d 'Target location for Dictionaries (default: `~/Library/Dictionaries`)'
-__fish_brew_complete_arg 'instal' -l display-times -d 'Print install times for each package at the end of the run. Enabled by default if `$HOMEBREW_DISPLAY_INSTALL_TIMES` is set'
-__fish_brew_complete_arg 'instal' -l dry-run -d 'Show what would be installed, but do not actually install anything'
-__fish_brew_complete_arg 'instal' -l fetch-HEAD -d 'Fetch the upstream repository to detect if the HEAD installation of the formula is outdated. Otherwise, the repository\'s HEAD will only be checked for updates when a new stable or development version has been released'
-__fish_brew_complete_arg 'instal' -l fontdir -d 'Target location for Fonts (default: `~/Library/Fonts`)'
-__fish_brew_complete_arg 'instal' -l force -d 'Install formulae without checking for previously installed keg-only or non-migrated versions. When installing casks, overwrite existing files (binaries and symlinks are excluded, unless originally from the same cask)'
-__fish_brew_complete_arg 'instal' -l force-bottle -d 'Install from a bottle if it exists for the current or newest version of macOS, even if it would not normally be used for installation'
-__fish_brew_complete_arg 'instal' -l formula -d 'Treat all named arguments as formulae'
-__fish_brew_complete_arg 'instal' -l git -d 'Create a Git repository, useful for creating patches to the software'
-__fish_brew_complete_arg 'instal' -l help -d 'Show this message'
-__fish_brew_complete_arg 'instal' -l ignore-dependencies -d 'An unsupported Homebrew development option to skip installing any dependencies of any kind. If the dependencies are not already present, the formula will have issues. If you\'re not developing Homebrew, consider adjusting your PATH rather than using this option'
-__fish_brew_complete_arg 'instal' -l include-test -d 'Install testing dependencies required to run `brew test` formula'
-__fish_brew_complete_arg 'instal' -l input-methoddir -d 'Target location for Input Methods (default: `~/Library/Input Methods`)'
-__fish_brew_complete_arg 'instal' -l interactive -d 'Download and patch formula, then open a shell. This allows the user to run `./configure --help` and otherwise determine how to turn the software package into a Homebrew package'
-__fish_brew_complete_arg 'instal' -l internet-plugindir -d 'Target location for Internet Plugins (default: `~/Library/Internet Plug-Ins`)'
-__fish_brew_complete_arg 'instal' -l keep-tmp -d 'Retain the temporary files created during installation'
-__fish_brew_complete_arg 'instal' -l keyboard-layoutdir -d 'Target location for Keyboard Layouts (default: `/Library/Keyboard Layouts`)'
-__fish_brew_complete_arg 'instal' -l language -d 'Comma-separated list of language codes to prefer for cask installation. The first matching language is used, otherwise it reverts to the cask\'s default language. The default value is the language of your system'
-__fish_brew_complete_arg 'instal' -l mdimporterdir -d 'Target location for Spotlight Plugins (default: `~/Library/Spotlight`)'
-__fish_brew_complete_arg 'instal' -l no-binaries -d 'Disable/enable linking of helper executables (default: enabled)'
-__fish_brew_complete_arg 'instal' -l only-dependencies -d 'Install the dependencies with specified options but do not install the formula itself'
-__fish_brew_complete_arg 'instal' -l overwrite -d 'Delete files that already exist in the prefix while linking'
-__fish_brew_complete_arg 'instal' -l prefpanedir -d 'Target location for Preference Panes (default: `~/Library/PreferencePanes`)'
-__fish_brew_complete_arg 'instal' -l qlplugindir -d 'Target location for Quick Look Plugins (default: `~/Library/QuickLook`)'
-__fish_brew_complete_arg 'instal' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'instal' -l require-sha -d 'Require all casks to have a checksum'
-__fish_brew_complete_arg 'instal' -l screen-saverdir -d 'Target location for Screen Savers (default: `~/Library/Screen Savers`)'
-__fish_brew_complete_arg 'instal' -l servicedir -d 'Target location for Services (default: `~/Library/Services`)'
-__fish_brew_complete_arg 'instal' -l skip-cask-deps -d 'Skip installing cask dependencies'
-__fish_brew_complete_arg 'instal' -l skip-link -d 'Install but skip linking the keg into the prefix'
-__fish_brew_complete_arg 'instal' -l skip-post-install -d 'Install but skip any post-install steps'
-__fish_brew_complete_arg 'instal' -l verbose -d 'Print the verification and post-install steps'
-__fish_brew_complete_arg 'instal' -l vst-plugindir -d 'Target location for VST Plugins (default: `~/Library/Audio/Plug-Ins/VST`)'
-__fish_brew_complete_arg 'instal' -l vst3-plugindir -d 'Target location for VST3 Plugins (default: `~/Library/Audio/Plug-Ins/VST3`)'
-__fish_brew_complete_arg 'instal' -l zap -d 'For use with `brew reinstall --cask`. Remove all files associated with a cask. *May remove files which are shared between applications.*'
-__fish_brew_complete_arg 'instal; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'instal; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'install' 'Install a formula or cask'
@@ -1288,26 +1187,6 @@ __fish_brew_complete_arg 'irb' -l help -d 'Show this message'
 __fish_brew_complete_arg 'irb' -l pry -d 'Use Pry instead of IRB. Enabled by default if `$HOMEBREW_PRY` is set'
 __fish_brew_complete_arg 'irb' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'irb' -l verbose -d 'Make some output more verbose'
-
-
-__fish_brew_complete_cmd 'lc' 'Check for newer versions of formulae and/or casks from upstream'
-__fish_brew_complete_arg 'lc' -l autobump -d 'Include packages that are autobumped by BrewTestBot. By default these are skipped'
-__fish_brew_complete_arg 'lc' -l cask -d 'Only check casks'
-__fish_brew_complete_arg 'lc' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg 'lc' -l eval-all -d 'Evaluate all available formulae and casks, whether installed or not, to check them'
-__fish_brew_complete_arg 'lc' -l extract-plist -d 'Enable checking multiple casks with ExtractPlist strategy'
-__fish_brew_complete_arg 'lc' -l formula -d 'Only check formulae'
-__fish_brew_complete_arg 'lc' -l full-name -d 'Print formulae and casks with fully-qualified names'
-__fish_brew_complete_arg 'lc' -l help -d 'Show this message'
-__fish_brew_complete_arg 'lc' -l installed -d 'Check formulae and casks that are currently installed'
-__fish_brew_complete_arg 'lc' -l json -d 'Output information in JSON format'
-__fish_brew_complete_arg 'lc' -l newer-only -d 'Show the latest version only if it\'s newer than the current formula or cask version'
-__fish_brew_complete_arg 'lc' -l quiet -d 'Suppress warnings, don\'t print a progress bar for JSON output'
-__fish_brew_complete_arg 'lc' -l resources -d 'Also check resources for formulae'
-__fish_brew_complete_arg 'lc' -l tap -d 'Check formulae and casks within the given tap, specified as user`/`repo'
-__fish_brew_complete_arg 'lc' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'lc; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'lc; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'leaves' 'List installed formulae that are not dependencies of another installed formula or cask'
@@ -1394,18 +1273,6 @@ __fish_brew_complete_arg 'livecheck; and not __fish_seen_argument -l cask -l cas
 __fish_brew_complete_arg 'livecheck; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
-__fish_brew_complete_cmd 'ln' 'Symlink all of formula\'s installed files into Homebrew\'s prefix'
-__fish_brew_complete_arg 'ln' -l HEAD -d 'Link the HEAD version of the formula if it is installed'
-__fish_brew_complete_arg 'ln' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg 'ln' -l dry-run -d 'List files which would be linked or deleted by `brew link --overwrite` without actually linking or deleting any files'
-__fish_brew_complete_arg 'ln' -l force -d 'Allow keg-only formulae to be linked'
-__fish_brew_complete_arg 'ln' -l help -d 'Show this message'
-__fish_brew_complete_arg 'ln' -l overwrite -d 'Delete files that already exist in the prefix while linking'
-__fish_brew_complete_arg 'ln' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'ln' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'ln' -a '(__fish_brew_suggest_formulae_installed)'
-
-
 __fish_brew_complete_cmd 'log' 'Show the `git log` for formula or cask, or show the log for the Homebrew repository if no formula or cask is provided'
 __fish_brew_complete_arg 'log' -l cask -d 'Treat all named arguments as casks'
 __fish_brew_complete_arg 'log' -l debug -d 'Display any debugging information'
@@ -1420,29 +1287,6 @@ __fish_brew_complete_arg 'log' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'log' -l 1 -d 'Print only one commit'
 __fish_brew_complete_arg 'log; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
 __fish_brew_complete_arg 'log; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
-
-
-__fish_brew_complete_cmd 'ls' 'List all installed formulae and casks'
-__fish_brew_complete_arg 'ls' -l built-from-source -d 'List the formulae compiled from source'
-__fish_brew_complete_arg 'ls' -l cask -d 'List only casks, or treat all named arguments as casks'
-__fish_brew_complete_arg 'ls' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg 'ls' -l formula -d 'List only formulae, or treat all named arguments as formulae'
-__fish_brew_complete_arg 'ls' -l full-name -d 'Print formulae with fully-qualified names. Unless `--full-name`, `--versions` or `--pinned` are passed, other options (i.e. `-1`, `-l`, `-r` and `-t`) are passed to `ls`(1) which produces the actual output'
-__fish_brew_complete_arg 'ls' -l help -d 'Show this message'
-__fish_brew_complete_arg 'ls' -l installed-as-dependency -d 'List the formulae installed as dependencies'
-__fish_brew_complete_arg 'ls' -l installed-on-request -d 'List the formulae installed on request'
-__fish_brew_complete_arg 'ls' -l multiple -d 'Only show formulae with multiple versions installed. Implies `--versions`'
-__fish_brew_complete_arg 'ls' -l pinned -d 'List only pinned packages, or only the specified (pinned) packages if formula or cask are provided. See also `pin`, `unpin`'
-__fish_brew_complete_arg 'ls' -l poured-from-bottle -d 'List the formulae installed from a bottle'
-__fish_brew_complete_arg 'ls' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'ls' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'ls' -l versions -d 'Show the version number for installed formulae, or only the specified formulae if formula are provided'
-__fish_brew_complete_arg 'ls' -l 1 -d 'Force output to be one entry per line. This is the default when output is not to a terminal'
-__fish_brew_complete_arg 'ls' -l l -d 'List formulae and/or casks in long format. Has no effect when a formula or cask name is passed as an argument'
-__fish_brew_complete_arg 'ls' -l r -d 'Reverse the order of formula and/or cask sorting to list the oldest entries first. Has no effect when a formula or cask name is passed as an argument'
-__fish_brew_complete_arg 'ls' -l t -d 'Sort formulae and/or casks by time modified, listing most recently modified first. Has no effect when a formula or cask name is passed as an argument'
-__fish_brew_complete_arg 'ls; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
-__fish_brew_complete_arg 'ls; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
 
 
 __fish_brew_complete_cmd 'mcp-server' 'Starts the Homebrew MCP (Model Context Protocol) server'
@@ -1518,14 +1362,6 @@ __fish_brew_complete_arg 'pin' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'pin' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'pin; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
 __fish_brew_complete_arg 'pin; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
-
-
-__fish_brew_complete_cmd 'post_install' 'Rerun the post-install steps for formula'
-__fish_brew_complete_arg 'post_install' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg 'post_install' -l help -d 'Show this message'
-__fish_brew_complete_arg 'post_install' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'post_install' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'post_install' -a '(__fish_brew_suggest_formulae_installed)'
 
 
 __fish_brew_complete_cmd 'postinstall' 'Rerun the post-install steps for formula'
@@ -1694,34 +1530,6 @@ __fish_brew_complete_arg 'release' -l major -d 'Create a major release'
 __fish_brew_complete_arg 'release' -l minor -d 'Create a minor release'
 __fish_brew_complete_arg 'release' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'release' -l verbose -d 'Make some output more verbose'
-
-
-__fish_brew_complete_cmd 'remove' 'Uninstall a formula or cask'
-__fish_brew_complete_arg 'remove' -l cask -d 'Treat all named arguments as casks'
-__fish_brew_complete_arg 'remove' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg 'remove' -l force -d 'Delete all installed versions of formula. Uninstall even if cask is not installed, overwrite existing files and ignore errors when removing files'
-__fish_brew_complete_arg 'remove' -l formula -d 'Treat all named arguments as formulae'
-__fish_brew_complete_arg 'remove' -l help -d 'Show this message'
-__fish_brew_complete_arg 'remove' -l ignore-dependencies -d 'Don\'t fail uninstall, even if formula is a dependency of any installed formulae'
-__fish_brew_complete_arg 'remove' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'remove' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'remove' -l zap -d 'Remove all files associated with a cask. *May remove files which are shared between applications.*'
-__fish_brew_complete_arg 'remove; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
-__fish_brew_complete_arg 'remove; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
-
-
-__fish_brew_complete_cmd 'rm' 'Uninstall a formula or cask'
-__fish_brew_complete_arg 'rm' -l cask -d 'Treat all named arguments as casks'
-__fish_brew_complete_arg 'rm' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg 'rm' -l force -d 'Delete all installed versions of formula. Uninstall even if cask is not installed, overwrite existing files and ignore errors when removing files'
-__fish_brew_complete_arg 'rm' -l formula -d 'Treat all named arguments as formulae'
-__fish_brew_complete_arg 'rm' -l help -d 'Show this message'
-__fish_brew_complete_arg 'rm' -l ignore-dependencies -d 'Don\'t fail uninstall, even if formula is a dependency of any installed formulae'
-__fish_brew_complete_arg 'rm' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'rm' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'rm' -l zap -d 'Remove all files associated with a cask. *May remove files which are shared between applications.*'
-__fish_brew_complete_arg 'rm; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
-__fish_brew_complete_arg 'rm; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
 
 
 __fish_brew_complete_cmd 'rubocop' 'Installs, configures and runs Homebrew\'s `rubocop`'
@@ -1964,22 +1772,6 @@ __fish_brew_complete_arg 'tap-new' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'tap-new' -a '(__fish_brew_suggest_taps_installed)'
 
 
-__fish_brew_complete_cmd 'tc' 'Check for typechecking errors using Sorbet'
-__fish_brew_complete_arg 'tc' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg 'tc' -l dir -d 'Typecheck all files in a specific directory'
-__fish_brew_complete_arg 'tc' -l file -d 'Typecheck a single file'
-__fish_brew_complete_arg 'tc' -l fix -d 'Automatically fix type errors'
-__fish_brew_complete_arg 'tc' -l help -d 'Show this message'
-__fish_brew_complete_arg 'tc' -l ignore -d 'Ignores input files that contain the given string in their paths (relative to the input path passed to Sorbet)'
-__fish_brew_complete_arg 'tc' -l lsp -d 'Start the Sorbet LSP server'
-__fish_brew_complete_arg 'tc' -l quiet -d 'Silence all non-critical errors'
-__fish_brew_complete_arg 'tc' -l suggest-typed -d 'Try upgrading `typed` sigils'
-__fish_brew_complete_arg 'tc' -l update -d 'Update RBI files'
-__fish_brew_complete_arg 'tc' -l update-all -d 'Update all RBI files rather than just updated gems'
-__fish_brew_complete_arg 'tc' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'tc' -a '(__fish_brew_suggest_taps_installed)'
-
-
 __fish_brew_complete_cmd 'test' 'Run the test method provided by an installed formula'
 __fish_brew_complete_arg 'test' -l HEAD -d 'Test the HEAD version of a formula'
 __fish_brew_complete_arg 'test' -l debug -d 'Display any debugging information'
@@ -2094,19 +1886,6 @@ __fish_brew_complete_arg 'unbottled' -l verbose -d 'Make some output more verbos
 __fish_brew_complete_arg 'unbottled' -a '(__fish_brew_suggest_formulae_all)'
 
 
-__fish_brew_complete_arg 'uninstal' -l cask -d 'Treat all named arguments as casks'
-__fish_brew_complete_arg 'uninstal' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg 'uninstal' -l force -d 'Delete all installed versions of formula. Uninstall even if cask is not installed, overwrite existing files and ignore errors when removing files'
-__fish_brew_complete_arg 'uninstal' -l formula -d 'Treat all named arguments as formulae'
-__fish_brew_complete_arg 'uninstal' -l help -d 'Show this message'
-__fish_brew_complete_arg 'uninstal' -l ignore-dependencies -d 'Don\'t fail uninstall, even if formula is a dependency of any installed formulae'
-__fish_brew_complete_arg 'uninstal' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'uninstal' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'uninstal' -l zap -d 'Remove all files associated with a cask. *May remove files which are shared between applications.*'
-__fish_brew_complete_arg 'uninstal; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
-__fish_brew_complete_arg 'uninstal; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
-
-
 __fish_brew_complete_cmd 'uninstall' 'Uninstall a formula or cask'
 __fish_brew_complete_arg 'uninstall' -l cask -d 'Treat all named arguments as casks'
 __fish_brew_complete_arg 'uninstall' -l debug -d 'Display any debugging information'
@@ -2163,16 +1942,6 @@ __fish_brew_complete_arg 'untap' -l help -d 'Show this message'
 __fish_brew_complete_arg 'untap' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'untap' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'untap' -a '(__fish_brew_suggest_taps_installed)'
-
-
-__fish_brew_complete_cmd 'up' 'Fetch the newest version of Homebrew and all formulae from GitHub using `git`(1) and perform any necessary migrations'
-__fish_brew_complete_arg 'up' -l auto-update -d 'Run on auto-updates (e.g. before `brew install`). Skips some slower steps'
-__fish_brew_complete_arg 'up' -l debug -d 'Display a trace of all shell commands as they are executed'
-__fish_brew_complete_arg 'up' -l force -d 'Always do a slower, full update check (even if unnecessary)'
-__fish_brew_complete_arg 'up' -l help -d 'Show this message'
-__fish_brew_complete_arg 'up' -l merge -d 'Use `git merge` to apply updates (rather than `git rebase`)'
-__fish_brew_complete_arg 'up' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'up' -l verbose -d 'Print the directories checked and `git` operations performed'
 
 
 __fish_brew_complete_cmd 'update' 'Fetch the newest version of Homebrew and all formulae from GitHub using `git`(1) and perform any necessary migrations'
@@ -2383,14 +2152,6 @@ __fish_brew_complete_arg 'which-update' -l removed-formulae-file -d 'Remove data
 __fish_brew_complete_arg 'which-update' -l repository -d 'GitHub repository for `--pull-request` (default: `$GITHUB_REPOSITORY`)'
 __fish_brew_complete_arg 'which-update' -l summary-file -d 'Output a summary of the changes to a file'
 __fish_brew_complete_arg 'which-update' -l verbose -d 'Make some output more verbose'
-
-
-__fish_brew_complete_cmd 'x' 'Run command in an environment populated by Homebrew formulae'
-__fish_brew_complete_arg 'x' -l debug -d 'Display any debugging information'
-__fish_brew_complete_arg 'x' -l formulae -d 'Comma-separated formulae to install and add to `PATH` before running command'
-__fish_brew_complete_arg 'x' -l help -d 'Show this message'
-__fish_brew_complete_arg 'x' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'x' -l verbose -d 'Make some output more verbose'
 
 
 

--- a/completions/internal_commands_list.txt
+++ b/completions/internal_commands_list.txt
@@ -1,16 +1,11 @@
 --cache
 --caskroom
 --cellar
---config
 --env
 --prefix
---repo
 --repository
 --taps
 --version
--S
--v
-abv
 alias
 analytics
 audit
@@ -39,9 +34,7 @@ developer
 dispatch-build-bottle
 docs
 doctor
-dr
 edit
-environment
 exec
 extract
 fetch
@@ -57,21 +50,17 @@ generate-zap
 gist-logs
 help
 home
-homepage
 info
 install
 install-bundler-gems
 irb
-lc
 leaves
 lgtm
 link
 linkage
 list
 livecheck
-ln
 log
-ls
 mcp-server
 migrate
 missing
@@ -79,7 +68,6 @@ nodenv-sync
 options
 outdated
 pin
-post_install
 postinstall
 pr-automerge
 pr-publish
@@ -91,8 +79,6 @@ rbenv-sync
 readall
 reinstall
 release
-remove
-rm
 rubocop
 ruby
 rubydoc
@@ -107,7 +93,6 @@ tab
 tap
 tap-info
 tap-new
-tc
 test
 test-bot
 tests
@@ -119,7 +104,6 @@ unlink
 unpack
 unpin
 untap
-up
 update
 update-if-needed
 update-license-data
@@ -137,4 +121,3 @@ verify
 version-install
 which-formula
 which-update
-x

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -327,15 +327,6 @@ _brew___cellar() {
     '*:formula:__brew_formulae'
 }
 
-# brew --config
-_brew___config() {
-  _arguments \
-    '--debug[Display any debugging information]' \
-    '--help[Show this message]' \
-    '--quiet[Make some output more quiet]' \
-    '--verbose[Make some output more verbose]'
-}
-
 # brew --env
 _brew___env() {
   _arguments \
@@ -360,17 +351,6 @@ _brew___prefix() {
     '--verbose[Make some output more verbose]' \
     - formula \
     '*:formula:__brew_formulae'
-}
-
-# brew --repo
-_brew___repo() {
-  _arguments \
-    '--debug[Display any debugging information]' \
-    '--help[Show this message]' \
-    '--quiet[Make some output more quiet]' \
-    '--verbose[Make some output more verbose]' \
-    - tap \
-    '*:tap:__brew_any_tap'
 }
 
 # brew --repository
@@ -400,65 +380,6 @@ _brew___version() {
     '--help[Show this message]' \
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]'
-}
-
-# brew -S
-_brew__s() {
-  _arguments \
-    '(--repology --macports --fink --opensuse --fedora --archlinux --debian --ubuntu)--alpine[Search for text in the given database]' \
-    '(--alpine --repology --macports --fink --opensuse --fedora --debian --ubuntu)--archlinux[Search for text in the given database]' \
-    '--cask[Search for casks]' \
-    '(--open)--closed[Search for only closed GitHub pull requests]' \
-    '(--alpine --repology --macports --fink --opensuse --fedora --archlinux --ubuntu)--debian[Search for text in the given database]' \
-    '--debug[Display any debugging information]' \
-    '(--pull-request)--desc[Search for formulae with a description matching text and casks with a name or description matching text]' \
-    '--eval-all[Evaluate all available formulae and casks, whether installed or not, to search their descriptions. Enabled by default if `$HOMEBREW_EVAL_ALL` is set]' \
-    '(--alpine --repology --macports --fink --opensuse --archlinux --debian --ubuntu)--fedora[Search for text in the given database]' \
-    '(--alpine --repology --macports --opensuse --fedora --archlinux --debian --ubuntu)--fink[Search for text in the given database]' \
-    '--formula[Search for formulae]' \
-    '--help[Show this message]' \
-    '(--alpine --repology --fink --opensuse --fedora --archlinux --debian --ubuntu)--macports[Search for text in the given database]' \
-    '(--closed)--open[Search for only open GitHub pull requests]' \
-    '(--alpine --repology --macports --fink --fedora --archlinux --debian --ubuntu)--opensuse[Search for text in the given database]' \
-    '(--desc)--pull-request[Search for GitHub pull requests containing text]' \
-    '--quiet[Make some output more quiet]' \
-    '(--alpine --macports --fink --opensuse --fedora --archlinux --debian --ubuntu)--repology[Search for text in the given database]' \
-    '(--alpine --repology --macports --fink --opensuse --fedora --archlinux --debian)--ubuntu[Search for text in the given database]' \
-    '--verbose[Make some output more verbose]'
-}
-
-# brew -v
-_brew__v() {
-  _arguments \
-    '--debug[Display any debugging information]' \
-    '--help[Show this message]' \
-    '--quiet[Make some output more quiet]' \
-    '--verbose[Make some output more verbose]'
-}
-
-# brew abv
-_brew_abv() {
-  _arguments \
-    '--analytics[List global Homebrew analytics data or, if specified, installation and build error data for formula (provided neither `$HOMEBREW_NO_ANALYTICS` nor `$HOMEBREW_NO_GITHUB_API` are set)]' \
-    '--category[Which type of analytics data to retrieve. The value for category must be `install`, `install-on-request` or `build-error`; `cask-install` or `os-version` may be specified if formula is not. The default is `install`]' \
-    '--days[How many days of analytics data to retrieve. The value for days must be `30`, `90` or `365`. The default is `30`]' \
-    '--debug[Display any debugging information]' \
-    '(--installed)--eval-all[Evaluate all available formulae and casks, whether installed or not, to print their JSON]' \
-    '(--cask --json)--fetch-manifest[Fetch GitHub Packages manifest for extra information when formula is not installed]' \
-    '--github[Open the GitHub source page for formula and cask in a browser. To view the history locally: `brew log -p` formula or cask]' \
-    '--help[Show this message]' \
-    '(--eval-all)--installed[Output a human-readable inventory of installed formulae and casks. If `--json` is passed, print JSON for installed formulae and, with `--json=v2`, installed casks]' \
-    '(--fetch-manifest)--json[Print a JSON representation. Currently the default value for version is `v1` for formula. For formula and cask use `v2`. See the docs for examples of using the JSON output: https://docs.brew.sh/Querying-Brew]' \
-    '--quiet[Make some output more quiet]' \
-    '--sizes[Show the size of installed formulae and casks]' \
-    '--variations[Include the variations hash in each formula'\''s JSON output]' \
-    '--verbose[Show more verbose data for formula, or full information with `--installed`]' \
-    - formula \
-    '(--cask)--formula[Treat all named arguments as formulae]' \
-    '*:formula:__brew_formulae' \
-    - cask \
-    '(--formula --fetch-manifest)--cask[Treat all named arguments as casks]' \
-    '*:cask:__brew_casks'
 }
 
 # brew alias
@@ -1300,19 +1221,6 @@ _brew_doctor() {
     '*:diagnostic_check:__brew_diagnostic_checks'
 }
 
-# brew dr
-_brew_dr() {
-  _arguments \
-    '--audit-debug[Enable debugging and profiling of audit methods]' \
-    '--debug[Display any debugging information]' \
-    '--help[Show this message]' \
-    '--list-checks[List all audit methods, which can be run individually if provided as arguments]' \
-    '--quiet[Make some output more quiet]' \
-    '--verbose[Make some output more verbose]' \
-    - diagnostic_check \
-    '*:diagnostic_check:__brew_diagnostic_checks'
-}
-
 # brew edit
 _brew_edit() {
   _arguments \
@@ -1329,19 +1237,6 @@ _brew_edit() {
     '*:cask:__brew_casks' \
     - tap \
     '*:tap:__brew_any_tap'
-}
-
-# brew environment
-_brew_environment() {
-  _arguments \
-    '--debug[Display any debugging information]' \
-    '--help[Show this message]' \
-    '--plain[Generate plain output even when piped]' \
-    '--quiet[Make some output more quiet]' \
-    '--shell[Generate a list of environment variables for the specified shell, or `--shell=auto` to detect the current shell]' \
-    '--verbose[Make some output more verbose]' \
-    - formula \
-    '*:formula:__brew_formulae'
 }
 
 # brew exec
@@ -1528,21 +1423,6 @@ _brew_home() {
     '*:cask:__brew_casks'
 }
 
-# brew homepage
-_brew_homepage() {
-  _arguments \
-    '--debug[Display any debugging information]' \
-    '--help[Show this message]' \
-    '--quiet[Make some output more quiet]' \
-    '--verbose[Make some output more verbose]' \
-    - formula \
-    '(--cask)--formula[Treat all named arguments as formulae]' \
-    '*:formula:__brew_formulae' \
-    - cask \
-    '(--formula)--cask[Treat all named arguments as casks]' \
-    '*:cask:__brew_casks'
-}
-
 # brew info
 _brew_info() {
   _arguments \
@@ -1565,66 +1445,6 @@ _brew_info() {
     '*:formula:__brew_formulae' \
     - cask \
     '(--formula --fetch-manifest)--cask[Treat all named arguments as casks]' \
-    '*:cask:__brew_casks'
-}
-
-# brew instal
-_brew_instal() {
-  _arguments \
-    '(--cask)--HEAD[If formula defines it, install the HEAD version, aka. main, trunk, unstable, master]' \
-    '(--formula --force)--adopt[Adopt existing artifacts in the destination that are identical to those being installed. Cannot be combined with `--force`]' \
-    '(--formula)--appdir[Target location for Applications (default: `/Applications`)]' \
-    '(--formula)--appimagedir[Target location for AppImages (default: `~/Applications`)]' \
-    '(--cask)--as-dependency[Install but mark as installed as a dependency and not installed on request]' \
-    '--ask[Ask for confirmation before downloading and installing. Print a dependency plan, including added, changed and removed packages and dependencies, with download and install sizes of formula bottles. Enabled by default if `$HOMEBREW_ASK` is set]' \
-    '(--formula)--audio-unit-plugindir[Target location for Audio Unit Plugins (default: `~/Library/Audio/Plug-Ins/Components`)]' \
-    '(--formula)--binaries[Disable/enable linking of helper executables (default: enabled)]' \
-    '(--cask)--bottle-arch[Optimise bottles for the specified architecture rather than the oldest architecture supported by the version of macOS the bottles are built on]' \
-    '(--cask --build-from-source --force-bottle)--build-bottle[Prepare the formula for eventual bottling during installation, skipping any post-install steps]' \
-    '(--cask --build-bottle --force-bottle)--build-from-source[Compile formula from source even if a bottle is provided. Dependencies will still be installed from bottles if they are available]' \
-    '(--cask)--cc[Attempt to compile using the specified compiler, which should be the name of the compiler'\''s executable, e.g. `gcc-9` for GCC 9. In order to use LLVM'\''s clang, specify `llvm_clang`. To use the Apple-provided clang, specify `clang`. This option will only accept compilers that are provided by Homebrew or bundled with macOS. Please do not file issues if you encounter errors while using this option]' \
-    '(--formula)--colorpickerdir[Target location for Color Pickers (default: `~/Library/ColorPickers`)]' \
-    '--debug[If brewing fails, open an interactive debugging session with access to IRB or a shell inside the temporary build directory]' \
-    '(--cask)--debug-symbols[Generate debug symbols on build. Source will be retained in a cache directory]' \
-    '(--formula)--dictionarydir[Target location for Dictionaries (default: `~/Library/Dictionaries`)]' \
-    '--display-times[Print install times for each package at the end of the run. Enabled by default if `$HOMEBREW_DISPLAY_INSTALL_TIMES` is set]' \
-    '--dry-run[Show what would be installed, but do not actually install anything]' \
-    '(--cask)--fetch-HEAD[Fetch the upstream repository to detect if the HEAD installation of the formula is outdated. Otherwise, the repository'\''s HEAD will only be checked for updates when a new stable or development version has been released]' \
-    '(--formula)--fontdir[Target location for Fonts (default: `~/Library/Fonts`)]' \
-    '(--adopt)--force[Install formulae without checking for previously installed keg-only or non-migrated versions. When installing casks, overwrite existing files (binaries and symlinks are excluded, unless originally from the same cask)]' \
-    '(--cask --build-from-source --build-bottle)--force-bottle[Install from a bottle if it exists for the current or newest version of macOS, even if it would not normally be used for installation]' \
-    '(--cask)--git[Create a Git repository, useful for creating patches to the software]' \
-    '--help[Show this message]' \
-    '(--cask --only-dependencies)--ignore-dependencies[An unsupported Homebrew development option to skip installing any dependencies of any kind. If the dependencies are not already present, the formula will have issues. If you'\''re not developing Homebrew, consider adjusting your PATH rather than using this option]' \
-    '(--cask)--include-test[Install testing dependencies required to run `brew test` formula]' \
-    '(--formula)--input-methoddir[Target location for Input Methods (default: `~/Library/Input Methods`)]' \
-    '(--cask)--interactive[Download and patch formula, then open a shell. This allows the user to run `./configure --help` and otherwise determine how to turn the software package into a Homebrew package]' \
-    '(--formula)--internet-plugindir[Target location for Internet Plugins (default: `~/Library/Internet Plug-Ins`)]' \
-    '(--cask)--keep-tmp[Retain the temporary files created during installation]' \
-    '(--formula)--keyboard-layoutdir[Target location for Keyboard Layouts (default: `/Library/Keyboard Layouts`)]' \
-    '(--formula)--language[Comma-separated list of language codes to prefer for cask installation. The first matching language is used, otherwise it reverts to the cask'\''s default language. The default value is the language of your system]' \
-    '(--formula)--mdimporterdir[Target location for Spotlight Plugins (default: `~/Library/Spotlight`)]' \
-    '--no-binaries[Disable/enable linking of helper executables (default: enabled)]' \
-    '(--cask --ignore-dependencies)--only-dependencies[Install the dependencies with specified options but do not install the formula itself]' \
-    '(--cask)--overwrite[Delete files that already exist in the prefix while linking]' \
-    '(--formula)--prefpanedir[Target location for Preference Panes (default: `~/Library/PreferencePanes`)]' \
-    '(--formula)--qlplugindir[Target location for Quick Look Plugins (default: `~/Library/QuickLook`)]' \
-    '--quiet[Make some output more quiet]' \
-    '(--formula)--require-sha[Require all casks to have a checksum]' \
-    '(--formula)--screen-saverdir[Target location for Screen Savers (default: `~/Library/Screen Savers`)]' \
-    '(--formula)--servicedir[Target location for Services (default: `~/Library/Services`)]' \
-    '(--formula)--skip-cask-deps[Skip installing cask dependencies]' \
-    '(--cask)--skip-link[Install but skip linking the keg into the prefix]' \
-    '(--cask)--skip-post-install[Install but skip any post-install steps]' \
-    '--verbose[Print the verification and post-install steps]' \
-    '(--formula)--vst-plugindir[Target location for VST Plugins (default: `~/Library/Audio/Plug-Ins/VST`)]' \
-    '(--formula)--vst3-plugindir[Target location for VST3 Plugins (default: `~/Library/Audio/Plug-Ins/VST3`)]' \
-    '(--formula)--zap[For use with `brew reinstall --cask`. Remove all files associated with a cask. *May remove files which are shared between applications.*]' \
-    - formula \
-    '(--casks --binaries --require-sha --quarantine --adopt --skip-cask-deps --zap --appdir --appimagedir --keyboard-layoutdir --colorpickerdir --prefpanedir --qlplugindir --mdimporterdir --dictionarydir --fontdir --servicedir --input-methoddir --internet-plugindir --audio-unit-plugindir --vst-plugindir --vst3-plugindir --screen-saverdir --language)--formula[Treat all named arguments as formulae]' \
-    '*:formula:__brew_formulae' \
-    - cask \
-    '(--formulae --env --ignore-dependencies --only-dependencies --cc --build-from-source --force-bottle --include-test --HEAD --fetch-HEAD --keep-tmp --debug-symbols --build-bottle --skip-post-install --skip-link --as-dependency --bottle-arch --interactive --git --overwrite)--cask[Treat all named arguments as casks]' \
     '*:cask:__brew_casks'
 }
 
@@ -1708,30 +1528,6 @@ _brew_irb() {
     '--pry[Use Pry instead of IRB. Enabled by default if `$HOMEBREW_PRY` is set]' \
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]'
-}
-
-# brew lc
-_brew_lc() {
-  _arguments \
-    '--autobump[Include packages that are autobumped by BrewTestBot. By default these are skipped]' \
-    '(--json)--debug[Display any debugging information]' \
-    '(--tap --installed)--eval-all[Evaluate all available formulae and casks, whether installed or not, to check them]' \
-    '(--formula)--extract-plist[Enable checking multiple casks with ExtractPlist strategy]' \
-    '--full-name[Print formulae and casks with fully-qualified names]' \
-    '--help[Show this message]' \
-    '(--tap --eval-all)--installed[Check formulae and casks that are currently installed]' \
-    '(--debug)--json[Output information in JSON format]' \
-    '--newer-only[Show the latest version only if it'\''s newer than the current formula or cask version]' \
-    '--quiet[Suppress warnings, don'\''t print a progress bar for JSON output]' \
-    '--resources[Also check resources for formulae]' \
-    '(--installed --eval-all)--tap[Check formulae and casks within the given tap, specified as user`/`repo]' \
-    '--verbose[Make some output more verbose]' \
-    - formula \
-    '(--cask --extract-plist)--formula[Only check formulae]' \
-    '*:formula:__brew_formulae' \
-    - cask \
-    '(--formula)--cask[Only check casks]' \
-    '*:cask:__brew_casks'
 }
 
 # brew leaves
@@ -1836,21 +1632,6 @@ _brew_livecheck() {
     '*:cask:__brew_casks'
 }
 
-# brew ln
-_brew_ln() {
-  _arguments \
-    '--HEAD[Link the HEAD version of the formula if it is installed]' \
-    '--debug[Display any debugging information]' \
-    '--dry-run[List files which would be linked or deleted by `brew link --overwrite` without actually linking or deleting any files]' \
-    '--force[Allow keg-only formulae to be linked]' \
-    '--help[Show this message]' \
-    '--overwrite[Delete files that already exist in the prefix while linking]' \
-    '--quiet[Make some output more quiet]' \
-    '--verbose[Make some output more verbose]' \
-    - installed_formula \
-    '*:installed_formula:__brew_installed_formulae'
-}
-
 # brew log
 _brew_log() {
   _arguments \
@@ -1869,33 +1650,6 @@ _brew_log() {
     - cask \
     '(--formula)--cask[Treat all named arguments as casks]' \
     '*:cask:__brew_casks'
-}
-
-# brew ls
-_brew_ls() {
-  _arguments \
-    '(--cask --versions --multiple --pinned -l)--built-from-source[List the formulae compiled from source]' \
-    '--debug[Display any debugging information]' \
-    '(--versions --multiple --pinned -l -r -t)--full-name[Print formulae with fully-qualified names. Unless `--full-name`, `--versions` or `--pinned` are passed, other options (i.e. `-1`, `-l`, `-r` and `-t`) are passed to `ls`(1) which produces the actual output]' \
-    '--help[Show this message]' \
-    '(--cask --versions --multiple --pinned -l)--installed-as-dependency[List the formulae installed as dependencies]' \
-    '(--cask --versions --multiple --pinned -l)--installed-on-request[List the formulae installed on request]' \
-    '(--cask --pinned --installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source -1 -l -r -t --full-name)--multiple[Only show formulae with multiple versions installed. Implies `--versions`]' \
-    '(--multiple --installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source -1 -l -r -t --full-name)--pinned[List only pinned packages, or only the specified (pinned) packages if formula or cask are provided. See also `pin`, `unpin`]' \
-    '(--cask --versions --multiple --pinned -l)--poured-from-bottle[List the formulae installed from a bottle]' \
-    '--quiet[Make some output more quiet]' \
-    '--verbose[Make some output more verbose]' \
-    '(--installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source -1 -l -r -t --full-name)--versions[Show the version number for installed formulae, or only the specified formulae if formula are provided]' \
-    '(--versions --multiple --pinned)-1[Force output to be one entry per line. This is the default when output is not to a terminal]' \
-    '(--installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source --versions --multiple --pinned --full-name)-l[List formulae and/or casks in long format. Has no effect when a formula or cask name is passed as an argument]' \
-    '(--versions --multiple --pinned --full-name)-r[Reverse the order of formula and/or cask sorting to list the oldest entries first. Has no effect when a formula or cask name is passed as an argument]' \
-    '(--versions --multiple --pinned --full-name)-t[Sort formulae and/or casks by time modified, listing most recently modified first. Has no effect when a formula or cask name is passed as an argument]' \
-    - installed_formula \
-    '(--cask)--formula[List only formulae, or treat all named arguments as formulae]' \
-    '*:installed_formula:__brew_installed_formulae' \
-    - installed_cask \
-    '(--formula --multiple --installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source)--cask[List only casks, or treat all named arguments as casks]' \
-    '*:installed_cask:__brew_installed_casks'
 }
 
 # brew mcp-server
@@ -1993,17 +1747,6 @@ _brew_pin() {
     - installed_cask \
     '(--formula)--cask[Treat all named arguments as casks]' \
     '*:installed_cask:__brew_installed_casks'
-}
-
-# brew post_install
-_brew_post_install() {
-  _arguments \
-    '--debug[Display any debugging information]' \
-    '--help[Show this message]' \
-    '--quiet[Make some output more quiet]' \
-    '--verbose[Make some output more verbose]' \
-    - installed_formula \
-    '*:installed_formula:__brew_installed_formulae'
 }
 
 # brew postinstall
@@ -2199,42 +1942,6 @@ _brew_release() {
     '(--major)--minor[Create a minor release]' \
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]'
-}
-
-# brew remove
-_brew_remove() {
-  _arguments \
-    '--debug[Display any debugging information]' \
-    '--force[Delete all installed versions of formula. Uninstall even if cask is not installed, overwrite existing files and ignore errors when removing files]' \
-    '--help[Show this message]' \
-    '--ignore-dependencies[Don'\''t fail uninstall, even if formula is a dependency of any installed formulae]' \
-    '--quiet[Make some output more quiet]' \
-    '--verbose[Make some output more verbose]' \
-    '(--formula)--zap[Remove all files associated with a cask. *May remove files which are shared between applications.*]' \
-    - installed_formula \
-    '(--cask --zap)--formula[Treat all named arguments as formulae]' \
-    '*:installed_formula:__brew_installed_formulae' \
-    - installed_cask \
-    '(--formula)--cask[Treat all named arguments as casks]' \
-    '*:installed_cask:__brew_installed_casks'
-}
-
-# brew rm
-_brew_rm() {
-  _arguments \
-    '--debug[Display any debugging information]' \
-    '--force[Delete all installed versions of formula. Uninstall even if cask is not installed, overwrite existing files and ignore errors when removing files]' \
-    '--help[Show this message]' \
-    '--ignore-dependencies[Don'\''t fail uninstall, even if formula is a dependency of any installed formulae]' \
-    '--quiet[Make some output more quiet]' \
-    '--verbose[Make some output more verbose]' \
-    '(--formula)--zap[Remove all files associated with a cask. *May remove files which are shared between applications.*]' \
-    - installed_formula \
-    '(--cask --zap)--formula[Treat all named arguments as formulae]' \
-    '*:installed_formula:__brew_installed_formulae' \
-    - installed_cask \
-    '(--formula)--cask[Treat all named arguments as casks]' \
-    '*:installed_cask:__brew_installed_casks'
 }
 
 # brew rubocop
@@ -2569,25 +2276,6 @@ _brew_tap_new() {
     '*:tap:__brew_any_tap'
 }
 
-# brew tc
-_brew_tc() {
-  _arguments \
-    '--debug[Display any debugging information]' \
-    '(--file)--dir[Typecheck all files in a specific directory]' \
-    '(--dir)--file[Typecheck a single file]' \
-    '(--lsp)--fix[Automatically fix type errors]' \
-    '--help[Show this message]' \
-    '--ignore[Ignores input files that contain the given string in their paths (relative to the input path passed to Sorbet)]' \
-    '(--update --update-all --fix)--lsp[Start the Sorbet LSP server]' \
-    '--quiet[Silence all non-critical errors]' \
-    '--suggest-typed[Try upgrading `typed` sigils]' \
-    '(--lsp)--update[Update RBI files]' \
-    '(--lsp)--update-all[Update all RBI files rather than just updated gems]' \
-    '--verbose[Make some output more verbose]' \
-    - tap \
-    '*:tap:__brew_any_tap'
-}
-
 # brew test
 _brew_test() {
   _arguments \
@@ -2717,24 +2405,6 @@ _brew_unbottled() {
     '*:formula:__brew_formulae'
 }
 
-# brew uninstal
-_brew_uninstal() {
-  _arguments \
-    '--debug[Display any debugging information]' \
-    '--force[Delete all installed versions of formula. Uninstall even if cask is not installed, overwrite existing files and ignore errors when removing files]' \
-    '--help[Show this message]' \
-    '--ignore-dependencies[Don'\''t fail uninstall, even if formula is a dependency of any installed formulae]' \
-    '--quiet[Make some output more quiet]' \
-    '--verbose[Make some output more verbose]' \
-    '(--formula)--zap[Remove all files associated with a cask. *May remove files which are shared between applications.*]' \
-    - installed_formula \
-    '(--cask --zap)--formula[Treat all named arguments as formulae]' \
-    '*:installed_formula:__brew_installed_formulae' \
-    - installed_cask \
-    '(--formula)--cask[Treat all named arguments as casks]' \
-    '*:installed_cask:__brew_installed_casks'
-}
-
 # brew uninstall
 _brew_uninstall() {
   _arguments \
@@ -2809,18 +2479,6 @@ _brew_untap() {
     '--verbose[Make some output more verbose]' \
     - tap \
     '*:tap:__brew_any_tap'
-}
-
-# brew up
-_brew_up() {
-  _arguments \
-    '--auto-update[Run on auto-updates (e.g. before `brew install`). Skips some slower steps]' \
-    '--debug[Display a trace of all shell commands as they are executed]' \
-    '--force[Always do a slower, full update check (even if unnecessary)]' \
-    '--help[Show this message]' \
-    '--merge[Use `git merge` to apply updates (rather than `git rebase`)]' \
-    '--quiet[Make some output more quiet]' \
-    '--verbose[Print the directories checked and `git` operations performed]'
 }
 
 # brew update
@@ -3072,16 +2730,6 @@ _brew_which_update() {
     '--removed-formulae-file[Remove database entries for formulae listed in the given file]' \
     '--repository[GitHub repository for `--pull-request` (default: `$GITHUB_REPOSITORY`)]' \
     '--summary-file[Output a summary of the changes to a file]' \
-    '--verbose[Make some output more verbose]'
-}
-
-# brew x
-_brew_x() {
-  _arguments \
-    '--debug[Display any debugging information]' \
-    '--formulae[Comma-separated formulae to install and add to `PATH` before running command]' \
-    '--help[Show this message]' \
-    '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]'
 }
 


### PR DESCRIPTION
Fixes https://github.com/orgs/Homebrew/discussions/6836

- Avoid suggesting internal aliases because they duplicate canonical commands.
- Keep alias expansion for option completion after users type an alias.
- Regenerate bash, fish, zsh and internal command completion data.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with manual review.

-----
