### PR TITLE
Fix cask upgrade env conflict

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -40,7 +40,8 @@ module Cask
       # Validate mutually exclusive opt-in/opt-out env vars before we start
       # selecting casks so `brew upgrade` errors consistently.
       if Homebrew::EnvConfig.upgrade_auto_updates_casks? &&
-         Homebrew::EnvConfig.no_upgrade_auto_updates_casks?
+         Homebrew::EnvConfig.no_upgrade_auto_updates_casks? &&
+         !Homebrew::EnvConfig.developer?
         raise UsageError,
               "`HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS` and `HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS` " \
               "cannot both be set."

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -138,6 +138,19 @@ RSpec.describe Cask::Upgrade, :cask do
         end
       end
 
+      it "lets HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS override the developer default" do
+        allow(Homebrew::EnvConfig).to receive(:upgrade_auto_updates_casks?).and_call_original
+
+        with_env(
+          "HOMEBREW_DEVELOPER"                     => "1",
+          "HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS"    => "1",
+          "HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS" => "1",
+        ) do
+          expect { klass.upgrade_casks!(dry_run: true, args:) }
+            .not_to raise_error
+        end
+      end
+
       it 'excludes "auto_updates true" casks when the installed bundle matches the tap version' do
         write_info_plist(auto_updates_path, short_version: "2.61", bundle_version: "2061")
 


### PR DESCRIPTION
- Avoid treating the developer default as an explicit `HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS` opt-in.
- Preserve the existing error when users explicitly set both `HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS` and `HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS` outside developer mode.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

OpenAI 5.5 xhigh with local testing and review.

-----
