### PR TITLE
Clarify env boolean parsing

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -60,16 +60,6 @@ module Homebrew
     # @api private
     class GhIncompatible < RuntimeError; end
 
-    # Returns whether attestation verification is enabled.
-    #
-    # @api private
-    sig { returns(T::Boolean) }
-    def self.enabled?
-      return false if Homebrew::EnvConfig.no_verify_attestations?
-
-      Homebrew::EnvConfig.verify_attestations?
-    end
-
     # Returns a path to a suitable `gh` executable for attestation verification.
     #
     # @api private

--- a/Library/Homebrew/bundle/subcommand.rb
+++ b/Library/Homebrew/bundle/subcommand.rb
@@ -26,7 +26,7 @@ module Homebrew
           ).void
         }
         def dispatch(args, extensions:)
-          ask = Homebrew::EnvConfig.ask? && !Homebrew::EnvConfig.no_ask?
+          ask = Homebrew::EnvConfig.ask?
 
           # Don't want to ask for input in Bundle
           ENV["HOMEBREW_ASK"] = nil

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -720,7 +720,6 @@ module Cask
 
     sig { returns(T::Boolean) }
     def auto_updates_bundle_outdated?
-      return false if Homebrew::EnvConfig.no_upgrade_auto_updates_casks?
       return false unless Homebrew::EnvConfig.upgrade_auto_updates_casks?
       return false if !auto_updates || version.latest?
       return false unless installed_app_info_plist

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -37,15 +37,6 @@ module Cask
     def self.outdated_casks(casks, args:, force:, quiet:,
                             greedy: false, greedy_latest: false, greedy_auto_updates: false,
                             summary_pinned: nil, summary_disabled: nil)
-      # Validate mutually exclusive opt-in/opt-out env vars before we start
-      # selecting casks so `brew upgrade` errors consistently.
-      if Homebrew::EnvConfig.upgrade_auto_updates_casks? &&
-         Homebrew::EnvConfig.no_upgrade_auto_updates_casks? &&
-         !Homebrew::EnvConfig.developer?
-        raise UsageError,
-              "`HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS` and `HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS` " \
-              "cannot both be set."
-      end
       greedy = true if Homebrew::EnvConfig.upgrade_greedy?
 
       outdated_casks = if casks.empty?

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -1137,8 +1137,6 @@ module Homebrew
       def value_for_env(env)
         return if env.blank?
 
-        return false if env.to_s == "ask" && Homebrew::EnvConfig.no_ask?
-
         method_name = :"#{env}?"
         if Homebrew::EnvConfig.respond_to?(method_name)
           Homebrew::EnvConfig.public_send(method_name)

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -236,7 +236,9 @@ module Homebrew
           Install.ask_casks fetch_casks, skip_cask_deps: args.skip_cask_deps? if args.ask?
         end
 
-        formulae = Homebrew::Attestation.sort_formulae_for_install(formulae) if Homebrew::Attestation.enabled?
+        if Homebrew::EnvConfig.verify_attestations?
+          formulae = Homebrew::Attestation.sort_formulae_for_install(formulae)
+        end
 
         # if the user's flags will prevent bottle only-installations when no
         # developer tools are available, we need to stop them early on

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -147,7 +147,9 @@ module Homebrew
           end
         end
 
-        formulae = Homebrew::Attestation.sort_formulae_for_install(formulae) if Homebrew::Attestation.enabled?
+        if Homebrew::EnvConfig.verify_attestations?
+          formulae = Homebrew::Attestation.sort_formulae_for_install(formulae)
+        end
         casks = casks.filter_map do |cask|
           if cask.pinned?
             onoe "#{cask.full_name} is pinned. You must unpin it to reinstall."

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -204,7 +204,9 @@ module Homebrew
         only_upgrade_formulae = (named_given && casks.blank?) || (formulae.present? && casks.blank?)
         only_upgrade_casks = (named_given && formulae.blank?) || (casks.present? && formulae.blank?)
 
-        formulae = Homebrew::Attestation.sort_formulae_for_install(formulae) if Homebrew::Attestation.enabled?
+        if Homebrew::EnvConfig.verify_attestations?
+          formulae = Homebrew::Attestation.sort_formulae_for_install(formulae)
+        end
 
         formulae_prefetched = T.let(false, T::Boolean)
         prefetched_casks = T.let(false, T::Boolean)

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -81,7 +81,7 @@ module Homebrew
         description: "When `$HOMEBREW_ARTIFACT_DOMAIN` and `$HOMEBREW_ARTIFACT_DOMAIN_NO_FALLBACK` are both set, " \
                      "if the request to `$HOMEBREW_ARTIFACT_DOMAIN` fails then Homebrew will error rather than " \
                      "trying any other/default URLs.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_ASK:                              {
         # odeprecated: make `HOMEBREW_ASK` the default in the next release
@@ -91,7 +91,8 @@ module Homebrew
                      "Ask mode prints the plan before proceeding and prompts only if the plan includes " \
                      "dependencies, dependants or packages other than named arguments. Otherwise, it only " \
                      "prints the plan. The confirmation prompt is skipped without a TTY.",
-        boolean:     true,
+        boolean:     :set,
+        disabled_by: :HOMEBREW_NO_ASK,
       },
       HOMEBREW_AUTO_UPDATE_SECS:                 {
         description:  "Run `brew update` once every `$HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, " \
@@ -216,7 +217,8 @@ module Homebrew
       },
       HOMEBREW_COLOR:                            {
         description: "If set, force colour output on non-TTY outputs.",
-        boolean:     true,
+        boolean:     :set,
+        disabled_by: :HOMEBREW_NO_COLOR,
       },
       HOMEBREW_CORE_GIT_REMOTE:                  {
         description:  "Use this URL as the Homebrew/homebrew-core `git`(1) remote.",
@@ -243,12 +245,12 @@ module Homebrew
       },
       HOMEBREW_DEBUG:                            {
         description: "If set, always assume `--debug` when running commands.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_DEVELOPER:                        {
         description: "If set, tweak behaviour to be more relevant for Homebrew developers (active or " \
                      "budding) by e.g. turning warnings into errors.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_DISABLE_DEBREW:                   {
         description: "If set, the interactive formula debugger available via `--debug` will be disabled.",
@@ -356,17 +358,17 @@ module Homebrew
       HOMEBREW_FORCE_BREWED_CA_CERTIFICATES:     {
         description: "If set, always use a Homebrew-installed `ca-certificates` rather than the system version. " \
                      "Automatically set if the system version is too old.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_FORCE_BREWED_CURL:                {
         description: "If set, always use a Homebrew-installed `curl`(1) rather than the system version. " \
                      "Automatically set if the system version of `curl` is too old.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_FORCE_BREWED_GIT:                 {
         description: "If set, always use a Homebrew-installed `git`(1) rather than the system version. " \
                      "Automatically set if the system version of `git` is too old.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_FORCE_BREW_WRAPPER:               {
         description: "If set, require `brew` to be invoked by the value of " \
@@ -379,7 +381,7 @@ module Homebrew
       HOMEBREW_FORCE_VENDOR_RUBY:                {
         description: "If set, always use Homebrew's vendored, relocatable Ruby version even if the system version " \
                      "of Ruby is new enough.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_FORMULA_BUILD_NETWORK:            {
         description: "If set, controls network access to the sandbox for formulae builds. Overrides any " \
@@ -467,12 +469,12 @@ module Homebrew
       HOMEBREW_NO_ANALYTICS:                     {
         description: "If set, do not send analytics. Google Analytics were destroyed. " \
                      "For more information, see: <https://docs.brew.sh/Analytics>",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_NO_ASK:                           {
         description: "If set, do not enable ask mode from `$HOMEBREW_ASK` or the `$HOMEBREW_DEVELOPER` default. " \
                      "This does not disable an explicit `--ask`.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_NO_AUTOREMOVE:                    {
         description: "If set, calls to `brew cleanup` and `brew uninstall` will not automatically " \
@@ -485,11 +487,11 @@ module Homebrew
                      "run this less often by setting `$HOMEBREW_AUTO_UPDATE_SECS` to a value higher than the " \
                      "default. Note that setting this and e.g. tapping new taps may result in a broken  " \
                      "configuration. Please ensure you always run `brew update` before reporting any issues.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_NO_BOOTSNAP:                      {
         description: "If set, do not use Bootsnap to speed up repeated `brew` calls.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_NO_CLEANUP_FORMULAE:              {
         description: "A comma-separated list of formulae. Homebrew will refuse to clean up " \
@@ -498,15 +500,15 @@ module Homebrew
       HOMEBREW_NO_COLOR:                         {
         description:  "If set, do not print text with colour added.",
         default_text: "`$NO_COLOR`.",
-        boolean:      true,
+        boolean:      :set,
       },
       HOMEBREW_NO_EMOJI:                         {
         description: "If set, do not print `$HOMEBREW_INSTALL_BADGE` on a successful build.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_NO_ENV_HINTS:                     {
         description: "If set, do not print any hints about changing Homebrew's behaviour with environment variables.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_NO_EVAL_ENV_SCRUBBING:            {
         # odeprecated: remove in a later release
@@ -517,7 +519,7 @@ module Homebrew
       },
       HOMEBREW_NO_FORCE_BREW_WRAPPER:            {
         description: "`Deprecated:` If set, disables `$HOMEBREW_FORCE_BREW_WRAPPER` behaviour, even if set.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_NO_GITHUB_API:                    {
         description: "If set, do not use the GitHub API, e.g. for searches or fetching relevant issues " \
@@ -542,12 +544,12 @@ module Homebrew
                      "cleanup installed/upgraded/reinstalled formulae or all formulae every " \
                      "`$HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS` days. Alternatively, `$HOMEBREW_NO_CLEANUP_FORMULAE` " \
                      "allows specifying specific formulae to not clean up.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_NO_INSTALL_FROM_API:              {
         description: "If set, do not install formulae and casks in homebrew/core and homebrew/cask taps using " \
                      "Homebrew's API and instead use (large, slow) local checkouts of these repositories.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_NO_INSTALL_UPGRADE:               {
         description: "If set, `brew install` <formula|cask> will not upgrade <formula|cask> if it is installed but " \
@@ -562,7 +564,7 @@ module Homebrew
       HOMEBREW_NO_REQUIRE_TAP_TRUST:             {
         # odeprecated: keep the current default until trust checks are default in a later release.
         description: "If set, do not require non-official tap formulae, casks or commands to be trusted.",
-        boolean:     true,
+        boolean:     :set,
         hidden:      true,
       },
       HOMEBREW_NO_SANDBOX_CASK:                  {
@@ -572,7 +574,7 @@ module Homebrew
       },
       HOMEBREW_NO_SANDBOX_LINUX:                 {
         description: "If set, disable the Linux sandbox.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_NO_UPDATE_REPORT_NEW:             {
         description: "If set, `brew update` will not show the list of newly added formulae/casks.",
@@ -581,7 +583,7 @@ module Homebrew
       HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS:    {
         description: "If set, `brew upgrade` will not automatically upgrade casks with `auto_updates true`. " \
                      "Does not affect `--greedy` or `--greedy-auto-updates` upgrades.",
-        boolean:     true,
+        boolean:     :set,
         hidden:      true, # odeprecated: remove in 5.2.0
       },
       HOMEBREW_NO_UPGRADE_QUIT_CASKS:            {
@@ -591,7 +593,7 @@ module Homebrew
       HOMEBREW_NO_VERIFY_ATTESTATIONS:           {
         description: "If set, Homebrew will not verify cryptographic attestations of build provenance for bottles " \
                      "from homebrew-core.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_PIP_INDEX_URL:                    {
         description:  "If set, `brew install` <formula> will use this URL to download PyPI package resources.",
@@ -605,7 +607,8 @@ module Homebrew
         # odeprecated: make tap trust checks default in a later release.
         description: "If set, require non-official tap formulae, casks and commands to be trusted before " \
                      "Homebrew loads them.",
-        boolean:     true,
+        boolean:     :set,
+        disabled_by: :HOMEBREW_NO_REQUIRE_TAP_TRUST,
         hidden:      true,
       },
       HOMEBREW_SANDBOX_LINUX:                    {
@@ -613,7 +616,8 @@ module Homebrew
         description: "If set, use the `bwrap`(1) sandbox for formula installation and testing on Linux. " \
                      "Enabled by default if `$HOMEBREW_DEVELOPER` is set. This will be the default in " \
                      "Homebrew 5.2.0.",
-        boolean:     true,
+        boolean:     :set,
+        disabled_by: :HOMEBREW_NO_SANDBOX_LINUX,
       },
       HOMEBREW_SBOM:                             {
         # odeprecated: edit in 5.2.0
@@ -639,7 +643,7 @@ module Homebrew
       HOMEBREW_SORBET_RUNTIME:                   {
         description: "If set, enable runtime typechecking using Sorbet. " \
                      "Set by default for `$HOMEBREW_DEVELOPER` or when running some developer commands.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_SSH_CONFIG_PATH:                  {
         description:  "If set, Homebrew will use the given config file instead of `~/.ssh/config` when " \
@@ -658,7 +662,7 @@ module Homebrew
       HOMEBREW_SYSTEM_ENV_TAKES_PRIORITY:        {
         description: "If set in Homebrew's system-wide environment file (`/etc/homebrew/brew.env`), " \
                      "the system-wide environment file will be loaded last to override any prefix or user settings.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_TEMP:                             {
         description:  "Use this path as the temporary directory for building packages. Changing " \
@@ -672,7 +676,7 @@ module Homebrew
       HOMEBREW_UPDATE_TO_TAG:                    {
         description: "If set, always use the latest stable tag (even if developer commands " \
                      "have been run).",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS:       {
         # odeprecated: edit in 5.2.0
@@ -680,7 +684,8 @@ module Homebrew
                      "Homebrew detects that the version in the app bundle is older than the version in the tap. " \
                      "Does not affect `--greedy` or `--greedy-auto-updates` upgrades. Enabled by default if " \
                      "`$HOMEBREW_DEVELOPER` is set. This will become the default behavior in Homebrew 5.2.0.",
-        boolean:     true,
+        boolean:     :set,
+        disabled_by: :HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS,
       },
       HOMEBREW_UPGRADE_GREEDY:                   {
         description: "If set, pass `--greedy` to all cask upgrade commands.",
@@ -693,11 +698,12 @@ module Homebrew
       HOMEBREW_USE_INTERNAL_API:                 {
         # odeprecated: make default next release
         description: "If set, test the new beta internal API for fetching formula and cask data.",
-        boolean:     true,
+        boolean:     :set,
+        disabled_by: :HOMEBREW_NO_INSTALL_FROM_API,
       },
       HOMEBREW_VERBOSE:                          {
         description: "If set, always assume `--verbose` when running commands.",
-        boolean:     true,
+        boolean:     :set,
       },
       HOMEBREW_VERBOSE_USING_DOTS:               {
         description: "If set, verbose output will print a `.` no more than once a minute. This can be " \
@@ -707,7 +713,8 @@ module Homebrew
       HOMEBREW_VERIFY_ATTESTATIONS:              {
         description: "If set, Homebrew will use the `gh` tool to verify cryptographic attestations " \
                      "of build provenance for bottles from homebrew-core.",
-        boolean:     true,
+        boolean:     :set,
+        disabled_by: :HOMEBREW_NO_VERIFY_ATTESTATIONS,
       },
       SUDO_ASKPASS:                              {
         description: "If set, pass the `-A` option when calling `sudo`(8).",
@@ -751,10 +758,13 @@ module Homebrew
       :HOMEBREW_DOWNLOAD_CONCURRENCY,
       :HOMEBREW_FORBID_PACKAGES_FROM_PATHS,
       :HOMEBREW_MAKE_JOBS,
-      :HOMEBREW_SANDBOX_LINUX,
-      :HOMEBREW_USE_INTERNAL_API,
     ]).freeze, T::Set[Symbol])
 
+    # Boolean env vars have two generated parsing modes. Use `boolean: true`
+    # for Ruby-only toggles that accept explicit false values like `0` or
+    # `false`. Use `boolean: :set` for toggles used by Bash or with inverse
+    # `_NO_` variants, where any non-empty value must mean enabled. Use
+    # `disabled_by:` when one boolean env var should override another.
     FALSY_VALUES = T.let(%w[false no off nil 0].freeze, T::Array[String])
 
     ENVS.each do |env, hash|
@@ -766,9 +776,14 @@ module Homebrew
 
       if hash[:boolean]
         define_method(method_name) do
+          return false if hash[:disabled_by] &&
+                          Homebrew::EnvConfig.public_send(
+                            env_method_name(hash[:disabled_by], ENVS.fetch(hash[:disabled_by])),
+                          )
+
           env_value = ENV.fetch(env, nil)
 
-          env_value.present? && FALSY_VALUES.exclude?(env_value.downcase)
+          env_value.present? && (hash[:boolean] == :set || FALSY_VALUES.exclude?(env_value.downcase))
         end
       elsif hash[:default].present?
         define_method(method_name) do
@@ -904,22 +919,6 @@ module Homebrew
       end
 
       [concurrency, 1].max
-    end
-
-    sig { returns(T::Boolean) }
-    def sandbox_linux?
-      return false if Homebrew::EnvConfig.no_sandbox_linux?
-
-      sandbox_linux = ENV.fetch("HOMEBREW_SANDBOX_LINUX", nil)
-      sandbox_linux.present? && FALSY_VALUES.exclude?(sandbox_linux.downcase)
-    end
-
-    sig { returns(T::Boolean) }
-    def use_internal_api?
-      return false if Homebrew::EnvConfig.no_install_from_api?
-
-      use_internal_api = ENV.fetch("HOMEBREW_USE_INTERNAL_API", nil)
-      use_internal_api.present? && FALSY_VALUES.exclude?(use_internal_api.downcase)
     end
   end
 end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1492,7 +1492,7 @@ on_request: installed_on_request?, options:)
     # to explicitly `brew install gh` without already having a version for bootstrapping.
     # We also skip bottle installs from local bottle paths, as these are done in CI
     # as part of the build lifecycle before attestations are produced.
-    check_attestation &&= Homebrew::Attestation.enabled? &&
+    check_attestation &&= Homebrew::EnvConfig.verify_attestations? &&
                           (formula.tap&.core_tap? || false) &&
                           formula.name != "gh"
     # Check attestation after download completes.

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -386,6 +386,9 @@ module Homebrew::EnvConfig
     def require_tap_trust?; end
 
     sig { returns(T::Boolean) }
+    def sandbox_linux?; end
+
+    sig { returns(T::Boolean) }
     def sbom?; end
 
     sig { returns(T::Boolean) }
@@ -429,6 +432,9 @@ module Homebrew::EnvConfig
 
     sig { returns(T.nilable(::String)) }
     def upgrade_greedy_casks; end
+
+    sig { returns(T::Boolean) }
+    def use_internal_api?; end
 
     sig { returns(T::Boolean) }
     def verbose?; end

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Cask::Upgrade, :cask do
         klass.upgrade_casks!(dry_run: true, args:)
       end
 
-      it "raises if HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS and HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS are set" do
+      it "lets HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS override HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS" do
         allow(Homebrew::EnvConfig).to receive(:upgrade_auto_updates_casks?).and_call_original
 
         with_env(
@@ -134,7 +134,7 @@ RSpec.describe Cask::Upgrade, :cask do
           "HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS" => "1",
         ) do
           expect { klass.upgrade_casks!(dry_run: true, args:) }
-            .to raise_error(UsageError, /cannot both be set/i)
+            .not_to raise_error
         end
       end
 

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -58,6 +58,37 @@ RSpec.describe Homebrew::EnvConfig do
       ENV["HOMEBREW_BAT"] = nil
       expect(env_config.bat?).to be(false)
     end
+
+    it "returns false if set to a falsey value" do
+      ENV["HOMEBREW_BAT"] = "0"
+      expect(env_config.bat?).to be(false)
+    end
+  end
+
+  describe ".ask?" do
+    before do
+      ENV["HOMEBREW_ASK"] = nil
+      ENV["HOMEBREW_NO_ASK"] = nil
+    end
+
+    it "returns false if HOMEBREW_NO_ASK is set" do
+      ENV["HOMEBREW_ASK"] = "1"
+      ENV["HOMEBREW_NO_ASK"] = "1"
+      expect(env_config.ask?).to be(false)
+    end
+  end
+
+  describe ".color?" do
+    before do
+      ENV["HOMEBREW_COLOR"] = nil
+      ENV["HOMEBREW_NO_COLOR"] = nil
+    end
+
+    it "returns false if HOMEBREW_NO_COLOR is set" do
+      ENV["HOMEBREW_COLOR"] = "1"
+      ENV["HOMEBREW_NO_COLOR"] = "1"
+      expect(env_config.color?).to be(false)
+    end
   end
 
   describe ".make_jobs" do
@@ -156,22 +187,38 @@ RSpec.describe Homebrew::EnvConfig do
   end
 
   describe ".upgrade_auto_updates_casks?" do
-    before do
-      ENV["HOMEBREW_DEVELOPER"] = nil
-      ENV["HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS"] = nil
+    around do |example|
+      with_env(
+        HOMEBREW_DEVELOPER:                     nil,
+        HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS:    nil,
+        HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS: nil,
+      ) { example.run }
     end
 
     it "does not infer a developer default" do
       ENV["HOMEBREW_DEVELOPER"] = "1"
       expect(env_config.upgrade_auto_updates_casks?).to be(false)
     end
+
+    it "returns true if set to a falsey value" do
+      ENV["HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS"] = "0"
+      expect(env_config.upgrade_auto_updates_casks?).to be(true)
+    end
+
+    it "returns false if HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS is set" do
+      ENV["HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS"] = "1"
+      ENV["HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS"] = "1"
+      expect(env_config.upgrade_auto_updates_casks?).to be(false)
+    end
   end
 
   describe ".sandbox_linux?" do
-    before do
-      ENV["HOMEBREW_DEVELOPER"] = nil
-      ENV["HOMEBREW_NO_SANDBOX_LINUX"] = nil
-      ENV["HOMEBREW_SANDBOX_LINUX"] = nil
+    around do |example|
+      with_env(
+        HOMEBREW_DEVELOPER:        nil,
+        HOMEBREW_NO_SANDBOX_LINUX: nil,
+        HOMEBREW_SANDBOX_LINUX:    nil,
+      ) { example.run }
     end
 
     it "returns true if HOMEBREW_SANDBOX_LINUX is set" do
@@ -184,10 +231,10 @@ RSpec.describe Homebrew::EnvConfig do
       expect(env_config.sandbox_linux?).to be(false)
     end
 
-    it "returns false if HOMEBREW_SANDBOX_LINUX is set to a falsey value with HOMEBREW_DEVELOPER" do
+    it "returns true if HOMEBREW_SANDBOX_LINUX is set to a falsey value with HOMEBREW_DEVELOPER" do
       ENV["HOMEBREW_DEVELOPER"] = "1"
       ENV["HOMEBREW_SANDBOX_LINUX"] = "0"
-      expect(env_config.sandbox_linux?).to be(false)
+      expect(env_config.sandbox_linux?).to be(true)
     end
 
     it "returns false if HOMEBREW_NO_SANDBOX_LINUX is set" do
@@ -203,6 +250,36 @@ RSpec.describe Homebrew::EnvConfig do
     end
   end
 
+  describe ".require_tap_trust?" do
+    around do |example|
+      with_env(
+        HOMEBREW_REQUIRE_TAP_TRUST:    nil,
+        HOMEBREW_NO_REQUIRE_TAP_TRUST: nil,
+      ) { example.run }
+    end
+
+    it "returns false if HOMEBREW_NO_REQUIRE_TAP_TRUST is set" do
+      ENV["HOMEBREW_REQUIRE_TAP_TRUST"] = "1"
+      ENV["HOMEBREW_NO_REQUIRE_TAP_TRUST"] = "1"
+      expect(env_config.require_tap_trust?).to be(false)
+    end
+  end
+
+  describe ".verify_attestations?" do
+    around do |example|
+      with_env(
+        HOMEBREW_VERIFY_ATTESTATIONS:    nil,
+        HOMEBREW_NO_VERIFY_ATTESTATIONS: nil,
+      ) { example.run }
+    end
+
+    it "returns false if HOMEBREW_NO_VERIFY_ATTESTATIONS is set" do
+      ENV["HOMEBREW_VERIFY_ATTESTATIONS"] = "1"
+      ENV["HOMEBREW_NO_VERIFY_ATTESTATIONS"] = "1"
+      expect(env_config.verify_attestations?).to be(false)
+    end
+  end
+
   describe ".no_sandbox_cask?" do
     it "returns true if HOMEBREW_NO_SANDBOX_CASK is set" do
       ENV["HOMEBREW_NO_SANDBOX_CASK"] = "1"
@@ -212,7 +289,23 @@ RSpec.describe Homebrew::EnvConfig do
     end
   end
 
+  describe ".no_sandbox_linux?" do
+    it "returns true if set to a falsey value" do
+      ENV["HOMEBREW_NO_SANDBOX_LINUX"] = "0"
+      expect(env_config.no_sandbox_linux?).to be(true)
+    ensure
+      ENV["HOMEBREW_NO_SANDBOX_LINUX"] = nil
+    end
+  end
+
   describe ".use_internal_api?" do
+    around do |example|
+      with_env(
+        HOMEBREW_USE_INTERNAL_API:    nil,
+        HOMEBREW_NO_INSTALL_FROM_API: nil,
+      ) { example.run }
+    end
+
     it "returns true if HOMEBREW_USE_INTERNAL_API is set" do
       ENV["HOMEBREW_USE_INTERNAL_API"] = "1"
       expect(env_config.use_internal_api?).to be(true)
@@ -221,6 +314,11 @@ RSpec.describe Homebrew::EnvConfig do
     it "returns false if HOMEBREW_USE_INTERNAL_API is not set" do
       ENV["HOMEBREW_USE_INTERNAL_API"] = nil
       expect(env_config.use_internal_api?).to be(false)
+    end
+
+    it "returns true if HOMEBREW_USE_INTERNAL_API is set to a falsey value" do
+      ENV["HOMEBREW_USE_INTERNAL_API"] = "0"
+      expect(env_config.use_internal_api?).to be(true)
     end
 
     it "returns false if HOMEBREW_NO_INSTALL_FROM_API is set" do

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -7,7 +7,7 @@ require "trust"
 RSpec.describe Homebrew::Trust do
   it "lets HOMEBREW_NO_REQUIRE_TAP_TRUST override HOMEBREW_REQUIRE_TAP_TRUST" do
     with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1", HOMEBREW_NO_REQUIRE_TAP_TRUST: "1") do
-      expect(Homebrew::Trust).not_to be_enabled
+      expect(Homebrew::EnvConfig.require_tap_trust?).to be(false)
     end
   end
 

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -24,11 +24,6 @@ module Homebrew
     TRUST_FILE = T.let((HOMEBREW_PREFIX/"var/homebrew/trust.json").freeze, Pathname)
     private_constant :TRUST_FILE
 
-    sig { returns(T::Boolean) }
-    def self.enabled?
-      Homebrew::EnvConfig.require_tap_trust? && !Homebrew::EnvConfig.no_require_tap_trust?
-    end
-
     sig { params(type: Symbol, name: String).returns(T::Boolean) }
     def self.trust!(type, name)
       key = setting_key(type)
@@ -84,7 +79,7 @@ module Homebrew
 
       full_name = "#{tap.name}/#{::Utils.name_from_full_name(name)}"
       return if trusted?(:formula, full_name)
-      return trust_by_default!(tap) unless enabled?
+      return trust_by_default!(tap) unless Homebrew::EnvConfig.require_tap_trust?
 
       raise_untrusted!(:formula, full_name, tap)
     end
@@ -97,7 +92,7 @@ module Homebrew
 
       full_name = "#{tap.name}/#{::Utils.name_from_full_name(token)}"
       return if trusted?(:cask, full_name)
-      return trust_by_default!(tap) unless enabled?
+      return trust_by_default!(tap) unless Homebrew::EnvConfig.require_tap_trust?
 
       raise_untrusted!(:cask, full_name, tap)
     end
@@ -110,7 +105,7 @@ module Homebrew
 
       full_name = "#{tap.name}/#{command || path.basename(path.extname).to_s.delete_prefix("brew-")}"
       return if trusted?(:command, full_name)
-      return trust_by_default!(tap) unless enabled?
+      return trust_by_default!(tap) unless Homebrew::EnvConfig.require_tap_trust?
 
       raise_untrusted!(:command, full_name, tap)
     end
@@ -270,7 +265,7 @@ module Homebrew
 
       return true if trusted?(type, "#{tap.name}/#{path.basename(path.extname)}")
 
-      !enabled?
+      !Homebrew::EnvConfig.require_tap_trust?
     end
     private_class_method :trusted_file?
 


### PR DESCRIPTION
- Add `boolean: :set` for generated env readers where any non-empty value must mean enabled, matching Bash checks and avoiding duplicate `_NO_` opt-outs.
- Add `disabled_by:` so generated readers can model one env var overriding another while keeping both env vars documented from `ENVS`.
- Use `disabled_by:` for generated enable/disable env pairs and remove redundant caller-side checks.
- Inline pass-through helpers that only forwarded to the generated EnvConfig readers.
- Document the generated boolean modes near `FALSY_VALUES` so future env vars can choose the correct Ruby and Bash contract.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex with local testing and review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
