### PR TITLE
HeaderMatch: fix type error

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -202,7 +202,12 @@ module Homebrew
       # @param url [String] the URL to fetch
       # @param options [Options] options to modify behavior
       # @return [Array]
-      sig { params(url: String, options: Options).returns(T::Array[T::Hash[String, String]]) }
+      sig {
+        params(
+          url:     String,
+          options: Options,
+        ).returns(T::Array[T::Hash[String, T.any(String, T::Array[String])]])
+      }
       def self.page_headers(url, options: Options.new)
         headers = []
 

--- a/Library/Homebrew/livecheck/strategy/header_match.rb
+++ b/Library/Homebrew/livecheck/strategy/header_match.rb
@@ -41,7 +41,7 @@ module Homebrew
         # @return [Array]
         sig {
           params(
-            headers: T::Array[T::Hash[String, String]],
+            headers: T::Array[T::Hash[String, T.any(String, T::Array[String])]],
             regex:   T.nilable(Regexp),
             block:   T.nilable(Proc),
           ).returns(T::Array[String])
@@ -49,7 +49,7 @@ module Homebrew
         def self.versions_from_content(headers, regex = nil, &block)
           # Merge the last value of each header from all responses into one hash
           # for convenience
-          merged_headers = T.cast(headers.reduce(&:merge), T::Hash[String, String])
+          merged_headers = T.cast(headers.reduce(&:merge), T::Hash[String, T.any(String, T::Array[String])])
 
           if block
             block_return_value = case block.parameters[0]
@@ -66,6 +66,7 @@ module Homebrew
 
           DEFAULT_HEADERS_TO_CHECK.filter_map do |header_name|
             header_value = merged_headers[header_name]
+            header_value = header_value.last if header_value.is_a?(Array)
             next if header_value.blank?
 
             if regex

--- a/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe Homebrew::Livecheck::Strategy::HeaderMatch do
       "location"            => http_url,
     })
 
+    # Location headers shouldn't appear more than once in an HTTP response but
+    # this is intended to exercise related logic in `versions_from_content`.
+    headers[:location_array] = headers[:location].merge({
+      "location" => [
+        "https://example.com/",
+        "https://github.com/Homebrew/brew/releases/tag/1.2.4",
+      ],
+    })
+
     headers
   end
   let(:matches) do
@@ -73,11 +82,15 @@ RSpec.describe Homebrew::Livecheck::Strategy::HeaderMatch do
       expect(header_match.versions_from_content([headers[:location]])).to eq(matches[:location])
       expect(header_match.versions_from_content([headers[:content_disposition_and_location]]))
         .to eq(matches[:content_disposition_and_location])
+      expect(header_match.versions_from_content([headers[:location_array]]))
+        .to eq(matches[:location])
 
       expect(header_match.versions_from_content([headers[:content_disposition]], regexes[:archive]))
         .to eq(matches[:content_disposition])
       expect(header_match.versions_from_content([headers[:location]], regexes[:latest])).to eq(matches[:location])
       expect(header_match.versions_from_content([headers[:content_disposition_and_location]], regexes[:latest]))
+        .to eq(matches[:location])
+      expect(header_match.versions_from_content([headers[:location_array]], regexes[:latest]))
         .to eq(matches[:location])
     end
 

--- a/Library/Homebrew/test/livecheck/strategy_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy_spec.rb
@@ -26,7 +26,10 @@ RSpec.describe Homebrew::Livecheck::Strategy do
       status_code: "200",
       status_text: "OK",
       headers:     {
-        "cache-control"  => "max-age=604800",
+        "cache-control"  => [
+          "max-age=604800, must-revalidate",
+          "public, no-transform",
+        ],
         "content-type"   => "text/html; charset=UTF-8",
         "date"           => "Wed, 1 Jan 2020 01:23:45 GMT",
         "expires"        => "Wed, 31 Jan 2020 01:23:45 GMT",
@@ -39,7 +42,10 @@ RSpec.describe Homebrew::Livecheck::Strategy do
       status_code: "301",
       status_text: "Moved Permanently",
       headers:     {
-        "cache-control"  => "max-age=604800",
+        "cache-control"  => [
+          "max-age=604800, must-revalidate",
+          "public, no-transform",
+        ],
         "content-type"   => "text/html; charset=UTF-8",
         "date"           => "Wed, 1 Jan 2020 01:23:45 GMT",
         "expires"        => "Wed, 31 Jan 2020 01:23:45 GMT",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

livecheck's `HeaderMatch` strategy works with data from `Strategy.page_headers`, which calls `Utils::Curl.curl_headers`, which calls `Curl.parse_curl_output`, which calls `Curl.parse_curl_response` and that determines the structure of header hash objects. `parse_curl_response` handles headers that appear more than once in a response by setting the hash value to an array. However, the `headers` parameter type in `HeaderMatch.versions_from_content` only expects a hash with a string value, not a string or an array of strings. This causes a type error when the `HOMEBREW_SORBET_RECURSIVE=1` environment variable is set and `brew livecheck` is run on a package using the `HeaderMatch` strategy.

This addresses the issue by updating the `headers` parameter and `merged_headers` type signatures to allow the hash value to correctly be a string or array of strings along with adjusting the default logic to handle an array value. These changes then surface the same type error in the `Strategy.page_headers` return type, so this updates that as well.