### PR TITLE
generate-cask-ci-matrix: remove deprecated `--signing` flag from `audit` arguments

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
@@ -277,7 +277,7 @@ module Homebrew
         cask_files_to_check.flat_map do |path|
           cask_token = path.basename(".rb")
 
-          audit_args = ["--online", "--signing"]
+          audit_args = ["--online"]
           audit_args << "--new" if changed_files.fetch(:added_files).include?(path) || new_cask
 
           audit_exceptions = []


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
This flag was deprecated in #22549 and causes CI failures in homebrew/cask repository (f.e. https://github.com/Homebrew/homebrew-cask/actions/runs/27137208617/job/80092761576)