### PR TITLE
Skip TestFlight apps in cleanup

### DIFF
--- a/Library/Homebrew/bundle/extensions/mac_app_store.rb
+++ b/Library/Homebrew/bundle/extensions/mac_app_store.rb
@@ -130,7 +130,7 @@ module Homebrew
           end
           return [].freeze if kept_app_ids.empty?
 
-          packages.reject { |app| kept_app_ids.any? { |id| app.id.to_i == id.to_i } }
+          packages.reject { |app| app.id.to_i.zero? || kept_app_ids.any? { |id| app.id.to_i == id.to_i } }
                   .map { |app| cleanup_item(app) }
         end
 

--- a/Library/Homebrew/test/bundle/mac_app_store_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_spec.rb
@@ -284,6 +284,7 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
       allow(klass).to receive_messages(package_manager_executable: Pathname.new("mas"), packages: [
         Homebrew::Bundle::MacAppStore::App.new(id: "123", name: "foo"),
         Homebrew::Bundle::MacAppStore::App.new(id: "456", name: "bar"),
+        Homebrew::Bundle::MacAppStore::App.new(id: "0", name: "testflight"),
       ])
     end
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22437

- Avoid uninstalling `mas list` entries with `id` zero because TestFlight apps cannot be represented in a `Brewfile`.
- Cover cleanup candidates so `mas uninstall 0` is not attempted.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local testing and review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
