### PR TITLE
Tweak macOS .pkg package-user plist handling

### DIFF
--- a/Library/Homebrew/test/cmd/as-console-user_spec.rb
+++ b/Library/Homebrew/test/cmd/as-console-user_spec.rb
@@ -98,7 +98,8 @@ RSpec.describe Homebrew::Cmd::AsConsoleUser do
       <<~SH,
         source "#{macos_user_script}"
         defaults() { printf 'munki\\n'; }
-        stat() { printf 'root\\n'; }
+        stat() { printf 'root 600\\n'; }
+        ls() { printf -- '-rw------- 1 root wheel 0 x\\n'; }
         homebrew-package-user
       SH
       "HOMEBREW_PKG_USER_PLIST" => homebrew_pkg_user_plist.to_s,
@@ -106,6 +107,108 @@ RSpec.describe Homebrew::Cmd::AsConsoleUser do
 
     expect(status.success?).to be true
     expect(stdout).to eq("munki\n")
+    expect(stderr).to be_empty
+  end
+
+  it "honours a root-owned plist that carries extended attributes" do
+    homebrew_pkg_user_plist = test_root/".homebrew_pkg_user.plist"
+    homebrew_pkg_user_plist.write "plist"
+
+    stdout, stderr, status = run_as_console_user_shell(
+      <<~SH,
+        source "#{macos_user_script}"
+        defaults() { printf 'munki\\n'; }
+        stat() { printf 'root 600\\n'; }
+        ls() { printf -- '-rw-------@ 1 root wheel 0 x\\n'; }
+        homebrew-package-user
+      SH
+      "HOMEBREW_PKG_USER_PLIST" => homebrew_pkg_user_plist.to_s,
+    )
+
+    expect(status.success?).to be true
+    expect(stdout).to eq("munki\n")
+    expect(stderr).to be_empty
+  end
+
+  it "ignores a package user plist not owned by root" do
+    homebrew_pkg_user_plist = test_root/".homebrew_pkg_user.plist"
+    homebrew_pkg_user_plist.write "plist"
+
+    stdout, stderr, status = run_as_console_user_shell(
+      <<~SH,
+        source "#{macos_user_script}"
+        defaults() { printf 'attacker\\n'; }
+        stat() { case "$*" in *"/dev/console") printf 'root\\n';; *) printf 'attacker 600\\n';; esac; }
+        ls() { printf -- '-rw------- 1 attacker staff 0 x\\n'; }
+        homebrew-package-user
+      SH
+      "HOMEBREW_PKG_USER_PLIST" => homebrew_pkg_user_plist.to_s,
+    )
+
+    expect(status.exitstatus).to eq 1
+    expect(stdout).to be_empty
+    expect(stderr).to be_empty
+  end
+
+  it "ignores a package user plist with loose permissions" do
+    homebrew_pkg_user_plist = test_root/".homebrew_pkg_user.plist"
+    homebrew_pkg_user_plist.write "plist"
+
+    stdout, stderr, status = run_as_console_user_shell(
+      <<~SH,
+        source "#{macos_user_script}"
+        defaults() { printf 'attacker\\n'; }
+        stat() { case "$*" in *"/dev/console") printf 'root\\n';; *) printf 'root 644\\n';; esac; }
+        ls() { printf -- '-rw-rw-rw- 1 root wheel 0 x\\n'; }
+        homebrew-package-user
+      SH
+      "HOMEBREW_PKG_USER_PLIST" => homebrew_pkg_user_plist.to_s,
+    )
+
+    expect(status.exitstatus).to eq 1
+    expect(stdout).to be_empty
+    expect(stderr).to be_empty
+  end
+
+  it "ignores a package user plist carrying an ACL" do
+    homebrew_pkg_user_plist = test_root/".homebrew_pkg_user.plist"
+    homebrew_pkg_user_plist.write "plist"
+
+    stdout, stderr, status = run_as_console_user_shell(
+      <<~SH,
+        source "#{macos_user_script}"
+        defaults() { printf 'attacker\\n'; }
+        stat() { case "$*" in *"/dev/console") printf 'root\\n';; *) printf 'root 600\\n';; esac; }
+        ls() { printf -- '-rw-------@ 1 root wheel 0 x\\n 0: group:everyone deny delete\\n'; }
+        homebrew-package-user
+      SH
+      "HOMEBREW_PKG_USER_PLIST" => homebrew_pkg_user_plist.to_s,
+    )
+
+    expect(status.exitstatus).to eq 1
+    expect(stdout).to be_empty
+    expect(stderr).to be_empty
+  end
+
+  it "ignores a package user plist that is a symlink" do
+    homebrew_pkg_user_target = test_root/"target.plist"
+    homebrew_pkg_user_target.write "plist"
+    homebrew_pkg_user_plist = test_root/".homebrew_pkg_user.plist"
+    FileUtils.ln_s homebrew_pkg_user_target, homebrew_pkg_user_plist
+
+    stdout, stderr, status = run_as_console_user_shell(
+      <<~SH,
+        source "#{macos_user_script}"
+        defaults() { printf 'attacker\\n'; }
+        stat() { case "$*" in *"/dev/console") printf 'root\\n';; *) printf 'root\\n';; esac; }
+        ls() { printf -- '-rw------- 1 root wheel 0 x\\n'; }
+        homebrew-package-user
+      SH
+      "HOMEBREW_PKG_USER_PLIST" => homebrew_pkg_user_plist.to_s,
+    )
+
+    expect(status.exitstatus).to eq 1
+    expect(stdout).to be_empty
     expect(stderr).to be_empty
   end
 

--- a/Library/Homebrew/utils/macos_user.sh
+++ b/Library/Homebrew/utils/macos_user.sh
@@ -30,7 +30,16 @@ homebrew-user-home() {
 # Print the package install user, preferring MDM's plist override.
 homebrew-package-user() {
   local homebrew_pkg_user_plist="${HOMEBREW_PKG_USER_PLIST:-/var/tmp/.homebrew_pkg_user.plist}"
-  if [[ -f "${homebrew_pkg_user_plist}" ]]
+  # Only honour an override plist that is securely managed by an administrator:
+  # a non-symlink regular file, owned by root, mode 0600 and free of ACLs.
+  # Otherwise fall back to the console user below. Read ownership and mode from
+  # `stat` so extended attributes are ignored, and detect ACLs with `ls -led`,
+  # which prints an extra line per ACL entry (its "@"/"+" mode suffix is not
+  # reliable as "@" for extended attributes masks "+" for ACLs).
+  # shellcheck disable=SC2012 # `ls -led` is needed to detect ACLs; `find` cannot.
+  if [[ ! -L "${homebrew_pkg_user_plist}" && -f "${homebrew_pkg_user_plist}" ]] &&
+     [[ "$(stat -f "%Su %Lp" "${homebrew_pkg_user_plist}" 2>/dev/null)" == "root 600" ]] &&
+     [[ "$(ls -led "${homebrew_pkg_user_plist}" 2>/dev/null | wc -l)" -eq 1 ]]
   then
     local homebrew_pkg_user
     if homebrew_pkg_user="$(defaults read "${homebrew_pkg_user_plist}" HOMEBREW_PKG_USER 2>/dev/null)" &&


### PR DESCRIPTION
Require a non-symlink regular file owned by root, mode 0600 and free of ACLs otherwise fall back to the console user

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 high with local review, tweaking and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
