### PR TITLE
Handle stale reinstall kegs

### DIFF
--- a/Library/Homebrew/reinstall/reinstall.rb
+++ b/Library/Homebrew/reinstall/reinstall.rb
@@ -119,6 +119,7 @@ module Homebrew
       def backup(keg)
         keg.unlink
         begin
+          FileUtils.rm_r(backup_path(keg)) if backup_path(keg).exist?
           keg.rename backup_path(keg)
         rescue Errno::EACCES, Errno::ENOTEMPTY
           odie <<~EOS

--- a/Library/Homebrew/test/reinstall_spec.rb
+++ b/Library/Homebrew/test/reinstall_spec.rb
@@ -1,0 +1,27 @@
+# typed: true
+# frozen_string_literal: true
+
+require "reinstall"
+
+RSpec.describe Homebrew::Reinstall do
+  let(:klass) { Homebrew::Reinstall }
+
+  describe ".backup" do
+    it "removes a stale reinstall backup keg" do
+      keg_path = HOMEBREW_CELLAR/"testball/0.1"
+      (keg_path/"bin").mkpath
+      keg = Keg.new(keg_path)
+      backup = Pathname.new("#{keg}.reinstall")
+
+      (keg_path/"bin/test").write("current")
+      (backup/"bin").mkpath
+      (backup/"bin/test").write("stale")
+
+      klass.send(:backup, keg)
+
+      expect(keg_path).not_to exist
+      expect(backup/"bin/test").to exist
+      expect((backup/"bin/test").read).to eq("current")
+    end
+  end
+end


### PR DESCRIPTION
- Avoid blocking `brew reinstall` when a previous run left a `.reinstall` keg behind.
- Cover the backup path with a unit regression test using a non-empty backup keg.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
