### PR TITLE
sorbet: Bump most `test/rubocops/` to `typed: true` or higher

### DIFF
--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -1,9 +1,11 @@
 # typed: strict
 
 class RSpec::Core::ExampleGroup
+  include CopHelper
   include RSpec::SharedContext
   include RSpec::Matchers
   include RSpec::Mocks::ExampleMethods
+  include RuboCop::RSpec::ExpectOffense
 
   # `mktmpdir` is mixed into specs via `config.include(Test::Helper::MkTmpDir)`
   # in `test/spec_helper.rb`; declare it here so Sorbet can resolve it in typed
@@ -31,4 +33,19 @@ end
 module RSpec::Mocks::ExampleMethods::ExpectHost
   sig { params(value: T.untyped, block: T.nilable(T.proc.void)).returns(T.untyped) }
   def expect(value = T.unsafe(nil), &block); end
+end
+
+# RuboCop cop specs include this helper at runtime via `rubocop/rspec/support`.
+module CopHelper
+  sig { params(source: String, file: T.untyped).returns(T::Array[T.untyped]) }
+  def inspect_source(source, file = T.unsafe(nil)); end
+
+  sig { params(source: String, file: T.untyped).returns(String) }
+  def autocorrect_source(source, file = T.unsafe(nil)); end
+
+  sig { params(source: String).returns(String) }
+  def autocorrect_source_file(source); end
+
+  sig { params(source: String, file: T.untyped).returns(T.untyped) }
+  def parse_source(source, file = T.unsafe(nil)); end
 end

--- a/Library/Homebrew/test/rubocops/blank_spec.rb
+++ b/Library/Homebrew/test/rubocops/blank_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/blank"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_digest_indentation_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_digest_indentation_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_format_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_format_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_order_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_tag_indentation_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_tag_indentation_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/cask/array_alphabetization_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/array_alphabetization_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/deprecate_disable_unsigned_reason_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/deprecate_disable_unsigned_reason_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/desc_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/discontinued_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/discontinued_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/homepage_url_styling_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/homepage_url_styling_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/no_autobump.rb
+++ b/Library/Homebrew/test/rubocops/cask/no_autobump.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/shared_filelist_glob_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/shared_filelist_glob_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/uninstall_methods_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/uninstall_methods_order_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/url_legacy_comma_separators_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_legacy_comma_separators_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/url_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/variables_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/variables_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/caveats_spec.rb
+++ b/Library/Homebrew/test/rubocops/caveats_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/caveats"

--- a/Library/Homebrew/test/rubocops/checksum/checksum_case_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum/checksum_case_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/checksum"

--- a/Library/Homebrew/test/rubocops/checksum/checksum_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum/checksum_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/checksum"

--- a/Library/Homebrew/test/rubocops/class/class_name_spec.rb
+++ b/Library/Homebrew/test/rubocops/class/class_name_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/class"

--- a/Library/Homebrew/test/rubocops/class/test_present.rb
+++ b/Library/Homebrew/test/rubocops/class/test_present.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/class"

--- a/Library/Homebrew/test/rubocops/class/test_spec.rb
+++ b/Library/Homebrew/test/rubocops/class/test_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/class"

--- a/Library/Homebrew/test/rubocops/compact_blank_spec.rb
+++ b/Library/Homebrew/test/rubocops/compact_blank_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/compact_blank"

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/components_order"

--- a/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/components_redundancy"

--- a/Library/Homebrew/test/rubocops/conflicts_spec.rb
+++ b/Library/Homebrew/test/rubocops/conflicts_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/conflicts"

--- a/Library/Homebrew/test/rubocops/dependency_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/dependency_order_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/dependency_order"

--- a/Library/Homebrew/test/rubocops/deprecate_disable/date_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_disable/date_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/deprecate_disable"

--- a/Library/Homebrew/test/rubocops/deprecate_disable/reason_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_disable/reason_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/deprecate_disable"

--- a/Library/Homebrew/test/rubocops/desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/desc_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/desc"

--- a/Library/Homebrew/test/rubocops/disable_comment_spec.rb
+++ b/Library/Homebrew/test/rubocops/disable_comment_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/disable_comment"

--- a/Library/Homebrew/test/rubocops/exec_shell_metacharacters_spec.rb
+++ b/Library/Homebrew/test/rubocops/exec_shell_metacharacters_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/shell_commands"

--- a/Library/Homebrew/test/rubocops/files_spec.rb
+++ b/Library/Homebrew/test/rubocops/files_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/files"

--- a/Library/Homebrew/test/rubocops/full_name_split_spec.rb
+++ b/Library/Homebrew/test/rubocops/full_name_split_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/full_name_split"

--- a/Library/Homebrew/test/rubocops/homepage_spec.rb
+++ b/Library/Homebrew/test/rubocops/homepage_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/homepage"

--- a/Library/Homebrew/test/rubocops/install_bundler_gems_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_bundler_gems_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/install_bundler_gems"

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/install_steps"

--- a/Library/Homebrew/test/rubocops/io_read_spec.rb
+++ b/Library/Homebrew/test/rubocops/io_read_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/io_read"

--- a/Library/Homebrew/test/rubocops/keg_only_spec.rb
+++ b/Library/Homebrew/test/rubocops/keg_only_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/keg_only"

--- a/Library/Homebrew/test/rubocops/lines/class_inheritance_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/class_inheritance_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/lines/full_dependency_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/full_dependency_check_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/lines/libiconv_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/libiconv_check_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/lines/quictls_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/quictls_check_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_case_insensitive_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_case_insensitive_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_extension_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_extension_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_if_page_match_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_if_page_match_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_parentheses_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_parentheses_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/skip_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/skip_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/url_symbol_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/url_symbol_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/move_to_extend_os_spec.rb
+++ b/Library/Homebrew/test/rubocops/move_to_extend_os_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/move_to_extend_os"

--- a/Library/Homebrew/test/rubocops/negate_include_spec.rb
+++ b/Library/Homebrew/test/rubocops/negate_include_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/negate_include"

--- a/Library/Homebrew/test/rubocops/no_autobump.rb
+++ b/Library/Homebrew/test/rubocops/no_autobump.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/no_autobump"

--- a/Library/Homebrew/test/rubocops/no_fileutils_rmrf_spec.rb
+++ b/Library/Homebrew/test/rubocops/no_fileutils_rmrf_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/no_fileutils_rmrf"

--- a/Library/Homebrew/test/rubocops/non_public_api_usage_spec.rb
+++ b/Library/Homebrew/test/rubocops/non_public_api_usage_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/non_public_api_usage"

--- a/Library/Homebrew/test/rubocops/options_spec.rb
+++ b/Library/Homebrew/test/rubocops/options_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/options"

--- a/Library/Homebrew/test/rubocops/os_depends_on_spec.rb
+++ b/Library/Homebrew/test/rubocops/os_depends_on_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/os_depends_on"

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/patches"

--- a/Library/Homebrew/test/rubocops/present_spec.rb
+++ b/Library/Homebrew/test/rubocops/present_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/present"

--- a/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/uses_from_macos"

--- a/Library/Homebrew/test/rubocops/public_api_cookbook_spec.rb
+++ b/Library/Homebrew/test/rubocops/public_api_cookbook_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/public_api_cookbook"

--- a/Library/Homebrew/test/rubocops/public_api_documentation_spec.rb
+++ b/Library/Homebrew/test/rubocops/public_api_documentation_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/public_api_documentation"

--- a/Library/Homebrew/test/rubocops/resource_requires_dependencies_spec.rb
+++ b/Library/Homebrew/test/rubocops/resource_requires_dependencies_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/resource_requires_dependencies"

--- a/Library/Homebrew/test/rubocops/safe_navigation_with_blank_spec.rb
+++ b/Library/Homebrew/test/rubocops/safe_navigation_with_blank_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/safe_navigation_with_blank"

--- a/Library/Homebrew/test/rubocops/service_spec.rb
+++ b/Library/Homebrew/test/rubocops/service_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/service"

--- a/Library/Homebrew/test/rubocops/shell_commands_spec.rb
+++ b/Library/Homebrew/test/rubocops/shell_commands_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/shell_commands"

--- a/Library/Homebrew/test/rubocops/text/assert_statements_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/assert_statements_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/comments_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/comments_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/license_arrays_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/license_arrays_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/licenses_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/licenses_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/macos_on_linux_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/macos_on_linux_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/make_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/make_check_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/miscellaneous_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/miscellaneous_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/mpi_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/mpi_check_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/safe_popen_commands_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/safe_popen_commands_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/shell_variables_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/shell_variables_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/std_npm_args_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/std_npm_args_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/strict_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/text"

--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/text"

--- a/Library/Homebrew/test/rubocops/urls/git_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/git_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/urls/git_strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/git_strict_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/urls/http_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/http_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/urls/pypi_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/pypi_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/uses_from_macos"

--- a/Library/Homebrew/test/rubocops/version_spec.rb
+++ b/Library/Homebrew/test/rubocops/version_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/version"

--- a/Library/Homebrew/test/rubocops/zero_zero_zero_zero_spec.rb
+++ b/Library/Homebrew/test/rubocops/zero_zero_zero_zero_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/zero_zero_zero_zero"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

- By including `Rubocop::RSpec::ExpectOffense` and `CopHelper` and its methods in the RSpec shim, to allow Sorbet to find `expect_offense` and `inspect_source` etc., we can typecheck 94 of the tests for our custom RuboCop rules.