### PR TITLE
utils/path: trust symlinked cellar roots

### DIFF
--- a/Library/Homebrew/test/utils/path_spec.rb
+++ b/Library/Homebrew/test/utils/path_spec.rb
@@ -34,4 +34,25 @@ RSpec.describe Utils::Path do
       expect(klass.child_of?("../foo", "./bar/baz/../../../foo/bar/baz")).to be(true)
     end
   end
+
+  describe "::loadable_package_path?" do
+    it "accepts formula paths under a symlinked cellar" do
+      tmpdir = mktmpdir
+      real_cellar = tmpdir/"real-cellar"
+      symlink_cellar = tmpdir/"cellar"
+
+      real_cellar.mkpath
+      FileUtils.ln_s(real_cellar, symlink_cellar)
+      stub_const("HOMEBREW_CELLAR", symlink_cellar)
+      allow(Homebrew::EnvConfig).to receive(:forbid_packages_from_paths?).and_return(true)
+
+      formula_path = real_cellar/"poshtui/0.16/.brew/poshtui.rb"
+      formula_path.dirname.mkpath
+      formula_path.write <<~RUBY
+        class Poshtui < Formula; end
+      RUBY
+
+      expect(klass.loadable_package_path?(formula_path, :formula)).to be(true)
+    end
+  end
 end

--- a/Library/Homebrew/utils/path.rb
+++ b/Library/Homebrew/utils/path.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 module Utils
+  # Helpers for Homebrew path handling and package path validation.
   module Path
     sig { params(parent: T.any(Pathname, String), child: T.any(Pathname, String)).returns(T::Boolean) }
     def self.child_of?(parent, child)
@@ -18,11 +19,11 @@ module Utils
       path_realpath = path.realpath.to_s
       path_string = path.to_s
 
-      allowed_paths = ["#{HOMEBREW_LIBRARY}/Taps/"]
+      allowed_paths = [trusted_package_root("#{HOMEBREW_LIBRARY}/Taps/")]
       allowed_paths << if package_type == :formula
-        "#{HOMEBREW_CELLAR}/"
+        trusted_package_root(HOMEBREW_CELLAR)
       else
-        "#{Cask::Caskroom.path}/"
+        trusted_package_root(Cask::Caskroom.path)
       end
 
       return true if !path_realpath.end_with?(".rb") && !path_string.end_with?(".rb")
@@ -49,5 +50,13 @@ module Utils
         path_string.count("/") != 2
       end
     end
+
+    sig { params(path: T.any(Pathname, String)).returns(String) }
+    def self.trusted_package_root(path)
+      Pathname(path).realpath.to_s
+    rescue Errno::ENOENT, Errno::EACCES, Errno::ENOTDIR
+      Pathname(path).expand_path.to_s
+    end
+    private_class_method :trusted_package_root
   end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?
  - Yes, but `brew lgtm` gives different results from `./bin/brew lgtm`, and only the latter is valid/correct. Adding `<details>` to the bottom, as this is not directly related.

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

This pull request was prepared with OpenAI Codex, gpt-5.4-mini (medium). It wrote the code, and most of the PR body, and I reviewed it all.

-----

# Fix `brew postinstall` on symlinked cellar roots

## Summary

`brew postinstall` can reject a Homebrew-managed keg formula path as if it were a local file when the cellar is reached through a symlinked prefix.

This shows up on atomic Fedora systems where `/home/linuxbrew/.linuxbrew` resolves to `/var/home/linuxbrew/.linuxbrew`. In that layout, the keg’s embedded `.brew/<formula>.rb` path is still Homebrew-managed, but the loader rejects it because the allowed cellar root check uses the non-canonical path.

NOTE:

On symlinked-home systems that integrate `brew upgrade` with `ujust update`, this is why the automated system update command "fails" (exit non-zero) everytime it runs.

## Reproduction

Run `brew upgrade` or `brew postinstall <tap>/<formula>` on a system with a symlinked Homebrew prefix/cellar layout, such as the standard atomic Fedora `/home` -> `/var/home` arrangement.

Homebrew can report:

```text
Error: Homebrew requires formulae to be in a tap, rejecting:
  /home/linuxbrew/.linuxbrew/opt/<formula>/.brew/<formula>.rb
```

## Fix

Canonicalize the trusted package roots before comparing them in `Utils::Path.loadable_package_path?`, so Homebrew recognizes its own cellar and tap directories even when the prefix resolves through a symlink.

## Test

Adds a regression test for a symlinked cellar root in `Library/Homebrew/test/utils/path_spec.rb`.

## Validation

- `./bin/brew style --fix --changed`
- `./bin/brew typecheck`
- `./bin/brew tests --only=utils/path`

-----

<details>
<summary>`brew` and `./bin/brew` difference</summary>

I get different results from:

- `brew` from `/home/linuxbrew/.linuxbrew/bin/brew`
- `./bin/brew from local clone of `homebrew-brew`

The difference matters because the two subcommands in `brew lgtm` use different repo roots:

- `brew style --changed` reads the current git repo from the working directory. See [style.rb#L64-L71](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/style.rb#L64-L71).
- `brew tests --changed` explicitly changes into `HOMEBREW_LIBRARY_PATH` before it runs the git diff. See [tests.rb#L74-L88](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/tests.rb#L74-L88) and [tests.rb#L235-L246](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/tests.rb#L235-L246).

So with `brew lgtm`:

- style is looking at the repo in my current directory, which is my homebrew-brew clone
- tests is looking at the installed Homebrew repo under `/home/linuxbrew/.linuxbrew/Homebrew/Library`

This results in an invalid warning:

```
  ==> brew style --changed --fix
  Inspecting 2 files
  # ...
  ==> brew tests --changed
  Warning: No tests are directly associated with the changed files!
```

When I run `./bin/brew lgtm` I get a clean run with no warnings.

The PR template should probably be updated to instruct usage with `./bin/brew lgtm`.

</details>