### PR TITLE
Fix bottle rebuild parsing

### DIFF
--- a/Library/Homebrew/test/utils/bottles/bottles_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/bottles_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe Utils::Bottles do
     end
   end
 
+  describe ".extname_tag_rebuild" do
+    it "returns an empty rebuild for bottles without rebuilds" do
+      expect(klass.extname_tag_rebuild("gh--2.93.0.arm64_sonoma.bottle.tar.gz"))
+        .to eq([".arm64_sonoma.bottle.tar.gz", "arm64_sonoma", ""])
+    end
+  end
+
   describe ".load_tab" do
     context "when tab_attributes and tabfile are missing" do
       before do

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -51,7 +51,7 @@ module Utils
 
       sig { params(filename: String).returns(T::Array[String]) }
       def extname_tag_rebuild(filename)
-        HOMEBREW_BOTTLES_EXTNAME_REGEX.match(filename).to_a
+        HOMEBREW_BOTTLES_EXTNAME_REGEX.match(filename).to_a.map(&:to_s)
       end
 
       sig { params(bottle_file: Pathname).returns(T.nilable(String)) }


### PR DESCRIPTION
- Avoid cleanup crashes when bottle filenames omit rebuilds
- Preserve `extname_tag_rebuild`'s string array contract
- Cover no-rebuild bottle filenames with a regression test

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
