### PR TITLE
Fix install step API normalisation

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -46,9 +46,24 @@ module Homebrew
       sig { params(steps: ::T::Array[::T.untyped]).returns(Steps) }
       def self.normalise_steps(steps)
         steps.map do |step|
-          ::T.cast(::Utils.deep_stringify_symbols(step), Step)
+          ::T.cast(normalise_step_value(step), Step)
         end
       end
+
+      sig { params(obj: ::T.untyped).returns(::T.untyped) }
+      def self.normalise_step_value(obj)
+        case obj
+        when Symbol
+          obj.to_s
+        when Hash
+          obj.to_h { |key, value| [key.to_s, normalise_step_value(value)] }
+        when Array
+          obj.map { |value| normalise_step_value(value) }
+        else
+          obj
+        end
+      end
+      private_class_method :normalise_step_value
 
       sig { params(path: ::T.any(::String, ::Pathname), base: ::T.nilable(::T.any(::String, ::Symbol))).void }
       def mkdir(path, base: nil)

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -240,6 +240,25 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
 
     context "with install step stanzas" do
       include_examples "loads from API", "with-install-steps", caskfile_only: false
+
+      context "when running install steps loaded from internal JSON API" do
+        include_context "with internal API setup", "with-install-steps"
+
+        it "runs the loaded steps" do
+          cask = internal_api_loader.load(config: nil)
+          cask.staged_path.mkpath
+          cask.config_path.dirname.mkpath
+          (cask.staged_path/"container").write "app"
+          (cask.staged_path/"move-source").write "moved"
+
+          Cask::Installer.new(cask, command: NeverSudoSystemCommand).install_artifacts
+
+          expect(cask.staged_path/"Prepared").to be_a_directory
+          expect(cask.staged_path/"Prepared/touched").to exist
+          expect(cask.staged_path/"Prepared/moved").to exist
+          expect(cask.staged_path/"PreparedLink").to be_a_symlink
+        end
+      end
     end
 
     context "with a preflight stanza" do

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -76,6 +76,26 @@ RSpec.describe Homebrew::InstallSteps do
     expect(root/"var/nested/example").to be_a_directory
   end
 
+  specify "normalises API step keys and values" do
+    steps = [
+      {
+        type: :mkdir_p,
+        path: {
+          base: :var,
+          path: "nested/example",
+        },
+      },
+    ]
+
+    expect(Homebrew::InstallSteps::DSL.normalise_steps(steps)).to contain_exactly(
+      "type" => "mkdir_p",
+      "path" => {
+        "base" => "var",
+        "path" => "nested/example",
+      },
+    )
+  end
+
   specify "does not add the default base to home paths" do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
       mkdir_p "~/example"


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22490

- Preserve install step keys when casks are loaded from API data
- Avoid `KeyError` from `Runner#run_install_step` on `type`
- Cover API-shaped steps and internal API cask installation

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
