### PR TITLE
Skip valid cached cask fetches

### DIFF
--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -87,6 +87,14 @@ module Cask
       downloader.basename
     end
 
+    sig { override.returns(T::Boolean) }
+    def downloaded_and_valid?
+      return false unless super
+
+      quarantine(cached_download)
+      true
+    end
+
     sig { override.params(filename: Pathname).void }
     def verify_download_integrity(filename)
       if no_checksum_defined? && !official_cask_tap?

--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -59,12 +59,16 @@ module Homebrew
         @download_threads.add(Thread.current)
         begin
           download.clear_cache if force
+          if !force && downloadable.downloaded_and_valid?
+            check_bottle_attestation(downloadable, check_attestation:)
+            create_symlinks_for_shared_download(cached_location)
+            next cached_location
+          end
+
           download.fetch(quiet:)
           raise CancelledDownloadError if cancelled.true?
 
-          if check_attestation && downloadable.is_a?(Bottle)
-            Utils::Attestation.check_attestation(downloadable, quiet: true)
-          end
+          check_bottle_attestation(downloadable, check_attestation:)
           create_symlinks_for_shared_download(cached_location)
         rescue Interrupt
           raise CancelledDownloadError
@@ -228,6 +232,14 @@ module Homebrew
     end
 
     private
+
+    sig { params(downloadable: Downloadable, check_attestation: T::Boolean).void }
+    def check_bottle_attestation(downloadable, check_attestation:)
+      return unless check_attestation
+      return unless downloadable.is_a?(Bottle)
+
+      Utils::Attestation.check_attestation(downloadable, quiet: true)
+    end
 
     sig { params(cached_location: Pathname).void }
     def create_symlinks_for_shared_download(cached_location)

--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -81,6 +81,17 @@ module Downloadable
     cached_download.exist?
   end
 
+  sig { overridable.returns(T::Boolean) }
+  def downloaded_and_valid?
+    return false unless cached_download.file?
+    return false if checksum.blank?
+
+    with_context(quiet: true) { verify_download_integrity(cached_download) }
+    true
+  rescue ChecksumMismatchError
+    false
+  end
+
   sig { overridable.returns(Pathname) }
   def cached_download
     downloader.cached_location

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -395,7 +395,7 @@ class Resource
       tab
     end
 
-    sig { returns(T::Boolean) }
+    sig { override.returns(T::Boolean) }
     def downloaded_and_valid?
       return false unless downloaded?
 

--- a/Library/Homebrew/test/cask/download_spec.rb
+++ b/Library/Homebrew/test/cask/download_spec.rb
@@ -60,6 +60,27 @@ RSpec.describe Cask::Download, :cask do
     end
   end
 
+  describe "#downloaded_and_valid?" do
+    it "quarantines valid cached downloads" do
+      cached_download = HOMEBREW_CACHE/"downloads/cask.zip"
+      cached_download.dirname.mkpath
+      cached_download.write("already downloaded")
+      checksum = Checksum.new(cached_download.sha256)
+      cask = instance_double(Cask::Cask, sha256: checksum)
+      download = described_class.new(cask, quarantine: true)
+
+      allow(download).to receive(:cached_download).and_return(cached_download)
+      allow(download).to receive(:verify_download_integrity) do |filename|
+        filename.verify_checksum(checksum)
+      end
+      allow(Cask::Quarantine).to receive(:available?).and_return(true)
+
+      expect(Cask::Quarantine).to receive(:cask!).with(cask:, download_path: cached_download)
+
+      expect(download.downloaded_and_valid?).to be(true)
+    end
+  end
+
   describe "#verify_download_integrity" do
     subject(:verification) { described_class.new(cask).verify_download_integrity(downloaded_path) }
 

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe Homebrew::DownloadQueue do
     instance_double(
       Downloadable,
       cached_download:,
+      checksum:               nil,
+      downloaded_and_valid?:  false,
+      downloader:             nil,
       download_queue_message: "Bottle testball",
       download_queue_name:    "testball",
       download_queue_type:    "Bottle",
@@ -36,5 +39,36 @@ RSpec.describe Homebrew::DownloadQueue do
 
     expect(download_queue.fetch_failed).to be(true)
     expect(Homebrew).to have_failed
+  end
+
+  it "skips fetching already downloaded files with a valid checksum" do
+    cached_download.dirname.mkpath
+    cached_download.write("already downloaded")
+
+    allow(downloadable).to receive(:downloaded_and_valid?).and_return(true)
+
+    expect(retryable_download).not_to receive(:fetch)
+    expect(downloadable).to receive(:downloader).and_return(nil)
+
+    download_queue.enqueue(downloadable)
+    download_queue.fetch
+  end
+
+  it "checks attestations for valid cached bottles" do
+    bottle = Bottle.allocate
+    allow(bottle).to receive_messages(
+      cached_download:,
+      checksum:               nil,
+      downloaded_and_valid?:  true,
+      downloader:             nil,
+      download_queue_message: "Bottle testball",
+      download_queue_name:    "testball",
+      download_queue_type:    "Bottle",
+    )
+
+    expect(Utils::Attestation).to receive(:check_attestation).with(bottle, quiet: true)
+
+    download_queue.enqueue(bottle, check_attestation: true)
+    download_queue.fetch
   end
 end


### PR DESCRIPTION
- Avoid network metadata checks when queued downloads already have a cached file that matches the declared checksum.
- Keep cask quarantine handling for valid cached downloads because it is local work required by cask fetches.
- Cover the queue skip and cached cask quarantine behaviour to prevent regressions.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
