### PR TITLE
keg: fix any_skip_relocation cellar on Linux

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -65,8 +65,10 @@ module OS
           old_interpreter.sub old_prefix, new_prefix
         end
         updated[:interpreter] = new_interpreter if old_interpreter != new_interpreter
+        return false if updated.empty?
 
         file.patch!(interpreter: updated[:interpreter], rpath: updated[:rpath])
+        require_relocation!
         true
       end
 

--- a/Library/Homebrew/extend/os/mac/keg.rb
+++ b/Library/Homebrew/extend/os/mac/keg.rb
@@ -39,18 +39,11 @@ module OS
         end
       end
 
-      sig { params(path: ::Pathname).void }
-      def initialize(path)
-        super
-
-        @require_relocation = T.let(false, T::Boolean)
-      end
-
       sig { params(id: String, file: MachOShim).returns(T::Boolean) }
       def change_dylib_id(id, file)
         return false if file.dylib_id == id
 
-        @require_relocation = true
+        require_relocation!
         odebug "Changing dylib ID of #{file}\n  from #{file.dylib_id}\n    to #{id}"
         file.change_dylib_id(id, strict: false)
         true
@@ -67,7 +60,7 @@ module OS
       def change_install_name(old, new, file)
         return false if old == new
 
-        @require_relocation = true
+        require_relocation!
         odebug "Changing install name in #{file}\n  from #{old}\n    to #{new}"
         file.change_install_name(old, new, strict: false)
         true
@@ -84,7 +77,7 @@ module OS
       def change_rpath(old, new, file)
         return false if old == new
 
-        @require_relocation = true
+        require_relocation!
         odebug "Changing rpath in #{file}\n  from #{old}\n    to #{new}"
         file.change_rpath(old, new, strict: false)
         true

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -212,7 +212,7 @@ class Keg
     @linked_keg_record = T.let(HOMEBREW_LINKED_KEGS/name, Pathname)
     @opt_record = T.let(HOMEBREW_PREFIX/"opt/#{name}", Pathname)
     @oldname_opt_records = T.let([], T::Array[Pathname])
-    @require_relocation = false
+    @require_relocation = T.let(false, T::Boolean)
   end
 
   sig { returns(Pathname) }
@@ -258,6 +258,11 @@ class Keg
 
   sig { returns(T::Boolean) }
   def require_relocation? = @require_relocation
+
+  sig { void }
+  def require_relocation!
+    @require_relocation = true
+  end
 
   sig { returns(T::Boolean) }
   def linked?


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

On Linux, `:any_skip_relocation` vs `:any` detection has been historically broken which is why we've ignored the value.

https://github.com/Homebrew/brew/blob/edf610ae45f91ba07953c72b1c70433651d6c468/Library/Homebrew/extend/os/linux/bottle_specification.rb#L6-L8

This PR tries to fix the actual cellar symbol used.

It does not fix the above `skip_relocation?` check yet. Thinking of fixing a few bottles first and using those to test this part later on. Will likely need to access tab information to check `parsed_homebrew_version` aligned to next release (e.g. >= 5.1.15).

---

Ran a few local checks on formulae via `brew install --build-bottle` and `brew bottle`:
- `snappy` - should be any bottle but currently isn't https://github.com/Homebrew/homebrew-core/blob/main/Formula/s/snappy.rb#L17-L18. Local test outputs:
  ```
      sha256 cellar: :any, arm64_linux: "3932df8110e3267ed98d0ae0ed335123dc971a9a5d3603c0617babe0341f8383"
  ```
  ```
      sha256 cellar: :any, arm64_tahoe: "61056dfcc56bd23496be6f12eb041bbd91e653dd507e32712adbcf25fa698595"
  ```

- `fx` - checking no regression on any_skip_relocation
  ```
      sha256 cellar: :any_skip_relocation, arm64_linux: "8350dd22443c51fc0fcff34c2c6ae1c2751650f11464b2b4336bdf93525733f1"
  ```
  ```
      sha256 cellar: :any_skip_relocation, arm64_tahoe: "0a04f691be96462647f02090a624c1d1b933f4b08d8873fd57f4d22493b2e2ba"
  ```

- `libfaketime` - checking no regression on non-relocatable
  ```
      sha256 arm64_linux: "6767394bc1f6b5823884957d6aee9d18f386705d53c12aa3654c5599eb43275e"
  ```
  ```
      sha256 arm64_tahoe: "e8b25817117c07f425b89871f6fe9179db9969998f076ece777413fc0ec9526c"
  ```

Not sure if our tests cover any of this yet.