### PR TITLE
Allow logs in build sandbox

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -194,6 +194,7 @@ class Sandbox
       HOMEBREW_PREFIX,
       HOMEBREW_REPOSITORY,
       HOMEBREW_CACHE,
+      HOMEBREW_LOGS,
       HOMEBREW_TEMP,
       ENV.fetch("GITHUB_WORKSPACE", nil),
       ENV.fetch("RUNNER_WORKSPACE", nil),

--- a/Library/Homebrew/test/sandbox_shared_spec.rb
+++ b/Library/Homebrew/test/sandbox_shared_spec.rb
@@ -162,14 +162,16 @@ RSpec.describe Sandbox do
     let(:repository) { mktmpdir/"repository" }
     let(:temp) { mktmpdir/"tmp" }
     let(:cache) { mktmpdir/"cache" }
+    let(:logs) { mktmpdir/"logs" }
 
     before do
-      [home, prefix, repository, temp, cache].each(&:mkpath)
+      [home, prefix, repository, temp, cache, logs].each(&:mkpath)
       allow(Dir).to receive(:home).with(ENV.fetch("USER")).and_return(home.to_s)
       stub_const("HOMEBREW_PREFIX", prefix)
       stub_const("HOMEBREW_REPOSITORY", repository)
       stub_const("HOMEBREW_TEMP", temp)
       stub_const("HOMEBREW_CACHE", cache)
+      stub_const("HOMEBREW_LOGS", logs)
     end
 
     it "denies reads from the real home" do
@@ -185,6 +187,7 @@ RSpec.describe Sandbox do
       [:HOMEBREW_REPOSITORY, "repository"],
       [:HOMEBREW_CACHE, "cache"],
       [:HOMEBREW_TEMP, "tmp"],
+      [:HOMEBREW_LOGS, "Library/Logs/Homebrew"],
     ].each do |constant, directory|
       it "skips the deny when #{constant} is inside the real home" do
         stub_const(constant.to_s, home/directory)


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22535

- Avoid denying the real home when `HOMEBREW_LOGS` is under it.
- Preserve stricter sandboxing when Homebrew paths are outside home.
- Cover the default macOS logs path in `deny_read_home` specs.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
