### PR TITLE
Fix prof vernier child hangs

### DIFF
--- a/Library/Homebrew/dev-cmd/prof.rb
+++ b/Library/Homebrew/dev-cmd/prof.rb
@@ -47,19 +47,33 @@ module Homebrew
           end
           output_filename = "prof/d3-flamegraph.html"
           safe_system "stackprof --d3-flamegraph prof/stackprof.dump > #{output_filename}"
-          exec_browser output_filename
+          # `brew prof` is often run from tests or scripts. Only open the HTML
+          # report automatically when the user is attached to a terminal.
+          exec_browser output_filename if $stdout.tty?
         elsif args.vernier?
           output_filename = "prof/vernier.json"
           Process::UID.change_privilege(Process.euid) if Process.euid != Process.uid
-          safe_system "vernier", "run", "--output=#{output_filename}", "--allocation_interval=500", "--",
-                      RUBY_PATH, brew_rb, *args.named
+          # Avoid `vernier run`: it injects `vernier/autorun` through `RUBYOPT`,
+          # which child Ruby processes inherit. Profiling only this Ruby process
+          # keeps nested `brew` commands from trying to write the same profile.
+          #
+          # `HOMEBREW_SPAWN_SYSTEM` is intentionally scoped to this profiled
+          # process. It lets selected process helpers avoid manual fork paths
+          # that can inherit Vernier's active native collector state.
+          safe_system({ "HOMEBREW_SPAWN_SYSTEM" => "1",
+                        "VERNIER_ALLOCATION_INTERVAL" => "500", "VERNIER_OUTPUT" => output_filename },
+                      RUBY_PATH, "-I", (Pathname(Gem::Specification.find_by_name("vernier").full_gem_path)/"lib").to_s,
+                      "-r", "vernier/autorun",
+                      "-r", (HOMEBREW_LIBRARY_PATH/"prof/vernier_fork_guard").to_s, brew_rb, *args.named)
           ohai "Profiling complete!"
           puts "Upload the results from #{output_filename} to:"
           puts "  #{Formatter.url("https://vernier.prof")}"
         else
           output_filename = "prof/call_stack.html"
           safe_system "ruby-prof", "--printer=call_stack", "--file=#{output_filename}", brew_rb, "--", *args.named
-          exec_browser output_filename
+          # Match the stackprof behaviour above: generating the file is useful
+          # in non-interactive runs but launching a browser is not.
+          exec_browser output_filename if $stdout.tty?
         end
       rescue OptionParser::InvalidOption => e
         ofail e

--- a/Library/Homebrew/prof/vernier_fork_guard.rb
+++ b/Library/Homebrew/prof/vernier_fork_guard.rb
@@ -1,0 +1,78 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Homebrew
+  module VernierForkGuard
+    # This file is required before Homebrew's usual command boot has installed
+    # the global `sig` helper.
+    # rubocop:disable Sorbet/RedundantExtendTSig
+    extend T::Sig
+    # rubocop:enable Sorbet/RedundantExtendTSig
+
+    sig { params(block: T.nilable(T.proc.returns(T.untyped))).returns(T.untyped) }
+    def self.without_running_collector(&block)
+      raise ArgumentError, "block required" unless block
+
+      return yield unless Object.const_defined?(:Vernier)
+
+      # `Vernier::Autorun` is created by `-r vernier/autorun`; Sorbet's RBI for
+      # the gem does not expose it, so keep this lookup dynamic.
+      autorun = T.let(Object.const_get(:Vernier).const_get(:Autorun), T.untyped)
+      return yield unless autorun.running?
+
+      # Vernier registers internal thread hooks and owns native mutexes while the
+      # collector is running. Forking with that state active can leave the child
+      # process stuck before it reaches exec.
+      #
+      # Stopping here loses samples taken during fork setup, but that is a better
+      # tradeoff than hanging the profiled command. The common process helpers use
+      # spawn while `HOMEBREW_SPAWN_SYSTEM` is set, so this remains a fallback.
+      autorun.collector.stop
+      autorun.collector = nil
+      pid = nil
+      begin
+        pid = yield
+      ensure
+        # Restart only in the parent. In the child, `yield` returns nil and exec
+        # should happen immediately through the original fork path.
+        autorun.start if pid && !autorun.running?
+      end
+      pid
+    end
+
+    sig { void }
+    def self.stop_running_collector
+      return unless Object.const_defined?(:Vernier)
+
+      autorun = T.let(Object.const_get(:Vernier).const_get(:Autorun), T.untyped)
+      return unless autorun.running?
+
+      autorun.stop
+    end
+  end
+end
+
+# Keep this monkey-patch local to `brew prof --vernier`: this file is only
+# loaded by that command after `vernier/autorun`.
+Kernel.module_eval <<~RUBY, __FILE__, __LINE__ + 1
+  # These aliases let us wrap direct process replacement paths without changing
+  # unrelated command code paths.
+  alias_method :homebrew_vernier_fork_guard_fork, :fork
+  alias_method :homebrew_vernier_fork_guard_exec, :exec
+
+  def fork(&block)
+    Homebrew::VernierForkGuard.without_running_collector do
+      homebrew_vernier_fork_guard_fork(&block)
+    end
+  end
+
+  def exec(...)
+    # `brew ruby` reaches here in the profiled process. Stop and write the
+    # Vernier result before replacing the process so no SIGPROF state carries
+    # into the new executable.
+    Homebrew::VernierForkGuard.stop_running_collector
+    homebrew_vernier_fork_guard_exec(...)
+  end
+RUBY

--- a/Library/Homebrew/test/dev-cmd/prof_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/prof_spec.rb
@@ -7,9 +7,56 @@ require "dev-cmd/prof"
 RSpec.describe Homebrew::DevCmd::Prof do
   it_behaves_like "parseable arguments"
 
+  describe "#run" do
+    before do
+      allow(Homebrew).to receive(:install_bundler_gems!)
+      allow(Homebrew).to receive(:setup_gem_environment!)
+    end
+
+    it "does not open HTML profiles outside a TTY" do
+      prof = Homebrew::DevCmd::Prof.new(["help"])
+
+      allow($stdout).to receive(:tty?).and_return(false)
+      expect(prof).to receive(:safe_system)
+        .with("ruby-prof", "--printer=call_stack", "--file=prof/call_stack.html",
+              (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path, "--", "help")
+      expect(prof).not_to receive(:exec_browser)
+
+      prof.run
+    end
+
+    it "runs Vernier without passing it to child Ruby processes" do
+      prof = Homebrew::DevCmd::Prof.new(["--vernier", "commands"])
+
+      expect(prof).to receive(:safe_system)
+        .with(
+          { "HOMEBREW_SPAWN_SYSTEM" => "1",
+            "VERNIER_ALLOCATION_INTERVAL" => "500", "VERNIER_OUTPUT" => "prof/vernier.json" },
+          RUBY_PATH,
+          "-I",
+          (Pathname(Gem::Specification.find_by_name("vernier").full_gem_path)/"lib").to_s,
+          "-r",
+          "vernier/autorun",
+          "-r",
+          (HOMEBREW_LIBRARY_PATH/"prof/vernier_fork_guard").to_s,
+          (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path,
+          "commands",
+        )
+      allow(prof).to receive(:ohai)
+      allow(prof).to receive(:puts)
+
+      prof.run
+    end
+  end
+
   describe "integration tests", :integration_test, :needs_network do
     after do
-      FileUtils.rm_rf HOMEBREW_LIBRARY_PATH/"prof"
+      FileUtils.rm_f [
+        HOMEBREW_LIBRARY_PATH/"prof/call_stack.html",
+        HOMEBREW_LIBRARY_PATH/"prof/d3-flamegraph.html",
+        HOMEBREW_LIBRARY_PATH/"prof/stackprof.dump",
+        HOMEBREW_LIBRARY_PATH/"prof/vernier.json",
+      ]
     end
 
     it "works using ruby-prof (the default)" do
@@ -23,6 +70,12 @@ RSpec.describe Homebrew::DevCmd::Prof do
       expect { brew "prof", "--stackprof", "help", "HOMEBREW_BROWSER" => "echo" }
         .to output(/^Example usage:/).to_stdout
         .and not_to_output.to_stderr
+        .and be_a_success
+    end
+
+    it "works using vernier with child processes" do
+      expect { brew "prof", "--vernier", "config" }
+        .to output(/^HOMEBREW_VERSION:/).to_stdout
         .and be_a_success
     end
   end

--- a/Library/Homebrew/utils/popen.rb
+++ b/Library/Homebrew/utils/popen.rb
@@ -86,6 +86,17 @@ module Utils
       ).returns(T.any(T.type_parameter(:U), String))
   }
   def self.popen(args, mode, options = {}, &_block)
+    # `brew prof --vernier` uses this to avoid inheriting Vernier's active
+    # native collector state through `IO.popen("-")` fork paths.
+    if ENV["HOMEBREW_SPAWN_SYSTEM"] == "1"
+      options[:err] ||= File::NULL unless ENV["HOMEBREW_STDERR"]
+      IO.popen(args, mode, options) do |pipe|
+        return pipe.read unless block_given?
+
+        return yield pipe
+      end
+    end
+
     IO.popen("-", mode) do |pipe|
       if pipe
         return pipe.read unless block_given?


### PR DESCRIPTION
- Avoid the `vernier` wrapper because it injects `RUBYOPT` into child Ruby processes and can make nested Homebrew commands profile themselves.
- Load a scoped fork and exec guard for `brew prof --vernier` so child and replacement processes do not inherit active Vernier collector state.
- Use spawn for `Utils.popen` while profiling to avoid its manual fork path.
- Keep HTML profiler output from opening a browser unless stdout is a TTY.
- Add regression coverage for Vernier child process profiling.
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
