### PR TITLE
cli/parser: don't restrict global options to subcommands

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -1025,11 +1025,23 @@ module Homebrew
         option_names.each do |name|
           option_name = option_to_name(name)
           @option_types[option_name] = type
+          # Global options are accepted everywhere, so a subcommand block
+          # re-declaring one (e.g. for a custom description) must not constrain it.
+          next if global_option?(name)
+
           effective_subcommands = effective_subcommands(subcommands)
           next if effective_subcommands.blank?
 
           @option_subcommands[option_name] = (@option_subcommands[option_name] || []) |
                                              effective_subcommands
+        end
+      end
+
+      sig { params(name: String).returns(T::Boolean) }
+      def global_option?(name)
+        option_name = option_to_name(name)
+        self.class.global_options.any? do |short, long, _desc|
+          option_to_name(short) == option_name || option_to_name(long) == option_name
         end
       end
 

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -711,6 +711,25 @@ RSpec.describe Homebrew::CLI::Parser do
         .to raise_error(UsageError, /`info` subcommand does not accept the `--force` switch/)
     end
 
+    it "accepts global options re-declared inside a subcommand on every subcommand", :aggregate_failures do
+      parser = lambda do
+        klass.new(Cmd) do
+          subcommand "install", default: true do
+            switch "-v", "--verbose", description: "Print output from commands as they are run."
+            named_args :none
+          end
+
+          subcommand "cleanup" do
+            named_args :none
+          end
+        end
+      end
+
+      expect(parser.call.parse(%w[install --verbose]).verbose?).to be(true)
+      expect(parser.call.parse(%w[cleanup --verbose]).verbose?).to be(true)
+      expect(parser.call.parse(%w[cleanup -v]).verbose?).to be(true)
+    end
+
     it "applies option constraints only for the matching subcommand", :aggregate_failures do
       parser = lambda do
         klass.new(Cmd) do

--- a/Library/Homebrew/test/cmd/bundle_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe Homebrew::Cmd::Bundle do
     end
   end
 
+  it "accepts global flags on subcommands that do not re-declare them", :aggregate_failures do
+    expect(klass.new(%w[cleanup --verbose]).args.verbose?).to be(true)
+    expect(klass.new(%w[cleanup -v]).args.verbose?).to be(true)
+    expect(klass.new(%w[dump --verbose]).args.subcommand).to eq("dump")
+    expect(klass.new(%w[list --verbose]).args.subcommand).to eq("list")
+  end
+
   it "uses subcommand-specific option descriptions", :aggregate_failures do
     subcommand_options = ->(subcommand) { Commands.command_options("bundle", subcommand:).to_h }
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

This PR was prepared with assistance from Claude Code (model: claude-opus-4-7). I reviewed all generated code and tests manually, reproduced the bug locally, and ran brew lgtm successfully before pushing. This is my only AI-assisted PR currently open.

-----

## Problem

Since 5.1.12, `brew bundle cleanup -v` is rejected:

```sh
$ brew bundle cleanup ---global --verbose --force
Error: Invalid usage: The `cleanup` subcommand does not accept the `-v` switch.
``` 

even though `brew bundle cleanup -h` still lists `-v`, `--verbose` among its options — help output and runtime disagree.

The same rejection happens on every bundle subcommand that doesn't re-declare `--verbose` itself: `cleanup`, `dump`, `list`, `add`, `remove`, `edit`, `exec`, `sh`, `env`. Only `install` and `check` still accept `-v`, because they declare it explicitly.

## Root cause

`Library/Homebrew/cli/parser.rb` auto-registers `-d`/`-q`/`-v`/`-h` as global options for every command. #22280 moved switch `-v`, `--verbose` declarations into the `install` and `check` subcommand blocks so they could carry subcommand-specific descriptions.

`record_option_metadata` treats any option declared inside a subcommand block as constrained to that subcommand. That's correct for genuine subcommand-only options (e.g. `--jobs` on `install`), but re-declaring a global option inside a subcommand block silently constrains the global option too. So `--verbose` got pinned to `["install", "check"]`, while help generation kept showing it as a root option everywhere — producing the mismatch above.

Same family of regression as #22325 (`--zap` constraint scope), but at the global-option layer rather than per-option.

## Fix

Skip subcommand-constraint recording for global options in record_option_metadata:

```rb
# Global options are accepted everywhere, so a subcommand block
# re-declaring one (e.g. for a custom description) must not constrain it.
next if global_option?(name)
```

`global_option?` checks against `self.class.global_options`. Subcommand-specific options keep their existing constraint behaviour — `brew bundle exec --jobs=1 true` still correctly errors. The `install`/`check` re-declarations of `--verbose` keep providing their custom descriptions; only the unintended constraint goes away.

## Alternative considered

Adding switch `-v`, `--verbose` to each of the ~10 affected bundle subcommands would also fix the immediate symptom, but:

- duplicates the declaration across many files;
- doesn't future-proof `--debug`/`--quiet` against the same mistake;
- doesn't help other commands that use the subcommand parser.

A single guard in the parser keeps the fix minimal and addresses the root cause.

## Scope

- `--verbose` is the only currently-broken global option; `--debug` and `--quiet` aren't re-declared anywhere today, but the fix protects all four.
- Other commands using the subcommand parser (`services`, `analytics`, `developer`, `completions`, `prof`) don't re-declare global options inside subcommand blocks, so no behaviour change there.
- `brew bundle upgrade` is unaffected here because #22348 already turned it into an alias of install `--upgrade`.

## Tests

- `test/cli/parser_spec.rb`: parser-level regression — a global option re-declared in one subcommand block is still accepted on other subcommands.
- `test/cmd/bundle_spec.rb`: bundle-level regression — `cleanup`, `dump`, `list` accept `--verbose`/`-v` after parsing.

Both verified with a red/green cycle (failing on main, passing with the fix).

### Manual verification

```sh
$ brew bundle cleanup -v --file=Brewfile    # works (was rejected before this PR)
$ brew bundle cleanup -h                    # still lists -v, --verbose
$ brew bundle exec --jobs=1 /usr/bin/true   # still correctly rejected
```