### PR TITLE
cmd/untap: allow to untap a repo if package raises `MethodDeprecatedError`

### DIFF
--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -79,8 +79,8 @@ module Homebrew
 
           cask = begin
             Cask::CaskLoader.load(cask_token)
-          rescue Cask::CaskUnavailableError
-            # Don't blow up because of a single unavailable cask.
+          rescue Cask::CaskUnavailableError, MethodDeprecatedError
+            # Don't blow up because of a single unavailable cask or a deprecated method.
             next
           end
 

--- a/Library/Homebrew/test/cmd/untap_spec.rb
+++ b/Library/Homebrew/test/cmd/untap_spec.rb
@@ -122,23 +122,28 @@ RSpec.describe Homebrew::Cmd::Untap do
 
   describe "#installed_casks_for", :cask do
     shared_examples "finds installed casks in tap", :no_api do
-      def load_cask(token:, with_cask_file: false, mock_install: false)
-        cask_loader = Cask::CaskLoader::FromContentLoader.new(<<~RUBY, tap:)
+      def load_cask(token:, with_cask_file: false, mock_install: false, deprecated: false)
+        cask_source = <<~RUBY
           cask '#{token}' do
             version "1.2.3"
             sha256 :no_check
 
             url 'https://brew.sh/'
+
+            #{"raise MethodDeprecatedError" if deprecated}
           end
         RUBY
-
-        cask = cask_loader.load(config: nil)
 
         if with_cask_file
           cask_path = tap.cask_dir/"#{token}.rb"
           cask_path.parent.mkpath
-          cask_path.write cask.source
+          cask_path.write cask_source
         end
+
+        return if deprecated
+
+        cask_loader = Cask::CaskLoader::FromContentLoader.new(cask_source, tap:)
+        cask = cask_loader.load(config: nil)
 
         InstallHelper.install_with_caskfile(cask) if mock_install
 
@@ -155,6 +160,9 @@ RSpec.describe Homebrew::Cmd::Untap do
 
         # Cask that was installed from a tap but is no longer available from that tap.
         load_cask(token: "legacy_install", mock_install: true)
+
+        # Cask that uses deprecated method.
+        load_cask(token: "deprecated_method", with_cask_file: true, deprecated: true)
       end
 
       it "returns the expected casks" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
Closes #22600