### PR TITLE
sorbet: Add RBI shims for the remainder of the test helper methods

### DIFF
--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -132,6 +132,25 @@ class RSpec::Core::ExampleGroup
 
   sig { params(name: String).returns(Pathname) }
   def fixture(name); end
+
+  # `formula(...) { ... }` helper blocks can be inferred as example group
+  # contexts in typed specs; declare Formula DSL methods to satisfy static
+  # analysis.
+  sig { params(val: String, specs: T::Hash[Symbol, T.anything]).returns(String) }
+  def url(val = "", specs = {}); end
+end
+
+# `formula(...) { ... }` helper blocks can be inferred as this helper module in
+# typed specs; declare Formula DSL methods to satisfy static analysis.
+module Test::Helper::Formula
+  sig { params(val: String, specs: T::Hash[Symbol, T.anything]).returns(String) }
+  def url(val = "", specs = {}); end
+end
+
+# Some helper blocks are inferred as Formula instances or class contexts.
+class Formula
+  sig { params(val: String, specs: T::Hash[Symbol, T.anything]).returns(String) }
+  def url(val = "", specs = {}); end
 end
 
 # The rspec-mocks RBI defines `ExpectHost#expect(target)` with a required

--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -35,8 +35,28 @@ class RSpec::Core::ExampleGroup
   sig { params(name: String, content: T.nilable(String), build_bottle: T::Boolean).void }
   def install_test_formula(name, content = T.unsafe(nil), build_bottle: false); end
 
+  sig { params(old_name: String, new_name: String).void }
+  def install_and_rename_coretap_formula(old_name, new_name); end
+
   sig { params(name: String).void }
   def uninstall_test_formula(name); end
+
+  # These methods are mixed into specs via
+  # `config.include(Test::Helper::{Formula,Cask})` in `test/spec_helper.rb`;
+  # declare them here so Sorbet can resolve them in typed spec files.
+  sig {
+    params(
+      name: String, path: T.nilable(Pathname), spec: Symbol, alias_path: T.nilable(Pathname),
+      tap: T.nilable(Tap), block: T.nilable(T.proc.bind(Formula).void)
+    ).returns(::Formula)
+  }
+  def formula(name = T.unsafe(nil), path: nil, spec: :stable, alias_path: nil, tap: nil, &block); end
+
+  sig { params(formula: ::Formula, ref: T.nilable(String), call_original: T::Boolean).void }
+  def stub_formula_loader(formula, ref = formula.full_name, call_original: false); end
+
+  sig { params(cask: Cask::Cask, ref: T.nilable(String), call_original: T::Boolean).void }
+  def stub_cask_loader(cask, ref = cask.token, call_original: false); end
 
   # `mktmpdir` is mixed into specs via `config.include(Test::Helper::MkTmpDir)`
   # in `test/spec_helper.rb`; declare it here so Sorbet can resolve it in typed
@@ -55,6 +75,63 @@ class RSpec::Core::ExampleGroup
     ).returns(Pathname)
   }
   def mktmpdir(prefix_suffix = T.unsafe(nil), &block); end
+
+  # These methods are mixed into specs via
+  # `config.include(Test::Helper::Subcommand)` in `test/spec_helper.rb`;
+  # declare them here so Sorbet can resolve them in typed spec files.
+  sig {
+    params(
+      subcommand: T.nilable(T.any(String, Symbol)),
+      named:      T.untyped,
+      options:    T.untyped,
+    ).returns(Test::Helper::Subcommand::Args)
+  }
+  def args_for_subcommand(subcommand = T.unsafe(nil), *named, **options); end
+
+  sig {
+    params(
+      subcommand:   T.any(String, Symbol),
+      global:       T::Boolean,
+      file:         T.nilable(String),
+      no_upgrade:   T::Boolean,
+      verbose:      T::Boolean,
+      force:        T::Boolean,
+      ask:          T::Boolean,
+      jobs:         Integer,
+      zap:          T::Boolean,
+      no_type_args: T::Boolean,
+    ).returns(Homebrew::Cmd::Bundle::SubcommandContext)
+  }
+  def bundle_subcommand_context(subcommand, global: false, file: nil, no_upgrade: false, verbose: false,
+                                force: false, ask: false, jobs: 1, zap: false, no_type_args: true)
+  end
+
+  # These methods are mixed into specs via
+  # `config.include(Test::Helper::Fixtures)` in `test/spec_helper.rb`;
+  # declare them here so Sorbet can resolve them in typed spec files.
+  sig { params(name: String).returns(MachOShim) }
+  def dylib_path(name); end
+
+  sig { params(name: String).returns(MachOShim) }
+  def bundle_path(name); end
+
+  sig { params(name: String).returns(Pathname) }
+  def cask_path(name); end
+
+  sig { params(name: String).returns(Pathname) }
+  def tarball_fixture(name); end
+
+  sig { params(name: String).returns(String) }
+  def tarball_fixture_sha256(name); end
+
+  sig { params(name: String).returns(Pathname) }
+  def patch_fixture(name); end
+
+  sig { params(name: String).returns(String) }
+  def patch_fixture_sha256(name); end
+
+  sig { params(name: String).returns(Pathname) }
+  def fixture(name); end
 end
 
 # The rspec-mocks RBI defines `ExpectHost#expect(target)` with a required

--- a/Library/Homebrew/test/bottle_filename_spec.rb
+++ b/Library/Homebrew/test/bottle_filename_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/bundle/mac_app_store_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/bundle/skipper_spec.rb
+++ b/Library/Homebrew/test/bundle/skipper_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/cask/artifact/generic_artifact_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/generic_artifact_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Artifact, :cask do

--- a/Library/Homebrew/test/cask/artifact/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/pkg_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Pkg, :cask do

--- a/Library/Homebrew/test/cask/artifact/suite_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/suite_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Suite, :cask do

--- a/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::App, :cask do

--- a/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Cask::Artifact::Zap, :cask do

--- a/Library/Homebrew/test/cask/artifact/zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/zap_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require_relative "shared_examples/uninstall_zap"

--- a/Library/Homebrew/test/cask/cask_loader/from_path_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_path_loader_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromPathLoader do

--- a/Library/Homebrew/test/cask/dsl/uninstall_postflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/uninstall_postflight_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/list_spec.rb
+++ b/Library/Homebrew/test/cask/list_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cask/list"

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cask/installer"

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cli/named_args"

--- a/Library/Homebrew/test/cmd/bundle/check_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/check_subcommand_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/cmd/bundle/dump_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/dump_subcommand_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/cmd/bundle/install_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/install_subcommand_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/cmd/doctor_spec.rb
+++ b/Library/Homebrew/test/cmd/doctor_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/doctor"

--- a/Library/Homebrew/test/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cmd/home_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/home"

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/install"

--- a/Library/Homebrew/test/cmd/migrate_spec.rb
+++ b/Library/Homebrew/test/cmd/migrate_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "cmd/migrate"

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/outdated"

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "extend/ENV"

--- a/Library/Homebrew/test/cmd/tab_spec.rb
+++ b/Library/Homebrew/test/cmd/tab_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/tab"

--- a/Library/Homebrew/test/description_cache_store_spec.rb
+++ b/Library/Homebrew/test/description_cache_store_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/update-report"

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/unpack_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/unpack_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/language/java_spec.rb
+++ b/Library/Homebrew/test/language/java_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "language/java"

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "language/node"

--- a/Library/Homebrew/test/livecheck/strategy/extract_plist_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/extract_plist_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "messages"

--- a/Library/Homebrew/test/os/mac/mach_spec.rb
+++ b/Library/Homebrew/test/os/mac/mach_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe MachOShim do

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "resource"

--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -10,6 +10,12 @@ module Test
 
       requires_ancestor { RSpec::Mocks::ExampleMethods }
 
+      sig {
+        params(
+          name: String, path: T.nilable(Pathname), spec: Symbol, alias_path: T.nilable(Pathname),
+          tap: T.nilable(Tap), block: T.nilable(T.proc.bind(Formula).void)
+        ).returns(::Formula)
+      }
       def formula(name = "formula_name", path: nil, spec: :stable, alias_path: nil, tap: nil, &block)
         path ||= Formulary.find_formula_in_tap(name, tap || CoreTap.instance)
         Class.new(::Formula, &block).new(name, path, spec, alias_path:, tap:)

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/analytics"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

OpenAI GPT-5.3-Codex for method usage stats and type signature generation, and deciphering the failures detailed in the second commit message. Human review and testing.

-----

- So that we can typecheck more tests, add the used `stub_{formula,cask}_loader` methods etc. to RSpec RBI shims.