### PR TITLE
Default Linux sandbox for developers

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -1057,6 +1057,8 @@ fi
 if [[ -n "${HOMEBREW_DEVELOPER}" ]]
 then
   export HOMEBREW_ASK="1"
+  export HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS="1"
+  export HOMEBREW_SANDBOX_LINUX="1"
 fi
 
 # Enable features for users who have run a devcmd before they become the default for everyone.

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -702,6 +702,7 @@ module Cask
 
     sig { returns(T::Boolean) }
     def auto_updates_bundle_outdated?
+      return false if Homebrew::EnvConfig.no_upgrade_auto_updates_casks?
       return false unless Homebrew::EnvConfig.upgrade_auto_updates_casks?
       return false if !auto_updates || version.latest?
       return false unless installed_app_info_plist

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -38,7 +38,12 @@ module Cask
                             summary_pinned: nil, summary_disabled: nil)
       # Validate mutually exclusive opt-in/opt-out env vars before we start
       # selecting casks so `brew upgrade` errors consistently.
-      Homebrew::EnvConfig.upgrade_auto_updates_casks?
+      if Homebrew::EnvConfig.upgrade_auto_updates_casks? &&
+         Homebrew::EnvConfig.no_upgrade_auto_updates_casks?
+        raise UsageError,
+              "`HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS` and `HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS` " \
+              "cannot both be set."
+      end
       greedy = true if Homebrew::EnvConfig.upgrade_greedy?
 
       outdated_casks = if casks.empty?

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -102,6 +102,9 @@ class DependencyCollector
   sig { params(related_formula_names: T::Set[String]).returns(T.nilable(Dependency)) }
   def glibc_dep_if_needed(related_formula_names); end
 
+  sig { params(related_formula_names: T::Set[String]).returns(T.nilable(Dependency)) }
+  def bubblewrap_dep_if_needed(related_formula_names); end
+
   sig { params(tags: T::Array[T.any(String, Symbol)]).returns(T.nilable(Dependency)) }
   def git_dep_if_needed(tags)
     require "utils/git"

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -506,7 +506,10 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_SANDBOX_LINUX:                    {
-        description: "If set, use the `bwrap`(1) sandbox for formula installation and testing on Linux.",
+        # odeprecated: edit in 5.2.0
+        description: "If set, use the `bwrap`(1) sandbox for formula installation and testing on Linux. " \
+                     "Enabled by default if `$HOMEBREW_DEVELOPER` is set. This will be the default in " \
+                     "Homebrew 5.2.0.",
         boolean:     true,
       },
       HOMEBREW_SBOM:                             {
@@ -633,6 +636,8 @@ module Homebrew
       method_name
     end
 
+    # Developer-mode defaults should be materialised in `brew.sh` by setting
+    # the matching environment variable rather than inferred here.
     CUSTOM_IMPLEMENTATIONS = T.let(Set.new([
       :HOMEBREW_MAKE_JOBS,
       :HOMEBREW_CASK_OPTS,
@@ -641,7 +646,6 @@ module Homebrew
       :HOMEBREW_FORBID_PACKAGES_FROM_PATHS,
       :HOMEBREW_DOWNLOAD_CONCURRENCY,
       :HOMEBREW_SANDBOX_LINUX,
-      :HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS,
       :HOMEBREW_USE_INTERNAL_API,
     ]).freeze, T::Set[Symbol])
 
@@ -740,24 +744,6 @@ module Homebrew
       # Provide an opt-out for tests and developers.
       # Our testing framework installs formulae from file paths all over the place.
       ENV["HOMEBREW_TESTS"].blank? && ENV["HOMEBREW_DEVELOPER"].blank?
-    end
-
-    sig { returns(T::Boolean) }
-    def upgrade_auto_updates_casks?
-      upgrade_auto_updates_casks = ENV.fetch("HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS", nil)
-      upgrade_auto_updates_casks = upgrade_auto_updates_casks.present? &&
-                                   FALSY_VALUES.exclude?(upgrade_auto_updates_casks.downcase)
-      no_upgrade_auto_updates_casks = T.unsafe(self).no_upgrade_auto_updates_casks?
-
-      if upgrade_auto_updates_casks && no_upgrade_auto_updates_casks
-        raise UsageError,
-              "`HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS` and `HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS` " \
-              "cannot both be set."
-      end
-
-      return false if no_upgrade_auto_updates_casks
-
-      upgrade_auto_updates_casks || Homebrew::EnvConfig.developer?
     end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/extend/os/linux/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/linux/dependency_collector.rb
@@ -2,10 +2,22 @@
 # frozen_string_literal: true
 
 require "os/linux/glibc"
+require "sandbox"
 
 module OS
   module Linux
     module DependencyCollector
+      sig { params(related_formula_names: T::Set[String]).returns(T.nilable(Dependency)) }
+      def bubblewrap_dep_if_needed(related_formula_names)
+        return unless bubblewrap_dependency_needed?
+        return if building_global_dep_tree?
+        return if related_formula_names.include?(BUBBLEWRAP)
+        return if global_dep_tree[BUBBLEWRAP]&.intersect?(related_formula_names)
+        return unless formula_for(BUBBLEWRAP)
+
+        Dependency.new(BUBBLEWRAP, [:implicit])
+      end
+
       sig { params(related_formula_names: T::Set[String]).returns(T.nilable(Dependency)) }
       def gcc_dep_if_needed(related_formula_names)
         # gcc is required for libgcc_s.so.1 if glibc or gcc are too old
@@ -33,18 +45,26 @@ module OS
 
       GLIBC = "glibc"
       GCC = OS::LINUX_PREFERRED_GCC_RUNTIME_FORMULA
-      private_constant :GLIBC, :GCC
+      BUBBLEWRAP = "bubblewrap"
+      private_constant :GLIBC, :GCC, :BUBBLEWRAP
 
       sig { void }
       def init_global_dep_tree_if_needed!
-        return unless ::DevelopmentTools.needs_build_formulae?
         return if building_global_dep_tree?
-        return unless global_dep_tree.empty?
+
+        sandbox_tree_needed = bubblewrap_dependency_needed?
+        build_formulae_tree_needed = ::DevelopmentTools.needs_build_formulae?
+        return if !sandbox_tree_needed && !build_formulae_tree_needed
+        return if (!sandbox_tree_needed || global_dep_tree.key?(BUBBLEWRAP)) &&
+                  (!build_formulae_tree_needed || (global_dep_tree.key?(GLIBC) && global_dep_tree.key?(GCC)))
 
         building_global_dep_tree!
-        global_dep_tree[GLIBC] = Set.new(global_deps_for(GLIBC))
-        # gcc depends on glibc
-        global_dep_tree[GCC] = Set.new([*global_deps_for(GCC), GLIBC, *@@global_dep_tree[GLIBC]])
+        global_dep_tree[BUBBLEWRAP] = Set.new(global_deps_for(BUBBLEWRAP)) if sandbox_tree_needed
+        if build_formulae_tree_needed
+          global_dep_tree[GLIBC] = Set.new(global_deps_for(GLIBC))
+          # gcc depends on glibc
+          global_dep_tree[GCC] = Set.new([*global_deps_for(GCC), GLIBC, *@@global_dep_tree[GLIBC]])
+        end
         built_global_dep_tree!
       end
 
@@ -54,6 +74,14 @@ module OS
         @formula_for[name] ||= ::Formula[name]
       rescue FormulaUnavailableError
         nil
+      end
+
+      sig { returns(T::Boolean) }
+      def bubblewrap_dependency_needed?
+        return false unless ::Homebrew::EnvConfig.sandbox_linux?
+        return false if ENV["HOMEBREW_TESTS"]
+
+        ::Sandbox.executable.blank?
       end
 
       sig { params(name: String).returns(T::Array[String]) }

--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -4,6 +4,7 @@
 require "tempfile"
 require "utils/shell"
 require "hardware"
+require "os/linux"
 require "os/linux/glibc"
 require "os/linux/kernel"
 require "sandbox"
@@ -174,6 +175,7 @@ module OS
         sig { returns(T.nilable(String)) }
         def check_linux_sandbox
           return unless Homebrew::EnvConfig.sandbox_linux?
+          return if OS::Linux.inside_docker?
 
           state = ::Sandbox.state
           return if [:disabled, :available].include?(state)

--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -28,17 +28,16 @@ module OS
 
       sig { params(spec: SoftwareSpec).void }
       def add_global_deps_to_spec(spec)
-        return unless ::DevelopmentTools.needs_build_formulae?
-
         @global_deps ||= T.let(nil, T.nilable(T::Array[Dependency]))
         @global_deps ||= begin
           dependency_collector = spec.dependency_collector
-          related_formula_names = Set.new([
-            name,
-            *aliases,
-            *versioned_formulae_names,
-          ])
+          related_formula_names = Set[name]
+          if ::DevelopmentTools.needs_build_formulae? || ::DevelopmentTools.needs_libc_formula?
+            related_formula_names.merge(aliases)
+            related_formula_names.merge(versioned_formulae_names)
+          end
           [
+            dependency_collector.bubblewrap_dep_if_needed(related_formula_names),
             dependency_collector.gcc_dep_if_needed(related_formula_names),
             dependency_collector.glibc_dep_if_needed(related_formula_names),
           ].compact.freeze

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -809,7 +809,14 @@ on_request: installed_on_request?, options:)
             "#{deps.map { Formatter.identifier(it) }.to_sentence}",
             truncate: false
       end
-      deps.each { install_dependency(it) }
+      bubblewrap_dependency_index = deps.index { |dep| dep.name == "bubblewrap" && dep.implicit? }
+      deps.each_with_index do |dep, index|
+        if formula.name == "bubblewrap" || (bubblewrap_dependency_index && index <= bubblewrap_dependency_index)
+          with_env(HOMEBREW_INSTALLING_BUBBLEWRAP: "1") { install_dependency(dep) }
+        else
+          install_dependency(dep)
+        end
+      end
     end
 
     @show_header = true if deps.length > 1
@@ -1017,6 +1024,8 @@ on_request: installed_on_request?, options:)
 
     # let's reset Utils::Git.available? if we just installed git
     Utils::Git.clear_available_cache if formula.name == "git"
+
+    Sandbox.reset_state! if formula.name == "bubblewrap"
 
     # use installed ca-certificates when it's needed and available
     if formula.name == "ca-certificates" &&

--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -46,6 +46,15 @@ module OS
       OS.wsl?
     end
 
+    sig { returns(T::Boolean) }
+    def self.inside_docker?
+      return true if File.file?("/.dockerenv")
+      return true if File.file?("/run/.containerenv")
+      return false unless File.file?("/proc/1/cgroup")
+
+      File.read("/proc/1/cgroup").match?(/azpl_job|actions_job|docker|garden|kubepods/)
+    end
+
     sig { returns(Version) }
     def self.wsl_version
       return Version::NULL unless wsl?

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -332,6 +332,9 @@ module Homebrew::EnvConfig
     def update_to_tag?; end
 
     sig { returns(T::Boolean) }
+    def upgrade_auto_updates_casks?; end
+
+    sig { returns(T::Boolean) }
     def upgrade_greedy?; end
 
     sig { returns(T.nilable(::String)) }

--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe Homebrew::DevCmd::Tests do
       allow(GitHub::Actions).to receive(:env_set?).and_return(false)
     end
 
-    it "does not require the Linux sandbox unless HOMEBREW_SANDBOX_LINUX is set" do
+    it "does not require the Linux sandbox when Linux sandboxing is disabled" do
       allow(Sandbox).to receive(:available?).and_return(false)
       expect(Sandbox).not_to receive(:ensure_sandbox_installed!)
       expect(Sandbox).not_to receive(:configure!)
 
-      with_env(HOMEBREW_SANDBOX_LINUX: nil) do
+      with_env(HOMEBREW_DEVELOPER: nil, HOMEBREW_SANDBOX_LINUX: nil) do
         expect { tests.send(:check_test_environment!) }.not_to raise_error
       end
     end

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -98,6 +98,10 @@ RSpec.describe Homebrew::EnvConfig do
   end
 
   describe ".forbid_packages_from_paths?" do
+    around do |example|
+      with_env(HOMEBREW_TESTS: ENV.fetch("HOMEBREW_TESTS", nil)) { example.run }
+    end
+
     before do
       ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = nil
       ENV["HOMEBREW_DEVELOPER"] = nil
@@ -131,45 +135,17 @@ RSpec.describe Homebrew::EnvConfig do
     before do
       ENV["HOMEBREW_DEVELOPER"] = nil
       ENV["HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS"] = nil
-      ENV["HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS"] = nil
     end
 
-    it "returns false if the opt-in is not set" do
-      expect(env_config.upgrade_auto_updates_casks?).to be(false)
-    end
-
-    it "returns true if HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS is set" do
-      ENV["HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS"] = "1"
-      expect(env_config.upgrade_auto_updates_casks?).to be(true)
-    end
-
-    it "returns true if HOMEBREW_DEVELOPER is set" do
+    it "does not infer a developer default" do
       ENV["HOMEBREW_DEVELOPER"] = "1"
-      expect(env_config.upgrade_auto_updates_casks?).to be(true)
-    end
-
-    it "returns false if HOMEBREW_DEVELOPER is set to a falsey value" do
-      ENV["HOMEBREW_DEVELOPER"] = "0"
       expect(env_config.upgrade_auto_updates_casks?).to be(false)
-    end
-
-    it "returns false if HOMEBREW_DEVELOPER and HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS are set" do
-      ENV["HOMEBREW_DEVELOPER"] = "1"
-      ENV["HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS"] = "1"
-      expect(env_config.upgrade_auto_updates_casks?).to be(false)
-    end
-
-    it "raises if both opt-in and opt-out are set" do
-      ENV["HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS"] = "1"
-      ENV["HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS"] = "1"
-
-      expect { env_config.upgrade_auto_updates_casks? }
-        .to raise_error(UsageError, /cannot both be set/i)
     end
   end
 
   describe ".sandbox_linux?" do
     before do
+      ENV["HOMEBREW_DEVELOPER"] = nil
       ENV["HOMEBREW_NO_SANDBOX_LINUX"] = nil
       ENV["HOMEBREW_SANDBOX_LINUX"] = nil
     end
@@ -179,9 +155,26 @@ RSpec.describe Homebrew::EnvConfig do
       expect(env_config.sandbox_linux?).to be(true)
     end
 
+    it "does not infer a developer default" do
+      ENV["HOMEBREW_DEVELOPER"] = "1"
+      expect(env_config.sandbox_linux?).to be(false)
+    end
+
+    it "returns false if HOMEBREW_SANDBOX_LINUX is set to a falsey value with HOMEBREW_DEVELOPER" do
+      ENV["HOMEBREW_DEVELOPER"] = "1"
+      ENV["HOMEBREW_SANDBOX_LINUX"] = "0"
+      expect(env_config.sandbox_linux?).to be(false)
+    end
+
     it "returns false if HOMEBREW_NO_SANDBOX_LINUX is set" do
       ENV["HOMEBREW_NO_SANDBOX_LINUX"] = "1"
       ENV["HOMEBREW_SANDBOX_LINUX"] = "1"
+      expect(env_config.sandbox_linux?).to be(false)
+    end
+
+    it "returns false if HOMEBREW_DEVELOPER and HOMEBREW_NO_SANDBOX_LINUX are set" do
+      ENV["HOMEBREW_DEVELOPER"] = "1"
+      ENV["HOMEBREW_NO_SANDBOX_LINUX"] = "1"
       expect(env_config.sandbox_linux?).to be(false)
     end
   end

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -228,6 +228,31 @@ RSpec.describe FormulaInstaller do
       expect(child_installer).not_to be_installed_on_request
       expect(child_installer&.link_keg).to be true
     end
+
+    it "disables Bubblewrap auto-install until the implicit Bubblewrap dependency is installed" do
+      formula = formula "homebrew-bubblewrap-bootstrap-target" do
+        url "foo-1.0"
+      end
+      installer = FormulaInstaller.new(formula)
+      dependency_names = %w[libcap bubblewrap zlib]
+      dependencies = dependency_names.map do |name|
+        instance_double(Dependency, name:, implicit?: name == "bubblewrap")
+      end
+      installing_bubblewrap_env = []
+
+      allow(installer).to receive(:oh1)
+      allow(installer).to receive(:install_dependency) do |dependency|
+        installing_bubblewrap_env << [dependency.name, ENV.fetch("HOMEBREW_INSTALLING_BUBBLEWRAP", nil)]
+      end
+
+      installer.send(:install_dependencies, dependencies)
+
+      expect(installing_bubblewrap_env).to eq([
+        ["libcap", "1"],
+        ["bubblewrap", "1"],
+        ["zlib", nil],
+      ])
+    end
   end
 
   describe "versioned keg-only linking defaults" do

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "dependency_collector"
+require "sandbox"
 
 RSpec.describe DependencyCollector do
   subject(:collector) { klass.new }
@@ -51,6 +52,41 @@ RSpec.describe DependencyCollector do
         allow_any_instance_of(Object).to receive(:which).with("bzip2").and_return(Pathname.new("foo"))
         expect(collector.add(resource)).to be_nil
       end
+    end
+  end
+
+  describe "#bubblewrap_dep_if_needed" do
+    around do |example|
+      with_env(HOMEBREW_TESTS: nil) { example.run }
+    end
+
+    before do
+      allow(Homebrew::EnvConfig).to receive(:sandbox_linux?).and_return(true)
+      allow(DevelopmentTools).to receive(:needs_build_formulae?).and_return(false)
+      allow(Sandbox).to receive(:executable)
+      allow(Formula).to receive(:[]).with("bubblewrap").and_return(instance_double(Formula, deps: []))
+      collector.send(:global_dep_tree).clear
+    end
+
+    after do
+      collector.send(:global_dep_tree).clear
+    end
+
+    it "returns a Bubblewrap implicit dependency when the Linux sandbox needs one" do
+      expect(collector.bubblewrap_dep_if_needed(Set.new)).to eq(Dependency.new("bubblewrap", [:implicit]))
+    end
+
+    it "returns nil when Bubblewrap is already available" do
+      allow(Sandbox).to receive(:executable).and_return(Pathname("/usr/bin/bwrap"))
+
+      expect(collector.bubblewrap_dep_if_needed(Set.new)).to be_nil
+    end
+
+    it "returns nil for Bubblewrap and its dependencies" do
+      collector.send(:global_dep_tree)["bubblewrap"] = Set["libcap"]
+
+      expect(collector.bubblewrap_dep_if_needed(Set["bubblewrap"])).to be_nil
+      expect(collector.bubblewrap_dep_if_needed(Set["libcap"])).to be_nil
     end
   end
 end

--- a/Library/Homebrew/test/os/linux/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/linux/diagnostic_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Homebrew::Diagnostic::Checks do
 
   let(:klass) { Homebrew::Diagnostic::Checks }
 
+  before do
+    allow(OS::Linux).to receive(:inside_docker?).and_return(false)
+  end
+
   specify "#check_supported_architecture" do
     allow(Hardware::CPU).to receive(:type).and_return(:arm64)
 
@@ -43,10 +47,10 @@ RSpec.describe Homebrew::Diagnostic::Checks do
     expect(checks.fatal_build_from_source_checks).to include("check_linux_sandbox")
   end
 
-  specify "#check_linux_sandbox returns nil unless HOMEBREW_SANDBOX_LINUX is set" do
+  specify "#check_linux_sandbox returns nil when Linux sandboxing is disabled" do
     expect(Sandbox).not_to receive(:failure_reason)
 
-    with_env(HOMEBREW_SANDBOX_LINUX: nil) do
+    with_env(HOMEBREW_DEVELOPER: nil, HOMEBREW_SANDBOX_LINUX: nil) do
       expect(checks.check_linux_sandbox).to be_nil
     end
   end
@@ -54,6 +58,15 @@ RSpec.describe Homebrew::Diagnostic::Checks do
   specify "#check_linux_sandbox returns nil when the Linux sandbox is available" do
     allow(Sandbox).to receive(:state).and_return(:available)
     expect(Sandbox).not_to receive(:failure_reason)
+
+    with_env(HOMEBREW_NO_SANDBOX_LINUX: nil, HOMEBREW_SANDBOX_LINUX: "1") do
+      expect(checks.check_linux_sandbox).to be_nil
+    end
+  end
+
+  specify "#check_linux_sandbox returns nil inside Docker" do
+    allow(OS::Linux).to receive(:inside_docker?).and_return(true)
+    expect(Sandbox).not_to receive(:state)
 
     with_env(HOMEBREW_NO_SANDBOX_LINUX: nil, HOMEBREW_SANDBOX_LINUX: "1") do
       expect(checks.check_linux_sandbox).to be_nil

--- a/Library/Homebrew/test/sandbox_linux_spec.rb
+++ b/Library/Homebrew/test/sandbox_linux_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Sandbox, :needs_linux do
     end
 
     it "returns false unless Linux sandboxing is enabled" do
-      with_env(HOMEBREW_SANDBOX_LINUX: nil) do
+      with_env(HOMEBREW_DEVELOPER: nil, HOMEBREW_SANDBOX_LINUX: nil) do
         expect(sandbox_class.available?).to be(false)
       end
     end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -4975,7 +4975,8 @@ command execution (e.g. `$(cat file)`).
 `HOMEBREW_SANDBOX_LINUX`
 
 : If set, use the `bwrap`(1) sandbox for formula installation and testing on
-  Linux.
+  Linux. Enabled by default if `$HOMEBREW_DEVELOPER` is set. This will be the
+  default in Homebrew 5.2.0.
 
 `HOMEBREW_SBOM`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3245,7 +3245,7 @@ If set, \fBbrew install\fP \fIformula\fP will use this URL to download PyPI pack
 If set, use Pry for the \fBbrew irb\fP command\.
 .TP
 \fBHOMEBREW_SANDBOX_LINUX\fP
-If set, use the \fBbwrap\fP(1) sandbox for formula installation and testing on Linux\.
+If set, use the \fBbwrap\fP(1) sandbox for formula installation and testing on Linux\. Enabled by default if \fB$HOMEBREW_DEVELOPER\fP is set\. This will be the default in Homebrew 5\.2\.0\.
 .TP
 \fBHOMEBREW_SBOM\fP
 If set, Homebrew will write SBOM files and run SBOM\-related installation logic\. This is a no\-op until Homebrew 5\.2\.0, when it will become required for that behaviour\.


### PR DESCRIPTION
- Enable `HOMEBREW_SANDBOX_LINUX` in developer mode so maintainers exercise the staged Linux sandbox default early.
- Keep `HOMEBREW_NO_SANDBOX_LINUX` as the explicit opt-out for systems where Bubblewrap is not yet usable.
- Add the `# odeprecated` note and regenerated manpage text for the next release default.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
