### PR TITLE
Preserve GitHub token during eval

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -103,7 +103,7 @@ module Cask
       def load(config:)
         @config = config
 
-        ENV.clear_sensitive_environment! do
+        ENV.clear_sensitive_environment_for_eval! do
           instance_eval(content, __FILE__, __LINE__)
         end
       end
@@ -190,7 +190,7 @@ module Cask
         end
 
         begin
-          ENV.clear_sensitive_environment! do
+          ENV.clear_sensitive_environment_for_eval! do
             instance_eval(content, path.to_s).tap do |cask|
               raise CaskUnreadableError.new(token, "'#{path}' does not contain a cask.") unless cask.is_a?(Cask)
             end

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -430,6 +430,13 @@ module Homebrew
         description: "If set, do not print any hints about changing Homebrew's behaviour with environment variables.",
         boolean:     true,
       },
+      HOMEBREW_NO_EVAL_ENV_SCRUBBING:            {
+        # odeprecated: remove in a later release
+        description: "If set, sensitive environment variables are available while evaluating formulae and casks. " \
+                     "`$HOMEBREW_GITHUB_API_TOKEN` is still available during evaluation when this is unset. " \
+                     "This setting will be removed in a later release.",
+        boolean:     true,
+      },
       HOMEBREW_NO_FORCE_BREW_WRAPPER:            {
         description: "`Deprecated:` If set, disables `$HOMEBREW_FORCE_BREW_WRAPPER` behaviour, even if set.",
         boolean:     true,

--- a/Library/Homebrew/extend/ENV/sensitive.rb
+++ b/Library/Homebrew/extend/ENV/sensitive.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "env_config"
+
 module EnvSensitive
   extend T::Helpers
 
@@ -16,20 +18,27 @@ module EnvSensitive
     select { |key, _| sensitive?(key) }
   end
 
-  sig { params(block: T.nilable(T.proc.returns(T.untyped))).returns(T.untyped) }
-  def clear_sensitive_environment!(&block)
+  sig { params(except: T::Array[String], block: T.nilable(T.proc.returns(T.untyped))).returns(T.untyped) }
+  def clear_sensitive_environment!(except: [], &block)
     unless block
-      each_key { |key| delete key if sensitive?(key) }
+      each_key { |key| delete key if sensitive?(key) && except.exclude?(key) }
       return
     end
 
     old_env = to_hash.dup
     begin
-      clear_sensitive_environment!
+      clear_sensitive_environment!(except:)
       yield
     ensure
       replace(old_env)
     end
+  end
+
+  sig { params(block: T.proc.returns(T.untyped)).returns(T.untyped) }
+  def clear_sensitive_environment_for_eval!(&block)
+    return yield if Homebrew::EnvConfig.no_eval_env_scrubbing?
+
+    clear_sensitive_environment!(except: ["HOMEBREW_GITHUB_API_TOKEN"], &block)
   end
 end
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -152,7 +152,7 @@ module Formulary
         raise FormulaUnreadableError.new(name, e)
       end
     end
-    ENV.clear_sensitive_environment! do
+    ENV.clear_sensitive_environment_for_eval! do
       if ignore_errors
         Ignorable.hook_raise(&eval_formula)
       else

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -245,6 +245,9 @@ module Homebrew::EnvConfig
     def no_emoji?; end
 
     sig { returns(T::Boolean) }
+    def no_eval_env_scrubbing?; end
+
+    sig { returns(T::Boolean) }
     def no_env_hints?; end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -157,6 +157,12 @@ RSpec.describe "ENV" do
         expect(subject).not_to include("SECRET_TOKEN")
       end
 
+      it "preserves excepted sensitive environment variables" do
+        subject["SECRET_TOKEN"] = "password"
+        subject.clear_sensitive_environment!(except: ["SECRET_TOKEN"])
+        expect(subject["SECRET_TOKEN"]).to eq("password")
+      end
+
       it "leaves non-sensitive environment variables alone" do
         subject["FOO"] = "bar"
         subject.clear_sensitive_environment!

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -299,6 +299,54 @@ RSpec.describe Cask::CaskLoader, :cask do
       end
     end
 
+    it "allows the GitHub API token while evaluating casks" do
+      cask_token = "github-token-env"
+      cask_file = mktmpdir/"#{cask_token}.rb"
+      cask_file.write <<~RUBY
+        cask "#{cask_token}" do
+          version "1.0.0"
+          sha256 "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+          url "https://example.com/app.dmg"
+          name "GitHub Token Env"
+          desc ENV.key?("HOMEBREW_GITHUB_API_TOKEN") ? "Token present" : "Token absent"
+          homepage "https://example.com"
+
+          app "App.app"
+        end
+      RUBY
+
+      with_env(HOMEBREW_GITHUB_API_TOKEN: "github-token") do
+        cask = Cask::CaskLoader::FromPathLoader.new(cask_file).load(config: nil)
+
+        expect(cask.desc).to eq("Token present")
+      end
+    end
+
+    it "supports temporarily opting out of scrubbing while evaluating casks" do
+      cask_token = "unscrubbed-env"
+      cask_file = mktmpdir/"#{cask_token}.rb"
+      cask_file.write <<~RUBY
+        cask "#{cask_token}" do
+          version "1.0.0"
+          sha256 "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+          url "https://example.com/app.dmg"
+          name "Unscrubbed Env"
+          desc ENV.key?("SECRET_TOKEN") ? "Secret present" : "Secret absent"
+          homepage "https://example.com"
+
+          app "App.app"
+        end
+      RUBY
+
+      with_env(HOMEBREW_NO_EVAL_ENV_SCRUBBING: "1", SECRET_TOKEN: "password") do
+        cask = Cask::CaskLoader::FromPathLoader.new(cask_file).load(config: nil)
+
+        expect(cask.desc).to eq("Secret present")
+      end
+    end
+
     describe "loading a cask with a removed DSL method" do
       let(:tmpdir) { mktmpdir }
       let(:cask_token) { "removed-method-cask" }

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -78,6 +78,46 @@ RSpec.describe Formulary do
         expect(ENV.fetch("SECRET_TOKEN", nil)).to eq("password")
       end
     end
+
+    it "allows the GitHub API token while evaluating formulae" do
+      with_env(HOMEBREW_GITHUB_API_TOKEN: "github-token") do
+        formula_class = Formulary.load_formula(
+          "github-token-env",
+          mktmpdir/"github-token-env.rb",
+          <<~RUBY,
+            class GithubTokenEnv < Formula
+              GITHUB_TOKEN_PRESENT = ENV.key?("HOMEBREW_GITHUB_API_TOKEN")
+              url "https://brew.sh/github-token-env-1.0.tar.gz"
+            end
+          RUBY
+          "GithubTokenEnvNamespace",
+          flags:         [],
+          ignore_errors: false,
+        )
+
+        expect(formula_class::GITHUB_TOKEN_PRESENT).to be(true)
+      end
+    end
+
+    it "supports temporarily opting out of scrubbing while evaluating formulae" do
+      with_env(HOMEBREW_NO_EVAL_ENV_SCRUBBING: "1", SECRET_TOKEN: "password") do
+        formula_class = Formulary.load_formula(
+          "unscrubbed-env",
+          mktmpdir/"unscrubbed-env.rb",
+          <<~RUBY,
+            class UnscrubbedEnv < Formula
+              SECRET_TOKEN_PRESENT = ENV.key?("SECRET_TOKEN")
+              url "https://brew.sh/unscrubbed-env-1.0.tar.gz"
+            end
+          RUBY
+          "UnscrubbedEnvNamespace",
+          flags:         [],
+          ignore_errors: false,
+        )
+
+        expect(formula_class::SECRET_TOKEN_PRESENT).to be(true)
+      end
+    end
   end
 
   describe "::factory" do


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22430

- Keep `$HOMEBREW_GITHUB_API_TOKEN` available while formulae and casks are evaluated so private taps can keep resolving assets.
- Share the eval scrubbing policy through `ENV` so formula and cask loaders do not drift.
- Add temporary `HOMEBREW_NO_EVAL_ENV_SCRUBBING` for users who need a short-term escape hatch while private taps migrate.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
