### PR TITLE
Share cask upgrade download queues

### DIFF
--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -49,20 +49,7 @@ module Homebrew
         ).returns(Homebrew::API::SourceDownload)
       }
       def self.source_download(cask, download_queue: Homebrew.default_download_queue, enqueue: false)
-        path = cask.ruby_source_path.to_s
-        sha256 = cask.ruby_source_checksum[:sha256]
-        checksum = Checksum.new(sha256) if sha256
-        git_head = cask.tap_git_head || "HEAD"
-        tap = cask.tap&.full_name || "Homebrew/homebrew-cask"
-
-        download = Homebrew::API::SourceDownload.new(
-          "https://raw.githubusercontent.com/#{tap}/#{git_head}/#{path}",
-          checksum,
-          mirrors: [
-            "#{HOMEBREW_API_DEFAULT_DOMAIN}/cask-source/#{File.basename(path)}",
-          ],
-          cache:   HOMEBREW_CACHE_API_SOURCE/"#{tap}/#{git_head}/Cask",
-        )
+        download = source_download_for(cask)
 
         if enqueue
           download_queue.enqueue(download)
@@ -71,6 +58,24 @@ module Homebrew
         end
 
         download
+      end
+
+      sig { params(cask: ::Cask::Cask).returns(Homebrew::API::SourceDownload) }
+      def self.source_download_for(cask)
+        path = cask.ruby_source_path.to_s
+        sha256 = cask.ruby_source_checksum[:sha256]
+        checksum = Checksum.new(sha256) if sha256
+        git_head = cask.tap_git_head || "HEAD"
+        tap = cask.tap&.full_name || "Homebrew/homebrew-cask"
+
+        Homebrew::API::SourceDownload.new(
+          "https://raw.githubusercontent.com/#{tap}/#{git_head}/#{path}",
+          checksum,
+          mirrors: [
+            "#{HOMEBREW_API_DEFAULT_DOMAIN}/cask-source/#{File.basename(path)}",
+          ],
+          cache:   HOMEBREW_CACHE_API_SOURCE/"#{tap}/#{git_head}/Cask",
+        )
       end
 
       sig { params(cask: ::Cask::Cask).returns(::Cask::Cask) }

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -54,6 +54,8 @@ module Cask
       @quiet = quiet
       @download_queue = download_queue
       @defer_fetch = defer_fetch
+      @source_download = T.let(nil, T.nilable(Homebrew::API::SourceDownload))
+      @ran_prelude_fetch = T.let(false, T::Boolean)
       @ran_prelude = T.let(false, T::Boolean)
       @cask_and_formula_dependencies = T.let(nil, T.nilable(T::Array[T.any(Formula, ::Cask::Cask)]))
     end
@@ -901,13 +903,7 @@ on_request: true)
     def prelude
       return if @ran_prelude
 
-      check_deprecate_disable
-      check_conflicts
-      check_requirements
-      # Run the cask-self forbidden checks before loading the caskfile from the
-      # Source API so a forbidden cask never triggers a network fetch.
-      forbidden_tap_check(cask_only: true)
-      forbidden_cask_and_formula_check(cask_only: true)
+      check_prelude_requirements unless @ran_prelude_fetch
       load_cask_from_source_api! if cask_from_source_api?
       forbidden_tap_check
       forbidden_cask_and_formula_check
@@ -916,25 +912,72 @@ on_request: true)
       @ran_prelude = true
     end
 
+    sig { returns(T::Boolean) }
+    def source_download_requires_pre_fetch?
+      cask_from_source_api? && @cask.languages.any?
+    end
+
+    sig { params(download_queue: Homebrew::DownloadQueue).void }
+    def prelude_fetch(download_queue: @download_queue)
+      return unless (download = prelude_fetch_download)
+
+      download_queue.enqueue(download)
+    end
+
+    sig { returns(T.nilable(Homebrew::API::SourceDownload)) }
+    def prelude_fetch_download
+      return if @ran_prelude_fetch
+
+      check_prelude_requirements
+      @ran_prelude_fetch = true
+      return unless source_download_requires_pre_fetch?
+
+      if source_download.downloaded?
+        source_download.verify_download_integrity(source_download.cached_download)
+        source_download.downloader.create_symlink_to_cached_download(source_download.cached_download)
+        return
+      end
+
+      source_download
+    end
+
     sig { void }
     def enqueue_downloads
       download_queue = @download_queue
-      check_requirements
+      prelude_fetch(download_queue:) unless @ran_prelude_fetch
 
       # FIXME: We need to load Cask source before enqueuing to support
       # language-specific URLs, but this will block the main process.
-      if cask_from_source_api?
-        if @cask.languages.any?
-          load_cask_from_source_api!
-        else
-          Homebrew::API::Cask.source_download(@cask, download_queue:, enqueue: true)
-        end
+      if source_download_requires_pre_fetch?
+        load_cask_from_source_api!
+      elsif cask_from_source_api?
+        Homebrew::API::Cask.source_download(@cask, download_queue:, enqueue: true)
       end
+
+      forbidden_tap_check
+      forbidden_cask_and_formula_check
+      forbidden_cask_artifacts_check
 
       download_queue.enqueue(downloader)
     end
 
     private
+
+    sig { void }
+    def check_prelude_requirements
+      check_deprecate_disable
+      check_conflicts
+      check_requirements
+      # Run the cask-self forbidden checks before loading the caskfile from the
+      # Source API so a forbidden cask never triggers a network fetch.
+      forbidden_tap_check(cask_only: true)
+      forbidden_cask_and_formula_check(cask_only: true)
+    end
+
+    sig { returns(Homebrew::API::SourceDownload) }
+    def source_download
+      @source_download ||= Homebrew::API::Cask.source_download_for(@cask)
+    end
 
     # load the same cask file that was used for installation, if possible
     sig { void }

--- a/Library/Homebrew/cask/reinstall.rb
+++ b/Library/Homebrew/cask/reinstall.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "utils/output"
+require "install"
 
 module Cask
   class Reinstall
@@ -58,11 +59,9 @@ module Cask
         end
 
         unless skip_prefetch
-          cask_installers.each(&:prelude)
-
+          Homebrew::Install.enqueue_cask_installers(cask_installers, download_queue:)
           oh1 "Fetching downloads for: #{casks.map { |cask| Formatter.identifier(cask.full_name) }.to_sentence}",
               truncate: false
-          cask_installers.each(&:enqueue_downloads)
           download_queue.fetch
         end
       ensure

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -5,6 +5,7 @@ require "env_config"
 require "cask/config"
 require "cask/quarantine"
 require "deprecate_disable"
+require "install"
 require "utils/output"
 
 module Cask
@@ -245,12 +246,10 @@ module Cask
             # rubocop:enable Style/DoubleNegation
           end
 
-          fetchable_cask_installers.each(&:prelude)
-
           fetchable_casks_sentence = fetchable_casks.map { |cask| Formatter.identifier(cask.full_name) }.to_sentence
+          Homebrew::Install.enqueue_cask_installers(fetchable_cask_installers,
+                                                    download_queue: prefetch_download_queue)
           oh1 "Fetching downloads for: #{fetchable_casks_sentence}", truncate: false
-
-          fetchable_cask_installers.each(&:enqueue_downloads)
           prefetch_download_queue.fetch
         ensure
           prefetch_download_queue.shutdown if created_download_queue

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -369,7 +369,7 @@ module Homebrew
                 )
               end
 
-              Install.enqueue_cask_installers(fetch_cask_installers)
+              Install.enqueue_cask_installers(fetch_cask_installers, download_queue:)
             end
 
             download_queue.fetch

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -248,7 +248,7 @@ module Homebrew
                   defer_fetch:    true,
                 )
               end
-              Install.enqueue_cask_installers(fetch_cask_installers)
+              Install.enqueue_cask_installers(fetch_cask_installers, download_queue: shared_download_queue)
               shared_download_queue.fetch
               casks_prefetched = true
               valid_formula_installers

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -748,7 +748,7 @@ module Homebrew
           )
         end
         cask_names = outdated_casks.map(&:full_name)
-        Install.enqueue_cask_installers(fetchable_cask_installers)
+        Install.enqueue_cask_installers(fetchable_cask_installers, download_queue:)
         prefetch_names&.replace(cask_names)
         prefetch_upgrades&.replace(
           outdated_casks.map { |cask| "#{cask.full_name} #{cask.installed_version} -> #{cask.version}" },

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -402,9 +402,17 @@ module Homebrew
         oh1 "Fetching downloads for: #{combined_fetch_targets.to_sentence}", truncate: false
       end
 
-      sig { params(cask_installers: T::Array[T.untyped]).void }
-      def enqueue_cask_installers(cask_installers)
-        cask_installers.each(&:prelude)
+      sig { params(cask_installers: T::Array[T.untyped], download_queue: Homebrew::DownloadQueue).void }
+      def enqueue_cask_installers(cask_installers, download_queue:)
+        if cask_installers.any?(&:source_download_requires_pre_fetch?)
+          source_downloads = cask_installers.filter_map(&:prelude_fetch_download)
+          if source_downloads.any?
+            oh1 "Downloading Cask files"
+            source_downloads.each { |source_download| download_queue.enqueue(source_download) }
+            download_queue.fetch
+          end
+        end
+
         cask_installers.each(&:enqueue_downloads)
       end
 

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -539,6 +539,40 @@ RSpec.describe Cask::Installer, :cask do
     end
   end
 
+  describe "#prelude_fetch" do
+    it "enqueues source API caskfiles before the main cask download" do
+      cask = Cask::Cask.new("source-api-cask") do
+        url "file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz"
+      end
+      allow(cask).to receive_messages(loaded_from_api?: true, caskfile_only?: true, languages: ["en"])
+      download_queue = instance_double(Homebrew::DownloadQueue)
+      installer = klass.new(cask, download_queue:)
+      source_download = instance_double(Homebrew::API::SourceDownload, downloaded?: false)
+
+      expect(Homebrew::API::Cask).to receive(:source_download_for).with(cask).and_return(source_download)
+      expect(download_queue).to receive(:enqueue).with(source_download)
+      expect(Homebrew::API::Cask).not_to receive(:source_download_cask)
+      expect(installer).not_to receive(:download)
+
+      installer.prelude_fetch
+    end
+
+    it "leaves source API caskfiles in the main queue when their URL is known" do
+      cask = Cask::Cask.new("source-api-cask") do
+        url "file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz"
+      end
+      allow(cask).to receive_messages(loaded_from_api?: true, caskfile_only?: true, languages: [])
+      download_queue = instance_double(Homebrew::DownloadQueue)
+      installer = klass.new(cask, download_queue:)
+
+      expect(Homebrew::API::Cask).to receive(:source_download).with(cask, download_queue:, enqueue: true)
+      expect(Homebrew::API::Cask).not_to receive(:source_download_cask)
+      expect(download_queue).to receive(:enqueue).with(instance_of(Cask::Download))
+
+      installer.enqueue_downloads
+    end
+  end
+
   describe "rename operations" do
     let(:tmpdir) { mktmpdir }
     let(:staged_path) { Pathname(tmpdir) }

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -69,11 +69,13 @@ RSpec.describe Cask::Reinstall, :cask do
 
     failing_installer = instance_double(Cask::Installer)
     allow(failing_installer).to receive(:prelude)
+    allow(failing_installer).to receive(:source_download_requires_pre_fetch?).and_return(false)
     allow(failing_installer).to receive(:enqueue_downloads)
     allow(failing_installer).to receive(:install).and_raise(Cask::CaskError.new("reinstall failed"))
 
     successful_installer = instance_double(Cask::Installer)
     allow(successful_installer).to receive(:prelude)
+    allow(successful_installer).to receive(:source_download_requires_pre_fetch?).and_return(false)
     allow(successful_installer).to receive(:enqueue_downloads)
 
     allow(Cask::Installer).to receive(:new).and_return(failing_installer, successful_installer)

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -448,7 +448,7 @@ RSpec.describe Cask::Upgrade, :cask do
     end
 
     it 'prefetches "auto_updates true" casks with quarantine until signed identity is checked' do
-      installer = instance_double(Cask::Installer, prelude: nil, enqueue_downloads: nil)
+      installer = instance_double(Cask::Installer, enqueue_downloads: nil, source_download_requires_pre_fetch?: false)
 
       expect(Cask::Installer).to receive(:new) do |cask, **options|
         expect(cask).to eq(auto_updates)

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     formula = formula("testball_bottle") { url "https://brew.sh/testball_bottle-0.1.tar.gz" }
     formula_installer = instance_double(FormulaInstaller, formula:)
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
-    installer = instance_double(Cask::Installer, prelude: nil, enqueue_downloads: nil)
+    installer = instance_double(Cask::Installer, enqueue_downloads: nil, source_download_requires_pre_fetch?: false)
 
     allow(Tap).to receive_messages(with_formula_name: nil, with_cask_token: nil)
     allow(cmd.args.named).to receive(:to_formulae_and_casks).with(warn: false).and_return([formula, cask])

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -379,9 +379,9 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       installed_version: "0.117.0",
       version:           "0.118.0",
     )
-    installer = instance_double(Cask::Installer, prelude: nil, enqueue_downloads: nil)
+    installer = instance_double(Cask::Installer, enqueue_downloads: nil, source_download_requires_pre_fetch?: false)
 
-    allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
+    expect(Homebrew::DownloadQueue).to receive(:new).once.and_return(download_queue)
     allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, prefetch_only: false,
                                                               prefetch_names: nil,
                                                               prefetch_upgrades: nil,
@@ -403,6 +403,102 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
       true
     end
+    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
+    allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
+    allow(Homebrew.messages).to receive(:display_messages)
+
+    expect { cmd.run }.to output(<<~EOS).to_stdout
+      ==> Upgrading 2 outdated packages:
+      deno 2.7.10 -> 2.7.11
+      codex 0.117.0 -> 0.118.0
+      ==> Fetching downloads for: deno and codex
+    EOS
+  end
+
+  it "prefetches language cask files before fetching combined downloads" do
+    cmd = klass.new([])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch_failed: false, shutdown: nil)
+    cask = instance_double(
+      Cask::Cask,
+      artifacts:         [],
+      full_name:         "codex",
+      installed_version: "0.117.0",
+      version:           "0.118.0",
+    )
+    installer = instance_double(
+      Cask::Installer,
+      enqueue_downloads:                   nil,
+      source_download_requires_pre_fetch?: true,
+    )
+    source_download = instance_double(Homebrew::API::SourceDownload)
+
+    expect(Homebrew::DownloadQueue).to receive(:new).once.and_return(download_queue)
+    allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, prefetch_only: false,
+                                                              prefetch_names: nil,
+                                                              prefetch_upgrades: nil,
+                                                              show_upgrade_summary: true,
+                                                              **|
+      if prefetch_only
+        expect(show_upgrade_summary).to be(false)
+        prefetch_names&.replace(["deno"])
+        prefetch_upgrades&.replace(["deno 2.7.10 -> 2.7.11"])
+      end
+
+      true
+    end
+    allow(Cask::Installer).to receive(:new).and_return(installer)
+    expect(installer).to receive(:prelude_fetch_download).and_return(source_download)
+    expect(download_queue).to receive(:enqueue).with(source_download).ordered
+    expect(download_queue).to receive(:fetch).ordered
+    expect(download_queue).to receive(:fetch).ordered
+    allow(Cask::Upgrade).to receive_messages(outdated_casks: [cask], upgrade_casks!: true)
+    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
+    allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
+    allow(Homebrew.messages).to receive(:display_messages)
+
+    expect { cmd.run }.to output(<<~EOS).to_stdout
+      ==> Downloading Cask files
+      ==> Upgrading 2 outdated packages:
+      deno 2.7.10 -> 2.7.11
+      codex 0.117.0 -> 0.118.0
+      ==> Fetching downloads for: deno and codex
+    EOS
+  end
+
+  it "omits the cask file heading for cached language cask files" do
+    cmd = klass.new([])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch_failed: false, shutdown: nil)
+    cask = instance_double(
+      Cask::Cask,
+      artifacts:         [],
+      full_name:         "codex",
+      installed_version: "0.117.0",
+      version:           "0.118.0",
+    )
+    installer = instance_double(
+      Cask::Installer,
+      enqueue_downloads:                   nil,
+      source_download_requires_pre_fetch?: true,
+    )
+
+    expect(Homebrew::DownloadQueue).to receive(:new).once.and_return(download_queue)
+    allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, prefetch_only: false,
+                                                              prefetch_names: nil,
+                                                              prefetch_upgrades: nil,
+                                                              show_upgrade_summary: true,
+                                                              **|
+      if prefetch_only
+        expect(show_upgrade_summary).to be(false)
+        prefetch_names&.replace(["deno"])
+        prefetch_upgrades&.replace(["deno 2.7.10 -> 2.7.11"])
+      end
+
+      true
+    end
+    allow(Cask::Installer).to receive(:new).and_return(installer)
+    expect(installer).to receive(:prelude_fetch_download).and_return(nil)
+    expect(download_queue).to receive(:fetch).once
+    allow(Cask::Upgrade).to receive_messages(outdated_casks: [cask], upgrade_casks!: true)
     allow(Homebrew::Cleanup).to receive(:periodic_clean!)
     allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
     allow(Homebrew.messages).to receive(:display_messages)
@@ -468,7 +564,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       installed_version: "0.117.0",
       version:           "0.118.0",
     )
-    installer = instance_double(Cask::Installer, prelude: nil, enqueue_downloads: nil)
+    installer = instance_double(Cask::Installer, enqueue_downloads: nil, source_download_requires_pre_fetch?: false)
 
     allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
     allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, prefetch_only: false,


### PR DESCRIPTION
- Avoid splitting cask source fetches from combined upgrade fetches
- Keep language-specific caskfiles on a prefetch queue only when needed
- Hide `Downloading Cask files` unless that queue will fetch new files

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.
-----
