### PR TITLE
Stop auto-tapping untrusted taps

### DIFF
--- a/Library/Homebrew/cmd/update_report/reporter.rb
+++ b/Library/Homebrew/cmd/update_report/reporter.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "trust"
+
 class Reporter
   include Utils::Output::Mixin
 
@@ -241,7 +243,8 @@ class Reporter
         next unless (HOMEBREW_PREFIX/"Caskroom"/name).exist?
 
         new_tap = Tap.fetch(new_tap_name)
-        new_tap.ensure_installed!
+        next unless ensure_trusted_tap_installed!(name, new_name, new_tap)
+
         ohai "#{name} has been moved to Homebrew.", <<~EOS
           To uninstall the cask, run:
             brew uninstall --cask --force #{name}
@@ -297,7 +300,8 @@ class Reporter
           EOS
         end
       else
-        new_tap.ensure_installed!
+        next unless ensure_trusted_tap_installed!(name, new_name, new_tap)
+
         # update tap for each Tab
         tabs.each { |tab| tab.tap = new_tap }
         tabs.each(&:write)
@@ -335,6 +339,34 @@ class Reporter
   end
 
   private
+
+  sig { params(name: String, new_name: String, new_tap: Tap).returns(T::Boolean) }
+  def ensure_trusted_tap_installed!(name, new_name, new_tap)
+    return true if new_tap.installed?
+
+    unless Homebrew::Trust.trusted_tap?(new_tap)
+      new_bare_name = Utils.name_from_full_name(new_name)
+      new_full_name = "#{new_tap.name}/#{new_bare_name}"
+      # `brew migrate` only migrates renamed packages, so a tap-only migration
+      # (unchanged name) needs a reinstall from the new tap instead.
+      complete_command = if new_bare_name == name
+        "brew reinstall #{name}"
+      else
+        "brew migrate #{name}"
+      end
+      opoo <<~EOS
+        Not automatically tapping #{new_tap} to migrate #{name} as it is not a
+        trusted tap. To complete the migration yourself, run:
+          brew tap #{new_tap}
+          brew trust #{new_full_name}
+          #{complete_command}
+      EOS
+      return false
+    end
+
+    new_tap.ensure_installed!
+    true
+  end
 
   sig { returns(Tap) }
   attr_reader :tap

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -154,6 +154,29 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
       end
     end
 
+    describe "#ensure_trusted_tap_installed!" do
+      let(:other_tap) { Tap.fetch("foo", "bar") }
+
+      before { allow(other_tap).to receive(:installed?).and_return(false) }
+
+      it "recommends trusting just the migrated package then migrating a rename" do
+        expect(other_tap).not_to receive(:ensure_installed!)
+        expect { reporter.send(:ensure_trusted_tap_installed!, "oldfoo", "newfoo", other_tap) }
+          .to output(%r{brew trust foo/bar/newfoo.*brew migrate oldfoo}m).to_stderr
+      end
+
+      it "recommends a reinstall for an unchanged-name tap migration" do
+        expect { reporter.send(:ensure_trusted_tap_installed!, "foo", "foo", other_tap) }
+          .to output(/brew reinstall foo/).to_stderr
+      end
+
+      it "taps a trusted tap" do
+        allow(other_tap).to receive(:official?).and_return(true)
+        expect(other_tap).to receive(:ensure_installed!)
+        reporter.send(:ensure_trusted_tap_installed!, "foo", "foo", other_tap)
+      end
+    end
+
     describe "#diff" do
       context "when using the API" do
         subject(:reporter) do

--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -107,17 +107,6 @@ module Homebrew
 
       private
 
-      sig { params(deps: T::Array[Dependency]).void }
-      def tap_needed_taps(deps)
-        deps.each { |d| d.to_formula.recursive_dependencies }
-      rescue TapFormulaUnavailableError => e
-        raise if e.tap.installed?
-
-        e.tap.clear_cache
-        safe_system "brew", "tap", e.tap.name
-        retry
-      end
-
       sig { void }
       def install_ca_certificates_if_needed
         return if DevelopmentTools.ca_file_handles_most_https_certificates?
@@ -616,7 +605,6 @@ module Homebrew
           deps |= formula.deps.to_a.reject(&:optional?)
           reqs |= formula.requirements.to_a.reject(&:optional?)
 
-          tap_needed_taps(deps)
           install_curl_if_needed(formula)
           install_mercurial_if_needed(deps, reqs)
           install_subversion_if_needed(deps, reqs)

--- a/Library/Homebrew/test_bot/formulae_dependents.rb
+++ b/Library/Homebrew/test_bot/formulae_dependents.rb
@@ -253,17 +253,9 @@ module Homebrew
             if skip_recursive_dependents
               f.deps.reject(&:implicit?)
             else
-              begin
-                Dependency.expand(f, cache_key: "test-bot-dependents") do |_, dependency|
-                  next Dependable::SKIP if dependency.implicit?
-                  next Dependable::KEEP_BUT_PRUNE_RECURSIVE_DEPS if dependency.build? || dependency.test?
-                end
-              rescue TapFormulaUnavailableError => e
-                raise if e.tap.installed?
-
-                e.tap.clear_cache
-                safe_system "brew", "tap", e.tap.name
-                retry
+              Dependency.expand(f, cache_key: "test-bot-dependents") do |_, dependency|
+                next Dependable::SKIP if dependency.implicit?
+                next Dependable::KEEP_BUT_PRUNE_RECURSIVE_DEPS if dependency.build? || dependency.test?
               end
             end.reject(&:optional?)
           end)
@@ -525,15 +517,7 @@ module Homebrew
         return if formula.linked_keg.exist?
 
         conflicts = formula.conflicts.map { |c| Formulary.factory(c.name) }.select(&:any_version_installed?)
-        formula_recursive_dependencies = begin
-          formula.recursive_dependencies
-        rescue TapFormulaUnavailableError => e
-          raise if e.tap.installed?
-
-          e.tap.clear_cache
-          safe_system "brew", "tap", e.tap.name
-          retry
-        end
+        formula_recursive_dependencies = formula.recursive_dependencies
         formula_recursive_dependencies.each do |dependency|
           conflicts += dependency.to_formula.conflicts.map do |c|
             Formulary.factory(c.name)

--- a/Library/Homebrew/test_bot/formulae_detect.rb
+++ b/Library/Homebrew/test_bot/formulae_detect.rb
@@ -229,14 +229,7 @@ module Homebrew
         Homebrew.with_no_api_env do
           Formulary.factory(formula_name).full_name
         end
-      rescue TapFormulaUnavailableError => e
-        raise if e.tap.installed?
-
-        test "brew", "tap", e.tap.name
-        retry unless steps.fetch(-1).failed?
-        onoe e
-        puts e.backtrace if args.debug?
-      rescue FormulaUnavailableError, TapFormulaAmbiguityError => e
+      rescue FormulaUnavailableError, TapFormulaUnavailableError, TapFormulaAmbiguityError => e
         onoe e
         puts e.backtrace if args.debug?
       end

--- a/Library/Homebrew/test_bot/test_formulae.rb
+++ b/Library/Homebrew/test_bot/test_formulae.rb
@@ -488,24 +488,16 @@ module Homebrew
         changed_formulae_dependents = {}
 
         @testing_formulae.each do |formula|
-          begin
-            formula_dependencies =
-              Utils.popen_read("brew", "deps", "--full-name",
-                               "--include-build",
-                               "--include-test", formula)
-                   .split("\n")
-            # deps can fail if deps are not tapped
-            unless $CHILD_STATUS.success?
-              Formulary.factory(formula).recursive_dependencies
-              # If we haven't got a TapFormulaUnavailableError, then something else is broken
-              raise "Failed to determine dependencies for '#{formula}'."
-            end
-          rescue TapFormulaUnavailableError => e
-            raise if e.tap.installed?
-
-            e.tap.clear_cache
-            safe_system "brew", "tap", e.tap.name
-            retry
+          formula_dependencies =
+            Utils.popen_read("brew", "deps", "--full-name",
+                             "--include-build",
+                             "--include-test", formula)
+                 .split("\n")
+          # deps can fail if deps are not tapped
+          unless $CHILD_STATUS.success?
+            Formulary.factory(formula).recursive_dependencies
+            # If we haven't got a TapFormulaUnavailableError, then something else is broken
+            raise "Failed to determine dependencies for '#{formula}'."
           end
 
           unchanged_dependencies = formula_dependencies - @testing_formulae


### PR DESCRIPTION
- remove `brew test-bot` auto-tapping that silently tapped and retried on `TapFormulaUnavailableError` for discovered dependency taps; missing taps now surface so they can be tapped explicitly
- gate `update` tap migrations behind `Trust.trusted_tap?` so only official or already-trusted taps are auto-tapped, otherwise warn with manual `brew tap`/`brew trust`/`brew migrate` instructions instead of erroring out the wider `brew update`
- recommend trusting just the migrated `user/repo/formula` rather than the whole tap, tapping first so `brew trust` can infer the package type from the on-disk tap files
- recommend `brew migrate` in that warning because a skipped tap migration will not re-run on a later `brew update`, so the user must complete it explicitly once they have tapped
- now that `brew trust` exists, tapping untrusted taps should be an explicit user action rather than an implicit side effect

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 high with local review, tweaking and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
