### PR TITLE
pathname: accept `Pathname` in `write_env_script` method

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -320,9 +320,16 @@ class Pathname
   #
   # @api public
   sig {
-    params(target:      T.any(Pathname, String),
-           args_or_env: T.any(String, T::Array[String], T::Hash[String, String], T::Hash[Symbol, String]),
-           env:         T.any(T::Hash[String, String], T::Hash[Symbol, String])).void
+    params(
+      target:      T.any(Pathname, String),
+      args_or_env: T.any(
+        String, Pathname,
+        T::Array[T.any(String, Pathname)],
+        T::Hash[String, T.any(String, Pathname)],
+        T::Hash[Symbol, T.any(String, Pathname)]
+      ),
+      env:         T.any(T::Hash[String, T.any(String, Pathname)], T::Hash[Symbol, T.any(String, Pathname)]),
+    ).void
   }
   def write_env_script(target, args_or_env, env = T.unsafe(nil))
     args = if env.nil?
@@ -332,7 +339,7 @@ class Pathname
     elsif args_or_env.is_a?(Array)
       args_or_env.join(" ")
     else
-      T.cast(args_or_env, T.nilable(String))
+      T.cast(args_or_env, T.nilable(T.any(String, Pathname)))
     end
 
     env_export = +""

--- a/Library/Homebrew/test/extend/pathname_spec.rb
+++ b/Library/Homebrew/test/extend/pathname_spec.rb
@@ -1,0 +1,28 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "extend/pathname"
+
+RSpec.describe Pathname do
+  describe ".write_env_script" do
+    it "creates script with arguments" do
+      mktmpdir do |tmpdir|
+        (tmpdir/"wrapper_script").write_env_script tmpdir/"test", ["foo", "bar"], TEST: "baz"
+        expect((tmpdir/"wrapper_script").read).to eq(<<~BASH)
+          #!/bin/bash
+          TEST="baz" exec "#{tmpdir}/test" foo bar "$@"
+        BASH
+      end
+    end
+
+    it "creates script without arguments" do
+      mktmpdir do |tmpdir|
+        (tmpdir/"wrapper_script").write_env_script "test", TEST: "bar", TEST2: tmpdir/"baz"
+        expect((tmpdir/"wrapper_script").read).to eq(<<~BASH)
+          #!/bin/bash
+          TEST="bar" TEST2="#{tmpdir}/baz" exec "test"  "$@"
+        BASH
+      end
+    end
+  end
+end


### PR DESCRIPTION
`write_env_script` is often used to set variable to a path. It used to work fine but now due to recent Sorbet changes it throws type exception. Let's accept `Pathname` for the convenience of contributors to homebrew/core and other taps

See https://github.com/Homebrew/homebrew-core/pull/286022 and https://github.com/Homebrew/homebrew-core/pull/286121

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
