### PR TITLE
install: avoid cask dry-run keg reads

### DIFF
--- a/Library/Homebrew/cask_dependent.rb
+++ b/Library/Homebrew/cask_dependent.rb
@@ -38,9 +38,11 @@ class CaskDependent
     @cask.full_name
   end
 
-  sig { returns(T::Array[Dependency]) }
-  def runtime_dependencies
-    deps.flat_map { |dep| [dep, *dep.to_installed_formula.runtime_dependencies] }.uniq
+  sig { params(read_from_tab: T::Boolean, undeclared: T::Boolean).returns(T::Array[Dependency]) }
+  def runtime_dependencies(read_from_tab: true, undeclared: true)
+    deps.flat_map do |dep|
+      [dep, *dep.to_installed_formula.runtime_dependencies(read_from_tab:, undeclared:)]
+    end.uniq
   end
 
   sig { returns(T::Array[Dependency]) }

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -602,7 +602,7 @@ module Homebrew
           end
           dep_names.concat(
             CaskDependent.new(cask)
-                         .runtime_dependencies
+                         .runtime_dependencies(read_from_tab: false, undeclared: false)
                          .reject(&:installed?)
                          .map(&:name),
           )

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -127,10 +127,12 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
   it "prompts when asking for casks with dependencies", :cask do
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
     dependency = instance_double(Dependency, installed?: false, name: "unar")
+    cask_dependent = instance_double(CaskDependent)
 
     allow(CaskDependent).to receive(:new)
       .with(cask)
-      .and_return(instance_double(CaskDependent, runtime_dependencies: [dependency]))
+      .and_return(cask_dependent)
+    allow(cask_dependent).to receive(:runtime_dependencies).and_return([dependency])
     expect(Homebrew::Install).to receive(:ask_input).with(action: "installation")
 
     expect do
@@ -140,6 +142,28 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
       local-caffeine
       ==> Would install 1 dependency for local-caffeine:
       unar
+    EOS
+  end
+
+  it "does not read installed formula metadata for cask dependency dry-run plans", :cask do
+    cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+    dependency = instance_double(Dependency, installed?: false, name: "ripgrep")
+    cask_dependent = instance_double(CaskDependent)
+
+    allow(CaskDependent).to receive(:new)
+      .with(cask)
+      .and_return(cask_dependent)
+    expect(cask_dependent).to receive(:runtime_dependencies)
+      .with(read_from_tab: false, undeclared: false)
+      .and_return([dependency])
+
+    expect do
+      Homebrew::Install.ask_casks([cask], prompt: false)
+    end.to output(<<~EOS).to_stdout
+      ==> Would install 1 cask:
+      local-caffeine
+      ==> Would install 1 dependency for local-caffeine:
+      ripgrep
     EOS
   end
 


### PR DESCRIPTION
Fixes a bug I observed on Linux installing casks with missing formula dependencies.

- avoid installed tab reads for pending cask formula deps
- keep cask ask-mode plans from failing on absent kegs

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
