### PR TITLE
Refine tap trust warnings

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -122,6 +122,13 @@ module Homebrew
       end
 
       sig { returns(T::Array[String]) }
+      def preinstall_checks
+        %w[
+          check_untrusted_taps
+        ].freeze
+      end
+
+      sig { returns(T::Array[String]) }
       def build_error_checks
         supported_configuration_checks + build_from_source_checks
       end
@@ -720,8 +727,7 @@ module Homebrew
         else
           "Homebrew will ignore formulae, casks and commands from these taps when " \
             "`HOMEBREW_REQUIRE_TAP_TRUST` is set.\n" \
-            "This will become the default in a future release.\n" \
-            "Set `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` to keep allowing them by default."
+            "This will become the default in Homebrew 6.0.0 or 5.2.0, whichever comes first."
         end
 
         <<~EOS
@@ -729,13 +735,21 @@ module Homebrew
             #{untrusted_tap_names.join("\n  ")}
 
           #{trust_required_message}
-          Untap them with:
-            brew untap #{untrusted_tap_names.join(" ")}
-          or trust specific formulae, casks or commands with:
+          Enable trust checks now with:
+            export HOMEBREW_REQUIRE_TAP_TRUST=1
+          Trust specific formulae, casks or commands with:
             brew trust --formula <user>/<tap>/<formula>
             brew trust --cask <user>/<tap>/<cask>
             brew trust --command <user>/<tap>/<command>
           #{"or trust installed formulae from these taps with:\n#{installed_formula_message}" if installed_formula_message.present?}
+          You can trust all formulae, casks and commands from these taps with:
+            brew trust #{untrusted_tap_names.join(" ")}
+          Prefer trusting only the specific formulae, casks or commands you need.
+          Untap them with:
+            brew untap #{untrusted_tap_names.join(" ")}
+          To keep allowing them by default during the transition:
+            export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
+          This is not recommended and will be removed in a later release.
         EOS
       end
 

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -565,11 +565,11 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_NO_REQUIRE_TAP_TRUST:             {
-        # odeprecated: keep the current default until trust checks are default in a later release.
+        # odeprecated: remove in a later release after tap trust checks are the default.
         description: "If set, do not require non-official tap formulae, casks or commands to be trusted. " \
-                     "Also enables commands that evaluate all formulae and casks.",
+                     "This is not recommended and will be removed in a later release. Also enables commands " \
+                     "that evaluate all formulae and casks.",
         boolean:     :set,
-        hidden:      true,
       },
       HOMEBREW_NO_SANDBOX_CASK:                  {
         # odeprecated: make cask executable sandboxing mandatory in a future release.
@@ -614,7 +614,6 @@ module Homebrew
                      "formulae and casks.",
         boolean:     :set,
         disabled_by: :HOMEBREW_NO_REQUIRE_TAP_TRUST,
-        hidden:      true,
       },
       HOMEBREW_SANDBOX_LINUX:                    {
         # odeprecated: edit in 5.2.0

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -718,6 +718,7 @@ module Homebrew
         check_cpu
         attempt_directory_creation
         Diagnostic.checks(:supported_configuration_checks, fatal: all_fatal)
+        Diagnostic.checks(:preinstall_checks, fatal: false)
         Diagnostic.checks(:fatal_preinstall_checks)
       end
 

--- a/Library/Homebrew/test/cmd/help_spec.rb
+++ b/Library/Homebrew/test/cmd/help_spec.rb
@@ -17,16 +17,16 @@ RSpec.describe Homebrew::Cmd::HelpCmd, :integration_test do
     end
 
     it "prints the originating tap for an external command from a third-party tap" do
-      tap_path = HOMEBREW_TAP_DIRECTORY/"thirdparty/homebrew-foo"
+      tap_path = HOMEBREW_TAP_DIRECTORY/"trusthelp/homebrew-foo"
       tap_path.mkpath
       tap_path.cd do
         system "git", "init"
-        system "git", "remote", "add", "origin", "https://github.com/thirdparty/homebrew-foo"
+        system "git", "remote", "add", "origin", "https://github.com/trusthelp/homebrew-foo"
         FileUtils.touch "readme"
         system "git", "add", "--all"
         system "git", "commit", "-m", "init"
       end
-      cmd_path = tap_path/"cmd/hello-tap.rb"
+      cmd_path = tap_path/"cmd/hello-trust-tap.rb"
       cmd_path.dirname.mkpath
       cmd_path.write <<~RUBY
         # typed: strict
@@ -38,7 +38,7 @@ RSpec.describe Homebrew::Cmd::HelpCmd, :integration_test do
 
         module Homebrew
           module Cmd
-            class HelloTap < AbstractCommand
+            class HelloTrustTap < AbstractCommand
               cmd_args do
                 description "A friendly greeter from a tap."
               end
@@ -51,26 +51,26 @@ RSpec.describe Homebrew::Cmd::HelpCmd, :integration_test do
       RUBY
       cmd_path.chmod(0755)
 
-      expect { brew "help", "hello-tap", "SECRET_TOKEN" => "password" }
-        .to output(%r{^From tap: thirdparty/foo$}).to_stdout
-        .and output(%r{Tap thirdparty/foo is allowed by default}).to_stderr
+      expect { brew "help", "hello-trust-tap", "SECRET_TOKEN" => "password" }
+        .to output(%r{^From tap: trusthelp/foo$}).to_stdout
+        .and not_to_output.to_stderr
         .and be_a_success
     ensure
       Homebrew::Trust.clear!(:tap)
-      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"trusthelp"
     end
 
     it "requires trust for an external command from a third-party tap" do
-      tap_path = HOMEBREW_TAP_DIRECTORY/"thirdparty/homebrew-foo"
+      tap_path = HOMEBREW_TAP_DIRECTORY/"trusthelp/homebrew-foo"
       tap_path.mkpath
       tap_path.cd do
         system "git", "init"
-        system "git", "remote", "add", "origin", "https://github.com/thirdparty/homebrew-foo"
+        system "git", "remote", "add", "origin", "https://github.com/trusthelp/homebrew-foo"
         FileUtils.touch "readme"
         system "git", "add", "--all"
         system "git", "commit", "-m", "init"
       end
-      cmd_path = tap_path/"cmd/hello-tap.rb"
+      cmd_path = tap_path/"cmd/hello-trust-tap.rb"
       cmd_path.dirname.mkpath
       cmd_path.write <<~RUBY
         # typed: strict
@@ -80,7 +80,7 @@ RSpec.describe Homebrew::Cmd::HelpCmd, :integration_test do
 
         module Homebrew
           module Cmd
-            class HelloTap < AbstractCommand
+            class HelloTrustTap < AbstractCommand
               cmd_args do
                 description "A friendly greeter from a tap."
               end
@@ -98,20 +98,20 @@ RSpec.describe Homebrew::Cmd::HelpCmd, :integration_test do
         "HOMEBREW_REQUIRE_TAP_TRUST" => "1",
       )
 
-      expect { brew "help", "hello-tap", require_trust_env.dup }
-        .to output(%r{thirdparty/foo}).to_stderr
+      expect { brew "help", "hello-trust-tap", require_trust_env.dup }
+        .to output(%r{trusthelp/foo}).to_stderr
         .and be_a_failure
 
-      expect { brew "trust", "--command", "thirdparty/foo/hello-tap", trust_env.dup }
-        .to output(%r{Trusted command: thirdparty/foo/hello-tap}).to_stdout
+      expect { brew "trust", "--command", "trusthelp/foo/hello-trust-tap", trust_env.dup }
+        .to output(%r{Trusted command: trusthelp/foo/hello-trust-tap}).to_stdout
         .and be_a_success
 
-      expect { brew "help", "hello-tap", require_trust_env.dup }
-        .to output(%r{^From tap: thirdparty/foo$}).to_stdout
+      expect { brew "help", "hello-trust-tap", require_trust_env.dup }
+        .to output(%r{^From tap: trusthelp/foo$}).to_stdout
         .and be_a_success
     ensure
       FileUtils.rm_rf trust_home if trust_home
-      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"trusthelp"
     end
 
     it "does not print the originating tap for an external command from an official tap" do

--- a/Library/Homebrew/test/cmd/untrust_spec.rb
+++ b/Library/Homebrew/test/cmd/untrust_spec.rb
@@ -34,46 +34,38 @@ RSpec.describe Homebrew::Cmd::Untrust do
   end
 
   it "untrusts a command with the plural switch alias" do
-    Homebrew::Trust.trust!(:command, "thirdparty/foo/hello")
+    expect(Homebrew::Trust).to receive(:untrust!).with(:command, "thirdparty/foo/hello").and_return(true)
 
     expect { Homebrew::Cmd::Untrust.new(["--commands", "thirdparty/foo/hello"]).run }
       .to output("Untrusted command: thirdparty/foo/hello\n").to_stdout
-
-    expect(Homebrew::Trust.trusted?(:command, "thirdparty/foo/hello")).to be(false)
-  ensure
-    Homebrew::Trust.clear!(:command)
   end
 
   it "untrusts trusted items from a tap" do
-    Homebrew::Trust.trust!(:formula, "thirdparty/foo/bar")
-    Homebrew::Trust.trust!(:cask, "thirdparty/foo/baz")
-    Homebrew::Trust.trust!(:command, "thirdparty/foo/hello")
+    expect(Homebrew::Trust).to receive(:untrust!).with(:tap, "thirdparty/foo").and_return(false)
+    allow(Homebrew::Trust).to receive(:trusted_entries).with(:formula).and_return(["thirdparty/foo/bar"])
+    allow(Homebrew::Trust).to receive(:trusted_entries).with(:cask).and_return(["thirdparty/foo/baz"])
+    allow(Homebrew::Trust).to receive(:trusted_entries).with(:command).and_return(["thirdparty/foo/hello"])
+    expect(Homebrew::Trust).to receive(:untrust!).with(:formula, "thirdparty/foo/bar").and_return(true)
+    expect(Homebrew::Trust).to receive(:untrust!).with(:cask, "thirdparty/foo/baz").and_return(true)
+    expect(Homebrew::Trust).to receive(:untrust!).with(:command, "thirdparty/foo/hello").and_return(true)
 
     expect { Homebrew::Cmd::Untrust.new(["thirdparty/foo"]).run }
       .to output("Untrusted tap: thirdparty/foo\n").to_stdout
-
-    expect(Homebrew::Trust.trusted?(:formula, "thirdparty/foo/bar")).to be(false)
-    expect(Homebrew::Trust.trusted?(:cask, "thirdparty/foo/baz")).to be(false)
-    expect(Homebrew::Trust.trusted?(:command, "thirdparty/foo/hello")).to be(false)
-  ensure
-    Homebrew::Trust.clear!(:formula)
-    Homebrew::Trust.clear!(:cask)
-    Homebrew::Trust.clear!(:command)
   end
 
   it "lists untrusted entries with no arguments" do
-    tap = Tap.fetch("thirdparty", "foo")
+    tap = Tap.fetch("untrustlist", "foo")
     tap.cask_dir.mkpath
     (tap.cask_dir/"bar.rb").write("cask 'bar'\n")
 
     expect { Homebrew::Cmd::Untrust.new([]).run }
       .to output(<<~EOS).to_stdout
         Untrusted taps:
-          thirdparty/foo
+          untrustlist/foo
         Untrusted casks:
-          thirdparty/foo/bar
+          untrustlist/foo/bar
       EOS
   ensure
-    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"untrustlist"
   end
 end

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -139,7 +139,9 @@ RSpec.describe Homebrew::Diagnostic::Checks do
           "Homebrew is currently ignoring formulae, casks and commands from these taps " \
           "because tap trust is required.",
           "brew untap thirdparty/foo",
+          "brew trust thirdparty/foo",
           "brew trust --formula thirdparty/foo/bar",
+          "Prefer trusting only the specific formulae, casks or commands you need.",
         )
     end
   end
@@ -154,9 +156,13 @@ RSpec.describe Homebrew::Diagnostic::Checks do
         .to include(
           "Homebrew will ignore formulae, casks and commands from these taps when " \
           "`HOMEBREW_REQUIRE_TAP_TRUST` is set.",
-          "This will become the default in a future release.",
-          "Set `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` to keep allowing them by default.",
+          "This will become the default in Homebrew 6.0.0 or 5.2.0, whichever comes first.",
+          "export HOMEBREW_REQUIRE_TAP_TRUST=1",
           "brew untap thirdparty/foo",
+          "brew trust thirdparty/foo",
+          "export HOMEBREW_NO_REQUIRE_TAP_TRUST=1",
+          "This is not recommended and will be removed in a later release.",
+          "Prefer trusting only the specific formulae, casks or commands you need.",
         )
     end
   end

--- a/Library/Homebrew/test/install_spec.rb
+++ b/Library/Homebrew/test/install_spec.rb
@@ -1,0 +1,24 @@
+# typed: true
+# frozen_string_literal: true
+
+require "install"
+
+RSpec.describe Homebrew::Install do
+  specify "::perform_preinstall_checks runs non-fatal preinstall diagnostics" do
+    allow(Homebrew::Install).to receive(:check_prefix)
+    allow(Homebrew::Install).to receive(:check_cpu)
+    allow(Homebrew::Install).to receive(:attempt_directory_creation)
+
+    expect(Homebrew::Diagnostic).to receive(:checks)
+      .with(:supported_configuration_checks, fatal: false)
+      .ordered
+    expect(Homebrew::Diagnostic).to receive(:checks)
+      .with(:preinstall_checks, fatal: false)
+      .ordered
+    expect(Homebrew::Diagnostic).to receive(:checks)
+      .with(:fatal_preinstall_checks)
+      .ordered
+
+    Homebrew::Install.send(:perform_preinstall_checks)
+  end
+end

--- a/Library/Homebrew/test/test_bot/test_cleanup_spec.rb
+++ b/Library/Homebrew/test/test_bot/test_cleanup_spec.rb
@@ -3,40 +3,63 @@
 
 require "dev-cmd/test-bot"
 
-RSpec.describe Homebrew::TestBot::CleanupAfter do
-  sig { returns(T.class_of(Homebrew::TestBot::CleanupAfter)) }
-  let(:klass) { Homebrew::TestBot::CleanupAfter }
+RSpec.describe Homebrew::TestBot do
+  describe Homebrew::TestBot::CleanupAfter do
+    sig { returns(T.class_of(Homebrew::TestBot::CleanupAfter)) }
+    let(:klass) { Homebrew::TestBot::CleanupAfter }
 
-  # Regression test: checkout_branch_if_needed, reset_if_needed, and clean_if_needed
-  # expect a String (repository path). Passing HOMEBREW_REPOSITORY (Pathname) would cause
-  # "Parameter 'repository': Expected type String, got type Pathname" in strict typing.
-  describe "#run!" do
-    it "passes a String to checkout_branch_if_needed, reset_if_needed, and clean_if_needed when tap is set" do
-      cleanup = klass.new(
-        tap:       CoreTap.instance,
-        git:       "git",
-        dry_run:   true,
-        fail_fast: false,
-        verbose:   false,
-      )
+    # Regression test: checkout_branch_if_needed, reset_if_needed, and clean_if_needed
+    # expect a String (repository path). Passing HOMEBREW_REPOSITORY (Pathname) would cause
+    # "Parameter 'repository': Expected type String, got type Pathname" in strict typing.
+    describe "#run!" do
+      it "passes a String to checkout_branch_if_needed, reset_if_needed, and clean_if_needed when tap is set" do
+        cleanup = klass.new(
+          tap:       CoreTap.instance,
+          git:       "git",
+          dry_run:   true,
+          fail_fast: false,
+          verbose:   false,
+        )
 
-      # Stub to avoid actual filesystem and process operations.
-      allow(FileUtils).to receive(:chmod_R)
-      allow(cleanup).to receive(:info_header)
-      allow(cleanup).to receive(:delete_or_move)
-      allow(cleanup).to receive(:test)
-      allow(cleanup).to receive_messages(repository:   Pathname.new("/nonexistent_#{SecureRandom.hex(8)}"),
-                                         quiet_system: false)
-      allow(Keg).to receive(:must_be_writable_directories).and_return([])
-      allow(Pathname).to receive(:glob).and_return([])
+        # Stub to avoid actual filesystem and process operations.
+        allow(FileUtils).to receive(:chmod_R)
+        allow(cleanup).to receive(:info_header)
+        allow(cleanup).to receive(:delete_or_move)
+        allow(cleanup).to receive(:test)
+        allow(cleanup).to receive_messages(repository:   Pathname.new("/nonexistent_#{SecureRandom.hex(8)}"),
+                                           quiet_system: false)
+        allow(Keg).to receive(:must_be_writable_directories).and_return([])
+        allow(Pathname).to receive(:glob).and_return([])
 
-      expect(cleanup).to receive(:checkout_branch_if_needed).with(String)
-      expect(cleanup).to receive(:reset_if_needed).with(String)
-      expect(cleanup).to receive(:clean_if_needed).with(String)
+        expect(cleanup).to receive(:checkout_branch_if_needed).with(String)
+        expect(cleanup).to receive(:reset_if_needed).with(String)
+        expect(cleanup).to receive(:clean_if_needed).with(String)
 
-      args = double(test_default_formula?: false, local?: false)
-      with_env("HOMEBREW_GITHUB_ACTIONS" => nil, "GITHUB_ACTIONS" => nil) do
-        cleanup.run!(args:)
+        args = double(test_default_formula?: false, local?: false)
+        with_env("HOMEBREW_GITHUB_ACTIONS" => nil, "GITHUB_ACTIONS" => nil) do
+          cleanup.run!(args:)
+        end
+      end
+    end
+  end
+
+  describe Homebrew::TestBot::CleanupBefore do
+    describe "#untap_untrusted_taps" do
+      it "does not untap the tap being tested" do
+        current_tap = instance_double(Tap, name: "current/tap", path: HOMEBREW_TAP_DIRECTORY/"current/homebrew-tap")
+        other_tap = instance_double(Tap, name: "other/tap")
+        cleanup = Homebrew::TestBot::CleanupBefore.new(
+          tap:       current_tap,
+          git:       "git",
+          dry_run:   true,
+          fail_fast: false,
+          verbose:   false,
+        )
+        allow(Homebrew::Trust).to receive(:untrusted_taps).and_return([current_tap, other_tap])
+
+        expect(cleanup).to receive(:test).with("brew", "untap", "other/tap")
+
+        cleanup.untap_untrusted_taps
       end
     end
   end

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -93,13 +93,14 @@ RSpec.describe Homebrew::Trust do
     Homebrew::Trust.clear!(:tap)
   end
 
-  it "allows third-party taps by default with an env hint" do
+  it "allows third-party taps by default" do
+    Homebrew::Trust.clear!(:tap)
     tap = Tap.fetch("thirdparty", "foo")
     formula_path = tap.formula_dir/"default-trust.rb"
     formula_path.dirname.mkpath
 
     expect { Homebrew::Trust.require_trusted_formula!("default-trust", formula_path) }
-      .to output(%r{Tap thirdparty/foo is allowed by default}).to_stderr
+      .not_to output.to_stderr
 
     expect(Homebrew::Trust.trusted?(:tap, "thirdparty/foo")).to be(false)
   ensure

--- a/Library/Homebrew/test_bot/cleanup_before.rb
+++ b/Library/Homebrew/test_bot/cleanup_before.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "trust"
+
 module Homebrew
   module TestBot
     class CleanupBefore < TestCleanup
@@ -17,6 +19,7 @@ module Homebrew
         if ENV["HOMEBREW_GITHUB_ACTIONS"] && !ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"]
           # minimally fix brew doctor failures (a full clean takes ~5m)
           cleanup_github_actions_hosted_runner
+          untap_untrusted_taps
           test "brew", "cleanup", "--prune-prefix"
         end
 
@@ -27,6 +30,14 @@ module Homebrew
 
       sig { void }
       def cleanup_github_actions_hosted_runner; end
+
+      sig { void }
+      def untap_untrusted_taps
+        taps_to_untap = Homebrew::Trust.untrusted_taps.reject { |untrusted_tap| untrusted_tap.name == tap&.name }
+        return if taps_to_untap.empty?
+
+        test "brew", "untap", *taps_to_untap.map(&:name)
+      end
     end
   end
 end

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -107,7 +107,7 @@ module Homebrew
       full_name = "#{tap.name}/#{::Utils.name_from_full_name(name)}"
       return if trusted?(:formula, full_name)
       return if explicitly_allowed?(:formula, full_name, tap)
-      return allow_by_default!(tap) unless Homebrew::EnvConfig.require_tap_trust?
+      return unless Homebrew::EnvConfig.require_tap_trust?
 
       raise_untrusted!(:formula, full_name, tap)
     end
@@ -121,7 +121,7 @@ module Homebrew
       full_name = "#{tap.name}/#{::Utils.name_from_full_name(token)}"
       return if trusted?(:cask, full_name)
       return if explicitly_allowed?(:cask, full_name, tap)
-      return allow_by_default!(tap) unless Homebrew::EnvConfig.require_tap_trust?
+      return unless Homebrew::EnvConfig.require_tap_trust?
 
       raise_untrusted!(:cask, full_name, tap)
     end
@@ -134,7 +134,7 @@ module Homebrew
 
       full_name = "#{tap.name}/#{command || path.basename(path.extname).to_s.delete_prefix("brew-")}"
       return if trusted?(:command, full_name)
-      return allow_by_default!(tap) unless Homebrew::EnvConfig.require_tap_trust?
+      return unless Homebrew::EnvConfig.require_tap_trust?
 
       raise_untrusted!(:command, full_name, tap)
     end
@@ -293,21 +293,6 @@ module Homebrew
       TRUST_FILE.chmod(0600)
     end
     private_class_method :write_trust_store
-
-    sig { params(tap: T.untyped).returns(T::Boolean) }
-    def self.allow_by_default!(tap)
-      unless Homebrew::EnvConfig.no_env_hints?
-        opoo <<~EOS
-          Tap #{tap.name} is allowed by default.
-          Homebrew will require explicit trust for non-official taps in a future release.
-          Set `HOMEBREW_REQUIRE_TAP_TRUST=1` to require explicit trust now or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` to keep allowing by default.
-          Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
-        EOS
-      end
-
-      true
-    end
-    private_class_method :allow_by_default!
 
     sig { params(path: Pathname).returns(T.untyped) }
     def self.tap_from_path(path)

--- a/docs/How-to-Create-and-Maintain-a-Tap.md
+++ b/docs/How-to-Create-and-Maintain-a-Tap.md
@@ -89,6 +89,8 @@ Cloning into '/opt/homebrew/Library/Taps/alice/homebrew-tap'...
 ```
 
 This is the most convenient method for users as it requires only one command.
+It also trusts only the formula being installed. See [Tap Trust](Tap-Trust.md)
+for more information.
 
 ### Manual tap installation
 
@@ -108,6 +110,10 @@ After tapping, users can install your formulae either with:
 
 - `brew install foo` if there's no core formula with the same name
 - `brew install user/repository/foo` to avoid conflicts with core formulae
+
+Users who install by short name will need to run `brew trust user/repository`
+first when Homebrew requires explicit trust for non-official taps, in
+Homebrew 6.0.0 or 5.2.0, whichever comes first.
 
 ## Maintaining a tap
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -5290,6 +5290,12 @@ command execution (e.g. `$(cat file)`).
 : If set, `brew info` and `brew install` will not warn when a formula's
   executables are shadowed by other commands earlier on `$PATH`.
 
+`HOMEBREW_NO_REQUIRE_TAP_TRUST`
+
+: If set, do not require non-official tap formulae, casks or commands to be
+  trusted. This is not recommended and will be removed in a later release. Also
+  enables commands that evaluate all formulae and casks.
+
 `HOMEBREW_NO_SANDBOX_CASK`
 
 : If set, disable sandboxing for cask artifacts that generate files by running
@@ -5323,6 +5329,12 @@ command execution (e.g. `$(cat file)`).
 `HOMEBREW_PRY`
 
 : If set, use Pry for the `brew irb` command.
+
+`HOMEBREW_REQUIRE_TAP_TRUST`
+
+: If set, require non-official tap formulae, casks and commands to be trusted
+  with `brew trust` before Homebrew loads them. Also enables commands that
+  evaluate all formulae and casks.
 
 `HOMEBREW_SANDBOX_LINUX`
 

--- a/docs/Tap-Trust.md
+++ b/docs/Tap-Trust.md
@@ -1,0 +1,104 @@
+---
+last_review_date: "2026-06-01"
+---
+
+# Tap Trust
+
+Homebrew taps can contain formulae, casks and external commands. Loading them
+can run Ruby code from the tap, so Homebrew distinguishes between official taps
+and non-official taps that you have explicitly trusted.
+
+Official Homebrew taps and Homebrew's built-in commands are always trusted.
+Non-official taps are currently allowed by default, but Homebrew will require
+explicit trust for them in Homebrew 6.0.0 or 5.2.0, whichever comes first.
+`brew doctor` warns about non-official taps that are not trusted, and install
+commands may print a warning before installing from them.
+
+## Why tap trust exists
+
+Formulae, casks and external commands are executable package definitions, not
+plain metadata. Homebrew sometimes needs to evaluate Ruby code from a tap to
+resolve dependencies, discover available packages or run commands. Trusting a
+tap means you accept that code running with your user's privileges whenever
+Homebrew needs to load it.
+
+Tap trust reduces the amount of non-official code Homebrew evaluates by
+default. This limits the impact of compromised tap repositories, unexpected
+repository ownership changes, name collisions with packages from other taps and
+commands that are loaded just because their tap is present. It also makes
+automation clearer: scripts can trust exactly the tap, formula, cask or command
+they intend to use instead of relying on every tapped repository being loaded.
+
+Prefer trusting the specific formula, cask or command you need. Trust a whole
+tap only when you are comfortable with all current and future formulae, casks
+and external commands from that tap being loaded by Homebrew.
+
+## Installing from a tap
+
+Installing a fully-qualified formula or cask name trusts only that item:
+
+```sh
+brew install user/repo/formula
+brew install --cask user/repo/cask
+```
+
+To install by short name from a tapped repository, trust the specific item
+first:
+
+```sh
+brew tap user/repo
+brew trust --formula user/repo/formula
+brew install formula
+```
+
+Use `brew trust --cask user/repo/cask` for casks and
+`brew trust --command user/repo/command` for external commands.
+
+You can also trust the whole tap:
+
+```sh
+brew tap user/repo
+brew trust user/repo
+brew install formula
+```
+
+Whole-tap trust is broader. It allows Homebrew to load every current and future
+formula, cask and external command from that tap. This may be appropriate for a
+tap you administer or rely on heavily, but for one-off installs, automation or
+software from a vendor you do not fully control, prefer trusting only the item
+you need.
+
+## Managing trust
+
+List trusted entries:
+
+```sh
+brew trust
+```
+
+List untrusted taps, formulae, casks and commands:
+
+```sh
+brew untrust
+```
+
+Stop trusting a tap or item:
+
+```sh
+brew untrust user/repo
+brew untrust --formula user/repo/formula
+```
+
+A trusted tap behaves as it did before tap trust checks were introduced. An
+untrusted tap is not loaded when tap trust is required, unless you explicitly
+install a fully-qualified formula or cask from that tap. If you trust only a
+specific formula, cask or command, Homebrew may load that item without trusting
+the rest of the tap.
+
+## Environment variables
+
+Set `HOMEBREW_REQUIRE_TAP_TRUST=1` to require explicit trust now.
+
+`HOMEBREW_NO_REQUIRE_TAP_TRUST=1` keeps allowing non-official taps by default
+during the transition. This is not recommended and will be removed in a later
+release.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3446,6 +3446,9 @@ If set, \fBbrew install\fP \fIformula|cask\fP will not upgrade \fIformula|cask\f
 \fBHOMEBREW_NO_PATH_SHADOW_CHECK\fP
 If set, \fBbrew info\fP and \fBbrew install\fP will not warn when a formula\[u2019]s executables are shadowed by other commands earlier on \fB$PATH\fP\&\.
 .TP
+\fBHOMEBREW_NO_REQUIRE_TAP_TRUST\fP
+If set, do not require non\-official tap formulae, casks or commands to be trusted\. This is not recommended and will be removed in a later release\. Also enables commands that evaluate all formulae and casks\.
+.TP
 \fBHOMEBREW_NO_SANDBOX_CASK\fP
 If set, disable sandboxing for cask artifacts that generate files by running executables\.
 .TP
@@ -3470,6 +3473,9 @@ If set, \fBbrew install\fP \fIformula\fP will use this URL to download PyPI pack
 .TP
 \fBHOMEBREW_PRY\fP
 If set, use Pry for the \fBbrew irb\fP command\.
+.TP
+\fBHOMEBREW_REQUIRE_TAP_TRUST\fP
+If set, require non\-official tap formulae, casks and commands to be trusted with \fBbrew trust\fP before Homebrew loads them\. Also enables commands that evaluate all formulae and casks\.
 .TP
 \fBHOMEBREW_SANDBOX_LINUX\fP
 If set, use the \fBbwrap\fP(1) sandbox for formula installation and testing on Linux\. Enabled by default if \fB$HOMEBREW_DEVELOPER\fP is set\. This will be the default in Homebrew 5\.2\.0\.


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22494

- keep `brew doctor` visibility while moving install-time hints to non-fatal preinstall diagnostics
- document why explicit trust matters before the default changes in Homebrew 6.0.0 or 5.2.0
- clean untrusted hosted-runner taps before test-bot setup so unrelated runner state does not fail `brew doctor`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
