### PR TITLE
sorbet: Handle `before` blocks using `let` values from within tests

### DIFF
--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -218,6 +218,10 @@ RSpec.describe Cask::DSL, :cask, :no_api do
         end
       end
 
+      # Required for Sorbet, but the actual value is set in the individual
+      # examples which provide their `let(:languages)` value to `before`.
+      let(:languages) { [] }
+
       before do
         config = cask.config
         config.languages = languages

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -883,6 +883,8 @@ RSpec.describe Formulary do
     context "when not using the API", :no_api do
       context "when a formula is migrated" do
         let(:token) { "foo" }
+        let(:old_tap) { core_tap }
+        let(:new_tap) { core_cask_tap }
 
         let(:core_tap) { CoreTap.instance }
         let(:core_cask_tap) { CoreCaskTap.instance }

--- a/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
+++ b/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Utils do
@@ -13,6 +13,11 @@ RSpec.describe Utils do
         quiet_system RUBY_PATH, "#{HOMEBREW_LIBRARY_PATH}/utils/ruby_check_version_script.rb", required_ruby_version
       end
     end
+
+    # Required for Sorbet, but the actual value is set in the individual
+    # examples which provide their `let(:required_ruby_version)` value to
+    # `subject`.
+    let(:required_ruby_version) { "1.2.3" }
 
     before do
       ENV.delete("HOMEBREW_DEVELOPER")

--- a/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
+++ b/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/string_inreplace_extension"
@@ -6,6 +6,9 @@ require "utils/string_inreplace_extension"
 RSpec.describe StringInreplaceExtension do
   subject(:string_extension) { klass.new(string.dup) }
 
+  # Required for Sorbet, but the actual value is set in the individual
+  # examples which provide their `let(:string)` value to `subject`.
+  let(:string) { "" }
   let(:klass) { StringInreplaceExtension }
 
   describe "#change_make_var!" do

--- a/Library/Homebrew/test/utils/user_spec.rb
+++ b/Library/Homebrew/test/utils/user_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/user"
@@ -11,6 +11,10 @@ RSpec.describe User do
   it { is_expected.to eq ENV.fetch("USER") }
 
   describe "#gui?" do
+    # Required for Sorbet, but the actual value is set in the individual
+    # examples which provide their `let(:who_output)` value to `before`.
+    let(:who_output) { "" }
+
     before do
       allow(SystemCommand).to receive(:run)
         .with("who", any_args)


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

OpenAI GPT-5.3 Codex for finding all occurrences of this pattern that upset Sorbet, with local review and testing.

-----

- Enable typechecking of tests where a top-level `before` or `subject` block references a value that is only defined via `let` in tests, which Sorbet cannot resolve statically.
- The actual value of the `let` that matters for the test and its setup is set in the individual tests, which will always override the top-level `let` value that we set.