### PR TITLE
Handle untrusted bundle formulae

### DIFF
--- a/Library/Homebrew/bundle/brew.rb
+++ b/Library/Homebrew/bundle/brew.rb
@@ -131,18 +131,36 @@ module Homebrew
 
         sig { params(formula: String).returns(T::Boolean) }
         def formula_installed?(formula)
+          # Fully qualified tap formulae can be checked by their Cellar rack name
+          # without loading the formula from an untrusted tap.
+          return installed_formulae.include?(Utils.name_from_full_name(formula)) if formula.count("/") == 2
+
           formula_in_array?(formula, installed_formulae)
         end
 
         sig { params(formula: String).returns(T::Boolean) }
         def formula_upgradable?(formula)
+          return false unless formula_installed?(formula)
+
+          # Reading the formula is needed for authoritative outdated state, so
+          # report trust problems before the upgrade check tries to load it.
+          if formula.count("/") == 2 && Homebrew::EnvConfig.require_tap_trust?
+            require "trust"
+
+            unless Homebrew::Trust.trusted?(:formula, formula)
+              opoo "Cannot check whether #{formula} is outdated because its tap is not trusted. " \
+                   "Run `brew trust --formula #{formula}` to trust it."
+              return true
+            end
+          end
+
           # Check local cache first and then authoritative Homebrew source.
           (formula_in_array?(formula, upgradable_formulae) && Formula[formula].outdated?) || false
         end
 
         sig { returns(T::Array[String]) }
         def installed_formulae
-          @installed_formulae ||= formulae.map { |f| f[:name] }
+          @installed_formulae ||= Formula.installed_formula_names
         end
 
         sig { returns(T::Array[String]) }

--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -7,6 +7,7 @@ require "bundle/brew_services"
 require "tsort"
 require "formula"
 require "tab"
+require "trust"
 require "utils/bottles"
 
 RSpec.describe Homebrew::Bundle::Brew do
@@ -610,6 +611,7 @@ RSpec.describe Homebrew::Bundle::Brew do
       before do
         klass.reset!
         allow_any_instance_of(Formula).to receive(:outdated?).and_return(true)
+        allow(Formula).to receive(:installed_formula_names).and_return(%w[foo bar])
         allow(klass).to receive_messages(outdated_formulae: %w[bar], formulae: [
           {
             name:         "foo",
@@ -639,6 +641,40 @@ RSpec.describe Homebrew::Bundle::Brew do
         expect(klass.formula_installed_and_up_to_date?("foobar")).to be(true)
         expect(klass.formula_installed_and_up_to_date?("bar")).to be(false)
         expect(klass.formula_installed_and_up_to_date?("baz")).to be(false)
+      end
+    end
+
+    describe ".formula_installed_and_up_to_date? with an untrusted tap formula" do
+      before do
+        klass.reset!
+        allow(Homebrew::EnvConfig).to receive(:require_tap_trust?).and_return(true)
+        allow(Formula).to receive(:installed_formula_names).and_return(["php@7.2"])
+        allow(Homebrew::Trust).to receive(:trusted?).with(:formula, "shivammathur/php/php@7.2").and_return(false)
+      end
+
+      it "warns and marks the formula actionable without loading it" do
+        expect(Formula).not_to receive(:installed)
+        expect(Formula).not_to receive(:[])
+        expect { expect(klass.formula_installed_and_up_to_date?("shivammathur/php/php@7.2")).to be(false) }
+          .to output(/Cannot check whether.*not trusted/).to_stderr
+      end
+
+      it "does not warn when upgrades are disabled" do
+        expect(Formula).not_to receive(:installed)
+        expect(Formula).not_to receive(:[])
+        expect do
+          expect(klass.formula_installed_and_up_to_date?("shivammathur/php/php@7.2", no_upgrade: true)).to be(true)
+        end
+          .not_to output.to_stderr
+      end
+
+      it "detects missing formulae without loading the formula" do
+        allow(Formula).to receive(:installed_formula_names).and_return([])
+
+        expect(Formula).not_to receive(:installed)
+        expect(Formula).not_to receive(:[])
+        expect { expect(klass.formula_installed_and_up_to_date?("shivammathur/php/php@7.2")).to be(false) }
+          .not_to output.to_stderr
       end
     end
 

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe Homebrew::Trust do
     FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
   end
 
+  it "trusts formulae from trusted taps" do
+    Tap.fetch("trustedformulae", "foo")
+
+    Homebrew::Trust.trust!(:tap, "trustedformulae/foo")
+
+    expect(Homebrew::Trust.trusted?(:formula, "trustedformulae/foo/bar")).to be(true)
+  ensure
+    Homebrew::Trust.clear!(:tap)
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"trustedformulae"
+  end
+
   it "ignores a trust file with a non-object JSON root" do
     trust_file = T.let(nil, T.nilable(Pathname))
     trust_file = Homebrew::Trust.trust_file
@@ -45,20 +56,20 @@ RSpec.describe Homebrew::Trust do
   end
 
   it "trusts fully-qualified formulae and casks" do
-    tap = Tap.fetch("thirdparty", "foo")
+    tap = Tap.fetch("qualified", "foo")
     tap.formula_dir.mkpath
     tap.cask_dir.mkpath
     (tap.formula_dir/"bar.rb").write("class Bar < Formula; end\n")
     (tap.cask_dir/"baz.rb").write("cask 'baz'\n")
 
-    Homebrew::Trust.trust_fully_qualified_items!(["thirdparty/foo/bar", "thirdparty/foo/baz"])
+    Homebrew::Trust.trust_fully_qualified_items!(["qualified/foo/bar", "qualified/foo/baz"])
 
-    expect(Homebrew::Trust.trusted?(:formula, "thirdparty/foo/bar")).to be(true)
-    expect(Homebrew::Trust.trusted?(:cask, "thirdparty/foo/baz")).to be(true)
+    expect(Homebrew::Trust.trusted?(:formula, "qualified/foo/bar")).to be(true)
+    expect(Homebrew::Trust.trusted?(:cask, "qualified/foo/baz")).to be(true)
   ensure
     Homebrew::Trust.clear!(:formula)
     Homebrew::Trust.clear!(:cask)
-    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"qualified"
   end
 
   it "does not trust missing fully-qualified formulae or casks" do

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -92,7 +92,14 @@ module Homebrew
 
     sig { params(type: Symbol, name: String).returns(T::Boolean) }
     def self.trusted?(type, name)
-      trusted_entries(type).include?(normalise_name(name))
+      name = normalise_name(name)
+      return true if trusted_entries(type).include?(name)
+      return false if type == :tap
+      return false unless (tap_name = ::Utils.tap_from_full_name(name))
+
+      trusted_tap?(Tap.fetch(tap_name))
+    rescue Tap::InvalidNameError
+      false
     end
 
     sig { params(tap: T.untyped).returns(T::Boolean) }


### PR DESCRIPTION
- Avoid loading untrusted formulae just to detect Cellar presence.
- Warn only when Bundle must check upgrade state for formulae.
- Let `trusted?` account for trusted taps for package entries.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
