### PR TITLE
Add Bundler cooldown

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -4,13 +4,13 @@
 require "abstract_command"
 require "bump_version_parser"
 require "livecheck/livecheck"
+require "release_cooldown"
 require "utils/curl"
 require "utils/repology"
 
 module Homebrew
   module DevCmd
     class Bump < AbstractCommand
-      MIN_RELEASE_AGE_DAYS = 1
       DEFAULT_CURL_ARGS = T.let([
         "--compressed",
         "--fail-with-body",
@@ -908,7 +908,7 @@ module Homebrew
 
           current_str = current.to_s
           current_is_prerelease = current_str.include?("-")
-          cooldown_interval = (DateTime.now - MIN_RELEASE_AGE_DAYS)
+          cooldown_interval = (DateTime.now - Homebrew::RELEASE_COOLDOWN_DAYS)
           release_dates.sort_by { |_, date| date }.reverse_each do |version_str, date|
             version = Version.new(version_str)
             return version if version_str == current_str
@@ -941,7 +941,7 @@ module Homebrew
 
           current_str = current.to_s
           current_is_prerelease = current_str.match?(PYPI_UNSTABLE_VERSION_REGEX)
-          cooldown_interval = (DateTime.now - MIN_RELEASE_AGE_DAYS)
+          cooldown_interval = (DateTime.now - Homebrew::RELEASE_COOLDOWN_DAYS)
           releases.sort_by { |k, _| Version.new(k) }.reverse_each do |version_str, assets|
             version = Version.new(version_str)
             return version if version_str == current_str
@@ -973,7 +973,7 @@ module Homebrew
           return unless json.is_a?(Array)
 
           current_str = current.to_s
-          cooldown_interval = (DateTime.now - MIN_RELEASE_AGE_DAYS)
+          cooldown_interval = (DateTime.now - Homebrew::RELEASE_COOLDOWN_DAYS)
           json.sort_by { |release| Version.new(release["number"]) }.reverse_each do |release|
             next if release["platform"] != (match[:platform] || "ruby")
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -43,6 +43,7 @@ require "utils/spdx"
 require "on_system"
 require "api"
 require "api_hashable"
+require "release_cooldown"
 require "trust"
 require "utils/output"
 require "pypi_packages"
@@ -2217,7 +2218,7 @@ class Formula
     args = ["--verbose", "--no-deps", "--no-binary=:all:", "--ignore-installed", "--no-compile"]
     # Delay packages published in the last day so builds are less likely to
     # install a freshly compromised PyPI release.
-    args << "--uploaded-prior-to=#{(Time.now.utc - (24 * 60 * 60)).iso8601(0)}"
+    args << "--uploaded-prior-to=#{(Time.now.utc - Homebrew::RELEASE_COOLDOWN_SECONDS).iso8601(0)}"
     args << "--prefix=#{prefix}" if prefix
     args << "--no-build-isolation" unless build_isolation
     args
@@ -3745,6 +3746,7 @@ class Formula
       GOCACHE:                 "#{HOMEBREW_CACHE}/go_cache",
       GOPATH:                  "#{HOMEBREW_CACHE}/go_mod_cache",
       CARGO_HOME:              "#{HOMEBREW_CACHE}/cargo_cache",
+      BUNDLE_COOLDOWN:         Homebrew::RELEASE_COOLDOWN_DAYS.to_s,
       PIP_CACHE_DIR:           "#{HOMEBREW_CACHE}/pip_cache",
       CURL_HOME:               ENV.fetch("CURL_HOME") { home.to_s },
       PYTHONDONTWRITEBYTECODE: "1",

--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "release_cooldown"
 require "utils/output"
 
 module Language
@@ -18,7 +19,7 @@ module Language
     sig { params(ignore_scripts: T::Boolean).returns(T::Array[String]) }
     def self.npm_install_security_args(ignore_scripts: true)
       args = %W[
-        --min-release-age=1
+        --min-release-age=#{Homebrew::RELEASE_COOLDOWN_DAYS}
         --#{npm_cache_config}
       ]
 

--- a/Library/Homebrew/release_cooldown.rb
+++ b/Library/Homebrew/release_cooldown.rb
@@ -1,0 +1,7 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Homebrew
+  RELEASE_COOLDOWN_DAYS = T.let(1, Integer)
+  RELEASE_COOLDOWN_SECONDS = T.let(RELEASE_COOLDOWN_DAYS * 24 * 60 * 60, Integer)
+end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -2939,6 +2939,18 @@ RSpec.describe Formula do
     end
   end
 
+  describe "#common_stage_test_env" do
+    let(:f) do
+      formula do
+        url "foo-1.0"
+      end
+    end
+
+    it "sets Bundler cooldown for RubyGems dependencies" do
+      expect(f.send(:common_stage_test_env, mktmpdir)[:BUNDLE_COOLDOWN]).to eq("1")
+    end
+  end
+
   describe ".no_autobump!" do
     it "raises an error when used in an unofficial tap" do
       unofficial_tap = Tap.fetch("someone", "repo")

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "release_cooldown"
 require "utils/output"
 require "utils/ast"
 require "time"
@@ -495,7 +496,8 @@ module PyPI
     # likely to pick a freshly compromised PyPI release.
     command = [
       Formula[python_name].opt_libexec/"bin/python", "-m", "pip", "install", "-q", "--disable-pip-version-check",
-      "--dry-run", "--ignore-installed", "--uploaded-prior-to=#{(Time.now.utc - (24 * 60 * 60)).iso8601(0)}",
+      "--dry-run", "--ignore-installed",
+      "--uploaded-prior-to=#{(Time.now.utc - Homebrew::RELEASE_COOLDOWN_SECONDS).iso8601(0)}",
       "--report=/dev/stdout", *packages.map(&:to_s)
     ]
     options = {}


### PR DESCRIPTION
- Set `BUNDLE_COOLDOWN` in `common_stage_test_env` so Bundler uses the same RubyGems release cooldown during staged formula work
- Centralise cooldown days for npm, PyPI and livecheck paths so the policy stays consistent

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
