### PR TITLE
Fetch ask upgrades together

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -208,6 +208,7 @@ module Homebrew
 
         formulae_prefetched = T.let(false, T::Boolean)
         prefetched_casks = T.let(false, T::Boolean)
+        ask_upgrade_planned = T.let(false, T::Boolean)
         shared_download_queue = T.let(nil, T.nilable(Homebrew::DownloadQueue))
         if args.ask?
           unless only_upgrade_casks
@@ -239,10 +240,11 @@ module Homebrew
           )
             Install.ask(action: "upgrade")
           end
+          ask_upgrade_planned = final_upgrade_summary.version_changes.present?
           @final_upgrade_summary = FinalUpgradeSummary.new
         end
 
-        if !args.dry_run? && !args.ask? && !only_upgrade_formulae && !only_upgrade_casks
+        if !args.dry_run? && (!args.ask? || ask_upgrade_planned) && !only_upgrade_formulae && !only_upgrade_casks
           shared_download_queue = Homebrew::DownloadQueue.new(pour: true)
           begin
             formulae_prefetched = upgrade_outdated_formulae!(
@@ -708,7 +710,6 @@ module Homebrew
                                    prefetch_upgrades: nil,
                                    show_downloads_heading: true)
         return false if args.formula?
-        return false if args.ask?
 
         casks = minimum_version_casks(casks, quiet: true)
         return false if minimum_version.present? && casks.empty?

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -226,6 +226,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   # upgrades with asking for user prompts
   it "prints formula and cask ask plans before upgrading" do
     cmd = klass.new(["--ask"])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, fetch_failed: false, shutdown: nil)
 
     expect(cmd).to receive(:upgrade_outdated_formulae!)
       .with([], dry_run: true, show_upgrade_summary: false)
@@ -241,12 +242,36 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     expect(cmd).to receive(:show_final_upgrade_summary).with(dry_run: true).ordered
     expect(Homebrew::Install).to receive(:ask).with(action: "upgrade")
                                               .ordered
+    expect(Homebrew::DownloadQueue).to receive(:new).ordered.and_return(download_queue)
     expect(cmd).to receive(:upgrade_outdated_formulae!)
-      .with([], use_prefetched: false, show_upgrade_summary: false)
+      .with(
+        [],
+        prefetch_only:          true,
+        download_queue:,
+        prefetch_names:         [],
+        prefetch_upgrades:      [],
+        show_upgrade_summary:   false,
+        show_downloads_heading: false,
+      )
+      .ordered
+      .and_return(true)
+    expect(cmd).to receive(:prefetch_outdated_casks!)
+      .with(
+        [],
+        download_queue:,
+        prefetch_names:         [],
+        prefetch_upgrades:      [],
+        show_downloads_heading: false,
+      )
+      .ordered
+      .and_return(true)
+    expect(download_queue).to receive(:fetch).ordered
+    expect(cmd).to receive(:upgrade_outdated_formulae!)
+      .with([], use_prefetched: true, show_upgrade_summary: false)
       .ordered
       .and_return(true)
     expect(cmd).to receive(:upgrade_outdated_casks!)
-      .with([], skip_prefetch: false, show_upgrade_summary: false, download_queue: nil)
+      .with([], skip_prefetch: true, show_upgrade_summary: false, download_queue: nil)
       .ordered
       .and_return(true)
     allow(Homebrew::Cleanup).to receive(:periodic_clean!)
@@ -479,6 +504,55 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       codex 0.117.0 -> 0.118.0
       ==> Fetching downloads for: deno and codex
     EOS
+  end
+
+  it "asks before fetching formulae and casks in the same download queue" do
+    cmd = klass.new(["--ask"])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, fetch_failed: false, shutdown: nil)
+    cask = instance_double(
+      Cask::Cask,
+      artifacts:         [],
+      full_name:         "codex",
+      installed_version: "0.117.0",
+      version:           "0.118.0",
+    )
+    installer = instance_double(Cask::Installer, enqueue_downloads: nil, source_download_requires_pre_fetch?: false)
+
+    allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, dry_run: false, prefetch_only: false,
+                                                              use_prefetched: false, prefetch_names: nil,
+                                                              prefetch_upgrades: nil, **|
+      if dry_run
+        cmd.send(:final_upgrade_summary).version_changes << "deno 2.7.10 -> 2.7.11"
+      elsif prefetch_only
+        prefetch_names&.replace(["deno"])
+        prefetch_upgrades&.replace(["deno 2.7.10 -> 2.7.11"])
+      else
+        expect(use_prefetched).to be(true)
+      end
+
+      true
+    end
+    allow(Cask::Upgrade).to receive(:outdated_casks).and_return([cask])
+    allow(Cask::Installer).to receive(:new).and_return(installer)
+    allow(Cask::Upgrade).to receive(:upgrade_casks!) do |*_, **kwargs|
+      if kwargs[:dry_run]
+        kwargs[:summary_upgrades] << "codex 0.117.0 -> 0.118.0"
+      else
+        expect(kwargs[:skip_prefetch]).to be(true)
+      end
+
+      true
+    end
+    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
+    allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
+    allow(Homebrew.messages).to receive(:display_messages)
+
+    expect(Homebrew::Install).to receive(:ask).with(action: "upgrade").ordered
+    expect(Homebrew::DownloadQueue).to receive(:new).ordered.and_return(download_queue)
+    expect(Homebrew::Install).to receive(:enqueue_cask_installers).ordered
+    expect(download_queue).to receive(:fetch).ordered
+
+    cmd.run
   end
 
   it "prefetches language cask files before fetching combined downloads" do


### PR DESCRIPTION
- Avoid splitting `brew upgrade --ask` downloads by package type
- Reuse the shared prefetch queue after confirmation so casks and formulae download together before the existing install order runs
- Keep no-op ask runs from creating an empty shared queue

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
