### PR TITLE
Delete unused `setup_remote_tap` method from the integration test helper

### DIFF
--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -257,22 +257,6 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
     path
   end
 
-  def setup_remote_tap(name)
-    Tap.fetch(name).tap do |tap|
-      next if tap.installed?
-
-      full_name = Tap.fetch(name).full_name
-      # Check to see if the original Homebrew process has taps we can use.
-      system_tap_path = Pathname("#{ENV.fetch("HOMEBREW_LIBRARY")}/Taps/#{full_name}")
-      if system_tap_path.exist?
-        system "git", "clone", "--shared", system_tap_path.to_s, tap.path.to_s
-        system "git", "-C", tap.path.to_s, "checkout", "master"
-      else
-        tap.install(quiet: true)
-      end
-    end
-  end
-
   def install_and_rename_coretap_formula(old_name, new_name)
     CoreTap.instance.path.cd do |tap_path|
       system "git", "init"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

- Since the last official tap, `homebrew/bundle`, migrated over to live in this repo in bdeca530ff6dc5a26d493501ed50ceab81faea00, we no longer use this method.