### PR TITLE
Warn about `HOMEBREW_EVAL_ALL` deprecation once

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -933,8 +933,12 @@ module Homebrew
       eval_all = ENV.fetch("HOMEBREW_EVAL_ALL", nil)
       if eval_all.present? && FALSY_VALUES.exclude?(eval_all.downcase)
         # odeprecated: deprecate in the next release.
-        opoo "`HOMEBREW_EVAL_ALL` will be deprecated soon. " \
-             "Use `HOMEBREW_REQUIRE_TAP_TRUST=1` or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` instead."
+        @eval_all_deprecation_warned = T.let(@eval_all_deprecation_warned, T.nilable(T::Boolean))
+        unless @eval_all_deprecation_warned
+          opoo "`HOMEBREW_EVAL_ALL` will be deprecated soon. " \
+               "Use `HOMEBREW_REQUIRE_TAP_TRUST=1` or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` instead."
+          @eval_all_deprecation_warned = true
+        end
         return true
       end
 

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -303,6 +303,7 @@ RSpec.describe Homebrew::EnvConfig do
       ENV["HOMEBREW_EVAL_ALL"] = nil
       ENV["HOMEBREW_REQUIRE_TAP_TRUST"] = nil
       ENV["HOMEBREW_NO_REQUIRE_TAP_TRUST"] = nil
+      env_config.instance_variable_set(:@eval_all_deprecation_warned, nil)
     end
 
     it "returns false if HOMEBREW_REQUIRE_TAP_TRUST is set" do
@@ -323,6 +324,13 @@ RSpec.describe Homebrew::EnvConfig do
       expect { expect(env_config.eval_all?).to be(true) }
         .to output(/HOMEBREW_EVAL_ALL.*deprecated.*HOMEBREW_REQUIRE_TAP_TRUST.*HOMEBREW_NO_REQUIRE_TAP_TRUST/m)
         .to_stderr
+    end
+
+    it "warns only once if HOMEBREW_EVAL_ALL is set and queried repeatedly" do
+      ENV["HOMEBREW_EVAL_ALL"] = "1"
+
+      env_config.eval_all?
+      expect { env_config.eval_all? }.not_to output.to_stderr
     end
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
My latest `brew update` was a bit noisy.

```
╰─ brew up
==> Updating Homebrew...
Already up-to-date.
Warning: `HOMEBREW_EVAL_ALL` will be deprecated soon. Use `HOMEBREW_REQUIRE_TAP_TRUST=1` or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` instead.
Warning: `HOMEBREW_EVAL_ALL` will be deprecated soon. Use `HOMEBREW_REQUIRE_TAP_TRUST=1` or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` instead.
Warning: `HOMEBREW_EVAL_ALL` will be deprecated soon. Use `HOMEBREW_REQUIRE_TAP_TRUST=1` or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` instead.
Warning: `HOMEBREW_EVAL_ALL` will be deprecated soon. Use `HOMEBREW_REQUIRE_TAP_TRUST=1` or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` instead.
Warning: `HOMEBREW_EVAL_ALL` will be deprecated soon. Use `HOMEBREW_REQUIRE_TAP_TRUST=1` or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` instead.
Warning: `HOMEBREW_EVAL_ALL` will be deprecated soon. Use `HOMEBREW_REQUIRE_TAP_TRUST=1` or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` instead.
Warning: `HOMEBREW_EVAL_ALL` will be deprecated soon. Use `HOMEBREW_REQUIRE_TAP_TRUST=1` or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` instead.
Warning: `HOMEBREW_EVAL_ALL` will be deprecated soon. Use `HOMEBREW_REQUIRE_TAP_TRUST=1` or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` instead.
Warning: `HOMEBREW_EVAL_ALL` will be deprecated soon. Use `HOMEBREW_REQUIRE_TAP_TRUST=1` or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` instead.
Warning: `HOMEBREW_EVAL_ALL` will be deprecated soon. Use `HOMEBREW_REQUIRE_TAP_TRUST=1` or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` instead.
Warning: `HOMEBREW_EVAL_ALL` will be deprecated soon. Use `HOMEBREW_REQUIRE_TAP_TRUST=1` or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` instead.
Warning: `HOMEBREW_EVAL_ALL` will be deprecated soon. Use `HOMEBREW_REQUIRE_TAP_TRUST=1` or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` instead.
Warning: `HOMEBREW_EVAL_ALL` will be deprecated soon. Use `HOMEBREW_REQUIRE_TAP_TRUST=1` or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` instead.
```