### PR TITLE
Align ask dry-run prompts

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -47,8 +47,7 @@ module Homebrew
                description: "Show what would be installed, but do not actually install anything."
         switch "--ask",
                description: "Ask for confirmation before downloading and installing. " \
-                            "Print a dependency plan, including added, changed and removed packages " \
-                            "and dependencies, with download and install sizes of formula bottles.",
+                            "Print the same plan as `--dry-run` before prompting.",
                env:         :ask
         [
           [:switch, "--formula", "--formulae", {
@@ -217,21 +216,7 @@ module Homebrew
         fetch_casks = T.let([], T::Array[Cask::Cask])
         if casks.any?
           if args.dry_run?
-            if (casks_to_install = casks.reject(&:installed?).presence)
-              ohai "Would install #{::Utils.pluralize("cask", casks_to_install.count, include_count: true)}:"
-              puts casks_to_install.map(&:full_name).join(" ")
-            end
-            casks.each do |cask|
-              dep_names = CaskDependent.new(cask)
-                                       .runtime_dependencies
-                                       .reject(&:installed?)
-                                       .map(&:name)
-              next if dep_names.blank?
-
-              ohai "Would install #{::Utils.pluralize("dependency", dep_names.count, include_count: true)} " \
-                   "for #{cask.full_name}:"
-              puts dep_names.join(" ")
-            end
+            Install.print_dry_run_casks(casks, skip_cask_deps: args.skip_cask_deps?, include_installed: false)
             return
           end
 
@@ -326,8 +311,23 @@ module Homebrew
           dry_run:                    args.dry_run?,
         )
 
-        # Main block: if asking the user is enabled, show dependency and size information.
-        Install.ask_formulae(formulae_installer, dependants, args: args) if args.ask?
+        # Main block: if asking the user is enabled, show dry-run information.
+        if args.ask?
+          Install.ask_formulae(
+            formulae_installer,
+            dependants,
+            flags:                      args.flags_only,
+            force_bottle:               args.force_bottle?,
+            build_from_source_formulae: args.build_from_source_formulae,
+            interactive:                args.interactive?,
+            keep_tmp:                   args.keep_tmp?,
+            debug_symbols:              args.debug_symbols?,
+            force:                      args.force?,
+            debug:                      args.debug?,
+            quiet:                      args.quiet?,
+            verbose:                    args.verbose?,
+          )
+        end
 
         if formulae_installer.any? && fetch_casks.empty? && !args.ask? && !args.dry_run? &&
            !Homebrew::EnvConfig.no_env_hints?

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -40,8 +40,7 @@ module Homebrew
                description: "Print the verification and post-install steps."
         switch "--ask",
                description: "Ask for confirmation before downloading and reinstalling. " \
-                            "Print a dependency plan, including added, changed and removed packages " \
-                            "and dependencies, with download and install sizes of formula bottles.",
+                            "Print what would be reinstalled before prompting.",
                env:         :ask
         [
           [:switch, "--formula", "--formulae", {
@@ -200,8 +199,24 @@ module Homebrew
 
           formulae_installers = reinstall_contexts.map(&:formula_installer)
 
-          # Main block: if asking the user is enabled, show dependency and size information.
-          Install.ask_formulae(formulae_installers, dependants, action: "reinstallation", args: args) if args.ask?
+          # Main block: if asking the user is enabled, show dry-run information.
+          if args.ask?
+            Install.ask_formulae(
+              formulae_installers,
+              dependants,
+              action:                     "reinstallation",
+              flags:                      args.flags_only,
+              force_bottle:               args.force_bottle?,
+              build_from_source_formulae: args.build_from_source_formulae,
+              interactive:                args.interactive?,
+              keep_tmp:                   args.keep_tmp?,
+              debug_symbols:              args.debug_symbols?,
+              force:                      args.force?,
+              debug:                      args.debug?,
+              quiet:                      args.quiet?,
+              verbose:                    args.verbose?,
+            )
+          end
 
           valid_formula_installers = if casks.any?
             shared_download_queue = Homebrew::DownloadQueue.new(pour: true)

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -140,6 +140,12 @@ module Homebrew
         named_args [:installed_formula, :installed_cask]
       end
 
+      sig { override.params(argv: T::Array[String]).void }
+      def initialize(argv = ARGV.freeze)
+        super
+        @ask_prompt_required = T.let(false, T::Boolean)
+      end
+
       sig { override.void }
       def run
         if args.build_from_source? && args.named.empty?
@@ -158,6 +164,7 @@ module Homebrew
         prefetched_cask_names = T.let([], T::Array[String])
         prefetched_cask_upgrades = T.let([], T::Array[String])
         @final_upgrade_summary = T.let(FinalUpgradeSummary.new, T.nilable(FinalUpgradeSummary))
+        @ask_prompt_required = false
 
         if args.named.present?
           args.named.to_formulae_and_casks_and_unavailable(method: :resolve).each do |item|
@@ -207,7 +214,17 @@ module Homebrew
           end
 
           show_final_upgrade_summary(dry_run: true)
-          Install.ask(action: "upgrade") if final_upgrade_summary.version_changes.present?
+          if Install.ask_prompt_needed?(
+            planned_names:   final_upgrade_summary.version_changes.map do |version_change|
+              planned_name = version_change.split.fetch(0)
+              formulae.find { |formula| formula.full_specified_name == planned_name }&.full_name || planned_name
+            end,
+            requested_names: args.named,
+            force:           @ask_prompt_required,
+            named:           args.named.present?,
+          )
+            Install.ask(action: "upgrade")
+          end
           @final_upgrade_summary = FinalUpgradeSummary.new
         end
 
@@ -579,6 +596,11 @@ module Homebrew
         end
 
         record_formula_upgrade_summary(context, include_sizes: dry_run)
+        if args.ask? && dry_run && args.named.present? &&
+           Install.formulae_ask_prompt_needed?(context.formulae_installer, context.dependants)
+          @ask_prompt_required = true
+        end
+
         skip_formula_names = if dry_run
           (context.formulae_installer.map(&:formula) + context.dependants.upgradeable)
             .uniq(&:full_name)

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -416,7 +416,7 @@ module Homebrew
                cc: T.nilable(String), git: T::Boolean, interactive: T::Boolean, keep_tmp: T::Boolean,
                debug_symbols: T::Boolean, force: T::Boolean, overwrite: T::Boolean, debug: T::Boolean,
                quiet: T::Boolean, verbose: T::Boolean, dry_run: T::Boolean,
-               skip_post_install: T::Boolean, skip_link: T::Boolean).void
+               dry_run_action: String, skip_post_install: T::Boolean, skip_link: T::Boolean).void
       }
       def install_formulae(
         formula_installers,
@@ -439,6 +439,7 @@ module Homebrew
         quiet: false,
         verbose: false,
         dry_run: false,
+        dry_run_action: "install",
         skip_post_install: false,
         skip_link: false
       )
@@ -446,7 +447,8 @@ module Homebrew
         return if formulae_names_to_install.empty?
 
         if dry_run
-          ohai "Would install #{Utils.pluralize("formula", formulae_names_to_install.count, include_count: true)}:"
+          ohai "Would #{dry_run_action} #{Utils.pluralize("formula", formulae_names_to_install.count,
+                                                          include_count: true)}:"
           puts formulae_names_to_install.join(" ")
 
           formula_installers.each do |fi|
@@ -487,80 +489,69 @@ module Homebrew
         puts formula_names.join("\n")
       end
 
-      # If asking the user is enabled, show dependency and size information.
+      # If asking the user is enabled, show dry-run information.
       sig {
         params(
-          formulae_installer: T::Array[FormulaInstaller],
-          dependants:         Homebrew::Upgrade::Dependents,
-          args:               Homebrew::CLI::Args,
-          prompt:             T::Boolean,
-          action:             String,
+          formulae_installer:         T::Array[FormulaInstaller],
+          dependants:                 Homebrew::Upgrade::Dependents,
+          flags:                      T::Array[String],
+          force_bottle:               T::Boolean,
+          build_from_source_formulae: T::Array[String],
+          interactive:                T::Boolean,
+          keep_tmp:                   T::Boolean,
+          debug_symbols:              T::Boolean,
+          force:                      T::Boolean,
+          debug:                      T::Boolean,
+          quiet:                      T::Boolean,
+          verbose:                    T::Boolean,
+          prompt:                     T::Boolean,
+          action:                     String,
         ).void
       }
-      def ask_formulae(formulae_installer, dependants, args:, prompt: true, action: "installation")
+      def ask_formulae(formulae_installer, dependants,
+                       flags: [],
+                       force_bottle: false,
+                       build_from_source_formulae: [],
+                       interactive: false,
+                       keep_tmp: false,
+                       debug_symbols: false,
+                       force: false,
+                       debug: false,
+                       quiet: false,
+                       verbose: false,
+                       prompt: true,
+                       action: "installation")
         return if formulae_installer.empty?
 
-        formulae = collect_dependencies(formulae_installer, dependants)
+        formula_names = formulae_installer.map { |formula_installer| formula_installer.formula.full_name }
 
-        sizes = compute_total_sizes(formulae, debug: args.debug?)
-        added_formulae = formulae.reject(&:any_version_installed?).map(&:full_specified_name)
-        changed_formulae = formulae.filter_map do |formula|
-          next unless formula.any_version_installed?
-          next if (installed_version = formula.any_installed_version).blank?
-          next if installed_version.to_s == formula.pkg_version.to_s
+        install_formulae(formulae_installer, dry_run: true, dry_run_action: dry_run_action(action))
 
-          "#{formula.full_specified_name} #{installed_version} -> #{formula.pkg_version}"
-        end
-        removed_formulae = formulae_installer.flat_map do |formula_installer|
-          formula = formula_installer.formula
-          next [] unless formula.any_version_installed?
+        Upgrade.upgrade_dependents(
+          Homebrew::Upgrade::Dependents.new(
+            upgradeable: dependants.upgradeable.dup,
+            pinned:      dependants.pinned.dup,
+            skipped:     dependants.skipped.dup,
+          ),
+          formulae_installer.map(&:formula),
+          flags:,
+          dry_run:                    true,
+          force_bottle:,
+          build_from_source_formulae:,
+          interactive:,
+          keep_tmp:,
+          debug_symbols:,
+          force:,
+          debug:,
+          quiet:,
+          verbose:,
+        )
 
-          formula.installed_runtime_formula_dependencies.reject do |dependency|
-            formulae.any? { |planned_formula| planned_formula.full_name == dependency.full_name } ||
-              formula.runtime_formula_dependencies(read_from_tab: false).any? do |runtime_dependency|
-                runtime_dependency.full_name == dependency.full_name
-              end
-          end
-        end.uniq(&:full_name).map(&:full_specified_name)
-        size_changed_formulae = formulae.filter_map do |formula|
-          next if formula.installed_kegs.none?
-          next unless (installed_size = formula.bottle&.installed_size)
-
-          installed_keg_size = formula.installed_kegs.sum { |keg| keg.disk_usage.to_i }
-          next if installed_keg_size == installed_size.to_i
-
-          "#{formula.full_specified_name} #{Formatter.disk_usage_readable(installed_keg_size)} -> " \
-            "#{Formatter.disk_usage_readable(installed_size.to_i)}"
-        end
-
-        puts "#{::Utils.pluralize("Formula", formulae.count, plural: "e")} (#{formulae.count}):"
-        puts formulae.join("\n")
-        puts
-        if added_formulae.present?
-          puts "Added #{::Utils.pluralize("Formula", added_formulae.count, plural: "e")} " \
-               "(#{added_formulae.count}):"
-          puts added_formulae.join("\n")
-        end
-        if changed_formulae.present?
-          puts "Changed #{::Utils.pluralize("Formula", changed_formulae.count, plural: "e")} " \
-               "(#{changed_formulae.count}):"
-          puts changed_formulae.join("\n")
-        end
-        if removed_formulae.present?
-          puts "Removed from Closure #{::Utils.pluralize("Formula", removed_formulae.count, plural: "e")} " \
-               "(#{removed_formulae.count}):"
-          puts removed_formulae.join("\n")
-        end
-        if size_changed_formulae.present?
-          puts "Size Changed #{::Utils.pluralize("Formula", size_changed_formulae.count, plural: "e")} " \
-               "(#{size_changed_formulae.count}):"
-          puts size_changed_formulae.join("\n")
-        end
-        ohai "Bottle Sizes"
-        puts "Download: #{Formatter.disk_usage_readable(sizes.fetch(:download))}"
-        puts "Install:  #{Formatter.disk_usage_readable(sizes.fetch(:installed))}"
-
-        ask_input(action:) if prompt
+        ask_input(action:) if prompt && ask_prompt_needed?(
+          planned_names:   formula_names,
+          requested_names: formula_names,
+          force:           formulae_ask_prompt_needed?(formulae_installer, dependants),
+        )
       end
 
       sig {
@@ -574,115 +565,82 @@ module Homebrew
       def ask_casks(casks, action: "installation", prompt: true, skip_cask_deps: false)
         return if casks.empty?
 
-        planned_casks, planned_formulae, closure_cask_full_names, closure_formula_full_names =
-          if skip_cask_deps
-            closure_casks, closure_formulae =
-              ::Utils::TopologicalHash.graph_package_dependencies(casks).tsort.partition do |cask_or_formula|
-                cask_or_formula.is_a?(Cask::Cask)
-              end
-            formulae = casks.flat_map { |cask| cask.depends_on.formula.map { |formula| Formula[formula] } }
-            [
-              casks,
-              ::Utils::TopologicalHash.graph_package_dependencies(formulae).tsort.grep(Formula),
-              closure_casks.uniq(&:full_name).map(&:full_name),
-              closure_formulae.uniq(&:full_name).map(&:full_name),
-            ]
-          else
-            planned_casks, planned_formulae =
-              ::Utils::TopologicalHash.graph_package_dependencies(casks).tsort.partition do |cask_or_formula|
-                cask_or_formula.is_a?(Cask::Cask)
-              end
-            [
-              planned_casks,
-              planned_formulae,
-              planned_casks.uniq(&:full_name).map(&:full_name),
-              planned_formulae.uniq(&:full_name).map(&:full_name),
-            ]
+        cask_names = casks.map(&:full_name)
+        dependency_names = print_dry_run_casks(casks, action: dry_run_action(action), skip_cask_deps:)
+
+        ask_input(action:) if prompt && ask_prompt_needed?(
+          planned_names:   cask_names + dependency_names,
+          requested_names: cask_names,
+        )
+      end
+
+      sig {
+        params(
+          casks:             T::Array[Cask::Cask],
+          action:            String,
+          skip_cask_deps:    T::Boolean,
+          include_installed: T::Boolean,
+        ).returns(T::Array[String])
+      }
+      def print_dry_run_casks(casks, action: "install", skip_cask_deps: false, include_installed: true)
+        if (casks_to_print = (include_installed ? casks : casks.reject(&:installed?)).presence)
+          ohai "Would #{action} #{::Utils.pluralize("cask", casks_to_print.count, include_count: true)}:"
+          puts casks_to_print.map(&:full_name).join(" ")
+        end
+
+        casks.flat_map do |cask|
+          dep_names = T.let([], T::Array[String])
+          unless skip_cask_deps
+            dep_names.concat(
+              ::Utils::TopologicalHash.graph_package_dependencies([cask]).tsort.grep(Cask::Cask).filter_map do |dep|
+                next if dep.full_name == cask.full_name
+                next if dep.installed?
+
+                dep.full_name
+              end,
+            )
           end
-        planned_casks = planned_casks.uniq(&:full_name)
-        planned_formulae = planned_formulae.uniq(&:full_name)
-        cask_full_names = casks.map(&:full_name)
-        missing_formulae = planned_formulae.reject { |formula| formula.any_version_installed? && formula.optlinked? }
+          dep_names.concat(
+            CaskDependent.new(cask)
+                         .runtime_dependencies
+                         .reject(&:installed?)
+                         .map(&:name),
+          )
+          dep_names.uniq!
+          next [] if dep_names.blank?
 
-        puts "#{::Utils.pluralize("Cask", planned_casks.count, plural: "s")} \
-(#{planned_casks.count}): #{planned_casks.map(&:full_name).join(", ")}\n\n"
-        if planned_formulae.present?
-          puts "#{::Utils.pluralize("Formula", planned_formulae.count, plural: "e")} \
-(#{planned_formulae.count}): #{planned_formulae.join(", ")}\n\n"
+          ohai "Would install #{::Utils.pluralize("dependency", dep_names.count, include_count: true)} " \
+               "for #{cask.full_name}:"
+          puts dep_names.join(" ")
+          dep_names
         end
-        added_casks = planned_casks.reject(&:installed?).map(&:full_name)
-        changed_casks = planned_casks.filter_map do |cask|
-          next unless cask_full_names.include?(cask.full_name)
-          next if (installed_version = cask.installed_version).blank?
-          next if installed_version == cask.version.to_s
+      end
 
-          "#{cask.full_name} #{installed_version} -> #{cask.version}"
-        end
-        removed_casks = casks.flat_map do |cask|
-          next [] unless cask.installed?
+      sig {
+        params(
+          planned_names:   T::Array[String],
+          requested_names: T::Array[String],
+          force:           T::Boolean,
+          named:           T::Boolean,
+        ).returns(T::Boolean)
+      }
+      def ask_prompt_needed?(planned_names:, requested_names:, force: false, named: true)
+        return false if planned_names.empty?
+        return true if force
+        return true unless named
 
-          runtime_dependencies = cask.tab.runtime_dependencies
-          next [] unless runtime_dependencies.is_a?(Hash)
+        planned_names.any? { |planned_name| requested_names.exclude?(planned_name) }
+      end
 
-          dependencies_by_type = T.let(runtime_dependencies, T::Hash[T.any(String, Symbol), T.untyped])
-          T.cast(
-            dependencies_by_type["cask"] || dependencies_by_type[:cask] || [],
-            T::Array[T::Hash[String, T.untyped]],
-          ).filter_map do |dependency|
-            full_name = dependency["full_name"].to_s
-            full_name if full_name.present? && closure_cask_full_names.exclude?(full_name)
-          end
-        end.uniq
-        added_formulae = missing_formulae.reject(&:any_version_installed?).map(&:full_specified_name)
-        changed_formulae = missing_formulae.filter_map do |formula|
-          next unless formula.any_version_installed?
-          next if (installed_version = formula.any_installed_version).blank?
-          next if installed_version.to_s == formula.pkg_version.to_s
-
-          "#{formula.full_specified_name} #{installed_version} -> #{formula.pkg_version}"
-        end
-        removed_formulae = casks.flat_map do |cask|
-          next [] unless cask.installed?
-
-          runtime_dependencies = cask.tab.runtime_dependencies
-          next [] unless runtime_dependencies.is_a?(Hash)
-
-          dependencies_by_type = T.let(runtime_dependencies, T::Hash[T.any(String, Symbol), T.untyped])
-          T.cast(
-            dependencies_by_type["formula"] || dependencies_by_type[:formula] || [],
-            T::Array[T::Hash[String, T.untyped]],
-          ).filter_map do |dependency|
-            full_name = dependency["full_name"].to_s
-            full_name if full_name.present? && closure_formula_full_names.exclude?(full_name)
-          end
-        end.uniq
-
-        if added_casks.present?
-          puts "Added #{::Utils.pluralize("Cask", added_casks.count, plural: "s")} " \
-               "(#{added_casks.count}): #{added_casks.join(", ")}"
-        end
-        if changed_casks.present?
-          puts "Changed #{::Utils.pluralize("Cask", changed_casks.count, plural: "s")} " \
-               "(#{changed_casks.count}): #{changed_casks.join(", ")}"
-        end
-        if removed_casks.present?
-          puts "Removed from Closure #{::Utils.pluralize("Cask", removed_casks.count, plural: "s")} " \
-               "(#{removed_casks.count}): #{removed_casks.join(", ")}"
-        end
-        if added_formulae.present?
-          puts "Added #{::Utils.pluralize("Formula", added_formulae.count, plural: "e")} " \
-               "(#{added_formulae.count}): #{added_formulae.join(", ")}"
-        end
-        if changed_formulae.present?
-          puts "Changed #{::Utils.pluralize("Formula", changed_formulae.count, plural: "e")} " \
-               "(#{changed_formulae.count}): #{changed_formulae.join(", ")}"
-        end
-        if removed_formulae.present?
-          puts "Removed from Closure #{::Utils.pluralize("Formula", removed_formulae.count, plural: "e")} " \
-               "(#{removed_formulae.count}): #{removed_formulae.join(", ")}"
-        end
-
-        ask_input(action:) if prompt
+      sig {
+        params(
+          formulae_installer: T::Array[FormulaInstaller],
+          dependants:         Homebrew::Upgrade::Dependents,
+        ).returns(T::Boolean)
+      }
+      def formulae_ask_prompt_needed?(formulae_installer, dependants)
+        formulae_installer.any? { |formula_installer| formula_installer.compute_dependencies.present? } ||
+          dependants.upgradeable.present?
       end
 
       sig { params(formula_installer: FormulaInstaller, upgrade: T::Boolean).void }
@@ -726,6 +684,18 @@ module Homebrew
       end
 
       private
+
+      sig { params(action: String).returns(String) }
+      def dry_run_action(action)
+        case action
+        when "reinstallation"
+          "reinstall"
+        when "upgrade"
+          "upgrade"
+        else
+          "install"
+        end
+      end
 
       sig { params(formula: Formula).returns(T::Array[Keg]) }
       def outdated_kegs(formula)

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -9,66 +9,65 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
 
   it_behaves_like "parseable arguments"
 
-  it "prints a formula closure diff when asking" do
+  it "prints a formula dry-run plan when asking" do
     added = formula("added") do
       url "https://brew.sh/added-1.0.tar.gz"
     end
     changed = formula("changed") do
       url "https://brew.sh/changed-2.0.tar.gz"
     end
-    removed = formula("removed") do
-      url "https://brew.sh/removed-1.0.tar.gz"
-    end
     added_installer = FormulaInstaller.new(added)
     changed_installer = FormulaInstaller.new(changed)
     dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
-    bottle = instance_double(Bottle, fetch_tab: nil, bottle_size: nil, installed_size: 2000)
-    keg = instance_double(Keg, disk_usage: 1000)
 
     allow(added_installer).to receive(:compute_dependencies).and_return([])
     allow(changed_installer).to receive(:compute_dependencies).and_return([])
-    allow(changed).to receive_messages(
-      any_version_installed?:                 true,
-      any_installed_version:                  PkgVersion.parse("1.0"),
-      bottle:                                 bottle,
-      installed_kegs:                         [keg],
-      installed_runtime_formula_dependencies: [removed],
-    )
 
     expect do
       Homebrew::Install.ask_formulae(
         [added_installer, changed_installer],
         dependants,
-        args:   described_class.new(["--ask", "added", "changed"]).args,
         prompt: false,
       )
     end.to output(<<~EOS).to_stdout
-      Formulae (2):
-      added
-      changed
-
-      Added Formula (1):
-      added
-      Changed Formula (1):
-      changed 1.0 -> 2.0
-      Removed from Closure Formula (1):
-      removed
-      Size Changed Formula (1):
-      changed 1KB -> 2KB
-      ==> Bottle Sizes
-      Download: 0B
-      Install:  2KB
+      ==> Would install 2 formulae:
+      added changed
     EOS
   end
 
-  it "uses the requested action when asking for formulae" do
-    formula = formula("changed") do
-      url "https://brew.sh/changed-2.0.tar.gz"
+  it "skips ask input when asking for only requested formulae" do
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
     end
     formula_installer = FormulaInstaller.new(formula)
     dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
 
     allow(formula_installer).to receive(:compute_dependencies).and_return([])
+    expect(Homebrew::Install).not_to receive(:ask_input)
+
+    expect do
+      Homebrew::Install.ask_formulae(
+        [formula_installer],
+        dependants,
+      )
+    end.to output(<<~EOS).to_stdout
+      ==> Would install 1 formula:
+      testball
+    EOS
+  end
+
+  it "uses the requested action when asking for formulae with dependencies" do
+    formula = formula("changed") do
+      url "https://brew.sh/changed-2.0.tar.gz"
+    end
+    dependency = formula("dependency") do
+      url "https://brew.sh/dependency-1.0.tar.gz"
+    end
+    formula_installer = FormulaInstaller.new(formula)
+    dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
+
+    allow(formula_installer).to receive(:compute_dependencies)
+      .and_return([instance_double(Dependency, to_formula: dependency)])
     expect(Homebrew::Install).to receive(:ask_input).with(action: "upgrade")
 
     expect do
@@ -76,9 +75,13 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
         [formula_installer],
         dependants,
         action: "upgrade",
-        args:   described_class.new(["--ask", "changed"]).args,
       )
-    end.to output(/Formula \(1\):\nchanged/).to_stdout
+    end.to output(<<~EOS).to_stdout
+      ==> Would upgrade 1 formula:
+      changed
+      ==> Would install 1 dependency for changed:
+      dependency
+    EOS
   end
 
   it "defaults ask input to no" do
@@ -90,77 +93,82 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
       .and output("==> Do you want to proceed with the upgrade? [y/N]\n").to_stdout
   end
 
+  it "uses shared prompt rules for ask plans" do
+    expect([
+      Homebrew::Install.ask_prompt_needed?(planned_names: ["fish"], requested_names: ["fish"]),
+      Homebrew::Install.ask_prompt_needed?(planned_names: ["fish", "openssl"], requested_names: ["fish"]),
+      Homebrew::Install.ask_prompt_needed?(planned_names: ["fish"], requested_names: [], named: false),
+      Homebrew::Install.ask_prompt_needed?(planned_names: ["fish"], requested_names: ["fish"], force: true),
+      Homebrew::Install.ask_prompt_needed?(planned_names: [], requested_names: [], named: false),
+    ]).to eq([false, true, true, true, false])
+  end
+
   it "prints casks when asking", :cask do
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
 
     expect do
       Homebrew::Install.ask_casks([cask], prompt: false)
     end.to output(<<~EOS).to_stdout
-      Cask (1): local-caffeine
-
-      Added Cask (1): local-caffeine
+      ==> Would install 1 cask:
+      local-caffeine
     EOS
   end
 
-  it "prints a cask dependency plan when asking", :cask do
-    cask = Cask::CaskLoader.load(cask_path("with-depends-on-everything"))
-    unar = Class.new(Formula) do
-      url "my_url"
-      version "1.2"
-    end.new("unar", Pathname.new(__FILE__).expand_path, :stable)
-
-    allow(Formulary).to receive(:factory).with("unar").and_return(unar)
-
-    expect do
-      Homebrew::Install.ask_casks([cask], prompt: false)
-    end.to output(Regexp.new(
-                    "Casks \\(4\\): .*with-depends-on-everything.*\\n\\n" \
-                    "Formula \\(1\\): unar\\n\\n" \
-                    "Added Casks \\(4\\): .*with-depends-on-everything.*\\n" \
-                    "Added Formula \\(1\\): unar\\n",
-                    Regexp::MULTILINE,
-                  )).to_stdout
-  end
-
-  it "prints changed and removed cask closure entries when asking", :cask do
+  it "prompts when asking for casks with dependencies", :cask do
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
-    tab = instance_double(
-      Cask::Tab,
-      runtime_dependencies: {
-        "cask"    => [{ "full_name" => "old-cask" }],
-        "formula" => [{ "full_name" => "old-formula" }],
-      },
-    )
+    dependency = instance_double(Dependency, installed?: false, name: "unar")
 
-    allow(cask).to receive_messages(installed?: true, installed_version: "1.0", tab:)
+    allow(CaskDependent).to receive(:new)
+      .with(cask)
+      .and_return(instance_double(CaskDependent, runtime_dependencies: [dependency]))
+    expect(Homebrew::Install).to receive(:ask_input).with(action: "installation")
 
     expect do
-      Homebrew::Install.ask_casks([cask], prompt: false)
+      Homebrew::Install.ask_casks([cask])
     end.to output(<<~EOS).to_stdout
-      Cask (1): local-caffeine
-
-      Changed Cask (1): local-caffeine 1.0 -> 1.2.3
-      Removed from Closure Cask (1): old-cask
-      Removed from Closure Formula (1): old-formula
+      ==> Would install 1 cask:
+      local-caffeine
+      ==> Would install 1 dependency for local-caffeine:
+      unar
     EOS
   end
 
-  it "does not print unchanged skipped cask dependencies as removed", :cask do
+  it "prompts when asking for casks with cask dependencies", :cask do
     cask = Cask::CaskLoader.load(cask_path("with-depends-on-cask"))
-    tab = instance_double(
-      Cask::Tab,
-      runtime_dependencies: {
-        "cask" => [{ "full_name" => "local-transmission-zip" }],
-      },
-    )
 
-    allow(cask).to receive_messages(installed?: true, installed_version: cask.version.to_s, tab:)
+    expect(Homebrew::Install).to receive(:ask_input).with(action: "installation")
 
     expect do
-      Homebrew::Install.ask_casks([cask], prompt: false, skip_cask_deps: true)
+      Homebrew::Install.ask_casks([cask])
     end.to output(<<~EOS).to_stdout
-      Cask (1): with-depends-on-cask
+      ==> Would install 1 cask:
+      with-depends-on-cask
+      ==> Would install 1 dependency for with-depends-on-cask:
+      local-transmission-zip
+    EOS
+  end
 
+  it "prints a cask reinstallation dry-run plan when asking", :cask do
+    cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+
+    expect do
+      Homebrew::Install.ask_casks([cask], action: "reinstallation", prompt: false)
+    end.to output(<<~EOS).to_stdout
+      ==> Would reinstall 1 cask:
+      local-caffeine
+    EOS
+  end
+
+  it "does not prompt when skipped cask dependencies will not be installed", :cask do
+    cask = Cask::CaskLoader.load(cask_path("with-depends-on-cask"))
+
+    expect(Homebrew::Install).not_to receive(:ask_input)
+
+    expect do
+      Homebrew::Install.ask_casks([cask], skip_cask_deps: true)
+    end.to output(<<~EOS).to_stdout
+      ==> Would install 1 cask:
+      with-depends-on-cask
     EOS
   end
 
@@ -240,7 +248,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
       uninstall_test_formula formula_name
 
       expect { brew "install", "--ask", formula_name }
-        .to output(/.*Formula\s*\(1\):\s*#{formula_name}.*/).to_stdout
+        .to output(/.*Would install 1 formula:\s*#{formula_name}.*/).to_stdout
         .and output(/✔︎.*/m).to_stderr
         .and be_a_success
       expect(option_file).not_to be_a_file

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Homebrew::Cmd::Reinstall do
     FileUtils.rm_r(formula_bin)
 
     expect { brew "reinstall", "--ask", formula_name }
-      .to output(/.*Formula\s*\(1\):\s*#{formula_name}.*/).to_stdout
+      .to output(/.*Would reinstall 1 formula:\s*#{formula_name}.*/).to_stdout
       .and output(/✔︎.*/m).to_stderr
       .and be_a_success
     expect(formula_bin).to exist

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -154,6 +154,42 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     cmd.run
   end
 
+  it "does not ask before upgrading only explicitly named formulae" do
+    expect(Homebrew::Install.ask_prompt_needed?(
+             planned_names:   ["testball"],
+             requested_names: ["testball"],
+           )).to be(false)
+  end
+
+  it "asks before upgrading formulae that resolve from a different name" do
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.2"
+    end
+    cmd = described_class.new(["--ask", "oldtestball"])
+    allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable)
+      .with(method: :resolve)
+      .and_return([formula])
+
+    expect(cmd).to receive(:upgrade_outdated_formulae!)
+      .with([formula], dry_run: true, show_upgrade_summary: false)
+      .ordered do
+        cmd.send(:final_upgrade_summary).version_changes << "testball 0.1 -> 0.2"
+        true
+      end
+    allow(cmd).to receive(:show_final_upgrade_summary).and_call_original
+    expect(cmd).to receive(:show_final_upgrade_summary).with(dry_run: true).ordered
+    expect(Homebrew::Install).to receive(:ask).with(action: "upgrade").ordered
+    expect(cmd).to receive(:upgrade_outdated_formulae!)
+      .with([formula], use_prefetched: false, show_upgrade_summary: false)
+      .ordered
+      .and_return(true)
+    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
+    allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
+    allow(Homebrew.messages).to receive(:display_messages)
+
+    expect { cmd.run }.to output(/testball 0\.1 -> 0\.2/).to_stdout
+  end
+
   it "prints formula download sizes in dry-run upgrade summaries" do
     cmd = described_class.new(["--dry-run"])
     formula = formula("testball") do


### PR DESCRIPTION
- Use dry-run-style `--ask` plans for install and reinstall commands.
- Make single-package operations proceed without a prompt e.g. if you `brew install foo` and there's no dependencies or dependents to install: just install without the prompt.
- Keep prompting when dependencies or dependents change the plan.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
