### PR TITLE
Enforce secure redirects

### DIFF
--- a/Library/Homebrew/download_strategy/curl_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/curl_download_strategy.rb
@@ -232,14 +232,18 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
   def _fetch(url:, resolved_url:, timeout:)
     ohai "Downloading from #{resolved_url}" if url != resolved_url
 
-    if Homebrew::EnvConfig.no_insecure_redirect? &&
-       url.start_with?("https://") && !resolved_url.start_with?("https://")
-      error_message = "HTTPS to HTTP redirect detected and `$HOMEBREW_NO_INSECURE_REDIRECT` is set."
-      $stderr.puts error_message unless quiet?
-      raise CurlDownloadStrategyError.new(url, error_message)
-    end
+    ensure_no_insecure_redirect!(url:, resolved_url:)
 
     _curl_download resolved_url, temporary_path, timeout
+  end
+
+  sig { params(url: String, resolved_url: String).void }
+  def ensure_no_insecure_redirect!(url:, resolved_url:)
+    return unless insecure_redirect?(url:, resolved_url:)
+
+    error_message = "HTTPS to HTTP redirect detected and `$HOMEBREW_NO_INSECURE_REDIRECT` is set."
+    $stderr.puts error_message unless quiet?
+    raise CurlDownloadStrategyError.new(url, error_message)
   end
 
   sig {

--- a/Library/Homebrew/download_strategy/curl_post_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/curl_post_download_strategy.rb
@@ -13,6 +13,8 @@ class CurlPostDownloadStrategy < CurlDownloadStrategy
             .returns(T.nilable(SystemCommand::Result))
   }
   def _fetch(url:, resolved_url:, timeout:)
+    ensure_no_insecure_redirect!(url:, resolved_url:)
+
     args = if meta.key?(:data)
       escape_data = ->(d) { ["-d", URI.encode_www_form([d])] }
       [url, *meta[:data].flat_map(&escape_data)]

--- a/Library/Homebrew/test/download_strategies/curl_post_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_post_spec.rb
@@ -77,5 +77,24 @@ RSpec.describe CurlPostDownloadStrategy do
         strategy.fetch
       end
     end
+
+    context "when a secure URL redirects to an insecure URL" do
+      let(:url) { "https://example.com/foo.tar.gz?form=data" }
+      let(:resolved_url) { "http://example.com/foo.tar.gz" }
+      let(:specs) { { using: :post } }
+
+      before do
+        allow(Homebrew::EnvConfig).to receive(:no_insecure_redirect?).and_return(true)
+        allow(strategy).to receive(:resolve_url_basename_time_file_size)
+          .and_return([resolved_url, "foo.tar.gz", nil, nil, nil, true])
+      end
+
+      it "raises before downloading" do
+        expect(strategy).not_to receive(:curl_download)
+
+        expect { strategy.fetch }
+          .to raise_error(CurlDownloadStrategyError, /HTTPS to HTTP redirect detected/)
+      end
+    end
   end
 end

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -615,6 +615,44 @@ RSpec.describe "Utils::Curl" do
     end
   end
 
+  describe "::no_insecure_redirect_curl_args" do
+    before do
+      allow(Homebrew::EnvConfig).to receive(:no_insecure_redirect?).and_return(true)
+    end
+
+    it "only allows HTTPS redirects for redirect-following calls" do
+      expect(no_insecure_redirect_curl_args(["--location", "http://example.com/example.tar.gz"]))
+        .to eq(["--proto-redir", "=https", "--location", "http://example.com/example.tar.gz"])
+    end
+
+    it "drops custom redirect protocol arguments" do
+      expect(no_insecure_redirect_curl_args(["--location", "--proto-redir", "=all",
+                                             "https://example.com/example.tar.gz"]))
+        .to eq(["--proto-redir", "=https", "--location", "https://example.com/example.tar.gz"])
+    end
+
+    it "drops custom redirect protocol arguments in assignment form" do
+      expect(no_insecure_redirect_curl_args(["--location", "--proto-redir=all",
+                                             "https://example.com/example.tar.gz"]))
+        .to eq(["--proto-redir", "=https", "--location", "https://example.com/example.tar.gz"])
+    end
+  end
+
+  describe "::curl_output" do
+    it "enforces HTTPS redirects before running curl" do
+      allow(Homebrew::EnvConfig).to receive(:no_insecure_redirect?).and_return(true)
+
+      expect(self).to receive(:system_command).with(
+        /curl/,
+        hash_including(args: array_including("--proto-redir", "=https")),
+      ).and_return(
+        instance_double(SystemCommand::Result, success?: true, stdout: ""),
+      )
+
+      curl_output("--location", "https://example.com/example.tar.gz")
+    end
+  end
+
   describe "::http_status_ok?" do
     it "returns `true` when `status` is 1xx or 2xx" do
       expect(http_status_ok?("200")).to be(true)

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -166,6 +166,34 @@ module Utils
       (args + extra_args).map(&:to_s)
     end
 
+    sig { params(url: String, resolved_url: String).returns(T::Boolean) }
+    def insecure_redirect?(url:, resolved_url:)
+      Homebrew::EnvConfig.no_insecure_redirect? &&
+        url.start_with?("https://") && !resolved_url.start_with?("https://")
+    end
+
+    sig { params(args: T::Array[String]).returns(T::Array[String]) }
+    def no_insecure_redirect_curl_args(args)
+      return args unless Homebrew::EnvConfig.no_insecure_redirect?
+
+      # `--proto-redir =https` tells `curl --location` to reject any redirect
+      # target that is not HTTPS. Drop caller-provided values first so they
+      # cannot relax the HTTPS-only redirect policy.
+      args = args.each_with_index.filter_map do |arg, i|
+        next if arg == "--proto-redir"
+        next if i.positive? && args.fetch(i - 1) == "--proto-redir"
+        next if arg.start_with?("--proto-redir=")
+
+        arg
+      end
+      return args unless args.include?("--location")
+
+      # This blocks an HTTPS request from following a redirect to HTTP at the
+      # curl layer, including cases where a preflight request saw a different
+      # redirect chain than the real download.
+      ["--proto-redir", "=https", *args]
+    end
+
     sig {
       params(
         args:              String,
@@ -185,6 +213,7 @@ module Utils
       secrets: [], print_stdout: false, print_stderr: false, debug: nil,
       verbose: nil, env: {}, timeout: nil, use_homebrew_curl: false, **options
     )
+      args = no_insecure_redirect_curl_args(args)
       end_time = Time.now + timeout if timeout
 
       command_options = {
@@ -461,8 +490,7 @@ module Utils
         end
       end
 
-      if url.start_with?("https://") && Homebrew::EnvConfig.no_insecure_redirect? &&
-         details[:final_url].present? && !details[:final_url].start_with?("https://")
+      if details[:final_url].present? && insecure_redirect?(url:, resolved_url: details[:final_url])
         return "The #{url_type} #{url} redirects back to HTTP"
       end
 

--- a/Library/Homebrew/utils/github/artifacts/github_artifact_download_strategy.rb
+++ b/Library/Homebrew/utils/github/artifacts/github_artifact_download_strategy.rb
@@ -17,10 +17,10 @@ class GitHubArtifactDownloadStrategy < AbstractFileDownloadStrategy
       puts "Already downloaded: #{cached_location}"
     else
       begin
-        Utils::Curl.curl("--location", "--create-dirs", "--output", temporary_path.to_s, url,
-                         "--header", "Authorization: token #{@token}",
-                         secrets: [@token],
-                         timeout:)
+        Utils::Curl.curl_download(url, to:      temporary_path,
+                                       header:  "Authorization: token #{@token}",
+                                       secrets: [@token],
+                                       timeout:)
       rescue ErrorDuringExecution
         raise CurlDownloadStrategyError, url
       end


### PR DESCRIPTION
- Share the `HOMEBREW_NO_INSECURE_REDIRECT` predicate with `CurlPostDownloadStrategy` and URL audits.
- Apply `--proto-redir =https` in the shared curl execution path so redirect-following calls use curl-level enforcement.
- Strip caller-provided `--proto-redir` values while the policy is enabled so they cannot weaken the redirect restriction.
- Route GitHub artifact downloads through `curl_download` for the same policy.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review, tweaking and testing.

-----
