### PR TITLE
bundle: try `mas install` before falling back to `mas get`

### DIFF
--- a/Library/Homebrew/bundle/extensions/mac_app_store.rb
+++ b/Library/Homebrew/bundle/extensions/mac_app_store.rb
@@ -200,7 +200,9 @@ module Homebrew
           end
 
           puts "Installing #{name} app. It is not currently installed." if verbose
-          return false unless Bundle.system(mas, "get", id.to_s, verbose:)
+          installed = Bundle.system(mas, "install", id.to_s, verbose:) ||
+                      Bundle.system(mas, "get", id.to_s, verbose:)
+          return false unless installed
 
           apps << [id.to_s, name] unless apps.any? { |app_id, _app_name| app_id.to_i == id }
           packages << App.new(id: id.to_s, name:) unless packages.any? { |app| app.id.to_i == id }

--- a/Library/Homebrew/test/bundle/mac_app_store_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_spec.rb
@@ -258,6 +258,15 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
         end
 
         it "installs app" do
+          expect(Homebrew::Bundle).to receive(:system).with(Pathname("mas"), "install", "123", verbose: false)
+                                                      .and_return(true)
+          expect(described_class.preinstall!("foo", 123)).to be(true)
+          expect(described_class.install!("foo", 123)).to be(true)
+        end
+
+        it "falls back to `mas get` when `mas install` fails" do
+          expect(Homebrew::Bundle).to receive(:system).with(Pathname("mas"), "install", "123", verbose: false)
+                                                      .and_return(false)
           expect(Homebrew::Bundle).to receive(:system).with(Pathname("mas"), "get", "123", verbose: false)
                                                       .and_return(true)
           expect(described_class.preinstall!("foo", 123)).to be(true)


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

(Ran components individually: `brew tests --only=bundle/mac_app_store --no-parallel` 14/14 pass, `brew style` no new offenses, `brew typecheck` clean. This is the byte-identical diff already validated for #22271.)

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

AI (Claude Code) drafted the patch and RSpec test based on issue #22270, which I authored after manually reproducing the regression on a fresh macOS 26.5 install. I verified the empirical reproducer myself (`mas get <id>` fails where `mas install <id>` succeeds for a purchase-history app not on disk). Tests, style, and typecheck were run locally before pushing. No prior AI-assisted PR is open (#22271 is closed).

-----

## What this fixes

Fixes #22270.

This re-submits #22271 against `main`. #22271 was opened against `master` (stale fork default) and merged there, but the merge-queue protection rule on `main` rejected the propagation, so the fix never reached `main`. @MikeMcQuaid asked for a fresh PR with `base=main` so it can go through the merge queue cleanly ([#22271 comment](https://github.com/Homebrew/brew/pull/22271#issuecomment-4485479991)). The diff is unchanged.

PR #21590 switched `brew bundle` from `mas install` to `mas get` based on the assertion in #21559 that they're equivalent for already-purchased apps. Empirically on macOS 26.5 / mas 7.0.0 this isn't true — `mas get` returns `No downloads initiated for ADAM ID <id>` for apps in the Apple ID's purchase history but not present on disk, while `mas install` succeeds for the same id in the same session.

This adopts the fallback strategy from the #21559 body that wasn't taken in #21590:

> Try `mas install` first (fast path for already-associated apps). Fall back to `mas get` if install fails with the redownload error.

Both scenarios are now covered: purchase-history restore (install succeeds, get not called) and fresh Apple Account (install fails, get takes over).

cc @rgoldberg @MikeMcQuaid
