### PR TITLE
sorbet: Add shims for methods in the 'integration test' shared context

### DIFF
--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -12,15 +12,30 @@ class RSpec::Core::ExampleGroup
   # here so Sorbet can resolve them in typed spec files.
   sig { params(args: T.untyped).returns(Process::Status) }
   def brew(*args); end
+
   sig { params(args: T.untyped).returns(Process::Status) }
   def brew_sh(*args); end
-  sig { params(name: Formula).returns(Pathname) }
-  def setup_test_formula(name); end
+
+  sig {
+    params(
+      name:           String,
+      content:        T.nilable(String),
+      tap:            Tap,
+      bottle_block:   T.nilable(String),
+      tab_attributes: T.nilable(T::Hash[T.untyped, T.untyped]),
+    ).returns(Pathname)
+  }
+  def setup_test_formula(name, content = T.unsafe(nil), tap: T.unsafe(nil), bottle_block: T.unsafe(nil),
+                         tab_attributes: T.unsafe(nil))
+  end
+
   sig { returns(Pathname) }
   def setup_test_tap; end
-  sig { params(name: String).returns(Pathname) }
-  def install_test_formula(name); end
-  sig { params(name: String).returns(Pathname) }
+
+  sig { params(name: String, content: T.nilable(String), build_bottle: T::Boolean).void }
+  def install_test_formula(name, content = T.unsafe(nil), build_bottle: false); end
+
+  sig { params(name: String).void }
   def uninstall_test_formula(name); end
 
   # `mktmpdir` is mixed into specs via `config.include(Test::Helper::MkTmpDir)`

--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -7,6 +7,22 @@ class RSpec::Core::ExampleGroup
   include RSpec::Mocks::ExampleMethods
   include RuboCop::RSpec::ExpectOffense
 
+  # These methods are added to specs in
+  # `test/support/helper/spec/shared_context/integration_test.rb`; declare them
+  # here so Sorbet can resolve them in typed spec files.
+  sig { params(args: T.untyped).returns(Process::Status) }
+  def brew(*args); end
+  sig { params(args: T.untyped).returns(Process::Status) }
+  def brew_sh(*args); end
+  sig { params(name: Formula).returns(Pathname) }
+  def setup_test_formula(name); end
+  sig { returns(Pathname) }
+  def setup_test_tap; end
+  sig { params(name: String).returns(Pathname) }
+  def install_test_formula(name); end
+  sig { params(name: String).returns(Pathname) }
+  def uninstall_test_formula(name); end
+
   # `mktmpdir` is mixed into specs via `config.include(Test::Helper::MkTmpDir)`
   # in `test/spec_helper.rb`; declare it here so Sorbet can resolve it in typed
   # spec files.

--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/cask_dependent_spec.rb
+++ b/Library/Homebrew/test/cask_dependent_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cask/cask_loader"

--- a/Library/Homebrew/test/cmd/command_spec.rb
+++ b/Library/Homebrew/test/cmd/command_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/deps_spec.rb
+++ b/Library/Homebrew/test/cmd/deps_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "cmd/deps"

--- a/Library/Homebrew/test/cmd/exec_spec.rb
+++ b/Library/Homebrew/test/cmd/exec_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/exec"

--- a/Library/Homebrew/test/cmd/fetch_spec.rb
+++ b/Library/Homebrew/test/cmd/fetch_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "cmd/fetch"

--- a/Library/Homebrew/test/cmd/mcp-server_spec.rb
+++ b/Library/Homebrew/test/cmd/mcp-server_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 RSpec.describe "brew mcp-server", type: :system do

--- a/Library/Homebrew/test/cmd/search_spec.rb
+++ b/Library/Homebrew/test/cmd/search_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/search"

--- a/Library/Homebrew/test/cmd/tap_spec.rb
+++ b/Library/Homebrew/test/cmd/tap_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/trust_spec.rb
+++ b/Library/Homebrew/test/cmd/trust_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/untrust_spec.rb
+++ b/Library/Homebrew/test/cmd/untrust_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/create_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/create_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/irb_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/irb_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/which-update_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/which-update_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/formula_info_spec.rb
+++ b/Library/Homebrew/test/formula_info_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "formula_info"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

- These are all included in specs via `config.include_context` at the end of `test/support/helper/spec/shared_context/integration_test.rb`.