### PR TITLE
patch: add type and resolves DSL for annotating patches

### DIFF
--- a/Library/Homebrew/external_patch.rb
+++ b/Library/Homebrew/external_patch.rb
@@ -33,6 +33,16 @@ class ExternalPatch
     true
   end
 
+  sig { returns(T::Array[String]) }
+  def resolves
+    (resource.resolves + Patch.extract_cves(url.to_s, *resource.patch_files.map(&:to_s))).uniq
+  end
+
+  sig { returns(T.nilable(Symbol)) }
+  def type
+    resource.type
+  end
+
   sig { params(owner: T.nilable(Resource::Owner)).void }
   def owner=(owner)
     resource.owner = owner

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3138,8 +3138,14 @@ class Formula
         h["sha256"] = external.resource.checksum&.hexdigest
         h["apply"] = external.resource.patch_files.map(&:to_s) if external.resource.patch_files.any?
         h["directory"] = external.resource.directory.to_s if external.resource.directory.present?
+        h["type"] = external.type.to_s.tr("_", "-") if external.type
+        resolves = external.resolves
+        h["resolves"] = resolves.map { |id| { "type" => Patch.resolves_type(id), "id" => id } } if resolves.any?
       elsif p.is_a?(LocalPatch)
         h["file"] = p.file.to_s
+        h["type"] = p.type.to_s.tr("_", "-") if p.type
+        resolves = p.resolves
+        h["resolves"] = resolves.map { |id| { "type" => Patch.resolves_type(id), "id" => id } } if resolves.any?
       else
         h["data"] = true
       end

--- a/Library/Homebrew/local_patch.rb
+++ b/Library/Homebrew/local_patch.rb
@@ -21,17 +21,29 @@ class LocalPatch < EmbeddedPatch
       !path.to_s.start_with?("../")
   end
 
+  sig { returns(T.nilable(Symbol)) }
+  attr_reader :type
+
   sig {
     params(
       strip:     T.any(String, Symbol),
       file:      T.any(String, Pathname),
       directory: T.nilable(T.any(String, Pathname)),
+      resolves:  T::Array[String],
+      type:      T.nilable(Symbol),
     ).void
   }
-  def initialize(strip, file, directory = nil)
+  def initialize(strip, file, directory = nil, resolves: [], type: nil)
     super(strip)
     @file = file
     self.directory = directory
+    @resolves = T.let(resolves.dup, T::Array[String])
+    @type = type
+  end
+
+  sig { returns(T::Array[String]) }
+  def resolves
+    (@resolves + Patch.extract_cves(file.to_s)).uniq
   end
 
   sig { override.returns(String) }

--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -9,6 +9,25 @@ require "local_patch"
 
 # Helper module for creating patches.
 module Patch
+  CVE_PATTERN = /CVE-?(\d{4})-(\d{4,})/i
+  GHSA_PATTERN = /\AGHSA(-[23456789cfghjmpqrvwx]{4}){3}\z/
+  # Keep in sync with `PATCH_TYPES` in `Library/Homebrew/rubocops/patches.rb`.
+  TYPES = T.let([:unofficial, :monkey, :backport, :cherry_pick].freeze, T::Array[Symbol])
+
+  sig { params(strings: String).returns(T::Array[String]) }
+  def self.extract_cves(*strings)
+    strings.flat_map { |s| s.scan(CVE_PATTERN) }
+           .map { |year, id| "CVE-#{year}-#{id}" }
+           .uniq
+  end
+
+  sig { params(id: String).returns(String) }
+  def self.resolves_type(id)
+    return "security" if id.match?(/\ACVE-\d{4}-\d{4,}\z/) || id.match?(GHSA_PATTERN)
+
+    "defect"
+  end
+
   sig {
     params(
       strip: T.any(Symbol, String),
@@ -36,7 +55,7 @@ module Patch
           raise ArgumentError, "Patch cannot use `sha256` with `file`." if resource.checksum
           raise ArgumentError, "Patch cannot use `apply` with `file`." if resource.patch_files.present?
 
-          LocalPatch.new(strip, file, resource.directory)
+          LocalPatch.new(strip, file, resource.directory, resolves: resource.resolves, type: resource.type)
         else
           external_patch
         end

--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -11,8 +11,18 @@ require "local_patch"
 module Patch
   CVE_PATTERN = /CVE-?(\d{4})-(\d{4,})/i
   GHSA_PATTERN = /\AGHSA(-[23456789cfghjmpqrvwx]{4}){3}\z/
+  # CycloneDX `pedigree.patches.type` values applicable to source diffs.
+  # `monkey` is omitted: it describes runtime modification, which `patch do` cannot express.
   # Keep in sync with `PATCH_TYPES` in `Library/Homebrew/rubocops/patches.rb`.
-  TYPES = T.let([:unofficial, :monkey, :backport, :cherry_pick].freeze, T::Array[Symbol])
+  TYPES = T.let({
+    unofficial:  "A patch that has not been developed by the upstream maintainers " \
+                 "(e.g. a Homebrew- or distribution-specific build fix).",
+    backport:    "A patch that takes code from a newer version of the software and " \
+                 "applies it to the older version Homebrew ships (e.g. an unreleased " \
+                 "upstream security fix).",
+    cherry_pick: "A patch created by selectively applying upstream commits that are " \
+                 "not strictly from a newer release (e.g. a fix from a maintenance branch).",
+  }.freeze, T::Hash[Symbol, String])
 
   sig { params(strings: String).returns(T::Array[String]) }
   def self.extract_cves(*strings)

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -469,6 +469,8 @@ class Resource
       @patch_files = T.let([], T::Array[T.any(String, Pathname)])
       @directory = T.let(nil, T.nilable(T.any(String, Pathname)))
       @file = T.let(nil, T.nilable(T.any(String, Pathname)))
+      @resolves = T.let([], T::Array[String])
+      @type = T.let(nil, T.nilable(Symbol))
       super "patch", &block
     end
 
@@ -476,6 +478,24 @@ class Resource
     def apply(*paths)
       @patch_files.concat(paths.flatten)
       @patch_files.uniq!
+    end
+
+    sig { params(cves: String).returns(T::Array[String]) }
+    def resolves(*cves)
+      return @resolves if cves.empty?
+
+      @resolves.concat(cves).uniq!
+      @resolves
+    end
+
+    sig { params(val: T.nilable(Symbol)).returns(T.nilable(Symbol)) }
+    def type(val = nil)
+      return @type if val.nil?
+      if ::Patch::TYPES.exclude?(val)
+        raise ArgumentError, "Patch type must be one of: #{::Patch::TYPES.map(&:inspect).join(", ")}"
+      end
+
+      @type = val
     end
 
     sig { params(val: T.nilable(T.any(String, Pathname))).returns(T.nilable(T.any(String, Pathname))) }

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -491,8 +491,8 @@ class Resource
     sig { params(val: T.nilable(Symbol)).returns(T.nilable(Symbol)) }
     def type(val = nil)
       return @type if val.nil?
-      if ::Patch::TYPES.exclude?(val)
-        raise ArgumentError, "Patch type must be one of: #{::Patch::TYPES.map(&:inspect).join(", ")}"
+      unless ::Patch::TYPES.key?(val)
+        raise ArgumentError, "Patch type must be one of: #{::Patch::TYPES.keys.map(&:inspect).join(", ")}"
       end
 
       @type = val

--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -11,7 +11,7 @@ module RuboCop
         extend AutoCorrector
 
         # Keep in sync with `Patch::TYPES` in `Library/Homebrew/patch.rb`.
-        PATCH_TYPES = T.let([:unofficial, :monkey, :backport, :cherry_pick].freeze, T::Array[Symbol])
+        PATCH_TYPES = T.let([:unofficial, :backport, :cherry_pick].freeze, T::Array[Symbol])
 
         sig { override.params(formula_nodes: FormulaNodes).void }
         def audit_formula(formula_nodes)

--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -10,6 +10,9 @@ module RuboCop
       class Patches < FormulaCop
         extend AutoCorrector
 
+        # Keep in sync with `Patch::TYPES` in `Library/Homebrew/patch.rb`.
+        PATCH_TYPES = T.let([:unofficial, :monkey, :backport, :cherry_pick].freeze, T::Array[Symbol])
+
         sig { override.params(formula_nodes: FormulaNodes).void }
         def audit_formula(formula_nodes)
           node = formula_nodes.node
@@ -24,6 +27,12 @@ module RuboCop
               sha256_node = find_every_method_call_by_name(patch_block, :sha256).first
               sha256_string = parameters(sha256_node).first if sha256_node
               patch_problems(url_string, sha256_string)
+            end
+            find_every_method_call_by_name(patch_block, :resolves).each do |resolves_node|
+              parameters(resolves_node).each { |arg| resolves_problems(arg) }
+            end
+            find_every_method_call_by_name(patch_block, :type).each do |type_node|
+              parameters(type_node).each { |arg| type_problems(arg) }
             end
           end
 
@@ -128,6 +137,38 @@ module RuboCop
             corrector.replace(patch_url_node.source_range,
                               patch_url_node.source.sub(%r{\A"http://}, '"https://'))
           end
+        end
+
+        sig { params(node: RuboCop::AST::Node).void }
+        def resolves_problems(node)
+          unless node.str_type?
+            offending_node(node)
+            problem "`resolves` should be passed identifier strings (CVE/GHSA id or issue URL)"
+            return
+          end
+
+          value = string_content(node)
+          return if value.match?(/\ACVE-\d{4}-\d{4,}\z/)
+          return if value.match?(/\AGHSA(-[23456789cfghjmpqrvwx]{4}){3}\z/)
+          return if value.match?(%r{\Ahttps?://})
+
+          offending_node(node)
+          if (m = value.match(/\ACVE-?(\d{4})-(\d{4,})\z/i))
+            corrected = "CVE-#{m[1]}-#{m[2]}"
+            problem "`resolves` should use the canonical CVE format: #{corrected}" do |corrector|
+              corrector.replace(node.source_range, corrected.inspect)
+            end
+          else
+            problem "`resolves` should be a CVE/GHSA identifier or issue URL, got: #{value.inspect}"
+          end
+        end
+
+        sig { params(node: RuboCop::AST::Node).void }
+        def type_problems(node)
+          return if node.sym_type? && PATCH_TYPES.include?(T.cast(node, RuboCop::AST::SymbolNode).value)
+
+          offending_node(node)
+          problem "Patch `type` should be one of: #{PATCH_TYPES.map(&:inspect).join(", ")}"
         end
 
         sig { params(patch: RuboCop::AST::Node).void }

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1748,6 +1748,76 @@ RSpec.describe Formula do
       expect(f.to_hash["patches"]).to eq([{ "strip" => "p2", "data" => true }])
     end
 
+    it "serialises type and explicit resolves on an external patch" do
+      f = formula "foo" do
+        url "foo-1.0"
+        patch do
+          url "https://example.com/foo.diff"
+          sha256 TEST_SHA256
+          type :cherry_pick
+          resolves "CVE-2024-1111", "CVE-2024-2222"
+        end
+      end
+
+      expect(f.to_hash["patches"]).to eq([
+        {
+          "strip"    => "p1",
+          "url"      => "https://example.com/foo.diff",
+          "sha256"   => TEST_SHA256,
+          "type"     => "cherry-pick",
+          "resolves" => [
+            { "type" => "security", "id" => "CVE-2024-1111" },
+            { "type" => "security", "id" => "CVE-2024-2222" },
+          ],
+        },
+      ])
+    end
+
+    it "serialises resolves inferred from url and apply paths" do
+      f = formula "foo" do
+        url "foo-1.0"
+        patch do
+          url "https://example.com/debian.tar.xz"
+          sha256 TEST_SHA256
+          apply "patches/CVE-2024-1234.patch", "patches/cve-2024-5678.patch"
+        end
+      end
+
+      expect(f.to_hash["patches"].first["resolves"]).to eq([
+        { "type" => "security", "id" => "CVE-2024-1234" },
+        { "type" => "security", "id" => "CVE-2024-5678" },
+      ])
+    end
+
+    it "serialises non-CVE resolves entries with the appropriate issue type" do
+      f = formula "foo" do
+        url "foo-1.0"
+        patch do
+          url "https://example.com/foo.diff"
+          sha256 TEST_SHA256
+          resolves "CVE-2024-1234", "GHSA-xr7r-f8xq-vfvv", "https://github.com/foo/bar/issues/1"
+        end
+      end
+
+      expect(f.to_hash["patches"].first["resolves"]).to eq([
+        { "type" => "security", "id" => "CVE-2024-1234" },
+        { "type" => "security", "id" => "GHSA-xr7r-f8xq-vfvv" },
+        { "type" => "defect", "id" => "https://github.com/foo/bar/issues/1" },
+      ])
+    end
+
+    it "serialises type on a local file patch" do
+      f = formula "foo" do
+        url "foo-1.0"
+        patch do
+          file "Patches/foo.diff"
+          type :unofficial
+        end
+      end
+
+      expect(f.to_hash["patches"]).to eq([{ "strip" => "p1", "file" => "Patches/foo.diff", "type" => "unofficial" }])
+    end
+
     it "serialises a local file patch" do
       f = formula "foo" do
         T.bind(self, T.class_of(Formula))

--- a/Library/Homebrew/test/patch_spec.rb
+++ b/Library/Homebrew/test/patch_spec.rb
@@ -130,6 +130,76 @@ RSpec.describe Patch do
     end
   end
 
+  describe ".extract_cves" do
+    it "extracts and normalises CVE identifiers from strings" do
+      result = described_class.extract_cves(
+        "patches/any/CVE-2024-2961.patch",
+        "patches/28-cve-2022-0529-and-cve-2022-0530.patch",
+        "patches/any/CVE-2024-33601_33602.patch",
+        "https://example.com/fix.diff",
+      )
+      expect(result).to eq(%w[CVE-2024-2961 CVE-2022-0529 CVE-2022-0530 CVE-2024-33601])
+    end
+
+    it "returns an empty array when nothing matches" do
+      expect(described_class.extract_cves("foo", "bar.patch")).to eq([])
+    end
+  end
+
+  describe ".resolves_type" do
+    it "classifies CVE and GHSA identifiers as security and everything else as defect" do
+      expect(described_class.resolves_type("CVE-2024-1234")).to eq("security")
+      expect(described_class.resolves_type("GHSA-xr7r-f8xq-vfvv")).to eq("security")
+      expect(described_class.resolves_type("https://github.com/foo/bar/issues/1")).to eq("defect")
+    end
+  end
+
+  describe "#resolves" do
+    it "merges explicit resolves with CVEs inferred from url and apply paths" do
+      patch = T.cast(described_class.create(:p1, nil) do
+        url "https://example.com/CVE-2024-1111.patch"
+        apply "patches/cve-2024-2222.patch"
+        resolves "CVE-2024-3333"
+      end, ExternalPatch)
+      expect(patch.resolves).to eq(["CVE-2024-3333", "CVE-2024-1111", "CVE-2024-2222"])
+    end
+
+    it "carries explicit resolves through to a local file patch and infers from the file path" do
+      patch = T.cast(described_class.create(:p1, nil) do
+        file "Patches/CVE-2024-1234.diff"
+        resolves "CVE-2024-5678"
+      end, LocalPatch)
+      expect(patch.resolves).to eq(["CVE-2024-5678", "CVE-2024-1234"])
+    end
+  end
+
+  describe "#type" do
+    it "stores a valid type on an external patch" do
+      patch = T.cast(described_class.create(:p1, nil) do
+        url "https://example.com/foo.diff"
+        type :backport
+      end, ExternalPatch)
+      expect(patch.type).to eq(:backport)
+    end
+
+    it "carries type through to a local file patch" do
+      patch = T.cast(described_class.create(:p1, nil) do
+        file "Patches/foo.diff"
+        type :unofficial
+      end, LocalPatch)
+      expect(patch.type).to eq(:unofficial)
+    end
+
+    it "rejects invalid types" do
+      expect do
+        described_class.create(:p1, nil) do
+          url "https://example.com/foo.diff"
+          type :hotfix
+        end
+      end.to raise_error(ArgumentError, /Patch type must be one of/)
+    end
+  end
+
   describe "#patch_files" do
     subject(:patch) { described_class.create(:p2, nil) }
 

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -452,4 +452,101 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Patches do
       RUBY
     end
   end
+
+  context "when auditing patch resolves" do
+    it "reports no offenses for CVE ids, GHSA ids and issue URLs" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          patch do
+            url "https://brew.sh/foo.diff"
+            sha256 "63376b8fdd6613a91976106d9376069274191860cd58f039b29ff16de1925621"
+            resolves "CVE-2024-1234", "GHSA-xr7r-f8xq-vfvv", "https://github.com/foo/bar/issues/1"
+          end
+        end
+      RUBY
+    end
+
+    it "reports and corrects non-canonical CVE identifiers" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          patch do
+            url "https://brew.sh/foo.diff"
+            sha256 "63376b8fdd6613a91976106d9376069274191860cd58f039b29ff16de1925621"
+            resolves "cve-2024-1234"
+                     ^^^^^^^^^^^^^^^ FormulaAudit/Patches: `resolves` should use the canonical CVE format: CVE-2024-1234
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          patch do
+            url "https://brew.sh/foo.diff"
+            sha256 "63376b8fdd6613a91976106d9376069274191860cd58f039b29ff16de1925621"
+            resolves "CVE-2024-1234"
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense for unrecognised identifiers" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          patch do
+            url "https://brew.sh/foo.diff"
+            sha256 "63376b8fdd6613a91976106d9376069274191860cd58f039b29ff16de1925621"
+            resolves "issue-123"
+                     ^^^^^^^^^^^ FormulaAudit/Patches: `resolves` should be a CVE/GHSA identifier or issue URL, got: "issue-123"
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense for non-string arguments" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          patch do
+            url "https://brew.sh/foo.diff"
+            sha256 "63376b8fdd6613a91976106d9376069274191860cd58f039b29ff16de1925621"
+            resolves :CVE_2024_1234
+                     ^^^^^^^^^^^^^^ FormulaAudit/Patches: `resolves` should be passed identifier strings (CVE/GHSA id or issue URL)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when auditing patch type" do
+    it "reports no offenses for valid types" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          patch do
+            url "https://brew.sh/foo.diff"
+            sha256 "63376b8fdd6613a91976106d9376069274191860cd58f039b29ff16de1925621"
+            type :backport
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense for invalid types" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          patch do
+            url "https://brew.sh/foo.diff"
+            sha256 "63376b8fdd6613a91976106d9376069274191860cd58f039b29ff16de1925621"
+            type :hotfix
+                 ^^^^^^^ FormulaAudit/Patches: Patch `type` should be one of: :unofficial, :monkey, :backport, :cherry_pick
+          end
+        end
+      RUBY
+    end
+  end
 end

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -543,7 +543,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Patches do
             url "https://brew.sh/foo.diff"
             sha256 "63376b8fdd6613a91976106d9376069274191860cd58f039b29ff16de1925621"
             type :hotfix
-                 ^^^^^^^ FormulaAudit/Patches: Patch `type` should be one of: :unofficial, :monkey, :backport, :cherry_pick
+                 ^^^^^^^ FormulaAudit/Patches: Patch `type` should be one of: :unofficial, :backport, :cherry_pick
           end
         end
       RUBY

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -690,6 +690,67 @@ patch :p0, "..."
 
 In embedded and external patches, the string "@@HOMEBREW\_PREFIX@@" is replaced with the value of the constant `HOMEBREW_PREFIX` before the patch is applied.
 
+### Annotating patches
+
+External and `file` patches can optionally declare a `type` and what they `resolve`. These annotations are exposed in `brew info --json` and the formula API for downstream tools such as SBOM generators and vulnerability scanners; they have no effect on how the patch is applied.
+
+`type` describes where the patch came from, using [CycloneDX](https://cyclonedx.org/docs/1.6/json/#components_items_pedigree_patches) terminology.
+
+`:backport` takes code from a newer version of the same software and applies it to the older version Homebrew ships. Most upstream-commit patches fall here. For example, `innoextract` applies an upstream commit that fixes the build with CMake 4 ahead of the next release:
+
+```ruby
+patch do
+  url "https://github.com/dscharrer/innoextract/commit/83d0bf4365b09ddd17dddb400ba5d262ddf16fb8.patch?full_index=1"
+  sha256 "fe5299d1fdea5c66287aef2f70fee41d86aedc460c5b165da621d699353db07d"
+  type :backport
+end
+```
+
+`:cherry_pick` selectively applies an upstream commit that is *not* from a strictly newer release line, such as a fix that only exists on a maintenance or release branch. `gecode` pulls Qt 6 support from the upstream `release/6.3.0` branch rather than `master`:
+
+```ruby
+patch do
+  url "https://github.com/Gecode/gecode/commit/c0ca0e5f4406099be22f87236ea8547c2f31ded3.patch?full_index=1"
+  sha256 "233b266a943c0619b027b4cb19912e2a8c9d1f8e4323a3627765cb32b47c59fe"
+  type :cherry_pick
+end
+```
+
+When in doubt between `:backport` and `:cherry_pick`, prefer `:backport` for anything taken from the upstream development tip.
+
+`:unofficial` is a patch not authored by the upstream maintainers, such as a Homebrew- or Debian-specific build fix. The widely-shared libtool/Big Sur configure fix is one example:
+
+```ruby
+patch do
+  url "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a0/Patches/libtool/configure-pre-0.4.2.418-big_sur.diff"
+  sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  type :unofficial
+end
+```
+
+`resolves` records what the patch fixes: one or more CVE identifiers (`CVE-YYYY-NNNN`), GHSA identifiers (`GHSA-xxxx-xxxx-xxxx`) or issue/PR URLs. CVE identifiers are also inferred automatically from the patch `url`, `apply` paths and `file` path, so a Debian-style `CVE-2016-2399.patch` is picked up without an explicit `resolves`.
+
+```ruby
+patch do
+  url "https://deb.debian.org/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-12.debian.tar.xz"
+  sha256 "e5b5fa3ec8391b92554d04528568d04ea9eb5145835e0c246eac7961c891a91a"
+  type :backport
+  resolves "CVE-2016-2399", "CVE-2017-9122"
+  apply "patches/CVE-2016-2399.patch", "patches/CVE-2017-9122_et_al.patch"
+end
+```
+
+For non-security build fixes, pass the upstream issue or PR URL instead:
+
+```ruby
+patch do
+  url "https://github.com/dscharrer/innoextract/commit/264c2fe6b84f90f6290c670e5f676660ec7b2387.patch?full_index=1"
+  sha256 "f968a9c0521083dd4076ce5eed56127099a9c9888113fc50f476b914396045cc"
+  type :backport
+  resolves "https://github.com/dscharrer/innoextract/pull/169"
+end
+```
+
 ### Creating the diff
 
 ```sh

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -694,7 +694,7 @@ In embedded and external patches, the string "@@HOMEBREW\_PREFIX@@" is replaced 
 
 External and `file` patches can optionally declare a `type` and what they `resolve`. These annotations are exposed in `brew info --json` and the formula API for downstream tools such as SBOM generators and vulnerability scanners; they have no effect on how the patch is applied.
 
-`type` describes where the patch came from, using [CycloneDX](https://cyclonedx.org/docs/1.6/json/#components_items_pedigree_patches) terminology.
+`type` describes where the patch came from, using the `pedigree.patches` terminology from the [CycloneDX specification](https://cyclonedx.org/docs/1.6/json/).
 
 `:backport` takes code from a newer version of the same software and applies it to the older version Homebrew ships. Most upstream-commit patches fall here. For example, `innoextract` applies an upstream commit that fixes the build with CMake 4 ahead of the next release:
 
@@ -718,13 +718,16 @@ end
 
 When in doubt between `:backport` and `:cherry_pick`, prefer `:backport` for anything taken from the upstream development tip.
 
-`:unofficial` is a patch not authored by the upstream maintainers, such as a Homebrew- or Debian-specific build fix. The widely-shared libtool/Big Sur configure fix is one example:
+`:unofficial` is a patch not authored by the upstream maintainers, such as a Homebrew- or distribution-specific build fix. As with all Homebrew patches, an `:unofficial` patch should have been [reported and/or submitted upstream](#patches) where practical. `unzip` carries a Debian-maintained patch set because upstream Info-ZIP no longer makes releases:
 
 ```ruby
 patch do
-  url "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a0/Patches/libtool/configure-pre-0.4.2.418-big_sur.diff"
-  sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  url "https://archive.ubuntu.com/ubuntu/pool/main/u/unzip/unzip_6.0-28ubuntu4.1.debian.tar.xz"
+  sha256 "d123c8e6972dbdd17ba1a4920fb57ed2ede9237dbae149dcbf55df829c77baf3"
   type :unofficial
+  apply "patches/04-handle-pkware-verification-bit.patch",
+        "patches/05-fix-uid-gid-handling.patch",
+        "patches/13-remove-build-date.patch"
 end
 ```
 


### PR DESCRIPTION
Part 2 of https://github.com/orgs/Homebrew/discussions/6869, following on from #22459 which exposed patches in `Formula#to_hash`.

This adds two optional stanzas to the `patch do` block so formulae can declare what kind of patch is being applied and what it resolves:

```ruby
patch do
  url "https://deb.debian.org/.../libquicktime_1.2.4-12.debian.tar.xz"
  sha256 "..."
  type :backport
  resolves "CVE-2016-2399", "CVE-2017-9122"
  apply "patches/CVE-2016-2399.patch", "patches/CVE-2017-9122_et_al.patch"
end
```

Both stanzas and the JSON output use [CycloneDX `pedigree.patches`](https://cyclonedx.org/docs/1.6/json/#components_items_pedigree_patches) terminology so a future CycloneDX SBOM emitter can consume the data directly:

- `type` is one of `:unofficial`, `:monkey`, `:backport`, `:cherry_pick`
- `resolves` takes one or more CVE identifiers, GHSA identifiers, or issue URLs

Serialised in `Formula#to_hash` / the JSON API as:

```json
"patches": [
  {
    "strip": "p1",
    "url": "https://...",
    "sha256": "...",
    "type": "backport",
    "resolves": [
      {"type": "security", "id": "CVE-2016-2399"},
      {"type": "security", "id": "CVE-2017-9122"}
    ]
  }
]
```

CVE/GHSA identifiers are emitted as `"type": "security"`; URLs are emitted as `"type": "defect"`, so non-security build-fix patches can also be annotated:

```ruby
patch do
  url "..."
  type :unofficial
  resolves "https://github.com/foo/bar/issues/123"
end
```

CVE identifiers are also inferred automatically from the patch `url`, `apply` paths and local `file` path, so formulae like `glibc`, `unzip`, `zip` and `libquicktime` that already apply Debian-style `CVE-YYYY-NNNN.patch` files get `resolves` data with no formula changes. With current homebrew-core that yields 22 CVEs for `glibc`/`unzip` alone. Explicit `resolves` declarations are merged with anything inferred.

The `FormulaAudit/Patches` cop validates that `resolves` arguments are CVE/GHSA identifiers or URLs (autocorrecting CVE case/hyphen variants) and that `type` is one of the permitted symbols.

The immediate consumer is [`brew vulns`](https://github.com/Homebrew/homebrew-brew-vulns), which can use `resolves` to suppress false positives where the upstream version is affected but Homebrew's bottle is patched. Related: #22467.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Written with Claude Code; I've reviewed the diff and run `brew lgtm` locally, and verified the inference output against `glibc` and `unzip` with `HOMEBREW_NO_INSTALL_FROM_API=1 brew info --json=v2`.

-----