### PR TITLE
test_bot: allow testing portable formulae with other PRs in merge queue

### DIFF
--- a/Library/Homebrew/test_bot/formulae_detect.rb
+++ b/Library/Homebrew/test_bot/formulae_detect.rb
@@ -168,7 +168,8 @@ module Homebrew
         elsif modified_formulae.present? &&
               modified_formulae.all? { |formula| formula.start_with?("portable-") }
           modified_formulae = ["portable-ruby"]
-        elsif modified_formulae.any? { |formula| formula.start_with?("portable-") }
+        elsif modified_formulae.any? { |formula| formula.start_with?("portable-") } &&
+              ENV["GITHUB_EVENT_NAME"] != "merge_group"
           odie "Portable Ruby (and related formulae) cannot be tested in the same job as other formulae!"
         end
 

--- a/Library/Homebrew/test_bot/formulae_detect.rb
+++ b/Library/Homebrew/test_bot/formulae_detect.rb
@@ -169,7 +169,7 @@ module Homebrew
               modified_formulae.all? { |formula| formula.start_with?("portable-") }
           modified_formulae = ["portable-ruby"]
         elsif modified_formulae.any? { |formula| formula.start_with?("portable-") } &&
-              ENV["GITHUB_EVENT_NAME"] != "merge_group"
+              !(ENV["GITHUB_EVENT_NAME"] == "merge_group" && args.only_formulae_detect?)
           odie "Portable Ruby (and related formulae) cannot be tested in the same job as other formulae!"
         end
 


### PR DESCRIPTION
The formulae-detect test currently refuses to run in the merge queue if any of the PRs in the queue modifies a portable formula. But since the purpose of this test is to determine bottles to be fetched (to avoid accidentally merging a PR without publishing bottles), it should be safe to allow it to run in the merge queue. So let's not abort this test if we are in the merge queue.

Addresses https://github.com/Homebrew/homebrew-core/pull/284256#issuecomment-4520521431.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
