### PR TITLE
Fix SBOM SPDX references

### DIFF
--- a/Library/Homebrew/api/formula/formula_struct_generator.rb
+++ b/Library/Homebrew/api/formula/formula_struct_generator.rb
@@ -175,6 +175,7 @@ module Homebrew
           )
 
           hash["stable_dependencies"] = stable_dependencies
+          hash["stable_patches"] = hash["patches"] || []
           hash["stable_uses_from_macos"] = stable_uses_from_macos
           hash["head_dependencies"] = head_dependencies
           hash["head_uses_from_macos"] = head_uses_from_macos

--- a/Library/Homebrew/api/formula_struct.rb
+++ b/Library/Homebrew/api/formula_struct.rb
@@ -114,6 +114,7 @@ module Homebrew
       const :service_run_args, T::Array[Homebrew::Service::RunParam], default: []
       const :service_run_kwargs, T::Hash[Symbol, Homebrew::Service::RunParam], default: {}
       const :stable_dependencies, T::Array[DependsOnArgs], default: []
+      const :stable_patches, T::Array[T::Hash[T.any(String, Symbol), T.untyped]], default: []
       const :stable_checksum, T.nilable(String)
       const :stable_url_args, [String, T::Hash[Symbol, T.anything]], default: ["", {}]
       const :stable_uses_from_macos, T::Array[UsesFromMacOSArgs], default: []

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -251,6 +251,25 @@ module Formulary
             sha256 checksum
           end
 
+          formula_struct.stable_patches.each do |patch_hash|
+            patch patch_hash.fetch("strip", patch_hash[:strip]).to_sym do
+              T.bind(self, Resource::Patch)
+
+              if (patch_url = patch_hash.fetch("url", patch_hash[:url]))
+                url patch_url
+                if (patch_sha256 = patch_hash.fetch("sha256", patch_hash[:sha256]))
+                  sha256 patch_sha256
+                end
+                apply patch_hash.fetch("apply", patch_hash[:apply]) if patch_hash.fetch("apply", patch_hash[:apply])
+                if (patch_directory = patch_hash.fetch("directory", patch_hash[:directory]))
+                  directory patch_directory
+                end
+              elsif (patch_file = patch_hash.fetch("file", patch_hash[:file]))
+                file patch_file
+              end
+            end
+          end
+
           formula_struct.stable_dependencies.each do |dep|
             depends_on dep
           end

--- a/Library/Homebrew/sbom.rb
+++ b/Library/Homebrew/sbom.rb
@@ -199,11 +199,13 @@ class SBOM
       {
         spdxElementId:      dependency[:SPDXID],
         relationshipType:   "RUNTIME_DEPENDENCY_OF",
-        relatedSpdxElement: "SPDXRef-Bottle-#{name}",
+        relatedSpdxElement: described_package_spdx_id(bottling:),
       }
     end
 
-    patches = source.patches.each_with_index.map do |_patch, index|
+    patches = source.patches.each_with_index.filter_map do |patch, index|
+      next unless patch.is_a?(ExternalPatch)
+
       {
         spdxElementId:      "SPDXRef-Patch-#{name}-#{index}",
         relationshipType:   "PATCH_APPLIED",
@@ -211,24 +213,28 @@ class SBOM
       }
     end
 
-    base = T.let([{
-      spdxElementId:      "SPDXRef-File-#{name}",
-      relationshipType:   "PACKAGE_OF",
-      relatedSpdxElement: "SPDXRef-Archive-#{name}-src",
-    }], T::Array[T::Hash[Symbol, T.untyped]])
+    base = T.let([], T::Array[T::Hash[Symbol, T.untyped]])
+
+    if source.checksum.present?
+      base << {
+        spdxElementId:      "SPDXRef-File-#{name}",
+        relationshipType:   "PACKAGE_OF",
+        relatedSpdxElement: "SPDXRef-Archive-#{name}-src",
+      }
+    end
 
     unless bottling
       base << {
         spdxElementId:      "SPDXRef-Compiler",
         relationshipType:   "BUILD_TOOL_OF",
-        relatedSpdxElement: "SPDXRef-Package-#{name}-src",
+        relatedSpdxElement: "SPDXRef-Archive-#{name}-src",
       }
 
       if compiler_declaration["SPDXRef-Stdlib"].present?
         base << {
           spdxElementId:      "SPDXRef-Stdlib",
           relationshipType:   "DEPENDENCY_OF",
-          relatedSpdxElement: "SPDXRef-Bottle-#{name}",
+          relatedSpdxElement: described_package_spdx_id(bottling:),
         }
       end
     end
@@ -245,8 +251,9 @@ class SBOM
   }
   def generate_packages_json(runtime_dependency_declaration, compiler_declaration, bottling:)
     bottle = []
-    if !bottling && (bottle_info = get_bottle_info(source.bottle)) &&
-       spec_symbol == :stable && (stable_version = source.version)
+    if bottle_package?(bottling:) &&
+       (bottle_info = get_bottle_info(source.bottle)) &&
+       (stable_version = source.version)
       bottle << {
         SPDXID:           "SPDXRef-Bottle-#{name}",
         name:             name.to_s,
@@ -271,6 +278,31 @@ class SBOM
           },
         ],
       }
+    end
+
+    patches = source.patches.each_with_index.filter_map do |patch, index|
+      next unless patch.is_a?(ExternalPatch)
+
+      package = {
+        SPDXID:           "SPDXRef-Patch-#{name}-#{index}",
+        name:             "#{name} patch #{index}",
+        filesAnalyzed:    false,
+        licenseDeclared:  assert_value(nil),
+        licenseConcluded: assert_value(nil),
+        downloadLocation: assert_value(patch.url),
+        copyrightText:    assert_value(nil),
+        checksums:        [],
+        externalRefs:     [],
+      }
+      if (checksum = patch.resource.checksum)
+        package[:checksums] = [
+          {
+            algorithm:     "SHA256",
+            checksumValue: checksum.hexdigest,
+          },
+        ]
+      end
+      package
     end
 
     compiler_declarations = if bottling
@@ -298,7 +330,26 @@ class SBOM
           },
         ],
       },
-    ] + runtime_dependency_declaration + compiler_declarations + bottle
+    ] + patches + runtime_dependency_declaration + compiler_declarations + bottle
+  end
+
+  sig { returns(T::Array[T::Hash[Symbol, T.anything]]) }
+  def generate_files_json
+    checksum = source.checksum
+    return [] unless checksum
+
+    [
+      {
+        SPDXID:    "SPDXRef-File-#{name}",
+        fileName:  source.url.to_s.split("/").last.presence || "#{name}-#{spec_version}",
+        checksums: [
+          {
+            algorithm:     "SHA256",
+            checksumValue: checksum.hexdigest,
+          },
+        ],
+      },
+    ]
   end
 
   sig {
@@ -388,6 +439,7 @@ class SBOM
     end
 
     packages = generate_packages_json(runtime_full, compiler_info, bottling:)
+    files = generate_files_json
     {
       SPDXID:            "SPDXRef-DOCUMENT",
       spdxVersion:       "SPDX-2.3",
@@ -396,7 +448,7 @@ class SBOM
       dataLicense:       "CC0-1.0",
       documentNamespace: "https://formulae.brew.sh/spdx/#{name}-#{spec_version}.json",
       documentDescribes: packages.map { |dependency| dependency[:SPDXID] },
-      files:             [],
+      files:,
       packages:,
       relationships:     generate_relations_json(runtime_full, compiler_info, bottling:),
     }
@@ -410,6 +462,20 @@ class SBOM
     return unless files
 
     files[Utils::Bottles.tag.to_sym] || files[:all]
+  end
+
+  sig { params(bottling: T::Boolean).returns(T::Boolean) }
+  def bottle_package?(bottling:)
+    !bottling && get_bottle_info(source.bottle).present? && spec_symbol == :stable && source.version.present?
+  end
+
+  sig { params(bottling: T::Boolean).returns(String) }
+  def described_package_spdx_id(bottling:)
+    if bottle_package?(bottling:)
+      "SPDXRef-Bottle-#{name}"
+    else
+      "SPDXRef-Archive-#{name}-src"
+    end
   end
 
   sig { returns(Symbol) }

--- a/Library/Homebrew/test/api/formula/formula_struct_generator_spec.rb
+++ b/Library/Homebrew/test/api/formula/formula_struct_generator_spec.rb
@@ -146,6 +146,26 @@ RSpec.describe Homebrew::API::Formula::FormulaStructGenerator do
     expect(struct.head_dependencies).to eq struct.stable_dependencies
   end
 
+  specify "::generate_formula_struct_hash preserves stable patches" do
+    hash = {
+      "desc"                 => "Test formula",
+      "homepage"             => "https://example.com",
+      "license"              => "MIT",
+      "ruby_source_checksum" => { "sha256" => "abc123" },
+      "versions"             => { "stable" => "1.0.0" },
+      "urls"                 => { "stable" => { "url" => "https://example.com/foo-1.0.tar.gz" } },
+      "patches"              => [
+        {
+          "strip"  => "p1",
+          "url"    => "https://example.com/foo.patch",
+          "sha256" => "def456",
+        },
+      ],
+    }
+
+    expect(klass.generate_formula_struct_hash(hash).stable_patches).to eq hash["patches"]
+  end
+
   specify "::symbolize_dependency_hash" do
     output = klass.symbolize_dependency_hash(raw_dependency_hash)
     expect(output).to eq symbolized_dependency_hash

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -608,6 +608,22 @@ RSpec.describe Formulary do
         expect(formula.to_hash_with_variations).to eq(expected_hash)
       end
 
+      it "loads patches from API JSON" do
+        allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents(
+          "patches" => [
+            {
+              "strip"  => "p1",
+              "url"    => "https://example.com/test.patch",
+              "sha256" => TEST_SHA256,
+            },
+          ],
+        )
+
+        formula = klass.factory(formula_name)
+
+        expect(formula.patchlist.first).to be_a(ExternalPatch)
+      end
+
       it "returns a deprecated Formula when given a name" do
         allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents(deprecate_json)
 

--- a/Library/Homebrew/test/sbom_spec.rb
+++ b/Library/Homebrew/test/sbom_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe SBOM do
 
           patch do
             url "patch_macos"
+            sha256 TEST_SHA256
           end
 
           bottle do
@@ -88,6 +89,28 @@ RSpec.describe SBOM do
 
       it "returns true if valid when bottling" do
         expect(sbom.schema_validation_errors(bottling: true)).to be_empty
+      end
+
+      it "only emits relationships with defined SPDX IDs" do
+        spdx = sbom.send(:to_spdx_sbom, bottling: false)
+        spdx_ids = Set.new(["SPDXRef-DOCUMENT"] + spdx[:packages].map { |package| package[:SPDXID] } +
+                           spdx[:files].map { |file| file[:SPDXID] })
+
+        expect(spdx[:relationships].flat_map do |relation|
+          [relation[:spdxElementId], relation[:relatedSpdxElement]]
+        end).to all(satisfy { |spdx_id| spdx_ids.include?(spdx_id) })
+      end
+
+      it "emits external patches as packages" do
+        spdx = sbom.send(:to_spdx_sbom, bottling: false)
+
+        expect(spdx[:packages]).to include(
+          hash_including(
+            SPDXID:           "SPDXRef-Patch-formula_name-0",
+            downloadLocation: "patch_macos",
+            checksums:        [{ algorithm: "SHA256", checksumValue: TEST_SHA256 }],
+          ),
+        )
       end
     end
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22467

- Ensure SBOM relationships point at SPDX IDs emitted in the document
- Preserve API patch metadata so patch relationships survive API loads
- Cover patch packages and API-loaded patch regression cases

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
