### PR TITLE
Improve cleanup ask output

### DIFF
--- a/Library/Homebrew/bundle/subcommand/cleanup.rb
+++ b/Library/Homebrew/bundle/subcommand/cleanup.rb
@@ -3,6 +3,7 @@
 
 require "abstract_subcommand"
 require "bundle/extensions/extension"
+require "cleanup"
 
 require "utils/formatter"
 require "utils"
@@ -172,13 +173,9 @@ module Homebrew
               would_uninstall = true
             end
 
-            cleanup = system_output_no_stderr(HOMEBREW_BREW_FILE, "cleanup", "--dry-run")
-            unless cleanup.empty?
-              puts "Would `brew cleanup`:"
-              puts cleanup
-            end
+            would_cleanup = Cleanup.printed_dry_run_output?(Cleanup.dry_run_output)
 
-            puts "Run `brew bundle cleanup --force` to make these changes." if would_uninstall || !cleanup.empty?
+            puts "Run `brew bundle cleanup --force` to make these changes." if would_uninstall || would_cleanup
             exit 1 if would_uninstall
           end
         end

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -4,6 +4,7 @@
 require "utils/bottles"
 require "utils/output"
 require "installed_dependents"
+require "stringio"
 
 require "formula"
 require "cask/cask_loader"
@@ -272,21 +273,53 @@ module Homebrew
     sig { returns(T::Boolean) }
     def scrub? = @scrub
 
-    sig { params(formula: Formula, dry_run: T::Boolean).void }
-    def self.install_formula_clean!(formula, dry_run: false)
-      return if Homebrew::EnvConfig.no_install_cleanup?
-      return unless formula.latest_version_installed?
-      return if skip_clean_formula?(formula)
+    sig { params(output: String, ohai: T::Boolean).returns(T::Boolean) }
+    def self.printed_dry_run_output?(output, ohai: false)
+      return false if output.blank?
 
-      if dry_run
-        ohai "Would run `brew cleanup #{formula}`"
+      if ohai
+        ohai "Would `brew cleanup`"
       else
-        ohai "Running `brew cleanup #{formula}`..."
+        puts "Would `brew cleanup`:"
       end
+      print output
+      puts unless output.end_with?("\n")
+      true
+    end
 
+    sig { params(args: String, formulae: T::Array[Formula]).returns(String) }
+    def self.dry_run_output(*args, formulae: [])
+      output = StringIO.new
+      old_stdout = $stdout
+      begin
+        $stdout = output
+        cleanup = Cleanup.new(*args, dry_run: true)
+        if formulae.empty?
+          cleanup.clean!
+        else
+          formulae.each { |formula| cleanup.cleanup_formula(formula) }
+        end
+      ensure
+        $stdout = old_stdout
+      end
+      output.string
+    end
+
+    sig { params(formulae: T::Array[Formula]).returns(T::Array[Formula]) }
+    def self.install_cleanup_formulae(formulae)
+      return [] if Homebrew::EnvConfig.no_install_cleanup?
+
+      formulae.select do |formula|
+        formula.latest_version_installed? && !skip_clean_formula?(formula)
+      end
+    end
+
+    sig { params(formula: Formula).void }
+    def self.install_formula_clean!(formula)
+      return if install_cleanup_formulae([formula]).blank?
+
+      ohai "Running `brew cleanup #{formula}`..."
       puts_no_install_cleanup_disable_message_if_not_already!
-      return if dry_run
-
       Cleanup.new.cleanup_formula(formula)
     end
 

--- a/Library/Homebrew/test/cmd/bundle/cleanup_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/cleanup_subcommand_spec.rb
@@ -382,7 +382,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
     it "lists casks, formulae and taps" do
       expect(Formatter).to receive(:columns).with(%w[a b]).exactly(5).times.and_return("a b")
       expect(Kernel).not_to receive(:system)
-      expect(klass).to receive(:system_output_no_stderr).and_return("")
+      expect(Homebrew::Cleanup).to receive(:dry_run_output).and_return("")
       output_pattern = Regexp.new(
         "Would uninstall casks:.*Would uninstall formulae:.*Would untap:.*" \
         "Would uninstall VSCode extensions:.*Would uninstall flatpaks:",
@@ -405,12 +405,13 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
     end
 
     define_method(:sane?) do
-      expect(klass).to receive(:system_output_no_stderr).and_return("cleaned")
+      expect(klass).not_to receive(:system_output_no_stderr)
+      expect(Homebrew::Cleanup).to receive(:dry_run_output).and_return("cleaned")
     end
 
     context "with --force" do
       it "prints output" do
-        sane?
+        expect(klass).to receive(:system_output_no_stderr).and_return("cleaned")
         expect { klass.cleanup(force: true) }.to output(/cleaned/).to_stdout
       end
     end
@@ -418,7 +419,11 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
     context "without --force" do
       it "prints output" do
         sane?
-        expect { klass.cleanup }.to output(/cleaned/).to_stdout
+        expect { klass.cleanup }.to output(<<~EOS).to_stdout
+          Would `brew cleanup`:
+          cleaned
+          Run `brew bundle cleanup --force` to make these changes.
+        EOS
       end
     end
   end

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -334,6 +334,34 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       .to eq(["testball 0.1 -> 0.2 (500B)"])
   end
 
+  it "prints dry-run cleanup output from one formula cleanup run" do
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.2"
+    end
+    other_formula = formula("otherball") do
+      url "https://brew.sh/otherball-0.2"
+    end
+
+    allow(Homebrew::Install).to receive(:print_dry_run_dependencies)
+    allow(formula).to receive(:latest_version_installed?).and_return(true)
+    allow(other_formula).to receive(:latest_version_installed?).and_return(true)
+    expect(Homebrew::Cleanup).to receive(:dry_run_output)
+      .with(formulae: [formula, other_formula])
+      .and_return("Would remove: #{HOMEBREW_CELLAR}/testball/0.1 (1KB)\n")
+
+    with_env(HOMEBREW_NO_ENV_HINTS: "1") do
+      expect do
+        Homebrew::Upgrade.upgrade_formulae(
+          [FormulaInstaller.new(formula), FormulaInstaller.new(other_formula)],
+          dry_run: true,
+        )
+      end.to output(<<~EOS).to_stdout
+        ==> Would `brew cleanup`
+        Would remove: #{HOMEBREW_CELLAR}/testball/0.1 (1KB)
+      EOS
+    end
+  end
+
   it "omits dry-run dependencies already listed in the final summary" do
     formula = formula("yt-dlp") do
       url "https://brew.sh/yt-dlp-2026.3.17_2.tar.gz"

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -142,7 +142,14 @@ module Homebrew
 
         valid_formula_installers.each do |fi|
           upgrade_formula(fi, dry_run:, verbose:, skip_formula_names:)
-          Cleanup.install_formula_clean!(fi.formula, dry_run:)
+          Cleanup.install_formula_clean!(fi.formula) unless dry_run
+        end
+        return unless dry_run
+
+        formulae_to_clean = Cleanup.install_cleanup_formulae(valid_formula_installers.map(&:formula))
+        if formulae_to_clean.present? &&
+           Cleanup.printed_dry_run_output?(Cleanup.dry_run_output(formulae: formulae_to_clean), ohai: true)
+          Cleanup.puts_no_install_cleanup_disable_message_if_not_already!
         end
       end
 


### PR DESCRIPTION
- Avoid noisy command previews during `brew upgrade --ask`.
- Share one dry-run cleanup heading across formulae.
- Get upgrade cleanup output from one named dry run.
- Reuse bundle cleanup output formatting for consistency.
- Avoid shelling out for bundle cleanup dry runs.
- Reuse `Cleanup#cleanup_formula` so dry runs show removals.
- Skip empty cleanup headings when there is no work.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
