### PR TITLE
mcp: fix required placement, add lgtm tool, nil safety, isError reporting

### DIFF
--- a/Library/Homebrew/mcp_server.rb
+++ b/Library/Homebrew/mcp_server.rb
@@ -317,7 +317,7 @@ module Homebrew
 
       require "open3"
 
-      command_args = tool_command_arguments(tool_name, request["params"]["arguments"])
+      command_args = tool_command_arguments(tool_name, request["params"]["arguments"] || {})
       progress_token = request["params"]["_meta"]&.fetch("progressToken", nil)
       brew_command = T.cast(tool.fetch(:command), String)
                       .delete_prefix("brew ")
@@ -325,9 +325,10 @@ module Homebrew
       progress = T.let(0, Integer)
       done = T.let(false, T::Boolean)
       new_output = T.let(false, T::Boolean)
+      success = T.let(true, T::Boolean)
       output = +""
 
-      text = Open3.popen2e(HOMEBREW_BREW_FILE, brew_command, *command_args) do |stdin, io, _wait|
+      text = Open3.popen2e(HOMEBREW_BREW_FILE, brew_command, *command_args) do |stdin, io, wait|
         stdin.close
 
         reader = Thread.new do
@@ -361,11 +362,14 @@ module Homebrew
         end
 
         reader.join
+        success = wait.value.success?
 
         output
       end
 
-      respond_result(id, { content: [{ type: "text", text: }] })
+      result = { content: [{ type: "text", text: }] }
+      result[:isError] = true unless success
+      respond_result(id, result)
     end
 
     sig { params(tool_name: Symbol, arguments: T::Hash[String, T.untyped]).returns(T::Array[String]) }

--- a/Library/Homebrew/mcp_server.rb
+++ b/Library/Homebrew/mcp_server.rb
@@ -46,8 +46,8 @@ module Homebrew
               description: "Text or regex to search for",
             },
           },
+          required:   ["text_or_regex"],
         },
-        required:    ["text_or_regex"],
       },
       info:      {
         name:        "info",
@@ -60,8 +60,7 @@ module Homebrew
         name:        "install",
         description: "Install a <formula> or <cask>.",
         command:     "brew install",
-        inputSchema: { type: "object", properties: FORMULA_OR_CASK_PROPERTIES },
-        required:    ["formula_or_cask"],
+        inputSchema: { type: "object", properties: FORMULA_OR_CASK_PROPERTIES, required: ["formula_or_cask"] },
       },
       update:    {
         name:        "update",
@@ -82,8 +81,7 @@ module Homebrew
         name:        "uninstall",
         description: "Uninstall a <formula> or <cask>.",
         command:     "brew uninstall",
-        inputSchema: { type: "object", properties: FORMULA_OR_CASK_PROPERTIES },
-        required:    ["formula_or_cask"],
+        inputSchema: { type: "object", properties: FORMULA_OR_CASK_PROPERTIES, required: ["formula_or_cask"] },
       },
       list:      {
         name:        "list",
@@ -161,6 +159,21 @@ module Homebrew
             online:    {
               type:        "boolean",
               description: "Run online tests",
+            },
+          },
+        },
+      },
+      lgtm:      {
+        name:        "lgtm",
+        description: "Run brew typecheck, brew style --changed and the relevant brew tests in one go. " \
+                     "Use this to verify file edits before committing.",
+        command:     "brew lgtm",
+        inputSchema: {
+          type:       "object",
+          properties: {
+            online: {
+              type:        "boolean",
+              description: "Run additional, slower checks that require a network connection",
             },
           },
         },
@@ -357,6 +370,8 @@ module Homebrew
     sig { params(tool_name: Symbol, arguments: T::Hash[String, T.untyped]).returns(T::Array[String]) }
     def tool_command_arguments(tool_name, arguments)
       case tool_name
+      when :lgtm
+        arguments["online"] ? ["--online"] : []
       when :style
         style_args = []
         style_args << "--fix" if arguments["fix"]

--- a/Library/Homebrew/mcp_server.rb
+++ b/Library/Homebrew/mcp_server.rb
@@ -165,7 +165,8 @@ module Homebrew
       },
       lgtm:      {
         name:        "lgtm",
-        description: "Run brew typecheck, brew style --changed and the relevant brew tests in one go. " \
+        description: "Run brew typecheck, brew style --changed and the relevant brew tests, " \
+                     "brew audit and brew test checks in one go. " \
                      "Use this to verify file edits before committing.",
         command:     "brew lgtm",
         inputSchema: {

--- a/Library/Homebrew/test/mcp_server_spec.rb
+++ b/Library/Homebrew/test/mcp_server_spec.rb
@@ -215,6 +215,54 @@ RSpec.describe Homebrew::McpServer do
     end
   end
 
+  describe "#respond_to_tools_call" do
+    it "sets isError: true when the brew command exits non-zero" do
+      mock_stdin = instance_double(IO, close: nil)
+      mock_io = instance_double(IO)
+      mock_wait = instance_double(Thread)
+      mock_status = instance_double(Process::Status, success?: false)
+      allow(mock_io).to receive(:readpartial).and_raise(EOFError)
+      allow(mock_wait).to receive(:value).and_return(mock_status)
+      allow(Open3).to receive(:popen2e).and_yield(mock_stdin, mock_io, mock_wait)
+
+      request = {
+        "id"     => id,
+        "method" => "tools/call",
+        "params" => { "name" => "config", "arguments" => {} },
+      }
+      result = server.handle_request(request)
+      expect(result[:result][:isError]).to be(true)
+    end
+
+    it "omits isError when the brew command exits zero" do
+      mock_stdin = instance_double(IO, close: nil)
+      mock_io = instance_double(IO)
+      mock_wait = instance_double(Thread)
+      mock_status = instance_double(Process::Status, success?: true)
+      allow(mock_io).to receive(:readpartial).and_raise(EOFError)
+      allow(mock_wait).to receive(:value).and_return(mock_status)
+      allow(Open3).to receive(:popen2e).and_yield(mock_stdin, mock_io, mock_wait)
+
+      request = {
+        "id"     => id,
+        "method" => "tools/call",
+        "params" => { "name" => "config", "arguments" => {} },
+      }
+      result = server.handle_request(request)
+      expect(result[:result]).not_to have_key(:isError)
+    end
+
+    it "does not crash when arguments is nil" do
+      allow(Open3).to receive(:popen2e).and_return("")
+      request = {
+        "id"     => id,
+        "method" => "tools/call",
+        "params" => { "name" => "config", "arguments" => nil },
+      }
+      expect { server.handle_request(request) }.not_to raise_error
+    end
+  end
+
   describe "#run" do
     let(:sleep_time) { 0.001 }
 

--- a/Library/Homebrew/test/mcp_server_spec.rb
+++ b/Library/Homebrew/test/mcp_server_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Homebrew::McpServer do
       it "responds to tools/call for #{tool_name}" do
         allow(Open3).to receive(:popen2e).and_return("output for #{tool_name}")
         arguments = {}
-        Array(tool_definition[:required]).each do |required_key|
+        Array(tool_definition.dig(:inputSchema, :required)).each do |required_key|
           arguments[required_key] = "dummy"
         end
         request = {


### PR DESCRIPTION
## Summary

- Move `required` inside `inputSchema` for `search`, `install` and `uninstall` so MCP clients (including Claude) correctly treat them as mandatory JSON Schema constraints — at the tool level they are silently ignored
- Add a `lgtm` tool exposing `brew lgtm [--online]`, the all-in-one typecheck + style + tests + audit command recommended in AGENTS.md for verifying edits before committing
- Fix a crash when MCP clients send `null` arguments (e.g. for tools with no parameters)
- Report `isError: true` in the tool result when a brew command exits non-zero, per the MCP spec which requires failed tool calls to be distinguished from successful ones

## Test plan

- [ ] `brew tests --only=mcp_server` passes (47 examples)
- [ ] `brew typecheck` passes
- [ ] `brew style Library/Homebrew/mcp_server.rb` passes
- [ ] `brew mcp-server --ping` starts and responds correctly