### PR TITLE
Fix zsh nested subcommand option completion

### DIFF
--- a/Library/Homebrew/completions.rb
+++ b/Library/Homebrew/completions.rb
@@ -435,7 +435,7 @@ module Homebrew
               _describe -t subcommands 'subcommand' subcommands
               ;;
             args)
-              case "$words[2]" in
+              case "$words[1]" in
         #{subcommand_cases.chomp}
                 *) ;;
               esac

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -464,6 +464,7 @@ RSpec.describe Homebrew::Completions do
         stub_nested_completion_command(nested_completion_command, nested_completion_subcommands)
         completion = klass.generate_zsh_subcommand_completion(nested_completion_command)
 
+        expect(completion).to include('case "$words[1]" in')
         expect(completion).to include("'1:subcommand:->subcommand'")
         expect(completion).to include("  _arguments -C \\\n    '--global[Use the global test file]' \\\n    " \
                                       "'1:subcommand:->subcommand'")

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -416,7 +416,7 @@ _brew_analytics() {
       _describe -t subcommands 'subcommand' subcommands
       ;;
     args)
-      case "$words[2]" in
+      case "$words[1]" in
 state)
         _arguments \
           '--debug[Display any debugging information]' \
@@ -679,7 +679,7 @@ _brew_bundle() {
       _describe -t subcommands 'subcommand' subcommands
       ;;
     args)
-      case "$words[2]" in
+      case "$words[1]" in
 sh)
         _arguments \
           '--check[Check that all dependencies in the Brewfile are installed before starting the shell. Enabled by default if `$HOMEBREW_BUNDLE_CHECK` is set]' \
@@ -981,7 +981,7 @@ _brew_completions() {
       _describe -t subcommands 'subcommand' subcommands
       ;;
     args)
-      case "$words[2]" in
+      case "$words[1]" in
 unlink)
         _arguments \
           '--debug[Display any debugging information]' \
@@ -1155,7 +1155,7 @@ _brew_developer() {
       _describe -t subcommands 'subcommand' subcommands
       ;;
     args)
-      case "$words[2]" in
+      case "$words[1]" in
 state)
         _arguments \
           '--debug[Display any debugging information]' \
@@ -2056,7 +2056,7 @@ _brew_services() {
       _describe -t subcommands 'subcommand' subcommands
       ;;
     args)
-      case "$words[2]" in
+      case "$words[1]" in
 stop|unload|terminate|term|t|u)
         _arguments \
           '(--file)--all[Stop all services and unregister them from launching at login (or boot), unless `--keep` is specified]' \


### PR DESCRIPTION
In zsh completion context, the words array excludes the command name, so subcommands are not matched and per-subcommand options are not suggested.

To fix that, use `$words[1]` instead of `$words[2]` when dispatching nested subcommands in generated zsh completions.

For reference, see zshcompsys's manpage [^1], specifically "the `words` special array and the `CURRENT` special parameter are modified to refer only to the normal arguments when the *action* is executed or evaluated":

```console
$ man zshcompsys | col -bx | grep -F -A 13 '*::message:action'
              *::message:action
              *:::message:action
                     This describes how arguments (usually non-option
                     arguments, those not beginning with - or +) are to be
                     completed when neither of the first two forms was
                     provided.  Any number of arguments can be completed in
                     this fashion.

                     With two colons before the message, the words special
                     array and the CURRENT special parameter are modified to
                     refer only to the normal arguments when the action is
                     executed or evaluated.  With three colons before the
                     message they are modified to refer only to the normal
                     arguments covered by this description.
```

Also confirmed that this issue is zsh-specific. Bash and fish completions work fine.

[^1]: https://zsh.sourceforge.io/Doc/Release/Completion-System.html

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->
Claude helped to locate and fix the problem.

-----
