### PR TITLE
Allow rebuild install step methods

### DIFF
--- a/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
+++ b/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
@@ -33,6 +33,9 @@ For each future operation type, check `homebrew/core` and `homebrew/cask`
 separately and add formula support only when needed by `homebrew/core` or cask
 support only when needed by `homebrew/cask`.
 
+When adding install step DSL methods, update the matching RuboCop allow-list so
+formula or cask tap syntax checks accept the new method in the same context.
+
 RuboCop autocorrection converts the simplest existing `post_install` and
 `*flight` Ruby blocks to steps blocks when every statement is a supported file
 preparation operation with literal paths and known bases. Future post-install

--- a/Library/Homebrew/rubocops/cask/install_steps.rb
+++ b/Library/Homebrew/rubocops/cask/install_steps.rb
@@ -41,10 +41,12 @@ module RuboCop
           stanzas.each do |stanza|
             next unless INSTALL_STEP_PAIRS.value?(stanza.stanza_name)
             next unless stanza.method_node.block_type?
-            next unless (offense_node = install_step_block_offense_node(T.cast(stanza.method_node,
-                                                                               RuboCop::AST::BlockNode)))
+            next unless (offense_node = install_step_block_offense_node(
+              T.cast(stanza.method_node, RuboCop::AST::BlockNode),
+              allowed_methods: FILE_PREPARATION_STEP_METHODS,
+            ))
 
-            add_offense(offense_node, message: STEP_BLOCK_MSG)
+            add_offense(offense_node, message: step_block_msg(FILE_PREPARATION_STEP_METHODS))
           end
         end
 

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -4,8 +4,17 @@
 module RuboCop
   module Cop
     module InstallStepsHelper
-      ALLOWED_STEP_METHODS = T.let(
+      FILE_PREPARATION_STEP_METHODS = T.let(
         [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :symlink, :ln_s, :ln_sf].freeze,
+        T::Array[Symbol],
+      )
+      REBUILD_ACTION_STEP_METHODS = T.let(
+        [:compile_gsettings_schemas, :gio_querymodules, :gdk_pixbuf_query_loaders, :gtk_update_icon_cache,
+         :update_mime_database, :update_desktop_database].freeze,
+        T::Array[Symbol],
+      )
+      ALLOWED_STEP_METHODS = T.let(
+        [*FILE_PREPARATION_STEP_METHODS, *REBUILD_ACTION_STEP_METHODS].freeze,
         T::Array[Symbol],
       )
 
@@ -21,13 +30,24 @@ module RuboCop
       )
       SIMPLE_STEP_CONVERSION_MSG = T.let("Use `%<steps_block>s` for simple file preparation.", String)
 
+      sig { params(allowed_methods: T::Array[Symbol]).returns(String) }
+      def step_block_msg(allowed_methods)
+        "Steps blocks may only contain install step DSL calls: " \
+          "#{allowed_methods.map { |method| "`#{method}`" }.join(", ")}."
+      end
+
       class InstallStepPath < T::Struct
         const :path, String
         const :base, T.nilable(Symbol)
       end
 
-      sig { params(block_node: T.nilable(RuboCop::AST::BlockNode)).returns(T.nilable(RuboCop::AST::Node)) }
-      def install_step_block_offense_node(block_node)
+      sig {
+        params(
+          block_node:      T.nilable(RuboCop::AST::BlockNode),
+          allowed_methods: T::Array[Symbol],
+        ).returns(T.nilable(RuboCop::AST::Node))
+      }
+      def install_step_block_offense_node(block_node, allowed_methods: ALLOWED_STEP_METHODS)
         return if block_node.nil?
         return if (body = block_node.body).nil?
 
@@ -36,7 +56,7 @@ module RuboCop
           return node unless node.send_type?
 
           send_node = T.cast(node, RuboCop::AST::SendNode)
-          return node if send_node.receiver.present? || !ALLOWED_STEP_METHODS.include?(send_node.method_name)
+          return node if send_node.receiver.present? || !allowed_methods.include?(send_node.method_name)
 
           invalid_argument_node = send_node.each_descendant.find do |descendant|
             next false if descendant.false_type? || descendant.true_type?

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -53,6 +53,20 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
     CASK
   end
 
+  it "reports an offense when cask steps contain formula rebuild actions" do
+    expect_offense <<~CASK
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        preflight_steps do
+          gio_querymodules
+          ^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`.
+        end
+      end
+    CASK
+  end
+
   it "autocorrects simple flight block file preparation" do
     expect_offense <<~CASK
       cask "foo" do

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
         end
       end
     RUBY
@@ -45,6 +45,12 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           mv "source", "target"
           move_children "source", "target"
           ln_sf "source", "target", source_base: :relative, uninstall: true
+          compile_gsettings_schemas
+          gio_querymodules
+          gdk_pixbuf_query_loaders
+          gtk_update_icon_cache
+          update_mime_database
+          update_desktop_database
         end
       end
     RUBY


### PR DESCRIPTION
Unblocks https://github.com/Homebrew/homebrew-core/pull/285885

- keep `homebrew/core` syntax checks accepting new rebuild DSLs
- limit cask steps to methods supported by cask install phases
- document that new DSLs need matching RuboCop support

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
