### PR TITLE
Secure `brew bundle` npm installs

### DIFF
--- a/Library/Homebrew/bundle/extensions/npm.rb
+++ b/Library/Homebrew/bundle/extensions/npm.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "bundle/extensions/extension"
+require "language/node"
 
 module Homebrew
   module Bundle
@@ -60,7 +61,7 @@ module Homebrew
 
           npm = package_manager_executable!
 
-          Bundle.system(npm.to_s, "install", "-g", name, verbose:)
+          Bundle.system(npm.to_s, "install", *Language::Node.npm_install_security_args, "-g", name, verbose:)
         end
 
         sig { override.returns(T::Array[String]) }

--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -15,6 +15,18 @@ module Language
       "cache=#{HOMEBREW_CACHE}/npm_cache"
     end
 
+    sig { params(ignore_scripts: T::Boolean).returns(T::Array[String]) }
+    def self.npm_install_security_args(ignore_scripts: true)
+      args = %W[
+        --min-release-age=1
+        --#{npm_cache_config}
+      ]
+
+      args << "--ignore-scripts" if ignore_scripts
+
+      args
+    end
+
     sig { returns(String) }
     def self.pack_for_installation
       # Homebrew assumes the buildpath/testpath will always be disposable
@@ -68,17 +80,15 @@ module Language
       # npm install args for global style module format installed into libexec
       # Delay packages published in the last day so builds are less likely to
       # install a freshly compromised npm release or dependency.
-      args = %W[
+      args = %w[
         --loglevel=silly
         --global
         --build-from-source
-        --min-release-age=1
-        --#{npm_cache_config}
+      ] + npm_install_security_args(ignore_scripts:) + %W[
         --prefix=#{libexec}
         #{Dir.pwd}/#{pack}
       ]
 
-      args << "--ignore-scripts" if ignore_scripts
       args << "--unsafe-perm" if Process.uid.zero?
 
       args
@@ -90,16 +100,10 @@ module Language
       # npm install args for local style module format
       # Delay packages published in the last day so builds are less likely to
       # install a freshly compromised npm release or dependency.
-      args = %W[
+      %w[
         --loglevel=silly
         --build-from-source
-        --min-release-age=1
-        --#{npm_cache_config}
-      ]
-
-      args << "--ignore-scripts" if ignore_scripts
-
-      args
+      ] + npm_install_security_args(ignore_scripts:)
     end
 
     # Mixin module for {Formula} adding shebang rewrite features.

--- a/Library/Homebrew/test/bundle/npm_spec.rb
+++ b/Library/Homebrew/test/bundle/npm_spec.rb
@@ -4,6 +4,7 @@
 require "bundle"
 require "bundle/dsl"
 require "bundle/extensions/npm"
+require "language/node"
 
 RSpec.describe Homebrew::Bundle::Npm do
   let(:klass) { Homebrew::Bundle::Npm }
@@ -161,7 +162,16 @@ RSpec.describe Homebrew::Bundle::Npm do
 
         it "installs package" do
           expect(Homebrew::Bundle).to receive(:system)
-            .with("/opt/homebrew/bin/npm", "install", "-g", "vercel", verbose: false)
+            .with(
+              "/opt/homebrew/bin/npm",
+              "install",
+              "--min-release-age=1",
+              "--cache=#{HOMEBREW_CACHE}/npm_cache",
+              "--ignore-scripts",
+              "-g",
+              "vercel",
+              verbose: false,
+            )
             .and_return(true)
           expect(klass.preinstall!("vercel")).to be(true)
           expect(klass.install!("vercel")).to be(true)

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe Language::Node do
     end
   end
 
+  describe "#npm_install_security_args" do
+    it "includes only npm install security arguments" do
+      expect(klass.npm_install_security_args).to eq([
+        "--min-release-age=1",
+        "--cache=#{HOMEBREW_CACHE}/npm_cache",
+        "--ignore-scripts",
+      ])
+    end
+  end
+
   describe "#local_npm_install_args" do
     before do
       allow(klass).to receive(:setup_npm_environment)


### PR DESCRIPTION
- Reuse `Language::Node.local_npm_install_args` so `brew bundle` npm installs get the same cooldown and script blocking used by formulae.
- Cover the command shape because package-manager installs otherwise drift from the hardened formula path without an obvious failure.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

OpenAI Codex 5.5 xhigh with local review and testing.

-----
