### PR TITLE
Trust taps in test-bot

### DIFF
--- a/Library/Homebrew/test/cmd/trust_spec.rb
+++ b/Library/Homebrew/test/cmd/trust_spec.rb
@@ -26,8 +26,10 @@ RSpec.describe Homebrew::Cmd::Trust do
   end
 
   it "lists trusted entries with no arguments" do
-    Homebrew::Trust.trust!(:tap, "thirdparty/foo")
-    Homebrew::Trust.trust!(:formula, "thirdparty/foo/bar")
+    allow(Homebrew::Trust).to receive(:trusted_entries).with(:tap).and_return(["thirdparty/foo"])
+    allow(Homebrew::Trust).to receive(:trusted_entries).with(:formula).and_return(["thirdparty/foo/bar"])
+    allow(Homebrew::Trust).to receive(:trusted_entries).with(:cask).and_return([])
+    allow(Homebrew::Trust).to receive(:trusted_entries).with(:command).and_return([])
 
     expect { Homebrew::Cmd::Trust.new([]).run }
       .to output(<<~EOS).to_stdout
@@ -37,8 +39,5 @@ RSpec.describe Homebrew::Cmd::Trust do
         Trusted formulae:
           thirdparty/foo/bar
       EOS
-  ensure
-    Homebrew::Trust.clear!(:tap)
-    Homebrew::Trust.clear!(:formula)
   end
 end

--- a/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
@@ -18,5 +18,9 @@ RSpec.describe Homebrew::DevCmd::TapNew do
 
     expect(HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/README.md").to exist
     expect(HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/tests.yml").to exist
+    expect((HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/tests.yml").read)
+      .not_to include("HOMEBREW_DEVELOPER")
+    expect((HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/publish.yml").read)
+      .not_to include("HOMEBREW_DEVELOPER")
   end
 end

--- a/Library/Homebrew/test/test_bot_spec.rb
+++ b/Library/Homebrew/test/test_bot_spec.rb
@@ -7,6 +7,31 @@ RSpec.describe Homebrew::TestBot do
   sig { returns(T.class_of(Homebrew::TestBot)) }
   let(:klass) { Homebrew::TestBot }
 
+  describe "::run!" do
+    it "trusts a third-party tap before running test-bot" do
+      tap = Tap.fetch("thirdparty", "foo")
+      tap.path.mkpath
+      args = double(
+        cleanup?:       false,
+        local?:         false,
+        tap:            tap.name,
+        only_formulae?: false,
+        git_name:       nil,
+        git_email:      nil,
+      )
+
+      allow(klass).to receive(:setup_github_actions_sandbox!)
+      allow(Utils).to receive(:safe_popen_read).and_return("revision")
+      allow(Homebrew::TestBot::TestRunner).to receive(:run!).and_return(true)
+
+      expect { klass.run!(args) }.to output(%r{==> Trusted tap: thirdparty/foo}).to_stdout
+      expect(Homebrew::Trust.trusted?(:tap, "thirdparty/foo")).to be(true)
+    ensure
+      Homebrew::Trust.clear!(:tap)
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+  end
+
   describe "::setup_github_actions_sandbox!" do
     around do |example|
       with_env(HOMEBREW_NO_SANDBOX_LINUX: nil) { example.run }

--- a/Library/Homebrew/test_bot.rb
+++ b/Library/Homebrew/test_bot.rb
@@ -13,12 +13,16 @@ require "formula"
 require "formula_installer"
 require "os"
 require "tap"
+require "trust"
 require "utils"
 require "utils/bottles"
+require "utils/output"
 require "utils/portable_ruby"
 
 module Homebrew
   module TestBot
+    extend Utils::Output::Mixin
+
     module_function
 
     GIT = "/usr/bin/git"
@@ -127,6 +131,11 @@ module Homebrew
           safe_system "brew", "tap", tap.name
         elsif (tap.path/".git/shallow").exist?
           raise unless quiet_system GIT, "-C", tap.path, "fetch", "--unshallow"
+        end
+
+        unless tap.official?
+          action = Homebrew::Trust.trust!(:tap, tap.name) ? "Trusted" : "Already trusted"
+          Homebrew::TestBot.ohai "#{action} tap: #{tap.name}"
         end
       end
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22494

- Prevents tap CI from failing in `brew doctor` after tap trust enforcement marks third-party taps as untrusted.
- Keeps the trust decision visible in CI output before test-bot runs.
- Guards `tap-new` workflows from setting `HOMEBREW_DEVELOPER`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review

Fixes https://github.com/Homebrew/brew/issues/22494

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
