### PR TITLE
Fix default audit test formula

### DIFF
--- a/Library/Homebrew/test/test_bot/formulae_detect_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_detect_spec.rb
@@ -5,8 +5,8 @@ require "test_bot"
 
 RSpec.describe Homebrew::TestBot::FormulaeDetect do
   describe "::DEFAULT_TEST_FORMULAE" do
-    it "uses dependency-free formulae for default formula testing" do
-      expect(Homebrew::TestBot::FormulaeDetect::DEFAULT_TEST_FORMULAE).to eq(%w[libspiro bats-core])
+    it "uses GitHub-hosted, dependency-free formulae for default formula testing" do
+      expect(Homebrew::TestBot::FormulaeDetect::DEFAULT_TEST_FORMULAE).to eq(%w[libdeflate bats-core])
     end
   end
 end

--- a/Library/Homebrew/test_bot/formulae_detect.rb
+++ b/Library/Homebrew/test_bot/formulae_detect.rb
@@ -4,8 +4,9 @@
 module Homebrew
   module TestBot
     class FormulaeDetect < Test
-      # Formulae must have GitHub homepages, no stable dependencies, one executable and one library between them.
-      DEFAULT_TEST_FORMULAE = %w[libspiro bats-core].freeze
+      # Formulae must have GitHub homepages and stable URLs, no stable dependencies,
+      # one executable and one library between them.
+      DEFAULT_TEST_FORMULAE = %w[libdeflate bats-core].freeze
 
       sig { returns(T::Array[String]) }
       attr_reader :testing_formulae, :added_formulae, :deleted_formulae


### PR DESCRIPTION
Fix flaky `brew test-bot` tests.

- Use `libdeflate` because its homepage and source URL are GitHub URLs.
- Keep default formula testing independent of `libspiro` release reachability.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
