### PR TITLE
test_bot/formulae_dependents: avoid overwriting shard_index

### DIFF
--- a/Library/Homebrew/test_bot/formulae_dependents.rb
+++ b/Library/Homebrew/test_bot/formulae_dependents.rb
@@ -339,11 +339,11 @@ module Homebrew
         shards = Array.new(shard_count) { T.let([], T::Array[DependentWithDependencies]) }
         groups.sort_by { |group| [-group.count, group.map { |dependent, _| dependent.full_name }.min.to_s] }
               .each do |group|
-          shard_index = 0
+          group_shard_index = 0
           shards.each_with_index do |current_shard, index|
-            shard_index = index if current_shard.count < shards.fetch(shard_index).count
+            group_shard_index = index if current_shard.count < shards.fetch(group_shard_index).count
           end
-          shards.fetch(shard_index).concat(group)
+          shards.fetch(group_shard_index).concat(group)
         end
 
         shards.fetch(shard_index - 1).sort_by { |dependent, _| dependent.full_name }


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

Trying to fix CI-parallel-dependents which wasn't working in
- https://github.com/Homebrew/homebrew-core/pull/286331

As every shard ran on same set of dependents.

I think this is due to the original `shard_index` value getting overwritten in the loop.