### PR TITLE
Fix test-bot tap trust config home

### DIFF
--- a/Library/Homebrew/test/test_bot_spec.rb
+++ b/Library/Homebrew/test/test_bot_spec.rb
@@ -24,10 +24,48 @@ RSpec.describe Homebrew::TestBot do
       allow(Utils).to receive(:safe_popen_read).and_return("revision")
       allow(Homebrew::TestBot::TestRunner).to receive(:run!).and_return(true)
 
-      expect { klass.run!(args) }.to output(%r{==> Trusted tap: thirdparty/foo}).to_stdout
-      expect(Homebrew::Trust.trusted?(:tap, "thirdparty/foo")).to be(true)
+      mktmpdir do |workdir|
+        with_env(HOMEBREW_USER_CONFIG_HOME: "#{workdir}/.homebrew") do
+          expect { klass.run!(args) }.to output(%r{==> Trusted tap: thirdparty/foo}).to_stdout
+          expect(Homebrew::Trust.trusted?(:tap, "thirdparty/foo")).to be(true)
+        end
+      end
     ensure
-      Homebrew::Trust.clear!(:tap)
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+
+    it "trusts a third-party tap in the local test-bot config home" do
+      tap = Tap.fetch("thirdparty", "foo")
+      tap.path.mkpath
+      args = double(
+        cleanup?:       false,
+        local?:         true,
+        tap:            tap.name,
+        only_formulae?: false,
+        git_name:       nil,
+        git_email:      nil,
+      )
+
+      allow(klass).to receive(:setup_github_actions_sandbox!)
+      allow(Utils).to receive(:safe_popen_read).and_return("revision")
+      allow(Homebrew::TestBot::TestRunner).to receive(:run!).and_return(true)
+
+      mktmpdir do |workdir|
+        workdir.cd do
+          with_env(
+            HOMEBREW_USER_CONFIG_HOME: "#{workdir}/original/.homebrew",
+            HOME:                      "#{workdir}/original",
+            XDG_CONFIG_HOME:           "#{workdir}/xdg",
+          ) do
+            expect { klass.run!(args) }.to output(%r{==> Trusted tap: thirdparty/foo}).to_stdout
+
+            trust_file = workdir/"home/.homebrew/trust.json"
+            expect(trust_file).to exist
+            expect(JSON.parse(trust_file.read).fetch("trustedtaps")).to include("thirdparty/foo")
+          end
+        end
+      end
+    ensure
       FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
     end
   end

--- a/Library/Homebrew/test/test_bot_spec.rb
+++ b/Library/Homebrew/test/test_bot_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Homebrew::TestBot do
         end
       end
     ensure
+      Homebrew::Trust.clear!(:tap)
       FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
     end
 
@@ -66,6 +67,7 @@ RSpec.describe Homebrew::TestBot do
         end
       end
     ensure
+      Homebrew::Trust.clear!(:tap)
       FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
     end
   end

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -25,13 +25,14 @@ RSpec.describe Homebrew::Trust do
   end
 
   it "ignores a trust file with a non-object JSON root" do
-    trust_file = Homebrew::Trust.send(:trust_file)
+    trust_file = T.let(nil, T.nilable(Pathname))
+    trust_file = Homebrew::Trust.trust_file
     trust_file.dirname.mkpath
     trust_file.write("[]")
 
     expect(Homebrew::Trust.trusted?(:tap, "thirdparty/foo")).to be(false)
   ensure
-    trust_file&.unlink if trust_file&.exist?
+    trust_file.unlink if trust_file&.exist?
   end
 
   it "untrusts third-party taps" do
@@ -87,7 +88,7 @@ RSpec.describe Homebrew::Trust do
   it "writes the trust store with user-only permissions" do
     Homebrew::Trust.trust!(:tap, "thirdparty/foo")
 
-    trust_file = Homebrew::Trust.send(:trust_file)
+    trust_file = Homebrew::Trust.trust_file
     expect(trust_file.stat.mode & 0777).to eq(0600)
   ensure
     Homebrew::Trust.clear!(:tap)

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Homebrew::Trust do
   end
 
   it "ignores a trust file with a non-object JSON root" do
-    trust_file = Homebrew::Trust.const_get(:TRUST_FILE)
+    trust_file = Homebrew::Trust.send(:trust_file)
     trust_file.dirname.mkpath
     trust_file.write("[]")
 
@@ -87,7 +87,7 @@ RSpec.describe Homebrew::Trust do
   it "writes the trust store with user-only permissions" do
     Homebrew::Trust.trust!(:tap, "thirdparty/foo")
 
-    trust_file = Homebrew::Trust.const_get(:TRUST_FILE)
+    trust_file = Homebrew::Trust.send(:trust_file)
     expect(trust_file.stat.mode & 0777).to eq(0600)
   ensure
     Homebrew::Trust.clear!(:tap)

--- a/Library/Homebrew/test_bot.rb
+++ b/Library/Homebrew/test_bot.rb
@@ -106,12 +106,15 @@ module Homebrew
         home = "#{Dir.pwd}/home"
         logs = "#{Dir.pwd}/logs"
         gitconfig = "#{Dir.home}/.gitconfig"
+        trust_file = Homebrew::Trust.trust_file
         ENV["HOMEBREW_HOME"] = ENV["HOME"] = home
         ENV["HOMEBREW_USER_CONFIG_HOME"] = "#{home}/.homebrew"
         ENV["HOMEBREW_LOGS"] = logs
         FileUtils.mkdir_p home
+        FileUtils.mkdir_p ENV.fetch("HOMEBREW_USER_CONFIG_HOME")
         FileUtils.mkdir_p logs
         FileUtils.cp gitconfig, home if File.exist?(gitconfig)
+        FileUtils.cp trust_file, ENV.fetch("HOMEBREW_USER_CONFIG_HOME") if trust_file.exist?
       end
 
       setup_github_actions_sandbox!

--- a/Library/Homebrew/test_bot.rb
+++ b/Library/Homebrew/test_bot.rb
@@ -107,6 +107,7 @@ module Homebrew
         logs = "#{Dir.pwd}/logs"
         gitconfig = "#{Dir.home}/.gitconfig"
         ENV["HOMEBREW_HOME"] = ENV["HOME"] = home
+        ENV["HOMEBREW_USER_CONFIG_HOME"] = "#{home}/.homebrew"
         ENV["HOMEBREW_LOGS"] = logs
         FileUtils.mkdir_p home
         FileUtils.mkdir_p logs

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -21,8 +21,11 @@ module Homebrew
     }.freeze, T::Hash[Symbol, Symbol])
     private_constant :SETTING_KEYS
 
-    TRUST_FILE = T.let((Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME"))/"trust.json").freeze, Pathname)
-    private_constant :TRUST_FILE
+    sig { returns(Pathname) }
+    def self.trust_file
+      Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME"))/"trust.json"
+    end
+    private_class_method :trust_file
 
     sig { params(type: Symbol, name: String).returns(T::Boolean) }
     def self.trust!(type, name)
@@ -270,9 +273,10 @@ module Homebrew
 
     sig { returns(T::Hash[String, T::Array[String]]) }
     def self.trust_store
-      return {} unless TRUST_FILE.exist?
+      trust_path = trust_file
+      return {} unless trust_path.exist?
 
-      parsed_store = JSON.parse(TRUST_FILE.read)
+      parsed_store = JSON.parse(trust_path.read)
       return {} unless parsed_store.is_a?(Hash)
 
       parsed_store.transform_values { |entries| Array(entries).map { |entry| normalise_name(entry.to_s) } }
@@ -283,14 +287,15 @@ module Homebrew
 
     sig { params(store: T::Hash[String, T::Array[String]]).void }
     def self.write_trust_store(store)
+      trust_path = trust_file
       if store.empty?
-        TRUST_FILE.unlink if TRUST_FILE.exist?
+        trust_path.unlink if trust_path.exist?
         return
       end
 
-      TRUST_FILE.dirname.mkpath
-      TRUST_FILE.atomic_write("#{JSON.pretty_generate(store)}\n")
-      TRUST_FILE.chmod(0600)
+      trust_path.dirname.mkpath
+      trust_path.atomic_write("#{JSON.pretty_generate(store)}\n")
+      trust_path.chmod(0600)
     end
     private_class_method :write_trust_store
 

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -25,7 +25,6 @@ module Homebrew
     def self.trust_file
       Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME"))/"trust.json"
     end
-    private_class_method :trust_file
 
     sig { params(type: Symbol, name: String).returns(T::Boolean) }
     def self.trust!(type, name)


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22494

- Ensures test-bot writes tap trust data to the same `HOMEBREW_USER_CONFIG_HOME` that child brew commands use after test-bot switches HOME for local/GitHub Actions runs.
- Makes the trust file path dynamic instead of caching it at load time, so trust reads/writes follow the current config home.
- Fixes `brew test-bot --only-setup` failing at `brew doctor` with “The following taps are not trusted” after the tap was already trusted.

-----
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [X] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?
-----
- [X] AI was used to generate or assist with generating this PR.
OpenAI Codex 5.5 xhigh with local review and testing.
-----