### PR TITLE
Accept one-key ask confirmations

### DIFF
--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -7,6 +7,7 @@ require "hardware"
 require "development_tools"
 require "upgrade"
 require "download_queue"
+require "io/console"
 require "utils/output"
 require "utils/topological_hash"
 
@@ -745,20 +746,23 @@ module Homebrew
       def ask_input(action: "installation")
         return if !$stdin.tty? || !$stdout.tty?
 
-        ohai "Do you want to proceed with the #{action}? [y/N]"
-        accepted_inputs = %w[y yes]
-        declined_inputs = %w[n no]
+        ohai "Do you want to proceed with the #{action}? [y/n]"
         loop do
-          result = $stdin.gets
-          return unless result
+          result = begin
+            $stdin.getch
+          rescue Interrupt
+            exit 1
+          end
+          exit 1 unless result
 
           result = result.chomp.strip.downcase
-          if accepted_inputs.include?(result)
+          if result == "y"
             break
-          elsif result.blank? || declined_inputs.include?(result)
+          # N, Escape, Ctrl-C and Ctrl-D.
+          elsif ["n", "\e", "\u0003", "\u0004"].include?(result)
             exit 1
           else
-            puts "Invalid input. Please enter 'y' or 'yes' to proceed, or 'n' or 'no' to abort."
+            puts "Invalid input. Please press 'y' to proceed, or 'n' to abort."
           end
         end
       end

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -86,19 +86,71 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     EOS
   end
 
-  it "defaults ask input to no" do
-    allow($stdin).to receive_messages(gets: "\n", tty?: true)
+  it "prompts again for return ask input" do
+    ["\r", "\n"].each do |input|
+      allow($stdin).to receive(:tty?).and_return(true)
+      allow($stdin).to receive(:getch).and_return(input, "n")
+      allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+      expect do
+        Homebrew::Install.ask(action: "upgrade")
+      end.to raise_error(SystemExit) { |error| expect(error.status).to eq(1) }
+        .and output(<<~EOS).to_stdout
+          ==> Do you want to proceed with the upgrade? [y/n]
+          Invalid input. Please press 'y' to proceed, or 'n' to abort.
+        EOS
+    end
+  end
+
+  it "accepts single character ask input" do
+    %w[y Y].each do |input|
+      allow($stdin).to receive_messages(getch: input, tty?: true)
+      allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+      expect do
+        Homebrew::Install.ask(action: "upgrade")
+      end.to output("==> Do you want to proceed with the upgrade? [y/n]\n").to_stdout
+    end
+  end
+
+  it "declines single character ask input" do
+    %w[n N].each do |input|
+      allow($stdin).to receive_messages(getch: input, tty?: true)
+      allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+      expect do
+        Homebrew::Install.ask(action: "upgrade")
+      end.to raise_error(SystemExit) { |error| expect(error.status).to eq(1) }
+        .and output("==> Do you want to proceed with the upgrade? [y/n]\n").to_stdout
+    end
+  end
+
+  it "terminates on ask cancellation input" do
+    ["\e", "\u0003", "\u0004"].each do |input|
+      allow($stdin).to receive_messages(getch: input, tty?: true)
+      allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+      expect do
+        Homebrew::Install.ask(action: "upgrade")
+      end.to raise_error(SystemExit) { |error| expect(error.status).to eq(1) }
+        .and output("==> Do you want to proceed with the upgrade? [y/n]\n").to_stdout
+    end
+  end
+
+  it "terminates on ask interrupt" do
+    allow($stdin).to receive_messages(tty?: true)
+    allow($stdin).to receive(:getch).and_raise(Interrupt)
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
     expect do
       Homebrew::Install.ask(action: "upgrade")
     end.to raise_error(SystemExit) { |error| expect(error.status).to eq(1) }
-      .and output("==> Do you want to proceed with the upgrade? [y/N]\n").to_stdout
+      .and output("==> Do you want to proceed with the upgrade? [y/n]\n").to_stdout
   end
 
   it "skips ask input without a TTY" do
     allow($stdin).to receive(:tty?).and_return(false)
-    expect($stdin).not_to receive(:gets)
+    expect($stdin).not_to receive(:getch)
 
     expect { Homebrew::Install.ask(action: "upgrade") }.not_to output.to_stdout
   end


### PR DESCRIPTION
- Allow `brew --ask` prompts to proceed from `y` or `Y`.
- Abort from `n` or `N` without waiting for a newline.
- Treat Escape, Ctrl-D and Ctrl-C as quiet cancellation.
- Reprompt after other keys so users choose explicitly.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with manual review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
