### PR TITLE
Ignore .git suffix when matching GitHub tap remotes

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -139,6 +139,23 @@ class Tap
     reference.include?("://") || reference.include?("@") || reference.start_with?("/", ".", "~")
   end
 
+  # On GitHub a `.git` suffix and trailing slashes are insignificant; we don't assume so elsewhere.
+  sig { params(remote: T.nilable(String)).returns(T.nilable(String)) }
+  def self.normalize_remote(remote)
+    return if remote.blank?
+
+    remote = remote.strip.downcase
+    return remote unless remote.match?(%r{\A(?:[a-z][a-z0-9+.-]*://)?(?:[^@/]+@)?github\.com[/:]})
+
+    remote.sub(%r{/+\z}, "").delete_suffix(".git")
+  end
+
+  sig { params(first: T.nilable(String), second: T.nilable(String)).returns(T::Boolean) }
+  def self.same_remote?(first, second)
+    first = normalize_remote(first)
+    first.present? && first == normalize_remote(second)
+  end
+
   # Normalise `user/repository` entries in a tap allow/forbid list to canonical tap names,
   # warning about invalid ones, while preserving remote URL or path entries verbatim.
   sig { params(env_taps: String, env_var: String).returns(T::Array[String]) }
@@ -737,7 +754,7 @@ class Tap
   def custom_remote?
     return true unless (remote = self.remote)
 
-    !T.must(remote.casecmp(default_remote)).zero?
+    !self.class.same_remote?(remote, default_remote)
   end
 
   # Unlike {#custom_remote?} this is false when no remote is set, so a remote-less
@@ -761,9 +778,9 @@ class Tap
   sig { params(reference: String, remote: T.nilable(String)).returns(T::Boolean) }
   def matches_reference?(reference, remote: self.remote)
     if self.class.remote_reference?(reference)
-      remote.present? && reference.casecmp?(remote) == true
+      self.class.same_remote?(reference, remote)
     else
-      uses_custom_remote = remote.present? && !remote.casecmp?(default_remote)
+      uses_custom_remote = remote.present? && !self.class.same_remote?(remote, default_remote)
       !uses_custom_remote && name == reference.downcase
     end
   end
@@ -1310,7 +1327,7 @@ class Tap
 
   sig { overridable.params(remote: T.nilable(String)).returns(T::Boolean) }
   def canonical_remote?(remote = self.remote)
-    remote.blank? || remote.casecmp?(default_remote) == true
+    remote.blank? || self.class.same_remote?(remote, default_remote)
   end
 
   private

--- a/Library/Homebrew/tap/core_tap.rb
+++ b/Library/Homebrew/tap/core_tap.rb
@@ -30,7 +30,7 @@ class CoreTap < AbstractCoreTap
   # The configured `HOMEBREW_CORE_GIT_REMOTE` is the official remote for this tap.
   sig { override.params(remote: T.nilable(String)).returns(T::Boolean) }
   def canonical_remote?(remote = self.remote)
-    remote.blank? || remote.casecmp?(Homebrew::EnvConfig.core_git_remote) == true
+    remote.blank? || self.class.same_remote?(remote, Homebrew::EnvConfig.core_git_remote)
   end
 
   # CoreTap never allows shallow clones (on request from GitHub).

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -172,11 +172,42 @@ RSpec.describe Tap do
     end
   end
 
+  describe "::same_remote?" do
+    it "ignores a GitHub `.git` suffix, trailing slash and case" do
+      expect(described_class.same_remote?("https://github.com/Homebrew/homebrew-core.git/",
+                                          "https://github.com/homebrew/homebrew-core")).to be true
+    end
+
+    it "keeps a `.git` suffix significant on non-GitHub remotes" do
+      expect(described_class.same_remote?("https://gitlab.com/other/repo.git",
+                                          "https://gitlab.com/other/repo")).to be false
+    end
+
+    it "still matches non-GitHub remotes case-insensitively" do
+      expect(described_class.same_remote?("https://gitlab.com/other/repo",
+                                          "https://GitLab.com/Other/Repo")).to be true
+    end
+
+    it "keeps a different scheme distinct" do
+      expect(described_class.same_remote?("git@github.com:Homebrew/homebrew-core",
+                                          "https://github.com/Homebrew/homebrew-core")).to be false
+    end
+
+    it "keeps a different host distinct" do
+      expect(described_class.same_remote?("https://evil.example/Homebrew/homebrew-core",
+                                          "https://github.com/Homebrew/homebrew-core")).to be false
+    end
+  end
+
   describe "#matches_reference?" do
     let(:tap) { described_class.fetch("user", "repo") }
 
     it "matches a default-remote tap by its name" do
       expect(tap.matches_reference?("user/repo", remote: "https://github.com/user/homebrew-repo")).to be true
+    end
+
+    it "matches a default-remote tap whose remote has a `.git` suffix" do
+      expect(tap.matches_reference?("user/repo", remote: "https://github.com/user/homebrew-repo.git")).to be true
     end
 
     it "does not match a custom-remote tap by its name" do
@@ -220,6 +251,13 @@ RSpec.describe Tap do
     it "is true for homebrew/core in API mode regardless of remote" do
       with_env(HOMEBREW_NO_INSTALL_FROM_API: nil) do
         expect(CoreTap.instance.implicitly_trusted?(remote: "https://evil.example/core")).to be true
+      end
+    end
+
+    it "is true for a homebrew/core Git checkout whose remote has a `.git` suffix" do
+      with_env(HOMEBREW_NO_INSTALL_FROM_API: "1") do
+        expect(CoreTap.instance.implicitly_trusted?(remote: "https://github.com/Homebrew/homebrew-core.git"))
+          .to be true
       end
     end
 
@@ -388,6 +426,12 @@ RSpec.describe Tap do
 
     context "when using the default remote" do
       let(:remote) { "https://github.com/Homebrew/homebrew-test-bot" }
+
+      it(:custom_remote?) { expect(tap.custom_remote?).to be false }
+    end
+
+    context "when the default remote has a `.git` suffix" do
+      let(:remote) { "https://github.com/Homebrew/homebrew-test-bot.git" }
 
       it(:custom_remote?) { expect(tap.custom_remote?).to be false }
     end


### PR DESCRIPTION
`brew update` and `brew install` fail with `Refusing to load formula homebrew/core/<name> from untrusted tap homebrew/core` for anyone using the tap-trust feature (`HOMEBREW_REQUIRE_TAP_TRUST`) together with a Git checkout of `homebrew/core` or `HOMEBREW_NO_INSTALL_FROM_API`.

Since #22590 the trust system matches Git remotes with an exact `casecmp?`, but a cloned tap's origin URL carries a `.git` suffix the canonical remote doesn't — so `https://github.com/Homebrew/homebrew-core.git` doesn't match `https://github.com/Homebrew/homebrew-core`, `canonical_remote?` returns false, and the official core tap is treated as untrusted. The same brittleness made any tap whose origin has a `.git` suffix (e.g. a cloned `homebrew/cask`) report `custom_remote?` incorrectly.

This adds a `Tap.same_remote?` helper that ignores a `.git` suffix, trailing slashes and case when comparing remotes, and routes the remote/trust comparisons through it. The leniency is scoped to `github.com`; other hosts keep their existing case-insensitive matching but without the `.git`/trailing-slash normalization, since `.git` being insignificant is a documented GitHub behaviour we shouldn't assume elsewhere. (Case-insensitivity is kept everywhere because trust-list entries are stored downcased.)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code (Opus 4.8) diagnosed the regression and wrote the fix and tests. Verified locally.

-----
