### PR TITLE
Use public API for autobump

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1083,15 +1083,15 @@ class Tap
   sig { overridable.returns(T::Array[String]) }
   def autobump
     autobump_packages = if core_cask_tap?
-      Homebrew::API::Internal.cask_hashes
+      Homebrew::API::Cask.all_casks
     elsif core_tap?
-      Homebrew::API::Internal.formula_hashes
+      Homebrew::API::Formula.all_formulae
     else
       {}
     end
 
     @autobump ||= T.let(autobump_packages.select do |_, p|
-      next if p["disable_present"]
+      next if p["disabled"]
       next if p["skip_livecheck"]
 
       p["autobump"] == true

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -860,6 +860,32 @@ RSpec.describe Tap do
       expect { core_tap.uninstall }.to raise_error(RuntimeError)
     end
 
+    specify "#autobump reads public formula API metadata" do
+      core_tap.remove_instance_variable(:@autobump) if core_tap.instance_variable_defined?(:@autobump)
+      expect(Homebrew::API::Internal).not_to receive(:formula_hashes)
+      allow(Homebrew::API::Formula).to receive(:all_formulae).and_return({
+        "autobumped" => { "autobump" => true, "skip_livecheck" => false },
+        "disabled"   => { "autobump" => true, "disabled" => true },
+        "skipped"    => { "autobump" => true, "skip_livecheck" => true },
+      })
+
+      expect(core_tap.autobump).to eq(["autobumped"])
+    end
+
+    specify "#autobump reads public cask API metadata" do
+      cask_tap = CoreCaskTap.instance
+      cask_tap.remove_instance_variable(:@autobump) if cask_tap.instance_variable_defined?(:@autobump)
+      expect(Homebrew::API::Formula).not_to receive(:all_formulae)
+      expect(Homebrew::API::Internal).not_to receive(:cask_hashes)
+      allow(Homebrew::API::Cask).to receive(:all_casks).and_return({
+        "autobumped" => { "autobump" => true, "skip_livecheck" => false },
+        "disabled"   => { "autobump" => true, "disabled" => true },
+        "skipped"    => { "autobump" => true, "skip_livecheck" => true },
+      })
+
+      expect(cask_tap.autobump).to eq(["autobumped"])
+    end
+
     specify "files", :no_api do
       path = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-core"
       formula_file = core_tap.formula_dir/"foo.rb"


### PR DESCRIPTION
- Keep autobump on the public API data because it carries the `autobump`, `skip_livecheck` and `disabled` metadata.
- Avoid expanding the internal API package payload just for BrewTestBot's autobump selection.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and nudging.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
