### PR TITLE
prefer pnpm over npm in npm extension

### DIFF
--- a/Library/Homebrew/bundle/extensions/npm.rb
+++ b/Library/Homebrew/bundle/extensions/npm.rb
@@ -23,14 +23,58 @@ module Homebrew
           banner_name
         end
 
+        BOOTSTRAP_RUNTIME = T.let("node", String)
+        BOOTSTRAP_PACKAGE_MANAGER = T.let("pnpm", String)
+        BOOTSTRAP_FORMULAE = T.let([BOOTSTRAP_RUNTIME, BOOTSTRAP_PACKAGE_MANAGER].freeze, T::Array[String])
+
         sig { override.returns(String) }
         def package_manager_name
-          "node"
+          BOOTSTRAP_PACKAGE_MANAGER
         end
 
         sig { override.returns(T.nilable(Pathname)) }
         def package_manager_executable
-          which("npm", ORIGINAL_PATHS)
+          which("pnpm", ORIGINAL_PATHS) || which("npm", ORIGINAL_PATHS)
+        end
+
+        sig {
+          override.params(
+            name:       String,
+            with:       T.nilable(T::Array[String]),
+            no_upgrade: T::Boolean,
+            verbose:    T::Boolean,
+            _options:   Homebrew::Bundle::EntryOption,
+          ).returns(T::Boolean)
+        }
+        def preinstall!(name, with: nil, no_upgrade: false, verbose: false, **_options)
+          _ = no_upgrade
+
+          unless package_manager_installed?
+            if verbose
+              puts "Installing #{BOOTSTRAP_RUNTIME} (runtime) and #{BOOTSTRAP_PACKAGE_MANAGER}. " \
+                   "They are not currently installed."
+            end
+            Bundle.system(HOMEBREW_BREW_FILE, "install", "--formula", *BOOTSTRAP_FORMULAE, verbose:)
+            formula_versions_from_env = T.let(
+              Bundle.formula_versions_from_env_cache,
+              T.nilable(T::Hash[String, String]),
+            )
+            upgrade_formulae = Bundle.upgrade_formulae
+            Bundle.reset!
+            Bundle.formula_versions_from_env_cache = formula_versions_from_env
+            Bundle.upgrade_formulae = upgrade_formulae.join(",")
+            unless package_manager_installed?
+              raise "Unable to install #{name} #{package_description}. " \
+                    "Node.js and pnpm installation failed."
+            end
+          end
+
+          if package_installed?(name, with:)
+            puts "Skipping install of #{name} #{package_description}. It is already installed." if verbose
+            return false
+          end
+
+          true
         end
 
         sig { override.returns(T::Array[String]) }
@@ -38,10 +82,10 @@ module Homebrew
           packages = @packages
           return packages if packages
 
-          @packages = if (npm = package_manager_executable) &&
-                         (!npm.to_s.start_with?("/") || npm.exist?)
-            with_env(package_manager_env(npm)) do
-              parse_package_list(`#{npm} list -g --depth=0 --json 2>/dev/null`)
+          @packages = if (executable = package_manager_executable) &&
+                         (!executable.to_s.start_with?("/") || executable.exist?)
+            with_env(package_manager_env(executable)) do
+              parse_package_list(`#{executable} list -g --depth=0 --json 2>/dev/null`)
             end
           end
           return [] if @packages.nil?
@@ -59,9 +103,13 @@ module Homebrew
         def install_package!(name, with: nil, verbose: false)
           _ = with
 
-          npm = package_manager_executable!
+          executable = package_manager_executable!
 
-          Bundle.system(npm.to_s, "install", *Language::Node.npm_install_security_args, "-g", name, verbose:)
+          if pnpm_executable?(executable)
+            Bundle.system(executable.to_s, "add", "-g", name, verbose:)
+          else
+            Bundle.system(executable.to_s, "install", *Language::Node.npm_install_security_args, "-g", name, verbose:)
+          end
         end
 
         sig { override.returns(T::Array[String]) }
@@ -74,7 +122,11 @@ module Homebrew
 
         sig { override.params(name: String, executable: Pathname).void }
         def uninstall_package!(name, executable: Pathname.new(""))
-          Bundle.system(executable.to_s, "uninstall", "-g", name, verbose: false)
+          if pnpm_executable?(executable)
+            Bundle.system(executable.to_s, "remove", "-g", name, verbose: false)
+          else
+            Bundle.system(executable.to_s, "uninstall", "-g", name, verbose: false)
+          end
         end
 
         sig { params(output: String).returns(T::Array[String]) }
@@ -82,12 +134,23 @@ module Homebrew
           return [] if output.blank?
 
           json = JSON.parse(output)
-          deps = json.fetch("dependencies", {})
-          deps.keys.reject { |name| name == "npm" }
+          package_entries = json.is_a?(Array) ? json : [json]
+          package_entries.flat_map do |package|
+            next [] unless package.is_a?(Hash)
+
+            deps = package.fetch("dependencies", {})
+            deps.keys.reject { |package_name| %w[npm pnpm].include?(package_name) }
+          end
         rescue JSON::ParserError
           []
         end
         private :parse_package_list
+
+        sig { params(executable: Pathname).returns(T::Boolean) }
+        def pnpm_executable?(executable)
+          executable.basename.to_s == "pnpm"
+        end
+        private :pnpm_executable?
       end
     end
   end

--- a/Library/Homebrew/test/bundle/npm_spec.rb
+++ b/Library/Homebrew/test/bundle/npm_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Homebrew::Bundle::Npm do
   describe "dumping" do
     subject(:dumper) { klass }
 
-    context "when npm is not installed" do
+    context "when neither pnpm nor npm is installed" do
       before do
         klass.reset!
         allow(klass).to receive(:package_manager_executable).and_return(nil)
@@ -87,6 +87,77 @@ RSpec.describe Homebrew::Bundle::Npm do
         expect(dumper.dump).to eql("npm \"vercel\"\nnpm \"typescript\"")
       end
     end
+
+    context "when pnpm is installed" do
+      before do
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("pnpm"))
+      end
+
+      it "returns package list" do
+        allow(klass).to receive(:`).with("pnpm list -g --depth=0 --json 2>/dev/null").and_return(<<~JSON)
+          [
+            {
+              "dependencies": {
+                "pnpm": { "version": "10.23.0" },
+                "vercel": { "version": "39.0.0" },
+                "typescript": { "version": "5.7.3" }
+              }
+            }
+          ]
+        JSON
+
+        expect(dumper.packages).to eql(%w[vercel typescript])
+      end
+
+      it "adds pnpm's directory to PATH when listing packages" do
+        pnpm = mktmpdir/"bin/pnpm"
+        pnpm.dirname.mkpath
+        pnpm.write("")
+
+        allow(klass).to receive(:package_manager_executable).and_return(pnpm)
+        expect(klass).to receive(:`).with("#{pnpm} list -g --depth=0 --json 2>/dev/null") do
+          expect(ENV.fetch("PATH", "")).to start_with("#{pnpm.dirname}:")
+          '[{"dependencies":{"eslint":{"version":"10.4.0"}}}]'
+        end
+
+        expect(dumper.packages).to eql(["eslint"])
+      end
+
+      it "excludes pnpm itself from the package list" do
+        allow(klass).to receive(:`).with("pnpm list -g --depth=0 --json 2>/dev/null").and_return(<<~JSON)
+          [
+            {
+              "dependencies": {
+                "pnpm": { "version": "10.23.0" }
+              }
+            }
+          ]
+        JSON
+
+        expect(dumper.packages).to be_empty
+      end
+
+      it "dumps package list using npm entries" do
+        allow(dumper).to receive(:packages).and_return(["vercel", "typescript"])
+        expect(dumper.dump).to eql("npm \"vercel\"\nnpm \"typescript\"")
+      end
+    end
+
+    context "when both pnpm and npm are installed" do
+      before do
+        klass.reset!
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("pnpm"))
+      end
+
+      it "prefers pnpm" do
+        allow(klass).to receive(:`).with("pnpm list -g --depth=0 --json 2>/dev/null").and_return(<<~JSON)
+          [{"dependencies":{"eslint":{"version":"10.4.0"}}}]
+        JSON
+
+        expect(dumper.packages).to eql(["eslint"])
+      end
+    end
   end
 
   describe "cleanup" do
@@ -121,15 +192,15 @@ RSpec.describe Homebrew::Bundle::Npm do
   end
 
   describe "installing" do
-    context "when npm is not installed" do
+    context "when neither pnpm nor npm is installed" do
       before do
         klass.reset!
         allow(klass).to receive(:package_manager_executable).and_return(nil)
       end
 
-      it "tries to install node" do
+      it "tries to install node and pnpm" do
         expect(Homebrew::Bundle).to \
-          receive(:system).with(HOMEBREW_BREW_FILE, "install", "--formula", "node", verbose: false)
+          receive(:system).with(HOMEBREW_BREW_FILE, "install", "--formula", "node", "pnpm", verbose: false)
                           .and_return(true)
         expect { klass.preinstall!("vercel") }.to raise_error(RuntimeError)
       end
@@ -168,6 +239,47 @@ RSpec.describe Homebrew::Bundle::Npm do
               "--min-release-age=1",
               "--cache=#{HOMEBREW_CACHE}/npm_cache",
               "--ignore-scripts",
+              "-g",
+              "vercel",
+              verbose: false,
+            )
+            .and_return(true)
+          expect(klass.preinstall!("vercel")).to be(true)
+          expect(klass.install!("vercel")).to be(true)
+        end
+      end
+    end
+
+    context "when pnpm is installed" do
+      before do
+        allow(klass).to receive(:package_manager_executable).and_return(Pathname.new("pnpm"))
+      end
+
+      context "when package is installed" do
+        before do
+          allow(klass).to receive(:installed_packages)
+            .and_return(["vercel"])
+        end
+
+        it "skips" do
+          expect(Homebrew::Bundle).not_to receive(:system)
+          expect(klass.preinstall!("vercel")).to be(false)
+        end
+      end
+
+      context "when package is not installed" do
+        before do
+          allow(klass).to receive_messages(
+            package_manager_executable: Pathname.new("/opt/homebrew/bin/pnpm"),
+            installed_packages:         [],
+          )
+        end
+
+        it "installs package" do
+          expect(Homebrew::Bundle).to receive(:system)
+            .with(
+              "/opt/homebrew/bin/pnpm",
+              "add",
               "-g",
               "vercel",
               verbose: false,


### PR DESCRIPTION
Per review feedback, this extends the existing `npm` bundle extension rather than adding a separate `pnpm` extension.

## Summary

- Prefer `pnpm` over `npm` when both are available (VSCode fork pattern)
- Fall back to `npm` when only it is available
- Brewfile entries remain `npm "package"`; dump/cleanup use the selected CLI
- Bootstrap on install when neither CLI is on PATH: `brew install --formula node pnpm`

## Test plan

- [x] `./bin/brew tests --only=bundle/npm`
- [x] `./bin/brew typecheck`
- [x] `./bin/brew style --fix` on changed files

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [X] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [X] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

- Manually reviewed against the npm extension and VSCode fork pattern
- Ran `./bin/brew tests --only=bundle/npm`, typecheck, and style locally
- Updated the PR per review feedback