### PR TITLE
Fix `linked_libraries` type in keg_relocate

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -411,7 +411,7 @@ class Keg
   end
 
   sig {
-    params(file: Pathname, string: String, ignores: T::Array[Regexp], linked_libraries: T::Array[Pathname],
+    params(file: Pathname, string: String, ignores: T::Array[Regexp], linked_libraries: T::Array[String],
            formula_and_runtime_deps_names: T.nilable(T::Array[String])).returns(T::Array[[String, String]])
   }
   def self.text_matches_in_file(file, string, ignores, linked_libraries, formula_and_runtime_deps_names)
@@ -454,7 +454,7 @@ class Keg
     text_matches
   end
 
-  sig { params(_file: Pathname, _string: String).returns(T::Array[Pathname]) }
+  sig { params(_file: Pathname, _string: String).returns(T::Array[String]) }
   def self.file_linked_libraries(_file, _string)
     []
   end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. Non-maintainers may only have one AI-assisted/generated PR open at a time.

-----

After `HOMEBREW_SORBET_RECURSIVE` is turned on, now array elements are also checked and got CI failure in core.

- https://github.com/Homebrew/homebrew-core/pull/285931
- https://github.com/Homebrew/homebrew-core/pull/285902

This is a fix for them.