### PR TITLE
sorbet: Regenerate predicate matcher RBI for `TrustSpec`

### DIFF
--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -352,11 +352,11 @@ module Homebrew::EnvConfig
     sig { returns(T::Boolean) }
     def no_path_shadow_check?; end
 
-    sig { returns(T::Boolean) }
-    def no_require_tap_trust?; end
-
     sig { returns(T.nilable(::String)) }
     def no_proxy; end
+
+    sig { returns(T::Boolean) }
+    def no_require_tap_trust?; end
 
     sig { returns(T::Boolean) }
     def no_sandbox_cask?; end

--- a/Library/Homebrew/sorbet/rbi/dsl/r_spec/matchers.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/r_spec/matchers.rbi
@@ -88,6 +88,9 @@ module RSpec::Matchers
   def be_empty(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def be_enabled(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def be_executable(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "tap"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

- Running `brew tc --update --suggest-typed` bumps the newly added `TrustSpec` to `typed: strict` via detecting the `be_enabled` predicate matcher.
- Also alphabetize the `EnvConfig` RBI methods because in the alphabet R is after P.