### PR TITLE
services: fix not loading with `--sudo-service-user`

### DIFF
--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -152,7 +152,10 @@ module Homebrew
             puts
           end
 
-          next if !take_root_ownership?(service) && System.root?
+          # Never skip loading when ownership was taken, otherwise
+          # only skip a `--sudo-service-user` service when not root.
+          root_ownership_taken = take_root_ownership?(service)
+          next if !root_ownership_taken && sudo_service_user && !System.root?
 
           service_load(service, nil, enable: true)
         end
@@ -372,7 +375,7 @@ module Homebrew
 
       sig { params(service: Services::FormulaWrapper, file: T.nilable(Pathname), enable: T::Boolean).void }
       def self.service_load(service, file, enable:)
-        if System.root? && !service.service_startup?
+        if System.root? && !service.service_startup? && !sudo_service_user
           opoo "#{service.name} must be run as non-root to start at user login!"
         elsif !System.root? && service.service_startup?
           opoo "#{service.name} must be run as root to start at system startup!"
@@ -409,7 +412,7 @@ module Homebrew
 
           if sudo_service_user && System.launchctl?
             # set the username in the new plist file
-            ohai "Setting username in #{service.service_name} to: #{System.user}"
+            ohai "Setting username in #{service.service_name} to: #{sudo_service_user}"
             plist_data = Plist.parse_xml(contents, marshal: false)
             plist_data["UserName"] = sudo_service_user
             plist_data.to_plist

--- a/Library/Homebrew/services/subcommand.rb
+++ b/Library/Homebrew/services/subcommand.rb
@@ -36,7 +36,7 @@ module Homebrew
           if (sudo_service_user = args.sudo_service_user)
             unless Homebrew::Services::System.root?
               raise UsageError,
-                    "`brew services` is supported only when running as root!"
+                    "`brew services --sudo-service-user` is supported only when running as root!"
             end
 
             unless Homebrew::Services::System.launchctl?

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -150,6 +150,50 @@ RSpec.describe Homebrew::Services::Cli do
         services_cli.start([service])
       end.to output(expected_output).to_stdout
     end
+
+    context "when deciding whether to load target service" do
+      let(:service) do
+        instance_double(
+          Homebrew::Services::FormulaWrapper,
+          name:         "name",
+          pid?:         false,
+          installed?:   true,
+          service_file: instance_double(Pathname, exist?: true),
+        )
+      end
+
+      before do
+        allow(services_cli).to receive(:install_service_file)
+      end
+
+      it "loads service for root" do
+        allow(Homebrew::Services::System).to receive(:root?).and_return(true)
+        allow(services_cli).to receive(:take_root_ownership?).and_return(true)
+        expect(services_cli).to receive(:service_load).with(service, nil, enable: true)
+        services_cli.start([service])
+      end
+
+      it "loads service for non-root user" do
+        allow(Homebrew::Services::System).to receive(:root?).and_return(false)
+        allow(services_cli).to receive(:take_root_ownership?).and_return(false)
+        expect(services_cli).to receive(:service_load).with(service, nil, enable: true)
+        services_cli.start([service])
+      end
+
+      it "loads service for root when given `--sudo-service-user`" do
+        allow(Homebrew::Services::System).to receive(:root?).and_return(true)
+        allow(services_cli).to receive_messages(sudo_service_user: "_serviced", take_root_ownership?: false)
+        expect(services_cli).to receive(:service_load).with(service, nil, enable: true)
+        services_cli.start([service])
+      end
+
+      it "does not load service for non-root user when given `--sudo-service-user`" do
+        allow(Homebrew::Services::System).to receive(:root?).and_return(false)
+        allow(services_cli).to receive_messages(sudo_service_user: "_serviced", take_root_ownership?: false)
+        expect(services_cli).not_to receive(:service_load)
+        services_cli.start([service])
+      end
+    end
   end
 
   describe "#stop" do
@@ -240,6 +284,21 @@ RSpec.describe Homebrew::Services::Cli do
     end
   end
 
+  describe "#take_root_ownership?" do
+    it "returns false when given non-root user" do
+      allow(Homebrew::Services::System).to receive(:root?).and_return(false)
+      service = instance_double(Homebrew::Services::FormulaWrapper)
+      expect(services_cli.take_root_ownership?(service)).to be(false)
+    end
+
+    it "returns false when given `--sudo-service-user`" do
+      allow(Homebrew::Services::System).to receive(:root?).and_return(true)
+      allow(services_cli).to receive(:sudo_service_user).and_return("_serviced")
+      service = instance_double(Homebrew::Services::FormulaWrapper)
+      expect(services_cli.take_root_ownership?(service)).to be(false)
+    end
+  end
+
   describe "#install_service_file" do
     it "checks service is installed" do
       service = instance_double(Homebrew::Services::FormulaWrapper, name: "name", installed?: false)
@@ -289,6 +348,53 @@ RSpec.describe Homebrew::Services::Cli do
       services_cli.install_service_file(service, nil)
 
       expect(service.timer_dest.read).to eq("timer")
+    end
+
+    context "when given `--sudo-service-user`" do
+      let(:dest_dir) { mktmpdir }
+      let(:service) do
+        source_dir = mktmpdir
+        service_file = source_dir/"homebrew.test.plist"
+        service_file.write <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>Label</key>
+            <string>homebrew.test</string>
+            <key>ProgramArguments</key>
+            <array>
+              <string>/opt/homebrew/opt/test/bin/test</string>
+            </array>
+          </dict>
+          </plist>
+        XML
+        instance_double(
+          Homebrew::Services::FormulaWrapper,
+          name:         "name",
+          service_name: "homebrew.test",
+          installed?:   true,
+          service_file:,
+          dest:         dest_dir/"homebrew.test.plist",
+          dest_dir:,
+        )
+      end
+
+      before do
+        allow(Homebrew::Services::System).to receive_messages(launchctl?: true, systemctl?: false)
+        allow(services_cli).to receive(:sudo_service_user).and_return("_serviced")
+      end
+
+      it "prints the given username" do
+        expect do
+          services_cli.install_service_file(service, nil)
+        end.to output(/Setting username in homebrew\.test to: _serviced/).to_stdout
+      end
+
+      it "sets username in the generated plist" do
+        services_cli.install_service_file(service, nil)
+        expect(service.dest.read).to include("<key>UserName</key>", "<string>_serviced</string>")
+      end
     end
   end
 
@@ -422,6 +528,43 @@ RSpec.describe Homebrew::Services::Cli do
           enable: false,
         )
       end.to output("==> Successfully ran `name` (label: service.name)\n").to_stdout
+    end
+
+    it "warns root for login without `--sudo-service-user`" do
+      expect(Homebrew::Services::System).to receive(:launchctl?).once.and_return(false)
+      expect(Homebrew::Services::System).to receive(:systemctl?).once.and_return(false)
+      expect(Homebrew::Services::System).to receive(:root?).once.and_return(true)
+      expect do
+        services_cli.service_load(
+          instance_double(
+            Homebrew::Services::FormulaWrapper,
+            name:             "name",
+            service_name:     "service.name",
+            service_startup?: false,
+          ),
+          nil,
+          enable: true,
+        )
+      end.to output(/name must be run as non-root to start at user login!/).to_stderr
+    end
+
+    it "does not warn root for login when given `--sudo-service-user`" do
+      expect(Homebrew::Services::System).to receive(:launchctl?).once.and_return(false)
+      expect(Homebrew::Services::System).to receive(:systemctl?).once.and_return(false)
+      expect(Homebrew::Services::System).to receive(:root?).twice.and_return(true)
+      allow(services_cli).to receive(:sudo_service_user).and_return("_serviced")
+      expect do
+        services_cli.service_load(
+          instance_double(
+            Homebrew::Services::FormulaWrapper,
+            name:             "name",
+            service_name:     "service.name",
+            service_startup?: false,
+          ),
+          nil,
+          enable: true,
+        )
+      end.not_to output(/must be run as non-root to start at user login!/).to_stderr
     end
 
     it "triggers launchctl" do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

Claude Opus 4.8 was used to assist writing tests given my specifications, then validate their coverage against human-identified problems and human-generated fixes. This is my only AI-assisted PR open at this time.

-----

## Problem
Using 5.1.14 on macOS, `brew services [start|restart] --sudo-service-user` configures the specified user, but silently fails to load the service:
```
$ sudo brew services start nginx --sudo-service-user _serviced --verbose
==> Setting username in homebrew.mxcl.nginx to: root
==> Generated service file for nginx:
   <?xml version="1.0" encoding="UTF-8"?>
   ⋮
   	<key>UserName</key>
   	<string>_serviced</string>
   ⋮
   </plist>


(exit code 0) $
```
This is caused by `Library/Homebrew/services/cli.rb#L155` preventing the `start()` method from calling `service_load()`, as `take_root_ownership?()` returns `false` when given a `--sudo-service-user`.

Further, misleading messages are observed when given a `--sudo-service-user` and
* Warning about system startup behaviour for services with `require_root false`
* Configuring the service file with the specified user
* Invoking `brew services [start|restart]` as a non-root user

## Fix
Do not consider the result of `take_root_ownership?()`; instead, always load the service unless a non-root user has provided a `--sudo-service-user` (invalid per `Library/Homebrew/services/subcommand.rb#L36-40`). Provide tests to ensure `service_load()` is invoked by `start()` per this logic. Provide tests to check the early-return behaviour of `take_root_ownership?()`, noting this is no longer captured by a working feature.

Change variables and a condition to correct informational/error messages. To prevent future regressions, extend tests for these changes to also check for the specified user in the generated `.plist`.

These changes resolve the problem:
```
$ sudo brew services start nginx --sudo-service-user _serviced --verbose
==> Setting username in homebrew.mxcl.nginx to: _serviced
==> Generated service file for nginx:
   <?xml version="1.0" encoding="UTF-8"?>
   ⋮
   </plist>
   

/bin/launchctl system/homebrew.mxcl.nginx
/bin/launchctl system /Library/LaunchDaemons/homebrew.mxcl.nginx.plist
==> Successfully started `nginx` (label: homebrew.mxcl.nginx)
(exit code 0) $
```

## Potential future work
If I may, I would suggest considering whether `brew services [start|restart] --sudo-service-user` should:
* Validate whether the provided user exists, warning/aborting if it doesn't
* Take user ownership of service-required directories, similarly to `take_root_ownership?()`

In both cases, it might offer a more complete experience for users of this feature. I'd be happy to implement following this fix :)