### PR TITLE
sorbet: Add more methods to `rspec.rbi`

### DIFF
--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -145,13 +145,6 @@ class RSpec::Core::ExampleGroup
   def url(val = "", specs = {}); end
 end
 
-# `formula(...) { ... }` helper blocks can be inferred as this helper module in
-# typed specs; declare Formula DSL methods to satisfy static analysis.
-module Test::Helper::Formula
-  sig { params(val: String, specs: T::Hash[Symbol, T.anything]).returns(String) }
-  def url(val = "", specs = {}); end
-end
-
 # Some helper blocks are inferred as Formula instances or class contexts.
 class Formula
   sig { params(names: T.untyped).void }

--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -149,8 +149,28 @@ end
 
 # Some helper blocks are inferred as Formula instances or class contexts.
 class Formula
+  sig { params(names: T.untyped).void }
+  def conflicts_with(*names); end
+
+  sig { params(dep: T.any(String, Symbol, T::Hash[T.any(String, Symbol, T::Class[Requirement]), T.untyped], T::Class[Requirement])).void }
+  def depends_on(dep); end
+
+  sig { params(reason: T.any(String, Symbol), explanation: String).void }
+  def keg_only(reason, explanation = ""); end
+
+  sig { params(paths: T.any(String, Symbol)).returns(T::Set[T.any(String, Symbol)]) }
+  def skip_clean(*paths); end
+
   sig { params(val: String, specs: T::Hash[Symbol, T.anything]).returns(String) }
   def url(val = "", specs = {}); end
+
+  sig {
+    params(
+      dep:    T.any(String, T::Hash[T.any(String, Symbol), T.any(Symbol, T::Array[Symbol])]),
+      bounds: T::Hash[Symbol, Symbol],
+    ).void
+  }
+  def uses_from_macos(dep, bounds = {}); end
 end
 
 # The rspec-mocks RBI defines `ExpectHost#expect(target)` with a required

--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -7,6 +7,11 @@ class RSpec::Core::ExampleGroup
   include RSpec::Mocks::ExampleMethods
   include RuboCop::RSpec::ExpectOffense
 
+  # RSpec::Matchers.alias_matcher is available in example groups at runtime;
+  # declare it here so Sorbet can resolve specs' direct usage.
+  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def self.alias_matcher(*args, &block); end
+
   # These methods are added to specs in
   # `test/support/helper/spec/shared_context/integration_test.rb`; declare them
   # here so Sorbet can resolve them in typed spec files.

--- a/Library/Homebrew/test/build_options_spec.rb
+++ b/Library/Homebrew/test/build_options_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "build_options"

--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "bundle"

--- a/Library/Homebrew/test/cleaner_spec.rb
+++ b/Library/Homebrew/test/cleaner_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cleaner"

--- a/Library/Homebrew/test/dependable_spec.rb
+++ b/Library/Homebrew/test/dependable_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependable"

--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependency_collector"

--- a/Library/Homebrew/test/dependency_spec.rb
+++ b/Library/Homebrew/test/dependency_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependency"

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "github_runner_matrix"

--- a/Library/Homebrew/test/install_spec.rb
+++ b/Library/Homebrew/test/install_spec.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "install"

--- a/Library/Homebrew/test/language/node/shebang_spec.rb
+++ b/Library/Homebrew/test/language/node/shebang_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "language/node"

--- a/Library/Homebrew/test/language/perl/shebang_spec.rb
+++ b/Library/Homebrew/test/language/perl/shebang_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "language/perl"

--- a/Library/Homebrew/test/language/php/shebang_spec.rb
+++ b/Library/Homebrew/test/language/php/shebang_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "language/php"

--- a/Library/Homebrew/test/language/python/shebang_spec.rb
+++ b/Library/Homebrew/test/language/python/shebang_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "language/python"

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependency_collector"

--- a/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependency_collector"

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Tap do

--- a/Library/Homebrew/test/test_bot/formulae_dependents_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_dependents_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_bot"

--- a/Library/Homebrew/test/test_bot/formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_spec.rb
@@ -32,8 +32,6 @@ RSpec.describe Homebrew::TestBot::Formulae do
 
   describe "#annotate_added_dependencies" do
     it "writes a warning annotation for the new recursive dependency impact" do
-      T.bind(self, T.untyped)
-
       formula = formula("foo") do
         url "foo-1.0"
         depends_on "existing"
@@ -127,8 +125,8 @@ RSpec.describe Homebrew::TestBot::Formulae do
     it "restores bottled config with InstallRenamed handling" do
       Dir.mktmpdir do |tmpdir|
         formula_class = Class.new(Formula)
-        T.unsafe(formula_class).url "foo-2.0"
-        T.unsafe(formula_class).version "2.0"
+        formula_class.url "foo-2.0"
+        formula_class.version "2.0"
         f = formula_class.new("test-bot-config", Formulary.core_path("test-bot-config"), :stable)
         config_file = HOMEBREW_PREFIX/"etc/test-bot-config.conf"
         default_config_file = Pathname.new("#{config_file}.default")

--- a/Library/Homebrew/test/test_runner_formula_spec.rb
+++ b/Library/Homebrew/test/test_runner_formula_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_runner_formula"

--- a/Library/Homebrew/test/uninstall_spec.rb
+++ b/Library/Homebrew/test/uninstall_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "uninstall"

--- a/Library/Homebrew/test/utils/autoremove_spec.rb
+++ b/Library/Homebrew/test/utils/autoremove_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/autoremove"

--- a/Library/Homebrew/test/utils/topological_hash_spec.rb
+++ b/Library/Homebrew/test/utils/topological_hash_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/topological_hash"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

- Since https://github.com/Homebrew/brew/commit/572aa16560fec2a8a07c58573d895c22a963e050, we know better how to type RSpec tests with the various shim RBI files, so teach Sorbet about some more methods (taking their sigs from the main `formula.rb` file).

- The `test/test_bot/formulae_spec.rb` file was Sorbet `typed: strict`, but had `T.bind(self, T.untyped)` in a test which used `depends_on`, and also `T.unsafe(formula_class)`, both of which were cheating for the purposes of actual typechecks. ;-)

- Run `brew tc --update --suggest-typed` gets us more typed tests, yay!