### PR TITLE
`brew bundle dump` trusted bundle entries

### DIFF
--- a/Library/Homebrew/bundle/brew.rb
+++ b/Library/Homebrew/bundle/brew.rb
@@ -6,6 +6,7 @@ require "tsort"
 require "utils"
 require "utils/output"
 require "bundle/package_type"
+require "trust"
 
 module Homebrew
   module Bundle
@@ -231,6 +232,7 @@ module Homebrew
           requested_formula = formulae.select do |f|
             f[:installed_on_request?]
           end
+          trusted_formulae = Homebrew::Trust.trusted_entries(:formula)
           requested_formula.map do |f|
             brewline = if describe && f[:desc].present?
               f[:desc].split("\n").map { |s| "# #{s}\n" }.join
@@ -243,6 +245,7 @@ module Homebrew
             brewline += ", args: [#{args}]" unless f[:args].empty?
             brewline += ", restart_service: :changed" if !no_restart && Services.started?(f[:full_name])
             brewline += ", link: #{f[:link?]}" unless f[:link?].nil?
+            brewline += ", trusted: true" if trusted_formulae.include?(f[:full_name])
             brewline
           end.join("\n")
         end

--- a/Library/Homebrew/bundle/cask.rb
+++ b/Library/Homebrew/bundle/cask.rb
@@ -4,6 +4,7 @@
 require "utils"
 require "utils/output"
 require "bundle/package_type"
+require "trust"
 
 module Homebrew
   module Bundle
@@ -219,10 +220,13 @@ module Homebrew
 
         sig { override.params(describe: T::Boolean).returns(String) }
         def dump(describe: false)
+          trusted_casks = Homebrew::Trust.trusted_entries(:cask)
           casks.map do |cask|
             description = "# #{cask.desc}\n" if describe && cask.desc.present?
             config = ", args: { #{explicit_s(cask.config)} }" if cask.config.present? && cask.config.explicit.present?
-            "#{description}cask \"#{cask.full_name}\"#{config}"
+            caskline = "#{description}cask \"#{cask.full_name}\"#{config}"
+            caskline += ", trusted: true" if trusted_casks.include?(cask.full_name)
+            caskline
           end.join("\n")
         end
 

--- a/Library/Homebrew/bundle/tap.rb
+++ b/Library/Homebrew/bundle/tap.rb
@@ -3,6 +3,7 @@
 
 require "json"
 require "bundle/package_type"
+require "trust"
 
 module Homebrew
   module Bundle
@@ -81,6 +82,7 @@ module Homebrew
 
         sig { override.returns(String) }
         def dump
+          trusted_taps = Homebrew::Trust.trusted_entries(:tap)
           taps.map do |tap|
             remote = if tap.custom_remote? && (tap_remote = tap.remote)
               if (api_token = ENV.fetch("HOMEBREW_GITHUB_API_TOKEN", false).presence)
@@ -90,7 +92,9 @@ module Homebrew
               end
               ", \"#{tap_remote}\""
             end
-            "tap \"#{tap.name}\"#{remote}"
+            tapline = "tap \"#{tap.name}\"#{remote}"
+            tapline += ", trusted: true" if trusted_taps.include?(tap.name)
+            tapline
           end.sort.uniq.join("\n")
         end
 

--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -235,10 +235,11 @@ RSpec.describe Homebrew::Bundle::Brew do
         expected = <<~EOS
           # barfoo
           brew "bar"
-          brew "bazzles/bizzles/baz", link: false
+          brew "bazzles/bizzles/baz", link: false, trusted: true
           # foobar
           brew "qux/quuz/foo"
         EOS
+        allow(Homebrew::Trust).to receive(:trusted_entries).with(:formula).and_return(["bazzles/bizzles/baz"])
         expect(dumper.dump(describe: true)).to eql(expected.chomp)
       end
     end

--- a/Library/Homebrew/test/bundle/cask_spec.rb
+++ b/Library/Homebrew/test/bundle/cask_spec.rb
@@ -72,10 +72,11 @@ RSpec.describe Homebrew::Bundle::Cask do
       it "dumps as `cask 'baz'` and `cask 'foo' cask 'bar'` plus descriptions and config values" do
         expected = <<~EOS
           cask "foo"
-          cask "bar", args: { fontdir: "/Library/Fonts", language: "zh-TW" }
+          cask "bar", args: { fontdir: "/Library/Fonts", language: "zh-TW" }, trusted: true
           # Software
           cask "baz"
         EOS
+        allow(Homebrew::Trust).to receive(:trusted_entries).with(:cask).and_return(["bar"])
         expect(dumper.dump(describe: true)).to eql(expected.chomp)
       end
 

--- a/Library/Homebrew/test/bundle/tap_spec.rb
+++ b/Library/Homebrew/test/bundle/tap_spec.rb
@@ -58,6 +58,14 @@ RSpec.describe Homebrew::Bundle::Tap do
         EOS
         expect(dumper.dump).to eql(expected_output.chomp)
       end
+
+      it "dumps trusted taps with trusted true" do
+        allow(Homebrew::Trust).to receive(:trusted_entries).with(:tap).and_return(["bitbucket/bar"])
+
+        expect(dumper.dump).to include(
+          "tap \"bitbucket/bar\", \"https://bitbucket.org/bitbucket/bar.git\", trusted: true",
+        )
+      end
     end
   end
 


### PR DESCRIPTION
- Preserve `brew trust` metadata when writing a `Brewfile`
- Avoid recording `trusted: false` so untrusted entries stay unchanged
- Cover trusted `tap`, `brew` and `cask` dump output

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
