### PR TITLE
Fix services completions

### DIFF
--- a/Library/Homebrew/completions/bash.erb
+++ b/Library/Homebrew/completions/bash.erb
@@ -132,6 +132,15 @@ __brew_complete_commands() {
   export __HOMEBREW_COMMANDS=${cmds}
 }
 
+__brew_complete_services() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local services
+  services="$(command find "$(brew --cellar)" -mindepth 3 -maxdepth 3 -name '*.service' \
+    | awk -F'homebrew.|.service' '{print $3}' \
+    | sort -d)"
+  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${services}" -- "${cur}")
+}
+
 # compopt is only available in newer versions of bash
 __brew_complete_files() {
   command -v compopt &> /dev/null && compopt -o default

--- a/Library/Homebrew/completions/zsh.erb
+++ b/Library/Homebrew/completions/zsh.erb
@@ -159,6 +159,16 @@ __brew_diagnostic_checks() {
   _describe -t diagnostic-checks 'diagnostic checks' diagnostic_checks
 }
 
+__brew_services() {
+  [[ -prefix '-' ]] && return 0
+
+  local -a services
+  services=($(command find "$(brew --cellar)" -mindepth 3 -maxdepth 3 -name '*.service' \
+    | awk -F'homebrew.|.service' '{print $3}' \
+    | sort -d))
+  _describe -t services 'services' services
+}
+
 <%= completion_functions.join("\n") %>
 
 # The main completion function

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -390,6 +390,7 @@ RSpec.describe Homebrew::Completions do
       it "returns the correct completion file" do
         file = klass.generate_bash_completion_file(%w[install missing update])
         expect(file).to match(/^__brewcomp\(\) {$/)
+        expect(file).to match(/^__brew_complete_services\(\) {$/)
         expect(file).to match(/^_brew_install\(\) {$/)
         expect(file).to match(/^_brew_missing\(\) {$/)
         expect(file).to match(/^_brew_update\(\) {$/)
@@ -493,6 +494,7 @@ RSpec.describe Homebrew::Completions do
       it "returns the correct completion file" do
         file = klass.generate_zsh_completion_file(%w[install missing update])
         expect(file).to match(/^__brew_list_aliases\(\) {$/)
+        expect(file).to match(/^__brew_services\(\) {$/)
         expect(file).to match(/^    up update$/)
         expect(file).to match(/^__brew_internal_commands\(\) {$/)
         expect(file).to match(/^    'install:Install a formula or cask'$/)

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -117,6 +117,15 @@ __brew_complete_commands() {
   export __HOMEBREW_COMMANDS=${cmds}
 }
 
+__brew_complete_services() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local services
+  services="$(command find "$(brew --cellar)" -mindepth 3 -maxdepth 3 -name '*.service' \
+    | awk -F'homebrew.|.service' '{print $3}' \
+    | sort -d)"
+  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${services}" -- "${cur}")
+}
+
 # compopt is only available in newer versions of bash
 __brew_complete_files() {
   command -v compopt &> /dev/null && compopt -o default

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -286,6 +286,16 @@ __brew_diagnostic_checks() {
   _describe -t diagnostic-checks 'diagnostic checks' diagnostic_checks
 }
 
+__brew_services() {
+  [[ -prefix '-' ]] && return 0
+
+  local -a services
+  services=($(command find "$(brew --cellar)" -mindepth 3 -maxdepth 3 -name '*.service' \
+    | awk -F'homebrew.|.service' '{print $3}' \
+    | sort -d))
+  _describe -t services 'services' services
+}
+
 # brew --cache
 _brew___cache() {
   _arguments \


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22519

- Define bash and zsh service helpers so `brew services info` can complete service names without command-not-found errors.
- Add coverage that generated completions include both helpers.
- Regenerate checked-in bash and zsh completion files for `#22519`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
