### PR TITLE
pathname: eagerly initialize lazy instance variables

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -3,6 +3,7 @@
 
 require "system_command"
 require "extend/pathname/disk_usage_extension"
+require "extend/pathname/eager_initialize_extension"
 require "extend/pathname/observer_pathname_extension"
 require "extend/pathname/write_mkpath_extension"
 require "utils/output"
@@ -29,6 +30,7 @@ class Pathname
   include SystemCommand::Mixin
   include DiskUsageExtension
   include Utils::Output::Mixin
+  prepend EagerInitializeExtension
 
   sig { void }
   def self.activate_extensions!

--- a/Library/Homebrew/extend/pathname/eager_initialize_extension.rb
+++ b/Library/Homebrew/extend/pathname/eager_initialize_extension.rb
@@ -1,6 +1,11 @@
 # typed: strict
 # frozen_string_literal: true
 
+# Eagerly initialises {Pathname}'s lazy memoised ivars so every instance
+# shares one object shape, avoiding Ruby's shape-variation warning.
+#
+# Any new `@x ||= ...` ivar added to {Pathname} or its mixed-in extensions
+# must also be added to `#initialize` below to keep the shape stable.
 module EagerInitializeExtension
   extend T::Helpers
 

--- a/Library/Homebrew/extend/pathname/eager_initialize_extension.rb
+++ b/Library/Homebrew/extend/pathname/eager_initialize_extension.rb
@@ -1,0 +1,19 @@
+# typed: strict
+# frozen_string_literal: true
+
+module EagerInitializeExtension
+  extend T::Helpers
+
+  requires_ancestor { Pathname }
+
+  sig { params(args: T.untyped).void }
+  def initialize(*args)
+    @magic_number = T.let(nil, T.nilable(String))
+    @file_type = T.let(nil, T.nilable(String))
+    @zipinfo = T.let(nil, T.nilable(T::Array[String]))
+    @which_install_info = T.let(nil, T.nilable(String))
+    @disk_usage = T.let(nil, T.nilable(Integer))
+    @file_count = T.let(nil, T.nilable(Integer))
+    super
+  end
+end

--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe Pathname do
   let(:file) { src/"foo" }
   let(:dir) { src/"bar" }
 
+  describe EagerInitializeExtension do
+    it "defines the lazy memoised ivars on every new Pathname" do
+      pathname = Pathname.new(file.to_s)
+      [:@magic_number, :@file_type, :@zipinfo, :@which_install_info, :@disk_usage, :@file_count].each do |ivar|
+        expect(pathname.instance_variable_defined?(ivar)).to be(true), "expected #{ivar} to be defined"
+        expect(pathname.instance_variable_get(ivar)).to be_nil
+      end
+    end
+  end
+
   describe DiskUsageExtension do
     before do
       mkdir_p dir/"a-directory"


### PR DESCRIPTION
Continues d57efd9ea2 by initialising the lazy memoised instance variables defined in `extend/pathname.rb` and `DiskUsageExtension` (`@magic_number`, `@file_type`, `@zipinfo`, `@which_install_info`, `@disk_usage`, `@file_count`) up front via a new `EagerInitializeExtension` module that's prepended at class-body time (same shape as the precedent in [`extend/os/mac/unpack_strategy/zip.rb`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb#L70)).

Every `Pathname` instance now shares the same object shape regardless of which lazy method is hit first, so we no longer see:

```
warning: The class Pathname reached 8 shape variations, instance variables accesses will be slower and memory usage increased.
It is recommended to define instance variables in a consistent order, for instance by eagerly defining them all in the #initialize method.
```

Verified locally: 50 `Pathname` instances exercising the lazy methods in varied orders all collapse to a single `ObjectSpace.dump` shape (vs 8+ before). A `pathname_spec.rb` example asserts every lazy ivar is defined and `nil` immediately after `Pathname.new` so future regressions are caught in CI.

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

Claude Code (Opus 4.7) located the remaining lazy ivars, drafted the prepended initializer module, and ran the verification steps. Manually reviewed the diff against the conventions in `extend/pathname/` (file layout, naming, `requires_ancestor`, sig style) and the `prepend` precedent in `extend/os/mac/unpack_strategy/zip.rb`; ran `brew lgtm` locally; confirmed the warning no longer reproduces and that `ObjectSpace.dump` collapses to a single shape across 50 instances exercising the lazy methods in varied orders.

-----