### PR TITLE
Label WSL analytics

### DIFF
--- a/Library/Homebrew/dev-cmd/formula-analytics.rb
+++ b/Library/Homebrew/dev-cmd/formula-analytics.rb
@@ -363,7 +363,10 @@ module Homebrew
         return if dimension.blank?
 
         require "macos_version"
+        require "utils/analytics"
 
+        wsl = dimension.end_with?(Utils::Analytics::WSL_SUFFIX)
+        dimension = dimension.delete_suffix(Utils::Analytics::WSL_SUFFIX)
         dimension = dimension.gsub(/^Intel ?/, "")
                              .gsub(/^macOS ?/, "")
                              .gsub(/ \(.+\)$/, "")
@@ -377,7 +380,7 @@ module Homebrew
           nil
         end
 
-        case dimension
+        formatted_dimension = case dimension
         when /Ubuntu(-Server)? (14|16|18|20|22|24)\.04/ then "Ubuntu #{Regexp.last_match(2)}.04 LTS"
         when /Ubuntu(-Server)? (\d+\.\d+).\d ?(LTS)?/
           "Ubuntu #{Regexp.last_match(2)} #{Regexp.last_match(3)}".strip
@@ -397,6 +400,8 @@ module Homebrew
         when /^10\.(\d+)/ then "macOS 10.#{Regexp.last_match(1)}"
         else dimension
         end
+
+        Utils::Analytics.with_wsl_suffix_if_needed(formatted_dimension, wsl:)
       end
     end
   end

--- a/Library/Homebrew/test/dev-cmd/formula-analytics_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/formula-analytics_spec.rb
@@ -3,7 +3,16 @@
 
 require "cmd/shared_examples/args_parse"
 require "dev-cmd/formula-analytics"
+require "utils/analytics"
 
 RSpec.describe Homebrew::DevCmd::FormulaAnalytics do
   it_behaves_like "parseable arguments"
+
+  describe "#format_os_version_dimension" do
+    it "preserves WSL in formatted Linux versions" do
+      expect(Homebrew::DevCmd::FormulaAnalytics.new([]).format_os_version_dimension(
+               "Ubuntu 24.04.3 LTS#{Utils::Analytics::WSL_SUFFIX}",
+             )).to eq("Ubuntu 24.04 LTS#{Utils::Analytics::WSL_SUFFIX}")
+    end
+  end
 end

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -7,6 +7,25 @@ require "formula_installer"
 RSpec.describe Utils::Analytics do
   let(:klass) { Utils::Analytics }
 
+  describe "::with_wsl_suffix_if_needed" do
+    it "adds WSL by default on WSL" do
+      allow(OS).to receive(:wsl?).and_return(true)
+
+      expect(klass.with_wsl_suffix_if_needed("Ubuntu 24.04 LTS")).to eq(
+        "Ubuntu 24.04 LTS#{Utils::Analytics::WSL_SUFFIX}",
+      )
+    end
+
+    it "does not add WSL with an explicit override" do
+      expect(klass.with_wsl_suffix_if_needed("Ubuntu 24.04 LTS", wsl: false)).to eq("Ubuntu 24.04 LTS")
+    end
+
+    it "does not add duplicate WSL suffixes" do
+      expect(klass.with_wsl_suffix_if_needed("Ubuntu 24.04 LTS#{Utils::Analytics::WSL_SUFFIX}", wsl: true))
+        .to eq("Ubuntu 24.04 LTS#{Utils::Analytics::WSL_SUFFIX}")
+    end
+  end
+
   describe "::default_package_tags" do
     let(:ci) { ", CI" if ENV["CI"] }
 
@@ -44,6 +63,22 @@ RSpec.describe Utils::Analytics do
     it "includes developer when ENV['HOMEBREW_DEVELOPER'] is set" do
       expect(Homebrew::EnvConfig).to receive(:developer?).and_return(true)
       expect(klass.default_package_tags).to have_key(:developer)
+    end
+
+    it "includes WSL in the OS tag on WSL" do
+      klass.clear_cache
+      allow(OS).to receive(:wsl?).and_return(true)
+
+      expect(klass.default_package_tags[:os]).to eq("#{HOMEBREW_SYSTEM}#{Utils::Analytics::WSL_SUFFIX}")
+    end
+  end
+
+  describe "::default_package_fields" do
+    it "includes WSL in the OS name and version on WSL" do
+      klass.clear_cache
+      allow(OS).to receive(:wsl?).and_return(true)
+
+      expect(klass.default_package_fields[:os_name_and_version]).to eq("#{OS_VERSION}#{Utils::Analytics::WSL_SUFFIX}")
     end
   end
 

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -14,6 +14,7 @@ module Utils
     INFLUX_TOKEN = "iVdsgJ_OjvTYGAA79gOfWlA_fX0QCuj4eYUNdb-qVUTrC3tp3JTWCADVNE9HxV0kp2ZjIK9tuthy_teX4szr9A=="
     INFLUX_HOST = "https://eu-central-1-1.aws.cloud2.influxdata.com"
     INFLUX_ORG = "d81a3e6d582d485f"
+    WSL_SUFFIX = " [WSL]"
 
     extend Utils::Output::Mixin
     extend T::Generic
@@ -366,6 +367,13 @@ module Utils
         nil
       end
 
+      sig { params(value: String, wsl: T::Boolean).returns(String) }
+      def with_wsl_suffix_if_needed(value, wsl: OS.wsl?)
+        return value if !wsl || value.end_with?(WSL_SUFFIX)
+
+        "#{value}#{WSL_SUFFIX}"
+      end
+
       sig { returns(T::Hash[Symbol, T.any(T::Boolean, String)]) }
       def default_package_tags
         cache[:default_package_tags] ||= begin
@@ -380,7 +388,7 @@ module Utils
             developer:      Homebrew::EnvConfig.developer?,
             devcmdrun:      Homebrew::EnvConfig.devcmdrun?,
             arch:           HOMEBREW_PHYSICAL_PROCESSOR,
-            os:             HOMEBREW_SYSTEM,
+            os:             with_wsl_suffix_if_needed(HOMEBREW_SYSTEM),
           }
         end
       end
@@ -399,7 +407,7 @@ module Utils
 
           # Only include OS versions with an actual name.
           os_name_and_version = if (os_version = OS_VERSION.presence) && os_version.downcase.match?(/^[a-z]/)
-            os_version
+            with_wsl_suffix_if_needed(os_version)
           end
 
           {


### PR DESCRIPTION
- Distinguish WSL usage in OS analytics dimensions
- Share suffix handling through `with_wsl_suffix_if_needed`
- Preserve `[WSL]` when normalising generated `os-version` data

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
