### PR TITLE
description_cache_store: require formula_versions

### DIFF
--- a/Library/Homebrew/description_cache_store.rb
+++ b/Library/Homebrew/description_cache_store.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "cache_store"
+require "formula_versions"
 
 #
 # {DescriptionCacheStore} provides methods to fetch and mutate formula descriptions used


### PR DESCRIPTION
Fixes the `brew update` crash `uninitialized constant DescriptionCacheStore::FormulaVersions` (originally reported in #22609; full root-cause + reproduction write-up in Homebrew/discussions#6886).

`Library/Homebrew/description_cache_store.rb` rescues `FormulaVersions::IGNORED_EXCEPTIONS` in `update_from_formula_names!`, but the file only `require "cache_store"` — it never `require "formula_versions"`. The constant therefore resolves only if another code path has already loaded `FormulaVersions`.

The `rescue` is evaluated lazily — only when `Formula[name].desc` raises — so the missing require stays latent until a reported formula is unavailable during the description-cache refresh, at which point `brew update` aborts:

```
Error: uninitialized constant DescriptionCacheStore::FormulaVersions
/opt/homebrew/Library/Homebrew/description_cache_store.rb:82:in 'block in DescriptionCacheStore#update_from_formula_names!'
...
```

This adds the missing `require "formula_versions"` (in alphabetical order, after `require "cache_store"`).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

This PR was diagnosed and written with AI assistance (Claude / Claude Code). **What it does:** adds the missing `require "formula_versions"` to `description_cache_store.rb`, which uses `FormulaVersions::IGNORED_EXCEPTIONS` in a `rescue` without requiring it. **How verified:** confirmed the file references `FormulaVersions` but lacks the require; confirmed `Library/Homebrew/formula_versions.rb` exists and `require "formula_versions"` is the exact form already used elsewhere in `Library/Homebrew`; placed the new require in alphabetical order in this `# typed: strict` file; and reproduced the original crash through a real `brew update` via a controlled local tap, confirming the require resolves the failing `rescue` (details in Homebrew/discussions#6886). I did **not** run `brew lgtm` locally (those boxes left unticked) — relying on CI for the full style/typecheck/test run.

-----
