### PR TITLE
formula: add `skip_relocate_dynamic_linkage`

### DIFF
--- a/Library/Homebrew/ast_constants.rb
+++ b/Library/Homebrew/ast_constants.rb
@@ -40,6 +40,7 @@ FORMULA_COMPONENT_PRECEDENCE_LIST = T.let([
   [{ name: :on_intel, type: :block_call }],
   [{ name: :conflicts_with, type: :method_call }],
   [{ name: :preserve_rpath, type: :method_call }],
+  [{ name: :skip_patchelf, type: :method_call }],
   [{ name: :skip_clean, type: :method_call }],
   [{ name: :cxxstdlib_check, type: :method_call }],
   [{ name: :link_overwrite, type: :method_call }],

--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -15,6 +15,9 @@ module OS
         # Patching the dynamic linker of glibc breaks it.
         return if name.match? Version.formula_optionally_versioned_regex(:glibc)
 
+        # Skip running patchelf.rb on formulae where resulting binaries are broken
+        return if formula_skip_patchelf?
+
         old_prefix, new_prefix = relocation.replacement_pair_for(:prefix)
 
         elf_files.each do |file|
@@ -103,6 +106,13 @@ module OS
           elf_files << pn
         end
         elf_files
+      end
+
+      sig { returns(T::Boolean) }
+      def formula_skip_patchelf?
+        to_formula.skip_patchelf?
+      rescue FormulaUnavailableError
+        false
       end
     end
   end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -399,6 +399,9 @@ class Formula
   sig { returns(T::Boolean) }
   def preserve_rpath? = self.class.preserve_rpath?
 
+  sig { returns(T::Boolean) }
+  def skip_patchelf? = self.class.skip_patchelf?
+
   private
 
   # Allow full name logic to be re-used between names, aliases and installed aliases.
@@ -3787,6 +3790,7 @@ class Formula
           [phase, DEFAULT_NETWORK_ACCESS_ALLOWED]
         end, T.nilable(T::Hash[Symbol, T::Boolean]))
         @preserve_rpath = T.let(false, T.nilable(T::Boolean))
+        @skip_patchelf = T.let(false, T.nilable(T::Boolean))
         @pypi_packages_info = T.let(nil, T.nilable(PypiPackages))
       end
     end
@@ -3800,6 +3804,7 @@ class Formula
       @link_overwrite_paths.freeze
       @post_install_steps.freeze
       @preserve_rpath&.freeze
+      @skip_patchelf&.freeze
       super
     end
 
@@ -4629,6 +4634,34 @@ class Formula
     sig { returns(T::Boolean) }
     def preserve_rpath?
       @preserve_rpath == true
+    end
+
+    # Skip running patchelf.rb when bottling on Linux.
+    #
+    # This is needed to avoid corrupting binaries in specific formulae, e.g.
+    # `bazel` and self-contained executables created by `sbcl` are actually
+    # concatenated ELF and data files where patchelf writes over the data part.
+    #
+    # Enabling this feature will usually result in a non-relocatable bottle.
+    #
+    # ### Example
+    #
+    # ```ruby
+    # skip_patchelf
+    # ```
+    #
+    # @api public
+    sig { params(value: T::Boolean).returns(T::Boolean) }
+    def skip_patchelf(value: true)
+      @skip_patchelf = value
+    end
+
+    # Check if patchelf.rb should be skipped.
+    #
+    # @api internal
+    sig { returns(T::Boolean) }
+    def skip_patchelf?
+      @skip_patchelf == true
     end
 
     # Software that will not be symlinked into the `brew --prefix` and will

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -2717,6 +2717,34 @@ RSpec.describe Formula do
     end
   end
 
+  describe "#skip_patchelf" do
+    it "defaults to false" do
+      f = formula do
+        url "foo-1.0"
+      end
+
+      expect(f.class.skip_patchelf?).to be(false)
+    end
+
+    it "can be enabled" do
+      f = formula do
+        url "foo-1.0"
+        skip_patchelf
+      end
+
+      expect(f.class.skip_patchelf?).to be(true)
+    end
+
+    it "can be explicitly disabled" do
+      f = formula do
+        url "foo-1.0"
+        skip_patchelf value: false
+      end
+
+      expect(f.class.skip_patchelf?).to be(false)
+    end
+  end
+
   describe "#deprecate! and #disable!" do
     let(:deprecation_date) { "2020-01-01" }
     let(:disable_date) { "2021-01-01" }


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

This is needed to avoid some bad hacks I added to Homebrew/core formulae to work around patchelf binary corruption. Without this, we need to manually hide non-patchable binaries from `brew bottle` by tar-ing them into archives and then unpacking them in post-install. This usually results in incorrectly marking formula relocatable and thus requires manually adding a `pour_bottle` stanza.

Formulae include
* `bazel` which is a stitched together ELF binary and zip file where the zip is extracted at runtime. See
  - https://github.com/Homebrew/homebrew-core/blob/main/Formula/b/bazel.rb#L18-L31
  - https://github.com/Homebrew/homebrew-core/blob/main/Formula/b/bazel.rb#L97-L117
* SBCL self-contained executables like `buildapp`, `cafeobj` and `pgloader` are stitched together ELF binary and SBCL core file
  - https://github.com/Homebrew/homebrew-core/blob/main/Formula/b/buildapp.rb#L26-L40
* Deno dependents like `fedify` use a magic trailer string **d3n0l4nd** which get incorrectly moved by patchelf
  - https://github.com/Homebrew/homebrew-core/blob/main/Formula/f/fedify.rb#L31-L46
* `bun` seems to be corrupted by modifying RPATHs.
  - https://github.com/Homebrew/homebrew-core/pull/284560/changes#diff-b22b3d5682ae737c24762261bd6d2c71deff2cb19e12d6f9abc1eccdf06ac10cR131-R150

Logic is mostly copied from `preserve_rpath` feature.
