### PR TITLE
Support casks in `brew missing`

### DIFF
--- a/Library/Homebrew/cmd/missing.rb
+++ b/Library/Homebrew/cmd/missing.rb
@@ -3,40 +3,55 @@
 
 require "abstract_command"
 require "formula"
-require "diagnostic"
+require "cask/caskroom"
+require "missing"
 
 module Homebrew
   module Cmd
     class Missing < AbstractCommand
       cmd_args do
         description <<~EOS
-          Check the given <formula> kegs for missing dependencies. If no <formula> are
-          provided, check all kegs. Will exit with a non-zero status if any kegs are found
-          to be missing dependencies.
+          Check the given <formula> kegs and <cask> installations for missing dependencies.
+          If no <formula> or <cask> are provided, check all kegs and casks. Will exit with
+          a non-zero status if any kegs or casks are found to be missing dependencies.
         EOS
         comma_array "--hide",
                     description: "Act as if none of the specified <hidden> are installed. <hidden> should be " \
-                                 "a comma-separated list of formulae."
+                                 "a comma-separated list of formulae or casks."
 
-        named_args :formula
+        named_args [:formula, :cask]
       end
 
       sig { override.void }
       def run
-        return unless HOMEBREW_CELLAR.exist?
+        return if !HOMEBREW_CELLAR.exist? && !Cask::Caskroom.path.exist?
 
-        ff = if args.no_named?
-          Formula.installed.sort
+        formulae, casks = if args.no_named?
+          [Formula.installed, Cask::Caskroom.casks]
         else
-          args.named.to_resolved_formulae.sort
+          args.named.to_resolved_formulae_to_casks
         end
+        formulae = formulae.sort
+        casks = casks.sort_by(&:full_name)
+        hide = args.hide || []
+        package_count = formulae.size + casks.size
+        missing_deps = Homebrew::Missing.deps(formulae, casks, hide)
 
-        ff.each do |f|
-          missing = f.missing_dependencies(hide: args.hide || [])
-          next if missing.empty?
+        formulae.each do |formula|
+          missing = missing_deps[formula.full_name]
+          next if missing.blank?
 
           Homebrew.failed = true
-          print "#{f}: " if ff.size > 1
+          print "#{formula}: " if package_count > 1
+          puts missing.join(" ")
+        end
+
+        casks.each do |cask|
+          missing = missing_deps[cask.full_name]
+          next if missing.blank?
+
+          Homebrew.failed = true
+          print "#{cask}: " if package_count > 1
           puts missing.join(" ")
         end
       end

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -12,29 +12,13 @@ require "utils/output"
 require "cask/caskroom"
 require "cask/quarantine"
 require "git_repository"
+require "missing"
 require "system_command"
 
 module Homebrew
   # Module containing diagnostic checks.
   module Diagnostic
     extend Utils::Output::Mixin
-
-    sig {
-      params(formulae: T::Array[Formula], hide: T::Array[String], _block: T.nilable(
-        T.proc.params(formula_name: String, missing_dependencies: T::Array[Dependency]).void,
-      )).returns(T::Hash[String, T::Array[String]])
-    }
-    def self.missing_deps(formulae, hide = [], &_block)
-      missing = {}
-      formulae.each do |f|
-        missing_dependencies = f.missing_dependencies(hide: hide)
-        next if missing_dependencies.empty?
-
-        yield f.full_name, missing_dependencies if block_given?
-        missing[f.full_name] = missing_dependencies
-      end
-      missing
-    end
 
     sig { params(type: Symbol, fatal: T::Boolean).void }
     def self.checks(type, fatal: true)
@@ -752,24 +736,18 @@ module Homebrew
 
       sig { returns(T.nilable(String)) }
       def check_missing_deps
-        return unless HOMEBREW_CELLAR.exist?
+        return if !HOMEBREW_CELLAR.exist? && !Cask::Caskroom.path.exist?
 
         missing = Set.new
-        Homebrew::Diagnostic.missing_deps(Formula.installed).each_value do |deps|
+        Homebrew::Missing.deps(Formula.installed, Cask::Caskroom.casks).each_value do |deps|
           missing.merge(deps)
         end
         return if missing.empty?
 
-        resolvable_missing = missing.filter_map do |d|
-          d.to_installed_formula
-        rescue FormulaUnavailableError
-          nil
-        end
-
         <<~EOS
-          Some installed formulae are missing dependencies.
+          Some installed formulae or casks are missing dependencies.
           You should `brew install` the missing dependencies:
-            brew install #{resolvable_missing.sort_by(&:full_name) * " "}
+            brew install #{missing.sort * " "}
 
           Run `brew missing` for more details.
         EOS

--- a/Library/Homebrew/missing.rb
+++ b/Library/Homebrew/missing.rb
@@ -1,0 +1,68 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "formula"
+require "utils"
+require "cask/caskroom"
+require "cask/tab"
+
+module Homebrew
+  module Missing
+    sig {
+      params(formulae: T::Array[Formula], casks: T::Array[Cask::Cask], hide: T::Array[String], _block: T.nilable(
+        T.proc.params(package_name: String, missing_dependencies: T::Array[String]).void,
+      )).returns(T::Hash[String, T::Array[String]])
+    }
+    def self.deps(formulae, casks = [], hide = [], &_block)
+      missing = {}
+      formulae.each do |formula|
+        missing_dependencies = formula.missing_dependencies(hide: hide).map(&:to_s)
+        next if missing_dependencies.empty?
+
+        yield formula.full_name, missing_dependencies if block_given?
+        missing[formula.full_name] = missing_dependencies
+      end
+
+      casks.each do |cask|
+        missing_dependencies = cask_deps(cask, hide)
+        next if missing_dependencies.empty?
+
+        yield cask.full_name, missing_dependencies if block_given?
+        missing[cask.full_name] = missing_dependencies
+      end
+      missing
+    end
+
+    sig { params(cask: Cask::Cask, hide: T::Array[String]).returns(T::Array[String]) }
+    def self.cask_deps(cask, hide)
+      tab_deps = T.let(Cask::Tab.for_cask(cask).runtime_dependencies, T.untyped)
+      return [] unless tab_deps.is_a?(Hash)
+
+      tab_deps.keys.flat_map do |type|
+        deps = tab_deps[type]
+        next [] unless deps.is_a?(Array)
+
+        deps.filter_map do |dep|
+          next unless dep.is_a?(Hash)
+
+          full_name = T.cast(dep["full_name"], T.nilable(String))
+          next if full_name.blank?
+
+          name = Utils.name_from_full_name(full_name)
+          installed = case type.to_s
+          when "cask"
+            (Cask::Caskroom.path/name).directory?
+          when "formula"
+            (HOMEBREW_CELLAR/name).directory?
+          else
+            true
+          end
+          next if hide.exclude?(name) && installed
+
+          full_name
+        end
+      end.sort
+    end
+    private_class_method :cask_deps
+  end
+end

--- a/Library/Homebrew/test/cmd/doctor_spec.rb
+++ b/Library/Homebrew/test/cmd/doctor_spec.rb
@@ -14,6 +14,27 @@ RSpec.describe Homebrew::Cmd::Doctor do
       .to output(/This is an integration test/).to_stderr
   end
 
+  specify "check_missing_deps reports formula and cask dependencies", :cask do
+    formula = instance_double(Formula, full_name:            "needs-foo",
+                                       missing_dependencies: [instance_double(Dependency, to_s: "foo")])
+    cask = instance_double(Cask::Cask, full_name: "with-depends-on-everything")
+    tab = instance_double(Cask::Tab, runtime_dependencies: {
+      "cask"    => [{ "full_name" => "local-caffeine" }],
+      "formula" => [{ "full_name" => "unar" }],
+    })
+    HOMEBREW_CELLAR.mkpath
+    allow(Formula).to receive(:installed).and_return([formula])
+    allow(Cask::Caskroom).to receive(:casks).and_return([cask])
+    allow(Cask::Tab).to receive(:for_cask).with(cask).and_return(tab)
+
+    expect(Homebrew::Diagnostic::Checks.new.check_missing_deps)
+      .to include(
+        "Some installed formulae or casks are missing dependencies.",
+        "brew install foo local-caffeine unar",
+        "Run `brew missing` for more details.",
+      )
+  end
+
   specify "does not print removed caveats method errors for installed casks", :cask do
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
     installer = InstallHelper.install_with_caskfile(cask)

--- a/Library/Homebrew/test/cmd/missing_spec.rb
+++ b/Library/Homebrew/test/cmd/missing_spec.rb
@@ -24,4 +24,40 @@ RSpec.describe Homebrew::Cmd::Missing do
       .and not_to_output.to_stderr
       .and be_a_failure
   end
+
+  it "prints missing cask dependencies", :cask, :no_api do
+    cask = instance_double(Cask::Cask, full_name: "with-depends-on-everything",
+                                       to_s:      "with-depends-on-everything")
+    tab = instance_double(Cask::Tab, runtime_dependencies: {
+      "cask"    => [{ "full_name" => "local-caffeine" }],
+      "formula" => [{ "full_name" => "unar" }],
+    })
+    HOMEBREW_CELLAR.mkpath
+    allow(Formula).to receive(:installed).and_return([])
+    allow(Cask::Caskroom).to receive(:casks).and_return([cask])
+    allow(Cask::Tab).to receive(:for_cask).with(cask).and_return(tab)
+
+    expect { Homebrew::Cmd::Missing.new([]).run }
+      .to output("local-caffeine unar\n").to_stdout
+
+    expect(Homebrew).to have_failed
+  end
+
+  it "prints missing cask dependencies for named casks", :cask, :no_api do
+    cmd = Homebrew::Cmd::Missing.new(["with-depends-on-everything"])
+    cask = instance_double(Cask::Cask, full_name: "with-depends-on-everything",
+                                       to_s:      "with-depends-on-everything")
+    tab = instance_double(Cask::Tab, runtime_dependencies: {
+      "cask"    => [{ "full_name" => "local-caffeine" }],
+      "formula" => [{ "full_name" => "unar" }],
+    })
+    HOMEBREW_CELLAR.mkpath
+    allow(cmd.args.named).to receive(:to_resolved_formulae_to_casks).and_return([[], [cask]].map(&:freeze).freeze)
+    allow(Cask::Tab).to receive(:for_cask).with(cask).and_return(tab)
+
+    expect { cmd.run }
+      .to output("local-caffeine unar\n").to_stdout
+
+    expect(Homebrew).to have_failed
+  end
 end

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Homebrew::Completions do
           "--debug"   => "Display any debugging information.",
           "--help"    => "Show this message.",
           "--hide"    => "Act as if none of the specified <hidden> are installed. <hidden> should be " \
-                         "a comma-separated list of formulae.",
+                         "a comma-separated list of formulae or casks.",
           "--quiet"   => "Make some output more quiet.",
           "--verbose" => "Make some output more verbose.",
         }
@@ -338,6 +338,7 @@ RSpec.describe Homebrew::Completions do
               *) ;;
             esac
             __brew_complete_formulae
+            __brew_complete_casks
           }
         COMPLETION
       end
@@ -424,11 +425,13 @@ RSpec.describe Homebrew::Completions do
             _arguments \\
               '--debug[Display any debugging information]' \\
               '--help[Show this message]' \\
-              '--hide[Act as if none of the specified hidden are installed. hidden should be a comma-separated list of formulae]' \\
+              '--hide[Act as if none of the specified hidden are installed. hidden should be a comma-separated list of formulae or casks]' \\
               '--quiet[Make some output more quiet]' \\
               '--verbose[Make some output more verbose]' \\
               - formula \\
-              '*:formula:__brew_formulae'
+              '*:formula:__brew_formulae' \\
+              - cask \\
+              '*:cask:__brew_casks'
           }
         COMPLETION
       end
@@ -493,7 +496,7 @@ RSpec.describe Homebrew::Completions do
         expect(file).to match(/^    up update$/)
         expect(file).to match(/^__brew_internal_commands\(\) {$/)
         expect(file).to match(/^    'install:Install a formula or cask'$/)
-        expect(file).to match(/^    'missing:Check the given formula kegs for missing dependencies'$/)
+        expect(file).to match(/^    'missing:Check the given formula kegs and cask installations for .*'$/)
         expect(file).to match(/^    'update:Fetch the newest version of Homebrew and all formulae from GitHub .*'$/)
         expect(file).to match(/^_brew_install\(\) {$/)
         expect(file).to match(/^_brew_missing\(\) {$/)
@@ -510,13 +513,14 @@ RSpec.describe Homebrew::Completions do
       it "returns appropriate completion for a ruby command" do
         completion = klass.generate_fish_subcommand_completion("missing")
         expect(completion).to eq <<~COMPLETION
-          __fish_brew_complete_cmd 'missing' 'Check the given formula kegs for missing dependencies'
+          __fish_brew_complete_cmd 'missing' 'Check the given formula kegs and cask installations for missing dependencies'
           __fish_brew_complete_arg 'missing' -l debug -d 'Display any debugging information'
           __fish_brew_complete_arg 'missing' -l help -d 'Show this message'
-          __fish_brew_complete_arg 'missing' -l hide -d 'Act as if none of the specified hidden are installed. hidden should be a comma-separated list of formulae'
+          __fish_brew_complete_arg 'missing' -l hide -d 'Act as if none of the specified hidden are installed. hidden should be a comma-separated list of formulae or casks'
           __fish_brew_complete_arg 'missing' -l quiet -d 'Make some output more quiet'
           __fish_brew_complete_arg 'missing' -l verbose -d 'Make some output more verbose'
           __fish_brew_complete_arg 'missing' -a '(__fish_brew_suggest_formulae_all)'
+          __fish_brew_complete_arg 'missing' -a '(__fish_brew_suggest_casks_all)'
         COMPLETION
       end
 
@@ -566,7 +570,7 @@ RSpec.describe Homebrew::Completions do
         file = klass.generate_fish_completion_file(%w[install missing update])
         expect(file).to match(/^function __fish_brew_complete_cmd/)
         expect(file).to match(/^__fish_brew_complete_cmd 'install' 'Install a formula or cask'$/)
-        expect(file).to match(/^__fish_brew_complete_cmd 'missing' 'Check the given formula kegs for .*'$/)
+        expect(file).to match(/^__fish_brew_complete_cmd 'missing' 'Check the given formula kegs and cask .*'$/)
         expect(file).to match(/^__fish_brew_complete_cmd 'update' 'Fetch the newest version of Homebrew .*'$/)
       end
 


### PR DESCRIPTION
- Report missing runtime dependencies for installed casks
- Keep formula and cask output consistent for mixed checks
- Update completion expectations for `brew missing` casks

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
