### PR TITLE
bundle: extend cleanup coverage

### DIFF
--- a/Library/Homebrew/bundle/extensions/extension.rb
+++ b/Library/Homebrew/bundle/extensions/extension.rb
@@ -238,6 +238,11 @@ module Homebrew
         installed_names - kept_packages
       end
 
+      sig { params(item: String).returns(String) }
+      def self.cleanup_item_name(item)
+        item
+      end
+
       sig { returns(Symbol) }
       def self.legacy_check_step
         :registered_extensions_to_install

--- a/Library/Homebrew/bundle/extensions/krew.rb
+++ b/Library/Homebrew/bundle/extensions/krew.rb
@@ -18,6 +18,11 @@ module Homebrew
           @package_manager_executable = T.let(nil, T.nilable(Pathname))
         end
 
+        sig { override.returns(T.nilable(String)) }
+        def cleanup_heading
+          banner_name
+        end
+
         sig { override.returns(T.nilable(Pathname)) }
         def package_manager_executable
           @package_manager_executable ||= T.let(which("kubectl-krew", ORIGINAL_PATHS), T.nilable(Pathname))
@@ -71,6 +76,11 @@ module Homebrew
           end.uniq
         end
         private :parse_plugin_list
+
+        sig { override.params(name: String, executable: Pathname).void }
+        def uninstall_package!(name, executable: Pathname.new(""))
+          Bundle.system(executable.to_s, "uninstall", name, verbose: false)
+        end
       end
     end
   end

--- a/Library/Homebrew/bundle/extensions/mac_app_store.rb
+++ b/Library/Homebrew/bundle/extensions/mac_app_store.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "bundle/extensions/extension"
+require "json"
 
 module Homebrew
   module Bundle
@@ -30,6 +31,11 @@ module Homebrew
         sig { override.returns(T::Boolean) }
         def dump_disable_supported?
           false
+        end
+
+        sig { override.returns(T.nilable(String)) }
+        def cleanup_heading
+          "Mac App Store apps"
         end
 
         sig { override.params(name: String, options: Homebrew::Bundle::EntryInputOptions).returns(Dsl::Entry) }
@@ -102,6 +108,41 @@ module Homebrew
         def dump_entry(package)
           app = T.cast(package, App)
           "mas #{quote(app.name)}, id: #{app.id}"
+        end
+
+        sig { params(app: App).returns(String) }
+        def cleanup_item(app)
+          JSON.generate("id" => app.id, "name" => app.name)
+        end
+
+        sig { override.params(item: String).returns(String) }
+        def cleanup_item_name(item)
+          app = parse_cleanup_item(item)
+          "#{app.name} (#{app.id})"
+        end
+
+        sig { override.params(entries: T::Array[Dsl::Entry]).returns(T::Array[String]) }
+        def cleanup_items(entries)
+          return [].freeze unless package_manager_installed?
+
+          kept_app_ids = entries.filter_map do |entry|
+            entry.options[:id].to_s if entry.type == type
+          end
+          return [].freeze if kept_app_ids.empty?
+
+          packages.reject { |app| kept_app_ids.any? { |id| app.id.to_i == id.to_i } }
+                  .map { |app| cleanup_item(app) }
+        end
+
+        sig { override.params(items: T::Array[String]).void }
+        def cleanup!(items)
+          mas = package_manager_executable
+          return if mas.nil?
+
+          items.each do |item|
+            Bundle.system(mas, "uninstall", parse_cleanup_item(item).id, verbose: false)
+          end
+          puts "Uninstalled #{items.size} Mac App Store app#{"s" if items.size != 1}"
         end
 
         sig { params(id: Integer).returns(T::Boolean) }
@@ -208,6 +249,18 @@ module Homebrew
           packages << App.new(id: id.to_s, name:) unless packages.any? { |app| app.id.to_i == id }
           installed_app_ids << id.to_s unless installed_app_ids.include?(id.to_s)
           true
+        end
+
+        sig { params(item: String).returns(App) }
+        def parse_cleanup_item(item)
+          parsed = JSON.parse(item)
+          raise TypeError, "Invalid Mac App Store cleanup item: #{item}" unless parsed.is_a?(Hash)
+
+          id = parsed["id"]
+          name = parsed["name"]
+          raise TypeError, "Invalid Mac App Store cleanup item: #{item}" if !id.is_a?(String) || !name.is_a?(String)
+
+          App.new(id:, name:)
         end
       end
 

--- a/Library/Homebrew/bundle/subcommand/cleanup.rb
+++ b/Library/Homebrew/bundle/subcommand/cleanup.rb
@@ -26,6 +26,8 @@ module Homebrew
                  description: "Run `install` before cleaning up dependencies."
           switch "-f", "--force",
                  description: "Actually perform cleanup operations."
+          switch "--all",
+                 description: "Clean up all supported dependencies."
           switch "--formula", "--formulae", "--brews",
                  description: "Clean up Homebrew formula dependencies."
           switch "--cask", "--casks",
@@ -47,13 +49,13 @@ module Homebrew
             file:            context.file,
             force:           context.force,
             zap:             context.zap,
-            formulae:        args.formulae? || context.no_type_args,
-            casks:           args.casks? || context.no_type_args,
-            taps:            args.taps? || context.no_type_args,
+            formulae:        args.formulae? || args.all? || context.no_type_args,
+            casks:           args.casks? || args.all? || context.no_type_args,
+            taps:            args.taps? || args.all? || context.no_type_args,
             extension_types: context.extensions.select(&:cleanup_supported?).to_h do |extension|
               [
                 extension.type,
-                context.extension_selected?(args, extension) || context.no_type_args,
+                context.extension_selected?(args, extension) || args.all? || context.no_type_args,
               ]
             end,
           )
@@ -166,7 +168,7 @@ module Homebrew
               next if items.empty?
 
               puts "Would uninstall #{extension.cleanup_heading}:"
-              puts Formatter.columns items
+              puts Formatter.columns items.map { |item| extension.cleanup_item_name(item) }
               would_uninstall = true
             end
 

--- a/Library/Homebrew/test/bundle/krew_spec.rb
+++ b/Library/Homebrew/test/bundle/krew_spec.rb
@@ -128,4 +128,32 @@ RSpec.describe Homebrew::Bundle::Krew do
       end
     end
   end
+
+  describe "cleanup" do
+    before do
+      klass.reset!
+      allow(klass).to receive_messages(
+        package_manager_executable: Pathname.new("/usr/local/bin/kubectl-krew"),
+        package_manager_installed?: true,
+        packages:                   %w[ctx ns neat],
+        installed_packages:         %w[ctx ns neat],
+      )
+    end
+
+    it "returns plugins not in Brewfile entries" do
+      entries = [Homebrew::Bundle::Dsl::Entry.new(:krew, "ctx")]
+      expect(klass.cleanup_items(entries)).to eql(%w[ns neat])
+    end
+
+    it "uninstalls plugins" do
+      expect(Homebrew::Bundle).to receive(:system) do |*args, verbose:|
+        expect(ENV.fetch("PATH", "")).to start_with("/usr/local/bin:")
+        expect(args).to eq(["/usr/local/bin/kubectl-krew", "uninstall", "ns"])
+        expect(verbose).to be(false)
+        true
+      end
+
+      expect { klass.cleanup!(["ns"]) }.to output(/Uninstalled 1 Krew plugin/).to_stdout
+    end
+  end
 end

--- a/Library/Homebrew/test/bundle/mac_app_store_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_spec.rb
@@ -277,4 +277,29 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
       end
     end
   end
+
+  describe "cleanup" do
+    before do
+      klass.reset!
+      allow(klass).to receive_messages(package_manager_executable: Pathname.new("mas"), packages: [
+        klass::App.new(id: "123", name: "foo"),
+        klass::App.new(id: "456", name: "bar"),
+      ])
+    end
+
+    it "returns apps not in Brewfile entries by ID" do
+      entries = [Homebrew::Bundle::Dsl::Entry.new(:mas, "renamed foo", id: 123)]
+      items = klass.cleanup_items(entries)
+
+      expect(items.map { |item| klass.cleanup_item_name(item) }).to eql(["bar (456)"])
+    end
+
+    it "uninstalls apps by ID" do
+      items = klass.cleanup_items([Homebrew::Bundle::Dsl::Entry.new(:mas, "foo", id: 123)])
+      expect(Homebrew::Bundle).to receive(:system).with(Pathname("mas"), "uninstall", "456", verbose: false)
+                                                  .and_return(true)
+
+      expect { klass.cleanup!(items) }.to output(/Uninstalled 1 Mac App Store app/).to_stdout
+    end
+  end
 end

--- a/Library/Homebrew/test/cmd/bundle/cleanup_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/cleanup_subcommand_spec.rb
@@ -8,6 +8,33 @@ require "utils"
 RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
   let(:klass) { Homebrew::Cmd::Bundle::CleanupSubcommand }
 
+  describe "#run" do
+    it "cleans up every supported type when --all is passed" do
+      args = args_for_subcommand(:cleanup, all?: true, formulae?: false, casks?: false, taps?: false, mas?: false,
+                                           vscode?: false, cargo?: false, flatpak?: false, go?: false, krew?: false,
+                                           npm?: false, uv?: false)
+      context = bundle_subcommand_context(:cleanup, no_type_args: false)
+
+      expect(klass).to receive(:cleanup) do |formulae:, casks:, taps:, extension_types:, **|
+        expect(formulae).to be(true)
+        expect(casks).to be(true)
+        expect(taps).to be(true)
+        expect(extension_types).to include(
+          cargo:   true,
+          flatpak: true,
+          go:      true,
+          krew:    true,
+          mas:     true,
+          npm:     true,
+          uv:      true,
+          vscode:  true,
+        )
+      end
+
+      klass.new(args, context:).run
+    end
+  end
+
   describe "read Brewfile and current installation", :no_api do
     before do
       klass.reset!

--- a/Library/Homebrew/test/cmd/bundle_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Homebrew::Cmd::Bundle do
     expect(subcommand_options.call("list")["--vscode"]).to eq("List VSCode (and forks/variants) extensions.")
     expect(subcommand_options.call("dump")["--vscode"]).to eq("Dump VSCode (and forks/variants) extensions.")
     expect(subcommand_options.call("cleanup")["--vscode"]).to eq("Clean up VSCode (and forks/variants) extensions.")
+    expect(subcommand_options.call("cleanup")["--all"]).to eq("Clean up all supported dependencies.")
     expect(subcommand_options.call("add")["--vscode"])
       .to eq("Add entries for VSCode (and forks/variants) extensions.")
     expect(subcommand_options.call("remove")["--vscode"])


### PR DESCRIPTION
- let `cleanup --all` opt in to all supported types
- support cleanup for `mas` and `krew`
- show readable cleanup item names for extensions

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
