### PR TITLE
sorbet: Commands can define subcommands

### DIFF
--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/analytics.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/analytics.rbi
@@ -10,4 +10,7 @@ class Homebrew::Cmd::Analytics
   def args; end
 end
 
-class Homebrew::Cmd::Analytics::Args < Homebrew::CLI::Args; end
+class Homebrew::Cmd::Analytics::Args < Homebrew::CLI::Args
+  sig { returns(T.nilable(String)) }
+  def subcommand; end
+end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/bundle.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/bundle.rbi
@@ -212,6 +212,9 @@ class Homebrew::Cmd::Bundle::Args < Homebrew::CLI::Args
   sig { returns(T::Boolean) }
   def services?; end
 
+  sig { returns(T.nilable(String)) }
+  def subcommand; end
+
   sig { returns(T::Boolean) }
   def tap?; end
 

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/completions_cmd.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/completions_cmd.rbi
@@ -10,4 +10,7 @@ class Homebrew::Cmd::CompletionsCmd
   def args; end
 end
 
-class Homebrew::Cmd::CompletionsCmd::Args < Homebrew::CLI::Args; end
+class Homebrew::Cmd::CompletionsCmd::Args < Homebrew::CLI::Args
+  sig { returns(T.nilable(String)) }
+  def subcommand; end
+end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/developer.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/developer.rbi
@@ -10,4 +10,7 @@ class Homebrew::Cmd::Developer
   def args; end
 end
 
-class Homebrew::Cmd::Developer::Args < Homebrew::CLI::Args; end
+class Homebrew::Cmd::Developer::Args < Homebrew::CLI::Args
+  sig { returns(T.nilable(String)) }
+  def subcommand; end
+end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/services.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/services.rbi
@@ -30,5 +30,8 @@ class Homebrew::Cmd::Services::Args < Homebrew::CLI::Args
   def no_wait?; end
 
   sig { returns(T.nilable(String)) }
+  def subcommand; end
+
+  sig { returns(T.nilable(String)) }
   def sudo_service_user; end
 end

--- a/Library/Homebrew/sorbet/tapioca/compilers/args.rb
+++ b/Library/Homebrew/sorbet/tapioca/compilers/args.rb
@@ -64,7 +64,13 @@ module Tapioca
       sig { params(klass: RBI::Scope, parser: Homebrew::CLI::Parser).void }
       def create_args_methods(klass, parser)
         comma_array_methods = comma_arrays(parser)
-        args_table(parser).each do |method_name|
+        args_methods = args_table(parser)
+
+        # `CLI::Parser` adds `subcommand` dynamically during parsing for commands
+        # that define subcommands.
+        args_methods << :subcommand if parser.subcommands.present? && !args_methods.include?(:subcommand)
+
+        args_methods.each do |method_name|
           method_name_str = method_name.to_s
           next if GLOBAL_OPTIONS.include?(method_name_str)
 

--- a/Library/Homebrew/test/cmd/analytics_spec.rb
+++ b/Library/Homebrew/test/cmd/analytics_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "cmd/analytics"

--- a/Library/Homebrew/test/cmd/completions_spec.rb
+++ b/Library/Homebrew/test/cmd/completions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "cmd/completions"

--- a/Library/Homebrew/test/cmd/developer_spec.rb
+++ b/Library/Homebrew/test/cmd/developer_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "cmd/developer"

--- a/Library/Homebrew/test/cmd/services_spec.rb
+++ b/Library/Homebrew/test/cmd/services_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "cmd/services"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

- The Args Tapioca compiler only detected methods via `args.methods(false)`, which didn't include `subcommand` for commands that define subcommands dynamically like in https://github.com/Homebrew/brew/blob/e2c800cddc7945890baf0925915407661eb960aa/Library/Homebrew/cmd/services.rb#L24.
- This caused errors when typechecking tests like `services_spec.rb` that call `args.subcommand` on the `services` command.
