### PR TITLE
livecheck/livecheck: type fix

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -43,7 +43,8 @@ module Homebrew
     private_class_method def self.livecheck_find_versions_parameters(strategy_class)
       @livecheck_find_versions_parameters ||= T.let({}, T.nilable(T::Hash[T::Class[Strategic], T::Array[Symbol]]))
       @livecheck_find_versions_parameters[strategy_class] ||=
-        T::Utils.signature_for_method(strategy_class.method(:find_versions)).parameters.map(&:second)
+        (T::Utils.signature_for_method(strategy_class.method(:find_versions))&.parameters ||
+         strategy_class.method(:find_versions).parameters).map(&:second)
     end
 
     # Uses `formulae_and_casks_to_check` to identify taps in use other than


### PR DESCRIPTION
`T::Utils.signature_for_method` is not available outside of `brew tests` so we have to fallback to a generic type when it isn't available.

Follow up to https://github.com/Homebrew/brew/pull/22496 - and should unblock `homebrew-cask` CI.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

Used `claude-code` to help debug and resolve the type issue.