### PR TITLE
fetch: add `--all-platforms` to fetch every variant

### DIFF
--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -131,7 +131,8 @@ module Homebrew
         # `--all-platforms` is equivalent to `--os=all --arch=all`.
         all_platforms = @table[:all_platforms?]
 
-        oses = case (os_sym = all_platforms ? :all : @table[:os]&.to_sym)
+        os_sym = all_platforms ? :all : @table[:os]&.to_sym
+        oses = case os_sym
         when nil
           [SimulateSystem.current_os]
         when :all
@@ -142,7 +143,8 @@ module Homebrew
           [os_sym]
         end
 
-        arches = case (arch_sym = all_platforms ? :all : @table[:arch]&.to_sym)
+        arch_sym = all_platforms ? :all : @table[:arch]&.to_sym
+        arches = case arch_sym
         when nil
           [SimulateSystem.current_arch]
         when :all

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -128,7 +128,10 @@ module Homebrew
       def os_arch_combinations
         skip_invalid_combinations = false
 
-        oses = case (os_sym = @table[:os]&.to_sym)
+        # `--all-platforms` is equivalent to `--os=all --arch=all`.
+        all_platforms = @table[:all_platforms?]
+
+        oses = case (os_sym = all_platforms ? :all : @table[:os]&.to_sym)
         when nil
           [SimulateSystem.current_os]
         when :all
@@ -139,7 +142,7 @@ module Homebrew
           [os_sym]
         end
 
-        arches = case (arch_sym = @table[:arch]&.to_sym)
+        arches = case (arch_sym = all_platforms ? :all : @table[:arch]&.to_sym)
         when nil
           [SimulateSystem.current_arch]
         when :all

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -4,6 +4,7 @@
 require "abstract_command"
 require "formula"
 require "fetch"
+require "cask/config"
 require "cask/download"
 require "download_queue"
 
@@ -25,6 +26,9 @@ module Homebrew
         flag   "--arch=",
                description: "Download for the given CPU architecture. " \
                             "(Pass `all` to download for all architectures.)"
+        switch "--all-platforms",
+               description: "Download for every supported operating system and architecture, plus each " \
+                            "language for <cask>s, fetching each distinct URL once."
         flag   "--bottle-tag=",
                description: "Download a bottle for given tag."
         switch "--HEAD",
@@ -65,6 +69,9 @@ module Homebrew
         conflicts "--formula", "--cask"
         conflicts "--os", "--bottle-tag"
         conflicts "--arch", "--bottle-tag"
+        conflicts "--all-platforms", "--os"
+        conflicts "--all-platforms", "--arch"
+        conflicts "--all-platforms", "--bottle-tag"
 
         named_args [:formula, :cask], min: 1
       end
@@ -154,30 +161,7 @@ module Homebrew
               end
             end
           when Cask::Cask
-            cask = formula_or_cask
-            ref = cask.loaded_from_api? ? cask.full_name : cask.sourcefile_path
-            odie "unexpected nil cask sourcefile_path" unless ref
-
-            os_arch_combinations.each do |os, arch|
-              SimulateSystem.with(os:, arch:) do
-                cask = Cask::CaskLoader.load(ref)
-
-                if cask.url.nil? || cask.sha256.nil?
-                  opoo "Cask #{cask} is not supported on os #{os} and arch #{arch}"
-                  next
-                end
-
-                quarantine = args.quarantine?
-                quarantine = true if quarantine.nil?
-
-                download = Cask::Download.new(
-                  cask,
-                  quarantine:,
-                  require_sha: Homebrew::EnvConfig.cask_opts_require_sha?,
-                )
-                download_queue.enqueue(download)
-              end
-            end
+            cask_downloads(formula_or_cask).each { |download| download_queue.enqueue(download) }
           else
             odie "Invalid formula or cask: #{formula_or_cask}"
           end
@@ -189,6 +173,72 @@ module Homebrew
       end
 
       private
+
+      sig { params(cask: Cask::Cask).returns(T::Array[Cask::Download]) }
+      def cask_downloads(cask)
+        ref = cask.loaded_from_api? ? cask.full_name : cask.sourcefile_path
+        odie "unexpected nil cask sourcefile_path" unless ref
+
+        quarantine = args.quarantine?
+        quarantine = true if quarantine.nil?
+
+        if args.all_platforms? && cask.loaded_from_api?
+          opoo "Cask #{cask} was loaded from the API; cannot fetch all operating system and " \
+               "architecture variants. Set `HOMEBREW_NO_INSTALL_FROM_API=1` to fetch them all."
+        end
+
+        # With `--all-platforms`, a cask without `on_system` blocks resolves
+        # identically everywhere, so one combination covers the whole matrix.
+        cask_combinations = args.os_arch_combinations
+        cask_combinations = cask_combinations.first(1) if args.all_platforms? && !cask.on_system_blocks_exist?
+
+        downloads = T.let([], T::Array[Cask::Download])
+        enqueued_urls = Set.new
+
+        cask_combinations.each do |os, arch|
+          SimulateSystem.with(os:, arch:) do
+            loaded_cask = begin
+              Cask::CaskLoader.load(ref)
+            rescue Cask::CaskInvalidError, Cask::CaskUnreadableError
+              raise unless cask.on_system_blocks_exist?
+            end
+            if loaded_cask.nil?
+              opoo "Cask #{cask} is not supported on os #{os} and arch #{arch}"
+              next
+            end
+
+            languages = (loaded_cask.languages if args.all_platforms?)
+            languages = [nil] if languages.blank?
+
+            languages.each do |language|
+              localized_cask = loaded_cask
+              if language
+                # Reload per language: `Cask::Download` reads `sha256`/`url`
+                # lazily, so each download needs its own cask instance.
+                localized_cask = Cask::CaskLoader.load(ref)
+                localized_cask.config = localized_cask.config.merge(
+                  Cask::Config.new(explicit: { languages: [language] }),
+                )
+              end
+
+              if localized_cask.url.nil? || localized_cask.sha256.nil?
+                opoo "Cask #{cask} is not supported on os #{os} and arch #{arch}"
+                next
+              end
+
+              next unless enqueued_urls.add?(localized_cask.url.to_s)
+
+              downloads << Cask::Download.new(
+                localized_cask,
+                quarantine:,
+                require_sha: Homebrew::EnvConfig.cask_opts_require_sha?,
+              )
+            end
+          end
+        end
+
+        downloads
+      end
 
       sig { returns(Integer) }
       def retries

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/fetch_cmd.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/fetch_cmd.rbi
@@ -14,6 +14,9 @@ class Homebrew::Cmd::FetchCmd::Args < Homebrew::CLI::Args
   sig { returns(T::Boolean) }
   def HEAD?; end
 
+  sig { returns(T::Boolean) }
+  def all_platforms?; end
+
   sig { returns(T.nilable(String)) }
   def arch; end
 

--- a/Library/Homebrew/test/cmd/fetch_spec.rb
+++ b/Library/Homebrew/test/cmd/fetch_spec.rb
@@ -19,4 +19,19 @@ RSpec.describe Homebrew::Cmd::FetchCmd do
     expect(HOMEBREW_CACHE/"testball2--0.1.tbz").to exist
     expect((HOMEBREW_CACHE/"downloads").glob("*--caffeine.zip")).not_to be_empty
   end
+
+  describe "#cask_downloads", :cask do
+    it "collects one download per distinct URL across all platforms" do
+      cmd = Homebrew::Cmd::FetchCmd.new(["--cask", "--all-platforms", "sha256-os"])
+      basenames = cmd.send(:cask_downloads, Cask::CaskLoader.load("sha256-os"))
+                     .map { |download| File.basename(download.url.to_s) }
+      expect(basenames).to contain_exactly("caffeine-arm-darwin.zip", "caffeine-intel-darwin.zip",
+                                           "caffeine-arm-linux.zip", "caffeine-intel-linux.zip")
+    end
+
+    it "collapses to a single download for a cask without on_system blocks" do
+      cmd = Homebrew::Cmd::FetchCmd.new(["--cask", "--all-platforms", "local-caffeine"])
+      expect(cmd.send(:cask_downloads, Cask::CaskLoader.load("local-caffeine")).length).to eq(1)
+    end
+  end
 end

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -1453,6 +1453,7 @@ _brew_fetch() {
     -*)
       __brewcomp "
       --HEAD
+      --all-platforms
       --arch
       --bottle-tag
       --build-bottle

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -974,6 +974,7 @@ __fish_brew_complete_arg 'extract' -a '(__fish_brew_suggest_taps_installed)'
 
 __fish_brew_complete_cmd 'fetch' 'Download a bottle (if available) or source packages for formulae and binaries for casks'
 __fish_brew_complete_arg 'fetch' -l HEAD -d 'Fetch HEAD version instead of stable version'
+__fish_brew_complete_arg 'fetch' -l all-platforms -d 'Download for every supported operating system and architecture, plus each language for casks, fetching each distinct URL once'
 __fish_brew_complete_arg 'fetch' -l arch -d 'Download for the given CPU architecture. (Pass `all` to download for all architectures.)'
 __fish_brew_complete_arg 'fetch' -l bottle-tag -d 'Download a bottle for given tag'
 __fish_brew_complete_arg 'fetch' -l build-bottle -d 'Download source packages (for eventual bottling) rather than a bottle'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -1274,8 +1274,9 @@ _brew_extract() {
 _brew_fetch() {
   _arguments \
     '(--cask)--HEAD[Fetch HEAD version instead of stable version]' \
-    '(--bottle-tag)--arch[Download for the given CPU architecture. (Pass `all` to download for all architectures.)]' \
-    '(--build-from-source --build-bottle --force-bottle --cask --os --arch)--bottle-tag[Download a bottle for given tag]' \
+    '(--os --arch --bottle-tag)--all-platforms[Download for every supported operating system and architecture, plus each language for casks, fetching each distinct URL once]' \
+    '(--bottle-tag --all-platforms)--arch[Download for the given CPU architecture. (Pass `all` to download for all architectures.)]' \
+    '(--build-from-source --build-bottle --force-bottle --cask --os --arch --all-platforms)--bottle-tag[Download a bottle for given tag]' \
     '(--build-from-source --force-bottle --bottle-tag --cask)--build-bottle[Download source packages (for eventual bottling) rather than a bottle]' \
     '(--build-bottle --force-bottle --bottle-tag)--build-from-source[Download source packages rather than a bottle]' \
     '--debug[Display any debugging information]' \
@@ -1283,7 +1284,7 @@ _brew_fetch() {
     '--force[Remove a previously cached version and re-fetch]' \
     '(--build-from-source --build-bottle --bottle-tag --cask)--force-bottle[Download a bottle if it exists for the current or newest version of macOS, even if it would not be used during installation]' \
     '--help[Show this message]' \
-    '(--bottle-tag)--os[Download for the given operating system. (Pass `all` to download for all operating systems.)]' \
+    '(--bottle-tag --all-platforms)--os[Download for the given operating system. (Pass `all` to download for all operating systems.)]' \
     '--quiet[Make some output more quiet]' \
     '--retry[Retry if downloading fails or re-download if the checksum of a previously cached version no longer matches. Tries at most 5 times with exponential backoff]' \
     '--verbose[Do a verbose VCS checkout, if the URL represents a VCS. This is useful for seeing if an existing VCS cache has been updated]' \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -993,6 +993,11 @@ binaries for *`cask`*s. For files, also print SHA-256 checksums.
 : Download for the given CPU architecture. (Pass `all` to download for all
   architectures.)
 
+`--all-platforms`
+
+: Download for every supported operating system and architecture, plus each
+  language for *`cask`*s, fetching each distinct URL once.
+
 `--bottle-tag`
 
 : Download a bottle for given tag.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -650,6 +650,9 @@ Download for the given operating system\. (Pass \fBall\fP to download for all op
 \fB\-\-arch\fP
 Download for the given CPU architecture\. (Pass \fBall\fP to download for all architectures\.)
 .TP
+\fB\-\-all\-platforms\fP
+Download for every supported operating system and architecture, plus each language for \fIcask\fPs, fetching each distinct URL once\.
+.TP
 \fB\-\-bottle\-tag\fP
 Download a bottle for given tag\.
 .TP


### PR DESCRIPTION
`brew fetch --cask --all-platforms <cask>` downloads every supported variant of a cask in one command, to verify that all URLs resolve and checksums match without manually iterating `--os`/`--arch`.

It iterates the full OS/arch matrix (every macOS version × `arm`/`intel`, plus Linux) and each `language` block, then downloads each *distinct* URL once (many combinations resolve to the same file). This covers casks whose URL varies by macOS version — e.g. `itsycal` resolves to `0.14.1` on Catalina and `0.15.12` on Big Sur and newer — not just a fixed set of platform corners.

Notes:

- `--all-platforms` is equivalent to `--os=all --arch=all` and reuses the existing `os_arch_combinations` machinery, so it also works for `<formula>`e (fetching every bottle); the `language` and distinct-URL handling are cask-specific.
- Under `--all-platforms`, a cask without `on_system` blocks resolves identically everywhere, so it collapses to a single combination (existing `--os=all`/`--arch=all` behaviour is unchanged).
- Casks that legitimately omit some platforms (e.g. an `on_linux` block with only `x86_64_linux`) are tolerated rather than raising, mirroring the `bump-cask-pr` rescue pattern.
- OS/arch cannot be simulated for casks loaded from the API, so an `opoo` points to `HOMEBREW_NO_INSTALL_FROM_API` (languages are unaffected). This matches the pre-existing behaviour of `--os=all --arch=all`.
- Profiling note: cask reloading under simulation is ~1 ms each; the dominant cost is one `curl --head` redirect resolution per *unique* URL, inherent to resolving a download's cached filename.

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

AI (Claude Code) assisted with the implementation and this description. The cask iteration is extracted into a `cask_downloads` helper with unit tests asserting the distinct-URL set (`sha256-os` → 4 URLs) and the single-combination collapse (`local-caffeine` → 1). Verified locally: `brew lgtm` passes, and the full-matrix + language iteration resolves the expected distinct URLs for source casks (`itsycal` → 2 macOS-version URLs, `git-credential-manager` → 4 of 15 combinations, `firefox` → 102 language URLs); API-loaded casks emit the warning.

-----