### PR TITLE
Sorbet now understands our custom `mktmpdir` helper method

### DIFF
--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -4,6 +4,24 @@ class RSpec::Core::ExampleGroup
   include RSpec::SharedContext
   include RSpec::Matchers
   include RSpec::Mocks::ExampleMethods
+
+  # `mktmpdir` is mixed into specs via `config.include(Test::Helper::MkTmpDir)`
+  # in `test/spec_helper.rb`; declare it here so Sorbet can resolve it in typed
+  # spec files.
+  sig {
+    type_parameters(:U)
+      .params(
+        prefix_suffix: T.nilable(T.any(String, T::Array[String])),
+        block:         T.proc.params(path: Pathname).returns(T.type_parameter(:U)),
+      ).returns(T.type_parameter(:U))
+  }
+  sig {
+    params(
+      prefix_suffix: T.nilable(T.any(String, T::Array[String])),
+      block:         T.nilable(T.proc.params(path: Pathname).returns(Pathname)),
+    ).returns(Pathname)
+  }
+  def mktmpdir(prefix_suffix = T.unsafe(nil), &block); end
 end
 
 # The rspec-mocks RBI defines `ExpectHost#expect(target)` with a required

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/api/internal_spec.rb
+++ b/Library/Homebrew/test/api/internal_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "api/internal"

--- a/Library/Homebrew/test/cask/artifact/installer_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/installer_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Installer, :cask do

--- a/Library/Homebrew/test/cask/dsl/rename_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/rename_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Cask::DSL::Rename do

--- a/Library/Homebrew/test/cmd/vendor-install_spec.rb
+++ b/Library/Homebrew/test/cmd/vendor-install_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "open3"

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dev-cmd/audit"

--- a/Library/Homebrew/test/dev-cmd/generate-internal-api_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-internal-api_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/download_strategies/abstract_spec.rb
+++ b/Library/Homebrew/test/download_strategies/abstract_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/pypi_spec.rb
+++ b/Library/Homebrew/test/download_strategies/pypi_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Kernel do

--- a/Library/Homebrew/test/extend/pathname/write_mkpath_extension_spec.rb
+++ b/Library/Homebrew/test/extend/pathname/write_mkpath_extension_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "extend/pathname/write_mkpath_extension"

--- a/Library/Homebrew/test/git_repository_spec.rb
+++ b/Library/Homebrew/test/git_repository_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "git_repository"

--- a/Library/Homebrew/test/os_spec.rb
+++ b/Library/Homebrew/test/os_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "os"

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "services/cli"

--- a/Library/Homebrew/test/services/system/systemctl_spec.rb
+++ b/Library/Homebrew/test/services/system/systemctl_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "services/system"

--- a/Library/Homebrew/test/services/system_spec.rb
+++ b/Library/Homebrew/test/services/system_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "services/system"

--- a/Library/Homebrew/test/style_spec.rb
+++ b/Library/Homebrew/test/style_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "style"

--- a/Library/Homebrew/test/unpack_strategy/bazaar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/bazaar_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/cvs_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/cvs_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/git_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/git_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/mercurial_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/mercurial_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/subversion_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/subversion_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/tar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/tar_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/uncompressed_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/uncompressed_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/zip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/zip_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/utils/gzip_spec.rb
+++ b/Library/Homebrew/test/utils/gzip_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/gzip"

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/pypi"

--- a/Library/Homebrew/test/utils/spdx_spec.rb
+++ b/Library/Homebrew/test/utils/spdx_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/spdx"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

- Copilot agent mode, OpenAI Codex 5.3 (medium), for generating the type signature in the shim. Human review for tightening the types it generated from `T.untyped`.

-----

- We use this extensively in tests to create temporary directories. It's mixed into specs via `config.include(Test::Helper::MkTmpDir)` in `test/spec_helper.rb`. By declaring it in our RSpec shim RBI, Sorbet can now resolve it in typed spec files, meaning that we can typecheck more of our tests.
- Confirmed this by running `brew tc --update --suggest-typed` and that's 29 more tests typechecked!