### PR TITLE
cask/upgrade: re-register application bundle before reopen

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -313,12 +313,23 @@ module Cask
       false
     end
 
-    sig { params(old_cask: Cask).void }
-    def self.reopen_apps_after_upgrade(old_cask)
+    sig { params(old_cask: Cask, new_cask: Cask).void }
+    def self.reopen_apps_after_upgrade(old_cask, new_cask)
       bundle_ids = old_cask.artifacts
                            .grep(Artifact::Uninstall)
                            .flat_map(&:bundle_ids_to_reopen)
       return if bundle_ids.empty?
+
+      # Re-register newly installed apps with Launch Services before reopening
+      lsregister = Pathname(
+        "/System/Library/Frameworks/CoreServices.framework" \
+        "/Frameworks/LaunchServices.framework/Support/lsregister",
+      )
+      if lsregister.executable?
+        new_cask.artifacts.grep(Artifact::App).each do |artifact|
+          system(lsregister.to_s, "-f", artifact.target.to_s) if artifact.target.exist?
+        end
+      end
 
       ohai "Reopening #{bundle_ids.count} #{::Utils.pluralize("application",
                                                               bundle_ids.count)} closed during upgrade:"
@@ -430,7 +441,7 @@ module Cask
         # If successful, wipe the old cask from staging.
         old_cask_installer.finalize_upgrade
 
-        reopen_apps_after_upgrade(old_cask) if quit
+        reopen_apps_after_upgrade(old_cask, new_cask) if quit
       rescue => e
         new_cask_installer.uninstall_artifacts(successor: old_cask, quit:) if new_artifacts_installed
         new_cask_installer.purge_versioned_files


### PR DESCRIPTION
After a cask upgrade installs a new app bundle, `open -b <bundle_id>` can fail with LSCopyApplicationURLsForBundleIdentifier() failed because Launch Services   hasn't re-indexed the new bundle yet.

Fix this by running `lsregister` on each newly installed .app artifact before attempting to reopen by bundle ID. This forces synchronous LS re-registration and has negligible overhead relative to the preceding download and install. Note: this only applies to `app` stanzas.

In testing this does not extend the time it takes to run `brew upgrade` an discernible amount.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

I used `claude-code` to help implement the registration of the replaced application.

-----
