### PR TITLE
Pin tap allow/forbid/trust lists to remotes

### DIFF
--- a/Library/Homebrew/cmd/trust.rb
+++ b/Library/Homebrew/cmd/trust.rb
@@ -56,7 +56,7 @@ module Homebrew
 
         args.named.each do |name|
           type, trust_name = Homebrew::Trust.target(name, type: selected_type)
-          if type == :tap && Tap.fetch(trust_name).official?
+          if type == :tap && Tap.fetch(name).official?
             puts "Official tap #{trust_name} is always trusted."
             next
           end

--- a/Library/Homebrew/cmd/untrust.rb
+++ b/Library/Homebrew/cmd/untrust.rb
@@ -80,7 +80,7 @@ module Homebrew
         args.named.each do |name|
           item_types = [:formula, :cask, :command]
           type, trust_name = Homebrew::Trust.target(name, type: selected_type, include_existing: true)
-          if type == :tap && Tap.fetch(trust_name).official?
+          if type == :tap && Tap.fetch(name).official?
             puts "Official tap #{trust_name} is always trusted."
             next
           end

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -47,7 +47,9 @@ module Homebrew
       HOMEBREW_ALLOWED_TAPS:                     {
         description: "A space-separated list of taps. Homebrew will refuse to install a " \
                      "formula unless it and all of its dependencies are in an official tap " \
-                     "or in a tap on this list.",
+                     "or in a tap on this list. Each entry is a `user/repository` name " \
+                     "(which matches only taps using the default GitHub remote) or a remote " \
+                     "URL (required to match taps with a custom remote).",
       },
       HOMEBREW_API_AUTO_UPDATE_SECS:             {
         description: "Check Homebrew's API for new formulae or cask data every " \
@@ -347,7 +349,10 @@ module Homebrew
       },
       HOMEBREW_FORBIDDEN_TAPS:                   {
         description: "A space-separated list of taps. Homebrew will refuse to install a " \
-                     "formula if it or any of its dependencies is in a tap on this list.",
+                     "formula if it or any of its dependencies is in a tap on this list. " \
+                     "Each entry is a `user/repository` name (which matches only taps using " \
+                     "the default GitHub remote) or a remote URL (required to match taps " \
+                     "with a custom remote).",
       },
       HOMEBREW_FORBID_CASKS:                     {
         description: "If set, Homebrew will refuse to install any casks.",

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -120,34 +120,37 @@ class Tap
     [tap, token.downcase]
   end
 
-  sig { returns(T::Set[Tap]) }
+  sig { returns(T::Array[String]) }
   def self.allowed_taps
     cache_key = :"allowed_taps_#{Homebrew::EnvConfig.allowed_taps.to_s.tr(" ", "_")}"
-    cache[cache_key] ||= begin
-      allowed_tap_list = Homebrew::EnvConfig.allowed_taps.to_s.split
-
-      Set.new(allowed_tap_list.filter_map do |tap|
-        Tap.fetch(tap)
-      rescue Tap::InvalidNameError
-        opoo "Invalid tap name in `$HOMEBREW_ALLOWED_TAPS`: #{tap}"
-        nil
-      end).freeze
-    end
+    cache[cache_key] ||= tap_list_references(Homebrew::EnvConfig.allowed_taps.to_s, "HOMEBREW_ALLOWED_TAPS")
   end
 
-  sig { returns(T::Set[Tap]) }
+  sig { returns(T::Array[String]) }
   def self.forbidden_taps
     cache_key = :"forbidden_taps_#{Homebrew::EnvConfig.forbidden_taps.to_s.tr(" ", "_")}"
-    cache[cache_key] ||= begin
-      forbidden_tap_list = Homebrew::EnvConfig.forbidden_taps.to_s.split
+    cache[cache_key] ||= tap_list_references(Homebrew::EnvConfig.forbidden_taps.to_s, "HOMEBREW_FORBIDDEN_TAPS")
+  end
 
-      Set.new(forbidden_tap_list.filter_map do |tap|
-        Tap.fetch(tap)
-      rescue Tap::InvalidNameError
-        opoo "Invalid tap name in `$HOMEBREW_FORBIDDEN_TAPS`: #{tap}"
-        nil
-      end).freeze
-    end
+  # Whether an allow/forbid/trust list reference is a remote URL or local path rather than a
+  # `user/repository` tap name (which can only match a tap on its default GitHub remote).
+  sig { params(reference: String).returns(T::Boolean) }
+  def self.remote_reference?(reference)
+    reference.include?("://") || reference.include?("@") || reference.start_with?("/", ".", "~")
+  end
+
+  # Normalise `user/repository` entries in a tap allow/forbid list to canonical tap names,
+  # warning about invalid ones, while preserving remote URL or path entries verbatim.
+  sig { params(env_taps: String, env_var: String).returns(T::Array[String]) }
+  def self.tap_list_references(env_taps, env_var)
+    env_taps.split.filter_map do |reference|
+      next reference if remote_reference?(reference)
+
+      Tap.fetch(reference).name
+    rescue Tap::InvalidNameError
+      opoo "Invalid tap name in `$#{env_var}`: #{reference}"
+      nil
+    end.freeze
   end
 
   class << self
@@ -498,16 +501,18 @@ class Tap
       raise TapAlreadyTappedError, name unless shallow?
     end
 
-    if !allowed_by_env? || forbidden_by_env?
+    tap_allowed = allowed_by_env?(remote: requested_remote)
+    tap_forbidden = forbidden_by_env?(remote: requested_remote)
+    if !tap_allowed || tap_forbidden
       owner = Homebrew::EnvConfig.forbidden_owner
       owner_contact = if (contact = Homebrew::EnvConfig.forbidden_owner_contact.presence)
         "\n#{contact}"
       end
 
       error_message = "The installation of the #{full_name} was requested but #{owner}\n"
-      error_message << "has not allowed this tap in `$HOMEBREW_ALLOWED_TAPS`" unless allowed_by_env?
-      error_message << " and\n" if !allowed_by_env? && forbidden_by_env?
-      error_message << "has forbidden this tap in `$HOMEBREW_FORBIDDEN_TAPS`" if forbidden_by_env?
+      error_message << "has not allowed this tap in `$HOMEBREW_ALLOWED_TAPS`" unless tap_allowed
+      error_message << " and\n" if !tap_allowed && tap_forbidden
+      error_message << "has forbidden this tap in `$HOMEBREW_FORBIDDEN_TAPS`" if tap_forbidden
       error_message << ".#{owner_contact}"
 
       odie error_message
@@ -733,6 +738,34 @@ class Tap
     return true unless (remote = self.remote)
 
     !T.must(remote.casecmp(default_remote)).zero?
+  end
+
+  # Unlike {#custom_remote?} this is false when no remote is set, so a remote-less
+  # local tap is still matched by its {#name} rather than requiring a URL.
+  sig { returns(T::Boolean) }
+  def uses_custom_remote?
+    remote.present? && custom_remote?
+  end
+
+  # The canonical allow/forbid/trust list reference for this {Tap}.
+  sig { returns(String) }
+  def reference
+    remote = self.remote
+    return name if remote.nil? || !custom_remote?
+
+    remote
+  end
+
+  # A `user/repository` reference matches only a tap on its default GitHub remote; a tap with a
+  # custom remote must be referenced by URL. The `remote` keyword matches a not-yet-installed remote.
+  sig { params(reference: String, remote: T.nilable(String)).returns(T::Boolean) }
+  def matches_reference?(reference, remote: self.remote)
+    if self.class.remote_reference?(reference)
+      remote.present? && reference.casecmp?(remote) == true
+    else
+      uses_custom_remote = remote.present? && !remote.casecmp?(default_remote)
+      !uses_custom_remote && name == reference.downcase
+    end
   end
 
   # Path to the directory of all {Formula} files for this {Tap}.
@@ -1254,18 +1287,30 @@ class Tap
     end
   end
 
-  sig { returns(T::Boolean) }
-  def allowed_by_env?
-    @allowed_by_env ||= T.let(begin
-      allowed_taps = self.class.allowed_taps
+  sig { params(remote: T.nilable(String)).returns(T::Boolean) }
+  def allowed_by_env?(remote: self.remote)
+    allowed_taps = self.class.allowed_taps
 
-      official? || allowed_taps.blank? || allowed_taps.include?(self)
-    end, T.nilable(T::Boolean))
+    implicitly_trusted?(remote:) || allowed_taps.blank? ||
+      allowed_taps.any? { |reference| matches_reference?(reference, remote:) }
   end
 
-  sig { returns(T::Boolean) }
-  def forbidden_by_env?
-    @forbidden_by_env ||= T.let(self.class.forbidden_taps.include?(self), T.nilable(T::Boolean))
+  sig { params(remote: T.nilable(String)).returns(T::Boolean) }
+  def forbidden_by_env?(remote: self.remote)
+    self.class.forbidden_taps.any? { |reference| matches_reference?(reference, remote:) }
+  end
+
+  # Whether to implicitly allow/trust this tap as an official one without it appearing in an
+  # allow/trust list. Only when its formulae come from the API or it is a Git checkout of an
+  # official remote, so an official-named tap on an untrusted custom remote is not implicitly trusted.
+  sig { overridable.params(remote: T.nilable(String)).returns(T::Boolean) }
+  def implicitly_trusted?(remote: self.remote)
+    official? && canonical_remote?(remote)
+  end
+
+  sig { overridable.params(remote: T.nilable(String)).returns(T::Boolean) }
+  def canonical_remote?(remote = self.remote)
+    remote.blank? || remote.casecmp?(default_remote) == true
   end
 
   private

--- a/Library/Homebrew/tap/abstract_core_tap.rb
+++ b/Library/Homebrew/tap/abstract_core_tap.rb
@@ -30,6 +30,15 @@ class AbstractCoreTap < Tap
     super
   end
 
+  # In API mode the formulae and casks come from the API rather than this tap's
+  # Git remote, so the remote is irrelevant to what is loaded.
+  sig { override.params(remote: T.nilable(String)).returns(T::Boolean) }
+  def implicitly_trusted?(remote: self.remote)
+    return true unless Homebrew::EnvConfig.no_install_from_api?
+
+    super
+  end
+
   sig { override.params(file: Pathname).returns(String) }
   def formula_file_to_name(file)
     file.basename(".rb").to_s

--- a/Library/Homebrew/tap/core_tap.rb
+++ b/Library/Homebrew/tap/core_tap.rb
@@ -27,6 +27,12 @@ class CoreTap < AbstractCoreTap
     Homebrew::EnvConfig.core_git_remote
   end
 
+  # The configured `HOMEBREW_CORE_GIT_REMOTE` is the official remote for this tap.
+  sig { override.params(remote: T.nilable(String)).returns(T::Boolean) }
+  def canonical_remote?(remote = self.remote)
+    remote.blank? || remote.casecmp?(Homebrew::EnvConfig.core_git_remote) == true
+  end
+
   # CoreTap never allows shallow clones (on request from GitHub).
   sig {
     override.params(quiet: T::Boolean, clone_target: T.nilable(T.any(Pathname, String)),

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -389,8 +389,8 @@ RSpec.describe Cask::Installer, :cask do
     let(:homebrew_forbidden) { Tap.fetch("homebrew/forbidden") }
     let(:allowed_third_party) { Tap.fetch("nothomebrew/allowed") }
     let(:disallowed_third_party) { Tap.fetch("nothomebrew/notallowed") }
-    let(:allowed_taps_set) { Set.new([allowed_third_party]) }
-    let(:forbidden_taps_set) { Set.new([homebrew_forbidden]) }
+    let(:allowed_taps_set) { [allowed_third_party.name] }
+    let(:forbidden_taps_set) { [homebrew_forbidden.name] }
 
     it "raises on forbidden tap on cask" do
       cask = Cask::Cask.new("homebrew-forbidden-tap", tap: homebrew_forbidden) do

--- a/Library/Homebrew/test/cmd/trust_spec.rb
+++ b/Library/Homebrew/test/cmd/trust_spec.rb
@@ -25,6 +25,31 @@ RSpec.describe Homebrew::Cmd::Trust do
     Homebrew::Trust.clear!(:command)
   end
 
+  context "with a custom-remote tap" do
+    before do
+      tap = Tap.fetch("thirdparty", "custom")
+      tap.path.mkpath
+      system "git", "-C", tap.path.to_s, "init"
+      system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://gitlab.com/other/repo"
+    end
+
+    after do
+      Homebrew::Trust.clear!(:tap)
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+
+    it "trusts the whole tap by its remote URL" do
+      expect { described_class.new(["--tap", "thirdparty/custom"]).run }
+        .to output("Trusted tap: https://gitlab.com/other/repo\n").to_stdout
+      expect(Homebrew::Trust.trusted_entries(:tap)).to contain_exactly("https://gitlab.com/other/repo")
+    end
+
+    it "refuses to trust an individual formula" do
+      expect { described_class.new(["--formula", "thirdparty/custom/bar"]).run }
+        .to raise_error(UsageError, /custom remote/)
+    end
+  end
+
   it "lists trusted entries with no arguments" do
     allow(Homebrew::Trust).to receive(:trusted_entries).with(:tap).and_return(["thirdparty/foo"])
     allow(Homebrew::Trust).to receive(:trusted_entries).with(:formula).and_return(["thirdparty/foo/bar"])

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Homebrew::FormulaAuditor do
   include FileUtils
   include Test::Helper::Formula
 
+  # These specs audit formula content loaded from fixture taps cloned over local
+  # paths, not tap trust, so treat those taps as trusted when loading formulae.
+  before { allow(Homebrew::Trust).to receive(:trusted_tap?).and_return(true) }
+
   def formula_auditor(name, text, options = {})
     path = Pathname.new "#{dir}/#{name}.rb"
     path.open("w") do |f|

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -648,8 +648,8 @@ RSpec.describe FormulaInstaller do
     let(:homebrew_forbidden) { Tap.fetch("homebrew/forbidden") }
     let(:allowed_third_party) { Tap.fetch("nothomebrew/allowed") }
     let(:disallowed_third_party) { Tap.fetch("nothomebrew/notallowed") }
-    let(:allowed_taps_set) { Set.new([allowed_third_party]) }
-    let(:forbidden_taps_set) { Set.new([homebrew_forbidden]) }
+    let(:allowed_taps_set) { [allowed_third_party.name] }
+    let(:forbidden_taps_set) { [homebrew_forbidden.name] }
 
     it "raises on forbidden tap on formula" do
       f_tap = homebrew_forbidden
@@ -807,7 +807,7 @@ RSpec.describe FormulaInstaller do
   describe "#prelude_fetch" do
     it "raises on forbidden formula tap before fetching the source from the API" do
       homebrew_forbidden = Tap.fetch("homebrew/forbidden")
-      allow(Tap).to receive_messages(allowed_taps: Set.new, forbidden_taps: Set.new([homebrew_forbidden]))
+      allow(Tap).to receive_messages(allowed_taps: [], forbidden_taps: [homebrew_forbidden.name])
       f_name = "homebrew-forbidden-fail-fast-tap"
       f_path = homebrew_forbidden.new_formula_path(f_name)
       f_path.parent.mkpath

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -144,18 +144,104 @@ RSpec.describe Tap do
   describe "::allowed_taps" do
     before { allow(Homebrew::EnvConfig).to receive(:allowed_taps).and_return("homebrew/allowed") }
 
-    it "returns a set of allowed taps according to the environment" do
-      expect(described_class.allowed_taps)
-        .to contain_exactly(described_class.fetch("homebrew/allowed"))
+    it "returns the references from the environment" do
+      expect(described_class.allowed_taps).to contain_exactly("homebrew/allowed")
+    end
+
+    it "normalises a `user/homebrew-repository` entry to a canonical tap name" do
+      allow(Homebrew::EnvConfig).to receive(:allowed_taps).and_return("User/homebrew-Repo")
+      expect(described_class.allowed_taps).to contain_exactly("user/repo")
+    end
+
+    it "preserves a remote URL entry verbatim" do
+      allow(Homebrew::EnvConfig).to receive(:allowed_taps).and_return("https://gitlab.com/other/repo")
+      expect(described_class.allowed_taps).to contain_exactly("https://gitlab.com/other/repo")
+    end
+
+    it "warns about and ignores an invalid tap name" do
+      allow(Homebrew::EnvConfig).to receive(:allowed_taps).and_return("not-a-tap")
+      expect { expect(described_class.allowed_taps).to be_empty }.to output(/Invalid tap name/).to_stderr
     end
   end
 
   describe "::forbidden_taps" do
     before { allow(Homebrew::EnvConfig).to receive(:forbidden_taps).and_return("homebrew/forbidden") }
 
-    it "returns a set of forbidden taps according to the environment" do
-      expect(described_class.forbidden_taps)
-        .to contain_exactly(described_class.fetch("homebrew/forbidden"))
+    it "returns the references from the environment" do
+      expect(described_class.forbidden_taps).to contain_exactly("homebrew/forbidden")
+    end
+  end
+
+  describe "#matches_reference?" do
+    let(:tap) { described_class.fetch("user", "repo") }
+
+    it "matches a default-remote tap by its name" do
+      expect(tap.matches_reference?("user/repo", remote: "https://github.com/user/homebrew-repo")).to be true
+    end
+
+    it "does not match a custom-remote tap by its name" do
+      expect(tap.matches_reference?("user/repo", remote: "https://gitlab.com/other/repo")).to be false
+    end
+
+    it "matches a custom-remote tap by its remote URL" do
+      expect(tap.matches_reference?("https://gitlab.com/other/repo", remote: "https://gitlab.com/other/repo"))
+        .to be true
+    end
+
+    it "matches a tap by its local path remote" do
+      expect(tap.matches_reference?("/Users/me/homebrew-tap", remote: "/Users/me/homebrew-tap")).to be true
+    end
+  end
+
+  describe "#allowed_by_env?" do
+    before { allow(Homebrew::EnvConfig).to receive(:allowed_taps).and_return("user/repo") }
+
+    it "does not allow a name-matched tap fetched from a custom remote" do
+      expect(described_class.fetch("user", "repo").allowed_by_env?(remote: "https://evil.example/repo")).to be false
+    end
+
+    it "does not implicitly allow an official tap fetched from a custom remote" do
+      expect(described_class.fetch("Homebrew",
+                                   "foo").allowed_by_env?(remote: "https://evil.example/repo")).to be false
+    end
+  end
+
+  describe "#implicitly_trusted?" do
+    it "is true for an official tap on its default remote" do
+      expect(described_class.fetch("Homebrew", "foo")
+        .implicitly_trusted?(remote: "https://github.com/Homebrew/homebrew-foo")).to be true
+    end
+
+    it "is false for an official tap on a custom remote" do
+      expect(described_class.fetch("Homebrew", "foo").implicitly_trusted?(remote: "https://evil.example/repo"))
+        .to be false
+    end
+
+    it "is true for homebrew/core in API mode regardless of remote" do
+      with_env(HOMEBREW_NO_INSTALL_FROM_API: nil) do
+        expect(CoreTap.instance.implicitly_trusted?(remote: "https://evil.example/core")).to be true
+      end
+    end
+
+    it "is false for a homebrew/core Git checkout from a non-official remote" do
+      with_env(HOMEBREW_NO_INSTALL_FROM_API: "1") do
+        expect(CoreTap.instance.implicitly_trusted?(remote: "https://evil.example/core")).to be false
+      end
+    end
+
+    it "accepts the configured HOMEBREW_CORE_GIT_REMOTE as official" do
+      with_env(HOMEBREW_NO_INSTALL_FROM_API: "1", HOMEBREW_CORE_GIT_REMOTE: "https://mirror.example/core") do
+        expect(CoreTap.instance.implicitly_trusted?(remote: "https://mirror.example/core")).to be true
+      end
+    end
+  end
+
+  describe "#forbidden_by_env?" do
+    before { allow(Homebrew::EnvConfig).to receive(:forbidden_taps).and_return("https://github.com/evil/homebrew-tap") }
+
+    it "forbids any locally-named tap fetched from a forbidden remote URL" do
+      expect(described_class.fetch("notevil", "tap").forbidden_by_env?(remote: "https://github.com/evil/homebrew-tap"))
+        .to be true
     end
   end
 
@@ -339,6 +425,14 @@ RSpec.describe Tap do
       expect(already_tapped_tap).to be_installed
       right_remote = homebrew_foo_tap.remote
       expect { already_tapped_tap.install clone_target: right_remote }.to raise_error(TapAlreadyTappedError)
+    end
+
+    it "refuses a name-allowed tap cloned from a custom remote (no HOMEBREW_ALLOWED_TAPS bypass)" do
+      allow(Homebrew::EnvConfig).to receive(:allowed_taps).and_return("user/repo")
+      tap = described_class.fetch("user", "repo")
+
+      expect { tap.install clone_target: "https://evil.example/repo" }.to raise_error(SystemExit)
+      expect(tap).not_to be_installed
     end
 
     it "raises an error when the remote doesn't match" do

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -31,6 +31,36 @@ RSpec.describe Homebrew::Trust do
     FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
   end
 
+  it "does not trust a custom-remote tap by its name but does by its remote URL" do
+    tap = Tap.fetch("thirdparty", "custom")
+    tap.path.mkpath
+    system "git", "-C", tap.path.to_s, "init"
+    system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://gitlab.com/other/repo"
+
+    described_class.trust!(:tap, "thirdparty/custom")
+    expect(described_class.trusted_tap?(tap)).to be(false)
+
+    described_class.trust!(:tap, "https://gitlab.com/other/repo")
+    expect(described_class.trusted_tap?(tap)).to be(true)
+  ensure
+    described_class.clear!(:tap)
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
+  it "refuses new per-item trust for a custom-remote tap but still resolves existing entries to untrust" do
+    tap = Tap.fetch("thirdparty", "custom")
+    tap.path.mkpath
+    system "git", "-C", tap.path.to_s, "init"
+    system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://gitlab.com/other/repo"
+
+    expect { described_class.target("thirdparty/custom/bar", type: :formula) }
+      .to raise_error(UsageError, /custom remote/)
+    expect(described_class.target("thirdparty/custom/bar", type: :formula, include_existing: true))
+      .to eq([:formula, "thirdparty/custom/bar"])
+  ensure
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
   it "trusts formulae from trusted taps" do
     Tap.fetch("trustedformulae", "foo")
 

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -64,7 +64,7 @@ module Homebrew
         tap_name = name.split("/").first(2).join("/")
         item_name = ::Utils.name_from_full_name(name)
         tap = Tap.fetch(tap_name)
-        next if tap.official?
+        next if tap.official? || tap.uses_custom_remote?
 
         types = if type == :formula
           tap.formula_files_by_name.key?(item_name) ? [:formula] : []
@@ -104,7 +104,7 @@ module Homebrew
 
     sig { params(tap: T.untyped).returns(T::Boolean) }
     def self.trusted_tap?(tap)
-      tap.official? || trusted?(:tap, tap.name)
+      tap.implicitly_trusted? || trusted_entries(:tap).any? { |reference| tap.matches_reference?(reference) }
     end
 
     sig { params(name: String, path: Pathname).void }
@@ -114,7 +114,7 @@ module Homebrew
       return if trusted_tap?(tap)
 
       full_name = "#{tap.name}/#{::Utils.name_from_full_name(name)}"
-      return if trusted?(:formula, full_name)
+      return if !tap.uses_custom_remote? && trusted?(:formula, full_name)
       return if explicitly_allowed?(:formula, full_name, tap)
       return unless Homebrew::EnvConfig.require_tap_trust?
 
@@ -128,7 +128,7 @@ module Homebrew
       return if trusted_tap?(tap)
 
       full_name = "#{tap.name}/#{::Utils.name_from_full_name(token)}"
-      return if trusted?(:cask, full_name)
+      return if !tap.uses_custom_remote? && trusted?(:cask, full_name)
       return if explicitly_allowed?(:cask, full_name, tap)
       return unless Homebrew::EnvConfig.require_tap_trust?
 
@@ -142,7 +142,7 @@ module Homebrew
       return if trusted_tap?(tap)
 
       full_name = "#{tap.name}/#{command || path.basename(path.extname).to_s.delete_prefix("brew-")}"
-      return if trusted?(:command, full_name)
+      return if !tap.uses_custom_remote? && trusted?(:command, full_name)
       return unless Homebrew::EnvConfig.require_tap_trust?
 
       raise_untrusted!(:command, full_name, tap)
@@ -175,7 +175,7 @@ module Homebrew
 
     sig { returns(T::Array[Tap]) }
     def self.untrusted_taps
-      Tap.installed.reject(&:official?).reject { |tap| trusted?(:tap, tap.name) }.sort_by(&:name)
+      Tap.installed.reject(&:official?).reject { |tap| trusted_tap?(tap) }.sort_by(&:name)
     end
 
     sig { returns(T::Array[Tap]) }
@@ -204,7 +204,7 @@ module Homebrew
 
     sig { params(name: String, type: T.nilable(Symbol), include_existing: T::Boolean).returns([Symbol, String]) }
     def self.target(name, type: nil, include_existing: false)
-      return [type, trust_name(type, name)] if type
+      return [type, trust_name(type, name, include_existing:)] if type
 
       infer_target(name, include_existing:)
     end
@@ -240,19 +240,22 @@ module Homebrew
     end
     private_class_method :infer_target
 
-    sig { params(type: Symbol, name: String).returns(String) }
-    def self.trust_name(type, name)
+    sig { params(type: Symbol, name: String, include_existing: T::Boolean).returns(String) }
+    def self.trust_name(type, name, include_existing: false)
       case type
       when :tap
-        Tap.fetch(name).name
+        Tap.fetch(name).reference
       when :formula
         tap, formula_name = fully_qualified_package_name(name, "Formulae")
+        require_default_remote_item!(tap) unless include_existing
         "#{tap.name}/#{formula_name}"
       when :cask
         tap, token = fully_qualified_package_name(name, "Casks")
+        require_default_remote_item!(tap) unless include_existing
         "#{tap.name}/#{token}"
       when :command
         tap, command_name = fully_qualified_package_name(name, "Commands")
+        require_default_remote_item!(tap) unless include_existing
         "#{tap.name}/#{command_name}"
       else
         raise UsageError, "Unsupported trust target type: #{type}"
@@ -261,6 +264,17 @@ module Homebrew
       raise UsageError, e.message
     end
     private_class_method :trust_name
+
+    # Per-item trust cannot be created for custom-remote taps (trust the whole tap by URL); existing
+    # entries are still resolvable so `brew untrust` (`include_existing`) can remove legacy ones.
+    sig { params(tap: Tap).void }
+    def self.require_default_remote_item!(tap)
+      return unless tap.uses_custom_remote?
+
+      raise UsageError, "Cannot trust individual items in #{tap.name} as it uses a custom remote.\n" \
+                        "Run `brew trust #{tap.name}` to trust the whole tap instead."
+    end
+    private_class_method :require_default_remote_item!
 
     sig { params(name: String, noun: String).returns([Tap, String]) }
     def self.fully_qualified_package_name(name, noun)
@@ -320,7 +334,7 @@ module Homebrew
       name = path.basename(path.extname).to_s
       name = name.delete_prefix("brew-") if type == :command
       full_name = "#{tap.name}/#{name}"
-      return true if trusted?(type, full_name)
+      return true if !tap.uses_custom_remote? && trusted?(type, full_name)
       return true if explicitly_allowed?(type, full_name, tap)
 
       !Homebrew::EnvConfig.require_tap_trust?

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -4174,7 +4174,9 @@ command execution (e.g. `$(cat file)`).
 
 : A space-separated list of taps. Homebrew will refuse to install a formula
   unless it and all of its dependencies are in an official tap or in a tap on
-  this list.
+  this list. Each entry is a `user/repository` name (which matches only taps
+  using the default GitHub remote) or a remote URL (required to match taps with
+  a custom remote).
 
 `HOMEBREW_API_AUTO_UPDATE_SECS`
 
@@ -4584,7 +4586,9 @@ command execution (e.g. `$(cat file)`).
 `HOMEBREW_FORBIDDEN_TAPS`
 
 : A space-separated list of taps. Homebrew will refuse to install a formula if
-  it or any of its dependencies is in a tap on this list.
+  it or any of its dependencies is in a tap on this list. Each entry is a
+  `user/repository` name (which matches only taps using the default GitHub
+  remote) or a remote URL (required to match taps with a custom remote).
 
 `HOMEBREW_FORBID_CASKS`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2658,7 +2658,7 @@ User\-specific environment files take precedence over prefix\-specific files and
 Note that these files do not support shell variable expansion (e\.g\. \fB$HOME\fP) or command execution (e\.g\. \fB$(cat file)\fP)\.
 .TP
 \fBHOMEBREW_ALLOWED_TAPS\fP
-A space\-separated list of taps\. Homebrew will refuse to install a formula unless it and all of its dependencies are in an official tap or in a tap on this list\.
+A space\-separated list of taps\. Homebrew will refuse to install a formula unless it and all of its dependencies are in an official tap or in a tap on this list\. Each entry is a \fBuser/repository\fP name (which matches only taps using the default GitHub remote) or a remote URL (required to match taps with a custom remote)\.
 .TP
 \fBHOMEBREW_API_AUTO_UPDATE_SECS\fP
 Check Homebrew\[u2019]s API for new formulae or cask data every \fB$HOMEBREW_API_AUTO_UPDATE_SECS\fP seconds\. Alternatively, disable API auto\-update checks entirely with \fB$HOMEBREW_NO_AUTO_UPDATE\fP\&\.
@@ -2975,7 +2975,7 @@ The person who has set any \fB$HOMEBREW_FORBIDDEN_*\fP variables\.
 How to contact the \fB$HOMEBREW_FORBIDDEN_OWNER\fP, if set and necessary\.
 .TP
 \fBHOMEBREW_FORBIDDEN_TAPS\fP
-A space\-separated list of taps\. Homebrew will refuse to install a formula if it or any of its dependencies is in a tap on this list\.
+A space\-separated list of taps\. Homebrew will refuse to install a formula if it or any of its dependencies is in a tap on this list\. Each entry is a \fBuser/repository\fP name (which matches only taps using the default GitHub remote) or a remote URL (required to match taps with a custom remote)\.
 .TP
 \fBHOMEBREW_FORBID_CASKS\fP
 If set, Homebrew will refuse to install any casks\.


### PR DESCRIPTION
- `HOMEBREW_ALLOWED_TAPS`, `HOMEBREW_FORBIDDEN_TAPS` and `trust.json` matched taps by `user/repository` name only, which `brew tap user/repository <url>` trivially spoofed by pointing that name at an arbitrary remote
- match a `user/repository` name only against a tap on its default GitHub remote; a tap with a custom remote must now be referenced by its remote URL, so non-GitHub taps are listed and trusted by URL
- evaluate the allow/forbid gate against the requested clone remote so the bypass is caught before cloning
- gate the implicit official-tap exemption behind `implicitly_official?` so an official-named tap is only auto-allowed/trusted when its content comes from the API or it uses an official (or `HOMEBREW_CORE_GIT_REMOTE`) remote, not when pointed at an untrusted custom remote
- refuse per-item trust for custom-remote taps; trust the whole tap by URL instead

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
