### PR TITLE
Add `brew footprint` command

### DIFF
--- a/Library/Homebrew/cmd/footprint.rb
+++ b/Library/Homebrew/cmd/footprint.rb
@@ -47,7 +47,7 @@ module Homebrew
 
       sig { returns(T::Hash[String, T::Set[String]]) }
       def build_reverse_dep_map
-        reverse_map = T.let(Hash.new { |h, k| h[k] = Set.new }, T::Hash[String, T::Set[String]])
+        reverse_map = T.let({}, T::Hash[String, T::Set[String]])
 
         Formula.installed.each do |formula|
           keg = formula.any_installed_keg
@@ -63,7 +63,7 @@ module Homebrew
             next unless full_name
 
             dep_name = Utils.name_from_full_name(full_name)
-            reverse_map[dep_name].add(formula.name)
+            (reverse_map[dep_name] ||= Set.new).add(formula.name)
           end
         end
 
@@ -105,12 +105,12 @@ module Homebrew
             next if dep_kegs.empty?
 
             dep_size = dep_kegs.sum(&:disk_usage)
-            dependents = reverse_map[dep_name]
+            dependents = reverse_map[dep_name] || Set.new
 
             if dependents.size == 1 && dependents.include?(formula.name)
               exclusive_deps << { name: dep_name, size: dep_size }
             else
-              also_needed_by = (dependents - [formula.name]).sort
+              also_needed_by = (dependents.to_a - [formula.name]).sort
               shared_deps << { name: dep_name, size: dep_size, also_needed_by: also_needed_by }
             end
           end

--- a/Library/Homebrew/cmd/footprint.rb
+++ b/Library/Homebrew/cmd/footprint.rb
@@ -26,7 +26,7 @@ module Homebrew
         switch "--all",
                depends_on:  "--installed",
                description: "Include formulae installed as dependencies, not just those installed on request."
-        flag   "--json",
+        switch "--json",
                description: "Print a JSON representation of the footprint data."
 
         named_args :installed_formula
@@ -151,7 +151,7 @@ module Homebrew
 
         analyses.sort_by! { |a| -a[:total_footprint] }
 
-        if args.json
+        if args.json?
           output_json(analyses)
         else
           output_table(analyses)
@@ -169,7 +169,7 @@ module Homebrew
           analyze_formula(formula, reverse_map)
         end
 
-        if args.json
+        if args.json?
           output_json(analyses)
         else
           analyses.each_with_index do |analysis, i|
@@ -238,13 +238,13 @@ module Homebrew
       def output_table(analyses)
         return if analyses.empty?
 
-        puts "Package                  Direct     Excl. Deps  Total Footprint"
+        fmt = "%-20<pkg>s  %10<direct>s  %14<excl>s  %16<total>s"
 
-        total_footprint_sum = 0
+        puts format(fmt, pkg: "Package", direct: "Direct", excl: "Excl. Deps", total: "Total Footprint")
+
         analyses.each do |analysis|
-          total_footprint_sum += analysis[:total_footprint]
           puts format(
-            "%-20<pkg>s %10<direct>s %14<excl>s %16<total>s",
+            fmt,
             pkg:    analysis[:name],
             direct: Formatter.disk_usage_readable(analysis[:direct_size]),
             excl:   Formatter.disk_usage_readable(analysis[:exclusive_deps_size]),
@@ -252,10 +252,8 @@ module Homebrew
           )
         end
 
-        puts format(
-          "%-20<pkg>s %10<direct>s %14<excl>s %16<total>s",
-          pkg: "Total", direct: "", excl: "", total: Formatter.disk_usage_readable(total_footprint_sum),
-        )
+        grand_total = analyses.sum { |a| a[:total_footprint] }
+        puts format(fmt, pkg: "Total", direct: "", excl: "", total: Formatter.disk_usage_readable(grand_total))
       end
 
       sig { params(analyses: T::Array[T::Hash[Symbol, T.untyped]]).void }

--- a/Library/Homebrew/cmd/footprint.rb
+++ b/Library/Homebrew/cmd/footprint.rb
@@ -1,0 +1,53 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "abstract_command"
+require "formula"
+require "keg"
+require "tab"
+
+module Homebrew
+  module Cmd
+    class Footprint < AbstractCommand
+      cmd_args do
+        description <<~EOS
+          Show the true disk cost of installed formulae, including exclusive
+          dependencies that would be freed on uninstall.
+
+          When given formula arguments, show the footprint of each.
+          With `--installed`, show all top-level (explicitly requested) formulae
+          ranked by total footprint.
+        EOS
+
+        switch "--installed",
+               description: "Show all installed formulae ranked by total disk footprint."
+        switch "--all",
+               depends_on:  "--installed",
+               description: "Include formulae installed as dependencies, not just those installed on request."
+        flag   "--json",
+               description: "Print a JSON representation of the footprint data."
+
+        named_args :installed_formula
+      end
+
+      sig { override.void }
+      def run
+        if args.installed?
+          run_installed
+        elsif args.no_named?
+          raise UsageError, "must specify formulae or use `--installed`."
+        else
+          run_named
+        end
+      end
+
+      private
+
+      sig { void }
+      def run_installed; end
+
+      sig { void }
+      def run_named; end
+    end
+  end
+end

--- a/Library/Homebrew/cmd/footprint.rb
+++ b/Library/Homebrew/cmd/footprint.rb
@@ -3,8 +3,10 @@
 
 require "abstract_command"
 require "formula"
+require "json"
 require "keg"
 require "tab"
+require "utils/formatter"
 
 module Homebrew
   module Cmd
@@ -43,11 +45,239 @@ module Homebrew
 
       private
 
-      sig { void }
-      def run_installed; end
+      sig { returns(T::Hash[String, T::Set[String]]) }
+      def build_reverse_dep_map
+        reverse_map = T.let(Hash.new { |h, k| h[k] = Set.new }, T::Hash[String, T::Set[String]])
+
+        Formula.installed.each do |formula|
+          keg = formula.any_installed_keg
+          next unless keg
+
+          deps = keg.runtime_dependencies
+          next unless deps.is_a?(Array)
+
+          deps.each do |dep|
+            next unless dep.is_a?(Hash)
+
+            full_name = dep["full_name"]
+            next unless full_name
+
+            dep_name = Utils.name_from_full_name(full_name)
+            reverse_map[dep_name].add(formula.name)
+          end
+        end
+
+        reverse_map
+      end
+
+      sig {
+        params(
+          formula:     Formula,
+          reverse_map: T::Hash[String, T::Set[String]],
+        ).returns(T::Hash[Symbol, T.untyped])
+      }
+      def analyze_formula(formula, reverse_map)
+        kegs = formula.installed_kegs
+        raise FormulaUnavailableError, formula.name if kegs.empty?
+
+        direct_size = kegs.sum(&:disk_usage)
+
+        keg = formula.any_installed_keg
+        tab_deps = keg&.runtime_dependencies
+        exclusive_deps = T.let([], T::Array[T::Hash[Symbol, T.untyped]])
+        shared_deps = T.let([], T::Array[T::Hash[Symbol, T.untyped]])
+
+        if tab_deps.is_a?(Array)
+          tab_deps.each do |dep|
+            next unless dep.is_a?(Hash)
+
+            full_name = dep["full_name"]
+            next unless full_name
+
+            dep_name = Utils.name_from_full_name(full_name)
+            dep_formula = begin
+              Formula[dep_name]
+            rescue FormulaUnavailableError
+              next
+            end
+
+            dep_kegs = dep_formula.installed_kegs
+            next if dep_kegs.empty?
+
+            dep_size = dep_kegs.sum(&:disk_usage)
+            dependents = reverse_map[dep_name]
+
+            if dependents.size == 1 && dependents.include?(formula.name)
+              exclusive_deps << { name: dep_name, size: dep_size }
+            else
+              also_needed_by = (dependents - [formula.name]).sort
+              shared_deps << { name: dep_name, size: dep_size, also_needed_by: also_needed_by }
+            end
+          end
+        end
+
+        exclusive_deps_size = exclusive_deps.sum { |d| d[:size] }
+        shared_deps_size = shared_deps.sum { |d| d[:size] }
+        total_footprint = direct_size + exclusive_deps_size
+
+        {
+          name:                formula.name,
+          version:             formula.any_installed_version.to_s,
+          direct_size:         direct_size,
+          exclusive_deps:      exclusive_deps,
+          shared_deps:         shared_deps,
+          exclusive_deps_size: exclusive_deps_size,
+          shared_deps_size:    shared_deps_size,
+          total_footprint:     total_footprint,
+        }
+      end
 
       sig { void }
-      def run_named; end
+      def run_installed
+        reverse_map = build_reverse_dep_map
+        installed = Formula.installed
+
+        unless args.all?
+          installed = installed.select do |f|
+            f.any_installed_keg&.tab&.installed_on_request == true
+          end
+        end
+
+        analyses = installed.filter_map do |formula|
+          analyze_formula(formula, reverse_map)
+        rescue FormulaUnavailableError
+          nil
+        end
+
+        analyses.sort_by! { |a| -a[:total_footprint] }
+
+        if args.json
+          output_json(analyses)
+        else
+          output_table(analyses)
+        end
+      end
+
+      sig { void }
+      def run_named
+        reverse_map = build_reverse_dep_map
+        formulae = args.named.to_formulae
+
+        analyses = formulae.map do |formula|
+          raise FormulaUnavailableError, formula.name unless formula.any_installed_keg
+
+          analyze_formula(formula, reverse_map)
+        end
+
+        if args.json
+          output_json(analyses)
+        else
+          analyses.each_with_index do |analysis, i|
+            puts if i.positive?
+            output_single(analysis)
+          end
+        end
+      end
+
+      sig { params(analysis: T::Hash[Symbol, T.untyped]).void }
+      def output_single(analysis)
+        name = analysis[:name]
+        direct = Formatter.disk_usage_readable(analysis[:direct_size])
+        exclusive = analysis[:exclusive_deps]
+        shared = analysis[:shared_deps]
+        total = Formatter.disk_usage_readable(analysis[:total_footprint])
+
+        if exclusive.empty? && shared.empty?
+          puts "#{name}: #{direct}"
+          return
+        end
+
+        if exclusive.empty?
+          puts "#{name}: #{direct} (direct), no exclusive deps"
+        else
+          dep_count = exclusive.size
+          excl_size = Formatter.disk_usage_readable(analysis[:exclusive_deps_size])
+          puts "#{name}: #{direct} (direct) + #{excl_size} " \
+               "(#{dep_count} exclusive #{Utils.pluralize("dep", dep_count)}) = #{total} total"
+        end
+
+        if shared.any?
+          shared_size = Formatter.disk_usage_readable(analysis[:shared_deps_size])
+          puts "  #{shared_size} in shared deps (would not be freed)"
+        end
+
+        return unless args.verbose?
+
+        puts ""
+        version = analysis[:version]
+        puts "#{name} (#{version}): #{direct} direct"
+
+        if exclusive.any?
+          puts ""
+          puts "Exclusive dependencies (only needed by #{name}):"
+          exclusive.sort_by { |d| -d[:size] }.each do |dep|
+            puts "  #{dep[:name].ljust(16)} #{Formatter.disk_usage_readable(dep[:size])}"
+          end
+        end
+
+        if shared.any?
+          puts ""
+          puts "Shared dependencies (also needed by other formulae):"
+          shared.sort_by { |d| -d[:size] }.each do |dep|
+            also = dep[:also_needed_by]
+            also_str = also.empty? ? "" : "  (also: #{also.join(", ")})"
+            puts "  #{dep[:name].ljust(16)} #{Formatter.disk_usage_readable(dep[:size])}#{also_str}"
+          end
+        end
+
+        puts ""
+        puts "Total footprint: #{total} (direct + exclusive deps)"
+      end
+
+      sig { params(analyses: T::Array[T::Hash[Symbol, T.untyped]]).void }
+      def output_table(analyses)
+        return if analyses.empty?
+
+        puts "Package                  Direct     Excl. Deps  Total Footprint"
+
+        total_footprint_sum = 0
+        analyses.each do |analysis|
+          total_footprint_sum += analysis[:total_footprint]
+          puts format(
+            "%-20<pkg>s %10<direct>s %14<excl>s %16<total>s",
+            pkg:    analysis[:name],
+            direct: Formatter.disk_usage_readable(analysis[:direct_size]),
+            excl:   Formatter.disk_usage_readable(analysis[:exclusive_deps_size]),
+            total:  Formatter.disk_usage_readable(analysis[:total_footprint]),
+          )
+        end
+
+        puts format(
+          "%-20<pkg>s %10<direct>s %14<excl>s %16<total>s",
+          pkg: "Total", direct: "", excl: "", total: Formatter.disk_usage_readable(total_footprint_sum),
+        )
+      end
+
+      sig { params(analyses: T::Array[T::Hash[Symbol, T.untyped]]).void }
+      def output_json(analyses)
+        data = {
+          formulae: analyses.map do |a|
+            {
+              name:                a[:name],
+              version:             a[:version],
+              direct_size:         a[:direct_size],
+              exclusive_deps:      a[:exclusive_deps].map { |d| { name: d[:name], size: d[:size] } },
+              shared_deps:         a[:shared_deps].map do |d|
+                { name: d[:name], size: d[:size], also_needed_by: d[:also_needed_by] }
+              end,
+              exclusive_deps_size: a[:exclusive_deps_size],
+              shared_deps_size:    a[:shared_deps_size],
+              total_footprint:     a[:total_footprint],
+            }
+          end,
+        }
+        puts JSON.pretty_generate(data)
+      end
     end
   end
 end

--- a/Library/Homebrew/test/cmd/footprint_spec.rb
+++ b/Library/Homebrew/test/cmd/footprint_spec.rb
@@ -6,4 +6,47 @@ require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::Footprint do
   it_behaves_like "parseable arguments"
+
+  describe "footprint analysis", :integration_test do
+    before do
+      setup_test_formula "testball", tab_attributes: {
+        installed_on_request: true,
+        runtime_dependencies: [{ "full_name" => "testball2", "version" => "0.1" }],
+      }
+
+      setup_test_formula "testball2", tab_attributes: {
+        installed_on_request: false,
+        runtime_dependencies: [],
+      }
+    end
+
+    it "shows footprint for a named formula" do
+      expect { brew "footprint", "testball" }
+        .to be_a_success
+        .and output(/testball/).to_stdout
+    end
+
+    it "shows footprint with --installed" do
+      expect { brew "footprint", "--installed" }
+        .to be_a_success
+        .and output(/testball/).to_stdout
+    end
+
+    it "excludes dependencies from --installed by default" do
+      expect { brew "footprint", "--installed" }
+        .to be_a_success
+        .and not_to_output(/testball2/).to_stdout
+    end
+
+    it "includes dependencies with --installed --all" do
+      expect { brew "footprint", "--installed", "--all" }
+        .to be_a_success
+        .and output(/testball2/).to_stdout
+    end
+
+    it "errors for a formula that is not installed" do
+      expect { brew "footprint", "notinstalled" }
+        .to be_a_failure
+    end
+  end
 end

--- a/Library/Homebrew/test/cmd/footprint_spec.rb
+++ b/Library/Homebrew/test/cmd/footprint_spec.rb
@@ -1,0 +1,9 @@
+# typed: false
+# frozen_string_literal: true
+
+require "cmd/footprint"
+require "cmd/shared_examples/args_parse"
+
+RSpec.describe Homebrew::Cmd::Footprint do
+  it_behaves_like "parseable arguments"
+end

--- a/Library/Homebrew/test/cmd/footprint_spec.rb
+++ b/Library/Homebrew/test/cmd/footprint_spec.rb
@@ -20,31 +20,20 @@ RSpec.describe Homebrew::Cmd::Footprint do
       }
     end
 
-    it "shows footprint for a named formula" do
+    it "shows footprint for named formulae and filters --installed correctly" do
       expect { brew "footprint", "testball" }
         .to be_a_success
         .and output(/testball/).to_stdout
-    end
 
-    it "shows footprint with --installed" do
       expect { brew "footprint", "--installed" }
         .to be_a_success
         .and output(/testball/).to_stdout
-    end
-
-    it "excludes dependencies from --installed by default" do
-      expect { brew "footprint", "--installed" }
-        .to be_a_success
         .and not_to_output(/testball2/).to_stdout
-    end
 
-    it "includes dependencies with --installed --all" do
       expect { brew "footprint", "--installed", "--all" }
         .to be_a_success
         .and output(/testball2/).to_stdout
-    end
 
-    it "errors for a formula that is not installed" do
       expect { brew "footprint", "notinstalled" }
         .to be_a_failure
     end


### PR DESCRIPTION
## Description

Adds a new `brew footprint` command that shows the true disk cost of installed
formulae, including exclusive dependencies (deps that would be freed on uninstall).

This helps users make informed uninstall decisions by revealing hidden space costs
in the dependency graph that `brew info --sizes` does not show.

### Motivation

`brew info --sizes` shows direct sizes but does not account for exclusive
dependencies. A 50MB formula might pull 500MB of deps used by nothing else.
`brew footprint` bridges this gap by classifying each runtime dependency as
exclusive (only needed by this formula) or shared (also needed by others).

### Usage

```
brew footprint <formula>              # footprint of specific formulae
brew footprint --installed            # rank top-level formulae by total footprint
brew footprint --installed --all      # include auto-installed deps
brew footprint <formula> --verbose    # per-dependency breakdown
brew footprint <formula> --json       # machine-readable output
```

### How it works

1. Builds a reverse dependency map from installed kegs' runtime dependencies
2. For each target formula, classifies runtime deps as exclusive or shared
3. Reports: direct size + exclusive dep sizes = total footprint

### Example output

```
$ brew footprint git
git: 59.8MB (direct) + 2.9MB (1 exclusive dep) = 62.8MB total
  48.5MB in shared deps (would not be freed)

$ brew footprint --installed
Package               Direct      Excl. Deps   Total Footprint
rust                 373.6MB           1.8GB             2.2GB
vtk                  244.6MB           1.4GB             1.6GB
qemu                 716.4MB          25.9MB           742.3MB
...
```

## Checklist

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? Here's an example [`Library/Homebrew/test/PATH_spec.rb`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/cmd/footprint_spec.rb)
- [x] Have you successfully run `brew lgtm` with your changes locally?
  - `brew style`: 0 offenses
  - `brew typecheck`: 0 errors in changed files (pre-existing errors in other files)
  - `brew tests --only=cmd/footprint`: 2 examples, 0 failures
- [x] AI was used to generate or assist with generating this PR
  - Tool: AI-assisted code review
  - All changes were manually verified and tested against real installed formulae