### PR TITLE
Silence trust warnings in completion

### DIFF
--- a/Library/Homebrew/completions/bash.erb
+++ b/Library/Homebrew/completions/bash.erb
@@ -55,14 +55,14 @@ __brewcomp() {
 __brew_complete_formulae() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local formulae
-  formulae="$(brew formulae)"
+  formulae="$(HOMEBREW_COMPLETION=1 brew formulae)"
   while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${formulae}" -- "${cur}")
 }
 
 __brew_complete_casks() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local casks
-  casks="$(brew casks)"
+  casks="$(HOMEBREW_COMPLETION=1 brew casks)"
   while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${casks}" -- "${cur}")
 }
 

--- a/Library/Homebrew/completions/fish.erb
+++ b/Library/Homebrew/completions/fish.erb
@@ -110,7 +110,7 @@ end
 # These functions return lists of suggestions for arguments completion
 
 function __fish_brew_suggest_formulae_all -d 'Lists all available formulae with their descriptions'
-    brew formulae
+    HOMEBREW_COMPLETION=1 brew formulae
 end
 
 function __fish_brew_suggest_formulae_installed
@@ -137,7 +137,7 @@ function __fish_brew_suggest_formula_options -a formula -d "List installation op
 end
 
 function __fish_brew_suggest_casks_all -d "Lists locally available casks"
-    brew casks
+    HOMEBREW_COMPLETION=1 brew casks
 end
 
 function __fish_brew_suggest_casks_installed -d "Lists installed casks"

--- a/Library/Homebrew/completions/zsh.erb
+++ b/Library/Homebrew/completions/zsh.erb
@@ -58,7 +58,7 @@ __brew_formulae() {
   local -a list
   local comp_cachename=brew_formulae
   if ! _retrieve_cache $comp_cachename; then
-    list=( $(brew formulae) )
+    list=( $(HOMEBREW_COMPLETION=1 brew formulae) )
     _store_cache $comp_cachename list
   fi
   _describe -t formulae 'all formulae' list
@@ -88,7 +88,7 @@ __brew_casks() {
   local comp_cachename=brew_casks
 
   if ! _retrieve_cache $comp_cachename; then
-    list=( $(brew casks) )
+    list=( $(HOMEBREW_COMPLETION=1 brew casks) )
     _store_cache $comp_cachename list
   fi
 

--- a/Library/Homebrew/items.sh
+++ b/Library/Homebrew/items.sh
@@ -82,13 +82,16 @@ homebrew-trusted-items() {
     store="$("${jq}" -c 'if type == "object" then . else {} end' "${trust_file}")" || store='{}'
   fi
 
-  local tap
-  while read -r tap
-  do
-    [[ -n "${tap}" ]] || continue
-    echo "Warning: Skipping ${tap} because it is not trusted. Run \`brew trust ${tap}\` to trust it." >&2
-  done < <(echo "${items}" | "${jq}" -Rr --argjson store "${store}" --arg trust_key "${trust_key}" \
-    --arg official_tap "${official_tap}" --arg item_dir "${item_dir}" "${untrusted_tap_filter}" | sort -u)
+  if [[ -z "${HOMEBREW_COMPLETION:-}" ]]
+  then
+    local tap
+    while read -r tap
+    do
+      [[ -n "${tap}" ]] || continue
+      opoo "Skipping ${tap} because it is not trusted. Run \`brew trust ${tap}\` to trust it."
+    done < <(echo "${items}" | "${jq}" -Rr --argjson store "${store}" --arg trust_key "${trust_key}" \
+      --arg official_tap "${official_tap}" --arg item_dir "${item_dir}" "${untrusted_tap_filter}" | sort -u)
+  fi
 
   local trusted
   trusted="$(echo "${items}" | "${jq}" -Rr --argjson store "${store}" --arg trust_key "${trust_key}" \

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -40,14 +40,14 @@ __brewcomp() {
 __brew_complete_formulae() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local formulae
-  formulae="$(brew formulae)"
+  formulae="$(HOMEBREW_COMPLETION=1 brew formulae)"
   while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${formulae}" -- "${cur}")
 }
 
 __brew_complete_casks() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local casks
-  casks="$(brew casks)"
+  casks="$(HOMEBREW_COMPLETION=1 brew casks)"
   while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${casks}" -- "${cur}")
 }
 

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -132,7 +132,7 @@ end
 # These functions return lists of suggestions for arguments completion
 
 function __fish_brew_suggest_formulae_all -d 'Lists all available formulae with their descriptions'
-    brew formulae
+    HOMEBREW_COMPLETION=1 brew formulae
 end
 
 function __fish_brew_suggest_formulae_installed
@@ -159,7 +159,7 @@ function __fish_brew_suggest_formula_options -a formula -d "List installation op
 end
 
 function __fish_brew_suggest_casks_all -d "Lists locally available casks"
-    brew casks
+    HOMEBREW_COMPLETION=1 brew casks
 end
 
 function __fish_brew_suggest_casks_installed -d "Lists installed casks"

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -61,7 +61,7 @@ __brew_formulae() {
   local -a list
   local comp_cachename=brew_formulae
   if ! _retrieve_cache $comp_cachename; then
-    list=( $(brew formulae) )
+    list=( $(HOMEBREW_COMPLETION=1 brew formulae) )
     _store_cache $comp_cachename list
   fi
   _describe -t formulae 'all formulae' list
@@ -91,7 +91,7 @@ __brew_casks() {
   local comp_cachename=brew_casks
 
   if ! _retrieve_cache $comp_cachename; then
-    list=( $(brew casks) )
+    list=( $(HOMEBREW_COMPLETION=1 brew casks) )
     _store_cache $comp_cachename list
   fi
 


### PR DESCRIPTION
- Avoid showing tap trust warnings while shells gather formula and cask suggestions, because completion output must stay quiet.
- Keep untrusted items filtered from suggestions and preserve the normal `opoo` warning for non-completion `brew formulae` and `brew casks` runs.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 with local review, testing and tweaks.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
