### PR TITLE
Avoid untap tracebacks

### DIFF
--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -19,7 +19,13 @@ module Homebrew
 
       sig { override.void }
       def run
-        args.named.to_installed_taps.each do |tap|
+        taps = begin
+          args.named.to_installed_taps
+        rescue Tap::InvalidNameError => e
+          odie e.message
+        end
+
+        taps.each do |tap|
           odie "Untapping #{tap} is not allowed" if tap.core_tap? && Homebrew::EnvConfig.no_install_from_api?
 
           if Homebrew::EnvConfig.no_install_from_api? || (!tap.core_tap? && !tap.core_cask_tap?)
@@ -54,8 +60,8 @@ module Homebrew
 
           formula = begin
             Formulary.factory(formula_name)
-          rescue FormulaUnavailableError
-            # Don't blow up because of a single unavailable formula.
+          rescue FormulaUnavailableError, FormulaSpecificationError
+            # Don't blow up because of a single unavailable or invalid formula.
             next
           end
 

--- a/Library/Homebrew/test/cmd/untap_spec.rb
+++ b/Library/Homebrew/test/cmd/untap_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe Homebrew::Cmd::Untap do
       .and be_a_success
   end
 
+  it "fails without a traceback when given a formula name" do
+    expect { described_class.new(["homebrew/foo/bar"]).run }
+      .to output(%r{Error: Invalid tap name: 'homebrew/foo/bar'}).to_stderr
+      .and raise_error(SystemExit)
+  end
+
   describe "#installed_formulae_for" do
     shared_examples "finds installed formulae in tap", :no_api do
       def load_formula(name:, with_formula_file: false, mock_install: false)
@@ -69,6 +75,29 @@ RSpec.describe Homebrew::Cmd::Untap do
       end
 
       it "returns the expected formulae" do
+        expect(class_instance.installed_formulae_for(tap:).map(&:full_name))
+          .to eq([currently_installed_formula.full_name])
+      end
+
+      it "ignores formulae with invalid specs" do
+        path = Formulary.find_formula_in_tap("invalid-spec", tap)
+        path.dirname.mkpath
+        path.write <<~RUBY
+          class InvalidSpec < Formula
+          end
+        RUBY
+        keg_path = HOMEBREW_CELLAR/"invalid-spec"/"1.2.3"
+        keg_path.mkpath
+
+        (keg_path/AbstractTab::FILENAME).write <<~JSON
+          {
+            "source": {
+              "tap": "#{tap}"
+            }
+          }
+        JSON
+        tap.clear_cache
+
         expect(class_instance.installed_formulae_for(tap:).map(&:full_name))
           .to eq([currently_installed_formula.full_name])
       end


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22570
Fixes https://github.com/Homebrew/brew/issues/22569

- Treat invalid tap arguments as command errors so user input like `homebrew/foo/bar` does not surface an internal backtrace.
- Ignore invalid formula specs while checking installed formulae so a malformed tapped formula does not prevent removing the tap.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review, testing and tweaking.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
