### PR TITLE
Audit redundant service path setup

### DIFF
--- a/Library/Homebrew/rubocops/install_steps.rb
+++ b/Library/Homebrew/rubocops/install_steps.rb
@@ -13,11 +13,13 @@ module RuboCop
         include InstallStepsHelper
 
         CONFLICT_MSG = "`post_install` and `post_install_steps` cannot both be used."
+        REDUNDANT_SERVICE_PATH_DIRS_MSG = "`%<block>s` only creates directories created by `brew services`."
 
         sig { override.params(formula_nodes: FormulaNodes).void }
         def audit_formula(formula_nodes)
           return if (body_node = formula_nodes.body_node).nil?
 
+          service_path_dirs = service_path_dirs(find_block(body_node, :service))
           post_install_steps_block = find_block(body_node, :post_install_steps)
           post_install_method = find_method_def(body_node, :post_install)
           if post_install_steps_block && post_install_method
@@ -26,7 +28,12 @@ module RuboCop
           end
 
           audit_step_block(post_install_steps_block)
-          audit_post_install_method(post_install_method) if post_install_steps_block.nil?
+          add_redundant_service_path_dirs_offense(post_install_steps_block, service_path_dirs, :post_install_steps)
+          redundant_post_install = post_install_method.present? &&
+                                   redundant_service_path_dirs_block?(post_install_method, service_path_dirs,
+                                                                      :post_install)
+          add_redundant_service_path_dirs_offense(post_install_method, service_path_dirs, :post_install)
+          audit_post_install_method(post_install_method) if post_install_steps_block.nil? && !redundant_post_install
         end
 
         private
@@ -58,6 +65,154 @@ module RuboCop
               install_steps_block_source(:post_install_steps, step_lines, post_install_method.source_range.column),
             )
           end
+        end
+
+        sig {
+          params(
+            node:              T.nilable(RuboCop::AST::Node),
+            service_path_dirs: T::Array[InstallStepPath],
+            block_name:        Symbol,
+          ).void
+        }
+        def add_redundant_service_path_dirs_offense(node, service_path_dirs, block_name)
+          return if node.nil? || service_path_dirs.empty?
+          return unless redundant_service_path_dirs_block?(node, service_path_dirs, block_name)
+
+          add_offense(node, message: format(REDUNDANT_SERVICE_PATH_DIRS_MSG, block: block_name)) do |corrector|
+            corrector.remove(range_with_surrounding_space(range: node.source_range, side: :left))
+          end
+        end
+
+        sig {
+          params(
+            node:              RuboCop::AST::Node,
+            service_path_dirs: T::Array[InstallStepPath],
+            block_name:        Symbol,
+          ).returns(T::Boolean)
+        }
+        def redundant_service_path_dirs_block?(node, service_path_dirs, block_name)
+          body = if node.def_type?
+            T.cast(node, RuboCop::AST::DefNode).body
+          elsif node.block_type?
+            T.cast(node, RuboCop::AST::BlockNode).body
+          end
+          return false if body.nil?
+
+          direct_nodes = body.begin_type? ? body.child_nodes : [body]
+          direct_nodes.all? do |direct_node|
+            service_path_dirs.any? do |path_dir|
+              redundant_service_path_dir?(direct_node, path_dir, block_name)
+            end
+          end
+        end
+
+        sig {
+          params(
+            node:       RuboCop::AST::Node,
+            path_dir:   InstallStepPath,
+            block_name: Symbol,
+          ).returns(T::Boolean)
+        }
+        def redundant_service_path_dir?(node, path_dir, block_name)
+          return false unless node.send_type?
+
+          send_node = T.cast(node, RuboCop::AST::SendNode)
+          path = if block_name == :post_install && send_node.method_name == :mkpath && send_node.arguments.empty?
+            install_step_path(send_node.receiver)
+          else
+            return false unless [:mkdir, :mkdir_p].include?(send_node.method_name)
+
+            fileutils_receiver = block_name == :post_install &&
+                                 send_node.receiver&.const_type? &&
+                                 send_node.receiver&.const_name == "FileUtils"
+            return false if send_node.receiver.present? && !fileutils_receiver
+
+            install_step_path_with_base(send_node.arguments.first, send_node.last_argument, default_base: :var)
+          end
+          paths_match?(path, path_dir)
+        end
+
+        sig { params(block_node: T.nilable(RuboCop::AST::BlockNode)).returns(T::Array[InstallStepPath]) }
+        def service_path_dirs(block_node)
+          return [] if block_node.nil?
+
+          body = block_node.body
+          return [] if body.nil?
+
+          direct_nodes = body.begin_type? ? body.child_nodes : [body]
+          paths = direct_nodes.filter_map do |node|
+            next unless node.send_type?
+
+            send_node = T.cast(node, RuboCop::AST::SendNode)
+            next if send_node.receiver.present? || send_node.arguments.empty?
+
+            path = install_step_path(send_node.arguments.first)
+            case send_node.method_name
+            when :working_dir, :root_dir
+              path
+            when :input_path, :log_path, :error_log_path
+              path_parent(path)
+            end
+          end
+          paths.uniq { |path| path_key(path) }
+        end
+
+        sig {
+          params(
+            node:         T.nilable(RuboCop::AST::Node),
+            last_arg:     T.nilable(RuboCop::AST::Node),
+            default_base: Symbol,
+          ).returns(T.nilable(InstallStepPath))
+        }
+        def install_step_path_with_base(node, last_arg, default_base:)
+          path = install_step_path(node)
+          return if path.nil?
+
+          base = install_step_path_hash_base(last_arg)
+          return InstallStepPath.new(path: path.path, base:) if base
+          if path.base.nil? && !absolute_install_step_path?(path)
+            return InstallStepPath.new(path: path.path,
+                                       base: default_base)
+          end
+
+          path
+        end
+
+        sig { params(node: T.nilable(RuboCop::AST::Node)).returns(T.nilable(Symbol)) }
+        def install_step_path_hash_base(node)
+          return unless node&.hash_type?
+
+          T.cast(node, RuboCop::AST::HashNode).pairs.each do |pair|
+            key = pair.key
+            next unless key.sym_type?
+            next if T.cast(key, RuboCop::AST::SymbolNode).value != :base
+
+            value = pair.value
+            return T.cast(value, RuboCop::AST::SymbolNode).value if value.sym_type?
+          end
+          nil
+        end
+
+        sig { params(path: T.nilable(InstallStepPath)).returns(T.nilable(InstallStepPath)) }
+        def path_parent(path)
+          return if path.nil?
+
+          parent_path = Pathname.new(path.path).dirname.to_s
+          return if parent_path == "."
+
+          InstallStepPath.new(path: parent_path, base: path.base)
+        end
+
+        sig { params(path: T.nilable(InstallStepPath), other_path: InstallStepPath).returns(T::Boolean) }
+        def paths_match?(path, other_path)
+          return false if path.nil?
+
+          path_key(path) == path_key(other_path)
+        end
+
+        sig { params(path: InstallStepPath).returns([T.nilable(Symbol), String]) }
+        def path_key(path)
+          [path.base, path.path]
         end
       end
     end

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -109,4 +109,106 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
       end
     RUBY
   end
+
+  it "autocorrects redundant service path directories in `post_install`" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        def post_install
+        ^^^^^^^^^^^^^^^^ FormulaAudit/InstallSteps: `post_install` only creates directories created by `brew services`.
+          (var/"run/foo").mkpath
+          (var/"log/foo").mkpath
+        end
+
+        service do
+          run opt_bin/"foo"
+          working_dir var/"run/foo"
+          log_path var/"log/foo/out.log"
+          error_log_path var/"log/foo/err.log"
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        service do
+          run opt_bin/"foo"
+          working_dir var/"run/foo"
+          log_path var/"log/foo/out.log"
+          error_log_path var/"log/foo/err.log"
+        end
+      end
+    RUBY
+  end
+
+  it "autocorrects redundant service path directories in `post_install_steps`" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        post_install_steps do
+        ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/InstallSteps: `post_install_steps` only creates directories created by `brew services`.
+          mkdir_p "run/foo"
+          mkdir_p "log/foo"
+        end
+
+        service do
+          run opt_bin/"foo"
+          working_dir var/"run/foo"
+          log_path var/"log/foo/out.log"
+          error_log_path var/"log/foo/err.log"
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        service do
+          run opt_bin/"foo"
+          working_dir var/"run/foo"
+          log_path var/"log/foo/out.log"
+          error_log_path var/"log/foo/err.log"
+        end
+      end
+    RUBY
+  end
+
+  it "does not report mixed `post_install_steps` bodies" do
+    expect_no_offenses(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        post_install_steps do
+          mkdir_p "run/foo"
+          mkdir_p "state/foo"
+        end
+
+        service do
+          run opt_bin/"foo"
+          working_dir var/"run/foo"
+        end
+      end
+    RUBY
+  end
+
+  it "does not use runtime arguments as service path directories" do
+    expect_no_offenses(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        post_install_steps do
+          mkdir_p "run"
+        end
+
+        service do
+          run [opt_bin/"foo", "-s", var/"run/foo.sock"]
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Needs https://github.com/Homebrew/brew/pull/22512 merged first and be in a stable release.
Needs https://github.com/Homebrew/homebrew-core/pull/285882 to get 🟢 

- Detect `post_install` service path directory setup
- Detect `post_install_steps` service path directory setup
- Ignore service paths only present in runtime arguments

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
