### PR TITLE
trust: support trusting tap by remote URL

### DIFF
--- a/Library/Homebrew/cmd/trust.rb
+++ b/Library/Homebrew/cmd/trust.rb
@@ -56,7 +56,7 @@ module Homebrew
 
         args.named.each do |name|
           type, trust_name = Homebrew::Trust.target(name, type: selected_type)
-          if type == :tap && Tap.fetch(name).official?
+          if type == :tap && !Tap.remote_reference?(trust_name) && Tap.fetch(trust_name).official?
             puts "Official tap #{trust_name} is always trusted."
             next
           end

--- a/Library/Homebrew/cmd/untrust.rb
+++ b/Library/Homebrew/cmd/untrust.rb
@@ -80,7 +80,7 @@ module Homebrew
         args.named.each do |name|
           item_types = [:formula, :cask, :command]
           type, trust_name = Homebrew::Trust.target(name, type: selected_type, include_existing: true)
-          if type == :tap && Tap.fetch(name).official?
+          if type == :tap && !Tap.remote_reference?(trust_name) && Tap.fetch(trust_name).official?
             puts "Official tap #{trust_name} is always trusted."
             next
           end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -134,9 +134,12 @@ class Tap
 
   # Whether an allow/forbid/trust list reference is a remote URL or local path rather than a
   # `user/repository` tap name (which can only match a tap on its default GitHub remote).
+  # A genuine remote reference is a URL (contains `://`), scp-like syntax (`user@host:path`,
+  # i.e. an `@` followed later by a `:`) or a local path (starts with `/`, `.` or `~`).
+  # A bare `@`-containing string such as `foo@bar` is not a remote reference.
   sig { params(reference: String).returns(T::Boolean) }
   def self.remote_reference?(reference)
-    reference.include?("://") || reference.include?("@") || reference.start_with?("/", ".", "~")
+    reference.include?("://") || reference.match?(/@[^@]+:/) || reference.start_with?("/", ".", "~")
   end
 
   # On GitHub a `.git` suffix and trailing slashes are insignificant; we don't assume so elsewhere.

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -150,6 +150,28 @@ class Tap
     remote.sub(%r{/+\z}, "").delete_suffix(".git")
   end
 
+  # Converts a remote URL to the canonical trust-list reference for the tap it identifies.
+  # A default-style GitHub remote canonicalises to the `owner/repo` name form (matching how
+  # {#reference} works for an installed tap); any other remote is stored as the normalised URL.
+  # Returns `nil` if the URL is blank or otherwise invalid.
+  sig { params(url: String).returns(T.nilable(String)) }
+  def self.remote_to_reference(url)
+    normalised = normalize_remote(url)
+    return if normalised.blank?
+
+    match = normalised.match(HOMEBREW_TAP_REPOSITORY_REGEX)
+    return normalised unless match
+
+    remote_repo = T.must(match[:remote_repository])
+    user, full_repo = remote_repo.split("/", 2)
+    return normalised if user.nil? || full_repo.nil?
+
+    tap = fetch(user, full_repo)
+    same_remote?(normalised, tap.default_remote) ? tap.name : normalised
+  rescue InvalidNameError
+    normalised
+  end
+
   sig { params(first: T.nilable(String), second: T.nilable(String)).returns(T::Boolean) }
   def self.same_remote?(first, second)
     first = normalize_remote(first)

--- a/Library/Homebrew/test/cmd/trust_spec.rb
+++ b/Library/Homebrew/test/cmd/trust_spec.rb
@@ -50,6 +50,22 @@ RSpec.describe Homebrew::Cmd::Trust do
     end
   end
 
+  it "trusts a not-yet-installed tap directly by its non-GitHub remote URL" do
+    expect { described_class.new(["--tap", "https://gitlab.com/absent/repo"]).run }
+      .to output("Trusted tap: https://gitlab.com/absent/repo\n").to_stdout
+    expect(Homebrew::Trust.trusted_entries(:tap)).to contain_exactly("https://gitlab.com/absent/repo")
+  ensure
+    Homebrew::Trust.clear!(:tap)
+  end
+
+  it "canonicalises a GitHub default-remote URL to the tap name" do
+    expect { described_class.new(["--tap", "https://github.com/thirdparty/homebrew-foo"]).run }
+      .to output("Trusted tap: thirdparty/foo\n").to_stdout
+    expect(Homebrew::Trust.trusted_entries(:tap)).to contain_exactly("thirdparty/foo")
+  ensure
+    Homebrew::Trust.clear!(:tap)
+  end
+
   it "lists trusted entries with no arguments" do
     allow(Homebrew::Trust).to receive(:trusted_entries).with(:tap).and_return(["thirdparty/foo"])
     allow(Homebrew::Trust).to receive(:trusted_entries).with(:formula).and_return(["thirdparty/foo/bar"])

--- a/Library/Homebrew/test/cmd/trust_spec.rb
+++ b/Library/Homebrew/test/cmd/trust_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe Homebrew::Cmd::Trust do
     Homebrew::Trust.clear!(:tap)
   end
 
+  it "rejects a bare @-string instead of trusting it as a tap" do
+    expect { described_class.new(["foo@bar"]).run }
+      .to raise_error(UsageError, /fully-qualified/)
+    expect(Homebrew::Trust.trusted_entries(:tap)).to be_empty
+  ensure
+    Homebrew::Trust.clear!(:tap)
+  end
+
   it "lists trusted entries with no arguments" do
     allow(Homebrew::Trust).to receive(:trusted_entries).with(:tap).and_return(["thirdparty/foo"])
     allow(Homebrew::Trust).to receive(:trusted_entries).with(:formula).and_return(["thirdparty/foo/bar"])

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -47,6 +47,38 @@ RSpec.describe Homebrew::Trust do
     FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
   end
 
+  it "canonicalises a GitHub default-remote URL to the tap name" do
+    result = described_class.target("https://github.com/thirdparty/homebrew-foo", type: :tap)
+    expect(result).to eq([:tap, "thirdparty/foo"])
+  end
+
+  it "stores a non-GitHub URL verbatim" do
+    result = described_class.target("https://gitlab.com/other/repo", type: :tap)
+    expect(result).to eq([:tap, "https://gitlab.com/other/repo"])
+  end
+
+  it "trusts a not-yet-installed tap by its non-GitHub remote URL" do
+    described_class.trust!(:tap, "https://gitlab.com/absent/repo")
+    expect(described_class.trusted_entries(:tap)).to include("https://gitlab.com/absent/repo")
+  ensure
+    described_class.clear!(:tap)
+  end
+
+  it "untrusts a tap by its remote URL" do
+    described_class.trust!(:tap, "https://gitlab.com/other/repo")
+    type, trust_name = described_class.target("https://gitlab.com/other/repo", type: :tap, include_existing: true)
+    removed = described_class.untrust!(type, trust_name)
+    expect(removed).to be(true)
+    expect(described_class.trusted_entries(:tap)).not_to include("https://gitlab.com/other/repo")
+  ensure
+    described_class.clear!(:tap)
+  end
+
+  it "infers tap type for a remote URL argument" do
+    result = described_class.target("https://gitlab.com/other/repo")
+    expect(result).to eq([:tap, "https://gitlab.com/other/repo"])
+  end
+
   it "refuses new per-item trust for a custom-remote tap but still resolves existing entries to untrust" do
     tap = Tap.fetch("thirdparty", "custom")
     tap.path.mkpath

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -79,6 +79,23 @@ RSpec.describe Homebrew::Trust do
     expect(result).to eq([:tap, "https://gitlab.com/other/repo"])
   end
 
+  it "infers tap type for an scp-style remote URL argument" do
+    result = described_class.target("git@gitlab.com:other/repo")
+    expect(result).to eq([:tap, "git@gitlab.com:other/repo"])
+  end
+
+  it "rejects a bare @-string rather than trusting it as a tap" do
+    expect { described_class.target("foo@bar") }
+      .to raise_error(UsageError, /fully-qualified/)
+    expect(described_class.trusted_entries(:tap)).to be_empty
+  end
+
+  it "rejects a bare @-string even with an explicit tap type" do
+    expect { described_class.target("not@valid", type: :tap) }
+      .to raise_error(UsageError, /Invalid tap name/)
+    expect(described_class.trusted_entries(:tap)).to be_empty
+  end
+
   it "refuses new per-item trust for a custom-remote tap but still resolves existing entries to untrust" do
     tap = Tap.fetch("thirdparty", "custom")
     tap.path.mkpath

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -211,7 +211,7 @@ module Homebrew
 
     sig { params(name: String, include_existing: T::Boolean).returns([Symbol, String]) }
     def self.infer_target(name, include_existing:)
-      return [:tap, trust_name(:tap, name)] if name.count("/") == 1
+      return [:tap, trust_name(:tap, name)] if name.count("/") == 1 || Tap.remote_reference?(name)
 
       tap_with_name = Tap.with_formula_name(name)
       unless tap_with_name
@@ -244,7 +244,14 @@ module Homebrew
     def self.trust_name(type, name, include_existing: false)
       case type
       when :tap
-        Tap.fetch(name).reference
+        if Tap.remote_reference?(name)
+          reference = Tap.remote_to_reference(name)
+          raise UsageError, "Invalid tap remote URL: #{name}" if reference.nil?
+
+          reference
+        else
+          Tap.fetch(name).reference
+        end
       when :formula
         tap, formula_name = fully_qualified_package_name(name, "Formulae")
         require_default_remote_item!(tap) unless include_existing


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Implemented by Claude Sonnet 4.6 (orchestrated by Claude Opus 4.8). Verified by reviewing the code and manual testing/`brew lgtm`.

-----

In #22590, we tightened `brew trust` to track remotes that do not match
the tap short name (i.e. when it's not on GitHub, or otherwise has a
custom remote).

However, this also made it impossible to `brew trust` such taps if they
were not already on-disk. This is inconsistent with the first-class path
where a tap is hosted on GitHub and uses a name matching the remote,
where you could `brew trust owner/repo` without having `owner/repo`
tapped on-disk. This change fixes that.

The commit message (generated by Claude) follows.

-----

`brew trust`/`brew untrust` only accepted a `user/repository` tap name, so a tap
with a custom remote, or one not yet installed, could not be trusted by URL.
Since #22590 pinned trust matching to remotes, that left no way to trust such
taps ahead of time.

Accept a remote URL as a tap trust target:
- Add Tap.remote_to_reference, which canonicalises a default-style GitHub URL
  to its `owner/repository` name and stores any other host's URL verbatim,
  mirroring Tap#reference.
- infer_target routes URL-shaped arguments to the tap type; trust_name resolves
  them via remote_to_reference instead of Tap.fetch (which raised for URLs).
- trust/untrust resolve the canonical reference before the official? check so a
  URL argument no longer raises.

Builds on the remote-pinning in #22590.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
