### PR TITLE
cask/dsl/caveats: fix built_in_caveats type

### DIFF
--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -86,16 +86,10 @@ module Cask
       caveat :kext do
         next if MacOS.version < :sonoma
 
-        navigation_path = if MacOS.version >= :ventura
-          "System Settings → Privacy & Security"
-        else
-          "System Preferences → Security & Privacy → General"
-        end
-
         <<~EOS
           #{cask} requires a kernel extension to work.
           If the installation fails, retry after you enable it in:
-            #{navigation_path}
+            System Settings → Privacy & Security
 
           For more information, refer to vendor documentation or this Apple Technical Note:
             #{Formatter.url("https://developer.apple.com/library/content/technotes/tn2459/_index.html")}

--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -20,7 +20,7 @@ module Cask
       sig { params(args: T.anything).void }
       def initialize(*args)
         super
-        @built_in_caveats = T.let({}, T::Hash[T::Array[Symbol], String])
+        @built_in_caveats = T.let({}, T::Hash[T::Array[T.any(String, Symbol)], String])
         @custom_caveats = T.let([], T::Array[String])
         @discontinued = T.let(false, T::Boolean)
         @invoked_caveats = T.let(Set.new, T::Set[Symbol])
@@ -211,7 +211,7 @@ module Cask
       sig { returns(T::Set[Symbol]) }
       attr_reader :invoked_caveats
 
-      sig { returns(T::Hash[T::Array[Symbol], String]) }
+      sig { returns(T::Hash[T::Array[T.any(String, Symbol)], String]) }
       attr_reader :built_in_caveats
     end
   end

--- a/Library/Homebrew/test/cask/dsl/caveats_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/caveats_spec.rb
@@ -69,20 +69,20 @@ RSpec.describe Cask::DSL::Caveats, :cask do
   describe "#kext" do
     let(:cask) { instance_double(Cask::Cask) }
 
-    it "returns System Settings on macOS Ventura or later" do
-      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:ventura))
-      caveats.eval_caveats do
-        kext
-      end
-      expect(caveats.to_s).to be_empty
-    end
-
-    it "returns System Preferences on macOS Sonoma and earlier" do
+    it "returns System Settings on macOS Sonoma or later" do
       allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:sonoma))
       caveats.eval_caveats do
         kext
       end
       expect(caveats.to_s).to include("System Settings → Privacy & Security")
+    end
+
+    it "does not include kext caveat text on macOS Ventura and earlier" do
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:ventura))
+      caveats.eval_caveats do
+        kext
+      end
+      expect(caveats.to_s).to be_empty
     end
   end
 end

--- a/Library/Homebrew/test/cask/dsl/caveats_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/caveats_spec.rb
@@ -6,42 +6,66 @@ require "test/cask/dsl/shared_examples/base"
 RSpec.describe Cask::DSL::Caveats, :cask do
   subject(:caveats) { described_class.new(cask) }
 
-  let(:cask) { Cask::CaskLoader.load(cask_path("basic-cask")) }
+  let(:cask) { Cask::CaskLoader.load(cask_path("with-caveats-everything")) }
   let(:dsl) { caveats }
 
   it_behaves_like Cask::DSL::Base
 
-  describe "#to_s_without_conditional" do
-    let(:cask) { instance_double(Cask::Cask, token: "test-cask") }
+  describe "#to_s" do
+    it "includes caveat text for methods and strings" do
+      expected_caveats_str = <<~EOS
+        Custom caveat text.
 
+        You must log out and log back in for the installation of #{cask} to take effect.
+      EOS
+
+      caveats.eval_caveats do
+        logout
+        "Custom caveat text."
+      end
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
+    end
+  end
+
+  describe "#to_s_without_conditional" do
     it "excludes requires_rosetta caveat text" do
+      expected_caveats_str = <<~EOS
+        #{cask} is built for Intel macOS and so requires Rosetta 2 to be installed.
+        You can install Rosetta 2 with:
+          softwareupdate --install-rosetta --agree-to-license
+        Note that it is very difficult to remove Rosetta 2 once it is installed.
+      EOS
+
       allow(Homebrew::SimulateSystem).to receive(:current_arch).and_return(:arm)
       caveats.eval_caveats do
         requires_rosetta
       end
 
-      expect(caveats.to_s).to include("requires Rosetta 2")
-      expect(caveats.to_s_without_conditional).not_to include("requires Rosetta 2")
+      expect(caveats.to_s).to eq(expected_caveats_str)
+      expect(caveats.to_s_without_conditional).to be_empty
     end
 
     it "keeps non-conditional built-in caveats" do
+      expected_caveats_str = <<~EOS
+        You must reboot for the installation of #{cask} to take effect.
+      EOS
+
       caveats.eval_caveats do
         reboot
       end
 
-      expect(caveats.to_s_without_conditional).to include("must reboot")
+      expect(caveats.to_s_without_conditional).to eq(expected_caveats_str)
     end
 
     it "keeps custom caveats" do
       caveats.eval_caveats { "Custom caveat text\n" }
 
-      expect(caveats.to_s_without_conditional).to include("Custom caveat text")
+      expect(caveats.to_s_without_conditional).to eq("Custom caveat text\n")
     end
   end
 
   describe "#invoked?" do
-    let(:cask) { instance_double(Cask::Cask, token: "test-cask") }
-
     it "returns true for invoked caveats" do
       allow(Homebrew::SimulateSystem).to receive(:current_arch).and_return(:arm)
       caveats.eval_caveats do
@@ -66,23 +90,278 @@ RSpec.describe Cask::DSL::Caveats, :cask do
     end
   end
 
-  describe "#kext" do
-    let(:cask) { instance_double(Cask::Cask) }
+  describe "#eval_caveats" do
+    it "returns nil if the block does not return anything" do
+      caveats.eval_caveats do
+        # Intentionally empty to exercise the `return unless result` guard
+      end
 
+      expect(caveats.to_s).to be_empty
+    end
+  end
+
+  describe "#kext" do
     it "returns System Settings on macOS Sonoma or later" do
       allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:sonoma))
+      expected_caveats_str = <<~EOS
+        #{cask} requires a kernel extension to work.
+        If the installation fails, retry after you enable it in:
+          System Settings → Privacy & Security
+
+        For more information, refer to vendor documentation or this Apple Technical Note:
+          https://developer.apple.com/library/content/technotes/tn2459/_index.html
+      EOS
+
       caveats.eval_caveats do
         kext
       end
-      expect(caveats.to_s).to include("System Settings → Privacy & Security")
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
     end
 
-    it "does not include kext caveat text on macOS Ventura and earlier" do
+    it "does not return kext caveat text on macOS Ventura and earlier" do
       allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:ventura))
       caveats.eval_caveats do
         kext
       end
+
       expect(caveats.to_s).to be_empty
+    end
+  end
+
+  describe "#unsigned_accessibility" do
+    it "returns System Settings text on macOS Ventura or later" do
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:ventura))
+      expected_caveats_str = <<~EOS
+        #{cask} is not signed and requires Accessibility access,
+        so you will need to re-grant Accessibility access every time the app is updated.
+
+        Enable or re-enable it in:
+          System Settings → Privacy & Security → Accessibility
+        To re-enable, untick and retick #{cask}.app.
+      EOS
+
+      caveats.eval_caveats do
+        unsigned_accessibility
+      end
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
+    end
+
+    it "returns System Preferences text on macOS Monterey and earlier" do
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:monterey))
+      expected_caveats_str = <<~EOS
+        #{cask} is not signed and requires Accessibility access,
+        so you will need to re-grant Accessibility access every time the app is updated.
+
+        Enable or re-enable it in:
+          System Preferences → Security & Privacy → Privacy → Accessibility
+        To re-enable, untick and retick #{cask}.app.
+      EOS
+
+      caveats.eval_caveats do
+        unsigned_accessibility
+      end
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
+    end
+  end
+
+  describe "#path_environment_variable" do
+    it "returns PATH environment variable caveat text" do
+      expected_caveats_str = <<~EOS
+        To use #{cask}, you may need to add the /example/path directory
+        to your PATH environment variable, e.g. (for Bash shell):
+          export PATH=/example/path:"$PATH"
+      EOS
+
+      caveats.eval_caveats do
+        path_environment_variable "/example/path"
+      end
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
+    end
+  end
+
+  describe "#zsh_path_helper" do
+    it "returns Zsh PATH helper caveat text" do
+      expected_caveats_str = <<~EOS
+        To use #{cask}, zsh users may need to add the following line to their
+        ~/.zprofile. (Among other effects, /example/path will be added to the
+        PATH environment variable):
+          eval `/usr/libexec/path_helper -s`
+      EOS
+
+      caveats.eval_caveats do
+        zsh_path_helper "/example/path"
+      end
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
+    end
+  end
+
+  describe "#files_in_usr_local" do
+    it "returns files in /usr/local caveat text when HOMEBREW_PREFIX starts with /usr/local" do
+      stub_const("HOMEBREW_PREFIX", "/usr/local")
+      expected_caveats_str = <<~EOS
+        Cask #{cask} installs files under /usr/local. The presence of such
+        files can cause warnings when running `brew doctor`, which is considered
+        to be a bug in Homebrew Cask.
+      EOS
+
+      caveats.eval_caveats do
+        files_in_usr_local
+      end
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
+    end
+
+    it "does not return caveat text when HOMEBREW_PREFIX does not start /usr/local" do
+      stub_const("HOMEBREW_PREFIX", "/opt/homebrew")
+      caveats.eval_caveats do
+        files_in_usr_local
+      end
+
+      expect(caveats.to_s).to be_empty
+    end
+  end
+
+  describe "#depends_on_java" do
+    it "returns generic required Java caveat text without an argument" do
+      expected_caveats_str = <<~EOS
+        #{cask} requires Java. You can install the latest version with:
+          brew install --cask temurin
+      EOS
+
+      caveats.eval_caveats do
+        depends_on_java
+      end
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
+    end
+
+    it "returns generic required Java caveat text for `:any` value" do
+      expected_caveats_str = <<~EOS
+        #{cask} requires Java. You can install the latest version with:
+          brew install --cask temurin
+      EOS
+
+      caveats.eval_caveats do
+        depends_on_java :any
+      end
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
+    end
+
+    it "returns required Java caveat text with latest temurin for a version string including a plus sign" do
+      expected_caveats_str = <<~EOS
+        #{cask} requires Java 11+. You can install the latest version with:
+          brew install --cask temurin
+      EOS
+
+      caveats.eval_caveats do
+        depends_on_java "11+"
+      end
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
+    end
+
+    it "returns required Java caveat text with versioned temurin for a version string not including a plus sign" do
+      expected_caveats_str = <<~EOS
+        #{cask} requires Java 11. You can install it with:
+          brew install --cask temurin@11
+      EOS
+
+      caveats.eval_caveats do
+        depends_on_java "11"
+      end
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
+    end
+  end
+
+  describe "#requires_rosetta" do
+    it "returns Rosetta caveat text if the current arch is :arm" do
+      allow(Homebrew::SimulateSystem).to receive(:current_arch).and_return(:arm)
+      expected_caveats_str = <<~EOS
+        #{cask} is built for Intel macOS and so requires Rosetta 2 to be installed.
+        You can install Rosetta 2 with:
+          softwareupdate --install-rosetta --agree-to-license
+        Note that it is very difficult to remove Rosetta 2 once it is installed.
+      EOS
+
+      caveats.eval_caveats do
+        requires_rosetta
+      end
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
+    end
+
+    it "does not return a caveat string if the current arch is not :arm" do
+      allow(Homebrew::SimulateSystem).to receive(:current_arch).and_return(:intel)
+      caveats.eval_caveats do
+        requires_rosetta
+      end
+
+      expect(caveats.to_s).to be_empty
+    end
+  end
+
+  describe "#logout" do
+    it "returns log out caveat text" do
+      expected_caveats_str = <<~EOS
+        You must log out and log back in for the installation of #{cask} to take effect.
+      EOS
+
+      caveats.eval_caveats do
+        logout
+      end
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
+    end
+  end
+
+  describe "#reboot" do
+    it "returns reboot caveat text" do
+      expected_caveats_str = <<~EOS
+        You must reboot for the installation of #{cask} to take effect.
+      EOS
+
+      caveats.eval_caveats do
+        reboot
+      end
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
+    end
+  end
+
+  describe "#license" do
+    it "returns license caveat text" do
+      expected_caveats_str = <<~EOS
+        Installing #{cask} means you have AGREED to the license at:
+          https://brew.sh/test-license/
+      EOS
+
+      caveats.eval_caveats do
+        license "https://brew.sh/test-license/"
+      end
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
+    end
+  end
+
+  describe "#free_license" do
+    it "returns license caveat text" do
+      expected_caveats_str = <<~EOS
+        The vendor offers a free license for #{cask} at:
+          https://brew.sh/test-free-license/
+      EOS
+
+      caveats.eval_caveats do
+        free_license "https://brew.sh/test-free-license/"
+      end
+
+      expect(caveats.to_s).to eq(expected_caveats_str)
     end
   end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-caveats-everything.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-caveats-everything.rb
@@ -1,0 +1,37 @@
+# typed: false
+
+cask "with-caveats-everything" do
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/"
+
+  depends_on macos: :catalina
+
+  app "Caffeine.app"
+
+  # simple string is evaluated at compile-time
+  caveats <<~EOS
+    Here are some things you might want to know.
+  EOS
+  # do block is evaluated at install-time
+  caveats do
+    "Cask token: #{token}"
+  end
+  # a do block may print and use a DSL
+  caveats do
+    puts "Custom text via puts followed by DSL-generated text:"
+    kext
+    unsigned_accessibility
+    path_environment_variable "/custom/path/bin"
+    zsh_path_helper "/example/path"
+    files_in_usr_local
+    depends_on_java "11+"
+    requires_rosetta
+    logout
+    reboot
+    license "https://brew.sh/test-license/"
+    free_license "https://brew.sh/test-free-license/"
+  end
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

When the `HOMEBREW_SORBET_RECURSIVE=1` environment variable is set and brew parses a cask with a `caveat` block that contains a method call using a string argument (e.g., `depends_on_java "8+"`), we can encounter a type error. This specifically happens when `Cask::CaskLoader.load` is used. The type signature for `built_in_caveats` suggests that the hash key is always an array of symbols but in the aforementioned scenario, the key is an array with a symbol and a string instead (e.g., `[:depends_on_java, "8+"]`).

This addresses the error by updating the type for `built_in_caveats` to also allow strings in the key array.

-----

In the process, I've expanded tests in `test/cask/dsl/caveats_spec.rb` to increase coverage from 77.91% of lines and 50% of branches to 100% of lines and branches. This also involved removing dead code in `#kext` which was no longer applicable after the `MacOS.version` guard was changed from `:high_sierra` to `:sonoma` (as that logic couldn't be exercised in tests).