### PR TITLE
Create service path directories

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -394,6 +394,20 @@ module Homebrew
       !@run.empty?
     end
 
+    sig { returns(T::Array[Pathname]) }
+    def path_dirs
+      [
+        path_dir(@working_dir),
+        path_dir(@root_dir),
+      ].push(
+        path_parent_dir(@input_path),
+        path_parent_dir(@log_path),
+        path_parent_dir(@error_log_path),
+      )
+       .compact
+       .uniq
+    end
+
     # Returns the `String` command to run manually instead of the service.
     sig { returns(String) }
     def manual_command
@@ -680,6 +694,19 @@ module Homebrew
             .gsub(HOMEBREW_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
             .gsub(HOMEBREW_CELLAR_PLACEHOLDER, HOMEBREW_CELLAR)
             .gsub(HOMEBREW_HOME_PLACEHOLDER, Dir.home)
+    end
+
+    sig { params(path: T.nilable(String)).returns(T.nilable(Pathname)) }
+    def path_dir(path)
+      return if path.blank?
+      return unless path.start_with?("/", "~")
+
+      Pathname.new(File.expand_path(path))
+    end
+
+    sig { params(path: T.nilable(String)).returns(T.nilable(Pathname)) }
+    def path_parent_dir(path)
+      path_dir(path)&.dirname
     end
   end
 end

--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -380,11 +380,13 @@ module Homebrew
 
         if System.launchctl?
           file ||= enable ? service.dest : service.service_file
+          service.path_dirs.each(&:mkpath)
           launchctl_load(service, file:, enable:)
         elsif System.systemctl?
           # Systemctl loads based upon location so only install service
           # file when it is not installed. Used with the `run` command.
           install_service_file(service, file) unless service.dest.exist?
+          service.path_dirs.each(&:mkpath)
           systemd_load(service, enable:)
         end
 

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -67,6 +67,13 @@ module Homebrew
         @keep_alive ||= false
       end
 
+      sig { returns(T::Array[Pathname]) }
+      def path_dirs
+        return [] unless service?
+
+        load_service.path_dirs
+      end
+
       # service_name delegates with formula.plist_name or formula.service_name
       # for systemd (e.g., `homebrew.<formula>`).
       sig { returns(String) }

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -374,6 +374,28 @@ RSpec.describe Homebrew::Service do
     end
   end
 
+  describe "#path_dirs" do
+    it "returns directories needed by service paths" do
+      f = stub_formula do
+        service do
+          run [opt_bin/"beanstalkd", "-l", var/"run/beanstalkd.sock", "relative/path"]
+          error_log_path var/"log/beanstalkd.error.log"
+          log_path var/"log/beanstalkd.log"
+          input_path var/"in/beanstalkd"
+          root_dir var/"root"
+          working_dir var/"work"
+        end
+      end
+
+      expect(f.service.path_dirs).to contain_exactly(
+        HOMEBREW_PREFIX/"var/log",
+        HOMEBREW_PREFIX/"var/in",
+        HOMEBREW_PREFIX/"var/root",
+        HOMEBREW_PREFIX/"var/work",
+      )
+    end
+  end
+
   describe "#to_plist" do
     it "returns valid plist" do
       f = stub_formula do

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -437,6 +437,36 @@ RSpec.describe Homebrew::Services::Cli do
             service_name:     "service.name",
             service_startup?: false,
             service_file:     instance_double(Pathname, exist?: false),
+            path_dirs:        [],
+          ),
+          nil,
+          enable: false,
+        )
+      end.to output("==> Successfully ran `name` (label: service.name)\n").to_stdout
+    end
+
+    it "creates service path directories before loading" do
+      expect(Homebrew::Services::System).to receive(:launchctl?).once.and_return(true)
+      expect(Homebrew::Services::System).not_to receive(:systemctl?)
+      expect(Homebrew::Services::System).to receive(:root?).twice.and_return(false)
+
+      path_dirs = [
+        mktmpdir/"var/run",
+        mktmpdir/"var/log",
+      ]
+      expect(klass).to receive(:launchctl_load).once do
+        path_dirs.each { expect(it).to be_a_directory }
+      end
+
+      expect do
+        services_cli.service_load(
+          instance_double(
+            Homebrew::Services::FormulaWrapper,
+            name:             "name",
+            service_name:     "service.name",
+            service_startup?: false,
+            service_file:     instance_double(Pathname, exist?: false),
+            path_dirs:,
           ),
           nil,
           enable: false,
@@ -458,6 +488,7 @@ RSpec.describe Homebrew::Services::Cli do
             service_startup?: false,
             dest:             instance_double(Pathname, exist?: true),
             timed?:           false,
+            path_dirs:        [],
           ),
           nil,
           enable: false,
@@ -479,6 +510,7 @@ RSpec.describe Homebrew::Services::Cli do
             service_startup?: false,
             dest:             instance_double(Pathname, exist?: true),
             timed?:           false,
+            path_dirs:        [],
           ),
           nil,
           enable: true,


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22501

- Avoid service startup failures when explicit DSL paths need dirs
- Keep creation scoped to `service` block path fields
- Cover path inference and load-time creation in service specs

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
