### PR TITLE
Add cask upgrade quit opt-out

### DIFF
--- a/Library/Homebrew/cask/artifact/uninstall.rb
+++ b/Library/Homebrew/cask/artifact/uninstall.rb
@@ -13,10 +13,11 @@ module Cask
         params(
           upgrade:   T::Boolean,
           reinstall: T::Boolean,
+          quit:      T::Boolean,
           options:   T.anything,
         ).void
       }
-      def uninstall_phase(upgrade: false, reinstall: false, **options)
+      def uninstall_phase(upgrade: false, reinstall: false, quit: true, **options)
         raw_on_upgrade = directives[:on_upgrade]
         on_upgrade_syms =
           case raw_on_upgrade
@@ -31,6 +32,7 @@ module Cask
 
         filtered_directives = ORDERED_DIRECTIVES.filter do |directive_sym|
           next false if directive_sym == :rmdir
+          next false if directive_sym == :quit && !quit
 
           if (upgrade || reinstall) &&
              UPGRADE_REINSTALL_SKIP_DIRECTIVES.include?(directive_sym) &&

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -587,9 +587,9 @@ on_request: true)
       @cask.download_sha_path.parent.rmdir_if_possible
     end
 
-    sig { params(successor: T.nilable(Cask)).void }
-    def start_upgrade(successor:)
-      uninstall_artifacts(successor:)
+    sig { params(successor: T.nilable(Cask), quit: T::Boolean).void }
+    def start_upgrade(successor:, quit: true)
+      uninstall_artifacts(successor:, quit:)
       backup
     end
 
@@ -638,8 +638,8 @@ on_request: true)
       puts summary
     end
 
-    sig { params(clear: T::Boolean, successor: T.nilable(Cask)).void }
-    def uninstall_artifacts(clear: false, successor: nil)
+    sig { params(clear: T::Boolean, successor: T.nilable(Cask), quit: T::Boolean).void }
+    def uninstall_artifacts(clear: false, successor: nil, quit: true)
       odebug "Uninstalling artifacts"
       odebug "#{::Utils.pluralize("artifact", artifacts.length, include_count: true)} defined", artifacts
 
@@ -659,7 +659,7 @@ on_request: true)
           )
 
           odebug "Uninstalling artifact of class #{artifact.class}"
-          artifact.uninstall_phase(
+          uninstall_options = {
             command:   @command,
             verbose:   verbose?,
             skip:      clear,
@@ -667,7 +667,9 @@ on_request: true)
             successor:,
             upgrade:   upgrade?,
             reinstall: reinstall?,
-          )
+          }
+          uninstall_options[:quit] = quit if artifact.is_a?(Artifact::Uninstall)
+          artifact.uninstall_phase(**uninstall_options)
         end
 
         next unless artifact.respond_to?(:post_uninstall_phase)

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -112,6 +112,7 @@ module Cask
         binaries:             T.nilable(T::Boolean),
         quarantine:           T.nilable(T::Boolean),
         require_sha:          T.nilable(T::Boolean),
+        quit:                 T::Boolean,
         skip_prefetch:        T::Boolean,
         show_upgrade_summary: T::Boolean,
         download_queue:       T.nilable(Homebrew::DownloadQueue),
@@ -135,6 +136,7 @@ module Cask
       binaries: nil,
       quarantine: nil,
       require_sha: nil,
+      quit: true,
       skip_prefetch: false,
       show_upgrade_summary: true,
       download_queue: nil,
@@ -261,7 +263,7 @@ module Cask
         upgrade_cask(
           old_cask, new_cask,
           binaries:, force:, skip_cask_deps:, verbose:,
-          quarantine:, require_sha:, download_queue:
+          quarantine:, require_sha:, quit:, download_queue:
         )
       rescue => e
         new_exception = e.exception("#{new_cask.full_name}: #{e}")
@@ -331,6 +333,7 @@ module Cask
         force:          T.nilable(T::Boolean),
         quarantine:     T.nilable(T::Boolean),
         require_sha:    T.nilable(T::Boolean),
+        quit:           T::Boolean,
         skip_cask_deps: T.nilable(T::Boolean),
         verbose:        T.nilable(T::Boolean),
         download_queue: Homebrew::DownloadQueue,
@@ -338,7 +341,7 @@ module Cask
     }
     def self.upgrade_cask(
       old_cask, new_cask,
-      binaries:, force:, quarantine:, require_sha:, skip_cask_deps:, verbose:, download_queue:
+      binaries:, force:, quarantine:, require_sha:, quit:, skip_cask_deps:, verbose:, download_queue:
     )
       require "cask/installer"
 
@@ -402,7 +405,7 @@ module Cask
         end
 
         # Move the old cask's artifacts back to staging
-        old_cask_installer.start_upgrade(successor: new_cask)
+        old_cask_installer.start_upgrade(successor: new_cask, quit:)
         # And flag it so in case of error
         started_upgrade = true
 
@@ -423,9 +426,9 @@ module Cask
         # If successful, wipe the old cask from staging.
         old_cask_installer.finalize_upgrade
 
-        reopen_apps_after_upgrade(old_cask)
+        reopen_apps_after_upgrade(old_cask) if quit
       rescue => e
-        new_cask_installer.uninstall_artifacts(successor: old_cask) if new_artifacts_installed
+        new_cask_installer.uninstall_artifacts(successor: old_cask, quit:) if new_artifacts_installed
         new_cask_installer.purge_versioned_files
         old_cask_installer.revert_upgrade(predecessor: new_cask) if started_upgrade
         raise e

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -109,6 +109,10 @@ module Homebrew
           [:switch, "--skip-cask-deps", {
             description: "Skip installing cask dependencies.",
           }],
+          [:switch, "--no-quit", {
+            description: "Prevent running cask applications from being quit during upgrade.",
+            env:         :no_upgrade_quit_casks,
+          }],
           [:switch, "-g", "--greedy", {
             description: "Also include casks with `version :latest` and `auto_updates true` casks " \
                          "that would otherwise be skipped.",
@@ -778,6 +782,7 @@ module Homebrew
           quarantine:           args.quarantine?,
           require_sha:          args.require_sha?,
           skip_cask_deps:       args.skip_cask_deps?,
+          quit:                 !args.no_quit?,
           verbose:              args.verbose?,
           quiet:                args.quiet?,
           skip_prefetch:,

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -483,6 +483,10 @@ module Homebrew
         boolean:     true,
         hidden:      true, # odeprecated: remove in 5.2.0
       },
+      HOMEBREW_NO_UPGRADE_QUIT_CASKS:            {
+        description: "If set, `brew upgrade` will not quit running applications for casks during upgrades.",
+        boolean:     true,
+      },
       HOMEBREW_NO_VERIFY_ATTESTATIONS:           {
         description: "If set, Homebrew will not verify cryptographic attestations of build provenance for bottles " \
                      "from homebrew-core.",

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/upgrade_cmd.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/upgrade_cmd.rbi
@@ -117,6 +117,9 @@ class Homebrew::Cmd::UpgradeCmd::Args < Homebrew::CLI::Args
   def n?; end
 
   sig { returns(T::Boolean) }
+  def no_quit?; end
+
+  sig { returns(T::Boolean) }
   def overwrite?; end
 
   sig { returns(T.nilable(String)) }

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -284,6 +284,9 @@ module Homebrew::EnvConfig
     def no_upgrade_auto_updates_casks?; end
 
     sig { returns(T::Boolean) }
+    def no_upgrade_quit_casks?; end
+
+    sig { returns(T::Boolean) }
     def no_verify_attestations?; end
 
     sig { returns(T.nilable(::String)) }

--- a/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
@@ -27,6 +27,17 @@ RSpec.describe Cask::Artifact::Uninstall, :cask do
           expect(quit_called).to be true
         end
 
+        it "skips :quit during upgrade when quit is false" do
+          quit_called = false
+          allow(artifact).to receive(:dispatch_uninstall_directive) do |directive, **options|
+            quit_called ||= directive == :quit && options[:command] == fake_system_command
+          end
+
+          artifact.uninstall_phase(upgrade: true, quit: false, command: fake_system_command)
+
+          expect(quit_called).to be false
+        end
+
         it "invokes :quit during reinstall" do
           quit_called = false
           allow(artifact).to receive(:dispatch_uninstall_directive) do |directive, **options|

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -173,6 +173,20 @@ RSpec.describe Cask::Upgrade, :cask do
         expect(summary_deprecated).to include("local-caffeine")
       end
 
+      it "passes the quit option to cask upgrades" do
+        expect(Cask::Upgrade).to receive(:upgrade_cask) do |_, _, **options|
+          expect(options[:quit]).to be(false)
+        end
+
+        Cask::Upgrade.upgrade_casks!(
+          local_caffeine,
+          quit:                 false,
+          skip_prefetch:        true,
+          show_upgrade_summary: false,
+          args:,
+        )
+      end
+
       it "excludes pinned Casks" do
         local_caffeine.pin
         summary_pinned = []

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -162,6 +162,30 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     cmd.send(:upgrade_outdated_casks!, [])
   end
 
+  it "passes --no-quit to cask upgrades" do
+    cmd = Homebrew::Cmd::UpgradeCmd.new(["--cask", "--no-quit"])
+
+    expect(Cask::Upgrade).to receive(:upgrade_casks!) do |*_, **kwargs|
+      expect(kwargs[:quit]).to be(false)
+      true
+    end
+
+    cmd.send(:upgrade_outdated_casks!, [])
+  end
+
+  it "passes HOMEBREW_NO_UPGRADE_QUIT_CASKS to cask upgrades" do
+    with_env("HOMEBREW_NO_UPGRADE_QUIT_CASKS" => "1") do
+      cmd = Homebrew::Cmd::UpgradeCmd.new(["--cask"])
+
+      expect(Cask::Upgrade).to receive(:upgrade_casks!) do |*_, **kwargs|
+        expect(kwargs[:quit]).to be(false)
+        true
+      end
+
+      cmd.send(:upgrade_outdated_casks!, [])
+    end
+  end
+
   it "prints formula and cask ask plans before upgrading" do
     cmd = klass.new(["--ask"])
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22376

- Support `--no-quit` for users who need cask apps left open.
- Add `HOMEBREW_NO_UPGRADE_QUIT_CASKS` for persistent opt-out.
- Cover command, upgrade and uninstall-stanza paths with regressions.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
