### PR TITLE
Avoid install warning annotations

### DIFF
--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -147,7 +147,7 @@ module Homebrew
           elsif only_dependencies
             return true
           elsif !quiet
-            opoo <<~EOS
+            opoo_without_github_actions_annotation <<~EOS
               #{formula.full_name} #{formula.pkg_version} is already installed and up-to-date.
               To reinstall #{formula.pkg_version}, run:
                 brew reinstall #{formula.name}
@@ -185,15 +185,14 @@ module Homebrew
                 brew link #{formula.full_name}
             EOS
           else
-            msg = if quiet
-              nil
-            else
-              <<~EOS
+            unless quiet
+              opoo_without_github_actions_annotation <<~EOS
                 #{msg} and up-to-date.
                 To reinstall #{formula.pkg_version}, run:
                   brew reinstall #{formula.name}
               EOS
             end
+            msg = nil
           end
           opoo msg if msg
         elsif !formula.any_version_installed? && (old_formula = formula.old_installed_formulae.first)

--- a/Library/Homebrew/test/utils/output_spec.rb
+++ b/Library/Homebrew/test/utils/output_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "utils/output"
+require "utils/github/actions"
 
 RSpec.describe Utils::Output do
   let(:klass) { Utils::Output }
@@ -133,6 +134,18 @@ RSpec.describe Utils::Output do
       end.to output("Error: foo\n").to_stderr
 
       expect(Homebrew).to have_failed
+    end
+  end
+
+  describe "#opoo_without_github_actions_annotation" do
+    it "prints a warning without a GitHub Actions annotation" do
+      with_env(GITHUB_ACTIONS: "true") do
+        expect(GitHub::Actions).not_to receive(:puts_annotation_if_env_set!)
+
+        expect do
+          klass.opoo_without_github_actions_annotation "foo"
+        end.to output("Warning: foo\n").to_stderr
+      end
     end
   end
 

--- a/Library/Homebrew/utils/output.rb
+++ b/Library/Homebrew/utils/output.rb
@@ -76,6 +76,18 @@ module Utils
         end
       end
 
+      sig { params(message: T.any(String, Exception)).void }
+      def opoo_without_github_actions_annotation(message)
+        require "utils/github/actions"
+        return opoo(message) unless GitHub::Actions.env_set?
+
+        require "utils/formatter"
+
+        Tty.with($stderr) do |stderr|
+          stderr.puts Formatter.warning(message, label: "Warning")
+        end
+      end
+
       # Print a warning message only if not running in GitHub Actions.
       #
       # @api public


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22433

- Keep idempotent `brew install` warnings visible in CI logs.
- Avoid noisy GitHub Actions annotations for harmless installs.
- Preserve annotation behaviour for other `opoo` callers.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
