### PR TITLE
Upload coverage to GitHub

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,3 +6,7 @@ self-hosted-runner:
 # Empty array means no configuration variable is allowed.
 config-variables:
   - BREW_COMMIT_APP_ID
+paths:
+  "**/.github/workflows/tests.yml":
+    ignore:
+      - unknown permission scope "code-quality"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -212,6 +212,10 @@ jobs:
     needs: syntax
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30
+    permissions:
+      contents: read
+      code-quality: write
+      pull-requests: read
     strategy:
       fail-fast: false
       matrix:
@@ -320,6 +324,12 @@ jobs:
           files: Library/Homebrew/test/coverage/coverage.xml
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1
+        with:
+          file: ${{ steps.set-up-homebrew.outputs.repository-path }}/Library/Homebrew/test/coverage/coverage.xml
+          language: Ruby
+          label: code-coverage/simplecov
 
   test-bot:
     name: ${{ matrix.name }}

--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -23,15 +23,22 @@ RSpec.describe GitHub do
     end
   end
 
-  describe "::search_issues", :needs_network do
+  describe "::search_issues" do
     it "queries GitHub issues with the passed parameters" do
-      results = klass.search_issues("brew search",
-                                    repo:   "Homebrew/legacy-homebrew",
-                                    author: "MikeMcQuaid",
-                                    is:     "issue",
-                                    no:     "milestone")
-      expect(results).not_to be_empty
-      expect(results.first["title"]).to eq("Shall we move more things to taps?")
+      issue = { "title" => "Shall we move more things to taps?" }
+
+      expect(GitHub::API).to receive(:open_rest) do |uri|
+        expect(uri.to_s).to eq("https://api.github.com/search/issues?" \
+                               "q=brew+search+repo%3AHomebrew%2Flegacy-homebrew+" \
+                               "author%3AMikeMcQuaid+type%3Aissue+no%3Amilestone&per_page=100")
+        { "items" => [issue] }
+      end
+
+      expect(klass.search_issues("brew search",
+                                 repo:   "Homebrew/legacy-homebrew",
+                                 author: "MikeMcQuaid",
+                                 type:   "issue",
+                                 no:     "milestone")).to eq([issue])
     end
   end
 


### PR DESCRIPTION
- Surface `brew tests --coverage` results in GitHub pull requests.
- Reuse the existing Cobertura report uploaded to Codecov.
- Allow `code-quality` until actionlint recognises the new scope.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
