### PR TITLE
tap: recognise more equivalent remote forms

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -139,13 +139,23 @@ class Tap
     reference.include?("://") || reference.include?("@") || reference.start_with?("/", ".", "~")
   end
 
-  # On GitHub a `.git` suffix and trailing slashes are insignificant; we don't assume so elsewhere.
+  # A `.git` suffix and trailing slashes never change which repository a remote identifies, so we
+  # strip them for all hosts. On GitHub the scheme and userinfo are also insignificant (any of
+  # HTTPS, SSH SCP syntax, `ssh://`, or `git://` identify the same repository), so those forms are
+  # canonicalised to HTTPS; we don't assume that for other hosts.
   sig { params(remote: T.nilable(String)).returns(T.nilable(String)) }
   def self.normalize_remote(remote)
     return if remote.blank?
 
     remote = remote.strip.downcase
-    return remote unless remote.match?(%r{\A(?:[a-z][a-z0-9+.-]*://)?(?:[^@/]+@)?github\.com[/:]})
+
+    # Canonicalise every GitHub remote form to `https://github.com/<owner>/<repo>` so SSH and
+    # HTTPS remotes for the same repository compare equal.
+    remote = remote
+             # scheme URLs, e.g. `https://`, `ssh://git@`, `git://`
+             .sub(%r{\A(?:https?|ssh|git)://(?:[^@/]+@)?github\.com/}, "https://github.com/")
+             # SCP-style SSH shorthand, e.g. `git@github.com:`
+             .sub(%r{\A(?:[^@/]+@)?github\.com:}, "https://github.com/")
 
     remote.sub(%r{/+\z}, "").delete_suffix(".git")
   end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -139,10 +139,15 @@ class Tap
     reference.include?("://") || reference.include?("@") || reference.start_with?("/", ".", "~")
   end
 
-  # A `.git` suffix and trailing slashes never change which repository a remote identifies, so we
-  # strip them for all hosts. On GitHub the scheme and userinfo are also insignificant (any of
-  # HTTPS, SSH SCP syntax, `ssh://`, or `git://` identify the same repository), so those forms are
-  # canonicalised to HTTPS; we don't assume that for other hosts.
+  # Hosts where a `.git` suffix and trailing slashes are known not to change which repository a
+  # remote identifies, so we can safely strip them. We don't assume this for arbitrary hosts
+  # (including self-hosted GitLab and GitHub Enterprise) where `repo.git` and `repo` may differ.
+  NORMALIZE_REMOTE_HOSTS = %w[github.com gitlab.com].freeze
+
+  # On GitHub the scheme and userinfo are insignificant (any of HTTPS, SSH SCP syntax, `ssh://`, or
+  # `git://` identify the same repository), so those forms are canonicalised to HTTPS. For hosts in
+  # {NORMALIZE_REMOTE_HOSTS} a `.git` suffix and trailing slashes are also insignificant, so we
+  # strip them; we don't assume that for other hosts.
   sig { params(remote: T.nilable(String)).returns(T.nilable(String)) }
   def self.normalize_remote(remote)
     return if remote.blank?
@@ -156,6 +161,10 @@ class Tap
              .sub(%r{\A(?:https?|ssh|git)://(?:[^@/]+@)?github\.com/}, "https://github.com/")
              # SCP-style SSH shorthand, e.g. `git@github.com:`
              .sub(%r{\A(?:[^@/]+@)?github\.com:}, "https://github.com/")
+
+    # Only strip `.git`/trailing slashes for hosts where this is known to be safe.
+    host = remote[%r{\A(?:[^@/]+://)?(?:[^@/]+@)?([^/:]+)}, 1]
+    return remote unless NORMALIZE_REMOTE_HOSTS.include?(host)
 
     remote.sub(%r{/+\z}, "").delete_suffix(".git")
   end

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -178,19 +178,19 @@ RSpec.describe Tap do
                                           "https://github.com/homebrew/homebrew-core")).to be true
     end
 
-    it "ignores a `.git` suffix on non-GitHub remotes" do
+    it "ignores a `.git` suffix on GitLab remotes" do
       expect(described_class.same_remote?("https://gitlab.com/other/repo.git",
                                           "https://gitlab.com/other/repo")).to be true
     end
 
-    it "ignores a trailing slash on non-GitHub remotes" do
+    it "ignores a trailing slash on GitLab remotes" do
       expect(described_class.same_remote?("https://gitlab.com/other/repo/",
                                           "https://gitlab.com/other/repo")).to be true
     end
 
-    it "ignores a `.git` suffix and trailing slash on a self-hosted remote" do
+    it "keeps a `.git` suffix and trailing slash significant on a self-hosted remote" do
       expect(described_class.same_remote?("https://git.example.com/other/repo.git/",
-                                          "https://git.example.com/other/repo")).to be true
+                                          "https://git.example.com/other/repo")).to be false
     end
 
     it "still matches non-GitHub remotes case-insensitively" do

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -178,9 +178,19 @@ RSpec.describe Tap do
                                           "https://github.com/homebrew/homebrew-core")).to be true
     end
 
-    it "keeps a `.git` suffix significant on non-GitHub remotes" do
+    it "ignores a `.git` suffix on non-GitHub remotes" do
       expect(described_class.same_remote?("https://gitlab.com/other/repo.git",
-                                          "https://gitlab.com/other/repo")).to be false
+                                          "https://gitlab.com/other/repo")).to be true
+    end
+
+    it "ignores a trailing slash on non-GitHub remotes" do
+      expect(described_class.same_remote?("https://gitlab.com/other/repo/",
+                                          "https://gitlab.com/other/repo")).to be true
+    end
+
+    it "ignores a `.git` suffix and trailing slash on a self-hosted remote" do
+      expect(described_class.same_remote?("https://git.example.com/other/repo.git/",
+                                          "https://git.example.com/other/repo")).to be true
     end
 
     it "still matches non-GitHub remotes case-insensitively" do
@@ -188,9 +198,29 @@ RSpec.describe Tap do
                                           "https://GitLab.com/Other/Repo")).to be true
     end
 
-    it "keeps a different scheme distinct" do
+    it "keeps non-GitHub remotes with different paths distinct" do
+      expect(described_class.same_remote?("https://gitlab.com/other/repo",
+                                          "https://gitlab.com/other/other-repo")).to be false
+    end
+
+    it "treats a GitHub SSH SCP remote the same as HTTPS" do
       expect(described_class.same_remote?("git@github.com:Homebrew/homebrew-core",
-                                          "https://github.com/Homebrew/homebrew-core")).to be false
+                                          "https://github.com/Homebrew/homebrew-core")).to be true
+    end
+
+    it "treats a GitHub ssh:// remote the same as HTTPS" do
+      expect(described_class.same_remote?("ssh://git@github.com/Homebrew/homebrew-core",
+                                          "https://github.com/Homebrew/homebrew-core")).to be true
+    end
+
+    it "treats a GitHub git:// remote the same as HTTPS" do
+      expect(described_class.same_remote?("git://github.com/Homebrew/homebrew-core",
+                                          "https://github.com/Homebrew/homebrew-core")).to be true
+    end
+
+    it "treats a GitHub SSH SCP remote with .git suffix the same as HTTPS" do
+      expect(described_class.same_remote?("git@github.com:Homebrew/homebrew-core.git",
+                                          "https://github.com/Homebrew/homebrew-core")).to be true
     end
 
     it "keeps a different host distinct" do
@@ -221,6 +251,15 @@ RSpec.describe Tap do
 
     it "matches a tap by its local path remote" do
       expect(tap.matches_reference?("/Users/me/homebrew-tap", remote: "/Users/me/homebrew-tap")).to be true
+    end
+
+    it "matches a GitHub SSH-remote tap by its name" do
+      expect(tap.matches_reference?("user/repo", remote: "git@github.com:user/homebrew-repo")).to be true
+    end
+
+    it "matches a GitHub SSH-remote tap by its HTTPS URL reference" do
+      expect(tap.matches_reference?("https://github.com/user/homebrew-repo",
+                                    remote: "git@github.com:user/homebrew-repo")).to be true
     end
   end
 
@@ -436,8 +475,14 @@ RSpec.describe Tap do
       it(:custom_remote?) { expect(tap.custom_remote?).to be false }
     end
 
-    context "when using a non-default remote" do
+    context "when using the SSH SCP remote for the same repository" do
       let(:remote) { "git@github.com:Homebrew/homebrew-test-bot" }
+
+      it(:custom_remote?) { expect(tap.custom_remote?).to be false }
+    end
+
+    context "when using a truly non-default remote" do
+      let(:remote) { "https://gitlab.com/Homebrew/homebrew-test-bot" }
 
       it(:custom_remote?) { expect(tap.custom_remote?).to be true }
     end

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -88,6 +88,9 @@ RSpec.describe Homebrew::Trust do
     tap.path.mkpath
     system "git", "-C", tap.path.to_s, "init"
     system "git", "-C", tap.path.to_s, "remote", "add", "origin", "git@github.com:thirdparty/homebrew-foo"
+    # Guard the setup so the test genuinely exercises SSH-vs-HTTPS equivalence: a
+    # remote-less tap would also be trusted by name, passing for the wrong reason.
+    expect(tap.remote).to eq("git@github.com:thirdparty/homebrew-foo")
 
     described_class.trust!(:tap, "thirdparty/foo")
 

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -83,6 +83,20 @@ RSpec.describe Homebrew::Trust do
     trust_file.unlink if trust_file&.exist?
   end
 
+  it "trusts a GitHub SSH-remote tap by its name" do
+    tap = Tap.fetch("thirdparty", "foo")
+    tap.path.mkpath
+    system "git", "-C", tap.path.to_s, "init"
+    system "git", "-C", tap.path.to_s, "remote", "add", "origin", "git@github.com:thirdparty/homebrew-foo"
+
+    described_class.trust!(:tap, "thirdparty/foo")
+
+    expect(described_class.trusted_tap?(tap)).to be(true)
+  ensure
+    described_class.clear!(:tap)
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
   it "untrusts third-party taps" do
     described_class.trust!(:tap, "thirdparty/foo")
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

Implemented by Claude Sonnet 4.6 (orchestrated by Opus 4.8). Manually reviewed and ran `brew lgtm`.

-----

This is a follow-up to #22604, and fixes #22603.

Commit message (generated by Claude) follows.

-----

Tap.normalize_remote underpins same_remote?, custom_remote?, and
matches_reference?, which back the tap allow/forbid/trust lists pinned
to remotes. Two classes of equivalent remotes were being treated as
distinct:

1. GitHub SSH vs HTTPS. git@github.com:owner/repo,
   ssh://git@github.com/owner/repo, and git://github.com/owner/repo
   identify the same repository as https://github.com/owner/repo, but
   only the .git suffix and case were normalised, leaving the
   scheme/userinfo intact. As a result an SSH-cloned GitHub tap was
   wrongly treated as a custom remote and could not be matched by its
   owner/repo name.

2. .git suffix / trailing slash on github.com and gitlab.com (allowlisted). These never change
   which repository a URL identifies, but the cleanup was gated to
   github.com, so e.g. https://gitlab.com/o/r.git and
   https://gitlab.com/o/r compared unequal.

normalize_remote now: downcases/strips, canonicalises GitHub remote
forms (scheme URLs and SCP syntax over https/http/ssh/git) to
https://github.com/<owner>/<repo> -- GitHub-only, since scheme/userinfo
equivalence can't be assumed for arbitrary hosts -- then strips a
trailing slash and .git suffix only for the github.com / gitlab.com allowlist. Arbitrary and self-hosted remotes (including self-hosted GitLab and GitHub Enterprise) stay strict, since repo.git == repo cannot be assumed there.

Closes #22603

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

