### PR TITLE
Preserve cask choice zeroes

### DIFF
--- a/Library/Homebrew/api/cask_struct.rb
+++ b/Library/Homebrew/api/cask_struct.rb
@@ -116,12 +116,15 @@ module Homebrew
           [prop.to_s, send(prop)]
         end.to_h
 
-        hash["raw_artifacts"] = raw_artifacts.map do |artifact|
+        hash["raw_artifacts"] = ::Utils.deep_compact_blank(raw_artifacts.map do |artifact|
           serialize_artifact_args(artifact)
-        end
+        end, compact_zero: false)
 
         hash = ::Utils.deep_stringify_symbols(hash)
-        ::Utils.deep_compact_blank(hash)
+        raw_artifacts = hash["raw_artifacts"]
+        hash = ::Utils.deep_compact_blank(hash)
+        hash["raw_artifacts"] = raw_artifacts if raw_artifacts.present?
+        hash
       end
 
       sig { params(hash: T::Hash[String, T.untyped]).returns(CaskStruct) }

--- a/Library/Homebrew/test/api/cask_struct_spec.rb
+++ b/Library/Homebrew/test/api/cask_struct_spec.rb
@@ -138,6 +138,32 @@ RSpec.describe Homebrew::API::CaskStruct do
       .to eq([:preflight, ["foo"], { bar: "baz" }, nil])
   end
 
+  it "preserves zero values in serialized artifact arguments" do
+    struct = klass.new(
+      sha256:               "abc123",
+      version:              "1.0.0",
+      ruby_source_checksum: { sha256: "def456" },
+      raw_artifacts:        [
+        [
+          :pkg,
+          ["Test.pkg"],
+          { choices: [{ choiceIdentifier: "choice1", choiceAttribute: "selected", attributeSetting: 0 }] },
+          nil,
+        ],
+      ],
+    )
+
+    expect(struct.serialize.fetch("raw_artifacts"))
+      .to eq([
+        [
+          ":pkg",
+          ["Test.pkg"],
+          { ":choices" => [{ ":choiceIdentifier" => "choice1", ":choiceAttribute" => "selected",
+                             ":attributeSetting" => 0 }] },
+        ],
+      ])
+  end
+
   specify "::deserialize_artifact_args", :aggregate_failures do
     expect(klass.deserialize_artifact_args([:foo]))
       .to eq([:foo, [], {}, nil])

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -185,21 +185,21 @@ module Utils
 
   sig {
     type_parameters(:U)
-      .params(obj: T.all(T.type_parameter(:U), Object))
+      .params(obj: T.all(T.type_parameter(:U), Object), compact_zero: T::Boolean)
       .returns(T.nilable(T.type_parameter(:U)))
   }
-  def self.deep_compact_blank(obj)
+  def self.deep_compact_blank(obj, compact_zero: true)
     obj = case obj
     when Hash
-      obj.transform_values { |v| deep_compact_blank(v) }
+      obj.transform_values { |v| deep_compact_blank(v, compact_zero:) }
          .compact
     when Array
-      obj.filter_map { |v| deep_compact_blank(v) }
+      obj.filter_map { |v| deep_compact_blank(v, compact_zero:) }
     else
       obj
     end
 
-    return if obj.blank? || (obj.is_a?(Numeric) && obj.zero?)
+    return if obj.blank? || (compact_zero && obj.is_a?(Numeric) && obj.zero?)
 
     obj
   end


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22400

- Keep `attributeSetting: 0` in internal API cask artifacts because installer choices need zero as a meaningful value.
- Allow `Utils.deep_compact_blank` callers to opt out of dropping zeroes while preserving existing default behaviour.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
