### PR TITLE
Use stable test-bot formulae

### DIFF
--- a/Library/Homebrew/test/test_bot/formulae_detect_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_detect_spec.rb
@@ -1,0 +1,12 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "test_bot"
+
+RSpec.describe Homebrew::TestBot::FormulaeDetect do
+  describe "::DEFAULT_TEST_FORMULAE" do
+    it "uses dependency-free formulae for default formula testing" do
+      expect(Homebrew::TestBot::FormulaeDetect::DEFAULT_TEST_FORMULAE).to eq(%w[libspiro bats-core])
+    end
+  end
+end

--- a/Library/Homebrew/test_bot/formulae_detect.rb
+++ b/Library/Homebrew/test_bot/formulae_detect.rb
@@ -4,6 +4,9 @@
 module Homebrew
   module TestBot
     class FormulaeDetect < Test
+      # Formulae must have GitHub homepages, no stable dependencies, one executable and one library between them.
+      DEFAULT_TEST_FORMULAE = %w[libspiro bats-core].freeze
+
       sig { returns(T::Array[String]) }
       attr_reader :testing_formulae, :added_formulae, :deleted_formulae
 
@@ -161,7 +164,7 @@ module Homebrew
 
         if args.test_default_formula?
           # Build the default test formulae.
-          modified_formulae << "libfaketime" << "xz"
+          modified_formulae += DEFAULT_TEST_FORMULAE
         elsif @added_formulae.present? &&
               @added_formulae.all? { |formula| formula.start_with?("portable-") }
           @added_formulae = ["portable-ruby"]


### PR DESCRIPTION
- Avoid default test-bot audits depending on `xz`, whose homepage can make unrelated CI fail when the upstream site is unreachable.
- Use `libspiro` and `bats-core` because they have reachable GitHub homepages, no stable dependencies and cover library and executable bottle contents.
- Pin the default formula list in `formulae_detect_spec.rb` so this assumption does not drift unnoticed.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
