### PR TITLE
Default to internal API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,18 +117,7 @@ jobs:
           package_api_cache="${RUNNER_TEMP}/homebrew-api-cache"
           rm -rvf ~/Library/Caches/Homebrew/api "${package_api_cache}"
 
-          # TODO: Remove this forced regular API refresh when the internal API is default.
-          # Developer mode currently downloads the internal API cache, but the package
-          # should keep shipping the regular API files until all installs use internal API.
-          unset HOMEBREW_DEVELOPER HOMEBREW_DEV_CMD_RUN HOMEBREW_USE_INTERNAL_API HOMEBREW_NO_INSTALL_FROM_API
-          HOMEBREW_UPDATE_SKIP_BREW=1 brew update --auto-update --verbose
-          mkdir -vp "${package_api_cache}"
-          cp -vR ~/Library/Caches/Homebrew/api/. "${package_api_cache}/"
-
-          # Run developer mode too so the package cache works with both current
-          # developer behaviour and the future internal API default.
           HOMEBREW_DEVELOPER=1 HOMEBREW_UPDATE_SKIP_BREW=1 brew update --auto-update --verbose
-          cp -vR "${package_api_cache}/." ~/Library/Caches/Homebrew/api
           cp -vR ~/Library/Caches/Homebrew/api brew/cache_api
 
       - name: Check installer Git safety

--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -194,16 +194,7 @@ module Homebrew
         DEFAULT_API_STALE_SECONDS
       end
 
-      if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.fetch_packages_api!(download_queue:, stale_seconds:, enqueue: true)
-      else
-        Homebrew::API::Formula.fetch_api!(download_queue:, stale_seconds:, enqueue: true)
-        Homebrew::API::Formula.fetch_tap_migrations!(download_queue:, stale_seconds: DEFAULT_API_STALE_SECONDS,
-                                                     enqueue: true)
-        Homebrew::API::Cask.fetch_api!(download_queue:, stale_seconds:, enqueue: true)
-        Homebrew::API::Cask.fetch_tap_migrations!(download_queue:, stale_seconds: DEFAULT_API_STALE_SECONDS,
-                                                  enqueue: true)
-      end
+      Homebrew::API::Internal.fetch_packages_api!(download_queue:, stale_seconds:, enqueue: true)
 
       ENV["HOMEBREW_API_UPDATED"] = "1"
 
@@ -216,13 +207,8 @@ module Homebrew
 
     sig { void }
     def self.write_names_and_aliases
-      if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.write_formula_names_and_aliases
-        Homebrew::API::Internal.write_cask_names
-      else
-        Homebrew::API::Formula.write_names_and_aliases
-        Homebrew::API::Cask.write_names
-      end
+      Homebrew::API::Internal.write_formula_names_and_aliases
+      Homebrew::API::Internal.write_cask_names
     end
 
     sig { params(names: T::Array[String], type: String, regenerate: T::Boolean).returns(T::Boolean) }
@@ -373,83 +359,47 @@ module Homebrew
 
     sig { returns(T::Array[String]) }
     def self.formula_names
-      if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.formula_hashes.keys
-      else
-        Homebrew::API::Formula.all_formulae.keys
-      end
+      Homebrew::API::Internal.formula_hashes.keys
     end
 
     sig { returns(T::Hash[String, String]) }
     def self.formula_aliases
-      if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.formula_aliases
-      else
-        Homebrew::API::Formula.all_aliases
-      end
+      Homebrew::API::Internal.formula_aliases
     end
 
     sig { returns(T::Hash[String, String]) }
     def self.formula_renames
-      if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.formula_renames
-      else
-        Homebrew::API::Formula.all_renames
-      end
+      Homebrew::API::Internal.formula_renames
     end
 
     sig { returns(T::Hash[String, String]) }
     def self.formula_tap_migrations
-      if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.formula_tap_migrations
-      else
-        Homebrew::API::Formula.tap_migrations
-      end
+      Homebrew::API::Internal.formula_tap_migrations
     end
 
     sig { returns(Pathname) }
     def self.cached_formula_json_file_path
-      if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.cached_packages_json_file_path
-      else
-        Homebrew::API::Formula.cached_json_file_path
-      end
+      Homebrew::API::Internal.cached_packages_json_file_path
     end
 
     sig { returns(T::Array[String]) }
     def self.cask_tokens
-      if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.cask_hashes.keys
-      else
-        Homebrew::API::Cask.all_casks.keys
-      end
+      Homebrew::API::Internal.cask_hashes.keys
     end
 
     sig { returns(T::Hash[String, String]) }
     def self.cask_renames
-      if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.cask_renames
-      else
-        Homebrew::API::Cask.all_renames
-      end
+      Homebrew::API::Internal.cask_renames
     end
 
     sig { returns(T::Hash[String, String]) }
     def self.cask_tap_migrations
-      if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.cask_tap_migrations
-      else
-        Homebrew::API::Cask.tap_migrations
-      end
+      Homebrew::API::Internal.cask_tap_migrations
     end
 
     sig { returns(Pathname) }
     def self.cached_cask_json_file_path
-      if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Internal.cached_packages_json_file_path
-      else
-        Homebrew::API::Cask.cached_json_file_path
-      end
+      Homebrew::API::Internal.cached_packages_json_file_path
     end
   end
 

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -1078,8 +1078,7 @@ fi
 # Enable features for users who have run a devcmd before they become the default for everyone.
 if [[ -n "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_DEV_CMD_RUN}" ]]
 then
-  # odeprecated: make default next release
-  export HOMEBREW_USE_INTERNAL_API="1"
+  :
 fi
 
 # Only enable runtime typechecking for commands where correctness matters more

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -438,25 +438,12 @@ module Cask
           else
             load_from_json(config:, api_source:)
           end
-        elsif Homebrew::EnvConfig.use_internal_api?
-          load_from_internal_api(config:)
         else
-          load_from_api(config:)
+          load_from_internal_api(config:)
         end
       end
 
       private
-
-      sig { params(config: T.nilable(Config)).returns(Cask) }
-      def load_from_api(config:)
-        api_source = Homebrew::API::Cask.all_casks.fetch(token)
-        tap_git_head = api_source["tap_git_head"]
-        cask_struct = Homebrew::API::Cask::CaskStructGenerator.generate_cask_struct_hash(
-          api_source, ignore_types: @from_installed_caskfile
-        )
-
-        load_from_struct(config:, cask_struct:, api_source:, tap_git_head:)
-      end
 
       sig { params(config: T.nilable(Config)).returns(Cask) }
       def load_from_internal_api(config:)

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -981,12 +981,7 @@ EOS
 
   if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]]
   then
-    if [[ -n "${HOMEBREW_USE_INTERNAL_API}" ]]
-    then
-      api_files=("internal/packages.$(bottle_tag)")
-    else
-      api_files=(formula cask formula_tap_migrations cask_tap_migrations)
-    fi
+    api_files=("internal/packages.$(bottle_tag)")
 
     for json in "${api_files[@]}"
     do
@@ -994,15 +989,8 @@ EOS
       fetch_api_file "${filename}" "${update_failed_file}"
     done
 
-    if [[ -n "${HOMEBREW_USE_INTERNAL_API}" ]]
-    then
-      # Remove files only downloaded by the regular API
-      rm -f "${HOMEBREW_CACHE}/api/formula.jws.json" "${HOMEBREW_CACHE}/api/cask.jws.json"
-      rm -f "${HOMEBREW_CACHE}/api/formula_tap_migrations.jws.json" "${HOMEBREW_CACHE}/api/cask_tap_migrations.jws.json"
-    else
-      # Remove files only downloaded by the internal API
-      rm -f "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json"
-    fi
+    rm -f "${HOMEBREW_CACHE}/api/formula.jws.json" "${HOMEBREW_CACHE}/api/cask.jws.json"
+    rm -f "${HOMEBREW_CACHE}/api/formula_tap_migrations.jws.json" "${HOMEBREW_CACHE}/api/cask_tap_migrations.jws.json"
 
     # Not a typo, these are the files we used to download that no longer need so should cleanup.
     rm -f "${HOMEBREW_CACHE}/api/formula.json" "${HOMEBREW_CACHE}/api/cask.json"

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -698,12 +698,6 @@ module Homebrew
         description: "A space-separated list of casks. Homebrew will act as " \
                      "if `--greedy` was passed when upgrading any cask on this list.",
       },
-      HOMEBREW_USE_INTERNAL_API:                 {
-        # odeprecated: make default next release
-        description: "If set, test the new beta internal API for fetching formula and cask data.",
-        boolean:     :set,
-        disabled_by: :HOMEBREW_NO_INSTALL_FROM_API,
-      },
       HOMEBREW_VERBOSE:                          {
         description: "If set, always assume `--verbose` when running commands.",
         boolean:     :set,

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -946,18 +946,6 @@ module Formulary
 
     sig { overridable.params(flags: T::Array[String]).void }
     def load_from_api(flags:)
-      return load_from_internal_api(flags:) if Homebrew::EnvConfig.use_internal_api?
-
-      api_source = Homebrew::API::Formula.all_formulae[name]
-      raise FormulaUnavailableError, name if api_source.nil?
-
-      tap_git_head = api_source.fetch("tap_git_head", "")
-      formula_struct = Homebrew::API::Formula::FormulaStructGenerator.generate_formula_struct_hash(api_source)
-      Formulary.load_formula_from_struct!(name, formula_struct, api_source:, tap_git_head:, flags:)
-    end
-
-    sig { params(flags: T::Array[String]).void }
-    def load_from_internal_api(flags:)
       formula_struct = Homebrew::API::Internal.formula_struct(name)
       api_source = Homebrew::API::Internal.formula_hashes[name]
       tap_git_head = Homebrew::API::Internal.formula_tap_git_head

--- a/Library/Homebrew/search.rb
+++ b/Library/Homebrew/search.rb
@@ -79,7 +79,7 @@ module Homebrew
                  "#{unofficial} additional " \
                  "#{Utils.pluralize("formula", unofficial)} in third party taps."
           end
-          formulae = Homebrew::API::Formula.all_formulae
+          formulae = Homebrew::API::Internal.formula_hashes
           descriptions = formulae.transform_values { |data| data["desc"] }
           status_data = formulae.transform_values do |data|
             { deprecated: data["deprecate_present"].present?, disabled: data["disable_present"].present? }
@@ -104,8 +104,8 @@ module Homebrew
                "#{unofficial} additional " \
                "#{Utils.pluralize("cask", unofficial)} in third party taps."
         end
-        casks = Homebrew::API::Cask.all_casks
-        descriptions = casks.transform_values { |cask| [cask["name"].join(", "), cask["desc"]] }
+        casks = Homebrew::API::Internal.cask_hashes
+        descriptions = casks.transform_values { |cask| [cask["names"].join(", "), cask["desc"]] }
         status_data = casks.transform_values do |cask|
           { deprecated: cask["deprecate_present"].present?, disabled: cask["disable_present"].present? }
         end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -440,9 +440,6 @@ module Homebrew::EnvConfig
     def upgrade_greedy_casks; end
 
     sig { returns(T::Boolean) }
-    def use_internal_api?; end
-
-    sig { returns(T::Boolean) }
     def verbose?; end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1083,15 +1083,15 @@ class Tap
   sig { overridable.returns(T::Array[String]) }
   def autobump
     autobump_packages = if core_cask_tap?
-      Homebrew::API::Cask.all_casks
+      Homebrew::API::Internal.cask_hashes
     elsif core_tap?
-      Homebrew::API::Formula.all_formulae
+      Homebrew::API::Internal.formula_hashes
     else
       {}
     end
 
     @autobump ||= T.let(autobump_packages.select do |_, p|
-      next if p["disabled"]
+      next if p["disable_present"]
       next if p["skip_livecheck"]
 
       p["autobump"] == true

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -57,7 +57,17 @@ RSpec.describe Homebrew::API::Cask do
     end
 
     before do
-      allow(Homebrew::API).to receive(:fetch_json_api_file).and_return([[], true])
+      allow(Homebrew::API).to receive(:fetch_json_api_file).and_return([{
+        "formulae"               => {},
+        "casks"                  => {},
+        "formula_aliases"        => {},
+        "formula_renames"        => {},
+        "cask_renames"           => {},
+        "formula_tap_git_head"   => "",
+        "cask_tap_git_head"      => "",
+        "formula_tap_migrations" => {},
+        "cask_tap_migrations"    => {},
+      }, true])
       allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:fetch)
       allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:symlink_location).and_return(
         TEST_FIXTURE_DIR/"cask/Casks/everything.rb",

--- a/Library/Homebrew/test/api/internal_spec.rb
+++ b/Library/Homebrew/test/api/internal_spec.rb
@@ -216,7 +216,6 @@ RSpec.describe Homebrew::API::Internal do
   end
 
   it "writes formula executables from the internal packages JSON" do
-    allow(Homebrew::EnvConfig).to receive(:use_internal_api?).and_return(true)
     Homebrew::API.write_names_and_aliases
 
     expect((cache_dir/"internal/executables.txt").read).to eq("foo:foo-bin food\n")

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
     let(:api_loader) { klass.new(api_token, from_json: cask_json) }
 
     before do
+      allow(Homebrew::API).to receive_messages(cask_tokens: casks_from_api_hash.keys, cask_renames: {})
       allow(Homebrew::API::Cask)
         .to receive_messages(all_casks: casks_from_api_hash, all_renames: {})
 
@@ -50,7 +51,6 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
     end
 
     before do
-      allow(Homebrew::EnvConfig).to receive(:use_internal_api?).and_return(true)
       allow(Homebrew::API::Internal)
         .to receive_messages(cask_hashes:         casks_from_internal_api_hash,
                              cask_renames:        {},

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Cask::CaskLoader, :cask do
       end
 
       before do
+        allow(Homebrew::API).to receive_messages(cask_tokens: api_casks.keys, cask_renames:)
         allow(Homebrew::API::Cask)
           .to receive(:all_casks)
           .and_return(api_casks)

--- a/Library/Homebrew/test/cmd/bundle_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "cmd/bundle"
+require "bundle"
 require "cmd/shared_examples/args_parse"
 require "commands"
 

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -360,34 +360,4 @@ RSpec.describe Homebrew::EnvConfig do
       expect(env_config.no_require_tap_trust?).to be(true)
     end
   end
-
-  describe ".use_internal_api?" do
-    around do |example|
-      with_env(
-        HOMEBREW_USE_INTERNAL_API:    nil,
-        HOMEBREW_NO_INSTALL_FROM_API: nil,
-      ) { example.run }
-    end
-
-    it "returns true if HOMEBREW_USE_INTERNAL_API is set" do
-      ENV["HOMEBREW_USE_INTERNAL_API"] = "1"
-      expect(env_config.use_internal_api?).to be(true)
-    end
-
-    it "returns false if HOMEBREW_USE_INTERNAL_API is not set" do
-      ENV["HOMEBREW_USE_INTERNAL_API"] = nil
-      expect(env_config.use_internal_api?).to be(false)
-    end
-
-    it "returns true if HOMEBREW_USE_INTERNAL_API is set to a falsey value" do
-      ENV["HOMEBREW_USE_INTERNAL_API"] = "0"
-      expect(env_config.use_internal_api?).to be(true)
-    end
-
-    it "returns false if HOMEBREW_NO_INSTALL_FROM_API is set" do
-      ENV["HOMEBREW_USE_INTERNAL_API"] = "1"
-      ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
-      expect(env_config.use_internal_api?).to be(false)
-    end
-  end
 end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -573,6 +573,15 @@ RSpec.describe Formulary do
 
       before do
         # avoid unnecessary network calls
+        allow(Homebrew::API).to receive_messages(formula_names: [formula_name], formula_aliases: {},
+                                                 formula_renames: {})
+        allow(Homebrew::API::Internal).to receive(:formula_hashes) { Homebrew::API::Formula.all_formulae }
+        allow(Homebrew::API::Internal).to receive(:formula_struct) do |name|
+          Homebrew::API::Formula::FormulaStructGenerator.generate_formula_struct_hash(
+            Homebrew::API::Formula.all_formulae.fetch(name),
+          )
+        end
+        allow(Homebrew::API::Internal).to receive(:formula_tap_git_head).and_return("")
         allow(Homebrew::API::Formula).to receive_messages(all_aliases: {}, all_renames: {})
         allow(CoreTap.instance).to receive(:tap_migrations).and_return({})
         allow(CoreCaskTap.instance).to receive(:tap_migrations).and_return({})
@@ -621,16 +630,13 @@ RSpec.describe Formulary do
         end.to raise_error("Cannot build from source from abstract formula.")
       end
 
-      it "returns a Formula that can regenerate its JSON API" do
+      it "returns a Formula loaded from the internal API" do
         allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents
 
         formula = klass.factory(formula_name)
         expect(formula).to be_a(Formula)
         expect(formula.loaded_from_api?).to be true
-        expect(formula.loaded_from_internal_api?).to be false
-
-        expected_hash = formula_json_contents[formula_name]
-        expect(formula.to_hash_with_variations).to eq(expected_hash)
+        expect(formula.loaded_from_internal_api?).to be true
       end
 
       it "loads patches from API JSON" do
@@ -748,6 +754,8 @@ RSpec.describe Formulary do
         let(:foo_tap) { Tap.fetch("homebrew", "foo") }
 
         before do
+          allow(Homebrew::API)
+            .to receive_messages(formula_names: [formula_name], formula_aliases: {}, formula_renames: {})
           allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents
           foo_tap.path.mkpath
         end

--- a/Library/Homebrew/test/search_spec.rb
+++ b/Library/Homebrew/test/search_spec.rb
@@ -158,12 +158,11 @@ RSpec.describe Homebrew::Search do
       end
 
       let(:api_casks) do
-        { "testball" => { "desc" => "Some test", "name" => ["Test Ball"] } }
+        { "testball" => { "desc" => "Some test", "names" => ["Test Ball"] } }
       end
 
       before do
-        allow(Homebrew::API::Formula).to receive(:all_formulae).and_return(api_formulae)
-        allow(Homebrew::API::Cask).to receive(:all_casks).and_return(api_casks)
+        allow(Homebrew::API::Internal).to receive_messages(formula_hashes: api_formulae, cask_hashes: api_casks)
       end
 
       it "searches formula descriptions" do

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -284,6 +284,23 @@ RSpec.configure do |config|
     Pathname("#{ENV.fetch("HOMEBREW_CACHE")}/api").glob("*.json").each do |path|
       FileUtils.ln_s path, HOMEBREW_CACHE/"api/#{path.basename}"
     end
+    Pathname("#{ENV.fetch("HOMEBREW_CACHE")}/api").glob("*.txt").each do |path|
+      FileUtils.cp path, HOMEBREW_CACHE/"api/#{path.basename}"
+    end
+    Pathname("#{ENV.fetch("HOMEBREW_CACHE")}/api/internal").glob("*.{json,txt}").each do |path|
+      target = HOMEBREW_CACHE/"api/internal/#{path.basename}"
+      target.dirname.mkpath
+      (path.extname == ".txt") ? FileUtils.cp(path, target) : FileUtils.ln(path, target)
+      next unless path.basename.to_s.start_with?("packages.")
+
+      [:generic, :linux, :macos, *MacOSVersion::SYMBOLS.keys].product([:arm, :intel]).each do |system, arch|
+        tag = Utils::Bottles::Tag.new(system:, arch:)
+        next unless tag.valid_combination?
+
+        target = HOMEBREW_CACHE/"api/internal/packages.#{tag}.jws.json"
+        FileUtils.ln path, target unless target.exist?
+      end
+    end
 
     begin
       if example.metadata.keys.exclude?(:focus) && !ENV.key?("HOMEBREW_VERBOSE_TESTS")

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -5048,10 +5048,6 @@ command execution (e.g. `$(cat file)`).
 : A space-separated list of casks. Homebrew will act as if `--greedy` was passed
   when upgrading any cask on this list.
 
-`HOMEBREW_USE_INTERNAL_API`
-
-: If set, test the new beta internal API for fetching formula and cask data.
-
 `HOMEBREW_VERBOSE`
 
 : If set, always assume `--verbose` when running commands.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3280,9 +3280,6 @@ If set, pass \fB\-\-greedy\fP to all cask upgrade commands\.
 \fBHOMEBREW_UPGRADE_GREEDY_CASKS\fP
 A space\-separated list of casks\. Homebrew will act as if \fB\-\-greedy\fP was passed when upgrading any cask on this list\.
 .TP
-\fBHOMEBREW_USE_INTERNAL_API\fP
-If set, test the new beta internal API for fetching formula and cask data\.
-.TP
 \fBHOMEBREW_VERBOSE\fP
 If set, always assume \fB\-\-verbose\fP when running commands\.
 .TP


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/19204

- Avoid the regular JSON API at runtime now that the internal package data is the supported default.
- Keep public and internal JSON generation separate so website data continues to be produced.
- Hide `HOMEBREW_USE_INTERNAL_API` because it is only an internal compatibility toggle now.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
