### PR TITLE
Add rebuild step RuboCop checks

### DIFF
--- a/Library/Homebrew/rubocops/cask/install_steps.rb
+++ b/Library/Homebrew/rubocops/cask/install_steps.rb
@@ -60,7 +60,8 @@ module RuboCop
           step_lines = simple_install_step_lines(block_node.body,
                                                  default_base:        :staged_path,
                                                  default_source_base: :staged_path,
-                                                 default_target_base: :staged_path)
+                                                 default_target_base: :staged_path,
+                                                 rebuild_actions:     false)
           return if step_lines.blank?
 
           add_offense(block_node.source_range,

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -29,6 +29,41 @@ module RuboCop
         String,
       )
       SIMPLE_STEP_CONVERSION_MSG = T.let("Use `%<steps_block>s` for simple file preparation.", String)
+      REBUILD_ACTION_STEP_LINES = T.let(
+        T.let([
+          [
+            "system Formula[\"glib\"].opt_bin/\"glib-compile-schemas\", " \
+            "HOMEBREW_PREFIX/\"share/glib-2.0/schemas\"",
+            "compile_gsettings_schemas",
+          ],
+          [
+            "system Formula[\"glib\"].opt_bin/\"gio-querymodules\", " \
+            "HOMEBREW_PREFIX/\"lib/gio/modules\"",
+            "gio_querymodules",
+          ],
+          [
+            "system Formula[\"gdk-pixbuf\"].opt_bin/\"gdk-pixbuf-query-loaders\", " \
+            "\"--update-cache\"",
+            "gdk_pixbuf_query_loaders",
+          ],
+          [
+            "system Formula[\"gtk+3\"].opt_bin/\"gtk3-update-icon-cache\", " \
+            "\"-q\", \"-t\", \"-f\", HOMEBREW_PREFIX/\"share/icons/hicolor\"",
+            "gtk_update_icon_cache",
+          ],
+          [
+            "system Formula[\"shared-mime-info\"].opt_bin/\"update-mime-database\", " \
+            "HOMEBREW_PREFIX/\"share/mime\"",
+            "update_mime_database",
+          ],
+          [
+            "system Formula[\"desktop-file-utils\"].opt_bin/\"update-desktop-database\", " \
+            "HOMEBREW_PREFIX/\"share/applications\"",
+            "update_desktop_database",
+          ],
+        ], T::Array[[String, String]]).to_h.freeze,
+        T::Hash[String, String],
+      )
 
       sig { params(allowed_methods: T::Array[Symbol]).returns(String) }
       def step_block_msg(allowed_methods)
@@ -75,14 +110,16 @@ module RuboCop
           default_base:        Symbol,
           default_source_base: Symbol,
           default_target_base: Symbol,
+          rebuild_actions:     T::Boolean,
         ).returns(T.nilable(T::Array[String]))
       }
-      def simple_install_step_lines(body_node, default_base:, default_source_base:, default_target_base:)
+      def simple_install_step_lines(body_node, default_base:, default_source_base:, default_target_base:,
+                                    rebuild_actions: true)
         return if body_node.nil?
 
         direct_nodes = body_node.begin_type? ? body_node.child_nodes : [body_node]
         step_lines = direct_nodes.map do |node|
-          simple_install_step_line(node, default_base:, default_source_base:, default_target_base:)
+          simple_install_step_line(node, default_base:, default_source_base:, default_target_base:, rebuild_actions:)
         end
         return if step_lines.any?(&:nil?)
 
@@ -108,12 +145,17 @@ module RuboCop
           default_base:        Symbol,
           default_source_base: Symbol,
           default_target_base: Symbol,
+          rebuild_actions:     T::Boolean,
         ).returns(T.nilable(String))
       }
-      def simple_install_step_line(node, default_base:, default_source_base:, default_target_base:)
+      def simple_install_step_line(node, default_base:, default_source_base:, default_target_base:, rebuild_actions:)
         return unless node.send_type?
 
         send_node = T.cast(node, RuboCop::AST::SendNode)
+        if rebuild_actions && send_node.receiver.nil? && send_node.method_name == :system
+          return REBUILD_ACTION_STEP_LINES[send_node.source.gsub(/\s+/, " ")]
+        end
+
         if send_node.method_name == :mkpath && send_node.arguments.empty? && send_node.receiver
           path = install_step_path(send_node.receiver)
           return mkdir_step_line(:mkdir_p, path, default_base)

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -36,6 +36,20 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
     CASK
   end
 
+  it "reports an offense when cask steps contain formula rebuild actions" do
+    expect_offense <<~CASK
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        preflight_steps do
+          update_desktop_database
+          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`.
+        end
+      end
+    CASK
+  end
+
   it "accepts install step DSL calls" do
     expect_no_offenses <<~CASK
       cask "foo" do
@@ -48,20 +62,6 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
           mv "source", "target"
           move_children "source", "target"
           ln_sf "source", "target", source_base: :relative, uninstall: true
-        end
-      end
-    CASK
-  end
-
-  it "reports an offense when cask steps contain formula rebuild actions" do
-    expect_offense <<~CASK
-      cask "foo" do
-        version :latest
-        sha256 :no_check
-
-        preflight_steps do
-          gio_querymodules
-          ^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`.
         end
       end
     CASK
@@ -106,6 +106,19 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         postflight do
           system_command "/usr/bin/true"
+        end
+      end
+    CASK
+  end
+
+  it "does not autocorrect formula rebuild actions in flight blocks" do
+    expect_no_offenses <<~CASK
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        postflight do
+          system Formula["desktop-file-utils"].opt_bin/"update-desktop-database", HOMEBREW_PREFIX/"share/applications"
         end
       end
     CASK

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -85,6 +85,39 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
     RUBY
   end
 
+  it "autocorrects known `post_install` rebuild actions" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        def post_install
+        ^^^^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Use `post_install_steps` for simple file preparation.
+          system Formula["glib"].opt_bin/"glib-compile-schemas", HOMEBREW_PREFIX/"share/glib-2.0/schemas"
+          system Formula["glib"].opt_bin/"gio-querymodules", HOMEBREW_PREFIX/"lib/gio/modules"
+          system Formula["gdk-pixbuf"].opt_bin/"gdk-pixbuf-query-loaders", "--update-cache"
+          system Formula["gtk+3"].opt_bin/"gtk3-update-icon-cache", "-q", "-t", "-f", HOMEBREW_PREFIX/"share/icons/hicolor"
+          system Formula["shared-mime-info"].opt_bin/"update-mime-database", HOMEBREW_PREFIX/"share/mime"
+          system Formula["desktop-file-utils"].opt_bin/"update-desktop-database", HOMEBREW_PREFIX/"share/applications"
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        post_install_steps do
+          compile_gsettings_schemas
+          gio_querymodules
+          gdk_pixbuf_query_loaders
+          gtk_update_icon_cache
+          update_mime_database
+          update_desktop_database
+        end
+      end
+    RUBY
+  end
+
   it "does not autocorrect non-file preparation in `post_install`" do
     expect_no_offenses(<<~RUBY)
       class Foo < Formula


### PR DESCRIPTION
- defer autocorrection until rebuild actions are in stable releases
- keep cask audits limited to cask-supported step methods
- catch exact formula cache rebuild patterns conservatively

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
