### PR TITLE
pathname: change `env_script_all_files` type

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -356,7 +356,7 @@ class Pathname
   # Writes a wrapper env script and moves all files to the dst.
   #
   # @api public
-  sig { params(dst: Pathname, env: T::Hash[Symbol, String]).void }
+  sig { params(dst: Pathname, env: T::Hash[Symbol, T.any(String, Pathname)]).void }
   def env_script_all_files(dst, env)
     dst.mkpath
     Pathname.glob("#{self}/*") do |file|

--- a/Library/Homebrew/test/extend/pathname_spec.rb
+++ b/Library/Homebrew/test/extend/pathname_spec.rb
@@ -25,4 +25,38 @@ RSpec.describe Pathname do
       end
     end
   end
+
+  describe ".env_script_all_files" do
+    it "create scipts for files" do
+      mktmpdir do |input_dir|
+        FileUtils.touch input_dir/"foo"
+        FileUtils.touch input_dir/"bar"
+
+        mktmpdir do |output_dir|
+          input_dir.env_script_all_files(output_dir, FOO: "foo", BAR: input_dir/"test")
+
+          expect((input_dir/"foo").read).to eq(<<~BASH)
+            #!/bin/bash
+            FOO="foo" BAR="#{input_dir}/test" exec "#{output_dir}/foo"  "$@"
+          BASH
+
+          expect((input_dir/"bar").read).to eq(<<~BASH)
+            #!/bin/bash
+            FOO="foo" BAR="#{input_dir}/test" exec "#{output_dir}/bar"  "$@"
+          BASH
+        end
+      end
+    end
+
+    it "raises an exception when file already exists" do
+      mktmpdir do |input_dir|
+        FileUtils.touch input_dir/"foo"
+
+        mktmpdir do |output_dir|
+          FileUtils.touch output_dir/"foo"
+          expect { input_dir.env_script_all_files(output_dir, FOO: "foo") }.to raise_error(Errno::EEXIST)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Accept `Pathname` in `env` hash as `write_env_script` supports this type

Related CI failure:
https://github.com/Homebrew/homebrew-core/actions/runs/26948407745/job/79508245818

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
