### PR TITLE
Avoid frozen update report arrays

### DIFF
--- a/Library/Homebrew/cmd/update_report/reporter_hub.rb
+++ b/Library/Homebrew/cmd/update_report/reporter_hub.rb
@@ -24,7 +24,7 @@ class ReporterHub
   def add(reporter, auto_update: false)
     @reporters << reporter
     report = reporter.report(auto_update:).reject { |_k, v| v.empty? }
-    @hash.update(report) { |_key, oldval, newval| oldval.concat(newval) }
+    @hash.update(report) { |_key, oldval, newval| oldval + newval }
   end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -280,5 +280,15 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
       allow(Cask::Caskroom).to receive(:casks).and_return([])
       expect { hub.dump }.not_to output.to_stdout
     end
+
+    it "merges frozen report arrays" do
+      first_reporter = instance_double(Reporter, report: { A: ["foo"].freeze })
+      second_reporter = instance_double(Reporter, report: { A: ["bar"] })
+
+      hub.add(first_reporter)
+      hub.add(second_reporter)
+
+      expect(hub.instance_variable_get(:@hash)[:A]).to eq(%w[foo bar])
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22571

- Prevent `ReporterHub` from mutating arrays supplied by reports.
- Cover frozen report arrays to avoid `brew update` `FrozenError`s.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
