### PR TITLE
Use worktrees for local core taps

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -270,6 +270,36 @@ class Tap
     @config = nil
   end
 
+  sig { params(path: Pathname).returns(T.nilable(Pathname)) }
+  def worktree_source_tap_path_for(path:)
+    return unless (git_file = path/".git").file?
+    return unless (git_dir = git_file.read[/\Agitdir: (.+)\n?\z/, 1])
+
+    git_dir_path = Pathname(git_dir)
+    git_dir_path = path/git_dir_path unless git_dir_path.absolute?
+
+    # A linked worktree points at `<source>/.git/worktrees/<name>`, so use
+    # the matching source tap when it is already checked out there.
+    if git_dir_path.dirname.dirname.basename.to_s == ".git" && git_dir_path.dirname.basename.to_s == "worktrees"
+      source_path = git_dir_path.dirname.dirname.dirname
+      return source_path if path != HOMEBREW_REPOSITORY
+
+      candidate_source_tap_path = source_path/"Library/Taps/#{full_name.downcase}"
+      return candidate_source_tap_path if (candidate_source_tap_path/".git").exist?
+
+    end
+
+    Utils.popen_read("git", "-C", path, "worktree", "list", "--porcelain")
+         .each_line do |line|
+      next unless line.start_with?("worktree ")
+
+      candidate_source_tap_path = Pathname(line.delete_prefix("worktree ").chomp)/"Library/Taps/#{full_name.downcase}"
+      return candidate_source_tap_path if (candidate_source_tap_path/".git").exist?
+    end
+
+    nil
+  end
+
   sig { overridable.void }
   def ensure_installed!
     return if installed?
@@ -486,6 +516,9 @@ class Tap
     # ensure git is installed
     Utils::Git.ensure_installed!
 
+    use_worktree_source_tap = core_tap? || (core_cask_tap? && clone_target.nil? && !custom_remote)
+    worktree_source_tap_path = use_worktree_source_tap ? worktree_source_tap_path_for(path: HOMEBREW_REPOSITORY) : nil
+
     if installed?
       if requested_remote != remote # we are sure that clone_target is not nil and custom_remote is true here
         fix_remote_configuration(requested_remote:, quiet:)
@@ -500,7 +533,8 @@ class Tap
       args << "-q" if quiet
       path.cd { safe_system "git", *args }
       return
-    elsif (core_tap? || core_cask_tap?) && !Homebrew::EnvConfig.no_install_from_api? && !force
+    elsif (core_tap? || core_cask_tap?) && !Homebrew::EnvConfig.no_install_from_api? && !force &&
+          worktree_source_tap_path.blank?
       odie "Tapping #{name} is no longer typically necessary.\n" \
            "Add #{Formatter.option("--force")} if you are sure you need it for contributing to Homebrew."
     end
@@ -522,7 +556,15 @@ class Tap
     args << "--config" << "core.fsmonitor=false"
 
     begin
-      safe_system "git", *args
+      if worktree_source_tap_path
+        # Keep core and cask taps connected to the same local source checkout as brew.
+        worktree_args = ["-C", worktree_source_tap_path, "worktree", "add"]
+        worktree_args << "--quiet" if quiet
+        worktree_args += ["--detach", path, "HEAD"]
+        safe_system "git", *worktree_args
+      else
+        safe_system "git", *args
+      end
 
       if verify && !Homebrew::EnvConfig.developer? && !Readall.valid_tap?(self, aliases: true)
         raise "Cannot tap #{name}: invalid syntax in tap!"
@@ -659,7 +701,10 @@ class Tap
     require "utils/link"
     Utils::Link.unlink_manpages(path)
     Utils::Link.unlink_completions(path)
-    FileUtils.rm_r(path)
+    if (worktree_source_tap_path = worktree_source_tap_path_for(path:))
+      safe_system "git", "-C", worktree_source_tap_path, "worktree", "remove", "--force", path
+    end
+    FileUtils.rm_r(path) if path.exist?
     path.parent.rmdir_if_possible
     $stderr.puts "Untapped#{formatted_contents} (#{abv})."
 

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -355,6 +355,109 @@ RSpec.describe Tap do
       end.to raise_error(TapCoreRemoteMismatchError)
     end
 
+    it "creates core and cask taps as worktrees when the brew source repository has them" do
+      source_repository = HOMEBREW_PREFIX.parent/"source-repository"
+      worktree_git_dir = HOMEBREW_REPOSITORY/".git"
+
+      [CoreTap.instance, CoreCaskTap.instance].each do |tap|
+        source_tap = source_repository/"Library/Taps/#{tap.full_name.downcase}"
+
+        FileUtils.rm_rf tap.path
+        source_tap.mkpath
+        source_tap.cd do
+          system "git", "init"
+          FileUtils.touch "README.md"
+          system "git", "add", "--all"
+          system "git", "commit", "-m", "init"
+        end
+        FileUtils.mkdir_p worktree_git_dir.dirname
+        worktree_git_dir.write "gitdir: #{source_repository}/.git/worktrees/#{HOMEBREW_REPOSITORY.basename}\n"
+
+        allow(tap).to receive_messages(command_files: [], formula_files: [], cask_files: [],
+                                       formula_names: [], cask_tokens: [])
+        expect(tap).to receive(:safe_system)
+          .with("git", "-C", source_tap, "worktree", "add", "--detach", tap.path, "HEAD")
+          .and_wrap_original do
+            tap.path.mkpath
+            (tap.path/".git").write "gitdir: #{source_tap}/.git/worktrees/#{tap.full_repository.downcase}\n"
+          end
+
+        tap.install
+      end
+    ensure
+      FileUtils.rm_rf source_repository
+      FileUtils.rm_rf CoreTap.instance.path
+      FileUtils.rm_rf CoreCaskTap.instance.path
+      (CoreTap.instance.path/"Formula").mkpath
+    end
+
+    it "creates a tap from another brew worktree when that has the source repository" do
+      tap = CoreCaskTap.instance
+      source_repository = HOMEBREW_PREFIX.parent/"source-repository"
+      source_worktree = HOMEBREW_PREFIX.parent/"source-worktree"
+      source_tap = source_worktree/"Library/Taps/#{tap.full_name.downcase}"
+
+      FileUtils.rm_rf tap.path
+      source_tap.mkpath
+      source_tap.cd do
+        system "git", "init"
+        FileUtils.touch "README.md"
+        system "git", "add", "--all"
+        system "git", "commit", "-m", "init"
+      end
+      FileUtils.mkdir_p (HOMEBREW_REPOSITORY/".git").dirname
+      (HOMEBREW_REPOSITORY/".git")
+        .write "gitdir: #{source_repository}/.git/worktrees/#{HOMEBREW_REPOSITORY.basename}\n"
+
+      allow(Utils).to receive(:popen_read).and_call_original
+      allow(Utils).to receive(:popen_read)
+        .with("git", "-C", HOMEBREW_REPOSITORY, "worktree", "list", "--porcelain")
+        .and_return("worktree #{source_worktree}\n")
+      allow(tap).to receive_messages(command_files: [], formula_files: [], cask_files: [],
+                                     formula_names: [], cask_tokens: [])
+      expect(tap).to receive(:safe_system)
+        .with("git", "-C", source_tap, "worktree", "add", "--detach", tap.path, "HEAD")
+        .and_wrap_original do
+          tap.path.mkpath
+          (tap.path/".git").write "gitdir: #{source_tap}/.git/worktrees/#{tap.full_repository.downcase}\n"
+        end
+
+      tap.install
+    ensure
+      FileUtils.rm_rf source_repository
+      FileUtils.rm_rf source_worktree
+      FileUtils.rm_rf CoreCaskTap.instance.path
+    end
+
+    it "uses the requested remote for cask taps with an explicit clone target" do
+      tap = CoreCaskTap.instance
+      requested_remote = "https://example.com/Homebrew/homebrew-cask"
+      source_repository = HOMEBREW_PREFIX.parent/"source-repository"
+      source_tap = source_repository/"Library/Taps/#{tap.full_name.downcase}"
+
+      FileUtils.rm_rf tap.path
+      source_tap.mkpath
+      (source_tap/".git").mkpath
+      FileUtils.mkdir_p (HOMEBREW_REPOSITORY/".git").dirname
+      (HOMEBREW_REPOSITORY/".git")
+        .write "gitdir: #{source_repository}/.git/worktrees/#{HOMEBREW_REPOSITORY.basename}\n"
+
+      allow(tap).to receive_messages(command_files: [], formula_files: [], cask_files: [],
+                                     formula_names: [], cask_tokens: [])
+      expect(tap).to receive(:safe_system)
+        .with("git", "clone", requested_remote, tap.path.to_s, "--origin=origin", "--template=",
+              "--config", "core.fsmonitor=false")
+        .and_wrap_original do
+          tap.path.mkpath
+          (tap.path/".git").mkpath
+        end
+
+      tap.install clone_target: requested_remote, force: true
+    ensure
+      FileUtils.rm_rf source_repository
+      FileUtils.rm_rf CoreCaskTap.instance.path
+    end
+
     it "raises an error when run `brew tap --custom-remote` without a custom remote (already installed)" do
       setup_git_repo
       already_tapped_tap = klass.fetch("Homebrew", "foo")
@@ -390,6 +493,26 @@ RSpec.describe Tap do
     it "raises an error if the Tap is not available" do
       tap = klass.fetch("Homebrew", "bar")
       expect { tap.uninstall }.to raise_error(TapUnavailableError)
+    end
+
+    it "removes Git worktree metadata for worktree-installed taps" do
+      tap = CoreCaskTap.instance
+      source_tap = HOMEBREW_PREFIX.parent/"source-tap"
+
+      FileUtils.rm_rf tap.path
+      source_tap.mkpath
+      (source_tap/".git").mkpath
+      tap.path.mkpath
+      (tap.path/".git").write "gitdir: #{source_tap}/.git/worktrees/#{tap.full_repository.downcase}\n"
+
+      allow(tap).to receive_messages(contents: [], formula_names: [], cask_tokens: [])
+      expect(tap).to receive(:safe_system)
+        .with("git", "-C", source_tap, "worktree", "remove", "--force", tap.path)
+
+      tap.uninstall
+    ensure
+      FileUtils.rm_rf source_tap
+      FileUtils.rm_rf CoreCaskTap.instance.path
     end
   end
 


### PR DESCRIPTION
- Avoid cloning `homebrew/core` and `homebrew/cask` when a brew worktree already has those repositories in its source checkout.
- Keep contributor worktree setups efficient by sharing local Git object storage instead of creating another network-backed checkout.
- Preserve normal tap cloning when brew is not running from a linked worktree or the matching source tap is unavailable.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
