### PR TITLE
Speed up cask backup copies

### DIFF
--- a/Library/Homebrew/cask/artifact/moved.rb
+++ b/Library/Homebrew/cask/artifact/moved.rb
@@ -218,7 +218,7 @@ module Cask
         [!source.parent.writable?, true].uniq.each do |sudo|
           result = command.run(
             "/bin/cp",
-            args:         ["-pR", target, source],
+            args:         backup_copy_args(target, source),
             must_succeed: sudo,
             sudo:,
           )
@@ -258,6 +258,11 @@ module Cask
       sig { params(target: Pathname).returns(T::Boolean) }
       def undeletable?(target)
         !target.parent.writable?
+      end
+
+      sig { overridable.params(target: Pathname, source: Pathname).returns(T::Array[T.any(String, Pathname)]) }
+      def backup_copy_args(target, source)
+        ["-pR", target, source]
       end
     end
   end

--- a/Library/Homebrew/extend/os/cask/artifact/moved.rb
+++ b/Library/Homebrew/extend/os/cask/artifact/moved.rb
@@ -1,4 +1,5 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "extend/os/linux/cask/artifact/moved" if OS.linux?
 require "extend/os/mac/cask/artifact/moved" if OS.mac?

--- a/Library/Homebrew/extend/os/linux/cask/artifact/moved.rb
+++ b/Library/Homebrew/extend/os/linux/cask/artifact/moved.rb
@@ -1,0 +1,24 @@
+# typed: strict
+# frozen_string_literal: true
+
+module OS
+  module Linux
+    module Cask
+      module Artifact
+        module Moved
+          extend T::Helpers
+
+          requires_ancestor { ::Cask::Artifact::Moved }
+
+          sig { params(target: ::Pathname, source: ::Pathname).returns(T::Array[T.any(String, ::Pathname)]) }
+          def backup_copy_args(target, source)
+            # GNU `cp --reflink=auto` reduces I/O when the filesystem supports it.
+            ["--reflink=auto", *super]
+          end
+        end
+      end
+    end
+  end
+end
+
+Cask::Artifact::Moved.prepend(OS::Linux::Cask::Artifact::Moved)

--- a/Library/Homebrew/extend/os/mac/cask/artifact/moved.rb
+++ b/Library/Homebrew/extend/os/mac/cask/artifact/moved.rb
@@ -16,6 +16,16 @@ module OS
           def undeletable?(target)
             MacOS.undeletable?(target)
           end
+
+          sig { params(target: ::Pathname, source: ::Pathname).returns(T::Array[T.any(String, ::Pathname)]) }
+          def backup_copy_args(target, source)
+            args = super
+
+            return args if MacOS.version < :sonoma
+            return args if target.stat.dev != source.dirname.stat.dev
+
+            ["-c", *args]
+          end
         end
       end
     end

--- a/Library/Homebrew/test/cask/artifact/app_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/app_spec.rb
@@ -311,6 +311,34 @@ RSpec.describe Cask::Artifact::App, :cask do
 
       expect(source_path).to be_a_directory
     end
+
+    it "uses clonefile copy arguments on supported macOS versions", :needs_macos do
+      install_phase
+
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:sonoma))
+
+      expect(app.send(:backup_copy_args, target_path, source_path)).to eq(["-c", "-pR", target_path, source_path])
+    end
+
+    it "uses portable copy arguments on older macOS versions", :needs_macos do
+      install_phase
+
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:ventura))
+
+      expect(app.send(:backup_copy_args, target_path, source_path)).to eq(["-pR", target_path, source_path])
+    end
+
+    it "uses portable copy arguments across filesystems", :needs_macos do
+      install_phase
+
+      source_dir = source_path.dirname
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:sonoma))
+      allow(target_path).to receive(:stat).and_return(instance_double(File::Stat, dev: 1))
+      allow(source_path).to receive(:dirname).and_return(source_dir)
+      allow(source_dir).to receive(:stat).and_return(instance_double(File::Stat, dev: 2))
+
+      expect(app.send(:backup_copy_args, target_path, source_path)).to eq(["-pR", target_path, source_path])
+    end
   end
 
   describe "summary" do


### PR DESCRIPTION
- Use clone-capable copy arguments for cask artifact backups because large app bundles can make the existing recursive copy visibly slow.
- Keep Linux on a separate override because GNU `cp` uses `--reflink=auto` instead of macOS `cp -c`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
