### PR TITLE
utils/inreplace: fix `errors` type

### DIFF
--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -8,7 +8,7 @@ module Utils
   module Inreplace
     # Error during text replacement.
     class Error < RuntimeError
-      sig { params(errors: T::Hash[String, T::Array[String]]).void }
+      sig { params(errors: T::Hash[T.any(String, Pathname), T::Array[String]]).void }
       def initialize(errors)
         formatted_errors = errors.reduce(+"inreplace failed\n") do |s, (path, errs)|
           s << "#{path}:\n" << errs.map { |e| "  #{e}\n" }.join


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
`paths` (which are used as keys for `errors` hash) may contain `Pathname`s but the error class constructor accepts only strings `T::Hash[String, T::Array[String]]`

Found in https://github.com/Homebrew/homebrew-core/actions/runs/27169068637/job/80204726514