### PR TITLE
Fix brew tests tap trust config home

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /Library/Homebrew/prof
 /Library/Homebrew/test/.gem
 /Library/Homebrew/test/.cargo/
+/Library/Homebrew/test/.homebrew/
 /Library/Homebrew/test/.subversion
 /Library/Homebrew/test/coverage
 /Library/Homebrew/test/junit

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -344,6 +344,8 @@ module Homebrew
         # Avoid local configuration messing with tests, e.g. git being configured
         # to use GPG to sign by default
         ENV["HOME"] = "#{HOMEBREW_LIBRARY_PATH}/test"
+        # Sandbox the config home too, so the spec teardown can't delete the real `trust.json`.
+        ENV["HOMEBREW_USER_CONFIG_HOME"] = "#{Dir.home}/.homebrew"
 
         # Print verbose output when requesting debug or verbose output.
         ENV["HOMEBREW_VERBOSE_TESTS"] = "1" if args.debug? || args.verbose?

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -354,13 +354,22 @@ RSpec.configure do |config|
       Tap.all.each(&:clear_cache)
       Cachable::Registry.clear_all_caches
 
+      # Refuse to clean a config home outside the sandboxed `HOME`, else this deletes the user's
+      # real `~/.homebrew/trust.json`; canonicalise first so `..`/symlinks can't slip past.
+      home = Pathname(Dir.home).realpath
+      user_config_home = Pathname(ENV.fetch("HOMEBREW_USER_CONFIG_HOME")).expand_path
+      resolved_ancestor = user_config_home.ascend.find(&:exist?)&.realpath
+      unless resolved_ancestor&.ascend&.include?(home)
+        raise "HOMEBREW_USER_CONFIG_HOME (#{user_config_home}) is not sandboxed under HOME (#{Dir.home})"
+      end
+
       FileUtils.rm_rf [
         *TEST_DIRECTORIES,
         *Keg.must_exist_subdirectories,
         HOMEBREW_LINKED_KEGS,
         HOMEBREW_PINNED_KEGS,
         HOMEBREW_PINNED_CASKS,
-        Pathname(ENV.fetch("HOMEBREW_USER_CONFIG_HOME"))/"trust.json",
+        user_config_home/"trust.json",
         HOMEBREW_PREFIX/"Caskroom",
         HOMEBREW_PREFIX/"Frameworks",
         HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-cask",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

Claude Code helped diagnose the root cause and write the fix. Verified locally with a red/green check (a test run deletes the real `trust.json` before this change and preserves it after), `brew style` and `brew typecheck`, and the `trust`, `cmd/trust`, `cmd/untrust`, `cask/list`, `bundle/brewfile` and `formulary` specs. I did not run the full `brew lgtm` suite locally; CI covers it.

-----

`brew tests` reassigns `HOME` to a sandbox but leaves `HOMEBREW_USER_CONFIG_HOME` set to the value `bin/brew` derived from the real `HOME` at startup. The spec teardown in `spec_helper.rb` removes `$HOMEBREW_USER_CONFIG_HOME/trust.json`, so every local test run silently deleted the user's real `~/.homebrew/trust.json` — the same footgun `test_bot.rb` already works around. This re-points the config home at the sandboxed `HOME` as `test_bot.rb` does, and additionally refuses to clean a `trust.json` that isn't sandboxed under `HOME`, so a runner that forgets fails loudly instead of deleting real user data.
