### PR TITLE
Only warn on rename when migration destination exists

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -715,7 +715,12 @@ module Cask
         end
       end
 
-      opoo "Cask #{old_token} was renamed to #{new_token}." if warn && old_token && new_token
+      if warn && old_token && new_token
+        destination_exists = find_cask_in_tap(token, tap).exist? ||
+                             (tap.core_cask_tap? && !Homebrew::EnvConfig.no_install_from_api? &&
+                              Homebrew::API.cask_tokens.include?(token))
+        opoo "Cask #{old_token} was renamed to #{new_token}." if destination_exists
+      end
 
       [token, tap, type]
     end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -1190,7 +1190,12 @@ module Formulary
       end
     end
 
-    opoo "Formula #{old_name} was renamed to #{new_name}." if warn && old_name && new_name
+    if warn && old_name && new_name
+      destination_exists = find_formula_in_tap(name, tap).exist? ||
+                           (tap.core_tap? && !Homebrew::EnvConfig.no_install_from_api? &&
+                            Homebrew::API.formula_names.include?(name))
+      opoo "Formula #{old_name} was renamed to #{new_name}." if destination_exists
+    end
 
     [name, tap, type]
   end

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Cask::CaskLoader, :cask do
           (old_tap.path/"tap_migrations.json").write tap_migrations.to_json
         end
 
-        context "to a cask in an other tap" do
+        context "to a cask in another tap" do
           # Can't use local-caffeine. It is a fixture in the :core_cask_tap and would take precedence over :new_tap.
           let(:token) { "some-cask" }
 
@@ -134,6 +134,26 @@ RSpec.describe Cask::CaskLoader, :cask do
         context "to a formula in the default tap" do
           let(:old_tap) { core_cask_tap }
           let(:new_tap) { core_tap }
+
+          let(:formula_file) { new_tap.formula_dir/"#{token}.rb" }
+
+          before do
+            new_tap.formula_dir.mkpath
+            FileUtils.touch formula_file
+          end
+
+          it "does not warn when loading the short token" do
+            expect do
+              klass.for(token)
+            end.not_to output.to_stderr
+          end
+        end
+
+        context "to a formula in another tap" do
+          let(:token) { "some-cask" }
+
+          let(:old_tap) { Tap.fetch("homebrew", "foo") }
+          let(:new_tap) { Tap.fetch("homebrew", "bar") }
 
           let(:formula_file) { new_tap.formula_dir/"#{token}.rb" }
 

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -883,6 +883,27 @@ RSpec.describe Formulary do
           # end
         end
 
+        context "to a cask in a third-party tap" do
+          let(:old_tap) { Tap.fetch("another", "foo") }
+          let(:new_tap) { Tap.fetch("another", "bar") }
+          let(:cask_file) { new_tap.cask_dir/"#{token}.rb" }
+
+          before do
+            new_tap.cask_dir.mkpath
+            FileUtils.touch cask_file
+          end
+
+          after do
+            FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"another"
+          end
+
+          it "does not warn when loading the short token" do
+            expect do
+              klass.loader_for(token)
+            end.not_to output.to_stderr
+          end
+        end
+
         context "to a third-party tap" do
           let(:old_tap) { Tap.fetch("another", "foo") }
           let(:new_tap) { Tap.fetch("another", "bar") }


### PR DESCRIPTION
`brew edit <name>` (and any other `NamedArgs#to_paths` caller) emits **two** rename warnings — one for Formula, one for Cask — when only one of the two actually exists at the migration destination:

```
Warning: Formula p-linnane/tap/pinprick was renamed to starhaven-io/tap/pinprick.
Warning: Cask p-linnane/tap/pinprick was renamed to starhaven-io/tap/pinprick.
Editing /opt/homebrew/Library/Taps/starhaven-io/homebrew-tap/Casks/pinprick.rb
```

`NamedArgs#to_paths` calls both `Formulary.path(name)` and `Cask::CaskLoader.path(name)` speculatively to resolve a name. Both lookups walk `tap_formula_name_type` / `tap_cask_token_type`, which unconditionally `opoo` for any matching `tap_migrations.json` entry — including when the migrated formula (or cask) does not exist at the destination tap.

This generalises the existing `!(type == :migration && migrated_tap.core_cask_tap?)` carve-out in `FromNameLoader.try_new` (and its cask twin) to all cross-type migrations between any taps: only warn when the migrated file actually exists at the destination (or, for the core tap, is published via the API).

After:
```
Warning: Cask p-linnane/tap/pinprick was renamed to starhaven-io/tap/pinprick.
Editing /opt/homebrew/Library/Taps/starhaven-io/homebrew-tap/Casks/pinprick.rb
```

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

Claude Code (Opus 4.7) traced the duplicate warning to both `Formulary.path` and `Cask::CaskLoader.path` walking `tap_formula_name_type`/`tap_cask_token_type` from `NamedArgs#to_paths`, then drafted the destination-existence gate and the two new test contexts. I reviewed the diff, confirmed the carve-out matches the existing `core_cask_tap?` precedent, and verified `./bin/brew lgtm` passes locally; reproduced the original double warning and the fixed single warning against a real `tap_migrations.json` setup.

-----