### PR TITLE
cask/audit: normalize 10.16 minimum macOS

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -899,11 +899,7 @@ module Cask
       end
       return if items.blank?
 
-      min_os = items[0]&.minimum_system_version&.strip_patch
-      # Big Sur is sometimes identified as 10.16, so we override it to the
-      # expected macOS version (11).
-      min_os = MacOSVersion.new("11") if min_os == "10.16"
-      min_os
+      normalize_min_os(items[0]&.minimum_system_version)
     end
 
     sig { returns(T.nilable(MacOSVersion)) }
@@ -992,11 +988,27 @@ module Cask
         end
       end
 
-      begin
+      normalize_min_os(min_os)
+    end
+
+    sig { params(min_os: T.nilable(T.any(String, MacOSVersion))).returns(T.nilable(MacOSVersion)) }
+    def normalize_min_os(min_os)
+      return if min_os.nil?
+      return if min_os.is_a?(String) && min_os.blank?
+
+      min_os = if min_os.is_a?(MacOSVersion)
+        min_os.strip_patch
+      else
         MacOSVersion.new(min_os).strip_patch
-      rescue MacOSVersion::Error
-        nil
       end
+
+      # Big Sur is sometimes identified as 10.16, so we override it to the
+      # expected macOS version (11).
+      min_os = MacOSVersion.new("11") if min_os == "10.16"
+
+      min_os
+    rescue MacOSVersion::Error
+      nil
     end
 
     sig { params(path: Pathname).returns(T.nilable(String)) }

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -1127,6 +1127,10 @@ RSpec.describe Cask::Audit, :cask do
       end
 
       it { is_expected.to pass }
+
+      it "normalizes 10.16.0 minimum macOS to Big Sur" do
+        expect(audit.send(:normalize_min_os, "10.16.0")).to eq(MacOSVersion.from_symbol(:big_sur))
+      end
     end
 
     describe "preferred download URL formats" do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?
- [x] AI was used to generate or assist with generating this PR.

Codex was used to help identify the relevant audit path, update the code and test, and review the PR description. I reviewed the generated changes and verified them with the commands listed above.

-----
This fixes a false positive in the cask minimum macOS audit.

Some pkg `Distribution` files declare Big Sur using Apple's compatibility version `10.16.0`:

```xml
<os-version min="10.16.0"/>
```

Before this change, artifact-derived minimum macOS values were converted with `MacOSVersion.new(...).strip_patch`, so
 `10.16.0` became `10.16`, which Homebrew reports as `:dunno`.

This caused audit failures when a cask correctly declared Big Sur as its minimum macOS version:

```ruby
depends_on macos: :big_sur
```

Example failure:

```text
Artifact defined :dunno as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS 
version of :big_sur
```

Homebrew already normalizes Sparkle `minimumSystemVersion` values of `10.16` to Big Sur (`11`). This change moves that normalization into a shared helper and applies it to artifact-derived minimum macOS values as well.

I verified this with `elektron-overbridge` versions `2.21.3` and `2.25.7`. The `2.25.7`.
The `2.25.7` cask update is here:
https://github.com/SSakutaro/homebrew-cask/blob/elektron-overbridge-2.25.7/Casks/e/elektron-overbridge.rb

Before this change, both reported `:dunno`; after this change, both report `:big_sur`.

Tested with:

```sh
brew lgtm
brew tests --only=cask/audit
brew style cask/audit.rb test/cask/audit_spec.rb
HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --cask --online --strict elektron-overbridge
```