### PR TITLE
tests: Use full constant names sometimes (for Sorbet rule 5001 compat)

### DIFF
--- a/Library/Homebrew/test/api/cask_struct_spec.rb
+++ b/Library/Homebrew/test/api/cask_struct_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "api"
@@ -175,19 +175,19 @@ RSpec.describe Homebrew::API::CaskStruct do
       .to eq([:foo, [], { ghi: "jkl" }, nil])
 
     expect(klass.deserialize_artifact_args([:foo, :empty_block]))
-      .to eq([:foo, [], {}, klass::EMPTY_BLOCK])
+      .to eq([:foo, [], {}, Homebrew::API::CaskStruct::EMPTY_BLOCK])
 
     expect(klass.deserialize_artifact_args([:foo, ["abc", "def"], { ghi: "jkl" }]))
       .to eq([:foo, ["abc", "def"], { ghi: "jkl" }, nil])
 
     expect(klass.deserialize_artifact_args([:foo, ["abc", "def"], :empty_block]))
-      .to eq([:foo, ["abc", "def"], {}, klass::EMPTY_BLOCK])
+      .to eq([:foo, ["abc", "def"], {}, Homebrew::API::CaskStruct::EMPTY_BLOCK])
 
     expect(klass.deserialize_artifact_args([:foo, { ghi: "jkl" }, :empty_block]))
-      .to eq([:foo, [], { ghi: "jkl" }, klass::EMPTY_BLOCK])
+      .to eq([:foo, [], { ghi: "jkl" }, Homebrew::API::CaskStruct::EMPTY_BLOCK])
 
     expect(klass.deserialize_artifact_args([:foo, ["abc", "def"], { ghi: "jkl" }, :empty_block]))
-      .to eq([:foo, ["abc", "def"], { ghi: "jkl" }, klass::EMPTY_BLOCK])
+      .to eq([:foo, ["abc", "def"], { ghi: "jkl" }, Homebrew::API::CaskStruct::EMPTY_BLOCK])
   end
 
   describe "::deserialize" do
@@ -200,7 +200,7 @@ RSpec.describe Homebrew::API::CaskStruct do
 
       struct = klass.deserialize(hash)
 
-      klass::PREDICATES.each do |predicate|
+      Homebrew::API::CaskStruct::PREDICATES.each do |predicate|
         expect(struct.send(:"#{predicate}?")).to be false
       end
     end
@@ -223,7 +223,7 @@ RSpec.describe Homebrew::API::CaskStruct do
 
       struct = klass.deserialize(hash)
 
-      klass::PREDICATES.each do |predicate|
+      Homebrew::API::CaskStruct::PREDICATES.each do |predicate|
         expect(struct.send(:"#{predicate}?")).to be true
       end
     end

--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -139,8 +139,8 @@ RSpec.describe Homebrew::Attestation do
 
       expect do
         klass.check_attestation fake_bottle,
-                                klass::HOMEBREW_CORE_REPO
-      end.to raise_error(klass::GhAuthNeeded)
+                                Homebrew::Attestation::HOMEBREW_CORE_REPO
+      end.to raise_error(Homebrew::Attestation::GhAuthNeeded)
     end
 
     it "raises when gh subprocess fails" do
@@ -149,15 +149,15 @@ RSpec.describe Homebrew::Attestation do
 
       expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
+                              Homebrew::Attestation::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_raise(ErrorDuringExecution.new(["foo"], status: fake_error_status))
 
       expect do
         klass.check_attestation fake_bottle,
-                                klass::HOMEBREW_CORE_REPO
-      end.to raise_error(klass::InvalidAttestationError)
+                                Homebrew::Attestation::HOMEBREW_CORE_REPO
+      end.to raise_error(Homebrew::Attestation::InvalidAttestationError)
     end
 
     it "raises auth error when gh subprocess fails with auth exit code" do
@@ -166,15 +166,15 @@ RSpec.describe Homebrew::Attestation do
 
       expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
+                              Homebrew::Attestation::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_raise(ErrorDuringExecution.new(["foo"], status: fake_auth_status))
 
       expect do
         klass.check_attestation fake_bottle,
-                                klass::HOMEBREW_CORE_REPO
-      end.to raise_error(klass::GhAuthInvalid)
+                                Homebrew::Attestation::HOMEBREW_CORE_REPO
+      end.to raise_error(Homebrew::Attestation::GhAuthInvalid)
     end
 
     it "raises when gh returns invalid JSON" do
@@ -183,15 +183,15 @@ RSpec.describe Homebrew::Attestation do
 
       expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
+                              Homebrew::Attestation::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_invalid_json)
 
       expect do
         klass.check_attestation fake_bottle,
-                                klass::HOMEBREW_CORE_REPO
-      end.to raise_error(klass::InvalidAttestationError)
+                                Homebrew::Attestation::HOMEBREW_CORE_REPO
+      end.to raise_error(Homebrew::Attestation::InvalidAttestationError)
     end
 
     it "raises when gh returns other subjects" do
@@ -200,15 +200,15 @@ RSpec.describe Homebrew::Attestation do
 
       expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
+                              Homebrew::Attestation::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_json_resp_wrong_sub)
 
       expect do
         klass.check_attestation fake_bottle,
-                                klass::HOMEBREW_CORE_REPO
-      end.to raise_error(klass::InvalidAttestationError)
+                                Homebrew::Attestation::HOMEBREW_CORE_REPO
+      end.to raise_error(Homebrew::Attestation::InvalidAttestationError)
     end
 
     it "checks subject prefix when the bottle is an :all bottle" do
@@ -217,12 +217,12 @@ RSpec.describe Homebrew::Attestation do
 
       expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
+                              Homebrew::Attestation::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_json_resp)
 
-      klass.check_attestation fake_all_bottle, klass::HOMEBREW_CORE_REPO
+      klass.check_attestation fake_all_bottle, Homebrew::Attestation::HOMEBREW_CORE_REPO
     end
   end
 
@@ -238,7 +238,7 @@ RSpec.describe Homebrew::Attestation do
     it "calls gh with args for homebrew-core" do
       expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
+                              Homebrew::Attestation::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_json_resp)
@@ -249,7 +249,7 @@ RSpec.describe Homebrew::Attestation do
     it "calls gh with args for homebrew-core and handles a multi-subject attestation" do
       expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
+                              Homebrew::Attestation::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_json_resp_multi_subject)
@@ -260,15 +260,15 @@ RSpec.describe Homebrew::Attestation do
     it "calls gh with args for backfill when homebrew-core attestation is missing" do
       expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
+                              Homebrew::Attestation::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .once
-        .and_raise(klass::MissingAttestationError)
+        .and_raise(Homebrew::Attestation::MissingAttestationError)
 
       expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              klass::BACKFILL_REPO, "--format", "json"],
+                              Homebrew::Attestation::BACKFILL_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_json_resp_backfill)
@@ -279,23 +279,23 @@ RSpec.describe Homebrew::Attestation do
     it "raises when the backfilled attestation is too new" do
       expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              klass::HOMEBREW_CORE_REPO, "--format", "json"],
+                              Homebrew::Attestation::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
-        .exactly(klass::ATTESTATION_MAX_RETRIES + 1)
-        .and_raise(klass::MissingAttestationError)
+        .exactly(Homebrew::Attestation::ATTESTATION_MAX_RETRIES + 1)
+        .and_raise(Homebrew::Attestation::MissingAttestationError)
 
       expect(klass).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              klass::BACKFILL_REPO, "--format", "json"],
+                              Homebrew::Attestation::BACKFILL_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
-        .exactly(klass::ATTESTATION_MAX_RETRIES + 1)
+        .exactly(Homebrew::Attestation::ATTESTATION_MAX_RETRIES + 1)
         .and_return(fake_result_json_resp_too_new)
 
       expect do
         klass.check_core_attestation fake_bottle
-      end.to raise_error(klass::InvalidAttestationError)
+      end.to raise_error(Homebrew::Attestation::InvalidAttestationError)
     end
   end
 end

--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe Homebrew::Bundle::Brew do
 
       it "exits on cyclic exceptions" do
         expect(Formula).to receive(:installed).and_return([foo, bar, baz])
-        expect_any_instance_of(klass::Topo).to receive(:tsort).and_raise(
+        expect_any_instance_of(Homebrew::Bundle::Brew::Topo).to receive(:tsort).and_raise(
           TSort::Cyclic,
           'topological sort failed: ["foo", "bar"]',
         )

--- a/Library/Homebrew/test/bundle/mac_app_store_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_spec.rb
@@ -282,8 +282,8 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
     before do
       klass.reset!
       allow(klass).to receive_messages(package_manager_executable: Pathname.new("mas"), packages: [
-        klass::App.new(id: "123", name: "foo"),
-        klass::App.new(id: "456", name: "bar"),
+        Homebrew::Bundle::MacAppStore::App.new(id: "123", name: "foo"),
+        Homebrew::Bundle::MacAppStore::App.new(id: "456", name: "bar"),
       ])
     end
 

--- a/Library/Homebrew/test/bundle/winget_spec.rb
+++ b/Library/Homebrew/test/bundle/winget_spec.rb
@@ -87,19 +87,24 @@ RSpec.describe Homebrew::Bundle::Winget do
         allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("winget.exe"))
         allow(klass).to receive(:export_apps).with(Pathname.new("winget.exe"), source: "winget").and_return(
           [
-            klass::App.new(id: "Microsoft.EdgeWebView2Runtime", name: "Microsoft Edge WebView2 Runtime",
-                           source: "winget"),
-            klass::App.new(id: "Microsoft.OneDrive", name: "Microsoft OneDrive", source: "winget"),
-            klass::App.new(id: "Microsoft.WSL", name: "Windows Subsystem for Linux", source: "winget"),
-            klass::App.new(id: "Valve.Steam", name: "Steam", source: "winget"),
+            Homebrew::Bundle::Winget::App.new(
+              id:     "Microsoft.EdgeWebView2Runtime",
+              name:   "Microsoft Edge WebView2 Runtime",
+              source: "winget",
+            ),
+            Homebrew::Bundle::Winget::App.new(id: "Microsoft.OneDrive", name: "Microsoft OneDrive", source: "winget"),
+            Homebrew::Bundle::Winget::App.new(id: "Microsoft.WSL", name: "Windows Subsystem for Linux",
+                                              source: "winget"),
+            Homebrew::Bundle::Winget::App.new(id: "Valve.Steam", name: "Steam", source: "winget"),
           ],
         )
         allow(klass).to receive(:export_apps).with(Pathname.new("winget.exe"), source: "msstore").and_return(
           [
-            klass::App.new(id: "9NBLGGH4NNS1", name: "App Installer", source: "msstore"),
-            klass::App.new(id: "XP89DCGQ3K6VLD", name: "PowerToys", source: "msstore"),
-            klass::App.new(id: "Microsoft.UI.Xaml.2.8", name: "Microsoft.UI.Xaml.2.8", source: "msstore"),
-            klass::App.new(id: "9N0DX20HK701", name: "Windows Terminal", source: "msstore"),
+            Homebrew::Bundle::Winget::App.new(id: "9NBLGGH4NNS1", name: "App Installer", source: "msstore"),
+            Homebrew::Bundle::Winget::App.new(id: "XP89DCGQ3K6VLD", name: "PowerToys", source: "msstore"),
+            Homebrew::Bundle::Winget::App.new(id: "Microsoft.UI.Xaml.2.8", name: "Microsoft.UI.Xaml.2.8",
+                                              source: "msstore"),
+            Homebrew::Bundle::Winget::App.new(id: "9N0DX20HK701", name: "Windows Terminal", source: "msstore"),
           ],
         )
       end
@@ -127,8 +132,8 @@ RSpec.describe Homebrew::Bundle::Winget do
         winget = Pathname.new("winget.exe")
         allow(klass).to receive(:export_apps).and_call_original
         allow(klass).to receive(:exported_apps).with(winget, source: "winget").and_return([
-          klass::App.new(id: "Valve.Steam", name: "Valve.Steam", source: "winget"),
-          klass::App.new(id: "Unknown.Package", name: "Unknown.Package", source: "winget"),
+          Homebrew::Bundle::Winget::App.new(id: "Valve.Steam", name: "Valve.Steam", source: "winget"),
+          Homebrew::Bundle::Winget::App.new(id: "Unknown.Package", name: "Unknown.Package", source: "winget"),
         ])
         allow(Utils).to receive(:popen_read)
           .with(winget, "list", "--source", "winget", "--accept-source-agreements", "--disable-interactivity",
@@ -229,7 +234,7 @@ RSpec.describe Homebrew::Bundle::Winget do
 
       it "keeps the package dump cache filtered and sorted after installation" do
         allow(klass).to receive(:export_apps).with(Pathname("winget.exe"), source: "winget").and_return([
-          klass::App.new(id: "Valve.Steam", name: "Steam", source: "winget"),
+          Homebrew::Bundle::Winget::App.new(id: "Valve.Steam", name: "Steam", source: "winget"),
         ])
         allow(klass).to receive(:export_apps).with(Pathname("winget.exe"), source: "msstore").and_return([])
 
@@ -340,10 +345,10 @@ RSpec.describe Homebrew::Bundle::Winget do
       klass.reset!
       allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("winget.exe"))
       allow(klass).to receive(:exported_apps).with(Pathname("winget.exe"), source: "winget").and_return([
-        klass::App.new(id: "Valve.Steam", name: "Steam", source: "winget"),
+        Homebrew::Bundle::Winget::App.new(id: "Valve.Steam", name: "Steam", source: "winget"),
       ])
       allow(klass).to receive(:exported_apps).with(Pathname("winget.exe"), source: "msstore").and_return([
-        klass::App.new(id: "XPDC2RH70K22MN", name: "Discord", source: "msstore"),
+        Homebrew::Bundle::Winget::App.new(id: "XPDC2RH70K22MN", name: "Discord", source: "msstore"),
       ])
     end
 

--- a/Library/Homebrew/test/cask/list_spec.rb
+++ b/Library/Homebrew/test/cask/list_spec.rb
@@ -120,28 +120,28 @@ RSpec.describe Cask::List, :cask do
   describe "TAP_AND_NAME_COMPARISON" do
     describe "both strings are only names" do
       it "alphabetizes the strings" do
-        expect(%w[a b].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[a b])
-        expect(%w[b a].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[a b])
+        expect(%w[a b].sort(&Cask::List::TAP_AND_NAME_COMPARISON)).to eq(%w[a b])
+        expect(%w[b a].sort(&Cask::List::TAP_AND_NAME_COMPARISON)).to eq(%w[a b])
       end
     end
 
     describe "both strings include tap" do
       it "alphabetizes the strings" do
-        expect(%w[a/z/z b/z/z].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[a/z/z b/z/z])
-        expect(%w[b/z/z a/z/z].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[a/z/z b/z/z])
+        expect(%w[a/z/z b/z/z].sort(&Cask::List::TAP_AND_NAME_COMPARISON)).to eq(%w[a/z/z b/z/z])
+        expect(%w[b/z/z a/z/z].sort(&Cask::List::TAP_AND_NAME_COMPARISON)).to eq(%w[a/z/z b/z/z])
 
-        expect(%w[z/a/z z/b/z].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[z/a/z z/b/z])
-        expect(%w[z/b/z z/a/z].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[z/a/z z/b/z])
+        expect(%w[z/a/z z/b/z].sort(&Cask::List::TAP_AND_NAME_COMPARISON)).to eq(%w[z/a/z z/b/z])
+        expect(%w[z/b/z z/a/z].sort(&Cask::List::TAP_AND_NAME_COMPARISON)).to eq(%w[z/a/z z/b/z])
 
-        expect(%w[z/z/a z/z/b].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[z/z/a z/z/b])
-        expect(%w[z/z/b z/z/a].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[z/z/a z/z/b])
+        expect(%w[z/z/a z/z/b].sort(&Cask::List::TAP_AND_NAME_COMPARISON)).to eq(%w[z/z/a z/z/b])
+        expect(%w[z/z/b z/z/a].sort(&Cask::List::TAP_AND_NAME_COMPARISON)).to eq(%w[z/z/a z/z/b])
       end
     end
 
     describe "only one string includes tap" do
       it "prefers the string without tap" do
-        expect(%w[a/z/z z].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[z a/z/z])
-        expect(%w[z a/z/z].sort(&klass::TAP_AND_NAME_COMPARISON)).to eq(%w[z a/z/z])
+        expect(%w[a/z/z z].sort(&Cask::List::TAP_AND_NAME_COMPARISON)).to eq(%w[z a/z/z])
+        expect(%w[z a/z/z].sort(&Cask::List::TAP_AND_NAME_COMPARISON)).to eq(%w[z a/z/z])
       end
     end
   end

--- a/Library/Homebrew/test/cmd/bundle_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Homebrew::Cmd::Bundle do
   it "treats upgrade as install --upgrade", :aggregate_failures do
     with_env("HOMEBREW_BUNDLE_NO_UPGRADE" => "1") do
       args = klass.new(%w[upgrade -fq]).args
-      context = klass.context(args, extensions: klass::BUNDLE_EXTENSIONS)
+      context = klass.context(args, extensions: Homebrew::Cmd::Bundle::BUNDLE_EXTENSIONS)
 
       expect(args.subcommand).to eq("install")
       expect(args.upgrade?).to be(true)

--- a/Library/Homebrew/test/cmd/services/cleanup_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/services/cleanup_subcommand_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "services/subcommand/cleanup"
@@ -10,7 +10,7 @@ RSpec.describe Homebrew::Cmd::Services::CleanupSubcommand do
 
   describe "#TRIGGERS" do
     it "contains all restart triggers" do
-      expect(klass::TRIGGERS).to eq(%w[cleanup clean cl rm])
+      expect(Homebrew::Cmd::Services::CleanupSubcommand::TRIGGERS).to eq(%w[cleanup clean cl rm])
     end
   end
 

--- a/Library/Homebrew/test/cmd/services/info_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/services/info_subcommand_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/services"
@@ -12,7 +12,7 @@ RSpec.describe Homebrew::Cmd::Services::InfoSubcommand do
 
   describe "#TRIGGERS" do
     it "contains all restart triggers" do
-      expect(klass::TRIGGERS).to eq(%w[info i])
+      expect(Homebrew::Cmd::Services::InfoSubcommand::TRIGGERS).to eq(%w[info i])
     end
   end
 

--- a/Library/Homebrew/test/cmd/services/list_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/services/list_subcommand_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/services"
@@ -8,7 +8,7 @@ RSpec.describe Homebrew::Cmd::Services::ListSubcommand do
 
   describe "#TRIGGERS" do
     it "contains all restart triggers" do
-      expect(klass::TRIGGERS).to eq([nil, "list", "ls"])
+      expect(Homebrew::Cmd::Services::ListSubcommand::TRIGGERS).to eq([nil, "list", "ls"])
     end
   end
 
@@ -54,7 +54,7 @@ RSpec.describe Homebrew::Cmd::Services::ListSubcommand do
         schedulable: false,
       }
 
-      filtered_formula = formula.slice(*klass::JSON_FIELDS)
+      filtered_formula = formula.slice(*Homebrew::Cmd::Services::ListSubcommand::JSON_FIELDS)
       expected_output = "#{JSON.pretty_generate([filtered_formula])}\n"
 
       expect(Homebrew::Services::Formulae).to receive(:services_list).and_return([formula])
@@ -109,7 +109,7 @@ RSpec.describe Homebrew::Cmd::Services::ListSubcommand do
 
     it "prints without user or file data" do
       formula = { name: "a", user: nil, file: nil, status: :started, loaded: true }
-      filtered_formula = formula.slice(*klass::JSON_FIELDS)
+      filtered_formula = formula.slice(*Homebrew::Cmd::Services::ListSubcommand::JSON_FIELDS)
       expected_output = "#{JSON.pretty_generate([filtered_formula])}\n"
       expect do
         klass.print_json([formula])
@@ -119,7 +119,7 @@ RSpec.describe Homebrew::Cmd::Services::ListSubcommand do
     it "includes an exit code" do
       file = Pathname.new("/tmp/file.file")
       formula = { name: "a", user: "u", file:, status: :error, exit_code: 256, loaded: true }
-      filtered_formula = formula.slice(*klass::JSON_FIELDS)
+      filtered_formula = formula.slice(*Homebrew::Cmd::Services::ListSubcommand::JSON_FIELDS)
       expected_output = "#{JSON.pretty_generate([filtered_formula])}\n"
       expect do
         klass.print_json([formula])

--- a/Library/Homebrew/test/cmd/services/restart_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/services/restart_subcommand_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/services"
@@ -8,7 +8,7 @@ RSpec.describe Homebrew::Cmd::Services::RestartSubcommand do
 
   describe "#TRIGGERS" do
     it "contains all restart triggers" do
-      expect(klass::TRIGGERS).to eq(%w[restart relaunch reload r])
+      expect(Homebrew::Cmd::Services::RestartSubcommand::TRIGGERS).to eq(%w[restart relaunch reload r])
     end
   end
 

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
   it "does not print aggregate package sizes" do
     cmd = klass.new(["--dry-run"])
-    summary = klass::FinalUpgradeSummary.new(
+    summary = Homebrew::Cmd::UpgradeCmd::FinalUpgradeSummary.new(
       version_changes: ["testball 0.1 -> 0.2 (500B)", "codex 1.0 -> 2.0"],
     )
 
@@ -666,7 +666,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
   it "prints a narrow final upgrade summary" do
     cmd = klass.new([])
-    summary = klass::FinalUpgradeSummary.new(
+    summary = Homebrew::Cmd::UpgradeCmd::FinalUpgradeSummary.new(
       version_changes:       ["testball 0.1 -> 0.2"],
       pinned_formulae:       ["pinnedball 1.0"],
       pinned_casks:          ["pinned-cask 2.0"],
@@ -715,7 +715,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     allow(formula).to receive_messages(optlinked?: true, opt_prefix: old_keg)
 
     cmd = klass.new([])
-    context = klass::FormulaeUpgradeContext.new(
+    context = Homebrew::Cmd::UpgradeCmd::FormulaeUpgradeContext.new(
       formulae_to_install: [formula, deprecated, disabled, source_build],
       formulae_installer:  [
         FormulaInstaller.new(formula),
@@ -749,7 +749,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     cmd = klass.new([])
 
     allow(cmd).to receive(:formulae_upgrade_context).and_return(
-      klass::FormulaeUpgradeContext.new(
+      Homebrew::Cmd::UpgradeCmd::FormulaeUpgradeContext.new(
         formulae_to_install: [formula],
         formulae_installer:  [FormulaInstaller.new(formula)],
         dependants:          Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: []),

--- a/Library/Homebrew/test/cmd/which-formula_spec.rb
+++ b/Library/Homebrew/test/cmd/which-formula_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe Homebrew::Cmd::WhichFormula do
 
     before do
       # Override DATABASE_FILE to use test environment's HOMEBREW_CACHE
-      test_db_file = HOMEBREW_CACHE/"api"/klass::ENDPOINT
+      test_db_file = HOMEBREW_CACHE/"api"/Homebrew::Cmd::WhichFormula::ENDPOINT
       stub_const("#{klass}::DATABASE_FILE", test_db_file)
 
-      db = klass::DATABASE_FILE
+      db = Homebrew::Cmd::WhichFormula::DATABASE_FILE
       db.dirname.mkpath
       db.write(<<~EOS)
         foo(1.0.0):foo2 foo3

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "completions"
@@ -14,7 +14,7 @@ RSpec.describe Homebrew::Completions do
     HOMEBREW_REPOSITORY.cd do
       system "git", "init"
     end
-    klass::SHELLS.each do |shell|
+    Homebrew::Completions::SHELLS.each do |shell|
       (completions_dir/shell).mkpath
     end
     internal_path.mkpath

--- a/Library/Homebrew/test/dependency_expansion_spec.rb
+++ b/Library/Homebrew/test/dependency_expansion_spec.rb
@@ -34,12 +34,12 @@ RSpec.describe Dependency do
     end
 
     it "prunes all when given a block with PRUNE" do
-      expect(klass.expand(formula) { next klass::PRUNE }).to be_empty
+      expect(klass.expand(formula) { next Dependable::PRUNE }).to be_empty
     end
 
     it "can prune selectively" do
       deps = klass.expand(formula) do |_, dep|
-        next klass::PRUNE if dep.name == "foo"
+        next Dependable::PRUNE if dep.name == "foo"
       end
 
       expect(deps).to eq([bar, baz, qux])
@@ -94,7 +94,7 @@ RSpec.describe Dependency do
     )
 
     deps = klass.expand(f) do |_dependent, dep|
-      next klass::SKIP if %w[foo qux].include? dep.name
+      next Dependable::SKIP if %w[foo qux].include? dep.name
     end
 
     expect(deps).to eq([bar, baz])
@@ -106,7 +106,7 @@ RSpec.describe Dependency do
     f = instance_double(Formula, name: "f", deps: [foo, baz])
 
     deps = klass.expand(f) do |_dependent, dep|
-      next klass::KEEP_BUT_PRUNE_RECURSIVE_DEPS if dep.test?
+      next Dependable::KEEP_BUT_PRUNE_RECURSIVE_DEPS if dep.test?
     end
 
     expect(deps).to eq([foo, baz])

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "diagnostic"
@@ -10,7 +10,7 @@ RSpec.describe Homebrew::EnvConfig do
 
   describe "ENVS" do
     it "sorts alphabetically" do
-      expect(env_config::ENVS.keys).to eql(env_config::ENVS.keys.sort)
+      expect(Homebrew::EnvConfig::ENVS.keys).to eql(Homebrew::EnvConfig::ENVS.keys.sort)
     end
   end
 

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Formulary do
           ignore_errors: false,
         )
 
-        expect(formula_class.const_get(:SECRET_TOKEN_PRESENT)).to be(false)
+        expect(formula_class::SECRET_TOKEN_PRESENT).to be(false)
         expect(ENV.fetch("SECRET_TOKEN", nil)).to eq("password")
       end
     end
@@ -681,8 +681,8 @@ RSpec.describe Formulary do
             { "#{old_formula_name}": "homebrew/core/#{formula_name}" }
           JSON
 
-          loader = klass::FromNameLoader.try_new(old_formula_name)
-          expect(loader).to be_a(klass::FromAPILoader)
+          loader = Formulary::FromNameLoader.try_new(old_formula_name)
+          expect(loader).to be_a(Formulary::FromAPILoader)
           expect(loader.name).to eq formula_name
           expect(loader.path).not_to exist
         end
@@ -693,8 +693,8 @@ RSpec.describe Formulary do
             { "#{old_formula_name}": "homebrew/core/#{formula_name}" }
           JSON
 
-          loader = klass::FromTapLoader.try_new("#{foo_tap}/#{old_formula_name}")
-          expect(loader).to be_a(klass::FromAPILoader)
+          loader = Formulary::FromTapLoader.try_new("#{foo_tap}/#{old_formula_name}")
+          expect(loader).to be_a(Formulary::FromAPILoader)
           expect(loader.name).to eq formula_name
           expect(loader.path).not_to exist
         end

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -7,7 +7,7 @@ require "test/support/fixtures/testball"
 RSpec.describe GitHubRunnerMatrix, :no_api do
   let(:klass) { GitHubRunnerMatrix }
   let(:newest_supported_macos) do
-    MacOSVersion::SYMBOLS.find { |k, _| k == klass::NEWEST_HOMEBREW_CORE_MACOS_RUNNER }
+    MacOSVersion::SYMBOLS.find { |k, _| k == GitHubRunnerMatrix::NEWEST_HOMEBREW_CORE_MACOS_RUNNER }
   end
   let(:testball) { setup_test_runner_formula("testball") }
   let(:testball_depender) { setup_test_runner_formula("testball-depender", ["testball"]) }
@@ -37,7 +37,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
 
   describe "OLDEST_HOMEBREW_CORE_MACOS_RUNNER" do
     it "is not newer than HOMEBREW_MACOS_OLDEST_SUPPORTED" do
-      oldest_macos_runner = MacOSVersion.from_symbol(klass::OLDEST_HOMEBREW_CORE_MACOS_RUNNER)
+      oldest_macos_runner = MacOSVersion.from_symbol(GitHubRunnerMatrix::OLDEST_HOMEBREW_CORE_MACOS_RUNNER)
       expect(oldest_macos_runner).to be <= HOMEBREW_MACOS_OLDEST_SUPPORTED
     end
   end

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Homebrew::InstallSteps do
   end
 
   specify "runs mkdir, touch, move and symlink steps", :aggregate_failures do
-    steps = described_class::DSL.build(default_base: :var, default_source_base: :staged_path,
-                                       default_target_base: :staged_path) do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var, default_source_base: :staged_path,
+                                              default_target_base: :staged_path) do
       mkdir_p "log/example"
       touch "state/marker", base: :prefix
       mv "move-source", "move-target"
@@ -34,7 +34,7 @@ RSpec.describe Homebrew::InstallSteps do
     (root/"stage").mkpath
     (root/"stage/move-source").write "moved"
 
-    described_class::Runner.new(context:).run(steps)
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
 
     expect(root/"var/log/example").to be_a_directory
     expect(root/"prefix/state/marker").to exist
@@ -44,7 +44,7 @@ RSpec.describe Homebrew::InstallSteps do
   end
 
   specify "runs mkdir without creating parent directories" do
-    steps = described_class::DSL.build(default_base: :var) do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
       mkdir "missing-parent/example"
     end
 
@@ -55,11 +55,11 @@ RSpec.describe Homebrew::InstallSteps do
         "path" => "missing-parent/example",
       },
     )
-    expect { described_class::Runner.new(context:).run(steps) }.to raise_error(Errno::ENOENT)
+    expect { Homebrew::InstallSteps::Runner.new(context:).run(steps) }.to raise_error(Errno::ENOENT)
   end
 
   specify "runs mkdir_p recursively" do
-    steps = described_class::DSL.build(default_base: :var) do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
       mkdir_p "nested/example"
     end
 
@@ -71,13 +71,13 @@ RSpec.describe Homebrew::InstallSteps do
       },
     )
 
-    described_class::Runner.new(context:).run(steps)
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
 
     expect(root/"var/nested/example").to be_a_directory
   end
 
   specify "does not add the default base to home paths" do
-    steps = described_class::DSL.build(default_base: :var) do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
       mkdir_p "~/example"
     end
 
@@ -90,34 +90,34 @@ RSpec.describe Homebrew::InstallSteps do
   end
 
   specify "moves a directory's children without moving the new target directory" do
-    steps = described_class::DSL.build(default_source_base: :staged_path, default_target_base: :staged_path) do
+    steps = Homebrew::InstallSteps::DSL.build(default_source_base: :staged_path, default_target_base: :staged_path) do
       move_children ".", "Nested"
     end
 
     (root/"stage").mkpath
     (root/"stage/source-file").write "source"
 
-    described_class::Runner.new(context:).run(steps)
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
 
     expect(root/"stage/Nested/source-file").to exist
   end
 
   specify "removes symlinks marked for uninstall" do
-    steps = described_class::DSL.build(default_target_base: :staged_path) do
+    steps = Homebrew::InstallSteps::DSL.build(default_target_base: :staged_path) do
       ln_sf "target", "linked-target", source_base: :relative, uninstall: true
     end
 
     (root/"stage").mkpath
     File.symlink "target", root/"stage/linked-target"
 
-    described_class::Runner.new(context:).run(steps, phase: :uninstall)
+    Homebrew::InstallSteps::Runner.new(context:).run(steps, phase: :uninstall)
 
     expect(root/"stage/linked-target").not_to be_a_symlink
   end
 
   specify "does not expose the surrounding formula or cask DSL" do
     expect do
-      described_class::DSL.build(default_base: :var) do
+      Homebrew::InstallSteps::DSL.build(default_base: :var) do
         system "true"
       end
     end.to raise_error(NameError)

--- a/Library/Homebrew/test/keg_relocate/grep_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/grep_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "keg_relocate"

--- a/Library/Homebrew/test/keg_relocate/text_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/text_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Keg do
   end
 
   def setup_relocation(placeholders: false)
-    relocation = klass::Relocation.new
+    relocation = Keg::Relocation.new
 
     if placeholders
       relocation.add_replacement_pair :dir, placeholder, dir.to_s

--- a/Library/Homebrew/test/livecheck/strategy/crate_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/crate_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"
@@ -53,7 +53,7 @@ RSpec.describe Homebrew::Livecheck::Strategy::Crate do
         "1.0.1" => Version.new("1.0.1"),
         "1.0.0" => Version.new("1.0.0"),
       },
-      regex:   crate::DEFAULT_REGEX,
+      regex:   Homebrew::Livecheck::Strategy::Crate::DEFAULT_REGEX,
       url:     generated[:url],
     }
   end

--- a/Library/Homebrew/test/livecheck/strategy/extract_plist_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/extract_plist_spec.rb
@@ -12,20 +12,20 @@ RSpec.describe Homebrew::Livecheck::Strategy::ExtractPlist do
   let(:non_http_url) { "ftp://brew.sh/" }
   let(:items) do
     {
-      "first"  => extract_plist::Item.new(
+      "first"  => Homebrew::Livecheck::Strategy::ExtractPlist::Item.new(
         bundle_version: Homebrew::BundleVersion.new(nil, "1.2"),
       ),
-      "second" => extract_plist::Item.new(
+      "second" => Homebrew::Livecheck::Strategy::ExtractPlist::Item.new(
         bundle_version: Homebrew::BundleVersion.new(nil, "1.2.3"),
       ),
     }
   end
   let(:multipart_items) do
     {
-      "first"  => extract_plist::Item.new(
+      "first"  => Homebrew::Livecheck::Strategy::ExtractPlist::Item.new(
         bundle_version: Homebrew::BundleVersion.new(nil, "1.2.3-45"),
       ),
-      "second" => extract_plist::Item.new(
+      "second" => Homebrew::Livecheck::Strategy::ExtractPlist::Item.new(
         bundle_version: Homebrew::BundleVersion.new(nil, "1.2.3-45-abcdef"),
       ),
     }
@@ -40,7 +40,7 @@ RSpec.describe Homebrew::Livecheck::Strategy::ExtractPlist do
         expect(items["first"].to_h).to eq({
           bundle_version: { version: "1.2" },
         })
-        expect(extract_plist::Item.new.to_h).to eq({})
+        expect(Homebrew::Livecheck::Strategy::ExtractPlist::Item.new.to_h).to eq({})
       end
     end
   end

--- a/Library/Homebrew/test/livecheck/strategy/github_releases_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/github_releases_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"
@@ -17,7 +17,7 @@ RSpec.describe Homebrew::Livecheck::Strategy::GithubReleases do
     }
   end
   let(:non_github_url) { "https://brew.sh/test" }
-  let(:regex) { github_releases::DEFAULT_REGEX }
+  let(:regex) { Homebrew::Livecheck::Strategy::GithubReleases::DEFAULT_REGEX }
   let(:generated) do
     {
       def:  {
@@ -209,7 +209,7 @@ RSpec.describe Homebrew::Livecheck::Strategy::GithubReleases do
 
     it "returns default match_data when url is blank" do
       expect(github_releases.find_versions(url: ""))
-        .to eq({ matches: {}, regex: github_releases::DEFAULT_REGEX, url: "" })
+        .to eq({ matches: {}, regex: Homebrew::Livecheck::Strategy::GithubReleases::DEFAULT_REGEX, url: "" })
     end
 
     it "returns default match_data when content is blank" do

--- a/Library/Homebrew/test/livecheck/strategy/launchpad_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/launchpad_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"
@@ -83,7 +83,7 @@ RSpec.describe Homebrew::Livecheck::Strategy::Launchpad do
     let(:match_data) do
       cached = {
         matches: matches.to_h { |v| [v, Version.new(v)] },
-        regex:   launchpad::DEFAULT_REGEX,
+        regex:   Homebrew::Livecheck::Strategy::Launchpad::DEFAULT_REGEX,
         url:     generated[:url],
         cached:  true,
       }

--- a/Library/Homebrew/test/livecheck/strategy_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"
@@ -403,7 +403,7 @@ RSpec.describe Homebrew::Livecheck::Strategy do
 
     it "errors when given an invalid value" do
       expect { strategy.handle_block_return(123) }
-        .to raise_error(TypeError, strategy::INVALID_BLOCK_RETURN_VALUE_MSG)
+        .to raise_error(TypeError, Homebrew::Livecheck::Strategy::INVALID_BLOCK_RETURN_VALUE_MSG)
     end
   end
 end

--- a/Library/Homebrew/test/macos_version_spec.rb
+++ b/Library/Homebrew/test/macos_version_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "macos_version"
@@ -78,7 +78,7 @@ RSpec.describe MacOSVersion do
     expect(version).to be === Version.new("10.15") # rubocop:disable Style/CaseEquality
     expect(version).to be < Version.new("11")
     expect(klass.new("11").inspect).to eq("#<MacOSVersion: \"11\">")
-    expect(klass.new(klass::SYMBOLS.values.first).outdated_release?).to be false
+    expect(klass.new(MacOSVersion::SYMBOLS.values.first).outdated_release?).to be false
     expect(klass.new("10.0").outdated_release?).to be true
     expect(klass.new("1000").prerelease?).to be true
     expect(klass.new("10.0").unsupported_release?).to be true
@@ -107,7 +107,7 @@ RSpec.describe MacOSVersion do
     specify do
       expect(big_sur_update.strip_patch).to eq(klass.new("11"))
       expect(catalina_update.strip_patch).to eq(klass.new("10.15"))
-      expect(klass::NULL.strip_patch).to be klass::NULL
+      expect(MacOSVersion::NULL.strip_patch).to be MacOSVersion::NULL
     end
   end
 
@@ -123,7 +123,7 @@ RSpec.describe MacOSVersion do
     expect(frozen_version.to_sym).to eq(version_symbol)
     expect(frozen_version.instance_variable_get(:@sym)).to be_nil
 
-    expect(klass::NULL.to_sym).to eq(:dunno)
+    expect(MacOSVersion::NULL.to_sym).to eq(:dunno)
   end
 
   specify "#pretty_name" do
@@ -158,7 +158,7 @@ RSpec.describe MacOSVersion do
     end
 
     it "returns false when version is null" do
-      expect(klass::NULL.requires_nehalem_cpu?).to be false
+      expect(MacOSVersion::NULL.requires_nehalem_cpu?).to be false
     end
   end
 end

--- a/Library/Homebrew/test/os/linux/libstdcxx_spec.rb
+++ b/Library/Homebrew/test/os/linux/libstdcxx_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe OS::Linux::Libstdcxx do
 
   describe "::system_version" do
     let(:tmpdir) { mktmpdir }
-    let(:libstdcxx) { tmpdir/klass::SONAME }
-    let(:soversion) { Version.new(klass::SOVERSION.to_s) }
+    let(:libstdcxx) { tmpdir/OS::Linux::Libstdcxx::SONAME }
+    let(:soversion) { Version.new(OS::Linux::Libstdcxx::SOVERSION.to_s) }
 
     before do
       tmpdir.mkpath

--- a/Library/Homebrew/test/os/mac/reinstall_spec.rb
+++ b/Library/Homebrew/test/os/mac/reinstall_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "reinstall"
@@ -12,7 +12,7 @@ RSpec.describe Homebrew::Reinstall do
     let(:formula_installer) do
       instance_double(FormulaInstaller, formula:, prelude_fetch: true, prelude: true, fetch: true)
     end
-    let(:context) { instance_double(klass::InstallationContext, formula_installer:) }
+    let(:context) { instance_double(Homebrew::Reinstall::InstallationContext, formula_installer:) }
 
     before do
       allow(Formula).to receive(:[]).with("pkgconf").and_return(formula)

--- a/Library/Homebrew/test/os/mac/sdk_spec.rb
+++ b/Library/Homebrew/test/os/mac/sdk_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe OS::Mac::CLTSDKLocator do
 
     expect(locator.sdk_for(MacOSVersion.new("11"))).to eq(big_sur_sdk)
     expect(locator.sdk_for(MacOSVersion.new("10.15"))).to eq(catalina_sdk)
-    expect { locator.sdk_for(MacOSVersion.new("10.14")) }.to raise_error(klass::NoSDKError)
+    expect { locator.sdk_for(MacOSVersion.new("10.14")) }
+      .to raise_error { |e| expect(e.class.name).to eq("OS::Mac::BaseSDKLocator::NoSDKError") }
   end
 
   describe "#sdk_if_applicable" do

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -122,11 +122,11 @@ RSpec.describe Version do
   end
 
   describe "::NULL_TOKEN" do
-    subject(:null_version) { klass::NULL_TOKEN }
+    subject(:null_version) { Version::NULL_TOKEN }
 
     specify do
       expect(null_version.inspect).to eq("#<Version::NullToken>")
-      expect(null_version).to eq klass::NULL_TOKEN
+      expect(null_version).to eq Version::NULL_TOKEN
     end
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

I got OpenAI Codex 5.3 Medium to bump all the specs to `typed: true` (because Spoom wouldn't do it automatically), then run `brew tc` for only code 5001 errors. There were 120 of them.

-----

- After https://github.com/Homebrew/brew/pull/22307, I looked into what was needed to move the rest of the tests to Sorbet `typed: true` or higher.
- Running `spoom` in dry-run mode found that several files only had one error: using the new `klass` or `subject` variable as a dynamic constant, instead of the full constant name (that is, https://sorbet.org/docs/error-reference#5001).
- For each of the 120 errors upon bumping files, I replaced `klass` or `subject` with the full constant name. Now 30 more tests are typechecked to `true`, and we have less far to go on the others.
