### PR TITLE
Limit recursive Sorbet in test-bot

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -373,7 +373,14 @@ module Homebrew
         SimulateSystem.with(os: cask_audit_os, arch: cask_audit_arch) { Cask::CaskLoader.load(path) }
       end
 
-      sig { params(results: T::Hash[[Symbol, Pathname], T::Array[T::Hash[Symbol, T.untyped]]]).void }
+      sig {
+        params(
+          results: T::Hash[
+            T::Array[T.any(String, Pathname)],
+            T::Array[T::Hash[Symbol, T.untyped]],
+          ],
+        ).void
+      }
       def print_problems(results)
         results.each do |(name, path), problems|
           problem_lines = format_problem_lines(problems)

--- a/Library/Homebrew/test_bot/tap_syntax.rb
+++ b/Library/Homebrew/test_bot/tap_syntax.rb
@@ -23,10 +23,12 @@ module Homebrew
 
         return if tapped.formula_files.blank? && tapped.cask_files.blank?
 
-        test "brew", "readall", "--aliases", "--os=all", "--arch=all", tapped.name
+        # Recursive runtime checks are too slow for full-tap `readall` and `audit`.
+        without_recursive_sorbet = { "HOMEBREW_SORBET_RECURSIVE" => nil }
+        test "brew", "readall", "--aliases", "--os=all", "--arch=all", tapped.name, env: without_recursive_sorbet
         return if args.stable?
 
-        test "brew", "audit", "--except=installed", "--tap=#{tapped.name}"
+        test "brew", "audit", "--except=installed", "--tap=#{tapped.name}", env: without_recursive_sorbet
       end
     end
   end


### PR DESCRIPTION
- Unset `HOMEBREW_SORBET_RECURSIVE` for full-tap `readall` and `audit` because recursive runtime checks are too slow there.
- Allow nil `test-bot` env values so child commands can clear inherited variables when needed.
- Match `audit` problem result types to avoid runtime failures under recursive Sorbet checks.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
