### PR TITLE
Add formula install step audit

### DIFF
--- a/Library/Homebrew/rubocops/install_steps.rb
+++ b/Library/Homebrew/rubocops/install_steps.rb
@@ -9,6 +9,7 @@ module RuboCop
     module FormulaAudit
       # This cop checks declarative install step usage.
       class InstallSteps < FormulaCop
+        extend AutoCorrector
         include InstallStepsHelper
 
         CONFLICT_MSG = "`post_install` and `post_install_steps` cannot both be used."
@@ -25,6 +26,7 @@ module RuboCop
           end
 
           audit_step_block(post_install_steps_block)
+          audit_post_install_method(post_install_method) if post_install_steps_block.nil?
         end
 
         private
@@ -35,6 +37,27 @@ module RuboCop
 
           offending_node(offense_node)
           problem STEP_BLOCK_MSG
+        end
+
+        sig { params(post_install_method: T.nilable(RuboCop::AST::Node)).void }
+        def audit_post_install_method(post_install_method)
+          return if post_install_method.nil?
+          return unless post_install_method.def_type?
+
+          post_install_def = T.cast(post_install_method, RuboCop::AST::DefNode)
+          step_lines = simple_install_step_lines(post_install_def.body,
+                                                 default_base:        :var,
+                                                 default_source_base: :prefix,
+                                                 default_target_base: :prefix)
+          return if step_lines.blank?
+
+          add_offense(post_install_method,
+                      message: format(SIMPLE_STEP_CONVERSION_MSG, steps_block: "post_install_steps")) do |corrector|
+            corrector.replace(
+              post_install_method.source_range,
+              install_steps_block_source(:post_install_steps, step_lines, post_install_method.source_range.column),
+            )
+          end
         end
       end
     end

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -50,16 +50,55 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
     RUBY
   end
 
-  it "does not report simple legacy `post_install` file preparation" do
+  it "autocorrects simple `post_install` file preparation" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        def post_install
+        ^^^^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Use `post_install_steps` for simple file preparation.
+          (var/"log/foo").mkpath
+          FileUtils.touch var/"foo/state"
+          FileUtils.mv prefix/"move-source", prefix/"move-target"
+          FileUtils.ln_sf "move-target", prefix/"linked-target"
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        post_install_steps do
+          mkdir_p "log/foo"
+          touch "foo/state"
+          mv "move-source", "move-target"
+          ln_sf "move-target", "linked-target", source_base: :relative
+        end
+      end
+    RUBY
+  end
+
+  it "does not autocorrect non-file preparation in `post_install`" do
+    expect_no_offenses(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        def post_install
+          system "true"
+        end
+      end
+    RUBY
+  end
+
+  it "does not autocorrect mixed `post_install` bodies" do
     expect_no_offenses(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
 
         def post_install
           (var/"log/foo").mkpath
-          FileUtils.touch var/"foo/state"
-          FileUtils.mv prefix/"move-source", prefix/"move-target"
-          FileUtils.ln_sf "move-target", prefix/"linked-target"
+          system "true"
         end
       end
     RUBY


### PR DESCRIPTION
- Keep tap-wide conversion checks out of the implementation PR.
- Flag only simple legacy `post_install` file preparation here.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
