### PR TITLE
Make `brew bundle` honour the `trusted:` option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -450,7 +450,7 @@ jobs:
             brew "postgresql@15", restart_service: true
             cask "rectangle"
             cask "1password-cli"
-            cask "google-chrome"
+            cask "firefox"
             # VSCode cask is not available on Linux.
             vscode "shopify.ruby-lsp" if OS.mac?
           EOS

--- a/Library/Homebrew/bundle/brew.rb
+++ b/Library/Homebrew/bundle/brew.rb
@@ -456,6 +456,7 @@ module Homebrew
         @link = T.let(options.fetch(:link, nil), T.nilable(T.any(Symbol, T::Boolean)))
         @postinstall = T.let(options.fetch(:postinstall, nil), T.nilable(String))
         @version_file = T.let(options.fetch(:version_file, nil), T.nilable(String))
+        @trusted = T.let(options.fetch(:trusted, false), T::Boolean)
         @changed = T.let(nil, T.nilable(T::Boolean))
       end
 
@@ -552,6 +553,13 @@ module Homebrew
       sig { params(no_upgrade: T::Boolean, verbose: T::Boolean, force: T::Boolean).returns(T::Boolean) }
       def install_change_state!(no_upgrade:, verbose:, force:)
         require "tap"
+
+        # Trust before tapping: installing the tap loads the formula, which
+        # triggers the trust check before any later step could grant trust.
+        # Only fully-qualified names map to a tap, so unqualified names cannot
+        # be meaningfully trusted.
+        Homebrew::Trust.trust!(:formula, @full_name) if @trusted && @full_name.count("/") == 2
+
         if (tap_with_name = ::Tap.with_formula_name(@full_name))
           tap, = tap_with_name
           tap.ensure_installed!

--- a/Library/Homebrew/bundle/brew.rb
+++ b/Library/Homebrew/bundle/brew.rb
@@ -134,7 +134,7 @@ module Homebrew
         def formula_installed?(formula)
           # Fully qualified tap formulae can be checked by their Cellar rack name
           # without loading the formula from an untrusted tap.
-          return installed_formulae.include?(Utils.name_from_full_name(formula)) if formula.count("/") == 2
+          return installed_formulae.include?(Utils.name_from_full_name(formula)) if Utils.full_name?(formula)
 
           formula_in_array?(formula, installed_formulae)
         end
@@ -145,7 +145,7 @@ module Homebrew
 
           # Reading the formula is needed for authoritative outdated state, so
           # report trust problems before the upgrade check tries to load it.
-          if formula.count("/") == 2 && Homebrew::EnvConfig.require_tap_trust?
+          if Utils.full_name?(formula) && Homebrew::EnvConfig.require_tap_trust?
             require "trust"
 
             unless Homebrew::Trust.trusted?(:formula, formula)
@@ -558,7 +558,7 @@ module Homebrew
         # triggers the trust check before any later step could grant trust.
         # Only fully-qualified names map to a tap, so unqualified names cannot
         # be meaningfully trusted.
-        Homebrew::Trust.trust!(:formula, @full_name) if @trusted && @full_name.count("/") == 2
+        Homebrew::Trust.trust!(:formula, @full_name) if @trusted && Utils.full_name?(@full_name)
 
         if (tap_with_name = ::Tap.with_formula_name(@full_name))
           tap, = tap_with_name

--- a/Library/Homebrew/bundle/cask.rb
+++ b/Library/Homebrew/bundle/cask.rb
@@ -95,7 +95,11 @@ module Homebrew
         def install!(name, preinstall: true, no_upgrade: false, verbose: false, force: false, **options)
           return true unless preinstall
 
-          full_name = options.fetch(:full_name, name)
+          full_name = T.cast(options.fetch(:full_name, name), String)
+
+          # Only fully-qualified names map to a tap, so unqualified tokens
+          # cannot be meaningfully trusted.
+          Homebrew::Trust.trust!(:cask, full_name) if options[:trusted] && full_name.count("/") == 2
 
           install_result = if cask_installed?(name) && upgrading?(no_upgrade, name, options)
             status = "#{options[:greedy] ? "may not be" : "not"} up-to-date"

--- a/Library/Homebrew/bundle/cask.rb
+++ b/Library/Homebrew/bundle/cask.rb
@@ -99,7 +99,7 @@ module Homebrew
 
           # Only fully-qualified names map to a tap, so unqualified tokens
           # cannot be meaningfully trusted.
-          Homebrew::Trust.trust!(:cask, full_name) if options[:trusted] && full_name.count("/") == 2
+          Homebrew::Trust.trust!(:cask, full_name) if options[:trusted] && Utils.full_name?(full_name)
 
           install_result = if cask_installed?(name) && upgrading?(no_upgrade, name, options)
             status = "#{options[:greedy] ? "may not be" : "not"} up-to-date"

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1095,7 +1095,7 @@ class Tap
         # Only include renames:
         # + `homebrew/cask/water-buffalo`
         # - `homebrew/cask`
-        next if new_name.count("/") != 2
+        next unless Utils.full_name?(new_name)
 
         hash[new_name] ||= []
         hash[new_name] << old_name

--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -278,6 +278,10 @@ RSpec.describe Homebrew::Bundle::Brew do
     let(:installer) { described_class.new(formula_name, options) }
 
     before do
+      # Clear the class-level formula cache so a hash memoised by an earlier
+      # example (e.g. without conflicts) doesn't leak into this one.
+      described_class.reset!
+
       # don't try to load gcc/glibc
       allow(DevelopmentTools).to receive_messages(needs_libc_formula?: false, needs_compiler_formula?: false)
 
@@ -575,6 +579,31 @@ RSpec.describe Homebrew::Bundle::Brew do
       it "did not call restart service" do
         expect(Homebrew::Bundle::Brew::Services).not_to receive(:restart)
         described_class.preinstall!(formula_name, restart_service: true)
+      end
+    end
+
+    context "when the trusted option is true" do
+      let(:tapped_name) { "foo/bar/baz" }
+
+      before do
+        allow_any_instance_of(described_class).to receive_messages(installed?: false, resolve_conflicts!: true,
+                                                                   install_formula!: true)
+      end
+
+      it "trusts the formula before installing the tap that loads it" do
+        order = []
+        tap = instance_double(Tap, ensure_installed!: nil)
+        allow(Tap).to receive(:with_formula_name).with(tapped_name).and_return([tap, "baz"])
+        allow(tap).to receive(:ensure_installed!) { order << :tap }
+        allow(Homebrew::Trust).to receive(:trust!).with(:formula, tapped_name) { order << :trust }
+        described_class.install!(tapped_name, trusted: true)
+        expect(order).to eq([:trust, :tap])
+      end
+
+      it "does not trust an unqualified formula name" do
+        allow(Tap).to receive(:with_formula_name).and_return(nil)
+        expect(Homebrew::Trust).not_to receive(:trust!)
+        described_class.install!("baz", trusted: true)
       end
     end
 

--- a/Library/Homebrew/test/bundle/cask_spec.rb
+++ b/Library/Homebrew/test/bundle/cask_spec.rb
@@ -258,6 +258,18 @@ RSpec.describe Homebrew::Bundle::Cask do
           expect(described_class.install!("google-chrome")).to be(true)
         end
 
+        it "trusts the cask before installing it" do
+          allow(Homebrew::Bundle).to receive(:brew).and_return(true)
+          expect(Homebrew::Trust).to receive(:trust!).with(:cask, "puma/puma/puma-cask")
+          described_class.install!("puma-cask", full_name: "puma/puma/puma-cask", trusted: true)
+        end
+
+        it "does not trust an unqualified cask token" do
+          allow(Homebrew::Bundle).to receive(:brew).and_return(true)
+          expect(Homebrew::Trust).not_to receive(:trust!)
+          described_class.install!("google-chrome", trusted: true)
+        end
+
         it "installs cask with arguments" do
           expect(Homebrew::Bundle).to(
             receive(:brew).with("install", "--cask", "firefox", "--appdir=/Applications", "--adopt",

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -65,6 +65,20 @@ RSpec.describe Utils do
     end
   end
 
+  describe ".full_name?" do
+    it "is true for a fully-qualified name" do
+      expect(described_class.full_name?("homebrew/core/wget")).to be(true)
+    end
+
+    it "is false for an unqualified name" do
+      expect(described_class.full_name?("wget")).to be(false)
+    end
+
+    it "is false for a tap name" do
+      expect(described_class.full_name?("homebrew/core")).to be(false)
+    end
+  end
+
   specify ".parse_author!" do
     parse_error_msg = /Unable to parse name and email/
 

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -59,7 +59,7 @@ module Homebrew
     sig { params(names: T::Array[String], type: T.nilable(Symbol)).void }
     def self.trust_fully_qualified_items!(names, type: nil)
       names.each do |name|
-        next if name.count("/") != 2
+        next unless ::Utils.full_name?(name)
 
         tap_name = name.split("/").first(2).join("/")
         item_name = ::Utils.name_from_full_name(name)

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -60,6 +60,12 @@ module Utils
     "#{user}/#{repository}"
   end
 
+  # Whether `full_name` is fully-qualified with a tap prefix, e.g. `user/tap/name`.
+  sig { params(full_name: String).returns(T::Boolean) }
+  def self.full_name?(full_name)
+    full_name.count("/") == 2
+  end
+
   # A lightweight alternative to `ActiveSupport::Inflector.pluralize`:
   # Combines `stem` with the `singular` or `plural` suffix based on `count`.
   # Adds a prefix of the count value if `include_count` is set to true.


### PR DESCRIPTION
- `trusted: true` was parsed but ignored on install, so a formula or cask from an untrusted tap still failed to load mid-install
- persist trust before the formula/cask is loaded so the in-process conflict check and the `brew install` subprocess both see it trusted
- this completes the round-trip with `brew bundle dump`, which already emits `trusted: true` for trusted entries

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 high with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
