### PR TITLE
Audit cask flight step conversions

### DIFF
--- a/Library/Homebrew/rubocops/cask/install_steps.rb
+++ b/Library/Homebrew/rubocops/cask/install_steps.rb
@@ -8,6 +8,7 @@ module RuboCop
     module Cask
       # This cop checks declarative install step usage.
       class InstallSteps < Base
+        extend AutoCorrector
         include CaskHelp
         include ::RuboCop::Cop::InstallStepsHelper
 
@@ -32,6 +33,8 @@ module RuboCop
             if steps_stanza
               add_offense(steps_stanza.source_range,
                           message: "`#{flight_stanza.stanza_name}` and `#{steps_block}` cannot both be used.")
+            else
+              audit_flight_block(flight_stanza, steps_block)
             end
           end
 
@@ -42,6 +45,28 @@ module RuboCop
                                                                                RuboCop::AST::BlockNode)))
 
             add_offense(offense_node, message: STEP_BLOCK_MSG)
+          end
+        end
+
+        private
+
+        sig { params(flight_stanza: RuboCop::Cask::AST::Stanza, steps_block: Symbol).void }
+        def audit_flight_block(flight_stanza, steps_block)
+          return unless flight_stanza.method_node.block_type?
+
+          block_node = T.cast(flight_stanza.method_node, RuboCop::AST::BlockNode)
+          step_lines = simple_install_step_lines(block_node.body,
+                                                 default_base:        :staged_path,
+                                                 default_source_base: :staged_path,
+                                                 default_target_base: :staged_path)
+          return if step_lines.blank?
+
+          add_offense(block_node.source_range,
+                      message: format(SIMPLE_STEP_CONVERSION_MSG, steps_block:)) do |corrector|
+            corrector.replace(
+              block_node.source_range,
+              install_steps_block_source(steps_block, step_lines, block_node.source_range.column),
+            )
           end
         end
       end

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -53,17 +53,45 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
     CASK
   end
 
-  it "does not report simple legacy flight block file preparation" do
+  it "autocorrects simple flight block file preparation" do
+    expect_offense <<~CASK
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        postflight do
+        ^^^^^^^^^^^^^ Use `postflight_steps` for simple file preparation.
+          (staged_path/"Prepared").mkpath
+          FileUtils.touch staged_path/"Prepared/touched"
+          FileUtils.mv staged_path/"source", staged_path/"target"
+          FileUtils.ln_s "target", staged_path/"Linked"
+        end
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        postflight_steps do
+          mkdir_p "Prepared"
+          touch "Prepared/touched"
+          mv "source", "target"
+          ln_s "target", "Linked", source_base: :relative
+        end
+      end
+    CASK
+  end
+
+  it "does not autocorrect non-file preparation in flight blocks" do
     expect_no_offenses <<~CASK
       cask "foo" do
         version :latest
         sha256 :no_check
 
         postflight do
-          (staged_path/"Prepared").mkpath
-          FileUtils.touch staged_path/"Prepared/touched"
-          FileUtils.mv staged_path/"source", staged_path/"target"
-          FileUtils.ln_s "target", staged_path/"Linked"
+          system_command "/usr/bin/true"
         end
       end
     CASK


### PR DESCRIPTION
Blocked until next release.

- Keep tap-wide conversion checks separate from the cask DSL change.
- Encourage `*_steps` only when legacy `*flight` blocks are simple.
- Match literal file-preparation calls that the step runner can model.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
