### PR TITLE
Trust test-bot dependency taps

### DIFF
--- a/Library/Homebrew/test/test_bot/formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_spec.rb
@@ -4,6 +4,36 @@
 require "test_bot"
 
 RSpec.describe Homebrew::TestBot::Formulae do
+  describe "#tap_needed_taps" do
+    it "trusts a missing dependency tap after tapping it and retries" do
+      tap = Tap.fetch("thirdparty", "tap")
+      dependency = Dependency.new("thirdparty/tap/foo")
+      formula = instance_double(Formula, recursive_dependencies: [])
+      output_paths = {
+        bottle:                     Pathname.new("/tmp/bottle.txt"),
+        linkage:                    Pathname.new("/tmp/linkage.txt"),
+        skipped_or_failed_formulae: Pathname.new("/tmp/skipped.txt"),
+      }
+      formulae = described_class.new(
+        tap: nil, git: "git", dry_run: true, fail_fast: false, verbose: false,
+        output_paths:
+      )
+      attempts = 0
+
+      allow(tap).to receive(:installed?).and_return(false)
+      allow(dependency).to receive(:to_formula) do
+        attempts += 1
+        raise TapFormulaUnavailableError.new(tap, "foo") if attempts == 1
+
+        formula
+      end
+
+      expect(formulae).to receive(:tap_and_trust!).with(tap)
+
+      formulae.send(:tap_needed_taps, [dependency])
+    end
+  end
+
   describe "#dependency_name_match?" do
     it "requires exact matches when either name is tap-qualified", :aggregate_failures do
       Dir.mktmpdir do |tmpdir|

--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -113,8 +113,7 @@ module Homebrew
       rescue TapFormulaUnavailableError => e
         raise if e.tap.installed?
 
-        e.tap.clear_cache
-        safe_system "brew", "tap", e.tap.name
+        tap_and_trust!(e.tap)
         retry
       end
 

--- a/Library/Homebrew/test_bot/formulae_dependents.rb
+++ b/Library/Homebrew/test_bot/formulae_dependents.rb
@@ -261,8 +261,7 @@ module Homebrew
               rescue TapFormulaUnavailableError => e
                 raise if e.tap.installed?
 
-                e.tap.clear_cache
-                safe_system "brew", "tap", e.tap.name
+                tap_and_trust!(e.tap)
                 retry
               end
             end.reject(&:optional?)
@@ -530,8 +529,7 @@ module Homebrew
         rescue TapFormulaUnavailableError => e
           raise if e.tap.installed?
 
-          e.tap.clear_cache
-          safe_system "brew", "tap", e.tap.name
+          tap_and_trust!(e.tap)
           retry
         end
         formula_recursive_dependencies.each do |dependency|

--- a/Library/Homebrew/test_bot/test_formulae.rb
+++ b/Library/Homebrew/test_bot/test_formulae.rb
@@ -40,6 +40,13 @@ module Homebrew
         { "HOMEBREW_REQUIRE_TAP_TRUST" => "1" }
       end
 
+      sig { params(tap: Tap).void }
+      def tap_and_trust!(tap)
+        tap.clear_cache
+        safe_system "brew", "tap", tap.name
+        Homebrew::Trust.trust!(:tap, tap.name) unless tap.official?
+      end
+
       sig { returns(T.nilable(Pathname)) }
       def cached_event_json
         return unless (event_json = artifact_cache/"event.json").exist?
@@ -503,8 +510,7 @@ module Homebrew
           rescue TapFormulaUnavailableError => e
             raise if e.tap.installed?
 
-            e.tap.clear_cache
-            safe_system "brew", "tap", e.tap.name
+            tap_and_trust!(e.tap)
             retry
           end
 


### PR DESCRIPTION
This PR fixes `brew test-bot` failures when a tested formula depends on a formula from a third-party tap that is not already tapped. `test-bot` should trust non-official dependency taps after it auto-taps them, before retrying formula/dependency resolution.

Reference failing CI run: https://github.com/shivammathur/homebrew-extensions/actions/runs/27155851920/job/80159756942

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [X] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [X] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

-----
