### PR TITLE
sorbet: Bump `test/support/helper` files to `typed: true`

### DIFF
--- a/Library/Homebrew/test/support/helper/cask.rb
+++ b/Library/Homebrew/test/support/helper/cask.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cask/cask_loader"
@@ -6,6 +6,10 @@ require "cask/cask_loader"
 module Test
   module Helper
     module Cask
+      extend T::Helpers
+
+      requires_ancestor { RSpec::Mocks::ExampleMethods }
+
       def stub_cask_loader(cask, ref = cask.token, call_original: false)
         allow(::Cask::CaskLoader).to receive(:for).and_call_original if call_original
 

--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "formulary"
@@ -6,6 +6,10 @@ require "formulary"
 module Test
   module Helper
     module Formula
+      extend T::Helpers
+
+      requires_ancestor { RSpec::Mocks::ExampleMethods }
+
       def formula(name = "formula_name", path: nil, spec: :stable, alias_path: nil, tap: nil, &block)
         path ||= Formulary.find_formula_in_tap(name, tap || CoreTap.instance)
         Class.new(::Formula, &block).new(name, path, spec, alias_path:, tap:)

--- a/Library/Homebrew/test/support/helper/mktmpdir.rb
+++ b/Library/Homebrew/test/support/helper/mktmpdir.rb
@@ -1,12 +1,12 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module Test
   module Helper
     module MkTmpDir
-      def mktmpdir(prefix_suffix = nil)
+      def mktmpdir(prefix_suffix = nil, &block)
         new_dir = Pathname.new(Dir.mktmpdir(prefix_suffix, HOMEBREW_TEMP))
-        return yield new_dir if block_given?
+        return yield(new_dir) if block
 
         new_dir
       end

--- a/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cask/config"
@@ -34,6 +34,8 @@ end
 
 # These shared contexts starting with `when` don't make sense.
 RSpec.shared_context "Homebrew Cask", :needs_macos do # rubocop:disable RSpec/ContextWording
+  T.bind(self, T.class_of(RSpec::Core::ExampleGroup))
+
   around do |example|
     third_party_tap = Tap.fetch("third-party", "tap")
 

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "open3"
@@ -6,43 +6,47 @@ require "open3"
 require "formula_installer"
 require "uninstall"
 
+RSpec::Matchers.define :be_a_success do
+  T.bind(self, T.class_of(RSpec::Matchers::DSL::Matcher))
+
+  match do |actual|
+    T.bind(self, RSpec::Matchers::DSL::Matcher)
+
+    status = actual.is_a?(Proc) ? actual.call : actual
+    expect(status).to respond_to(:success?)
+    status.success?
+  end
+
+  def supports_block_expectations?
+    true
+  end
+
+  # It needs to be nested like this:
+  #
+  #   expect {
+  #     expect {
+  #       # command
+  #     }.to be_a_success
+  #   }.to output(something).to_stdout
+  #
+  # rather than this:
+  #
+  #   expect {
+  #     expect {
+  #       # command
+  #     }.to output(something).to_stdout
+  #   }.to be_a_success
+  #
+  def expects_call_stack_jump?
+    true
+  end
+end
+
 RSpec::Matchers.define_negated_matcher :be_a_failure, :be_a_success
 
 # These shared contexts starting with `when` don't make sense.
 RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWording
-  extend RSpec::Matchers::DSL
-
-  matcher :be_a_success do
-    match do |actual|
-      status = actual.is_a?(Proc) ? actual.call : actual
-      expect(status).to respond_to(:success?)
-      status.success?
-    end
-
-    def supports_block_expectations?
-      true
-    end
-
-    # It needs to be nested like this:
-    #
-    #   expect {
-    #     expect {
-    #       # command
-    #     }.to be_a_success
-    #   }.to output(something).to_stdout
-    #
-    # rather than this:
-    #
-    #   expect {
-    #     expect {
-    #       # command
-    #     }.to output(something).to_stdout
-    #   }.to be_a_success
-    #
-    def expects_call_stack_jump?
-      true
-    end
-  end
+  T.bind(self, T.class_of(RSpec::Core::ExampleGroup))
 
   around do |example|
     ENV["HOMEBREW_INTEGRATION_TEST"] = "1"
@@ -93,12 +97,13 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
       if ENV["HOMEBREW_TESTS_COVERAGE"]
         simplecov_spec = Gem.loaded_specs["simplecov"]
         parallel_tests_spec = Gem.loaded_specs["parallel_tests"]
-        specs = []
+        specs = T.let([], T::Array[Gem::Specification])
         [simplecov_spec, parallel_tests_spec].each do |spec|
           specs << spec
           spec.runtime_dependencies.each do |dep|
             specs += dep.to_specs
           rescue Gem::LoadError => e
+            T.bind(self, Utils::Output::Mixin)
             onoe e
           end
         end
@@ -260,8 +265,8 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
       # Check to see if the original Homebrew process has taps we can use.
       system_tap_path = Pathname("#{ENV.fetch("HOMEBREW_LIBRARY")}/Taps/#{full_name}")
       if system_tap_path.exist?
-        system "git", "clone", "--shared", system_tap_path, tap.path
-        system "git", "-C", tap.path, "checkout", "master"
+        system "git", "clone", "--shared", system_tap_path.to_s, tap.path.to_s
+        system "git", "-C", tap.path.to_s, "checkout", "master"
       else
         tap.install(quiet: true)
       end

--- a/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
@@ -1,9 +1,14 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.shared_examples "formulae exist" do |array|
-  array.each do |f|
+  T.bind(self, T.class_of(RSpec::Core::ExampleGroup))
+  formulae = T.cast(array, T::Array[Formula])
+
+  formulae.each do |f|
     it "#{f} formula exists", :needs_homebrew_core do
+      T.bind(self, RSpec::Core::ExampleGroup)
+
       core_tap = Pathname("#{HOMEBREW_LIBRARY_PATH}/../Taps/homebrew/homebrew-core")
       formula_paths = core_tap.glob("Formula/**/#{f}.rb")
       alias_path = core_tap/"Aliases/#{f}"

--- a/Library/Homebrew/test/support/helper/subcommand.rb
+++ b/Library/Homebrew/test/support/helper/subcommand.rb
@@ -1,9 +1,13 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module Test
   module Helper
     module Subcommand
+      extend T::Helpers
+
+      requires_ancestor { Kernel }
+
       class Args
         attr_reader :named
 

--- a/Library/Homebrew/test/support/helper/subcommand_spec.rb
+++ b/Library/Homebrew/test/support/helper/subcommand_spec.rb
@@ -1,8 +1,11 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Test::Helper::Subcommand::Args do
   specify "unknown predicates raise" do
-    expect { Test::Helper::Subcommand::Args.new(named: []).formuale? }.to raise_error(NoMethodError)
+    unknown_predicate = :formuale?
+    expect do
+      Test::Helper::Subcommand::Args.new(named: []).public_send(unknown_predicate)
+    end.to raise_error(NoMethodError)
   end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

- Used GPT-5.3 Codex (Medium reasoning) to add some of the types here. It was not actually particularly helpful and needed a lot of human reviewing and tweaking for less reliance on `T.untyped` and `T.unsafe` (particularly `Library/Homebrew/test/support/helper/subcommand_spec.rb`).

-----

- Add `T.bind`s for RSpec example groups and matcher test helpers.
- For the undefined predicate method raising NoMethodError, trick Sorbet into not flagging it as an error by using `public_send` instead of direct method call - because, correctly, the method does not exist but the test is already verifying that.