### PR TITLE
config: show Windows build on WSL

### DIFF
--- a/Library/Homebrew/extend/os/linux/system_config.rb
+++ b/Library/Homebrew/extend/os/linux/system_config.rb
@@ -55,13 +55,65 @@ module OS
           out
         end
 
+        sig { returns(T.nilable(String)) }
+        def windows_version
+          return unless OS.wsl?
+
+          cmd = Kernel.which("cmd.exe", ORIGINAL_PATHS) || ::Pathname.new("/mnt/c/Windows/System32/cmd.exe")
+          return unless cmd.executable?
+
+          windows_registry_version(cmd) || Utils.popen_read(cmd, "/d", "/c", "ver", err: :close)
+                                                .delete("\r")
+                                                .lines
+                                                .map(&:strip)
+                                                .find { |line| line.start_with?("Microsoft Windows") }
+        end
+
+        sig { params(cmd: ::Pathname).returns(T.nilable(String)) }
+        def windows_registry_version(cmd)
+          values = windows_registry_values(cmd)
+          product_name = values["ProductName"]
+          build = values["CurrentBuildNumber"]
+          return if product_name.blank? || build.blank?
+
+          product_name = product_name.sub(/\AWindows 10\b/, "Windows 11") if build.to_i >= 22_000
+          build += ".#{values["UBR"]}" if values["UBR"].present?
+
+          version = values["DisplayVersion"] || values["ReleaseId"]
+          return "#{product_name} [#{build}]" if version.blank?
+
+          "#{product_name} (#{version}) [#{build}]"
+        end
+
+        sig { params(cmd: ::Pathname).returns(T::Hash[String, String]) }
+        def windows_registry_values(cmd)
+          output = Utils.popen_read(cmd, "/d", "/c", "reg", "query",
+                                    "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+                                    err: :close)
+
+          output.each_line.with_object({}) do |line, values|
+            match = line.delete("\r").match(/^\s*(\S+)\s+REG_\S+\s+(.+?)\s*$/)
+            next if match.nil?
+
+            key = match[1]
+            value = match[2]
+            next if key.nil? || value.nil?
+
+            values[key] = value.start_with?("0x") ? value.to_i(16).to_s : value
+          end
+        end
+
         sig { params(out: T.any(File, StringIO, IO)).void }
         def dump_verbose_config(out = $stdout)
           kernel = Utils.safe_popen_read("uname", "-mors").chomp
           super
           out.puts "Kernel: #{kernel}"
           out.puts "OS: #{OS::Linux.os_version}"
-          out.puts "WSL: #{OS::Linux.wsl_version}" if OS.wsl?
+          if OS.wsl?
+            out.puts "WSL: #{OS::Linux.wsl_version}"
+            windows = windows_version
+            out.puts "Windows: #{windows}" if windows
+          end
           out.puts "Host glibc: #{host_glibc_version}"
           out.puts "Host libstdc++: #{host_libstdcxx_version}"
           out.puts "#{::DevelopmentTools.host_gcc_path}: #{host_gcc_version}"

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -90,6 +90,9 @@ module SystemConfig
       `uname -m`.chomp
     end
 
+    sig { returns(T.nilable(String)) }
+    def windows_version; end
+
     sig { returns(String) }
     def describe_git
       return "N/A" unless Utils::Git.available?

--- a/Library/Homebrew/test/cmd/config_spec.rb
+++ b/Library/Homebrew/test/cmd/config_spec.rb
@@ -5,6 +5,13 @@ require "cmd/config"
 require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::Config do
+  let(:windows_cmd) do
+    cmd = mktmpdir/"cmd.exe"
+    cmd.write("")
+    cmd.chmod(0755)
+    cmd
+  end
+
   it_behaves_like "parseable arguments"
 
   it "prints information about the current Homebrew configuration", :integration_test do
@@ -21,5 +28,41 @@ RSpec.describe Homebrew::Cmd::Config do
     SystemConfig.homebrew_env_config(output)
 
     expect(output.string).to include("HOMEBREW_CASK_OPTS_REQUIRE_SHA: 1")
+  end
+
+  it "reads the Windows version on WSL", :needs_linux do
+    allow(OS).to receive(:wsl?).and_return(true)
+    stub_const("ORIGINAL_PATHS", [windows_cmd.dirname])
+    allow(Utils).to receive(:popen_read)
+      .with(windows_cmd, "/d", "/c", "reg", "query", "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+            err: :close)
+      .and_return(<<~EOS)
+        HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion
+            ProductName    REG_SZ    Windows 10 Pro
+            DisplayVersion    REG_SZ    25H2
+            CurrentBuildNumber    REG_SZ    26200
+            UBR    REG_DWORD    0x2109
+      EOS
+
+    expect(SystemConfig.windows_version).to eq("Windows 11 Pro (25H2) [26200.8457]")
+  end
+
+  it "prints the Windows version in config output on WSL", :needs_linux do
+    output = StringIO.new
+
+    allow(OS).to receive(:wsl?).and_return(true)
+    allow(OS::Linux).to receive_messages(os_version: "Ubuntu 24.04.3 LTS", wsl_version: Version.new("2"))
+    allow(SystemConfig).to receive_messages(
+      homebrew_config:      nil,
+      core_tap_config:      nil,
+      homebrew_env_config:  nil,
+      hardware:             nil,
+      host_software_config: nil,
+      windows_version:      "Windows 11 Pro (25H2) [26200.8457]",
+    )
+
+    SystemConfig.dump_verbose_config(output)
+
+    expect(output.string).to include("Windows: Windows 11 Pro (25H2) [26200.8457]\n")
   end
 end


### PR DESCRIPTION
- read Edition, display version and build from registry
- expose the host Windows version in `brew config`
- fall back to `ver` when registry output is unavailable

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
