### PR TITLE
sorbet: Less RBI duplication to successfully typecheck RSpec tests

### DIFF
--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -152,6 +152,7 @@ module Homebrew
         return unless parsed.success?
 
         allowlist = %w[
+          CopHelper
           Parser::Source
           RuboCop::AST::Node
           RuboCop::AST::NodePattern

--- a/Library/Homebrew/sorbet/rbi/gems/rubocop@1.86.2.rbi
+++ b/Library/Homebrew/sorbet/rbi/gems/rubocop@1.86.2.rbi
@@ -5,6 +5,23 @@
 # Please instead update this file by running `bin/tapioca gem rubocop`.
 
 
+module CopHelper
+  extend ::RSpec::Core::SharedContext
+
+  def _investigate(cop, processed_source); end
+  def autocorrect_source(source, file = T.unsafe(nil)); end
+  def autocorrect_source_file(source); end
+  def configuration; end
+  def inspect_source(source, file = T.unsafe(nil)); end
+  def parse_source(source, file = T.unsafe(nil)); end
+  def registry; end
+
+  class << self
+    def integrated_plugins; end
+    def integrated_plugins=(_arg0); end
+  end
+end
+
 class Parser::Source::Comment
   include ::RuboCop::Ext::Comment
 end
@@ -4022,9 +4039,9 @@ RuboCop::Formatter::PacmanFormatter::FALLBACK_TERMINAL_WIDTH = T.let(T.unsafe(ni
 
 RuboCop::Formatter::PacmanFormatter::GHOST = T.let(T.unsafe(nil), String)
 
-RuboCop::Formatter::PacmanFormatter::PACDOT = T.let(T.unsafe(nil), Rainbow::NullPresenter)
+RuboCop::Formatter::PacmanFormatter::PACDOT = T.let(T.unsafe(nil), Rainbow::Presenter)
 
-RuboCop::Formatter::PacmanFormatter::PACMAN = T.let(T.unsafe(nil), Rainbow::NullPresenter)
+RuboCop::Formatter::PacmanFormatter::PACMAN = T.let(T.unsafe(nil), Rainbow::Presenter)
 
 RuboCop::Formatter::ProgressFormatter::DOT = T.let(T.unsafe(nil), String)
 

--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -1,6 +1,8 @@
 # typed: strict
 
 class RSpec::Core::ExampleGroup
+  extend RSpec::Matchers::DSL
+
   include CopHelper
   include RSpec::SharedContext
   include RSpec::Matchers

--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -22,18 +22,3 @@ module RSpec::Mocks::ExampleMethods::ExpectHost
   sig { params(value: T.untyped, block: T.nilable(T.proc.void)).returns(T.untyped) }
   def expect(value = T.unsafe(nil), &block); end
 end
-
-# RuboCop cop specs include this helper at runtime via `rubocop/rspec/support`.
-module CopHelper
-  sig { params(source: String, file: T.untyped).returns(T::Array[T.untyped]) }
-  def inspect_source(source, file = T.unsafe(nil)); end
-
-  sig { params(source: String, file: T.untyped).returns(String) }
-  def autocorrect_source(source, file = T.unsafe(nil)); end
-
-  sig { params(source: String).returns(String) }
-  def autocorrect_source_file(source); end
-
-  sig { params(source: String, file: T.untyped).returns(T.untyped) }
-  def parse_source(source, file = T.unsafe(nil)); end
-end

--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -6,6 +6,12 @@ class RSpec::Core::ExampleGroup
   include RSpec::Matchers
   include RSpec::Mocks::ExampleMethods
   include RuboCop::RSpec::ExpectOffense
+  include Test::Helper::Cask
+  include Test::Helper::Fixtures
+  include Test::Helper::Formula
+  include Test::Helper::MkTmpDir
+  include Test::Helper::Subcommand
+  include Test::Helper::Fixtures
 
   # These methods are added to specs in
   # `test/support/helper/spec/shared_context/integration_test.rb`; declare them
@@ -40,90 +46,6 @@ class RSpec::Core::ExampleGroup
 
   sig { params(name: String).void }
   def uninstall_test_formula(name); end
-
-  # These methods are mixed into specs via
-  # `config.include(Test::Helper::{Formula,Cask})` in `test/spec_helper.rb`;
-  # declare them here so Sorbet can resolve them in typed spec files.
-  sig { params(formula: ::Formula, ref: T.nilable(String), call_original: T::Boolean).void }
-  def stub_formula_loader(formula, ref = formula.full_name, call_original: false); end
-
-  sig { params(cask: Cask::Cask, ref: T.nilable(String), call_original: T::Boolean).void }
-  def stub_cask_loader(cask, ref = cask.token, call_original: false); end
-
-  # `mktmpdir` is mixed into specs via `config.include(Test::Helper::MkTmpDir)`
-  # in `test/spec_helper.rb`; declare it here so Sorbet can resolve it in typed
-  # spec files.
-  sig {
-    type_parameters(:U)
-      .params(
-        prefix_suffix: T.nilable(T.any(String, T::Array[String])),
-        block:         T.proc.params(path: Pathname).returns(T.type_parameter(:U)),
-      ).returns(T.type_parameter(:U))
-  }
-  sig {
-    params(
-      prefix_suffix: T.nilable(T.any(String, T::Array[String])),
-      block:         T.nilable(T.proc.params(path: Pathname).returns(Pathname)),
-    ).returns(Pathname)
-  }
-  def mktmpdir(prefix_suffix = T.unsafe(nil), &block); end
-
-  # These methods are mixed into specs via
-  # `config.include(Test::Helper::Subcommand)` in `test/spec_helper.rb`;
-  # declare them here so Sorbet can resolve them in typed spec files.
-  sig {
-    params(
-      subcommand: T.nilable(T.any(String, Symbol)),
-      named:      T.untyped,
-      options:    T.untyped,
-    ).returns(Test::Helper::Subcommand::Args)
-  }
-  def args_for_subcommand(subcommand = T.unsafe(nil), *named, **options); end
-
-  sig {
-    params(
-      subcommand:   T.any(String, Symbol),
-      global:       T::Boolean,
-      file:         T.nilable(String),
-      no_upgrade:   T::Boolean,
-      verbose:      T::Boolean,
-      force:        T::Boolean,
-      ask:          T::Boolean,
-      jobs:         Integer,
-      zap:          T::Boolean,
-      no_type_args: T::Boolean,
-    ).returns(Homebrew::Cmd::Bundle::SubcommandContext)
-  }
-  def bundle_subcommand_context(subcommand, global: false, file: nil, no_upgrade: false, verbose: false,
-                                force: false, ask: false, jobs: 1, zap: false, no_type_args: true)
-  end
-
-  # These methods are mixed into specs via
-  # `config.include(Test::Helper::Fixtures)` in `test/spec_helper.rb`;
-  # declare them here so Sorbet can resolve them in typed spec files.
-  sig { params(name: String).returns(MachOShim) }
-  def dylib_path(name); end
-
-  sig { params(name: String).returns(MachOShim) }
-  def bundle_path(name); end
-
-  sig { params(name: String).returns(Pathname) }
-  def cask_path(name); end
-
-  sig { params(name: String).returns(Pathname) }
-  def tarball_fixture(name); end
-
-  sig { params(name: String).returns(String) }
-  def tarball_fixture_sha256(name); end
-
-  sig { params(name: String).returns(Pathname) }
-  def patch_fixture(name); end
-
-  sig { params(name: String).returns(String) }
-  def patch_fixture_sha256(name); end
-
-  sig { params(name: String).returns(Pathname) }
-  def fixture(name); end
 end
 
 # The rspec-mocks RBI defines `ExpectHost#expect(target)` with a required

--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -9,43 +9,9 @@ class RSpec::Core::ExampleGroup
   include Test::Helper::Cask
   include Test::Helper::Fixtures
   include Test::Helper::Formula
+  include Test::Helper::IntegrationTest
   include Test::Helper::MkTmpDir
   include Test::Helper::Subcommand
-  include Test::Helper::Fixtures
-
-  # These methods are added to specs in
-  # `test/support/helper/spec/shared_context/integration_test.rb`; declare them
-  # here so Sorbet can resolve them in typed spec files.
-  sig { params(args: T.untyped).returns(Process::Status) }
-  def brew(*args); end
-
-  sig { params(args: T.untyped).returns(Process::Status) }
-  def brew_sh(*args); end
-
-  sig {
-    params(
-      name:           String,
-      content:        T.nilable(String),
-      tap:            Tap,
-      bottle_block:   T.nilable(String),
-      tab_attributes: T.nilable(T::Hash[T.untyped, T.untyped]),
-    ).returns(Pathname)
-  }
-  def setup_test_formula(name, content = T.unsafe(nil), tap: T.unsafe(nil), bottle_block: T.unsafe(nil),
-                         tab_attributes: T.unsafe(nil))
-  end
-
-  sig { returns(Pathname) }
-  def setup_test_tap; end
-
-  sig { params(name: String, content: T.nilable(String), build_bottle: T::Boolean).void }
-  def install_test_formula(name, content = T.unsafe(nil), build_bottle: false); end
-
-  sig { params(old_name: String, new_name: String).void }
-  def install_and_rename_coretap_formula(old_name, new_name); end
-
-  sig { params(name: String).void }
-  def uninstall_test_formula(name); end
 end
 
 # The rspec-mocks RBI defines `ExpectHost#expect(target)` with a required

--- a/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
+++ b/Library/Homebrew/sorbet/rbi/shims/rspec.rbi
@@ -44,14 +44,6 @@ class RSpec::Core::ExampleGroup
   # These methods are mixed into specs via
   # `config.include(Test::Helper::{Formula,Cask})` in `test/spec_helper.rb`;
   # declare them here so Sorbet can resolve them in typed spec files.
-  sig {
-    params(
-      name: String, path: T.nilable(Pathname), spec: Symbol, alias_path: T.nilable(Pathname),
-      tap: T.nilable(Tap), block: T.nilable(T.proc.bind(Formula).void)
-    ).returns(::Formula)
-  }
-  def formula(name = T.unsafe(nil), path: nil, spec: :stable, alias_path: nil, tap: nil, &block); end
-
   sig { params(formula: ::Formula, ref: T.nilable(String), call_original: T::Boolean).void }
   def stub_formula_loader(formula, ref = formula.full_name, call_original: false); end
 
@@ -132,25 +124,6 @@ class RSpec::Core::ExampleGroup
 
   sig { params(name: String).returns(Pathname) }
   def fixture(name); end
-
-  # `formula(...) { ... }` helper blocks can be inferred as example group
-  # contexts in typed specs; declare Formula DSL methods to satisfy static
-  # analysis.
-  sig { params(val: String, specs: T::Hash[Symbol, T.anything]).returns(String) }
-  def url(val = "", specs = {}); end
-end
-
-# `formula(...) { ... }` helper blocks can be inferred as this helper module in
-# typed specs; declare Formula DSL methods to satisfy static analysis.
-module Test::Helper::Formula
-  sig { params(val: String, specs: T::Hash[Symbol, T.anything]).returns(String) }
-  def url(val = "", specs = {}); end
-end
-
-# Some helper blocks are inferred as Formula instances or class contexts.
-class Formula
-  sig { params(val: String, specs: T::Hash[Symbol, T.anything]).returns(String) }
-  def url(val = "", specs = {}); end
 end
 
 # The rspec-mocks RBI defines `ExpectHost#expect(target)` with a required

--- a/Library/Homebrew/sorbet/tapioca/require.rb
+++ b/Library/Homebrew/sorbet/tapioca/require.rb
@@ -8,7 +8,7 @@ dependency_require_map = {
 
 additional_requires_map = {
   "parser"        => ["parser/current"],
-  "rubocop-rspec" => ["rubocop/rspec/expect_offense"],
+  "rubocop-rspec" => ["rubocop/rspec/expect_offense", "rubocop/rspec/cop_helper"],
 }.freeze
 
 # Freeze lockfile

--- a/Library/Homebrew/test/bottle_filename_spec.rb
+++ b/Library/Homebrew/test/bottle_filename_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Bottle::Filename do
 
     let(:f) do
       formula do
+        T.bind(self, T.class_of(Formula))
         url "https://brew.sh/foo.tar.gz"
         version "1.0"
       end

--- a/Library/Homebrew/test/build_options_spec.rb
+++ b/Library/Homebrew/test/build_options_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "build_options"

--- a/Library/Homebrew/test/bundle/mac_app_store_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_spec.rb
@@ -180,7 +180,10 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
 
   describe "installing" do
     before do
-      stub_formula_loader formula("mas") { url "mas-1.0" }
+      stub_formula_loader formula("mas") {
+        T.bind(self, T.class_of(Formula))
+        url "mas-1.0"
+      }
     end
 
     describe ".installed_app_ids" do

--- a/Library/Homebrew/test/bundle/skipper_spec.rb
+++ b/Library/Homebrew/test/bundle/skipper_spec.rb
@@ -34,7 +34,10 @@ RSpec.describe Homebrew::Bundle::Skipper do
       it "returns true" do
         allow(Hardware::CPU).to receive(:arm?).and_return(true)
         allow(Homebrew).to receive(:default_prefix?).and_return(true)
-        stub_formula_loader formula("mysql") { url "mysql-1.0" }
+        stub_formula_loader formula("mysql") {
+          T.bind(self, T.class_of(Formula))
+          url "mysql-1.0"
+        }
 
         expect(skipper.skip?(entry)).to be true
       end

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe Homebrew::CLI::NamedArgs do
   let(:klass) { Homebrew::CLI::NamedArgs }
   let(:foo) do
     formula "foo" do
+      T.bind(self, T.class_of(Formula))
       url "https://brew.sh"
       version "1.0"
     end
   end
   let(:bar) do
     formula "bar" do
+      T.bind(self, T.class_of(Formula))
       url "https://brew.sh"
       version "1.0"
     end
@@ -92,6 +94,7 @@ RSpec.describe Homebrew::CLI::NamedArgs do
     context "when a non-core formula and a core cask are present" do
       let(:non_core_formula) do
         formula "foo", tap: Tap.fetch("some/tap") do
+          T.bind(self, T.class_of(Formula))
           url "https://brew.sh"
           version "1.0"
         end

--- a/Library/Homebrew/test/cmd/--cache_spec.rb
+++ b/Library/Homebrew/test/cmd/--cache_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/--cache"

--- a/Library/Homebrew/test/cmd/bundle/check_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/check_subcommand_spec.rb
@@ -19,7 +19,10 @@ RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
   before do
     Homebrew::Bundle::Checker.reset!
     allow_any_instance_of(IO).to receive(:puts)
-    stub_formula_loader formula("mas") { url "mas-1.0" }
+    stub_formula_loader formula("mas") {
+      T.bind(self, T.class_of(Formula))
+      url "mas-1.0"
+    }
   end
 
   context "when dependencies are satisfied" do
@@ -85,7 +88,10 @@ RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
     before do
       allow(Homebrew::Bundle::Cask).to receive(:casks).and_return([])
       allow(Homebrew::Bundle::Brew).to receive_messages(upgradable_formulae: [], installed_formulae: ["abc"])
-      stub_formula_loader formula("abc") { url "abc-1.0" }
+      stub_formula_loader formula("abc") {
+        T.bind(self, T.class_of(Formula))
+        url "abc-1.0"
+      }
     end
 
     it "raises an error" do

--- a/Library/Homebrew/test/cmd/bundle/dump_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/dump_subcommand_spec.rb
@@ -101,7 +101,10 @@ RSpec.describe Homebrew::Cmd::Bundle::DumpSubcommand do
 
     before do
       ENV["HOMEBREW_BUNDLE_FILE"] = ""
-      stub_formula_loader formula("mas") { url "mas-1.0" }
+      stub_formula_loader formula("mas") {
+        T.bind(self, T.class_of(Formula))
+        url "mas-1.0"
+      }
       allow_any_instance_of(Pathname).to receive(:exist?).and_return(true)
       allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(true)
       allow(Cask::Caskroom).to receive(:casks).and_return([])

--- a/Library/Homebrew/test/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cmd/home_spec.rb
@@ -7,6 +7,7 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Home do
   let(:testballhome) do
     formula("testballhome") do
+      T.bind(self, T.class_of(Formula))
       homepage "https://brew.sh/testballhome"
       url "https://brew.sh/testballhome-1.0"
     end

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -13,9 +13,11 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
 
   it "prints a formula dry-run plan when asking" do
     added = formula("added") do
+      T.bind(self, T.class_of(Formula))
       url "https://brew.sh/added-1.0.tar.gz"
     end
     changed = formula("changed") do
+      T.bind(self, T.class_of(Formula))
       url "https://brew.sh/changed-2.0.tar.gz"
     end
     added_installer = FormulaInstaller.new(added)
@@ -39,6 +41,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
 
   it "skips ask input when asking for only requested formulae" do
     formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
       url "https://brew.sh/testball-0.1.tar.gz"
     end
     formula_installer = FormulaInstaller.new(formula)
@@ -60,9 +63,11 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
 
   it "uses the requested action when asking for formulae with dependencies" do
     formula = formula("changed") do
+      T.bind(self, T.class_of(Formula))
       url "https://brew.sh/changed-2.0.tar.gz"
     end
     dependency = formula("dependency") do
+      T.bind(self, T.class_of(Formula))
       url "https://brew.sh/dependency-1.0.tar.gz"
     end
     formula_installer = FormulaInstaller.new(formula)
@@ -261,7 +266,10 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
   it "prints an ask mode environment hint when installing formulae" do
     cmd = klass.new(["testball"])
     download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil)
-    formula = formula("testball") { url "https://brew.sh/testball-0.1.tar.gz" }
+    formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/testball-0.1.tar.gz"
+    end
     formula_installer = FormulaInstaller.new(formula)
     dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
 
@@ -386,7 +394,10 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
   it "prints a shared fetch heading and correct upgrade count", :cask do
     cmd = klass.new(["codex"])
     download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil)
-    formula = formula("testball_bottle") { url "https://brew.sh/testball_bottle-0.1.tar.gz" }
+    formula = formula("testball_bottle") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/testball_bottle-0.1.tar.gz"
+    end
     formula_installer = instance_double(FormulaInstaller, formula:)
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
     installer = instance_double(Cask::Installer, enqueue_downloads: nil, source_download_requires_pre_fetch?: false)

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -46,7 +46,10 @@ RSpec.describe Homebrew::Cmd::Reinstall do
 
   it "asks for casks before shared prefetch when reinstalling formulae and casks" do
     cmd = klass.new(["--ask", "testball", "local-caffeine"])
-    formula = formula("testball") { url "https://brew.sh/testball-0.1.tar.gz" }
+    formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/testball-0.1.tar.gz"
+    end
     formula_installer = FormulaInstaller.new(formula)
     dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))

--- a/Library/Homebrew/test/dependable_spec.rb
+++ b/Library/Homebrew/test/dependable_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependable"

--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependency_collector"

--- a/Library/Homebrew/test/dependency_spec.rb
+++ b/Library/Homebrew/test/dependency_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependency"

--- a/Library/Homebrew/test/description_cache_store_spec.rb
+++ b/Library/Homebrew/test/description_cache_store_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe DescriptionCacheStore do
   describe "#update_from_formula_names!" do
     it "sets the formulae descriptions" do
       f = formula do
+        T.bind(self, T.class_of(Formula))
         url "url-1"
         desc "desc"
       end

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Homebrew::DevCmd::Bump do
   let(:klass) { Homebrew::DevCmd::Bump }
   let(:f_basic) do
     formula("basic_formula") do
+      T.bind(self, T.class_of(Formula))
       desc "Basic formula"
       url "https://brew.sh/test-1.2.3.tgz"
     end

--- a/Library/Homebrew/test/install_spec.rb
+++ b/Library/Homebrew/test/install_spec.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "install"

--- a/Library/Homebrew/test/language/java_spec.rb
+++ b/Library/Homebrew/test/language/java_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Language::Java do
 
   let(:f) do
     formula("openjdk") do
+      T.bind(self, T.class_of(Formula))
       url "openjdk"
       version "15.0.1"
     end

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Language::Node do
 
     it "calls prepend_path when node formula exists only during the first call" do
       node = formula "node" do
+        T.bind(self, T.class_of(Formula))
         url "node-test-v1.0"
       end
       stub_formula_loader(node)

--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -8,7 +8,12 @@ RSpec.describe Messages do
   let(:klass) { Messages }
 
   let(:messages) { klass.new }
-  let(:test_formula) { formula("foo") { url("https://brew.sh/foo-0.1.tgz") } }
+  let(:test_formula) do
+    formula("foo") do
+      T.bind(self, T.class_of(Formula))
+      url("https://brew.sh/foo-0.1.tgz")
+    end
+  end
   let(:elapsed_time) { 1.1 }
 
   describe "#record_caveats" do
@@ -56,7 +61,12 @@ RSpec.describe Messages do
     end
 
     context "when package_count is greater than one and caveats are present" do
-      let(:test_formula2) { formula("bar") { url("https://brew.sh/bar-0.1.tgz") } }
+      let(:test_formula2) do
+        formula("bar") do
+          T.bind(self, T.class_of(Formula))
+          url("https://brew.sh/bar-0.1.tgz")
+        end
+      end
 
       before do
         messages.record_caveats(test_formula.name, "Zsh completions were installed")

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependency_collector"

--- a/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependency_collector"

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -184,7 +184,10 @@ RSpec.describe Resource do
     end
 
     it "sets its owner to be the patches' owner" do
-      resource.patch(:p1) { url "file:///my.patch" }
+      resource.patch(:p1) do
+        T.bind(self, Resource::Patch)
+        url "file:///my.patch"
+      end
       resource.owner = owner
       resource.patches.each do |p|
         expect(p.resource.owner).to eq(owner)

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "sandbox"

--- a/Library/Homebrew/test/support/helper/cask.rb
+++ b/Library/Homebrew/test/support/helper/cask.rb
@@ -10,6 +10,7 @@ module Test
 
       requires_ancestor { RSpec::Mocks::ExampleMethods }
 
+      sig { params(cask: ::Cask::Cask, ref: T.nilable(String), call_original: T::Boolean).void }
       def stub_cask_loader(cask, ref = cask.token, call_original: false)
         allow(::Cask::CaskLoader).to receive(:for).and_call_original if call_original
 

--- a/Library/Homebrew/test/support/helper/cask.rb
+++ b/Library/Homebrew/test/support/helper/cask.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "cask/cask_loader"

--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "formulary"

--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -13,7 +13,7 @@ module Test
       sig {
         params(
           name: String, path: T.nilable(Pathname), spec: Symbol, alias_path: T.nilable(Pathname),
-          tap: T.nilable(Tap), block: T.nilable(T.proc.bind(Formula).void)
+          tap: T.nilable(Tap), block: T.nilable(T.proc.bind(::Formula).void)
         ).returns(::Formula)
       }
       def formula(name = "formula_name", path: nil, spec: :stable, alias_path: nil, tap: nil, &block)
@@ -23,6 +23,7 @@ module Test
 
       # Use a stubbed {Formulary::FormulaLoader} to make a given formula be found
       # when loading from {Formulary} with `ref`.
+      sig { params(formula: ::Formula, ref: T.nilable(T.any(String, Pathname)), call_original: T::Boolean).void }
       def stub_formula_loader(formula, ref = formula.full_name, call_original: false)
         allow(Formulary).to receive(:loader_for).and_call_original if call_original
 

--- a/Library/Homebrew/test/support/helper/mktmpdir.rb
+++ b/Library/Homebrew/test/support/helper/mktmpdir.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Test

--- a/Library/Homebrew/test/support/helper/mktmpdir.rb
+++ b/Library/Homebrew/test/support/helper/mktmpdir.rb
@@ -4,6 +4,12 @@
 module Test
   module Helper
     module MkTmpDir
+      sig {
+        type_parameters(:U).params(
+          prefix_suffix: T.nilable(T.any(String, T::Array[String])),
+          block:         T.nilable(T.proc.params(path: Pathname).returns(T.type_parameter(:U))),
+        ).returns(T.any(Pathname, T.type_parameter(:U)))
+      }
       def mktmpdir(prefix_suffix = nil, &block)
         new_dir = Pathname.new(Dir.mktmpdir(prefix_suffix, HOMEBREW_TEMP))
         return yield(new_dir) if block

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -44,9 +44,254 @@ end
 
 RSpec::Matchers.define_negated_matcher :be_a_failure, :be_a_success
 
+module Test
+  module Helper
+    module IntegrationTest
+      extend T::Helpers
+
+      requires_ancestor { Kernel }
+
+      # Generate unique ID to be able to
+      # properly merge coverage results.
+      sig { returns(String) }
+      def command_id
+        Thread.current[:brew_integration_test_number] ||= 0
+        "#{Process.pid}:#{ENV.fetch("TEST_ENV_NUMBER", "")}:#{Thread.current[:brew_integration_test_number] += 1}"
+      end
+
+      # Runs a `brew` command with the test configuration
+      # and with coverage reporting enabled.
+      sig { params(args: T.untyped).returns(Process::Status) }
+      def brew(*args)
+        env = args.last.is_a?(Hash) ? args.pop : {}
+
+        # Avoid warnings when HOMEBREW_PREFIX/bin is not in PATH.
+        # Also include our extra commands directory.
+        path = [
+          env["PATH"],
+          (HOMEBREW_LIBRARY_PATH/"test/support/helper/cmd").realpath.to_s,
+          (HOMEBREW_PREFIX/"bin").realpath.to_s,
+          ENV.fetch("PATH"),
+        ].compact.join(File::PATH_SEPARATOR)
+
+        env.merge!(
+          "PATH"                         => path,
+          "HOMEBREW_PATH"                => path,
+          "HOMEBREW_BREW_FILE"           => HOMEBREW_PREFIX/"bin/brew",
+          "HOMEBREW_INTEGRATION_TEST"    => command_id,
+          "HOMEBREW_TEST_TMPDIR"         => TEST_TMPDIR,
+          "HOMEBREW_DEV_CMD_RUN"         => "true",
+          "HOMEBREW_USE_RUBY_FROM_PATH"  => ENV.fetch("HOMEBREW_USE_RUBY_FROM_PATH", nil),
+          "HOMEBREW_NO_INSTALL_FROM_API" => ENV.fetch("HOMEBREW_NO_INSTALL_FROM_API", nil),
+          "GEM_HOME"                     => nil,
+        )
+
+        @ruby_args ||= begin
+          ruby_args = HOMEBREW_RUBY_EXEC_ARGS.dup
+          if ENV["HOMEBREW_TESTS_COVERAGE"]
+            simplecov_spec = Gem.loaded_specs["simplecov"]
+            parallel_tests_spec = Gem.loaded_specs["parallel_tests"]
+            specs = T.let([], T::Array[Gem::Specification])
+            [simplecov_spec, parallel_tests_spec].each do |spec|
+              specs << spec
+              spec.runtime_dependencies.each do |dep|
+                specs += dep.to_specs
+              rescue Gem::LoadError => e
+                T.bind(self, Utils::Output::Mixin)
+                onoe e
+              end
+            end
+            specs.flat_map(&:full_require_paths).each { |lib| ruby_args << "-I" << lib }
+            ruby_args << "-rsimplecov"
+          end
+          ruby_args << "-r#{HOMEBREW_LIBRARY_PATH}/test/support/helper/integration_mocks"
+          ruby_args << "-e" << "$0 = ARGV.shift; load($0)"
+          ruby_args << (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path.to_s
+        end
+
+        Bundler.with_unbundled_env do
+          stdout, stderr, status = Open3.capture3(env, *@ruby_args, *args)
+          $stdout.print stdout
+          $stderr.print stderr
+          status
+        end
+      end
+
+      sig { params(args: T.untyped).returns(Process::Status) }
+      def brew_sh(*args)
+        env = args.last.is_a?(Hash) ? args.pop : {}
+        env = {
+          "HOMEBREW_USE_RUBY_FROM_PATH" => ENV.fetch("HOMEBREW_USE_RUBY_FROM_PATH", nil),
+          "HOMEBREW_CACHE"              => HOMEBREW_CACHE.to_s,
+          "HOMEBREW_INTEGRATION_TEST"   => command_id,
+        }.merge(env)
+        Bundler.with_unbundled_env do
+          brew_sh_path = env.delete("HOMEBREW_BREW_SH") || "#{ENV.fetch("HOMEBREW_PREFIX")}/bin/brew"
+          stdout, stderr, status = Open3.capture3(
+            env,
+            brew_sh_path,
+            *args,
+          )
+          $stdout.print stdout
+          $stderr.print stderr
+          status
+        end
+      end
+
+      sig {
+        params(
+          name:           String,
+          content:        T.nilable(String),
+          tap:            Tap,
+          bottle_block:   T.nilable(String),
+          tab_attributes: T.nilable(T::Hash[T.untyped, T.untyped]),
+        ).returns(Pathname)
+      }
+      def setup_test_formula(name, content = nil, tap: CoreTap.instance,
+                             bottle_block: nil, tab_attributes: nil)
+        case name
+        when /^testball/
+          # Use a different tarball for testball2 to avoid lock errors when writing concurrency tests
+          prefix = (name == "testball2") ? "testball2" : "testball"
+          tarball = if OS.linux?
+            TEST_FIXTURE_DIR/"tarballs/#{prefix}-0.1-linux.tbz"
+          else
+            TEST_FIXTURE_DIR/"tarballs/#{prefix}-0.1.tbz"
+          end
+          bottle_block ||= <<~RUBY if name == "testball_bottle"
+            bottle do
+              root_url "file://#{TEST_FIXTURE_DIR}/bottles"
+              sha256 cellar: :any_skip_relocation, all: "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97"
+            end
+          RUBY
+          content = <<~RUBY
+            desc "Some test"
+            homepage "https://brew.sh/#{name}"
+            url "file://#{tarball}"
+            sha256 "#{tarball.sha256}"
+
+            option "with-foo", "Build with foo"
+            #{bottle_block}
+            def install
+              (prefix/"foo"/"test").write("test") if build.with? "foo"
+              prefix.install Dir["*"]
+              (buildpath/"test.c").write \
+                "#include <stdio.h>\\nint main(){printf(\\"test\\");return 0;}"
+              bin.mkpath
+              system ENV.cc, "test.c", "-o", bin/"test"
+            end
+
+            #{content}
+
+            # something here
+          RUBY
+        when "bar"
+          content = <<~RUBY
+            url "https://brew.sh/#{name}-1.0"
+            depends_on "foo"
+          RUBY
+        when "package_license"
+          content = <<~RUBY
+            url "https://brew.sh/#patchelf-1.0"
+            license "0BSD"
+          RUBY
+        else
+          content ||= <<~RUBY
+            url "https://brew.sh/#{name}-1.0"
+          RUBY
+        end
+
+        formula_path = Formulary.find_formula_in_tap(name.downcase, tap).tap do |path|
+          path.dirname.mkpath
+          path.write <<~RUBY
+            class #{Formulary.class_s(name)} < Formula
+            #{content.gsub(/^(?!$)/, "  ")}
+            end
+          RUBY
+
+          tap.clear_cache
+        end
+
+        return formula_path if tab_attributes.nil?
+
+        keg = ::Formula[name].prefix
+        keg.mkpath
+
+        tab = Tab.for_name(name)
+        tab.tabfile ||= keg/AbstractTab::FILENAME
+        tab_attributes.each do |key, value|
+          tab.instance_variable_set(:"@#{key}", value)
+        end
+        tab.write
+
+        formula_path
+      end
+
+      sig { params(name: String, content: T.nilable(String), build_bottle: T::Boolean).void }
+      def install_test_formula(name, content = nil, build_bottle: false)
+        setup_test_formula(name, content)
+        fi = FormulaInstaller.new(::Formula[name], build_bottle:, installed_on_request: true)
+        fi.prelude_fetch
+        fi.prelude
+        fi.fetch
+        fi.install
+        fi.finish
+      end
+
+      sig { params(name: String).void }
+      def uninstall_test_formula(name)
+        rack = HOMEBREW_CELLAR/name
+        return unless rack.directory?
+
+        kegs = rack.children.map { |prefix| Keg.new(prefix) }
+        Homebrew::Uninstall.uninstall_kegs({ rack => kegs }, force: true, ignore_dependencies: true)
+      end
+
+      sig { returns(Pathname) }
+      def setup_test_tap
+        path = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo"
+        path.mkpath
+        path.cd do
+          system "git", "init"
+          system "git", "remote", "add", "origin", "https://github.com/Homebrew/homebrew-foo"
+          FileUtils.touch "readme"
+          system "git", "add", "--all"
+          system "git", "commit", "-m", "init"
+        end
+        path
+      end
+
+      sig { params(old_name: String, new_name: String).void }
+      def install_and_rename_coretap_formula(old_name, new_name)
+        CoreTap.instance.path.cd do |tap_path|
+          system "git", "init"
+          system "git", "add", "--all"
+          system "git", "commit", "-m",
+                 "#{old_name.capitalize} has not yet been renamed"
+
+          brew "install", old_name
+
+          (tap_path/"Formula/#{old_name}.rb").unlink
+          (tap_path/"formula_renames.json").write JSON.pretty_generate(old_name => new_name)
+
+          system "git", "add", "--all"
+          system "git", "commit", "-m",
+                 "#{old_name.capitalize} has been renamed to #{new_name.capitalize}"
+        end
+      end
+
+      sig { returns(String) }
+      def testball
+        "#{TEST_FIXTURE_DIR}/testball.rb"
+      end
+    end
+  end
+end
+
 # These shared contexts starting with `when` don't make sense.
 RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWording
   T.bind(self, T.class_of(RSpec::Core::ExampleGroup))
+  include Test::Helper::IntegrationTest
 
   around do |example|
     ENV["HOMEBREW_INTEGRATION_TEST"] = "1"
@@ -57,226 +302,6 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
   ensure
     FileUtils.rm_rf HOMEBREW_PREFIX/"bin"
     ENV.delete("HOMEBREW_INTEGRATION_TEST")
-  end
-
-  # Generate unique ID to be able to
-  # properly merge coverage results.
-  def command_id
-    Thread.current[:brew_integration_test_number] ||= 0
-    "#{Process.pid}:#{ENV.fetch("TEST_ENV_NUMBER", "")}:#{Thread.current[:brew_integration_test_number] += 1}"
-  end
-
-  # Runs a `brew` command with the test configuration
-  # and with coverage reporting enabled.
-  def brew(*args)
-    env = args.last.is_a?(Hash) ? args.pop : {}
-
-    # Avoid warnings when HOMEBREW_PREFIX/bin is not in PATH.
-    # Also include our extra commands directory.
-    path = [
-      env["PATH"],
-      (HOMEBREW_LIBRARY_PATH/"test/support/helper/cmd").realpath.to_s,
-      (HOMEBREW_PREFIX/"bin").realpath.to_s,
-      ENV.fetch("PATH"),
-    ].compact.join(File::PATH_SEPARATOR)
-
-    env.merge!(
-      "PATH"                         => path,
-      "HOMEBREW_PATH"                => path,
-      "HOMEBREW_BREW_FILE"           => HOMEBREW_PREFIX/"bin/brew",
-      "HOMEBREW_INTEGRATION_TEST"    => command_id,
-      "HOMEBREW_TEST_TMPDIR"         => TEST_TMPDIR,
-      "HOMEBREW_DEV_CMD_RUN"         => "true",
-      "HOMEBREW_USE_RUBY_FROM_PATH"  => ENV.fetch("HOMEBREW_USE_RUBY_FROM_PATH", nil),
-      "HOMEBREW_NO_INSTALL_FROM_API" => ENV.fetch("HOMEBREW_NO_INSTALL_FROM_API", nil),
-      "GEM_HOME"                     => nil,
-    )
-
-    @ruby_args ||= begin
-      ruby_args = HOMEBREW_RUBY_EXEC_ARGS.dup
-      if ENV["HOMEBREW_TESTS_COVERAGE"]
-        simplecov_spec = Gem.loaded_specs["simplecov"]
-        parallel_tests_spec = Gem.loaded_specs["parallel_tests"]
-        specs = T.let([], T::Array[Gem::Specification])
-        [simplecov_spec, parallel_tests_spec].each do |spec|
-          specs << spec
-          spec.runtime_dependencies.each do |dep|
-            specs += dep.to_specs
-          rescue Gem::LoadError => e
-            T.bind(self, Utils::Output::Mixin)
-            onoe e
-          end
-        end
-        specs.flat_map(&:full_require_paths).each { |lib| ruby_args << "-I" << lib }
-        ruby_args << "-rsimplecov"
-      end
-      ruby_args << "-r#{HOMEBREW_LIBRARY_PATH}/test/support/helper/integration_mocks"
-      ruby_args << "-e" << "$0 = ARGV.shift; load($0)"
-      ruby_args << (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path.to_s
-    end
-
-    Bundler.with_unbundled_env do
-      # Allow instance variable here to improve performance through memoization.
-      # rubocop:disable RSpec/InstanceVariable
-      stdout, stderr, status = Open3.capture3(env, *@ruby_args, *args)
-      # rubocop:enable RSpec/InstanceVariable
-      $stdout.print stdout
-      $stderr.print stderr
-      status
-    end
-  end
-
-  def brew_sh(*args)
-    env = args.last.is_a?(Hash) ? args.pop : {}
-    env = {
-      "HOMEBREW_USE_RUBY_FROM_PATH" => ENV.fetch("HOMEBREW_USE_RUBY_FROM_PATH", nil),
-      "HOMEBREW_CACHE"              => HOMEBREW_CACHE.to_s,
-      "HOMEBREW_INTEGRATION_TEST"   => command_id,
-    }.merge(env)
-    Bundler.with_unbundled_env do
-      brew_sh_path = env.delete("HOMEBREW_BREW_SH") || "#{ENV.fetch("HOMEBREW_PREFIX")}/bin/brew"
-      stdout, stderr, status = Open3.capture3(
-        env,
-        brew_sh_path,
-        *args,
-      )
-      $stdout.print stdout
-      $stderr.print stderr
-      status
-    end
-  end
-
-  def setup_test_formula(name, content = nil, tap: CoreTap.instance,
-                         bottle_block: nil, tab_attributes: nil)
-    case name
-    when /^testball/
-      # Use a different tarball for testball2 to avoid lock errors when writing concurrency tests
-      prefix = (name == "testball2") ? "testball2" : "testball"
-      tarball = if OS.linux?
-        TEST_FIXTURE_DIR/"tarballs/#{prefix}-0.1-linux.tbz"
-      else
-        TEST_FIXTURE_DIR/"tarballs/#{prefix}-0.1.tbz"
-      end
-      bottle_block ||= <<~RUBY if name == "testball_bottle"
-        bottle do
-          root_url "file://#{TEST_FIXTURE_DIR}/bottles"
-          sha256 cellar: :any_skip_relocation, all: "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97"
-        end
-      RUBY
-      content = <<~RUBY
-        desc "Some test"
-        homepage "https://brew.sh/#{name}"
-        url "file://#{tarball}"
-        sha256 "#{tarball.sha256}"
-
-        option "with-foo", "Build with foo"
-        #{bottle_block}
-        def install
-          (prefix/"foo"/"test").write("test") if build.with? "foo"
-          prefix.install Dir["*"]
-          (buildpath/"test.c").write \
-            "#include <stdio.h>\\nint main(){printf(\\"test\\");return 0;}"
-          bin.mkpath
-          system ENV.cc, "test.c", "-o", bin/"test"
-        end
-
-        #{content}
-
-        # something here
-      RUBY
-    when "bar"
-      content = <<~RUBY
-        url "https://brew.sh/#{name}-1.0"
-        depends_on "foo"
-      RUBY
-    when "package_license"
-      content = <<~RUBY
-        url "https://brew.sh/#patchelf-1.0"
-        license "0BSD"
-      RUBY
-    else
-      content ||= <<~RUBY
-        url "https://brew.sh/#{name}-1.0"
-      RUBY
-    end
-
-    formula_path = Formulary.find_formula_in_tap(name.downcase, tap).tap do |path|
-      path.dirname.mkpath
-      path.write <<~RUBY
-        class #{Formulary.class_s(name)} < Formula
-        #{content.gsub(/^(?!$)/, "  ")}
-        end
-      RUBY
-
-      tap.clear_cache
-    end
-
-    return formula_path if tab_attributes.nil?
-
-    keg = Formula[name].prefix
-    keg.mkpath
-
-    tab = Tab.for_name(name)
-    tab.tabfile ||= keg/AbstractTab::FILENAME
-    tab_attributes.each do |key, value|
-      tab.instance_variable_set(:"@#{key}", value)
-    end
-    tab.write
-
-    formula_path
-  end
-
-  def install_test_formula(name, content = nil, build_bottle: false)
-    setup_test_formula(name, content)
-    fi = FormulaInstaller.new(Formula[name], build_bottle:, installed_on_request: true)
-    fi.prelude_fetch
-    fi.prelude
-    fi.fetch
-    fi.install
-    fi.finish
-  end
-
-  def uninstall_test_formula(name)
-    rack = HOMEBREW_CELLAR/name
-    return unless rack.directory?
-
-    kegs = rack.children.map { |prefix| Keg.new(prefix) }
-    Homebrew::Uninstall.uninstall_kegs({ rack => kegs }, force: true, ignore_dependencies: true)
-  end
-
-  def setup_test_tap
-    path = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo"
-    path.mkpath
-    path.cd do
-      system "git", "init"
-      system "git", "remote", "add", "origin", "https://github.com/Homebrew/homebrew-foo"
-      FileUtils.touch "readme"
-      system "git", "add", "--all"
-      system "git", "commit", "-m", "init"
-    end
-    path
-  end
-
-  def install_and_rename_coretap_formula(old_name, new_name)
-    CoreTap.instance.path.cd do |tap_path|
-      system "git", "init"
-      system "git", "add", "--all"
-      system "git", "commit", "-m",
-             "#{old_name.capitalize} has not yet been renamed"
-
-      brew "install", old_name
-
-      (tap_path/"Formula/#{old_name}.rb").unlink
-      (tap_path/"formula_renames.json").write JSON.pretty_generate(old_name => new_name)
-
-      system "git", "add", "--all"
-      system "git", "commit", "-m",
-             "#{old_name.capitalize} has been renamed to #{new_name.capitalize}"
-    end
-  end
-
-  def testball
-    "#{TEST_FIXTURE_DIR}/testball.rb"
   end
 end
 

--- a/Library/Homebrew/test/support/helper/subcommand.rb
+++ b/Library/Homebrew/test/support/helper/subcommand.rb
@@ -97,14 +97,34 @@ module Test
         end
       end
 
+      sig {
+        params(
+          subcommand: T.nilable(T.any(String, Symbol)),
+          named:      T.untyped,
+          options:    T.untyped,
+        ).returns(Test::Helper::Subcommand::Args)
+      }
       def args_for_subcommand(subcommand = nil, *named, **options)
         Test::Helper::Subcommand::Args.new(named:, subcommand: subcommand&.to_s, **options)
       end
 
+      require "cmd/bundle"
+      sig {
+        params(
+          subcommand:   T.any(String, Symbol),
+          global:       T::Boolean,
+          file:         T.nilable(String),
+          no_upgrade:   T::Boolean,
+          verbose:      T::Boolean,
+          force:        T::Boolean,
+          ask:          T::Boolean,
+          jobs:         Integer,
+          zap:          T::Boolean,
+          no_type_args: T::Boolean,
+        ).returns(Homebrew::Cmd::Bundle::SubcommandContext)
+      }
       def bundle_subcommand_context(subcommand, global: false, file: nil, no_upgrade: false, verbose: false,
                                     force: false, ask: false, jobs: 1, zap: false, no_type_args: true)
-        require "cmd/bundle"
-
         Homebrew::Cmd::Bundle::SubcommandContext.new(
           subcommand:   subcommand.to_s,
           global:,

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Tap do

--- a/Library/Homebrew/test/test_bot/formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_spec.rb
@@ -32,20 +32,26 @@ RSpec.describe Homebrew::TestBot::Formulae do
 
   describe "#annotate_added_dependencies" do
     it "writes a warning annotation for the new recursive dependency impact" do
-      T.bind(self, T.untyped)
-
       formula = formula("foo") do
+        T.bind(self, T.class_of(Formula))
         url "foo-1.0"
         depends_on "existing"
         depends_on "bar"
       end
-      existing = formula("existing") { url "existing-1.0" }
+      existing = formula("existing") do
+        T.bind(self, T.class_of(Formula))
+        url "existing-1.0"
+      end
       bar = formula("bar") do
+        T.bind(self, T.class_of(Formula))
         url "bar-1.0"
         depends_on "existing"
         depends_on "baz"
       end
-      baz = formula("baz") { url "baz-1.0" }
+      baz = formula("baz") do
+        T.bind(self, T.class_of(Formula))
+        url "baz-1.0"
+      end
 
       [existing, bar, baz].each { |f| stub_formula_loader f }
       [[bar, 1_000_000], [baz, 500_000]].each do |f, size|
@@ -127,8 +133,8 @@ RSpec.describe Homebrew::TestBot::Formulae do
     it "restores bottled config with InstallRenamed handling" do
       Dir.mktmpdir do |tmpdir|
         formula_class = Class.new(Formula)
-        T.unsafe(formula_class).url "foo-2.0"
-        T.unsafe(formula_class).version "2.0"
+        formula_class.url "foo-2.0"
+        formula_class.version "2.0"
         f = formula_class.new("test-bot-config", Formulary.core_path("test-bot-config"), :stable)
         config_file = HOMEBREW_PREFIX/"etc/test-bot-config.conf"
         default_config_file = Pathname.new("#{config_file}.default")

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -48,8 +48,13 @@ RSpec.describe Utils::Analytics do
   end
 
   describe "::report_package_event" do
-    let(:f) { formula { url "foo-1.0" } }
-    let(:package_name)  { f.name }
+    let(:f) do
+      formula do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+    end
+    let(:package_name) { f.name }
     let(:tap_name) { f.tap.name }
     let(:on_request) { false }
     let(:options) { "--HEAD" }
@@ -92,7 +97,12 @@ RSpec.describe Utils::Analytics do
   end
 
   describe "::report_influx" do
-    let(:f) { formula { url "foo-1.0" } }
+    let(:f) do
+      formula do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+    end
     let(:package)  { f.name }
     let(:tap_name) { f.tap.name }
     let(:on_request) { false }
@@ -110,7 +120,12 @@ RSpec.describe Utils::Analytics do
   describe "::report_build_error" do
     context "when tap is installed" do
       let(:err) { BuildError.new(f, "badprg", %w[arg1 arg2], {}) }
-      let(:f) { formula { url "foo-1.0" } }
+      let(:f) do
+        formula do
+          T.bind(self, T.class_of(Formula))
+          url "foo-1.0"
+        end
+      end
 
       it "reports event if BuildError raised for a formula with a public remote repository" do
         allow_any_instance_of(Tap).to receive(:custom_remote?).and_return(false)


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

GPT-5.3-Codex (Medium) for commit c2c1e9271b5860f80537938e00c6a397d4947e1d because it was quite tedious.

-----

- Follow up from https://github.com/Homebrew/brew/pull/22531#pullrequestreview-4425923114 as the duplication was getting extremely bad.
- See commits for more details.