### PR TITLE
cask: extract `refresh_for_tag` to tolerate asymmetric variations

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -163,6 +163,24 @@ module Cask
       raise CaskInvalidError.new(token, e.message), e.backtrace
     end
 
+    # Refresh the cask as evaluated on `tag` and yield. Returns `nil` instead of
+    # raising when the cask has `on_system` blocks that omit the tag.
+    sig {
+      type_parameters(:U)
+        .params(tag: ::Utils::Bottles::Tag, _block: T.proc.returns(T.type_parameter(:U)))
+        .returns(T.nilable(T.type_parameter(:U)))
+    }
+    def refresh_for_tag(tag, &_block)
+      Homebrew::SimulateSystem.with(os: tag.system, arch: tag.arch) do
+        refresh
+        yield
+      end
+    rescue CaskInvalidError, CaskUnreadableError
+      raise unless on_system_blocks_exist?
+
+      nil
+    end
+
     def_delegators :@dsl, *::Cask::DSL::DSL_METHODS
 
     sig { returns(DSL::Caveats) }
@@ -592,9 +610,7 @@ module Cask
                     !dsl!.depends_on_set_in_block? &&
                     macos_requirements.any? { |requirement| !requirement.allows?(bottle_tag.to_macos_version) }
 
-            Homebrew::SimulateSystem.with_tag(bottle_tag) do
-              refresh
-
+            refresh_for_tag(bottle_tag) do
               to_h.each do |key, value|
                 next if HASH_KEYS_TO_SKIP.include? key
                 next if value.to_s == hash[key].to_s

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -293,17 +293,11 @@ module Homebrew
         cask_sourcefile_path = cask.sourcefile_path
         raise "unexpected nil cask.sourcefile_path" unless cask_sourcefile_path
 
+        old_cask = Cask::CaskLoader.load(cask_sourcefile_path)
         generate_system_options(cask, new_version).each do |os, arch|
-          SimulateSystem.with(os:, arch:) do
-            # Handle the cask being invalid for specific os/arch combinations
-            old_cask = begin
-              Cask::CaskLoader.load(cask_sourcefile_path)
-            rescue Cask::CaskInvalidError, Cask::CaskUnreadableError
-              raise unless cask.on_system_blocks_exist?
-            end
-            next if old_cask.nil?
-
-            # Skip archs excluded by the reloaded cask's `depends_on arch:`.
+          tag = Utils::Bottles::Tag.new(system: os, arch:)
+          old_cask.refresh_for_tag(tag) do
+            # Skip archs excluded by the cask's `depends_on arch:`.
             reloaded_archs = old_cask.depends_on.arch&.filter_map { |a| a[:type] }&.uniq
             next if reloaded_archs.present? && reloaded_archs.exclude?(arch)
 

--- a/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
@@ -188,10 +188,8 @@ module Homebrew
       def architectures(cask:, os:)
         architectures = T.let([], T::Array[Symbol])
         [:arm, :intel].each do |arch|
-          tag = Utils::Bottles::Tag.new(system: os, arch: arch)
-          Homebrew::SimulateSystem.with_tag(tag) do
-            cask.refresh
-
+          tag = Utils::Bottles::Tag.new(system: os, arch:)
+          cask.refresh_for_tag(tag) do
             if cask.depends_on.arch.blank?
               architectures = RUNNERS.keys.map { |r| r.fetch(:arch).to_sym }.uniq.sort
               next
@@ -199,8 +197,6 @@ module Homebrew
 
             architectures = cask.depends_on.arch.map { |arch| arch[:type] }
           end
-        rescue ::Cask::CaskInvalidError
-          # Can't read cask for this system-arch combination.
         end
 
         architectures

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -596,6 +596,20 @@ RSpec.describe Cask::Cask, :cask do
     end
   end
 
+  describe "#refresh_for_tag" do
+    let(:cask) { Cask::CaskLoader.load("on-linux-asymmetric") }
+
+    it "yields with the cask refreshed for a supported tag" do
+      tag = Utils::Bottles::Tag.new(system: :sonoma, arch: :intel)
+      expect(cask.refresh_for_tag(tag) { cask.url.to_s }).to include("caffeine-intel-darwin")
+    end
+
+    it "returns nil for a tag the cask does not support" do
+      tag = Utils::Bottles::Tag.new(system: :linux, arch: :arm)
+      expect(cask.refresh_for_tag(tag) { cask.url }).to be_nil
+    end
+  end
+
   describe "#to_hash_with_variations" do
     let!(:original_macos_version) { MacOS.full_version.to_s }
     let(:expected_versions_variations) do
@@ -742,6 +756,14 @@ RSpec.describe Cask::Cask, :cask do
 
       expect(h).to be_a(Hash)
       expect(JSON.pretty_generate(h["variations"])).to eq expected_sha256_variations_os.strip
+    end
+
+    it "omits tags a cask intentionally doesn't define in on_system blocks" do
+      c = Cask::CaskLoader.load("on-linux-asymmetric")
+      h = c.to_hash_with_variations
+
+      expect(h["variations"]).to include(:x86_64_linux)
+      expect(h["variations"]).not_to include(:arm64_linux)
     end
 
     # NOTE: The calls to `Cask.generating_hash!` and `Cask.generated_hash!`

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/on-linux-asymmetric.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/on-linux-asymmetric.rb
@@ -1,0 +1,24 @@
+# typed: false
+
+cask "on-linux-asymmetric" do
+  arch arm: "arm", intel: "intel"
+  os macos: "darwin", linux: "linux"
+
+  version "1.2.3"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine-#{arch}-#{os}.zip"
+  homepage "https://brew.sh/"
+
+  on_macos do
+    sha256 arm:   "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",
+           intel: "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+  end
+
+  on_linux do
+    sha256 x86_64_linux: "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+    depends_on arch: :x86_64
+  end
+
+  app "Caffeine.app"
+end


### PR DESCRIPTION
`Cask#to_hash_with_variations` iterates `OnSystem::VALID_OS_ARCH_TAGS` and refreshes the cask for each tag, but with no rescue. When a cask uses `on_system` blocks that legitimately omit some platforms — e.g.

```ruby
on_linux do
  sha256 x86_64_linux: "..."
  depends_on arch: :x86_64
end
```

— the `(linux, arm)` iteration raised `CaskInvalidError: invalid 'sha256' value: nil` and aborted variation generation entirely. This broke `generate-cask-ci-matrix` on `homebrew-cask` PRs submitting such casks (e.g. [Homebrew/homebrew-cask#266359](https://github.com/Homebrew/homebrew-cask/pull/266359)).

Per review feedback, rather than repeating the rescue in each caller, this extracts a shared **`Cask::Cask#refresh_for_tag(tag, &block)`** helper that refreshes the cask for a simulated OS/arch tag and returns `nil` (instead of raising) when the cask intentionally omits that tag. It re-raises for casks without `on_system` blocks, since those failures aren't platform-specific.

All three existing callers of the pattern now use it:

- `Cask#to_hash_with_variations`
- `dev-cmd/bump-cask-pr` (loads the source cask once, then refreshes per tag)
- `dev-cmd/generate-cask-ci-matrix`

The helper uses `SimulateSystem.with` (not `with_tag`) so it tolerates the invalid OS/arch combinations `bump-cask-pr` can generate on older macOS hosts, matching the previous behaviour.

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

AI (Claude Code) assisted with the implementation and this description. Added a fixture cask (`on-linux-asymmetric`) plus specs for `#refresh_for_tag` (supported tag yields; unsupported tag returns `nil`) and `#to_hash_with_variations` (omits the unsupported tag). Verified with `brew lgtm` and the `cask`, `bump-cask-pr` and `generate-cask-ci-matrix` specs.

-----