### PR TITLE
Default bundle jobs to auto

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -152,11 +152,10 @@ module Homebrew
         hidden:      true,
       },
       HOMEBREW_BUNDLE_JOBS:                      {
-        # odeprecated: make `HOMEBREW_BUNDLE_JOBS=auto` the default in a later minor release
+        # `HOMEBREW_BUNDLE_JOBS=auto` is the default.
         description: "Use this value as the number of formula installations to run in parallel for " \
-                     "`brew bundle install`. Use `auto` for the number of CPU cores (max 4). Enabled by default " \
-                     "with a value of `auto` if `$HOMEBREW_DEVELOPER` is set. This will become the default " \
-                     "behaviour in a later minor release.",
+                     "`brew bundle install`. Use `auto` for the number of CPU cores (max 4).",
+        default:     "auto",
       },
       HOMEBREW_BUNDLE_NO_DESCRIBE:               {
         description: "If set, do not enable bundle description comments from `$HOMEBREW_BUNDLE_DESCRIBE` or " \
@@ -164,8 +163,8 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_BUNDLE_NO_JOBS:                   {
-        description: "If set, do not enable parallel jobs from `$HOMEBREW_BUNDLE_JOBS` or the " \
-                     "`$HOMEBREW_DEVELOPER` default. This does not disable an explicit `--jobs`.",
+        description: "If set, do not enable parallel jobs from `$HOMEBREW_BUNDLE_JOBS` or its default. " \
+                     "This does not disable an explicit `--jobs`.",
         boolean:     true,
       },
       HOMEBREW_BUNDLE_NO_SECRETS:                {
@@ -877,7 +876,8 @@ module Homebrew
         return
       end
 
-      ENV["HOMEBREW_BUNDLE_JOBS"].presence
+      ENV["HOMEBREW_BUNDLE_JOBS"].presence ||
+        ENVS.fetch(:HOMEBREW_BUNDLE_JOBS).fetch(:default).to_s
     end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -137,6 +137,12 @@ RSpec.describe Homebrew::EnvConfig do
   end
 
   describe ".bundle_jobs" do
+    it "returns auto if unset" do
+      with_env(HOMEBREW_BUNDLE_JOBS: nil, HOMEBREW_BUNDLE_NO_JOBS: nil) do
+        expect(env_config.bundle_jobs).to eql("auto")
+      end
+    end
+
     it "returns nil if HOMEBREW_BUNDLE_NO_JOBS is set" do
       with_env(HOMEBREW_BUNDLE_JOBS: "auto", HOMEBREW_BUNDLE_NO_JOBS: "1") do
         expect(env_config.bundle_jobs).to be_nil


### PR DESCRIPTION
- Aligns `brew bundle install` defaults with the staged rollout.
- Keeps `HOMEBREW_BUNDLE_NO_JOBS` as the opt-out path.
- Covers the unset `HOMEBREW_BUNDLE_JOBS` regression.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
