### PR TITLE
bundle: filter VSCode server chatter

### DIFF
--- a/Library/Homebrew/bundle/extensions/vscode_extension.rb
+++ b/Library/Homebrew/bundle/extensions/vscode_extension.rb
@@ -9,6 +9,7 @@ module Homebrew
       PACKAGE_TYPE = :vscode
       PACKAGE_TYPE_NAME = "VSCode Extension"
       BANNER_NAME = "VSCode (and forks/variants) extensions"
+      EXTENSION_ID_REGEX = /\A[a-z0-9][a-z0-9-]*\.[a-z0-9][a-z0-9._-]*\z/i
 
       class << self
         sig { override.void }
@@ -46,7 +47,7 @@ module Homebrew
             Bundle.exchange_uid_if_needed! do
               ENV["WSL_DISTRO_NAME"] = ENV.fetch("HOMEBREW_WSL_DISTRO_NAME", nil)
               `"#{vscode}" --list-extensions 2>/dev/null`
-            end.split("\n").map(&:downcase)
+            end.split("\n").map(&:strip).grep(EXTENSION_ID_REGEX).map(&:downcase)
           end
           return [] if @extensions.nil?
 

--- a/Library/Homebrew/test/bundle/vscode_extension_spec.rb
+++ b/Library/Homebrew/test/bundle/vscode_extension_spec.rb
@@ -48,6 +48,21 @@ RSpec.describe Homebrew::Bundle::VscodeExtension do
           "tamasfe.even-better-toml",
         ])
       end
+
+      it "ignores VSCode server setup output" do
+        output = <<~EOF
+          updating vs code server to version f6cfa2ea2403534de03f069bdf160d06451ed282
+          downloading:     \b\b\b\b  0%\b\b\b\b100%
+          unpacked 3485 files and folders to /home/mike/.vscode-server/bin/f6cfa2ea2403534de03f069bdf160d06451ed282.
+          GitHub.codespaces
+        EOF
+
+        allow(klass).to receive(:`)
+          .with('"code" --list-extensions 2>/dev/null')
+          .and_return(output)
+
+        expect(dumper.extensions).to eql(["github.codespaces"])
+      end
     end
   end
 


### PR DESCRIPTION
- ignore VSCode server progress output during extension dumps
- keep only extension-shaped identifiers in Brewfile output

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
