### PR TITLE
Cask::Auditor: fix audit return type

### DIFF
--- a/Library/Homebrew/cask/auditor.rb
+++ b/Library/Homebrew/cask/auditor.rb
@@ -16,7 +16,7 @@ module Cask
         audit_strict: T.nilable(T::Boolean), audit_signing: T.nilable(T::Boolean),
         audit_new_cask: T.nilable(T::Boolean), quarantine: T::Boolean,
         any_named_args: T::Boolean, language: T.nilable(String), only: T::Array[String], except: T::Array[String]
-      ).returns(T::Set[String])
+      ).returns(T::Set[Audit::Error])
     }
     def self.audit(
       cask, audit_download: false, audit_online: nil, audit_strict: nil, audit_signing: nil,
@@ -71,7 +71,7 @@ module Cask
 
     LANGUAGE_BLOCK_LIMIT = 10
 
-    sig { returns(T::Set[String]) }
+    sig { returns(T::Set[Audit::Error]) }
     def audit
       errors = Set.new
 

--- a/Library/Homebrew/test/cask/auditor_spec.rb
+++ b/Library/Homebrew/test/cask/auditor_spec.rb
@@ -1,0 +1,73 @@
+# typed: true
+# frozen_string_literal: true
+
+require "cask/auditor"
+
+RSpec.describe Cask::Auditor, :cask do
+  subject(:auditor) { described_class }
+
+  describe "audit" do
+    it "returns an empty Set if there are no audit errors" do
+      basic_cask = Cask::CaskLoader.load(cask_path("basic-cask"))
+      expect(auditor.audit(basic_cask)).to eq(Set.new)
+
+      with_languages_cask = Cask::CaskLoader.load(cask_path("with-languages"))
+      expect(auditor.audit(with_languages_cask)).to eq(Set.new)
+
+      with_many_languages_cask = Cask::CaskLoader.load(cask_path("with-many-languages"))
+      expect(auditor.audit(with_many_languages_cask)).to eq(Set.new)
+    end
+
+    it "returns a Set of Audit::Error hashes if there are audit errors" do
+      error_hash = {
+        message:   "sha256 string must be of 64 hexadecimal characters",
+        location:  nil,
+        corrected: false,
+      }
+
+      invalid_sha256_cask = Cask::CaskLoader.load(cask_path("invalid-sha256"))
+      expect(auditor.audit(invalid_sha256_cask)).to eq(Set[error_hash])
+
+      with_many_languages_and_error_cask = Cask::CaskLoader.load(cask_path("with-many-languages-and-invalid-sha256"))
+      expect(auditor.audit(with_many_languages_and_error_cask)).to eq(Set[error_hash])
+      expect(auditor.audit(with_many_languages_and_error_cask, audit_strict: true)).to eq(Set[error_hash])
+    end
+  end
+
+  describe "output_summary?" do
+    let(:cask) { Cask::CaskLoader.load(cask_path("basic-cask")) }
+
+    it "returns true if @any_named_args is true" do
+      auditor_obj = auditor.new(cask, any_named_args: true)
+      expect(auditor_obj.send(:output_summary?)).to be(true)
+    end
+
+    it "returns true if @audit_strict is true" do
+      auditor_obj = auditor.new(cask, audit_strict: true)
+      expect(auditor_obj.send(:output_summary?)).to be(true)
+    end
+
+    it "returns false if the audit argument is nil" do
+      auditor_obj = auditor.new(cask)
+      expect(auditor_obj.send(:output_summary?)).to be(false)
+      expect(auditor_obj.send(:output_summary?, nil)).to be(false)
+    end
+
+    it "returns false if there are no audit errors" do
+      auditor_obj = auditor.new(cask)
+      audit = Cask::Audit.new(cask)
+      expect(auditor_obj.send(:output_summary?, audit)).to be(false)
+    end
+
+    it "returns true if there are audit errors" do
+      auditor_obj = auditor.new(cask)
+      audit = Cask::Audit.new(cask)
+      audit.instance_variable_set(:@errors, [{
+        message:   nil,
+        location:  nil,
+        corrected: false,
+      }])
+      expect(auditor_obj.send(:output_summary?, audit)).to be(true)
+    end
+  end
+end

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe Cask::Info, :cask do
     expect do
       described_class.info(Cask::CaskLoader.load("with-languages"), args:)
     end.to output(<<~EOS).to_stdout
-      #{oh1_title uninstalled("with-languages")}: 1.2.3
+      #{oh1_title uninstalled("with-languages")} (Caffeine): 1.2.3
       https://brew.sh/
       Not installed
       From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/w/with-languages.rb

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid-sha256.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid-sha256.rb
@@ -3,4 +3,13 @@
 cask "invalid-sha256" do
   version "1.2.3"
   sha256 "not a valid shasum"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  name "Caffeine"
+  desc "Cask for testing an invalid sha256"
+  homepage "https://brew.sh/"
+
+  depends_on macos: :catalina
+
+  app "Caffeine.app"
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
@@ -4,15 +4,16 @@ cask "with-languages" do
   version "1.2.3"
 
   language "zh" do
-    sha256 "abc123"
+    sha256 :no_check
     "zh-CN"
   end
   language "en-US", default: true do
-    sha256 "xyz789"
+    sha256 :no_check
     "en-US"
   end
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  name "Caffeine"
   homepage "https://brew.sh/"
 
   depends_on macos: :catalina

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-many-languages-and-invalid-sha256.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-many-languages-and-invalid-sha256.rb
@@ -1,0 +1,57 @@
+# typed: false
+
+cask "with-many-languages-and-invalid-sha256" do
+  version "1.2.3"
+
+  language "en", default: true do
+    sha256 "not a valid shasum"
+    "en"
+  end
+  language "cs" do
+    sha256 "not a valid shasum"
+    "cs"
+  end
+  language "es-AR" do
+    sha256 "not a valid shasum"
+    "es-AR"
+  end
+  language "ff" do
+    sha256 "not a valid shasum"
+    "ff"
+  end
+  language "fi" do
+    sha256 "not a valid shasum"
+    "fi"
+  end
+  language "gn" do
+    sha256 "not a valid shasum"
+    "gn"
+  end
+  language "gu" do
+    sha256 "not a valid shasum"
+    "gu"
+  end
+  language "ko" do
+    sha256 "not a valid shasum"
+    "ko"
+  end
+  language "ru" do
+    sha256 "not a valid shasum"
+    "ru"
+  end
+  language "sv" do
+    sha256 "not a valid shasum"
+    "sv"
+  end
+  language "th" do
+    sha256 "not a valid shasum"
+    "th"
+  end
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  name "Caffeine"
+  desc "Keep your computer awake"
+  homepage "https://brew.sh/"
+
+  app "Caffeine.app"
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

When the `HOMEBREW_SORBET_RECURSIVE=1` environment variable is set, running `brew audit` on a cask with audit errors will produce a type error: `Return value: Expected type T::Set[String], got T::Set[T::Hash[Symbol, T.nilable(T.any(String, T::Boolean))]]`. This occurs because the `Cask::Auditor.audit` and `#audit` methods are expected to return a Set of strings but the Set is populated with `Cask::Audit::Error` objects, which is a type alias for a specific hash structure. This updates the related return types to use `T::Set[Audit::Error]`.

`Cask::Auditor` doesn't have any dedicated tests and only has 36.23% of lines covered (0% of branches) when running all the other tests. Notably, the other tests don't exercise `Cask::Auditor` in any way that can trigger the previously-mentioned type error in the `audit` return type when the `HOMEBREW_SORBET_RECURSIVE=1` environment variable is set.

This also adds `test/cask/auditor_spec.rb`, which increases coverage to 100% of lines and branches by itself. A couple of the added tests will trigger the `audit` return type error when the fix in this branch is omitted. With the fix applied, the type error doesn't arise in the tests, as expected.

-----

It's worth mentioning that the changes in the `invalid-sha256` and `with-languages` cask fixtures are to ensure that the casks do not have unexpected audit errors. `invalid-sha256` should only have an audit error related to the `sha256` value and `with-languages` shouldn't have any audit errors. We should probably go through all the cask fixtures and fix unintended audit issues (e.g., missing `name`, etc.) but that's well out of scope for this PR, so I've fixed the ones I used in the `Auditor` tests.

The change to `cask/info_spec.rb` is because adding a `name` to the `with-languages` cask caused the output to change in one of those tests, so it needed to be updated.