### PR TITLE
Preliminary macOS 27 (Golden Gate) support

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -79,10 +79,14 @@ module Homebrew
         odie "Need to download #{url} but cannot as root! Run `brew update` without `sudo` first then try again."
       end
 
-      curl_args = Utils::Curl.curl_args(retries: 0) + %W[
-        --compressed
-        --speed-limit #{ENV.fetch("HOMEBREW_CURL_SPEED_LIMIT")}
-        --speed-time #{ENV.fetch("HOMEBREW_CURL_SPEED_TIME")}
+      curl_args = Utils::Curl.curl_args(retries: 0) + [
+        "--compressed",
+        "--speed-limit", ENV.fetch("HOMEBREW_CURL_SPEED_LIMIT"),
+        "--speed-time", ENV.fetch("HOMEBREW_CURL_SPEED_TIME"),
+        # This is a Curl format token, not a Ruby one.
+        # rubocop:disable Style/FormatStringToken
+        "--write-out", "%{stderr}HTTP status: %{http_code}"
+        # rubocop:enable Style/FormatStringToken
       ]
 
       insecure_download = DevelopmentTools.ca_file_substitution_required? ||

--- a/Library/Homebrew/api/internal.rb
+++ b/Library/Homebrew/api/internal.rb
@@ -20,9 +20,19 @@ module Homebrew
 
       private_class_method :cache
 
+      sig { returns(Utils::Bottles::Tag) }
+      private_class_method def self.effective_tag
+        @effective_tag ||= T.let(SimulateSystem.current_tag, T.nilable(Utils::Bottles::Tag))
+      end
+
+      sig { returns(Utils::Bottles::Tag) }
+      private_class_method def self.fallback_tag
+        effective_tag
+      end
+
       sig { returns(String) }
-      def self.packages_endpoint
-        "internal/packages.#{SimulateSystem.current_tag}.jws.json"
+      private_class_method def self.packages_endpoint
+        "internal/packages.#{effective_tag}.jws.json"
       end
 
       sig { params(name: String).returns(Homebrew::API::FormulaStruct) }
@@ -32,7 +42,7 @@ module Homebrew
         hash = formula_hashes[name]
         raise "No formula found for #{name}" unless hash
 
-        struct = Homebrew::API::FormulaStruct.deserialize(hash, bottle_tag: SimulateSystem.current_tag)
+        struct = Homebrew::API::FormulaStruct.deserialize(hash, bottle_tag: effective_tag)
 
         cache["formula_structs"] ||= {}
         cache["formula_structs"][name] = struct
@@ -66,8 +76,17 @@ module Homebrew
       }
       def self.fetch_packages_api!(download_queue: Homebrew.default_download_queue, stale_seconds: nil,
                                    enqueue: false)
-        json_contents, updated = Homebrew::API.fetch_json_api_file(packages_endpoint, stale_seconds:, download_queue:,
-                                                                   enqueue:)
+        old_failed = Homebrew.failed?
+        json_contents, updated = begin
+          Homebrew::API.fetch_json_api_file(packages_endpoint, stale_seconds:, download_queue:, enqueue:)
+        rescue ErrorDuringExecution => e
+          raise if e.stderr.exclude?("HTTP status: 404") || effective_tag == fallback_tag
+
+          @effective_tag = fallback_tag
+          Homebrew.failed = old_failed
+          retry
+        end
+
         [T.cast(json_contents, T::Hash[String, T.untyped]), updated]
       end
 
@@ -198,3 +217,5 @@ module Homebrew
     end
   end
 end
+
+require "extend/os/api/internal"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -16,7 +16,10 @@ source "${HOMEBREW_LIBRARY}/Homebrew/utils/lock.sh"
 
 macos_version_name() {
   # NOTE: Changes to this list must match `SYMBOLS` in `macos_version.rb`.
-  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -ge "260000" ]]
+  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -ge "270000" ]]
+  then
+    echo "golden_gate"
+  elif [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -ge "260000" ]]
   then
     echo "tahoe"
   elif [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -ge "150000" ]]
@@ -420,7 +423,7 @@ fetch_api_file() {
     echo "Checking if we need to fetch ${filename}..."
   fi
 
-  local arg json_url
+  local arg json_url last_json_url
   while read -r json_url
   do
     time_cond=()
@@ -437,6 +440,7 @@ fetch_api_file() {
       --user-agent "${HOMEBREW_USER_AGENT_CURL}" \
       "${json_url}"
     curl_exit_code=$?
+    last_json_url="${json_url}"
     [[ ${curl_exit_code} -eq 0 ]] && break
   done < <(api_urls "${filename}")
 
@@ -469,7 +473,7 @@ fetch_api_file() {
       fi
     fi
   else
-    echo "Failed to download ${json_url}!" >>"${update_failed_file}"
+    echo "Failed to download ${last_json_url}!" >>"${update_failed_file}"
   fi
 }
 

--- a/Library/Homebrew/extend/os/api/internal.rb
+++ b/Library/Homebrew/extend/os/api/internal.rb
@@ -1,0 +1,4 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "extend/os/mac/api/internal" if OS.mac?

--- a/Library/Homebrew/extend/os/mac/api/internal.rb
+++ b/Library/Homebrew/extend/os/mac/api/internal.rb
@@ -1,0 +1,32 @@
+# typed: strict
+# frozen_string_literal: true
+
+module OS
+  module Mac
+    module API
+      module Internal
+        module ClassMethods
+          extend T::Helpers
+
+          requires_ancestor { T.class_of(::Homebrew::API::Internal) }
+
+          private
+
+          sig { returns(Utils::Bottles::Tag) }
+          def fallback_tag
+            if MacOS.version.prerelease?
+              # When a new macOS version has been announced, we won't have generated a JSON file for it yet.
+              # We need to fallback to allow us to test that macOS version.
+              fallback_os = ::MacOSVersion.new(HOMEBREW_MACOS_NEWEST_SUPPORTED).to_sym
+              ::Utils::Bottles::Tag.new(system: fallback_os, arch: ::Hardware::CPU.arch)
+            else
+              effective_tag
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+Homebrew::API::Internal.singleton_class.prepend(OS::Mac::API::Internal::ClassMethods)

--- a/Library/Homebrew/macos_version.rb
+++ b/Library/Homebrew/macos_version.rb
@@ -21,21 +21,24 @@ class MacOSVersion < Version
   #       to `DEPRECATED_MACOS_VERSIONS` in `MacOSRequirement`.
   # NOTE: Changes to this list must match `macos_version_name` in `cmd/update.sh`.
   SYMBOLS = T.let({
-    tahoe:    "26",
-    sequoia:  "15",
-    sonoma:   "14",
-    ventura:  "13",
-    monterey: "12",
+    golden_gate: "27",
+    tahoe:       "26",
+    sequoia:     "15",
+    sonoma:      "14",
+    ventura:     "13",
+    monterey:    "12",
     # odisabled: remove support for Big Sur and macOS x86_64 September (or later) 2027
-    big_sur:  "11",
+    big_sur:     "11",
     # odisabled: remove support for Catalina September (or later) 2026
-    catalina: "10.15",
+    catalina:    "10.15",
   }.freeze, T::Hash[Symbol, String])
 
   sig { params(macos_version: MacOSVersion).returns(Version) }
   def self.kernel_major_version(macos_version)
     version_major = macos_version.major.to_i
-    if version_major >= 26
+    if version_major >= 27
+      Version.new(version_major.to_s)
+    elsif version_major == 26
       Version.new((version_major - 1).to_s)
     elsif version_major > 10
       Version.new((version_major + 9).to_s)

--- a/Library/Homebrew/os/mac/pkgconfig/27/bzip2.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/27/bzip2.pc
@@ -1,0 +1,12 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+bindir=${exec_prefix}/bin
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: Lossless, block-sorting data compression
+Version: 1.0.8
+Libs: -L${libdir} -lbz2
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/27/expat.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/27/expat.pc
@@ -1,0 +1,14 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: expat
+Version: 2.7.4
+Description: expat XML parser
+URL: https://libexpat.github.io/
+Libs: -L${libdir} -lexpat
+Libs.private:
+Cflags:
+Cflags.private: -DXML_STATIC

--- a/Library/Homebrew/os/mac/pkgconfig/27/libcurl.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/27/libcurl.pc
@@ -1,0 +1,42 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+# This should most probably benefit from getting a "Requires:" field added
+# dynamically by configure.
+#
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+supported_protocols="DICT FILE FTP FTPS GOPHER GOPHERS HTTP HTTPS IMAP IMAPS IPFS IPNS LDAP LDAPS MQTT POP3 POP3S RTSP SMB SMBS SMTP SMTPS TELNET TFTP"
+supported_features="alt-svc AsynchDNS GSS-API HSTS HTTP2 HTTPS-proxy IPv6 Kerberos Largefile libz MultiSSL NTLM SPNEGO SSL threadsafe UnixSockets"
+
+Name: libcurl
+URL: https://curl.se/
+Description: Library to transfer files with ftp, http, etc.
+Version: 8.7.1
+Libs: -L${libdir} -lcurl
+Libs.private: -lldap -lz
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/27/libedit.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/27/libedit.pc
@@ -1,0 +1,12 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: libedit
+Description: command line editor library provides generic line editing, history, and tokenization functions.
+Version: 3.0
+Requires:
+Libs: -L${libdir} -ledit
+Cflags: -I${includedir}/editline

--- a/Library/Homebrew/os/mac/pkgconfig/27/libexslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/27/libexslt.pc
@@ -1,0 +1,14 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+
+Name: libexslt
+Version: 0.8.20
+Description: EXSLT Extension library
+Requires: libxml-2.0, libxslt
+Cflags:
+Libs: -L${libdir} -lexslt
+Libs.private:

--- a/Library/Homebrew/os/mac/pkgconfig/27/libffi.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/27/libffi.pc
@@ -1,0 +1,12 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+toolexeclibdir=${libdir}
+includedir=${prefix}/include/ffi
+
+Name: libffi
+Description: Library supporting Foreign Function Interfaces
+Version: 3.4-rc1
+Libs: -L${toolexeclibdir} -lffi
+Cflags: -I${includedir}

--- a/Library/Homebrew/os/mac/pkgconfig/27/libxml-2.0.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/27/libxml-2.0.pc
@@ -1,0 +1,14 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+modules=1
+
+Name: libXML
+Version: 2.9.13
+Description: libXML library version2.
+Requires:
+Libs: -L${libdir} -lxml2
+Libs.private: -lz -lpthread -licucore -lm
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/27/libxslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/27/libxslt.pc
@@ -1,0 +1,14 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+
+Name: libxslt
+Version: 1.1.35
+Description: XSLT library version 2.
+Requires: libxml-2.0
+Cflags:
+Libs: -L${libdir} -lxslt
+Libs.private:

--- a/Library/Homebrew/os/mac/pkgconfig/27/ncurses.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/27/ncurses.pc
@@ -1,0 +1,17 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+abi_version=5.4
+major_version=6
+version=6.0.20150808
+
+Name: ncurses
+Description: ncurses 6.0 library
+Version: ${version}
+URL: http://invisible-island.net/ncurses
+Requires.private:
+Libs: -L${libdir} -lncurses
+Libs.private:
+Cflags: -D_DARWIN_C_SOURCE

--- a/Library/Homebrew/os/mac/pkgconfig/27/ncursesw.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/27/ncursesw.pc
@@ -1,0 +1,17 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+abi_version=5.4
+major_version=6
+version=6.0.20150808
+
+Name: ncursesw
+Description: ncurses 6.0 library
+Version: ${version}
+URL: http://invisible-island.net/ncurses
+Requires.private:
+Libs: -L${libdir} -lncurses
+Libs.private:
+Cflags: -D_DARWIN_C_SOURCE

--- a/Library/Homebrew/os/mac/pkgconfig/27/sqlite3.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/27/sqlite3.pc
@@ -1,0 +1,12 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: SQLite
+Description: SQL database engine
+Version: 3.54.0
+Libs: -L${libdir} -lsqlite3
+Libs.private:
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/27/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/27/uuid.pc
@@ -1,0 +1,14 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include/uuid
+
+Name: uuid
+Description: Universally unique id library
+Version: 1.0
+
+Requires:
+Libs:
+Cflags: -I${includedir}

--- a/Library/Homebrew/os/mac/pkgconfig/27/zlib.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/27/zlib.pc
@@ -1,0 +1,14 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include
+
+Name: zlib
+Description: zlib compression library
+Version: 1.2.12
+
+Requires:
+Libs: -L${libdir} -L${sharedlibdir} -lz
+Cflags:

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -324,6 +324,7 @@ module OS
       sig { returns(String) }
       def self.latest_clang_version
         case MacOS.version
+        when "27" then "2100.3.20.102"
         when "26", "15" then "1700.6.4.2"
         when "14" then "1600.0.26.6"
         when "13" then "1500.1.0.2.5"

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -655,6 +655,9 @@ RSpec.describe Cask::Cask, :cask do
     let(:expected_versions_variations) do
       <<~JSON
         {
+          "golden_gate": {
+            "url": "file://#{TEST_FIXTURE_DIR}/cask/caffeine/darwin/1.2.3/intel.zip"
+          },
           "tahoe": {
             "url": "file://#{TEST_FIXTURE_DIR}/cask/caffeine/darwin/1.2.3/intel.zip"
           },
@@ -691,6 +694,10 @@ RSpec.describe Cask::Cask, :cask do
     let(:expected_sha256_variations) do
       <<~JSON
         {
+          "golden_gate": {
+            "url": "file://#{TEST_FIXTURE_DIR}/cask/caffeine-intel.zip",
+            "sha256": "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+          },
           "tahoe": {
             "url": "file://#{TEST_FIXTURE_DIR}/cask/caffeine-intel.zip",
             "sha256": "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
@@ -725,6 +732,10 @@ RSpec.describe Cask::Cask, :cask do
     let(:expected_sha256_variations_os) do
       <<~JSON
         {
+          "golden_gate": {
+            "url": "file://#{TEST_FIXTURE_DIR}/cask/caffeine-intel-darwin.zip",
+            "sha256": "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+          },
           "tahoe": {
             "url": "file://#{TEST_FIXTURE_DIR}/cask/caffeine-intel-darwin.zip",
             "sha256": "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"

--- a/Library/Homebrew/test/support/fixtures/bottles/testball_bottle-0.1.arm64_golden_gate.bottle.tar.gz
+++ b/Library/Homebrew/test/support/fixtures/bottles/testball_bottle-0.1.arm64_golden_gate.bottle.tar.gz
@@ -1,0 +1,1 @@
+testball_bottle-0.1.yosemite.bottle.tar.gz

--- a/Library/Homebrew/test/support/fixtures/bottles/testball_bottle-0.1.golden_gate.bottle.tar.gz
+++ b/Library/Homebrew/test/support/fixtures/bottles/testball_bottle-0.1.golden_gate.bottle.tar.gz
@@ -1,0 +1,1 @@
+testball_bottle-0.1.yosemite.bottle.tar.gz


### PR DESCRIPTION
Pending:

* Do we need to do anything to handle Intel's deprecation?
  - Probably not because of Rosetta, so still will have `golden_gate` and `arm64_golden_gate` tags.
  - macOS 28 is probably when we can really do this
* Apple Clang version
* Library versions in macOS 27 SDK
* Do we need to release a new ruby-macho for new load commands?
* Beta 1 to be released so I can test this

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
