### PR TITLE
Fix dynamic completion audit crash

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -662,7 +662,10 @@ module RuboCop
           methods.each do |method|
             next unless method.source.include?("shells:")
 
-            shells << method.source.match(/shells: \[(:bash|:zsh|:fish)\]/).captures.first
+            shell = method.source[/shells: \[(:bash|:zsh|:fish)\]/, 1]
+            next if shell.nil?
+
+            shells << shell
             offenses << method
           end
 

--- a/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
@@ -143,5 +143,23 @@ RSpec.describe RuboCop::Cop::FormulaAudit do
         end
       RUBY
     end
+
+    it "does not report an offense when shells are generated dynamically" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", "completions")
+            [:zsh, :bash].each do |shell|
+              generate_completions_from_executable(
+                bin/"foo", "completions", shell.to_s, "bar", shells: [shell], base_name: "bar",
+                shell_parameter_format: :none
+              )
+            end
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22379

- Avoid crashing on formulae that build `shells:` from a loop.
- Keep the cop limited to literal shell lists it can safely rewrite.
- Cover the `rustup` completion pattern that exposed the issue.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
