### PR TITLE
Fix skip_relocation? on Linux

### DIFF
--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -143,7 +143,7 @@ class Bottle
   sig { returns(T::Boolean) }
   def skip_relocation?
     attrs = tab_attributes
-    tab = attrs.empty? ? nil : Tab.new(attrs)
+    tab = Tab.new(attrs) unless attrs.empty?
     @spec.skip_relocation?(tag: @tag, tab:)
   end
 

--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -142,7 +142,7 @@ class Bottle
   # Does the bottle need to be relocated?
   sig { returns(T::Boolean) }
   def skip_relocation?
-    @spec.skip_relocation?(tag: @tag)
+    @spec.skip_relocation?(tag: @tag, tab: Tab.new(tab_attributes))
   end
 
   sig { void }

--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -142,7 +142,9 @@ class Bottle
   # Does the bottle need to be relocated?
   sig { returns(T::Boolean) }
   def skip_relocation?
-    @spec.skip_relocation?(tag: @tag, tab: Tab.new(tab_attributes))
+    attrs = tab_attributes
+    tab = attrs.empty? ? nil : Tab.new(attrs)
+    @spec.skip_relocation?(tag: @tag, tab:)
   end
 
   sig { void }

--- a/Library/Homebrew/bottle_specification.rb
+++ b/Library/Homebrew/bottle_specification.rb
@@ -90,8 +90,12 @@ class BottleSpecification
   end
 
   # Does the {Bottle} this {BottleSpecification} belongs to need to be relocated?
-  sig { params(tag: Utils::Bottles::Tag).returns(T::Boolean) }
-  def skip_relocation?(tag: Utils::Bottles.tag)
+  #
+  # This will always return false on Linux unless a `tab` is provided that
+  # reports the bottle was built with Homebrew 5.1.15 or newer. The caller must
+  # make sure that the provided `tab` is for the requested `tag`.
+  sig { params(tag: Utils::Bottles::Tag, tab: T.nilable(Tab)).returns(T::Boolean) }
+  def skip_relocation?(tag: Utils::Bottles.tag, tab: nil)
     spec = collector.specification_for(tag)
     spec&.cellar == :any_skip_relocation
   end

--- a/Library/Homebrew/extend/os/linux/bottle_specification.rb
+++ b/Library/Homebrew/extend/os/linux/bottle_specification.rb
@@ -1,9 +1,16 @@
 # typed: strict
 # frozen_string_literal: true
 
-class BottleSpecification
-  sig { params(tag: Utils::Bottles::Tag).returns(T::Boolean) }
-  def skip_relocation?(tag: Utils::Bottles.tag)
-    false
+module OS
+  module Linux
+    module BottleSpecification
+      sig { params(tag: Utils::Bottles::Tag, tab: T.nilable(Tab)).returns(T::Boolean) }
+      def skip_relocation?(tag: Utils::Bottles.tag, tab: nil)
+        # Homebrew versions prior to 5.1.15 generated incorrect :any_skip_relocation
+        !tab.nil? && tab.parsed_homebrew_version >= "5.1.15" && super
+      end
+    end
   end
 end
+
+BottleSpecification.prepend(OS::Linux::BottleSpecification)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -978,7 +978,7 @@ on_request: installed_on_request?, options:)
 
     install_service
 
-    fix_dynamic_linkage(keg) if !@poured_bottle || !formula.bottle_specification.skip_relocation?
+    fix_dynamic_linkage(keg) if !@poured_bottle || !formula.bottle_specification.skip_relocation?(tab: keg.tab)
 
     require "install"
     Homebrew::Install.global_post_install
@@ -1564,7 +1564,7 @@ on_request: installed_on_request?, options:)
     tab.write
 
     keg = Keg.new(formula.prefix)
-    skip_linkage = formula.bottle_specification.skip_relocation?
+    skip_linkage = formula.bottle_specification.skip_relocation?(tab:)
     keg.replace_placeholders_with_locations(tab.changed_files, skip_linkage:)
 
     cellar = formula.bottle_specification.tag_to_cellar(Utils::Bottles.tag)

--- a/Library/Homebrew/test/bottle_specification_spec.rb
+++ b/Library/Homebrew/test/bottle_specification_spec.rb
@@ -55,6 +55,69 @@ RSpec.describe BottleSpecification do
     end
   end
 
+  describe "#skip_relocation?" do
+    let(:tag) { Utils::Bottles.tag.to_sym }
+    let(:digest) { "deadbeef" * 8 }
+
+    it "returns false when there is no matching spec" do
+      expect(bottle_spec.skip_relocation?).to be false
+    end
+
+    context "when running on Linux", :needs_linux do
+      context "with bottle built on Homebrew 5.1.15" do
+        let(:tab) { Tab.new(homebrew_version: "5.1.15") }
+
+        it "returns true for `:any_skip_relocation` cellar" do
+          bottle_spec.sha256(cellar: :any_skip_relocation, tag => digest)
+          expect(bottle_spec.skip_relocation?(tab:)).to be true
+        end
+
+        it "returns false for `:any` cellar" do
+          bottle_spec.sha256(cellar: :any, tag => digest)
+          expect(bottle_spec.skip_relocation?(tab:)).to be false
+        end
+      end
+
+      context "with bottle built on Homebrew 5.1.14" do
+        let(:tab) { Tab.new(homebrew_version: "5.1.14") }
+
+        it "returns false for `:any_skip_relocation` cellar" do
+          bottle_spec.sha256(cellar: :any_skip_relocation, tag => digest)
+          expect(bottle_spec.skip_relocation?(tab:)).to be false
+        end
+
+        it "returns false for `:any` cellar" do
+          bottle_spec.sha256(cellar: :any, tag => digest)
+          expect(bottle_spec.skip_relocation?(tab:)).to be false
+        end
+      end
+
+      context "without tab" do
+        it "returns false for `:any_skip_relocation` cellar" do
+          bottle_spec.sha256(cellar: :any_skip_relocation, tag => digest)
+          expect(bottle_spec.skip_relocation?).to be false
+        end
+
+        it "returns false for `:any` cellar" do
+          bottle_spec.sha256(cellar: :any, tag => digest)
+          expect(bottle_spec.skip_relocation?).to be false
+        end
+      end
+    end
+
+    context "when running on macOS", :needs_macos do
+      it "returns true for `:any_skip_relocation` cellar" do
+        bottle_spec.sha256(cellar: :any_skip_relocation, tag => digest)
+        expect(bottle_spec.skip_relocation?).to be true
+      end
+
+      it "returns false for `:any` cellar" do
+        bottle_spec.sha256(cellar: :any, tag => digest)
+        expect(bottle_spec.skip_relocation?).to be false
+      end
+    end
+  end
+
   specify "#rebuild" do
     bottle_spec.rebuild(1337)
     expect(bottle_spec.rebuild).to eq(1337)


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

Follow up to 
- #22441

which has been in stable release since 5.1.15 and generated bottles look correct now, e.g. 
- `bender` - Homebrew/homebrew-core@b4c0e492f86eb176ab58760bfdcb65c818764cd6 which matches required relocation of interpreter and rpaths:
  ```console
  ❯ file bin/bender
  bin/bender: ELF 64-bit LSB pie executable, x86-64, version 1 (GNU/Linux), dynamically linked, interpreter @@HOMEBREW_PREFIX@@/lib/ld.so, for GNU/Linux 3.2.0, BuildID[sha1]=352888c1e69e3373746c959a9ed8ac143d331ee8, not stripped
  ```
- `moor` - Homebrew/homebrew-core@f9c53aa39b927e2b4f998652d33c73d3d81d7a01 which is a statically linked executable so has nothing to relocate:
  ```console
  ❯ file bin/moor
  bin/moor: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=P62fetCvU3vj212zUx_O/wQ14vIJVNIHhrr2KXCVS/zTyBnrAmylTKH1qXYHOe/onqLg7E6IWGCQV1mSL0k, BuildID[sha1]=b088744af660151469b171cb3a14600c3b9744a8, stripped
  ```

---

Also did some local verification by added `ohai` to print out `skip_relocation?` value in extend/os/linux/bottle_specification.rb while installing bottles, i.e.
```diff
-        !tab.nil? && tab.parsed_homebrew_version >= "5.1.15" && super
+        r = !tab.nil? && tab.parsed_homebrew_version >= "5.1.15" && super
+        ohai "skip_relocation? #{r}"
+        r
```

And some output:
- `brew install bender`
  ```
  ==> skip_relocation? false
  ==> skip_relocation? false
  ```
  ```console
  $ file /home/linuxbrew/.linuxbrew/Cellar/bender/0.32.0/bin/bender
  /home/linuxbrew/.linuxbrew/Cellar/bender/0.32.0/bin/bender: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /home/linuxbrew/.linuxbrew/lib/ld.so, for GNU/Linux 3.7.0, BuildID[sha1]=0f3bfccb801a53102e522c2b644486d0bf454520, not stripped
  ```
- `brew install moor`
  ```
  ==> skip_relocation? true
  ==> skip_relocation? true
  ```
- `brew install certifi` - although this should be skip_relocation (no binaries), it was built on 5.1.13-22-g09c6423 so the output is expected to be false, which is correct:
  ```
  ==> skip_relocation? false
  ==> skip_relocation? false
  ```
