### PR TITLE
pypi_download_strategy: fix source_modified_time

### DIFF
--- a/Library/Homebrew/download_strategy/pypi_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/pypi_download_strategy.rb
@@ -7,7 +7,7 @@
 class PyPIDownloadStrategy < CurlDownloadStrategy
   sig { override.returns(Time) }
   def source_modified_time
-    last_modified = @last_modified
+    last_modified = cached_location.mtime if cached_location.exist?
     source_modified_time = super
     return source_modified_time if last_modified.nil? || source_modified_time > last_modified
 

--- a/Library/Homebrew/test/download_strategies/pypi_spec.rb
+++ b/Library/Homebrew/test/download_strategies/pypi_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe PyPIDownloadStrategy do
     allow(strategy).to receive(:_fetch)
     strategy.clear_cache
     strategy.temporary_path.dirname.mkpath
-    FileUtils.touch strategy.temporary_path
+    FileUtils.touch strategy.temporary_path, mtime: last_modified
   end
 
   describe "#source_modified_time" do
-    it "uses the PyPI last modified time when archive contents are older" do
+    it "uses the PyPI last modified time set on cached file when archive contents are older" do
       strategy.fetch
 
       mktmpdir("mtime").cd do

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -162,6 +162,7 @@ RSpec.describe Resource do
       allow(resource.downloader).to receive(:_fetch) do
         resource.downloader.temporary_path.dirname.mkpath
         FileUtils.cp tarball, resource.downloader.temporary_path
+        FileUtils.touch resource.downloader.temporary_path, mtime: last_modified
       end
     end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

The previous logic would try to use `@last_modified` but when method is called during `Resource#stage` this is actually nil.

Instead, we can use the cached download mtime since we run curl with `--remote-time` which sets timestamps of downloaded file to match Last-Modified value

`DownloadStrategy#source_modified_time` is only run inside staged path (otherwise `super` implementation would be wrong) so cached file should be downloaded and have correct mtime set before called.

---

This is a follow up to #22181.

Taking formula that was originally seeing mtime issue (mistral-vibe), I see:
* Existing bottle - 1580601600 = 2020-02-02 00:00:00 UTC
* Build with PR - 1780064391 = 2026-05-29 14:19:51 UTC

We use `--remote-time` at:
https://github.com/Homebrew/brew/blob/c6a08de114ec28574fe7fdbec7782d2ceb6dc3a1/Library/Homebrew/utils/curl.rb#L311

And this should set the correct mtime.
```console
❯ curl --remote-time -sLO https://files.pythonhosted.org/packages/ff/f7/671f45a47c41ce375d47e8acfa3dce331664c460e6f503a65b53febc46ca/mistral_vibe-2.13.0.tar.gz

❯ TZ=UTC gstat -c %y mistral_vibe-2.13.0.tar.gz
2026-05-29 14:19:51.000000000 +0000

❯ curl -sI https://files.pythonhosted.org/packages/ff/f7/671f45a47c41ce375d47e8acfa3dce331664c460e6f503a65b53febc46ca/mistral_vibe-2.13.0.tar.gz | grep last-modified
last-modified: Fri, 29 May 2026 14:19:51 GMT
```