### PR TITLE
formula_creator: update Ruby to match common env order

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -271,13 +271,13 @@ module Homebrew
             virtualenv_install_with_resources
         <% elsif @mode == :ruby %>
             ENV["BUNDLE_FORCE_RUBY_PLATFORM"] = "1"
-            ENV["BUNDLE_WITHOUT"] = "development test"
             ENV["BUNDLE_VERSION"] = "system" # Avoid installing Bundler into the keg
+            ENV["BUNDLE_WITHOUT"] = "development test"
             ENV["GEM_HOME"] = libexec
 
             system "bundle", "install"
             system "gem", "build", "\#{name}.gemspec"
-            system "gem", "install", "\#{name}-\#{version}.gem"
+            system "gem", "install", "--ignore-dependencies", "\#{name}-\#{version}.gem"
 
             bin.install libexec/"bin/\#{name}"
             bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

Formulae in Homebrew/core are currently using alphabetized order of environment variables so make sure new formulae keep same style.

And make `--ignore-dependencies` explicit. It was implicit by assumption that `bundle install` would install all dependencies, but better to make sure no unexpected downloads are happening.
