### PR TITLE
Add CI check against conventional commit messages

### DIFF
--- a/.github/workflows/reject-conventional-commits.yml
+++ b/.github/workflows/reject-conventional-commits.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          pattern='^(feat|fix|chore|docs|style|refactor|perf|test|build|ci)(\([^)]*\))?!?:'
+          pattern='^(feat|fix|chore|refactor|perf|ci)(\([^)]*\))?!?:'
           violations=()
           while IFS= read -r title; do
             if [[ "$title" =~ $pattern ]]; then

--- a/.github/workflows/reject-conventional-commits.yml
+++ b/.github/workflows/reject-conventional-commits.yml
@@ -1,0 +1,39 @@
+name: Commit Style
+
+on:
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  reject-conventional-commits:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 25
+          persist-credentials: false
+
+      - name: Check commit titles
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          pattern='^(feat|fix|chore|docs|style|refactor|perf|test|build|ci)(\([^)]*\))?!?:'
+          violations=()
+          while IFS= read -r title; do
+            if [[ "$title" =~ $pattern ]]; then
+              violations+=("$title")
+            fi
+          done < <(git log --format=%s "${BASE_SHA}..${HEAD_SHA}")
+          if (( ${#violations[@]} > 0 )); then
+            echo "Conventional commit prefixes are not allowed. Found:"
+            printf '  - %s\n' "${violations[@]}"
+            exit 1
+          fi
+          echo "OK — no conventional commit prefixes found."


### PR DESCRIPTION
Since we don't use conventional commit messages, it would be good to warn people about using them

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude generated the whole workflow for me.

-----
