### PR TITLE
Install Bubblewrap on hosted Ubuntu

### DIFF
--- a/Library/Homebrew/extend/os/linux/sandbox.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox.rb
@@ -3,6 +3,7 @@
 
 require "fileutils"
 require "env_config"
+require "utils/github/actions"
 
 module OS
   module Linux
@@ -196,9 +197,21 @@ module OS
 
         sig { void }
         def configure!
-          unless bubblewrap_executable
-            ensure_sandbox_installed!(install_from_tests: true)
-            unless bubblewrap_executable
+          unless (bubblewrap = bubblewrap_executable)
+            if GitHub::Actions.env_set? &&
+               ENV["RUNNER_ENVIRONMENT"] == "github-hosted" &&
+               ENV.fetch("ImageOS", "").start_with?("ubuntu")
+              ohai "Installing Bubblewrap..."
+              system "sudo", "apt-get", "install", "--yes", "bubblewrap"
+              reset_state!
+              bubblewrap = bubblewrap_executable
+            end
+
+            unless bubblewrap
+              ensure_sandbox_installed!(install_from_tests: true)
+              bubblewrap = bubblewrap_executable
+            end
+            unless bubblewrap
               reset_state!
               return
             end

--- a/Library/Homebrew/test/sandbox_linux_spec.rb
+++ b/Library/Homebrew/test/sandbox_linux_spec.rb
@@ -124,6 +124,10 @@ RSpec.describe Sandbox, :needs_linux do
   describe "::configuration_commands" do
     let(:sandbox_class) { Class.new(klass) }
 
+    around do |example|
+      with_env(GITHUB_ACTIONS: nil, ImageOS: nil, RUNNER_ENVIRONMENT: nil) { example.run }
+    end
+
     def expect_sandbox_configuration_command(sandbox_class, assignment, result:)
       command = ["sudo", "sysctl", "-w", assignment]
 
@@ -158,6 +162,26 @@ RSpec.describe Sandbox, :needs_linux do
       expect(sandbox_class).not_to receive(:system)
 
       sandbox_class.configure!
+    end
+
+    it "installs Bubblewrap with apt-get on default GitHub Actions Ubuntu runners" do
+      expect(sandbox_class).to receive(:bubblewrap_executable)
+        .twice
+        .and_return(nil, Pathname("/usr/bin/bwrap"))
+      expect(sandbox_class).to receive(:ohai).with("Installing Bubblewrap...")
+      expect(sandbox_class).to receive(:system)
+        .with("sudo", "apt-get", "install", "--yes", "bubblewrap")
+        .and_return(true)
+      expect(sandbox_class).not_to receive(:ensure_sandbox_installed!)
+      expect(sandbox_class).to receive(:ohai).with("Configuring Bubblewrap...").ordered
+      expect_sandbox_configuration_command(sandbox_class, "kernel.unprivileged_userns_clone=1", result: true)
+      expect_sandbox_configuration_command(sandbox_class, "user.max_user_namespaces=28633", result: true)
+      expect_sandbox_configuration_command(sandbox_class, "kernel.apparmor_restrict_unprivileged_userns=0",
+                                           result: false)
+
+      with_env(GITHUB_ACTIONS: "true", ImageOS: "ubuntu24", RUNNER_ENVIRONMENT: "github-hosted") do
+        sandbox_class.configure!
+      end
     end
 
     it "installs Bubblewrap and configures Linux sandbox sysctls" do


### PR DESCRIPTION
- Avoid forcing taps to disable Linux sandboxing on GitHub Actions
- Use Ubuntu's `bubblewrap` package before the Homebrew fallback
- Keep self-hosted and non-Ubuntu runners on the existing path

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
