### PR TITLE
Add initial tap trust enforcement

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -9,6 +9,7 @@ require "cask/metadata"
 require "cask/tab"
 require "utils/output"
 require "api_hashable"
+require "trust"
 
 module Cask
   # An instance of a cask.
@@ -59,6 +60,7 @@ module Cask
       # Load core casks from tokens so they load from the API when the core cask is not tapped.
       tokens_and_files = CoreCaskTap.instance.cask_tokens
       tokens_and_files += Tap.reject(&:core_cask_tap?).flat_map(&:cask_files)
+                             .select { |file| Homebrew::Trust.trusted_cask_file?(file) }
       tokens_and_files.filter_map do |token_or_file|
         CaskLoader.load(token_or_file)
       rescue CaskUnreadableError => e

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -10,6 +10,7 @@ require "utils/path"
 require "extend/hash/keys"
 require "extend/ENV/sensitive"
 require "api"
+require "trust"
 
 module Cask
   # Loads a cask from various sources.
@@ -163,6 +164,8 @@ module Cask
         raise CaskUnavailableError.new(token, "'#{path}' does not exist.")  unless path.exist?
         raise CaskUnavailableError.new(token, "'#{path}' is not readable.") unless path.readable?
         raise CaskUnavailableError.new(token, "'#{path}' is not a file.")   unless path.file?
+
+        Homebrew::Trust.require_trusted_cask!(token, path)
 
         @content = path.read(encoding: "UTF-8")
         @config = config

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -89,18 +89,32 @@ module Commands
   sig { params(cmd: String).returns(T.nilable(Pathname)) }
   def self.external_ruby_v2_cmd_path(cmd)
     path = which("#{cmd}.rb", tap_cmd_directories)
+    require_trusted_command!(path, cmd)
     path if ENV.clear_sensitive_environment! { Homebrew.require?(path) }
   end
 
   # Ruby commands which are run by being `require`d.
   sig { params(cmd: String).returns(T.nilable(Pathname)) }
   def self.external_ruby_cmd_path(cmd)
-    which("brew-#{cmd}.rb", PATH.new(ENV.fetch("PATH")).append(tap_cmd_directories))
+    path = which("brew-#{cmd}.rb", PATH.new(ENV.fetch("PATH")).append(tap_cmd_directories))
+    require_trusted_command!(path, cmd)
+    path
   end
 
   sig { params(cmd: String).returns(T.nilable(Pathname)) }
   def self.external_cmd_path(cmd)
-    which("brew-#{cmd}", PATH.new(ENV.fetch("PATH")).append(tap_cmd_directories))
+    path = which("brew-#{cmd}", PATH.new(ENV.fetch("PATH")).append(tap_cmd_directories))
+    require_trusted_command!(path, cmd)
+    path
+  end
+
+  sig { params(path: T.nilable(Pathname), cmd: String).void }
+  def self.require_trusted_command!(path, cmd)
+    return unless path
+    return if path.expand_path.ascend.none?(HOMEBREW_TAP_DIRECTORY)
+
+    require "trust"
+    Homebrew::Trust.require_trusted_command!(path, cmd)
   end
 
   sig { params(cmd: String).returns(T.nilable(Pathname)) }

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -557,6 +557,13 @@ module Homebrew
         description: "If set, use Pry for the `brew irb` command.",
         boolean:     true,
       },
+      HOMEBREW_REQUIRE_TAP_TRUST:                {
+        # odeprecated: make tap trust checks default in a later release.
+        description: "If set, require non-official tap formulae, casks and commands to be trusted before " \
+                     "Homebrew loads them.",
+        boolean:     true,
+        hidden:      true,
+      },
       HOMEBREW_SANDBOX_LINUX:                    {
         # odeprecated: edit in 5.2.0
         description: "If set, use the `bwrap`(1) sandbox for formula installation and testing on Linux. " \

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -43,6 +43,7 @@ require "utils/spdx"
 require "on_system"
 require "api"
 require "api_hashable"
+require "trust"
 require "utils/output"
 require "pypi_packages"
 require "time"
@@ -2567,7 +2568,9 @@ class Formula
       raise ArgumentError, "Formula#all cannot be used without `--eval-all` or `HOMEBREW_EVAL_ALL=1`"
     end
 
-    (core_names + tap_files).filter_map do |name_or_file|
+    trusted_tap_files = tap_files.select { |file| Homebrew::Trust.trusted_formula_file?(file) }
+
+    (core_names + trusted_tap_files).filter_map do |name_or_file|
       Formulary.factory(name_or_file)
     rescue FormulaUnavailableError, FormulaUnreadableError, FormulaSpecificationError => e
       # Don't let one broken formula break commands. But do complain.

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -10,6 +10,7 @@ require "utils/bottles"
 require "utils/output"
 require "utils/path"
 require "service"
+require "trust"
 require "utils/curl"
 require "extend/hash/deep_transform_values"
 require "extend/hash/keys"
@@ -126,6 +127,8 @@ module Formulary
   def self.load_formula(name, path, contents, namespace, flags:, ignore_errors:)
     raise "Formula loading disabled by `$HOMEBREW_DISABLE_LOAD_FORMULA`!" if Homebrew::EnvConfig.disable_load_formula?
 
+    Homebrew::Trust.require_trusted_formula!(name, path)
+
     require "formula"
     require "ignorable"
     require "stringio"
@@ -175,13 +178,13 @@ module Formulary
   ensure
     # TODO: Make printing to stdout an error so that we can print a tap name.
     #       See discussion at https://github.com/Homebrew/brew/pull/20226#discussion_r2195886888
-    if (printed_to_stdout = $stdout.string.strip.presence)
+    if old_stdout && $stdout.respond_to?(:string) && (printed_to_stdout = $stdout.string.strip.presence)
       opoo <<~WARNING
         Formula #{name} attempted to print the following while being loaded:
         #{printed_to_stdout}
       WARNING
     end
-    $stdout = old_stdout
+    $stdout = old_stdout if old_stdout
   end
 
   sig { params(identifier: String).returns(String) }

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -380,6 +380,9 @@ module Homebrew::EnvConfig
     def pry?; end
 
     sig { returns(T::Boolean) }
+    def require_tap_trust?; end
+
+    sig { returns(T::Boolean) }
     def sbom?; end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -347,6 +347,41 @@ RSpec.describe Cask::CaskLoader, :cask do
       end
     end
 
+    it "refuses untrusted third-party tap casks when trust is enabled" do
+      tap = Tap.fetch("thirdparty", "foo")
+      cask_token = "sensitive-env"
+      cask_file = tap.cask_dir/"#{cask_token}.rb"
+      cask_file.dirname.mkpath
+      cask_file.write <<~RUBY
+        cask "#{cask_token}" do
+          version "1.0.0"
+          sha256 "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+          url "https://example.com/app.dmg"
+          name "Sensitive Env"
+          desc "Sensitive Env"
+          homepage "https://example.com"
+
+          app "App.app"
+        end
+      RUBY
+
+      with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+        expect { Cask::CaskLoader::FromPathLoader.new(cask_file).load(config: nil) }
+          .to raise_error(Homebrew::UntrustedTapError, %r{thirdparty/foo})
+      end
+
+      Homebrew::Trust.trust!(:cask, "thirdparty/foo/sensitive-env")
+
+      with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+        expect(Cask::CaskLoader::FromPathLoader.new(cask_file).load(config: nil).full_name)
+          .to eq("thirdparty/foo/sensitive-env")
+      end
+    ensure
+      Homebrew::Trust.clear!(:cask)
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+
     describe "loading a cask with a removed DSL method" do
       let(:tmpdir) { mktmpdir }
       let(:cask_token) { "removed-method-cask" }

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -57,6 +57,27 @@ RSpec.describe Cask::Cask, :cask do
     Cask::CaskLoader.load(path)
   end
 
+  describe ".all" do
+    it "skips untrusted tap casks when trust is enabled" do
+      tap = Tap.fetch("thirdparty", "foo")
+      cask_path = tap.cask_dir/"untrusted.rb"
+      cask_path.dirname.mkpath
+      cask_path.write <<~RUBY
+        raise "untrusted cask evaluated"
+      RUBY
+
+      allow(CoreCaskTap.instance).to receive(:cask_tokens).and_return([])
+      allow(Tap).to receive(:reject).and_return([tap])
+      expect(Cask::CaskLoader).not_to receive(:load).with(cask_path)
+
+      with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+        expect(klass.all(eval_all: true)).to eq([])
+      end
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+  end
+
   context "when multiple versions are installed" do
     describe "#installed_version" do
       context "when there are duplicate versions" do

--- a/Library/Homebrew/test/cmd/help_spec.rb
+++ b/Library/Homebrew/test/cmd/help_spec.rb
@@ -3,6 +3,7 @@
 
 require "cmd/help"
 require "cmd/shared_examples/args_parse"
+require "trust"
 
 RSpec.describe Homebrew::Cmd::HelpCmd, :integration_test do
   it_behaves_like "parseable arguments"
@@ -55,6 +56,53 @@ RSpec.describe Homebrew::Cmd::HelpCmd, :integration_test do
         .and not_to_output.to_stderr
         .and be_a_success
     ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+
+    it "requires trust for an external command from a third-party tap" do
+      tap_path = HOMEBREW_TAP_DIRECTORY/"thirdparty/homebrew-foo"
+      tap_path.mkpath
+      tap_path.cd do
+        system "git", "init"
+        system "git", "remote", "add", "origin", "https://github.com/thirdparty/homebrew-foo"
+        FileUtils.touch "readme"
+        system "git", "add", "--all"
+        system "git", "commit", "-m", "init"
+      end
+      cmd_path = tap_path/"cmd/hello-tap.rb"
+      cmd_path.dirname.mkpath
+      cmd_path.write <<~RUBY
+        # typed: strict
+        # frozen_string_literal: true
+
+        require "abstract_command"
+
+        module Homebrew
+          module Cmd
+            class HelloTap < AbstractCommand
+              cmd_args do
+                description "A friendly greeter from a tap."
+              end
+
+              sig { override.void }
+              def run; end
+            end
+          end
+        end
+      RUBY
+      cmd_path.chmod(0755)
+
+      expect { brew "help", "hello-tap", "HOMEBREW_REQUIRE_TAP_TRUST" => "1" }
+        .to output(%r{thirdparty/foo}).to_stderr
+        .and be_a_failure
+
+      Homebrew::Trust.trust!(:command, "thirdparty/foo/hello-tap")
+
+      expect { brew "help", "hello-tap", "HOMEBREW_REQUIRE_TAP_TRUST" => "1" }
+        .to output(%r{^From tap: thirdparty/foo$}).to_stdout
+        .and be_a_success
+    ensure
+      Homebrew::Trust.clear!(:command)
       FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
     end
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -2896,6 +2896,24 @@ RSpec.describe Formula do
       expect { Formula.all(eval_all: true) }.not_to raise_error
       expect(Formula.all(eval_all: true)).to eq([])
     end
+
+    it "skips untrusted tap formulae when trust is enabled" do
+      tap = Tap.fetch("thirdparty", "foo")
+      formula_path = tap.formula_dir/"untrusted.rb"
+      formula_path.dirname.mkpath
+      formula_path.write <<~RUBY
+        raise "untrusted formula evaluated"
+      RUBY
+
+      allow(Formula).to receive_messages(core_names: [], tap_files: [formula_path])
+      expect(Formulary).not_to receive(:factory).with(formula_path)
+
+      with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+        expect(Formula.all(eval_all: true)).to eq([])
+      end
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
   end
 
   describe "#std_pip_args" do

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -118,6 +118,31 @@ RSpec.describe Formulary do
         expect(formula_class::SECRET_TOKEN_PRESENT).to be(true)
       end
     end
+
+    it "refuses untrusted third-party tap formulae when trust is enabled" do
+      tap = Tap.fetch("thirdparty", "foo")
+      formula_path = tap.formula_dir/"sensitive-env.rb"
+      formula_path.dirname.mkpath
+      formula_path.write <<~RUBY
+        class SensitiveEnv < Formula
+          url "https://brew.sh/sensitive-env-1.0.tar.gz"
+        end
+      RUBY
+
+      with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+        expect { Formulary.factory(formula_path) }
+          .to raise_error(Homebrew::UntrustedTapError, %r{thirdparty/foo})
+      end
+
+      Homebrew::Trust.trust!(:formula, "thirdparty/foo/sensitive-env")
+
+      with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+        expect(Formulary.factory(formula_path).full_name).to eq("thirdparty/foo/sensitive-env")
+      end
+    ensure
+      Homebrew::Trust.clear!(:formula)
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
   end
 
   describe "::factory" do

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+# frozen_string_literal: true
+
+require "tap"
+require "trust"
+
+RSpec.describe Homebrew::Trust do
+  it "is enabled by HOMEBREW_REQUIRE_TAP_TRUST" do
+    with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+      expect(Homebrew::Trust).to be_enabled
+    end
+  end
+
+  it "trusts third-party taps" do
+    tap = Tap.fetch("thirdparty", "foo")
+
+    expect(Homebrew::Trust.trusted_tap?(tap)).to be(false)
+
+    Homebrew::Trust.trust!(:tap, "thirdparty/foo")
+
+    expect(Homebrew::Trust.trusted_tap?(tap)).to be(true)
+  ensure
+    Homebrew::Trust.clear!(:tap)
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
+  it "ignores a trust file with a non-object JSON root" do
+    trust_file = HOMEBREW_PREFIX/"var/homebrew/trust.json"
+    trust_file.dirname.mkpath
+    trust_file.write("[]")
+
+    expect(Homebrew::Trust.trusted?(:tap, "thirdparty/foo")).to be(false)
+  ensure
+    trust_file&.unlink if trust_file&.exist?
+  end
+end

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -1,0 +1,168 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "env_config"
+require "json"
+require "tap"
+require "utils"
+
+module Homebrew
+  class UntrustedTapError < RuntimeError; end
+
+  module Trust
+    SETTING_KEYS = T.let({
+      tap:     :trustedtaps,
+      formula: :trustedformulae,
+      cask:    :trustedcasks,
+      command: :trustedcommands,
+    }.freeze, T::Hash[Symbol, Symbol])
+    private_constant :SETTING_KEYS
+
+    TRUST_FILE = T.let((HOMEBREW_PREFIX/"var/homebrew/trust.json").freeze, Pathname)
+    private_constant :TRUST_FILE
+
+    sig { returns(T::Boolean) }
+    def self.enabled?
+      Homebrew::EnvConfig.require_tap_trust?
+    end
+
+    sig { params(type: Symbol, name: String).returns(T::Boolean) }
+    def self.trust!(type, name)
+      key = setting_key(type)
+      entries = trusted_entries(type)
+      name = normalise_name(name)
+      return false if entries.include?(name)
+
+      store = trust_store
+      store[key] = (entries + [name]).sort
+      write_trust_store(store)
+      true
+    end
+
+    sig { params(type: Symbol).void }
+    def self.clear!(type)
+      store = trust_store
+      store.delete(setting_key(type))
+      write_trust_store(store)
+    end
+
+    sig { params(type: Symbol, name: String).returns(T::Boolean) }
+    def self.trusted?(type, name)
+      trusted_entries(type).include?(normalise_name(name))
+    end
+
+    sig { params(tap: T.untyped).returns(T::Boolean) }
+    def self.trusted_tap?(tap)
+      tap.official? || trusted?(:tap, tap.name)
+    end
+
+    sig { params(name: String, path: Pathname).void }
+    def self.require_trusted_formula!(name, path)
+      return unless (tap = tap_from_path(path))
+      return if trusted_tap?(tap)
+
+      full_name = "#{tap.name}/#{::Utils.name_from_full_name(name)}"
+      return if trusted?(:formula, full_name)
+      return unless enabled?
+
+      raise_untrusted!(:formula, full_name, tap)
+    end
+
+    sig { params(token: String, path: Pathname).void }
+    def self.require_trusted_cask!(token, path)
+      return unless (tap = tap_from_path(path))
+      return if trusted_tap?(tap)
+
+      full_name = "#{tap.name}/#{::Utils.name_from_full_name(token)}"
+      return if trusted?(:cask, full_name)
+      return unless enabled?
+
+      raise_untrusted!(:cask, full_name, tap)
+    end
+
+    sig { params(path: Pathname, command: T.nilable(String)).void }
+    def self.require_trusted_command!(path, command = nil)
+      return unless (tap = tap_from_path(path))
+      return if trusted_tap?(tap)
+
+      full_name = "#{tap.name}/#{command || path.basename(path.extname).to_s.delete_prefix("brew-")}"
+      return if trusted?(:command, full_name)
+      return unless enabled?
+
+      raise_untrusted!(:command, full_name, tap)
+    end
+
+    sig { params(path: Pathname).returns(T::Boolean) }
+    def self.trusted_formula_file?(path)
+      trusted_file?(:formula, path)
+    end
+
+    sig { params(path: Pathname).returns(T::Boolean) }
+    def self.trusted_cask_file?(path)
+      trusted_file?(:cask, path)
+    end
+
+    sig { params(type: Symbol).returns(String) }
+    def self.setting_key(type)
+      SETTING_KEYS.fetch(type).to_s
+    end
+
+    sig { params(type: Symbol).returns(T::Array[String]) }
+    def self.trusted_entries(type)
+      trust_store.fetch(setting_key(type), [])
+    end
+
+    sig { params(name: String).returns(String) }
+    def self.normalise_name(name)
+      name.downcase
+    end
+
+    sig { returns(T::Hash[String, T::Array[String]]) }
+    def self.trust_store
+      return {} unless TRUST_FILE.exist?
+
+      parsed_store = JSON.parse(TRUST_FILE.read)
+      return {} unless parsed_store.is_a?(Hash)
+
+      parsed_store.transform_values { |entries| Array(entries).map { |entry| normalise_name(entry.to_s) } }
+    rescue Errno::ENOENT, JSON::ParserError
+      {}
+    end
+    private_class_method :trust_store
+
+    sig { params(store: T::Hash[String, T::Array[String]]).void }
+    def self.write_trust_store(store)
+      if store.empty?
+        TRUST_FILE.unlink if TRUST_FILE.exist?
+        return
+      end
+
+      TRUST_FILE.dirname.mkpath
+      TRUST_FILE.atomic_write("#{JSON.pretty_generate(store)}\n")
+    end
+    private_class_method :write_trust_store
+
+    sig { params(path: Pathname).returns(T.untyped) }
+    def self.tap_from_path(path)
+      Tap.from_path(path)
+    end
+    private_class_method :tap_from_path
+
+    sig { params(type: Symbol, path: Pathname).returns(T::Boolean) }
+    def self.trusted_file?(type, path)
+      return true unless (tap = tap_from_path(path))
+      return true if trusted_tap?(tap)
+      return true if trusted?(type, "#{tap.name}/#{path.basename(path.extname)}")
+
+      !enabled?
+    end
+    private_class_method :trusted_file?
+
+    sig { params(type: Symbol, name: String, tap: T.untyped).void }
+    def self.raise_untrusted!(type, name, tap)
+      raise UntrustedTapError, "Refusing to load #{type} #{name} from untrusted tap #{tap.name}.\n" \
+                               "Run `brew trust --#{type} #{name}` or `brew trust #{tap.name}` to trust it."
+    end
+    private_class_method :raise_untrusted!
+  end
+end


### PR DESCRIPTION
Part of a few PRs that will move towards only trusting official taps for now.

- Store trust decisions in `var/homebrew/trust.json` so users can opt into tighter loading rules for third-party taps.
- Check formulae, casks and external commands before Ruby loads them when `HOMEBREW_REQUIRE_TAP_TRUST` is set.
- Keep the checks lazy for command lookup to avoid loading tap code at `brew` startup.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
