### PR TITLE
Skip untrusted cleanup formulae

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -154,6 +154,9 @@ module Homebrew
 
         formula = begin
           Formulary.from_rack(HOMEBREW_CELLAR/formula_name)
+        rescue Homebrew::UntrustedTapError
+          opoo "Skipping #{formula_name}: tap formula is not trusted"
+          nil
         rescue FormulaUnavailableError, TapFormulaAmbiguityError
           nil
         end
@@ -162,6 +165,9 @@ module Homebrew
         if formula.blank? && formula_name.delete_suffix!("_bottle_manifest")
           formula = begin
             Formulary.from_rack(HOMEBREW_CELLAR/formula_name)
+          rescue Homebrew::UntrustedTapError
+            opoo "Skipping #{formula_name}: tap formula is not trusted"
+            nil
           rescue FormulaUnavailableError, TapFormulaAmbiguityError
             nil
           end

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -69,6 +69,19 @@ RSpec.describe Homebrew::Cleanup do
       expect(lock_file).to exist
     end
 
+    it "doesn't load untrusted installed formulae while cleaning the cache" do
+      cache_file = HOMEBREW_CACHE/"untrusted--1.0"
+      cache_file.write "cached"
+      (HOMEBREW_CELLAR/"untrusted/1.0").mkpath
+
+      expect(Formulary).to receive(:from_rack).with(HOMEBREW_CELLAR/"untrusted")
+                                              .and_raise(Homebrew::UntrustedTapError)
+
+      expect { cleanup.cleanup_cache([{ path: cache_file, type: nil }]) }
+        .to output(/Skipping untrusted: tap formula is not trusted/).to_stderr
+      expect(cache_file).to exist
+    end
+
     context "when it can't remove a keg" do
       let(:formula_zero_dot_one) { Class.new(Testball) { version "0.1" }.new }
       let(:formula_zero_dot_two) { Class.new(Testball) { version "0.2" }.new }


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22551

- Avoid aborting `brew cleanup` when cache checks cannot load an installed formula from an untrusted tap.
- Warn that the tap formula is not trusted so users know why cleanup skipped that formula's cache eligibility check.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
