### PR TITLE
tap: add `trusted` field to `tap-info`

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1030,6 +1030,7 @@ class Tap
       "path"          => path.to_s,
       "installed"     => installed?,
       "official"      => official?,
+      "trusted"       => Homebrew::Trust.trusted_tap?(self),
       "formula_names" => formula_names,
       "cask_tokens"   => cask_tokens,
     }

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -314,6 +314,17 @@ RSpec.describe Tap do
   specify "files" do
     setup_tap_files
 
+    allow(Homebrew::Trust).to receive(:trusted_tap?).with(homebrew_foo_tap).and_return(true)
+    allow(homebrew_foo_tap).to receive_messages(
+      cask_tokens:     [],
+      remote:          "https://github.com/Homebrew/homebrew-foo",
+      custom_remote?:  false,
+      private?:        false,
+      git_head:        "abc123",
+      git_last_commit: "1 day ago",
+      git_branch:      "main",
+    )
+
     expect(homebrew_foo_tap.formula_files).to eq([formula_file])
     expect(homebrew_foo_tap.formula_names).to eq(["homebrew/foo/foo"])
     expect(homebrew_foo_tap.alias_files).to eq([alias_file])
@@ -323,7 +334,29 @@ RSpec.describe Tap do
     expect(homebrew_foo_tap.formula_renames).to eq("oldname" => "foo")
     expect(homebrew_foo_tap.tap_migrations).to eq("removed-formula" => "homebrew/foo")
     expect(homebrew_foo_tap.command_files).to eq([cmd_file])
-    expect(homebrew_foo_tap.to_hash).to be_a(Hash)
+    expect(homebrew_foo_tap.to_hash).to eq(
+      {
+        "name"          => "homebrew/foo",
+        "user"          => "Homebrew",
+        "repo"          => "foo",
+        "repository"    => "foo",
+        "path"          => path.to_s,
+        "installed"     => true,
+        "official"      => true,
+        "trusted"       => true,
+        "formula_names" => ["homebrew/foo/foo"],
+        "cask_tokens"   => [],
+        "formula_files" => [formula_file.to_s],
+        "cask_files"    => [],
+        "command_files" => [cmd_file.to_s],
+        "remote"        => "https://github.com/Homebrew/homebrew-foo",
+        "custom_remote" => false,
+        "private"       => false,
+        "HEAD"          => "abc123",
+        "last_commit"   => "1 day ago",
+        "branch"        => "main",
+      },
+    )
     expect(homebrew_foo_tap).to have_formula_file("Formula/foo.rb")
     expect(homebrew_foo_tap).not_to have_formula_file("bar.rb")
     expect(homebrew_foo_tap).not_to have_formula_file("Formula/baz.sh")

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -102,7 +102,7 @@ module Homebrew
       false
     end
 
-    sig { params(tap: T.untyped).returns(T::Boolean) }
+    sig { params(tap: Tap).returns(T::Boolean) }
     def self.trusted_tap?(tap)
       tap.implicitly_trusted? || trusted_entries(:tap).any? { |reference| tap.matches_reference?(reference) }
     end


### PR DESCRIPTION
This is useful for programatically determining which taps are trusted, since I don't think `trust.json` counts as public API?

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
