### PR TITLE
bundle: add WinGet support

### DIFF
--- a/Library/Homebrew/bundle/extensions.rb
+++ b/Library/Homebrew/bundle/extensions.rb
@@ -4,8 +4,9 @@
 require "bundle/extensions/extension"
 
 extensions_dir = File.join(__dir__, "extensions")
-# Preserve the historical Brewfile section order for dumped extension entries.
-legacy_order = %w[mac_app_store vscode_extension go cargo uv flatpak].freeze
+# Preserve the historical Brewfile section order for dumped extension entries;
+# add new extensions to the end.
+legacy_order = %w[mac_app_store vscode_extension go cargo uv flatpak winget].freeze
 extension_files = Dir.glob(File.join(extensions_dir, "*.rb")).sort_by do |file|
   basename = File.basename(file, ".rb")
   [legacy_order.index(basename) || legacy_order.length, basename]

--- a/Library/Homebrew/bundle/extensions/winget.rb
+++ b/Library/Homebrew/bundle/extensions/winget.rb
@@ -1,0 +1,532 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "bundle/extensions/extension"
+require "json"
+require "tempfile"
+require "utils/popen"
+
+module Homebrew
+  module Bundle
+    # Support dumping and installing Windows packages through WinGet from WSL.
+    class Winget < Extension
+      # Parsed WinGet package details.
+      class App < T::Struct
+        const :id, String
+        const :name, String
+        const :source, String
+      end
+
+      DEFAULT_SOURCE = "winget"
+      SOURCES = T.let([DEFAULT_SOURCE, "msstore"].freeze, T::Array[String])
+      ELEVATED_INSTALL_FAILURE_PATTERNS = T.let([
+        /Installer failed with exit code:\s*1603/i,
+        /\b(?:admin|administrator|elevat|UAC)\b/i,
+      ].freeze, T::Array[Regexp])
+      INSTALLER_UI_FAILURE_PATTERNS = T.let([
+        /\b(?:interactive|user input|user cancelled)\b/i,
+      ].freeze, T::Array[Regexp])
+      INTERNAL_PACKAGE_PATTERNS = T.let([
+        /\AApp Installer\z/i,
+        /\A9NBLGGH4NNS1\z/i,
+        /\AMicrosoft Store\z/i,
+        /\AStore Experience Host\z/i,
+        /\AWindows (?:Feature|Web) Experience Pack\z/i,
+        /\AMicrosoft Edge WebView2 Runtime\z/i,
+        /\AMicrosoft Visual C\+\+/i,
+        /\AWindows App Runtime/i,
+        /\AMicrosoft\.(?:AppInstaller|DesktopAppInstaller|DirectX|DotNet|Edge|EdgeWebView2Runtime|GameInput)\b/i,
+        /\AMicrosoft\.(?:HEVCVideoExtension|NET\.Native|RawImageExtension)\b/i,
+        /\AMicrosoft\.(?:OneDrive|WSL)\z/i,
+        /\AMicrosoft\.(?:Services\.Store\.Engagement|StorePurchaseApp|UI\.Xaml|VCLibs|WindowsAppRuntime)\b/i,
+        /\AMicrosoft\.(?:WindowsStore|WebMediaExtensions|WebpImageExtension|VP9VideoExtensions)\b/i,
+        /\AMicrosoft\.VCRedist\./i,
+        /\ANvidia\.PhysX\z/i,
+      ].freeze, T::Array[Regexp])
+
+      PACKAGE_TYPE = :winget
+      PACKAGE_TYPE_NAME = "WinGet Package"
+      BANNER_NAME = "WinGet packages"
+
+      class << self
+        sig { override.params(description: String).returns(String) }
+        def switch_description(description)
+          "#{super} Note: WSL only."
+        end
+
+        sig { override.returns(T::Boolean) }
+        def add_supported?
+          false
+        end
+
+        sig { override.returns(T.nilable(String)) }
+        def cleanup_heading
+          banner_name
+        end
+
+        sig { override.params(name: String, options: Homebrew::Bundle::EntryInputOptions).returns(Dsl::Entry) }
+        def entry(name, options = {})
+          unknown_options = options.keys - [:id, :source]
+          raise "unknown options(#{unknown_options.inspect}) for winget" if unknown_options.present?
+
+          id = options.fetch(:id, name)
+          raise "options[:id](#{id.inspect}) should be a String object" unless id.is_a?(String)
+
+          source = options.fetch(:source, DEFAULT_SOURCE)
+          raise "options[:source](#{source.inspect}) should be a String object" unless source.is_a?(String)
+          unless SOURCES.include?(source)
+            raise "options[:source](#{source.inspect}) should be one of #{SOURCES.inspect}"
+          end
+
+          Dsl::Entry.new(type, name, id:, source:)
+        end
+
+        sig { override.returns(T.nilable(Pathname)) }
+        def package_manager_executable
+          return unless OS.wsl?
+
+          which("winget.exe", ORIGINAL_PATHS) || windows_apps_executables.find(&:executable?)
+        end
+
+        sig { returns(T::Array[Pathname]) }
+        def windows_apps_executables
+          [
+            ENV.fetch("LOCALAPPDATA", nil)&.+("\\Microsoft\\WindowsApps\\winget.exe"),
+            ENV.fetch("USERPROFILE", nil)&.+("\\AppData\\Local\\Microsoft\\WindowsApps\\winget.exe"),
+            windows_local_appdata&.+("\\Microsoft\\WindowsApps\\winget.exe"),
+          ].compact.uniq.filter_map do |path|
+            windows_path_to_wsl_path(path) if path.exclude?("%")
+          end
+        end
+
+        sig { returns(T.nilable(String)) }
+        def windows_local_appdata
+          cmd = which("cmd.exe", ORIGINAL_PATHS) || Pathname.new("/mnt/c/Windows/System32/cmd.exe")
+          return unless cmd.executable?
+
+          `"#{cmd}" /d /c echo %LOCALAPPDATA% 2>/dev/null`.strip.presence
+        end
+
+        sig { params(path: String).returns(T.nilable(Pathname)) }
+        def windows_path_to_wsl_path(path)
+          path = path.tr("\\", "/")
+          return Pathname.new(path) if path.start_with?("/")
+
+          match = path.match(%r{\A([A-Za-z]):/(.+)\z})
+          return if match.nil?
+
+          drive = match[1]
+          relative_path = match[2]
+          return if drive.nil? || relative_path.nil?
+
+          Pathname.new("/mnt/#{drive.downcase}/#{relative_path}")
+        end
+
+        sig { override.void }
+        def reset!
+          @apps = T.let(nil, T.nilable(T::Array[App]))
+          @packages = T.let(nil, T.nilable(T::Array[App]))
+          @installed_app_records = T.let(nil, T.nilable(T::Array[[String, String]]))
+        end
+
+        sig { returns(T::Array[App]) }
+        def apps
+          apps = @apps
+          return apps if apps
+
+          @apps = if (winget = package_manager_executable)
+            SOURCES.flat_map do |source|
+              export_apps(winget, source:)
+            end
+          end
+          return [] if @apps.nil?
+
+          @apps
+        end
+
+        sig { params(winget: Pathname, source: String).returns(T::Array[App]) }
+        def export_apps(winget, source:)
+          names = listed_app_names(winget, source:)
+          exported_apps(winget, source:).map do |app|
+            App.new(id: app.id, name: names.fetch(app.id.downcase, app.name), source: app.source)
+          end
+        end
+
+        sig { params(winget: Pathname, source: String).returns(T::Array[App]) }
+        def exported_apps(winget, source:)
+          Tempfile.create(["brew-bundle-winget", ".json"]) do |file|
+            next [] unless Kernel.system(winget.to_s, "export", "--source", source, "--output",
+                                         windows_export_path(file.path), "--accept-source-agreements",
+                                         "--disable-interactivity", out: File::NULL, err: File::NULL)
+
+            parse_export(File.read(file.path), source:)
+          end
+        end
+
+        sig { params(winget: Pathname, source: String).returns(T::Hash[String, String]) }
+        def listed_app_names(winget, source:)
+          output = Utils.popen_read(winget, "list", "--source", source, "--accept-source-agreements",
+                                    "--disable-interactivity", "--nowarn", err: :close)
+
+          parse_list_names(output)
+        end
+
+        sig { params(output: String).returns(T::Hash[String, String]) }
+        def parse_list_names(output)
+          lines = output.encode("UTF-8", invalid: :replace, undef: :replace)
+                        .delete("\r")
+                        .lines
+                        .map(&:chomp)
+          header_index = lines.index { |line| line.match?(/\bName\s+Id\s+Version\b/) }
+          return {} if header_index.nil?
+
+          header = lines[header_index]
+          return {} if header.nil?
+
+          header_start = header.index("Name")
+          id_column = header.index("Id", header_start || 0)
+          version_column = header.index("Version", header_start || 0)
+          return {} if header_start.nil? || id_column.nil? || version_column.nil?
+
+          lines.drop(header_index + 1).each_with_object({}) do |line, names|
+            next if line.blank? || line[header_start..].to_s.match?(/\A-+\z/)
+
+            name = line[header_start...id_column].to_s.strip
+            id = line[id_column...version_column].to_s.strip
+            names[id.downcase] = name if name.present? && id.present?
+          end
+        end
+
+        sig { params(path: String).returns(String) }
+        def windows_export_path(path)
+          wslpath = which("wslpath", ORIGINAL_PATHS)
+          return path if wslpath.nil?
+
+          Utils.safe_popen_read(wslpath, "-w", path, err: :close).chomp.presence || path
+        rescue ErrorDuringExecution
+          path
+        end
+
+        sig { params(output: String, source: String).returns(T::Array[App]) }
+        def parse_export(output, source:)
+          export = JSON.parse(output)
+          return [] unless export.is_a?(Hash)
+
+          sources = export["Sources"]
+          return [] unless sources.is_a?(Array)
+
+          sources.flat_map do |source_export|
+            next [] unless source_export.is_a?(Hash)
+
+            packages = source_export["Packages"]
+            next [] unless packages.is_a?(Array)
+
+            packages.filter_map do |package|
+              next unless package.is_a?(Hash)
+
+              id = package["PackageIdentifier"]
+              next if !id.is_a?(String) || id.blank?
+
+              App.new(id:, name: id, source:)
+            end
+          end
+        rescue JSON::ParserError
+          []
+        end
+
+        sig { override.returns(T::Array[App]) }
+        def packages
+          packages = @packages
+          return packages if packages
+
+          @packages = apps.reject { |app| internal_package?(app) }
+                          .sort_by { |app| [SOURCES.index(app.source) || SOURCES.length, app.name.downcase] }
+        end
+
+        sig { override.returns(T::Array[App]) }
+        def installed_packages
+          apps
+        end
+
+        sig { params(app: App).returns(T::Boolean) }
+        def internal_package?(app)
+          INTERNAL_PACKAGE_PATTERNS.any? do |pattern|
+            pattern.match?(app.id) || pattern.match?(app.name)
+          end
+        end
+
+        sig { returns(T::Array[[String, String]]) }
+        def installed_app_records
+          installed_app_records = @installed_app_records
+          return installed_app_records if installed_app_records
+
+          @installed_app_records = apps.map { |app| [app.id, app.source] }
+        end
+
+        sig { override.params(package: Object).returns(String) }
+        def dump_name(package)
+          T.cast(package, App).name
+        end
+
+        sig { override.params(package: Object).returns(String) }
+        def dump_entry(package)
+          app = T.cast(package, App)
+          line = "winget #{quote(app.name)}"
+          line += ", id: #{quote(app.id)}" if app.id != app.name
+          return line if app.source == DEFAULT_SOURCE
+
+          "#{line}, source: #{quote(app.source)}"
+        end
+
+        sig { params(app: App).returns(String) }
+        def cleanup_item(app)
+          JSON.generate("id" => app.id, "name" => app.name, "source" => app.source)
+        end
+
+        sig { params(item: String).returns(String) }
+        def cleanup_item_name(item)
+          app = parse_cleanup_item(item)
+          return app.id if app.name == app.id && app.source == DEFAULT_SOURCE
+          return "#{app.id} (#{app.source})" if app.name == app.id
+
+          return "#{app.name} (#{app.id})" if app.source == DEFAULT_SOURCE
+
+          "#{app.name} (#{app.id}, #{app.source})"
+        end
+
+        sig { override.params(entries: T::Array[Dsl::Entry]).returns(T::Array[String]) }
+        def cleanup_items(entries)
+          kept_apps = entries.filter_map do |entry|
+            next if entry.type != type
+
+            [entry.options.fetch(:id, entry.name).to_s, entry.options.fetch(:source, DEFAULT_SOURCE).to_s]
+          end
+          return [].freeze if kept_apps.empty?
+
+          winget = package_manager_executable
+          return [].freeze if winget.nil?
+
+          cleanup_packages = SOURCES.flat_map { |source| exported_apps(winget, source:) }
+                                    .reject { |app| internal_package?(app) }
+                                    .sort_by do |app|
+                                      [SOURCES.index(app.source) || SOURCES.length, app.name.downcase]
+                                    end
+          packages_to_cleanup = cleanup_packages.reject do |app|
+            kept_apps.any? { |id, source| app.id.casecmp?(id) && app.source == source }
+          end
+          packages_to_cleanup.map { |app| cleanup_item(app) }
+        end
+
+        sig { override.params(items: T::Array[String]).void }
+        def cleanup!(items)
+          winget = package_manager_executable
+          return if winget.nil?
+
+          items.each do |item|
+            app = parse_cleanup_item(item)
+            Bundle.system(winget, "uninstall", "--id", app.id, "--exact", "--source", app.source,
+                          "--accept-source-agreements", "--disable-interactivity", verbose: false)
+          end
+          puts "Uninstalled #{items.size} WinGet package#{"s" if items.size != 1}"
+        end
+
+        sig { params(id: String, source: String).returns(T::Boolean) }
+        def app_installed?(id, source:)
+          installed_app_records.any? { |app_id, app_source| app_id.casecmp?(id) && app_source == source }
+        end
+
+        sig {
+          override.params(
+            name:       String,
+            id:         T.nilable(String),
+            with:       T.nilable(T::Array[String]),
+            no_upgrade: T::Boolean,
+            verbose:    T::Boolean,
+            source:     String,
+            options:    Homebrew::Bundle::EntryOption,
+          ).returns(T::Boolean)
+        }
+        def preinstall!(name, id: nil, with: nil, no_upgrade: false, verbose: false, source: DEFAULT_SOURCE,
+                        **options)
+          _ = with
+          _ = no_upgrade
+          _ = options
+
+          id ||= name
+
+          unless package_manager_installed?
+            raise "Unable to install #{name} WinGet package. winget.exe is not installed."
+          end
+
+          if app_installed?(id, source:)
+            puts "Skipping install of #{name} WinGet package. It is already installed." if verbose
+            return false
+          end
+
+          true
+        end
+
+        sig {
+          override.params(
+            name:       String,
+            id:         T.nilable(String),
+            with:       T.nilable(T::Array[String]),
+            preinstall: T::Boolean,
+            no_upgrade: T::Boolean,
+            verbose:    T::Boolean,
+            force:      T::Boolean,
+            source:     String,
+            options:    Homebrew::Bundle::EntryOption,
+          ).returns(T::Boolean)
+        }
+        def install!(name, id: nil, with: nil, preinstall: true, no_upgrade: false, verbose: false, force: false,
+                     source: DEFAULT_SOURCE, **options)
+          _ = with
+          _ = no_upgrade
+          _ = force
+          _ = options
+
+          return true unless preinstall
+
+          id ||= name
+          winget = package_manager_executable!
+          args = ["install", "--id", id, "--exact", "--source", source,
+                  "--accept-source-agreements", "--accept-package-agreements",
+                  "--disable-interactivity"]
+          success, output = run_install_command(winget, args, verbose:, elevated: false)
+          if !success && elevation_failure?(output)
+            puts "WinGet install for #{name} may require Windows UAC/elevation; retrying elevated."
+            success, elevated_output = run_install_command(winget, args, verbose:, elevated: true)
+            output = elevated_output.presence || output
+          end
+          unless success
+            report_install_failure(name, id:, source:, output:)
+            return false
+          end
+
+          unless apps.any? { |app| app.id.casecmp?(id) && app.source == source }
+            apps << App.new(id:, name:, source:)
+            @packages = nil
+          end
+          installed_app_records << [id, source] unless installed_app_records.any? do |app_id, app_source|
+            app_id.casecmp?(id) && app_source == source
+          end
+          true
+        end
+
+        sig {
+          params(
+            winget:   Pathname,
+            args:     T::Array[String],
+            verbose:  T::Boolean,
+            elevated: T::Boolean,
+          ).returns([T::Boolean, String])
+        }
+        def run_install_command(winget, args, verbose:, elevated:)
+          return run_elevated_install_command(winget, args, verbose:) if elevated
+
+          logs = T.let([], T::Array[String])
+          success = T.let(false, T::Boolean)
+          IO.popen([winget.to_s, *args], err: [:child, :out]) do |pipe|
+            while (line = pipe.gets)
+              print line if verbose
+              logs << line
+            end
+            Process.wait(pipe.pid)
+            success = $CHILD_STATUS.success?
+            pipe.close
+          end
+          [success, logs.join]
+        end
+
+        sig { params(winget: Pathname, args: T::Array[String], verbose: T::Boolean).returns([T::Boolean, String]) }
+        def run_elevated_install_command(winget, args, verbose:)
+          powershell = which("powershell.exe", ORIGINAL_PATHS) ||
+                       Pathname.new("/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe")
+          return [false, "powershell.exe is not available.\n"] unless powershell.executable?
+
+          winget_path = winget.to_s.include?("/") ? windows_export_path(winget.to_s) : winget.to_s
+          argument_list = args.map { |arg| powershell_quote(arg) }.join(", ")
+          script = <<~POWERSHELL
+            $startProcessArgs = @{
+              FilePath = #{powershell_quote(winget_path)}
+              ArgumentList = @(#{argument_list})
+              Verb = 'RunAs'
+              Wait = $true
+              PassThru = $true
+            }
+            $process = Start-Process @startProcessArgs
+            $process.WaitForExit()
+            exit $process.ExitCode
+          POWERSHELL
+
+          [Bundle.system(powershell, "-NoProfile", "-Command", script, verbose:), ""]
+        end
+
+        sig { params(value: String).returns(String) }
+        def powershell_quote(value)
+          "'#{value.gsub("'", "''")}'"
+        end
+
+        sig { params(output: String).returns(T::Boolean) }
+        def elevation_failure?(output)
+          ELEVATED_INSTALL_FAILURE_PATTERNS.any? { |pattern| output.match?(pattern) }
+        end
+
+        sig { params(output: String).returns(T::Boolean) }
+        def installer_ui_failure?(output)
+          INSTALLER_UI_FAILURE_PATTERNS.any? { |pattern| output.match?(pattern) }
+        end
+
+        sig { params(name: String, id: String, source: String, output: String).void }
+        def report_install_failure(name, id:, source:, output:)
+          puts "WinGet failed to install #{name} (#{id}) from #{source}."
+          if elevation_failure?(output)
+            puts "The installer may require Windows UAC/elevation."
+            puts "Try installing it from an elevated Windows Terminal:"
+            puts "  winget install --id #{id} --exact --source #{source} --disable-interactivity"
+          elsif installer_ui_failure?(output)
+            puts "The installer appears to require installer UI or user input, which brew bundle does not automate."
+            puts "Install it manually from Windows:"
+            puts "  winget install --id #{id} --exact --source #{source}"
+          else
+            puts "Try installing it manually from Windows:"
+            puts "  winget install --id #{id} --exact --source #{source}"
+          end
+        end
+
+        sig { params(item: String).returns(App) }
+        def parse_cleanup_item(item)
+          parsed = JSON.parse(item)
+          raise TypeError, "Invalid WinGet cleanup item: #{item}" unless parsed.is_a?(Hash)
+
+          id = parsed["id"]
+          name = parsed["name"]
+          source = parsed["source"]
+          if !id.is_a?(String) || !name.is_a?(String) || !source.is_a?(String)
+            raise TypeError, "Invalid WinGet cleanup item: #{item}"
+          end
+
+          App.new(id:, name:, source:)
+        end
+      end
+
+      sig { override.params(entries: T::Array[Object]).returns(T::Array[Object]) }
+      def format_checkable(entries)
+        checkable_entries(entries).map do |entry|
+          entry = T.cast(entry, Dsl::Entry)
+          App.new(id: T.cast(entry.options.fetch(:id), String), name: entry.name,
+                  source: T.cast(entry.options.fetch(:source), String))
+        end
+      end
+
+      sig { override.params(package: Object, no_upgrade: T::Boolean).returns(T::Boolean) }
+      def installed_and_up_to_date?(package, no_upgrade: false)
+        _ = no_upgrade
+
+        app = T.cast(package, App)
+        self.class.app_installed?(app.id, source: app.source)
+      end
+    end
+  end
+end

--- a/Library/Homebrew/bundle/skipper.rb
+++ b/Library/Homebrew/bundle/skipper.rb
@@ -41,7 +41,7 @@ module Homebrew
           return @skipped_entries if @skipped_entries
 
           @skipped_entries ||= T.let({}, T.nilable(T::Hash[Symbol, T.nilable(T::Array[String])]))
-          [:brew, :cask, :mas, :tap, :flatpak].each do |type|
+          [:brew, :cask, :mas, :tap, :flatpak, :winget].each do |type|
             @skipped_entries[type] =
               ENV["HOMEBREW_BUNDLE_#{type.to_s.upcase}_SKIP"]&.split
           end

--- a/Library/Homebrew/extend/os/linux/bundle/skipper.rb
+++ b/Library/Homebrew/extend/os/linux/bundle/skipper.rb
@@ -27,8 +27,18 @@ module OS
             true
           end
 
+          sig { params(entry: Homebrew::Bundle::Dsl::Entry).returns(T::Boolean) }
+          def requires_wsl?(entry)
+            entry.type == :winget && !OS.wsl?
+          end
+
           sig { params(entry: Homebrew::Bundle::Dsl::Entry, silent: T::Boolean).returns(T::Boolean) }
           def skip?(entry, silent: false)
+            if requires_wsl?(entry)
+              $stdout.puts Formatter.warning("Skipping #{entry.type} #{entry.name} (requires WSL)") unless silent
+              return true
+            end
+
             return super unless requires_macos?(entry)
 
             $stdout.puts Formatter.warning("Skipping #{entry.type} #{entry.name} (requires macOS)") unless silent

--- a/Library/Homebrew/extend/os/mac/bundle/skipper.rb
+++ b/Library/Homebrew/extend/os/mac/bundle/skipper.rb
@@ -13,7 +13,10 @@ module OS
 
           sig { params(entry: Homebrew::Bundle::Dsl::Entry, silent: T::Boolean).returns(T::Boolean) }
           def skip?(entry, silent: false)
-            if linux_only_entry?(entry)
+            if entry.type == :winget
+              Kernel.puts Formatter.warning "Skipping #{entry.type} #{entry.name} (requires WSL)" unless silent
+              true
+            elsif linux_only_entry?(entry)
               unless silent
                 Kernel.puts Formatter.warning "Skipping #{entry.type} #{entry.name} (unsupported on macOS)"
               end

--- a/Library/Homebrew/test/bundle/dsl_spec.rb
+++ b/Library/Homebrew/test/bundle/dsl_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Homebrew::Bundle::Dsl do
         cask 'firefox', args: { appdir: '~/my-apps/Applications' }
         mas '1Password', id: 443987910
         vscode 'GitHub.codespaces'
+        winget 'PowerToys', id: 'XP89DCGQ3K6VLD', source: 'msstore'
         go 'github.com/charmbracelet/crush'
         cargo 'ripgrep'
         uv 'mkdocs', with: ['mkdocs-material<10']
@@ -58,10 +59,12 @@ RSpec.describe Homebrew::Bundle::Dsl do
       expect(dsl.entries[9].name).to eql("1Password")
       expect(dsl.entries[9].options).to eql(id: 443_987_910)
       expect(dsl.entries[10].name).to eql("GitHub.codespaces")
-      expect(dsl.entries[11].name).to eql("github.com/charmbracelet/crush")
-      expect(dsl.entries[12].name).to eql("ripgrep")
-      expect(dsl.entries[13].name).to eql("mkdocs")
-      expect(dsl.entries[13].options).to eql(with: ["mkdocs-material<10"])
+      expect(dsl.entries[11].name).to eql("PowerToys")
+      expect(dsl.entries[11].options).to eql(id: "XP89DCGQ3K6VLD", source: "msstore")
+      expect(dsl.entries[12].name).to eql("github.com/charmbracelet/crush")
+      expect(dsl.entries[13].name).to eql("ripgrep")
+      expect(dsl.entries[14].name).to eql("mkdocs")
+      expect(dsl.entries[14].options).to eql(with: ["mkdocs-material<10"])
     end
   end
 
@@ -148,6 +151,21 @@ RSpec.describe Homebrew::Bundle::Dsl do
       expect do
         dsl_from_string 'uv "mkdocs", with: false'
       end.to raise_error(RuntimeError, /options\[:with\].*Array of String objects/)
+    end
+
+    it "errors on invalid winget options" do
+      expect do
+        dsl_from_string 'winget "PowerToys", id: 123'
+      end.to raise_error(RuntimeError, /options\[:id\].*String object/)
+      expect do
+        dsl_from_string 'winget "PowerToys", source: "chocolatey"'
+      end.to raise_error(RuntimeError, /options\[:source\].*one of/)
+      expect do
+        dsl_from_string 'winget "PowerToys", interactive: true'
+      end.to raise_error(RuntimeError, /unknown options\(\[:interactive\]\) for winget/)
+      expect do
+        dsl_from_string 'winget "PowerToys", elevated: true'
+      end.to raise_error(RuntimeError, /unknown options\(\[:elevated\]\) for winget/)
     end
   end
 

--- a/Library/Homebrew/test/bundle/dumper_spec.rb
+++ b/Library/Homebrew/test/bundle/dumper_spec.rb
@@ -16,11 +16,13 @@ RSpec.describe Homebrew::Bundle::Dumper do
 
     allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(true)
     allow(Homebrew::Bundle::MacAppStore).to receive(:package_manager_executable).and_return(nil)
+    allow(Homebrew::Bundle::Winget).to receive(:package_manager_executable).and_return(nil)
     allow(Homebrew::Bundle::VscodeExtension).to receive(:package_manager_executable).and_return(nil)
     Homebrew::Bundle::Brew.reset!
     Homebrew::Bundle::Tap.reset!
     Homebrew::Bundle::Cask.reset!
     Homebrew::Bundle::MacAppStore.reset!
+    Homebrew::Bundle::Winget.reset!
     Homebrew::Bundle::VscodeExtension.reset!
     Homebrew::Bundle::Go.reset!
     Homebrew::Bundle::Cargo.reset!
@@ -59,6 +61,8 @@ RSpec.describe Homebrew::Bundle::Dumper do
   end
 
   it "preserves the legacy extension dump order" do
+    allow(Homebrew::Bundle::Winget).to receive(:dump)
+      .and_return('winget "PowerToys", id: "XP89DCGQ3K6VLD", source: "msstore"')
     allow(Homebrew::Bundle::Go).to receive(:dump).and_return('go "github.com/charmbracelet/crush"')
     allow(Homebrew::Bundle::Cargo).to receive(:dump).and_return('cargo "ripgrep"')
     allow(Homebrew::Bundle::Uv).to receive(:dump).and_return('uv "mkdocs"')
@@ -66,12 +70,14 @@ RSpec.describe Homebrew::Bundle::Dumper do
 
     expect(dumper.build_brewfile(
              describe: false, no_restart: false, formulae: false, taps: false, casks: false,
-             extension_types: { mas: false, vscode: false, cargo: true, flatpak: true, go: true, uv: true }
+             extension_types: { mas: false, winget: true, vscode: false, cargo: true, flatpak: true, go: true,
+                                uv: true }
            )).to eql(<<~BREWFILE)
              go "github.com/charmbracelet/crush"
              cargo "ripgrep"
              uv "mkdocs"
              flatpak "org.gnome.Calculator"
+             winget "PowerToys", id: "XP89DCGQ3K6VLD", source: "msstore"
            BREWFILE
   end
 end

--- a/Library/Homebrew/test/bundle/skipper_spec.rb
+++ b/Library/Homebrew/test/bundle/skipper_spec.rb
@@ -64,10 +64,42 @@ RSpec.describe Homebrew::Bundle::Skipper do
       end
     end
 
+    context "with a WinGet entry", :needs_macos do
+      let(:entry) { Homebrew::Bundle::Dsl::Entry.new(:winget, "Valve.Steam") }
+
+      it "skips on macOS with warning" do
+        expect($stdout).to receive(:puts).with(
+          Formatter.warning("Skipping winget Valve.Steam (requires WSL)"),
+        )
+        expect(skipper.skip?(entry)).to be true
+      end
+    end
+
     context "with a flatpak entry on Linux", :needs_linux do
       let(:entry) { Homebrew::Bundle::Dsl::Entry.new(:flatpak, "org.gnome.Calculator") }
 
       it "does not skip" do
+        expect(skipper.skip?(entry)).to be false
+      end
+    end
+
+    context "with a WinGet entry on Linux outside WSL", :needs_linux do
+      let(:entry) { Homebrew::Bundle::Dsl::Entry.new(:winget, "App Installer") }
+
+      it "skips with warning" do
+        allow(OS).to receive(:wsl?).and_return(false)
+        expect($stdout).to receive(:puts).with(
+          Formatter.warning("Skipping winget App Installer (requires WSL)"),
+        )
+        expect(skipper.skip?(entry)).to be true
+      end
+    end
+
+    context "with a WinGet entry on WSL", :needs_linux do
+      let(:entry) { Homebrew::Bundle::Dsl::Entry.new(:winget, "App Installer") }
+
+      it "does not skip" do
+        allow(OS).to receive(:wsl?).and_return(true)
         expect(skipper.skip?(entry)).to be false
       end
     end

--- a/Library/Homebrew/test/bundle/winget_spec.rb
+++ b/Library/Homebrew/test/bundle/winget_spec.rb
@@ -1,0 +1,378 @@
+# typed: false
+# frozen_string_literal: true
+
+require "bundle"
+require "bundle/dsl"
+require "bundle/extensions/winget"
+require "bundle/skipper"
+
+RSpec.describe Homebrew::Bundle::Winget do
+  let(:klass) { Homebrew::Bundle::Winget }
+
+  describe "checking" do
+    let(:entry) do
+      Homebrew::Bundle::Dsl::Entry.new(:winget, "PowerToys", id: "XP89DCGQ3K6VLD", source: "msstore")
+    end
+
+    before do
+      allow(OS).to receive(:wsl?).and_return(true)
+      allow(Homebrew::Bundle::Skipper).to receive(:skip?).with(entry).and_return(false)
+    end
+
+    it "checks app installation by source and ID" do
+      allow(klass).to receive(:installed_app_records).and_return([["XP89DCGQ3K6VLD", "msstore"]])
+      expect(klass.check([entry])).to be_empty
+    end
+
+    it "returns app names in failure messages" do
+      allow(klass).to receive(:installed_app_records).and_return([])
+      expect(klass.check([entry])).to eql(["WinGet Package PowerToys needs to be installed."])
+    end
+  end
+
+  describe "dumping" do
+    subject(:dumper) { klass }
+
+    context "when winget is not available" do
+      before do
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(nil)
+      end
+
+      it "returns an empty list and dumps an empty string" do
+        expect(dumper.apps).to be_empty
+        expect(dumper.dump).to eql("")
+      end
+    end
+
+    context "when winget is available" do
+      let(:winget_export) do
+        <<~EOS
+          {
+            "Sources": [
+              {
+                "Packages": [
+                  { "PackageIdentifier": "Microsoft.EdgeWebView2Runtime" },
+                  { "PackageIdentifier": "Microsoft.OneDrive" },
+                  { "PackageIdentifier": "Microsoft.WSL" },
+                  { "PackageIdentifier": "Valve.Steam" }
+                ],
+                "SourceDetails": { "Name": "winget" }
+              }
+            ]
+          }
+        EOS
+      end
+
+      let(:msstore_export) do
+        <<~EOS
+          {
+            "Sources": [
+              {
+                "Packages": [
+                  { "PackageIdentifier": "9NBLGGH4NNS1" },
+                  { "PackageIdentifier": "XP89DCGQ3K6VLD" },
+                  { "PackageIdentifier": "Microsoft.UI.Xaml.2.8" },
+                  { "PackageIdentifier": "9N0DX20HK701" }
+                ],
+                "SourceDetails": { "Name": "msstore" }
+              }
+            ]
+          }
+        EOS
+      end
+
+      before do
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("winget.exe"))
+        allow(klass).to receive(:export_apps).with(Pathname.new("winget.exe"), source: "winget").and_return(
+          [
+            klass::App.new(id: "Microsoft.EdgeWebView2Runtime", name: "Microsoft Edge WebView2 Runtime",
+                           source: "winget"),
+            klass::App.new(id: "Microsoft.OneDrive", name: "Microsoft OneDrive", source: "winget"),
+            klass::App.new(id: "Microsoft.WSL", name: "Windows Subsystem for Linux", source: "winget"),
+            klass::App.new(id: "Valve.Steam", name: "Steam", source: "winget"),
+          ],
+        )
+        allow(klass).to receive(:export_apps).with(Pathname.new("winget.exe"), source: "msstore").and_return(
+          [
+            klass::App.new(id: "9NBLGGH4NNS1", name: "App Installer", source: "msstore"),
+            klass::App.new(id: "XP89DCGQ3K6VLD", name: "PowerToys", source: "msstore"),
+            klass::App.new(id: "Microsoft.UI.Xaml.2.8", name: "Microsoft.UI.Xaml.2.8", source: "msstore"),
+            klass::App.new(id: "9N0DX20HK701", name: "Windows Terminal", source: "msstore"),
+          ],
+        )
+      end
+
+      it "returns app details and dumps Brewfile entries" do
+        expect(dumper.apps.map { |app| [app.id, app.name, app.source] }).to eql([
+          ["Microsoft.EdgeWebView2Runtime", "Microsoft Edge WebView2 Runtime", "winget"],
+          ["Microsoft.OneDrive", "Microsoft OneDrive", "winget"],
+          ["Microsoft.WSL", "Windows Subsystem for Linux", "winget"],
+          ["Valve.Steam", "Steam", "winget"],
+          ["9NBLGGH4NNS1", "App Installer", "msstore"],
+          ["XP89DCGQ3K6VLD", "PowerToys", "msstore"],
+          ["Microsoft.UI.Xaml.2.8", "Microsoft.UI.Xaml.2.8", "msstore"],
+          ["9N0DX20HK701", "Windows Terminal", "msstore"],
+        ])
+
+        expect(dumper.dump).to eql(<<~BREWFILE.strip)
+          winget "Steam", id: "Valve.Steam"
+          winget "PowerToys", id: "XP89DCGQ3K6VLD", source: "msstore"
+          winget "Windows Terminal", id: "9N0DX20HK701", source: "msstore"
+        BREWFILE
+      end
+
+      it "resolves exported IDs through their source before dumping" do
+        winget = Pathname.new("winget.exe")
+        allow(klass).to receive(:export_apps).and_call_original
+        allow(klass).to receive(:exported_apps).with(winget, source: "winget").and_return([
+          klass::App.new(id: "Valve.Steam", name: "Valve.Steam", source: "winget"),
+          klass::App.new(id: "Unknown.Package", name: "Unknown.Package", source: "winget"),
+        ])
+        allow(Utils).to receive(:popen_read)
+          .with(winget, "list", "--source", "winget", "--accept-source-agreements", "--disable-interactivity",
+                "--nowarn", err: :close)
+          .and_return(<<~EOS)
+            Name                                       Id                                          Version
+            -----------------------------------------------------------------------------------------------
+            Steam                                      Valve.Steam                                 2.10.91.91
+          EOS
+
+        expect(klass.export_apps(winget, source: "winget").map { |app| [app.id, app.name] })
+          .to eql([["Valve.Steam", "Steam"], ["Unknown.Package", "Unknown.Package"]])
+      end
+
+      it "parses human-readable names from winget list output" do
+        output = <<~EOS
+          \r   - \r
+          Name       Id                Version
+          ------------------------------------
+          Steam      Valve.Steam       2.10.91.91
+          Discord    XPDC2RH70K22MN    1.0.9188
+        EOS
+
+        expect(klass.parse_list_names(output)).to eql(
+          "valve.steam"    => "Steam",
+          "xpdc2rh70k22mn" => "Discord",
+        )
+      end
+
+      it "parses indented winget list output" do
+        output = "    Name       Id                Version\n    " \
+                 "------------------------------------\n    " \
+                 "Long Name  Example.App       1.0\n"
+
+        expect(klass.parse_list_names(output)).to eql(
+          "example.app" => "Long Name",
+        )
+      end
+    end
+
+    context "when winget is not in PATH" do
+      it "finds winget in the default Windows app location" do
+        allow(OS).to receive(:wsl?).and_return(true)
+        allow(klass).to receive(:which).with("winget.exe", ORIGINAL_PATHS).and_return(nil)
+        winget = Pathname.new("/mnt/c/Users/BrewTest/AppData/Local/Microsoft/WindowsApps/winget.exe")
+        expect(winget).to receive(:executable?).and_return(true)
+        allow(klass).to receive(:windows_apps_executables).and_return([winget])
+
+        expect(klass.package_manager_executable)
+          .to eq(Pathname.new("/mnt/c/Users/BrewTest/AppData/Local/Microsoft/WindowsApps/winget.exe"))
+      end
+
+      it "converts default Windows app paths to WSL paths" do
+        allow(klass).to receive(:windows_local_appdata).and_return(nil)
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("LOCALAPPDATA", nil).and_return("C:\\Users\\BrewTest\\AppData\\Local")
+        allow(ENV).to receive(:fetch).with("USERPROFILE", nil).and_return(nil)
+
+        expect(klass.windows_apps_executables)
+          .to eq([Pathname.new("/mnt/c/Users/BrewTest/AppData/Local/Microsoft/WindowsApps/winget.exe")])
+      end
+    end
+  end
+
+  describe "installing" do
+    before do
+      klass.reset!
+      allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("winget.exe"))
+    end
+
+    context "when app is installed" do
+      before do
+        allow(klass).to receive(:installed_app_records).and_return([["XP89DCGQ3K6VLD", "msstore"]])
+      end
+
+      it "skips" do
+        expect(Homebrew::Bundle).not_to receive(:system)
+        expect(klass.preinstall!("PowerToys", id: "XP89DCGQ3K6VLD", source: "msstore")).to be(false)
+      end
+    end
+
+    context "when app is not installed" do
+      before do
+        allow(klass).to receive(:installed_app_records).and_return([])
+      end
+
+      it "installs app using its source and ID" do
+        expect(klass).to receive(:run_install_command)
+          .with(Pathname("winget.exe"),
+                ["install", "--id", "XP89DCGQ3K6VLD", "--exact", "--source", "msstore",
+                 "--accept-source-agreements", "--accept-package-agreements", "--disable-interactivity"],
+                verbose: false, elevated: false)
+          .and_return([true, ""])
+
+        expect(klass.preinstall!("PowerToys", id: "XP89DCGQ3K6VLD", source: "msstore")).to be(true)
+        expect(klass.install!("PowerToys", id: "XP89DCGQ3K6VLD", source: "msstore")).to be(true)
+      end
+
+      it "keeps the package dump cache filtered and sorted after installation" do
+        allow(klass).to receive(:export_apps).with(Pathname("winget.exe"), source: "winget").and_return([
+          klass::App.new(id: "Valve.Steam", name: "Steam", source: "winget"),
+        ])
+        allow(klass).to receive(:export_apps).with(Pathname("winget.exe"), source: "msstore").and_return([])
+
+        expect(klass.packages.map(&:name)).to eql(["Steam"])
+
+        expect(klass).to receive(:run_install_command)
+          .with(Pathname("winget.exe"),
+                ["install", "--id", "7zip.7zip", "--exact", "--source", "winget",
+                 "--accept-source-agreements", "--accept-package-agreements", "--disable-interactivity"],
+                verbose: false, elevated: false)
+          .and_return([true, ""])
+        expect(klass.install!("7-Zip", id: "7zip.7zip")).to be(true)
+
+        expect(klass).to receive(:run_install_command)
+          .with(Pathname("winget.exe"),
+                ["install", "--id", "Microsoft.VCLibs.140.00.UWPDesktop", "--exact", "--source", "msstore",
+                 "--accept-source-agreements", "--accept-package-agreements", "--disable-interactivity"],
+                verbose: false, elevated: false)
+          .and_return([true, ""])
+        expect(klass.install!("Microsoft VCLibs", id: "Microsoft.VCLibs.140.00.UWPDesktop", source: "msstore"))
+          .to be(true)
+
+        expect(klass.packages.map { |app| [app.name, app.id, app.source] }).to eql([
+          ["7-Zip", "7zip.7zip", "winget"],
+          ["Steam", "Valve.Steam", "winget"],
+        ])
+      end
+
+      it "retries elevated when winget reports an elevation-like installer failure" do
+        expect(klass).to receive(:run_install_command)
+          .with(Pathname("winget.exe"),
+                ["install", "--id", "Philips.HueSync", "--exact", "--source", "winget",
+                 "--accept-source-agreements", "--accept-package-agreements", "--disable-interactivity"],
+                verbose: false, elevated: false)
+          .and_return([false, "Installer failed with exit code: 1603\n"])
+        expect(klass).to receive(:run_install_command)
+          .with(Pathname("winget.exe"),
+                ["install", "--id", "Philips.HueSync", "--exact", "--source", "winget",
+                 "--accept-source-agreements", "--accept-package-agreements", "--disable-interactivity"],
+                verbose: false, elevated: true)
+          .and_return([true, ""])
+
+        expect do
+          expect(klass.install!("Hue Sync", id: "Philips.HueSync")).to be(true)
+        end.to output("WinGet install for Hue Sync may require Windows UAC/elevation; retrying elevated.\n")
+          .to_stdout
+      end
+
+      it "suggests an elevated Windows install when the elevated retry fails" do
+        expect(klass).to receive(:run_install_command)
+          .with(Pathname("winget.exe"),
+                ["install", "--id", "Philips.HueSync", "--exact", "--source", "winget",
+                 "--accept-source-agreements", "--accept-package-agreements", "--disable-interactivity"],
+                verbose: false, elevated: false)
+          .and_return([false, "Installer failed with exit code: 1603\n"])
+        expect(klass).to receive(:run_install_command)
+          .with(Pathname("winget.exe"),
+                ["install", "--id", "Philips.HueSync", "--exact", "--source", "winget",
+                 "--accept-source-agreements", "--accept-package-agreements", "--disable-interactivity"],
+                verbose: false, elevated: true)
+          .and_return([false, ""])
+
+        expect do
+          expect(klass.install!("Hue Sync", id: "Philips.HueSync")).to be(false)
+        end.to output(<<~EOS).to_stdout
+          WinGet install for Hue Sync may require Windows UAC/elevation; retrying elevated.
+          WinGet failed to install Hue Sync (Philips.HueSync) from winget.
+          The installer may require Windows UAC/elevation.
+          Try installing it from an elevated Windows Terminal:
+            winget install --id Philips.HueSync --exact --source winget --disable-interactivity
+        EOS
+      end
+
+      it "suggests manual installation for installers that need UI" do
+        expect(klass).to receive(:run_install_command)
+          .with(Pathname("winget.exe"),
+                ["install", "--id", "Philips.HueSync", "--exact", "--source", "winget",
+                 "--accept-source-agreements", "--accept-package-agreements", "--disable-interactivity"],
+                verbose: false, elevated: false)
+          .and_return([false, "Installer requires interactive user input\n"])
+
+        expect do
+          expect(klass.install!("Hue Sync", id: "Philips.HueSync")).to be(false)
+        end.to output(<<~EOS).to_stdout
+          WinGet failed to install Hue Sync (Philips.HueSync) from winget.
+          The installer appears to require installer UI or user input, which brew bundle does not automate.
+          Install it manually from Windows:
+            winget install --id Philips.HueSync --exact --source winget
+        EOS
+      end
+    end
+
+    context "when winget is not available" do
+      before do
+        allow(klass).to receive(:package_manager_executable).and_return(nil)
+      end
+
+      it "raises an error" do
+        expect do
+          klass.preinstall!("PowerToys", id: "XP89DCGQ3K6VLD", source: "msstore")
+        end.to raise_error(RuntimeError, /winget.exe is not installed/)
+      end
+    end
+  end
+
+  describe "cleanup" do
+    before do
+      klass.reset!
+      allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("winget.exe"))
+      allow(klass).to receive(:exported_apps).with(Pathname("winget.exe"), source: "winget").and_return([
+        klass::App.new(id: "Valve.Steam", name: "Steam", source: "winget"),
+      ])
+      allow(klass).to receive(:exported_apps).with(Pathname("winget.exe"), source: "msstore").and_return([
+        klass::App.new(id: "XPDC2RH70K22MN", name: "Discord", source: "msstore"),
+      ])
+    end
+
+    it "returns packages not in Brewfile entries by source and ID" do
+      entries = [Homebrew::Bundle::Dsl::Entry.new(:winget, "Steam", id: "Valve.Steam", source: "winget")]
+      items = klass.cleanup_items(entries)
+
+      expect(items.map { |item| klass.cleanup_item_name(item) }).to eql(["Discord (XPDC2RH70K22MN, msstore)"])
+    end
+
+    it "uses the default source when computing kept packages" do
+      entries = [Homebrew::Bundle::Dsl::Entry.new(:winget, "Valve.Steam", id: "Valve.Steam", source: "winget")]
+      expect(klass.cleanup_items(entries).map { |item| klass.cleanup_item_name(item) })
+        .to eql(["Discord (XPDC2RH70K22MN, msstore)"])
+    end
+
+    it "does not resolve app names during cleanup discovery" do
+      expect(klass).not_to receive(:listed_app_names)
+      klass.cleanup_items([Homebrew::Bundle::Dsl::Entry.new(:winget, "Steam", id: "Valve.Steam")])
+    end
+
+    it "uninstalls packages by exact ID and source" do
+      items = klass.cleanup_items([Homebrew::Bundle::Dsl::Entry.new(:winget, "Steam", id: "Valve.Steam")])
+      expect(Homebrew::Bundle).to receive(:system)
+        .with(Pathname("winget.exe"), "uninstall", "--id", "XPDC2RH70K22MN", "--exact", "--source", "msstore",
+              "--accept-source-agreements", "--disable-interactivity", verbose: false)
+        .and_return(true)
+
+      expect { klass.cleanup!(items) }.to output(/Uninstalled 1 WinGet package/).to_stdout
+    end
+  end
+end

--- a/Library/Homebrew/test/support/helper/subcommand.rb
+++ b/Library/Homebrew/test/support/helper/subcommand.rb
@@ -32,6 +32,7 @@ module Test
           :no_upgrade?,
           :no_uv?,
           :no_vscode?,
+          :no_winget?,
           :npm?,
           :quiet?,
           :services?,
@@ -40,6 +41,7 @@ module Test
           :uv?,
           :verbose?,
           :vscode?,
+          :winget?,
           :zap?,
         ].freeze
 

--- a/docs/Brew-Bundle-and-Brewfile.md
+++ b/docs/Brew-Bundle-and-Brewfile.md
@@ -58,7 +58,7 @@ If this fails without `--verbose`, run `brew bundle check --verbose` to list unm
 
 ### Types
 
-As well as supporting formulae (`brew "..."`), you can also use `brew bundle` with casks, taps, Mac App Store apps, VSCode extensions, Go packages, Cargo packages, uv tools, Flatpak packages and krew kubectl plugins and to start background services with `brew services`.
+As well as supporting formulae (`brew "..."`), you can also use `brew bundle` with casks, taps, Mac App Store apps, WinGet packages on WSL, VSCode extensions, Go packages, Cargo packages, uv tools, Flatpak packages and krew kubectl plugins and to start background services with `brew services`.
 
 ```ruby
 tap "apple/apple"
@@ -66,6 +66,8 @@ brew "apple/apple/game-porting-toolkit"
 brew "postgresql@16", restart_service: true
 cask "firefox"
 mas "Refined GitHub", id: 1519867270
+winget "Steam", id: "Valve.Steam"
+winget "PowerToys", id: "XP89DCGQ3K6VLD", source: "msstore"
 vscode "editorconfig.editorconfig"
 go "github.com/charmbracelet/crush"
 cargo "ripgrep"
@@ -75,6 +77,8 @@ flatpak "com.visualstudio.code"
 flatpak "org.godotengine.Godot", remote: "flathub-beta", url: "https://dl.flathub.org/beta-repo/"
 flatpak "io.github.dvlv.boxbuddyrs", remote: "flathub-beta"
 ```
+
+WinGet installs run with installer interactivity disabled. If WinGet reports that elevation is required, `brew bundle` retries through Windows UAC.
 
 Run `brew bundle` again and this outputs:
 
@@ -348,7 +352,7 @@ For the tradeoffs and alternatives, see [Locking installed formulae at specific 
 
 ## Adding New Packages Support
 
-`brew bundle` currently supports Homebrew, Homebrew Cask, Mac App Store, Visual Studio Code (and forks/variants), Go packages, Cargo packages, uv tools, Flatpak packages and krew kubectl plugins.
+`brew bundle` currently supports Homebrew, Homebrew Cask, Mac App Store, WinGet packages on WSL, Visual Studio Code (and forks/variants), Go packages, Cargo packages, uv tools, Flatpak packages and krew kubectl plugins.
 
 We are interested in contributions for other packages' installers/checkers/dumpers but they must:
 


### PR DESCRIPTION
- make Windows package state manageable from WSL
- use `winget` and `msstore` sources with stable IDs
- keep installer UI disabled while allowing UAC retry
- dump non-internal packages with readable names

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
