### PR TITLE
Skip sandbox setup for syntax-only jobs

### DIFF
--- a/Library/Homebrew/test/test_bot_spec.rb
+++ b/Library/Homebrew/test/test_bot_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe Homebrew::TestBot do
         git_email:      nil,
       )
 
+      allow(args).to receive_messages(only_cleanup_before?:  false,
+                                      only_setup?:           false,
+                                      only_tap_syntax?:      false,
+                                      only_formulae_detect?: false,
+                                      only_bottles_fetch?:   false,
+                                      only_cleanup_after?:   false)
       allow(klass).to receive(:setup_github_actions_sandbox!)
       allow(Utils).to receive(:safe_popen_read).and_return("revision")
       allow(Homebrew::TestBot::TestRunner).to receive(:run!).and_return(true)
@@ -47,6 +53,12 @@ RSpec.describe Homebrew::TestBot do
         git_email:      nil,
       )
 
+      allow(args).to receive_messages(only_cleanup_before?:  false,
+                                      only_setup?:           false,
+                                      only_tap_syntax?:      false,
+                                      only_formulae_detect?: false,
+                                      only_bottles_fetch?:   false,
+                                      only_cleanup_after?:   false)
       allow(klass).to receive(:setup_github_actions_sandbox!)
       allow(Utils).to receive(:safe_popen_read).and_return("revision")
       allow(Homebrew::TestBot::TestRunner).to receive(:run!).and_return(true)
@@ -69,6 +81,70 @@ RSpec.describe Homebrew::TestBot do
     ensure
       Homebrew::Trust.clear!(:tap)
       FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+
+    it "does not set up the sandbox for only runs without sandboxed code" do
+      allow(klass).to receive(:local?).and_return(false)
+      allow(Utils).to receive(:safe_popen_read).and_return("revision")
+      allow(Homebrew::TestBot::TestRunner).to receive(:run!).and_return(true)
+
+      expect(klass).not_to receive(:setup_github_actions_sandbox!)
+
+      [
+        :only_cleanup_before?,
+        :only_setup?,
+        :only_tap_syntax?,
+        :only_formulae_detect?,
+        :only_bottles_fetch?,
+        :only_cleanup_after?,
+      ].each do |only_arg|
+        args = double(
+          cleanup?:       false,
+          local?:         false,
+          tap:            nil,
+          only_formulae?: false,
+          git_name:       nil,
+          git_email:      nil,
+        )
+        allow(args).to receive_messages(only_cleanup_before?:  false,
+                                        only_setup?:           false,
+                                        only_tap_syntax?:      false,
+                                        only_formulae_detect?: false,
+                                        only_bottles_fetch?:   false,
+                                        only_cleanup_after?:   false,
+                                        only_arg => true)
+
+        klass.run!(args)
+      end
+    end
+
+    it "sets up the sandbox for formulae runs" do
+      allow(klass).to receive(:local?).and_return(false)
+      allow(Utils).to receive(:safe_popen_read).and_return("revision")
+      allow(Homebrew::TestBot::TestRunner).to receive(:run!).and_return(true)
+
+      expect(klass).to receive(:setup_github_actions_sandbox!).twice
+
+      [:only_formulae?, :only_formulae_dependents?].each do |only_arg|
+        args = double(
+          cleanup?:       false,
+          local?:         false,
+          tap:            nil,
+          only_formulae?: only_arg == :only_formulae?,
+          git_name:       nil,
+          git_email:      nil,
+        )
+
+        allow(args).to receive_messages(only_cleanup_before?:      false,
+                                        only_setup?:               false,
+                                        only_tap_syntax?:          false,
+                                        only_formulae_detect?:     false,
+                                        only_formulae_dependents?: only_arg == :only_formulae_dependents?,
+                                        only_bottles_fetch?:       false,
+                                        only_cleanup_after?:       false)
+
+        klass.run!(args)
+      end
     end
   end
 

--- a/Library/Homebrew/test_bot.rb
+++ b/Library/Homebrew/test_bot.rb
@@ -117,7 +117,14 @@ module Homebrew
         FileUtils.cp trust_file, ENV.fetch("HOMEBREW_USER_CONFIG_HOME") if trust_file.exist?
       end
 
-      setup_github_actions_sandbox!
+      if !args.only_cleanup_before? &&
+         !args.only_setup? &&
+         !args.only_tap_syntax? &&
+         !args.only_formulae_detect? &&
+         !args.only_bottles_fetch? &&
+         !args.only_cleanup_after?
+        setup_github_actions_sandbox!
+      end
 
       tap = resolve_test_tap(args.tap)
 


### PR DESCRIPTION
- Avoid Bubblewrap configuration for `test-bot` modes that do not run sandboxed formula install or test commands.
- Keep sandbox setup for formula-only jobs because they can execute sandboxed formula work.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
