### PR TITLE
Document XDG trust config

### DIFF
--- a/Library/Homebrew/cmd/trust.rb
+++ b/Library/Homebrew/cmd/trust.rb
@@ -11,6 +11,8 @@ module Homebrew
         description <<~EOS
           Trust non-official tap formulae, casks or commands so Homebrew may load them when
           `$HOMEBREW_REQUIRE_TAP_TRUST` is set.
+          Trusted entries are stored in `${XDG_CONFIG_HOME}/homebrew/trust.json` if
+          `$XDG_CONFIG_HOME` is set or `~/.homebrew/trust.json` otherwise.
         EOS
         switch "--tap",
                description: "Trust the named tap."

--- a/Library/Homebrew/cmd/untrust.rb
+++ b/Library/Homebrew/cmd/untrust.rb
@@ -10,6 +10,8 @@ module Homebrew
       cmd_args do
         description <<~EOS
           Stop trusting non-official tap formulae, casks or commands.
+          Trusted entries are stored in `${XDG_CONFIG_HOME}/homebrew/trust.json` if
+          `$XDG_CONFIG_HOME` is set or `~/.homebrew/trust.json` otherwise.
         EOS
         switch "--tap",
                description: "Untrust the named tap."

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -14,7 +14,9 @@ module Homebrew
           Check for newer versions of formulae and/or casks from upstream.
           If no formula or cask argument is passed, the list of formulae and
           casks to check is taken from `$HOMEBREW_LIVECHECK_WATCHLIST` or
-          `~/.homebrew/livecheck_watchlist.txt`.
+          `${XDG_CONFIG_HOME}/homebrew/livecheck_watchlist.txt` if
+          `$XDG_CONFIG_HOME` is set or `~/.homebrew/livecheck_watchlist.txt`
+          otherwise.
         EOS
         switch "--full-name",
                description: "Print formulae and casks with fully-qualified names."


### PR DESCRIPTION
Closes https://github.com/Homebrew/brew/issues/22504
It was already working, just not clearly documented.


- Explain the `trust.json` path in `brew trust` and `brew untrust` help so users can find the stored policy file.
- Keep documenting `livecheck_watchlist.txt` consistently with `HOMEBREW_USER_CONFIG_HOME` startup behaviour.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
