### PR TITLE
Clean up leftover `.reinstall` kegs

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -406,6 +406,7 @@ module Homebrew
         cleanup_bootsnap
         cleanup_logs
         cleanup_temp_cellar
+        cleanup_reinstall_kegs
         cleanup_lockfiles
         cleanup_python_site_packages
         prune_prefix_symlinks_and_directories
@@ -496,6 +497,15 @@ module Homebrew
 
       HOMEBREW_TEMP_CELLAR.each_child do |child|
         cleanup_path(child) { FileUtils.rm_r(child) }
+      end
+    end
+
+    sig { void }
+    def cleanup_reinstall_kegs
+      return unless HOMEBREW_CELLAR.directory?
+
+      HOMEBREW_CELLAR.glob("*/*.reinstall").each do |reinstall_keg|
+        cleanup_path(reinstall_keg) { FileUtils.rm_r(reinstall_keg) }
       end
     end
 

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -60,6 +60,15 @@ RSpec.describe Homebrew::Cleanup do
       expect(lock_file).to exist
     end
 
+    it "removes leftover `.reinstall` kegs in the Cellar" do
+      reinstall_keg = HOMEBREW_CELLAR/"foo/1.0.reinstall"
+      reinstall_keg.mkpath
+
+      cleanup.clean!
+
+      expect(reinstall_keg).not_to exist
+    end
+
     it "doesn't remove the lock file if it is locked" do
       lock_file.open(File::RDWR | File::CREAT).flock(File::LOCK_EX | File::LOCK_NB)
 

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -883,6 +883,7 @@ RSpec.describe Formulary do
           old_tap.path.mkpath
           new_tap.path.mkpath
           (old_tap.path/"tap_migrations.json").write tap_migrations.to_json
+          old_tap.clear_cache
         end
 
         context "to a cask in the default tap" do


### PR DESCRIPTION
- `brew reinstall` backs up a keg to `<keg>.reinstall` before reinstalling and can leave it behind on failure or interruption
- have `brew cleanup` remove these so they don't accumulate in the Cellar

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 high with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
