### PR TITLE
Harden sandboxed install phases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -186,6 +186,7 @@ jobs:
     needs: syntax
     if: github.event_name != 'push'
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: update-test (Linux)
@@ -212,6 +213,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: tests (online)
@@ -326,6 +328,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     container: ${{ matrix.container }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: test-bot (Linux arm64)
@@ -414,6 +417,7 @@ jobs:
     if: github.repository_owner == 'Homebrew' && github.event_name != 'push'
     runs-on: ${{ matrix.runs-on }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: bundle and services (Linux)
@@ -463,6 +467,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runs-on }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: analytics (Linux)

--- a/Library/Homebrew/cask/artifact/abstract_artifact.rb
+++ b/Library/Homebrew/cask/artifact/abstract_artifact.rb
@@ -5,6 +5,7 @@ require "extend/object/deep_dup"
 require "env_config"
 require "sandbox"
 require "tempfile"
+require "tmpdir"
 require "utils/output"
 
 module Cask
@@ -199,6 +200,7 @@ module Cask
         Sandbox.new.tap do |sandbox|
           sandbox.allow_read(path: cask.staged_path, type: :subpath)
           sandbox.allow_write_temp_and_cache
+          sandbox.deny_read_home
           sandbox.deny_all_network
         end
       end
@@ -207,9 +209,11 @@ module Cask
         params(
           env:  T::Hash[String, T.any(String, T::Boolean, PATH)],
           args: T::Array[T.any(String, Pathname)],
+          home: String,
         ).returns(T::Array[T.any(String, Pathname)])
       }
-      def cask_sandbox_command(env, args)
+      def cask_sandbox_command(env, args, home:)
+        env = { "HOME" => home }.merge(env)
         ["/usr/bin/env", *env.map { |key, value| "#{key}=#{value}" }, *args]
       end
 

--- a/Library/Homebrew/cask/artifact/generated_completion.rb
+++ b/Library/Homebrew/cask/artifact/generated_completion.rb
@@ -136,19 +136,22 @@ module Cask
         end
 
         Tempfile.create("homebrew-cask-completions", HOMEBREW_TEMP) do |output|
-          sandbox.run(
-            *cask_sandbox_command(
-              env,
-              [
-                "/bin/sh",
-                "-c",
-                "output=$1; shift; exec \"$@\" > \"$output\"#{" 2>/dev/null" unless ENV["HOMEBREW_STDERR"]}",
-                "sh",
-                output.path,
-                *(completion_commands + Array(shell_parameter)),
-              ],
-            ),
-          )
+          Dir.mktmpdir("homebrew-cask-home") do |home|
+            sandbox.run(
+              *cask_sandbox_command(
+                env,
+                [
+                  "/bin/sh",
+                  "-c",
+                  "output=$1; shift; exec \"$@\" > \"$output\"#{" 2>/dev/null" unless ENV["HOMEBREW_STDERR"]}",
+                  "sh",
+                  output.path,
+                  *(completion_commands + Array(shell_parameter)),
+                ],
+                home:,
+              ),
+            )
+          end
           output.read
         end
       end

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -91,6 +91,7 @@ module Homebrew
               sandbox.allow_write_log(f)
               sandbox.allow_write_xcode
               sandbox.allow_write_path(HOMEBREW_PREFIX/"var/homebrew/locks")
+              sandbox.deny_read_home
               optional_prefix_var_dirs.each do |dir|
                 sandbox.allow_write_path_if_exists HOMEBREW_PREFIX/dir
               end

--- a/Library/Homebrew/extend/os/linux/sandbox.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox.rb
@@ -281,6 +281,7 @@ module OS
       sig { params(args: T.any(String, ::Pathname)).void }
       def run(*args)
         @prepared_writable_paths = T.let([], T.nilable(T::Array[::Pathname]))
+        @masked_read_paths = T.let([], T.nilable(T::Array[::Pathname]))
         old_report_on_exception = T.let(Thread.report_on_exception, T.nilable(T::Boolean))
         Thread.report_on_exception = false
         super
@@ -292,6 +293,8 @@ module OS
           nil
         end
         @prepared_writable_paths = nil
+        @masked_read_paths&.reverse_each { |path| FileUtils.rm_rf(path) }
+        @masked_read_paths = nil
       end
 
       private
@@ -326,6 +329,16 @@ module OS
           next unless File.exist?(path)
 
           args += ["--ro-bind", path, path]
+        end
+
+        denied_read_paths.each do |path|
+          next unless File.exist?(path)
+
+          args += if File.directory?(path)
+            ["--bind", masked_read_path, path]
+          else
+            ["--ro-bind", File::NULL, path]
+          end
         end
 
         args += ["--bind", tmpdir, tmpdir, "--chdir", tmpdir]
@@ -365,6 +378,23 @@ module OS
           filter = rule.filter
           filter.path if filter && [:literal, :subpath].include?(filter.type)
         end.uniq
+      end
+
+      sig { returns(T::Array[String]) }
+      def denied_read_paths
+        profile.rules.filter_map do |rule|
+          next if rule.allow || !rule.operation.start_with?("file-read")
+
+          filter = rule.filter
+          filter.path if filter && [:literal, :subpath].include?(filter.type)
+        end.uniq
+      end
+
+      sig { returns(String) }
+      def masked_read_path
+        path = ::Pathname.new(Dir.mktmpdir("homebrew-sandbox-deny-read", HOMEBREW_TEMP))
+        @masked_read_paths&.<< path
+        path.to_s
       end
 
       sig { params(path: String, type: Symbol).void }

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1659,12 +1659,18 @@ class Formula
         PATH:          PATH.new(ORIGINAL_PATHS),
       }
 
-      with_env(new_env) do
-        ENV.clear_sensitive_environment!
-        ENV.activate_extensions!
+      Dir.mktmpdir("#{name}-postinstall-") do |home|
+        postinstall_home = Pathname(home)
+        new_env[:HOME] = postinstall_home.to_s
+        setup_home postinstall_home
 
-        with_logging("post_install") do
-          post_install
+        with_env(new_env) do
+          ENV.clear_sensitive_environment!
+          ENV.activate_extensions!
+
+          with_logging("post_install") do
+            post_install
+          end
         end
       end
     ensure
@@ -3245,8 +3251,7 @@ class Formula
       PATH:          PATH.new(ENV.fetch("PATH"), HOMEBREW_PREFIX/"bin"),
       HOMEBREW_TERM: ENV.fetch("TERM", nil),
       HOMEBREW_PATH: nil,
-    }.merge(common_stage_test_env)
-    test_env[:_JAVA_OPTIONS] += " -Djava.io.tmpdir=#{HOMEBREW_TEMP}"
+    }
 
     ENV.clear_sensitive_environment!
     Utils::Git.set_name_email!
@@ -3255,6 +3260,8 @@ class Formula
       staging.retain! if keep_tmp
       @testpath = T.let(staging.tmpdir, T.nilable(Pathname))
       test_env[:HOME] = @testpath
+      test_env.merge!(common_stage_test_env(T.must(@testpath)))
+      test_env[:_JAVA_OPTIONS] += " -Djava.io.tmpdir=#{HOMEBREW_TEMP}"
       setup_home T.must(@testpath)
       begin
         with_logging("test") do
@@ -3706,15 +3713,15 @@ class Formula
   end
 
   # Common environment variables used at both build and test time.
-  sig { returns(T::Hash[Symbol, String]) }
-  def common_stage_test_env
+  sig { params(home: Pathname).returns(T::Hash[Symbol, String]) }
+  def common_stage_test_env(home)
     {
       _JAVA_OPTIONS:           "-Duser.home=#{HOMEBREW_CACHE}/java_cache",
       GOCACHE:                 "#{HOMEBREW_CACHE}/go_cache",
       GOPATH:                  "#{HOMEBREW_CACHE}/go_mod_cache",
       CARGO_HOME:              "#{HOMEBREW_CACHE}/cargo_cache",
       PIP_CACHE_DIR:           "#{HOMEBREW_CACHE}/pip_cache",
-      CURL_HOME:               ENV.fetch("CURL_HOME") { Dir.home },
+      CURL_HOME:               ENV.fetch("CURL_HOME") { home.to_s },
       PYTHONDONTWRITEBYTECODE: "1",
     }
   end
@@ -3733,7 +3740,7 @@ class Formula
 
       unless interactive
         stage_env[:HOME] = env_home
-        stage_env.merge!(common_stage_test_env)
+        stage_env.merge!(common_stage_test_env(env_home))
       end
 
       setup_home env_home

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1136,7 +1136,11 @@ on_request: installed_on_request?, options:)
       sandbox.allow_read_if_exists path: formula_path
       formula.logs.mkpath
       sandbox.record_log(formula.logs/"build.sandbox.log")
-      sandbox.allow_write_path(Dir.home) if interactive?
+      if interactive?
+        sandbox.allow_write_path(Dir.home)
+      else
+        sandbox.deny_read_home
+      end
       sandbox.allow_write_temp_and_cache
       sandbox.allow_write_log(formula)
       sandbox.allow_cvs
@@ -1383,6 +1387,7 @@ on_request: installed_on_request?, options:)
       sandbox.allow_write_log(formula)
       sandbox.allow_write_xcode
       sandbox.deny_write_homebrew_repository
+      sandbox.deny_read_home
       sandbox.allow_write_cellar(formula)
       sandbox.deny_all_network unless formula.network_access_allowed?(:postinstall)
       Keg.keg_link_directories.each do |dir|

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -177,6 +177,63 @@ class Sandbox
     add_rule allow: true, operation: "file-read*", filter: path_filter(path, type)
   end
 
+  sig { params(path: T.any(String, Pathname), type: Symbol).void }
+  def deny_read(path:, type: :literal)
+    add_rule allow: false, operation: "file-read*", filter: path_filter(path, type)
+  end
+
+  sig { params(path: T.any(String, Pathname)).void }
+  def deny_read_path(path)
+    deny_read path:, type: :subpath
+  end
+
+  sig { void }
+  def deny_read_home
+    home = Pathname(Dir.home(ENV.fetch("USER"))).realpath
+    if [
+      HOMEBREW_PREFIX,
+      HOMEBREW_REPOSITORY,
+      HOMEBREW_CACHE,
+      HOMEBREW_TEMP,
+      ENV.fetch("GITHUB_WORKSPACE", nil),
+      ENV.fetch("RUNNER_WORKSPACE", nil),
+      ENV.fetch("RUNNER_TEMP", nil),
+    ].compact.any? do |path|
+      path = Pathname(path)
+      [path.expand_path, path.exist? ? path.realpath : nil].compact.any? { |pathname| pathname.ascend.include?(home) }
+    end
+      [
+        ".ssh",
+        ".aws",
+        ".azure",
+        ".config/gcloud",
+        ".docker",
+        ".gnupg",
+        ".kube",
+        ".netrc",
+        ".npmrc",
+        ".pypirc",
+        ".gem/credentials",
+        "Documents",
+        "Movies",
+        "Music",
+        "Pictures",
+        "Library/Keychains",
+        "Library/Mobile Documents",
+        "Library/CloudStorage",
+        "Dropbox",
+        "Google Drive",
+        "OneDrive",
+      ].each do |path|
+        path = home/path
+        deny_read_path path if path.exist?
+      end
+      return
+    end
+
+    deny_read_path home
+  end
+
   sig { params(path: T.nilable(T.any(String, Pathname)), type: Symbol).void }
   def allow_read_if_exists(path:, type: :literal)
     return unless path

--- a/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
@@ -40,9 +40,10 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
         instance_double(Sandbox).tap do |sandbox|
           allow(sandbox).to receive(:allow_read)
           allow(sandbox).to receive(:allow_write_temp_and_cache)
+          allow(sandbox).to receive(:deny_read_home)
           allow(sandbox).to receive(:deny_all_network)
           allow(sandbox).to receive(:run) do |*args|
-            Pathname(args.fetch(6)).write("#{args.fetch(1).delete_prefix("SHELL=")} completion output")
+            Pathname(args.fetch(7)).write("#{args.grep(/^SHELL=/).first.delete_prefix("SHELL=")} completion output")
           end
         end
       end
@@ -57,17 +58,24 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
       expect((fish_dir/"foo.fish").read).to eq("fish completion output")
     end
 
-    it "sandboxes completion generation" do
+    it "sandboxes completion generation without network access" do
       artifact = cask.artifacts.grep(klass).first
       sandboxes = []
+      calls = []
+      homes = []
 
       allow(Sandbox).to receive_messages(ensure_sandbox_installed!: nil, available?: true)
       allow(Sandbox).to receive(:new) do
         instance_double(Sandbox).tap do |sandbox|
           expect(sandbox).to receive(:allow_read).with(path: staged_path, type: :subpath)
           expect(sandbox).to receive(:allow_write_temp_and_cache)
-          expect(sandbox).to receive(:deny_all_network)
-          allow(sandbox).to receive(:run) { |*args| Pathname(args.fetch(6)).write("completion") }
+          expect(sandbox).to receive(:deny_read_home)
+          expect(sandbox).to receive(:deny_all_network) { calls << :deny_all_network }
+          allow(sandbox).to receive(:run) do |*args|
+            calls << :run
+            homes << Pathname(args.grep(/^HOME=/).first.delete_prefix("HOME="))
+            Pathname(args.fetch(7)).write("completion")
+          end
           sandboxes << sandbox
         end
       end
@@ -75,6 +83,9 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
       artifact.install_phase
 
       expect(sandboxes.length).to eq(3)
+      expect(calls).to eq([:deny_all_network, :run, :deny_all_network, :run, :deny_all_network, :run])
+      expect(homes.uniq.length).to eq(3)
+      expect(homes).to all(satisfy { |home| !home.exist? })
     end
 
     it "does not sandbox when HOMEBREW_NO_SANDBOX_CASK is set" do
@@ -101,11 +112,12 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
           instance_double(Sandbox).tap do |sandbox|
             allow(sandbox).to receive(:allow_read)
             allow(sandbox).to receive(:allow_write_temp_and_cache)
+            allow(sandbox).to receive(:deny_read_home)
             allow(sandbox).to receive(:deny_all_network)
             allow(sandbox).to receive(:run) do |*args|
-              raise "boom" if args.fetch(1) == "SHELL=bash"
+              raise "boom" if args.include?("SHELL=bash")
 
-              Pathname(args.fetch(6)).write("zsh completion")
+              Pathname(args.fetch(7)).write("zsh completion")
             end
           end
         end
@@ -159,10 +171,11 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
         instance_double(Sandbox).tap do |sandbox|
           allow(sandbox).to receive(:allow_read)
           allow(sandbox).to receive(:allow_write_temp_and_cache)
+          allow(sandbox).to receive(:deny_read_home)
           allow(sandbox).to receive(:deny_all_network)
           allow(sandbox).to receive(:run) do |*args|
             captured_args = args
-            Pathname(args.fetch(6)).write("zsh completion")
+            Pathname(args.fetch(7)).write("zsh completion")
           end
         end
       end
@@ -170,7 +183,7 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
       artifact.install_phase
 
       expect(captured_args).to include("--shell=zsh")
-      expect(captured_args.fetch(4)).to end_with(" 2>/dev/null")
+      expect(captured_args.fetch(5)).to end_with(" 2>/dev/null")
       expect(zsh_dir/"_bar").to be_a_file
       expect(bash_dir/"bar").not_to exist
       expect(fish_dir/"bar.fish").not_to exist

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -1008,7 +1008,8 @@ RSpec.describe FormulaInstaller do
       allow(Sandbox).to receive_messages(ensure_sandbox_installed!: nil, available?: true, new: sandbox)
       allow(sandbox).to receive_messages(record_log: nil, allow_read_if_exists: nil, allow_write_temp_and_cache: nil,
                                          allow_write_log: nil, allow_cvs: nil, allow_fossil: nil,
-                                         allow_write_xcode: nil, allow_write_cellar: nil, run: nil)
+                                         allow_write_xcode: nil, allow_write_cellar: nil, deny_read_home: nil,
+                                         run: nil)
       allow(formula).to receive_messages(logs: mktmpdir, update_head_version: nil, prefix: mktmpdir,
                                          network_access_allowed?: true)
       allow(Keg).to receive(:new).and_return(instance_double(Keg, empty_installation?: false))

--- a/Library/Homebrew/test/sandbox_linux_spec.rb
+++ b/Library/Homebrew/test/sandbox_linux_spec.rb
@@ -202,6 +202,14 @@ RSpec.describe Sandbox, :needs_linux do
       expect(args.index("--ro-bind")).to be < args.index("--dev")
     end
 
+    it "masks denied read directories" do
+      sandbox.deny_read_path dir
+
+      bind = args.each_cons(3).find { |arg| arg.fetch(0) == "--bind" && arg.fetch(2) == dir.to_s }
+      expect(bind).not_to be_nil
+      expect(Pathname(bind.fetch(1)).children).to be_empty
+    end
+
     it "overlays Linux runtime filesystems" do
       expect(args.each_cons(2)).to include(["--dev", "/dev"], ["--proc", "/proc"])
     end

--- a/Library/Homebrew/test/sandbox_shared_spec.rb
+++ b/Library/Homebrew/test/sandbox_shared_spec.rb
@@ -143,6 +143,108 @@ RSpec.describe Sandbox do
     end
   end
 
+  describe "#deny_read_path" do
+    it "denies reads for a subpath" do
+      dir = mktmpdir/"foo"
+      dir.mkpath
+
+      sandbox.deny_read_path dir
+
+      rule = sandbox.send(:profile).rules.fetch(-1)
+      expect(rule).to have_attributes(allow: false, operation: "file-read*")
+      expect(rule.filter).to have_attributes(path: dir.realpath.to_s, type: :subpath)
+    end
+  end
+
+  describe "#deny_read_home" do
+    let(:home) { mktmpdir/"home" }
+    let(:prefix) { mktmpdir/"prefix" }
+    let(:repository) { mktmpdir/"repository" }
+    let(:temp) { mktmpdir/"tmp" }
+    let(:cache) { mktmpdir/"cache" }
+
+    before do
+      [home, prefix, repository, temp, cache].each(&:mkpath)
+      allow(Dir).to receive(:home).with(ENV.fetch("USER")).and_return(home.to_s)
+      stub_const("HOMEBREW_PREFIX", prefix)
+      stub_const("HOMEBREW_REPOSITORY", repository)
+      stub_const("HOMEBREW_TEMP", temp)
+      stub_const("HOMEBREW_CACHE", cache)
+    end
+
+    it "denies reads from the real home" do
+      sandbox.deny_read_home
+
+      rule = sandbox.send(:profile).rules.fetch(-1)
+      expect(rule).to have_attributes(allow: false, operation: "file-read*")
+      expect(rule.filter).to have_attributes(path: home.realpath.to_s, type: :subpath)
+    end
+
+    [
+      [:HOMEBREW_PREFIX, "prefix"],
+      [:HOMEBREW_REPOSITORY, "repository"],
+      [:HOMEBREW_CACHE, "cache"],
+      [:HOMEBREW_TEMP, "tmp"],
+    ].each do |constant, directory|
+      it "skips the deny when #{constant} is inside the real home" do
+        stub_const(constant.to_s, home/directory)
+        Object.const_get(constant).mkpath
+
+        sandbox.deny_read_home
+
+        expect(sandbox.send(:profile).rules).to be_empty
+      end
+    end
+
+    [
+      ["GITHUB_WORKSPACE", "workspace"],
+      ["RUNNER_WORKSPACE", "runner-workspace"],
+      ["RUNNER_TEMP", "runner-temp"],
+    ].each do |env, directory|
+      it "skips the deny when #{env} is inside the real home" do
+        (home/directory).mkpath
+
+        with_env(env => (home/directory).to_s) do
+          sandbox.deny_read_home
+        end
+
+        expect(sandbox.send(:profile).rules).to be_empty
+      end
+    end
+
+    it "skips the deny when a runner path resolves inside the real home" do
+      (home/"workspace").mkpath
+      workspace_link = mktmpdir/"workspace"
+      FileUtils.ln_s home/"workspace", workspace_link
+
+      with_env(GITHUB_WORKSPACE: workspace_link.to_s) do
+        sandbox.deny_read_home
+      end
+
+      expect(sandbox.send(:profile).rules).to be_empty
+    end
+
+    it "denies sensitive home paths when the real home cannot be denied" do
+      [".ssh", "Documents", "Library/Keychains", "Library/Mobile Documents", "Dropbox"].each do |directory|
+        (home/directory).mkpath
+      end
+
+      with_env(GITHUB_WORKSPACE: (home/"workspace").to_s) do
+        sandbox.deny_read_home
+      end
+
+      expect(sandbox.send(:profile).rules.map { |rule| rule.filter&.path }).to eq(
+        [
+          home/".ssh",
+          home/"Documents",
+          home/"Library/Keychains",
+          home/"Library/Mobile Documents",
+          home/"Dropbox",
+        ].map { |path| path.realpath.to_s },
+      )
+    end
+  end
+
   describe "#allow_write_path_if_exists" do
     it "allows writes for existing paths" do
       dir = mktmpdir/"foo"


### PR DESCRIPTION
- Refuse reads of real user `$HOME` during builds, we expose a fake one instead
- Keep cask completion generation offline before running it
- Mask denied read paths where the Linux sandbox can enforce them

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
