### PR TITLE
info: clarify same-named conflicts and shadowed formulae

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -141,24 +141,26 @@ module Homebrew
       end
 
       sig {
-        params(only: T.nilable(Symbol), method: T.nilable(Symbol))
+        params(only: T.nilable(Symbol), method: T.nilable(Symbol), uniq: T::Boolean)
           .returns(T::Array[T.any(Formula, Keg, Cask::Cask, T::Array[Keg],
                                   FormulaOrCaskUnavailableError, NoSuchKegError)])
       }
-      def to_formulae_and_casks_and_unavailable(only: parent.only_formula_or_cask, method: nil)
+      def to_formulae_and_casks_and_unavailable(only: parent.only_formula_or_cask, method: nil, uniq: true)
         @to_formulae_casks_unknowns ||= T.let(
           {},
           T.nilable(T::Hash[
-            T.nilable(Symbol),
+            [T.nilable(Symbol), T::Boolean],
             T::Array[T.any(Formula, Keg, Cask::Cask, T::Array[Keg],
                            FormulaOrCaskUnavailableError, NoSuchKegError)],
           ]),
         )
-        @to_formulae_casks_unknowns[method] = downcased_unique_named.map do |name|
+        items = downcased_unique_named.map do |name|
           load_formula_or_cask(name, only:, method:)
         rescue FormulaOrCaskUnavailableError, NoSuchKegError => e
           e
-        end.uniq.freeze
+        end
+        items = items.uniq if uniq
+        @to_formulae_casks_unknowns[[method, uniq]] = items.freeze
       end
 
       sig { params(uniq: T::Boolean).returns(T::Array[Formula]) }
@@ -314,8 +316,6 @@ module Homebrew
         downcased_unique_named.grep(HOMEBREW_CASK_TAP_CASK_REGEX)
       end
 
-      private
-
       sig { returns(T::Array[String]) }
       def downcased_unique_named
         # Only lowercase names, not paths, bottle filenames or URLs
@@ -327,6 +327,8 @@ module Homebrew
           end
         end.uniq
       end
+
+      private
 
       sig {
         params(name: String, only: T.nilable(Symbol), method: T.nilable(Symbol), warn: T::Boolean)

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -637,9 +637,17 @@ module Homebrew
           puts deprecate_disable_info_string
         end
 
-        conflicts = formula.conflicts.map do |conflict|
+        conflicts = formula.conflicts.filter_map do |conflict|
+          resolved = begin
+            Formulary.factory(conflict.name)
+          rescue FormulaUnavailableError
+            nil
+          end
+          next if resolved && resolved.full_name == formula.full_name
+
+          conflict_name = resolved&.full_name || conflict.name
           reason = " (because #{conflict.reason})" if conflict.reason
-          "#{conflict.name}#{reason}"
+          "#{conflict_name}#{reason}"
         end.sort!
         unless conflicts.empty?
           puts <<~EOS

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -437,14 +437,21 @@ module Homebrew
 
       sig { params(formula: Formula).returns([Formula, T.nilable(Tap)]) }
       def installed_resolution(formula)
-        return [formula, nil] if formula.installed_kegs.empty?
+        keg = formula.installed_kegs.last
+        return [formula, nil] if keg.nil?
 
-        installed_tap = Tab.for_formula(formula).tap
+        installed_tap = keg.tab.tap
         return [formula, nil] if installed_tap.nil? || installed_tap == formula.tap
 
-        [Formulary.from_rack(formula.rack), formula.tap]
+        [Formulary.factory("#{installed_tap}/#{keg.name}"), formula.tap]
       rescue FormulaUnavailableError, TapFormulaAmbiguityError
         [formula, nil]
+      end
+
+      sig { params(formula: Formula).returns(T.nilable(Formula)) }
+      def shadowing_installed_formula(formula)
+        installed_formula, shadowed_by = installed_resolution(formula)
+        installed_formula if shadowed_by
       end
 
       sig { params(formula: Formula, qualified_inputs: T::Set[String]).returns(Formula) }
@@ -602,7 +609,8 @@ module Homebrew
         attrs = []
         attrs << "keg-only" if formula.keg_only?
 
-        kegs = formula.installed_kegs
+        shadowing_formula = shadowing_installed_formula(formula)
+        kegs = shadowing_formula ? [] : formula.installed_kegs
         installed = kegs.any?
         outdated = installed && formula.outdated?
         if outdated && (upgrade_version = specs.first.presence)
@@ -610,7 +618,13 @@ module Homebrew
                               kegs.max_by(&:scheme_and_version)&.version
           specs[0] = "#{installed_version} → #{upgrade_version}"
         end
-        title_name = shadowed_by ? formula.name : formula.full_name
+        title_name = if shadowing_formula && (formula_tap = formula.tap)
+          "#{formula_tap}/#{formula.name}"
+        elsif shadowed_by
+          formula.name
+        else
+          formula.full_name
+        end
         name_with_status = pretty_install_status(
           title_name,
           installed:,
@@ -686,7 +700,7 @@ module Homebrew
         metadata = self.class.metadata_lines(formula)
         puts metadata if metadata.present?
 
-        installed_lines = installed_section_lines(formula, verbose: args.verbose?)
+        installed_lines = installed_section_lines(shadowing_formula || formula, verbose: args.verbose?)
         unless installed_lines.empty?
           ohai "Installed Kegs and Versions"
           installed_lines.each { |line| puts line }

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -385,16 +385,21 @@ module Homebrew
 
       sig { params(quiet: T::Boolean).void }
       def print_info(quiet: false)
-        qualified_inputs = args.named.select { |name| name.include?("/") }.to_set
+        objects = args.named.to_formulae_and_casks_and_unavailable(uniq: false)
+        user_qualified = args.named.downcased_unique_named.map { |name| name.include?("/") }
 
-        args.named.to_formulae_and_casks_and_unavailable.each_with_index do |obj, i|
+        resolved = user_qualified.zip(objects).map do |qualified, obj|
+          if obj.is_a?(Formula)
+            display_resolution(obj, user_qualified: qualified)
+          else
+            [obj, nil]
+          end
+        end
+
+        unique_by_display_name(resolved).each_with_index do |(obj, shadowed_by), i|
           puts unless i.zero?
 
-          case obj
-          when Formula, Cask::Cask
-            user_qualified = formula_qualified_by_user?(obj, qualified_inputs)
-            info_formula_or_cask(obj, quiet:, user_qualified:)
-          when FormulaOrCaskUnavailableError
+          if obj.is_a?(FormulaOrCaskUnavailableError)
             # The formula/cask could not be found
             ofail obj.message
             # No formula with this name, try a missing formula lookup
@@ -402,9 +407,28 @@ module Homebrew
               $stderr.puts reason
             end
           else
-            raise
+            info_formula_or_cask(obj, quiet:, shadowed_by:)
           end
         end
+      end
+
+      sig {
+        params(resolved: T::Array[[T.untyped, T.nilable(Tap)]]).returns(T::Array[[T.untyped, T.nilable(Tap)]])
+      }
+      def unique_by_display_name(resolved)
+        resolved.uniq do |obj, _shadowed_by|
+          case obj
+          when Formula, Cask::Cask then obj.full_name
+          else obj
+          end
+        end
+      end
+
+      sig { params(formula: Formula, user_qualified: T::Boolean).returns([Formula, T.nilable(Tap)]) }
+      def display_resolution(formula, user_qualified:)
+        return [formula, nil] if user_qualified
+
+        installed_resolution(formula)
       end
 
       sig { params(formula_or_cask: T.any(Formula, Cask::Cask), qualified_inputs: T::Set[String]).returns(T::Boolean) }
@@ -418,20 +442,21 @@ module Homebrew
         names.any? { |n| qualified_inputs.include?(n) }
       end
 
-      sig {
-        params(formula_or_cask: T.any(Formula, Cask::Cask), quiet: T::Boolean, user_qualified: T::Boolean).void
-      }
-      def info_formula_or_cask(formula_or_cask, quiet:, user_qualified: false)
+      sig { params(formula_or_cask: T.any(Formula, Cask::Cask), quiet: T::Boolean, shadowed_by: T.nilable(Tap)).void }
+      def info_formula_or_cask(formula_or_cask, quiet:, shadowed_by: nil)
         case formula_or_cask
         when Formula
-          if user_qualified
-            quiet ? info_formula_summary(formula_or_cask) : info_formula(formula_or_cask)
+          if quiet
+            info_formula_summary(formula_or_cask)
           else
-            formula, shadowed_by = installed_resolution(formula_or_cask)
-            quiet ? info_formula_summary(formula) : info_formula(formula, shadowed_by:)
+            info_formula(formula_or_cask, shadowed_by:)
           end
         when Cask::Cask
-          quiet ? info_cask_summary(formula_or_cask) : info_cask(formula_or_cask)
+          if quiet
+            info_cask_summary(formula_or_cask)
+          else
+            info_cask(formula_or_cask)
+          end
         end
       end
 

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -311,6 +311,40 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
+  it "shows separate blocks for an unqualified and a qualified input that resolve to the same shadowed formula" do
+    info = described_class.new([])
+    core = installed_info_formula
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.source["tap"] = "ataraxy-labs/tap"
+    tab.write
+    allow(core).to receive(:tap).and_return(Tap.fetch("homebrew/core"))
+    installed = formula("testball") { url "https://brew.sh/testball-0.1.tar.gz" }
+    allow(installed).to receive_messages(tap: Tap.fetch("ataraxy-labs/tap"), full_name: "ataraxy-labs/tap/testball")
+    allow(Formulary).to receive(:factory).with("ataraxy-labs/tap/testball").and_return(installed)
+    allow(info).to receive(:github_info).and_return("https://example.com/testball.rb")
+    allow(info.args.named).to receive_messages(
+      downcased_unique_named:                ["testball", "homebrew/core/testball"],
+      to_formulae_and_casks_and_unavailable: [core, core],
+    )
+
+    expect { info.send(:print_info) }
+      .to output(%r{ataraxy-labs/tap/testball.*homebrew/core/testball.*Not installed}m).to_stdout
+  end
+
+  it "reports an unavailable name without raising" do
+    info = described_class.new([])
+    error = FormulaOrCaskUnavailableError.new("nonexistent-formula")
+    allow(info.args.named).to receive_messages(
+      downcased_unique_named:                ["nonexistent-formula"],
+      to_formulae_and_casks_and_unavailable: [error],
+    )
+
+    expect { info.send(:print_info) }
+      .to output(/No available formula or cask with the name "nonexistent-formula"/).to_stderr
+  end
+
   it "qualifies the name, reports not installed and shows the shadowing keg when the keg belongs to another tap" do
     info = described_class.new([])
     formula = installed_info_formula
@@ -323,7 +357,7 @@ RSpec.describe Homebrew::Cmd::Info do
     allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
     shadowing = formula("testball") { url "https://brew.sh/testball-0.1.tar.gz" }
     allow(shadowing).to receive_messages(tap: Tap.fetch("ataraxy-labs/tap"), full_name: "ataraxy-labs/tap/testball")
-    allow(Formulary).to receive(:from_rack).with(formula.rack).and_return(shadowing)
+    allow(Formulary).to receive(:factory).with("ataraxy-labs/tap/testball").and_return(shadowing)
 
     expect { info.send(:info_formula, formula) }
       .to output(%r{homebrew/core/testball.*Not installed.*ataraxy-labs/tap/testball}m).to_stdout
@@ -344,9 +378,21 @@ RSpec.describe Homebrew::Cmd::Info do
     keg_formula = formula("testball") do
       url "https://brew.sh/testball-0.1.tar.gz"
     end
-    allow(Formulary).to receive(:from_rack).with(formula.rack).and_return(keg_formula)
+    allow(Formulary).to receive(:factory).with("ataraxy-labs/tap/testball").and_return(keg_formula)
 
     expect(info.send(:installed_resolution, formula)).to eq([keg_formula, shadowing_tap])
+  end
+
+  it "resolves the keg's own name when it differs from the formula (installed via alias)" do
+    info = described_class.new([])
+    formula = installed_info_formula
+    tab = instance_double(Tab, tap: Tap.fetch("stripe/stripe-cli"))
+    keg = instance_double(Keg, name: "stripe", tab:)
+    allow(formula).to receive_messages(tap: Tap.fetch("homebrew/core"), installed_kegs: [keg])
+    keg_formula = formula("stripe") { url "https://brew.sh/stripe-1.0.tar.gz" }
+    allow(Formulary).to receive(:factory).with("stripe/stripe-cli/stripe").and_return(keg_formula)
+
+    expect(info.send(:installed_resolution, formula)).to eq([keg_formula, Tap.fetch("homebrew/core")])
   end
 
   it "returns the original formula and no shadowing tap when the install receipt has no tap" do
@@ -358,7 +404,6 @@ RSpec.describe Homebrew::Cmd::Info do
     tab.tabfile = keg_path/AbstractTab::FILENAME
     tab.write
 
-    expect(Formulary).not_to receive(:from_rack)
     expect(info.send(:installed_resolution, formula)).to eq([formula, nil])
   end
 
@@ -373,7 +418,6 @@ RSpec.describe Homebrew::Cmd::Info do
     tab.write
 
     allow(formula).to receive(:tap).and_return(Tap.fetch("homebrew/core"))
-    expect(Formulary).not_to receive(:from_rack)
     expect(info.send(:installed_resolution, formula)).to eq([formula, nil])
   end
 
@@ -426,7 +470,7 @@ RSpec.describe Homebrew::Cmd::Info do
     end
     allow(installed_formula).to receive(:tap).and_return(Tap.fetch("ataraxy-labs/tap"))
     allow(info.args.named).to receive(:to_formulae).and_return([shadowed_formula])
-    allow(Formulary).to receive(:from_rack).with(shadowed_formula.rack).and_return(installed_formula)
+    allow(Formulary).to receive(:factory).with("ataraxy-labs/tap/testball").and_return(installed_formula)
 
     output = +""
     expect { info.run }.to output(satisfy { |s|
@@ -448,7 +492,6 @@ RSpec.describe Homebrew::Cmd::Info do
 
     allow(formula).to receive(:tap).and_return(Tap.fetch("homebrew/core"))
     allow(info.args.named).to receive(:to_formulae).and_return([formula])
-    expect(Formulary).not_to receive(:from_rack)
 
     output = +""
     expect { info.run }.to output(satisfy { |s|

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -311,6 +311,24 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
+  it "qualifies the name, reports not installed and shows the shadowing keg when the keg belongs to another tap" do
+    info = described_class.new([])
+    formula = installed_info_formula
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.source["tap"] = "ataraxy-labs/tap"
+    tab.write
+    allow(formula).to receive(:tap).and_return(Tap.fetch("homebrew/core"))
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    shadowing = formula("testball") { url "https://brew.sh/testball-0.1.tar.gz" }
+    allow(shadowing).to receive_messages(tap: Tap.fetch("ataraxy-labs/tap"), full_name: "ataraxy-labs/tap/testball")
+    allow(Formulary).to receive(:from_rack).with(formula.rack).and_return(shadowing)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(%r{homebrew/core/testball.*Not installed.*ataraxy-labs/tap/testball}m).to_stdout
+  end
+
   it "reloads the formula from the install receipt's tap and reports the shadowing tap" do
     info = described_class.new([])
     formula = installed_info_formula

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -249,6 +249,34 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
+  it "shows a conflict by its resolved full name" do
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      conflicts_with "other"
+    end
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    other = formula("other") { url "https://brew.sh/other-0.1.tar.gz" }
+    allow(other).to receive(:full_name).and_return("someuser/tap/other")
+    allow(Formulary).to receive(:factory).with("other").and_return(other)
+
+    expect { info.send(:info_formula, formula) }
+      .to output(%r{Conflicts with:\n  someuser/tap/other}).to_stdout
+  end
+
+  it "omits a stale conflict that resolves to the formula itself" do
+    info = described_class.new([])
+    formula = formula("testball") do
+      url "https://brew.sh/testball-0.1.tar.gz"
+      conflicts_with "testball"
+    end
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(Formulary).to receive(:factory).with("testball").and_return(formula)
+
+    expect { info.send(:info_formula, formula) }
+      .not_to output(/Conflicts with:/).to_stdout
+  end
+
   it "marks a deprecated formula with `(deprecated)` in the title" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 


### PR DESCRIPTION
1. Remove this incorrect warning when a package is reported as conflicting with itself (for Terraform I believe it's a remnant of before it was moved out of core):

```
❯ brew info terraform
==> hashicorp/tap/terraform ↑: 1.9.7 → stable 1.15.5
Terraform
https://www.terraform.io/
Conflicts with:
  terraform
Installed (on request)
From: https://github.com/hashicorp/homebrew-tap/blob/HEAD/Formula/terraform.rb
Tap: hashicorp/tap
==> Installed Kegs and Versions
hashicorp/tap/terraform ↑ 1.9.7 → 1.15.5 (5 files, 87.9MB) [Linked]
```

2. Treat formulae as siblings and show "Installed Kegs and Versions" when they occupy the same disk space but are not technically siblings (like `ataraxy-labs/tap/weave` and `homebrew/core/weave`).

3. Improve `info` when running on multiple formulae that resolve to same *short name* but don't have same full name. Before, de-duplication would incorrectly collapse to the same formula, and end up showing only one of them, even when running both individually with `info` proves that they are different:

```
❯ brew info weave homebrew/core/weave
==> weave ↑: 0.1.6 → stable 0.2.7, HEAD
Warning: `weave` shadows `homebrew/core/weave`.
Entity-level semantic merge driver for Git — resolves conflicts by understanding code structure
https://github.com/Ataraxy-Labs/weave
Installed (on request)
From: https://github.com/ataraxy-labs/homebrew-tap/blob/HEAD/Formula/weave.rb
Tap: ataraxy-labs/tap
License: MIT OR Apache-2.0
==> Installed Kegs and Versions
ataraxy-labs/tap/weave ↑ 0.1.6 → 0.2.7 (11 files, 92.6MB) [Linked]

==> homebrew/core/weave ✘: stable 0.3.5 (bottled), HEAD
Entity-level semantic merge driver for Git using tree-sitter
https://github.com/Ataraxy-Labs/weave
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/w/weave.rb
License: MIT OR Apache-2.0
==> Installed Kegs and Versions
ataraxy-labs/tap/weave ↑ 0.1.6 → 0.2.7 (11 files, 92.6MB) [Linked]
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claud Code, Extra High

-----
