### PR TITLE
tests: Run tagged tests with `--changed` when shared contexts change

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -272,14 +272,29 @@ module Homebrew
 
       sig { params(tag: String).returns(T::Array[Pathname]) }
       def tests_tagged_with(tag)
-        tag_match = /:#{Regexp.escape(tag)}\b/
-
         Dir.glob("test/**/*_spec.rb").filter_map do |file|
           path = Pathname(file)
           next unless path.exist?
-          next unless path.read.match?(tag_match)
+          next unless file_uses_rspec_tag?(path, tag)
 
           path
+        end
+      end
+
+      sig { params(path: Pathname, tag: String).returns(T::Boolean) }
+      def file_uses_rspec_tag?(path, tag)
+        escaped_tag = Regexp.escape(tag)
+        rspec_declaration_methods = %w[describe context it specify example].join("|")
+        rspec_declaration_regex = /^\s*(?:RSpec\.)?(?:#{rspec_declaration_methods})\b/
+        # Match symbol tag syntax: `:tag_name`.
+        symbol_tag_regex = /(?:^|[,(])\s*:#{escaped_tag}\b/
+        # Match hash tag syntax: `tag_name: true/false/nil/value`.
+        hash_tag_regex = /(?:^|[,(])\s*#{escaped_tag}:\s*(?:true|false|nil|:[a-z_]\w*|[a-z_]\w*)?/i
+
+        path.read.each_line.any? do |line|
+          is_rspec_declaration = line.match?(rspec_declaration_regex)
+          has_tag = line.match?(symbol_tag_regex) || line.match?(hash_tag_regex)
+          is_rspec_declaration && has_tag
         end
       end
 

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -241,17 +241,46 @@ module Homebrew
         filestub_regex = %r{Library/Homebrew/([\w/-]+).rb}
         T.cast(changed_files.scan(filestub_regex), T::Array[T::Array[String]])
          .map { it.fetch(-1) }
-         .filter_map do |filestub|
+         .flat_map do |filestub|
+          shared_context_tests = shared_context_test_files(filestub)
+          next shared_context_tests if shared_context_tests.present?
+
           if filestub.start_with?("test/")
             # Only run tests on *_spec.rb files in test/ folder
-            Pathname("#{filestub}.rb") if filestub.end_with?("_spec")
+            filestub.end_with?("_spec") ? [Pathname("#{filestub}.rb")] : []
           else
             # For all other changed .rb files guess the associated test file name
-            Pathname("test/#{filestub}_spec.rb")
+            [Pathname("test/#{filestub}_spec.rb")]
           end
         end
+          .uniq
           .select(&:exist?)
           .map(&:to_s)
+      end
+
+      sig { params(filestub: String).returns(T::Array[Pathname]) }
+      def shared_context_test_files(filestub)
+        case filestub
+        when "test/support/helper/spec/shared_context/integration_test"
+          tests_tagged_with("integration_test")
+        when "test/support/helper/spec/shared_context/homebrew_cask"
+          tests_tagged_with("cask")
+        else
+          []
+        end
+      end
+
+      sig { params(tag: String).returns(T::Array[Pathname]) }
+      def tests_tagged_with(tag)
+        tag_match = /:#{Regexp.escape(tag)}\b/
+
+        Dir.glob("test/**/*_spec.rb").filter_map do |file|
+          path = Pathname(file)
+          next unless path.exist?
+          next unless path.read.match?(tag_match)
+
+          path
+        end
       end
 
       sig { returns(T::Array[String]) }

--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -60,4 +60,68 @@ RSpec.describe Homebrew::DevCmd::Tests do
       end
     end
   end
+
+  describe "#changed_test_files" do
+    subject(:changed_test_files) { tests.send(:changed_test_files) }
+
+    let(:tests) { klass.new([]) }
+
+    context "when a spec file changed" do
+      let(:changed_file) { "Library/Homebrew/test/cmd/help_spec.rb\n" }
+
+      before do
+        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "main")
+                                            .and_return(changed_file)
+      end
+
+      it "includes the changed spec file" do
+        expect(changed_test_files).to include("test/cmd/help_spec.rb")
+      end
+    end
+
+    context "when a non-test Ruby file changed" do
+      let(:changed_file) { "Library/Homebrew/cmd/help.rb\n" }
+
+      before do
+        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "main")
+                                            .and_return(changed_file)
+      end
+
+      it "maps the file to its corresponding spec" do
+        expect(changed_test_files).to include("test/cmd/help_spec.rb")
+      end
+    end
+
+    context "when integration shared context changed" do
+      let(:changed_file) do
+        "Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb\n"
+      end
+
+      before do
+        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "main")
+                                            .and_return(changed_file)
+      end
+
+      it "includes integration tests and excludes unrelated tests", :aggregate_failures do
+        expect(changed_test_files).to include("test/cmd/help_spec.rb")
+        expect(changed_test_files).not_to include("test/dev-cmd/tests_spec.rb")
+      end
+    end
+
+    context "when cask shared context changed" do
+      let(:changed_file) do
+        "Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb\n"
+      end
+
+      before do
+        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "main")
+                                            .and_return(changed_file)
+      end
+
+      it "includes cask tests and excludes non-cask tests", :aggregate_failures do
+        expect(changed_test_files).to include("test/cmd/outdated_spec.rb")
+        expect(changed_test_files).not_to include("test/cmd/help_spec.rb")
+      end
+    end
+  end
 end

--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -121,6 +121,8 @@ RSpec.describe Homebrew::DevCmd::Tests do
       it "includes cask tests and excludes non-cask tests", :aggregate_failures do
         expect(changed_test_files).to include("test/cmd/outdated_spec.rb")
         expect(changed_test_files).not_to include("test/cmd/help_spec.rb")
+        expect(changed_test_files).not_to include("test/dev-cmd/pr-pull_spec.rb")
+        expect(changed_test_files).not_to include("test/cmd/bundle/remove_subcommand_spec.rb")
       end
     end
   end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

- Assisted by GPT-5.3 Codex (Medium reasoning). Human review, tests and tweaks.

-----

- When a shared context file changes, the tests that include that shared context should be run when `brew tests --changed` is invoked. This ensures that relevant test failures are caught.
- I found this bug while working on #22469 where I changed shared contexts, ran `brew lgtm` which ran `brew tests --changed` which lulled me into a false sense of security that the changes were fine, until CI ran the full test suite[1].
- Add some standard behaviour tests for `brew tests --changed` as well as there was zero coverage before.

[1]: https://github.com/Homebrew/brew/pull/22469#issuecomment-4583056266