### PR TITLE
Consolidate tap remote normalisation logic

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -147,7 +147,18 @@ class Tap
   # (including self-hosted GitLab and GitHub Enterprise) where `repo.git` and `repo` may differ.
   NORMALIZE_REMOTE_HOSTS = %w[github.com gitlab.com].freeze
 
-  # On GitHub the scheme and userinfo are insignificant (any of HTTPS, SSH SCP syntax, `ssh://`, or
+  # An optional RFC 3986-ish `scheme://` (e.g. `https://`, `ssh://` or `git+https://`) followed by
+  # optional `user@` userinfo: the part of a remote URL that can precede the host.
+  REMOTE_SCHEME_USERINFO_REGEX = %r{(?:[a-z][a-z0-9+.-]*://)?(?:[^@/]+@)?}
+  # The leading `<scheme>://<user>@github.com/` of a GitHub URL or the SCP-style `<user>@github.com:`
+  # shorthand. The `:` form is only SCP syntax when there is no scheme; with a scheme a `:` starts a
+  # port rather than the path, so it must not be rewritten.
+  GITHUB_REMOTE_PREFIX_REGEX =
+    %r{\A(?:[a-z][a-z0-9+.-]*://(?:[^@/]+@)?github\.com/|(?:[^@/]+@)?github\.com:)}
+  # The host of a remote: the first `/`- or `:`-delimited segment after any scheme and userinfo.
+  REMOTE_HOST_REGEX = %r{\A#{REMOTE_SCHEME_USERINFO_REGEX.source}([^/:]+)}
+
+  # On GitHub the scheme and userinfo are insignificant (any of HTTPS, SSH SCP syntax, `ssh://` or
   # `git://` identify the same repository), so those forms are canonicalised to HTTPS. For hosts in
   # {NORMALIZE_REMOTE_HOSTS} a `.git` suffix and trailing slashes are also insignificant, so we
   # strip them; we don't assume that for other hosts.
@@ -159,14 +170,10 @@ class Tap
 
     # Canonicalise every GitHub remote form to `https://github.com/<owner>/<repo>` so SSH and
     # HTTPS remotes for the same repository compare equal.
-    remote = remote
-             # scheme URLs, e.g. `https://`, `ssh://git@`, `git://`
-             .sub(%r{\A(?:https?|ssh|git)://(?:[^@/]+@)?github\.com/}, "https://github.com/")
-             # SCP-style SSH shorthand, e.g. `git@github.com:`
-             .sub(%r{\A(?:[^@/]+@)?github\.com:}, "https://github.com/")
+    remote = remote.sub(GITHUB_REMOTE_PREFIX_REGEX, "https://github.com/")
 
     # Only strip `.git`/trailing slashes for hosts where this is known to be safe.
-    host = remote[%r{\A(?:[^@/]+://)?(?:[^@/]+@)?([^/:]+)}, 1]
+    host = remote[REMOTE_HOST_REGEX, 1]
     return remote unless NORMALIZE_REMOTE_HOSTS.include?(host)
 
     remote.sub(%r{/+\z}, "").delete_suffix(".git")
@@ -184,12 +191,15 @@ class Tap
     match = normalised.match(HOMEBREW_TAP_REPOSITORY_REGEX)
     return normalised unless match
 
-    remote_repo = T.must(match[:remote_repository])
-    user, full_repo = remote_repo.split("/", 2)
-    return normalised if user.nil? || full_repo.nil?
+    remote_repository = match[:remote_repository]
+    return normalised unless remote_repository
 
-    tap = fetch(user, full_repo)
-    same_remote?(normalised, tap.default_remote) ? tap.name : normalised
+    tap = fetch(remote_repository)
+    if same_remote?(normalised, tap.default_remote)
+      tap.name
+    else
+      normalised
+    end
   rescue InvalidNameError
     normalised
   end

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -172,6 +172,13 @@ RSpec.describe Tap do
     end
   end
 
+  describe "::normalize_remote" do
+    it "keeps an explicit port on a GitHub remote rather than turning it into a path" do
+      expect(described_class.normalize_remote("https://github.com:443/Homebrew/homebrew-core"))
+        .to eq("https://github.com:443/homebrew/homebrew-core")
+    end
+  end
+
   describe "::same_remote?" do
     it "ignores a GitHub `.git` suffix, trailing slash and case" do
       expect(described_class.same_remote?("https://github.com/Homebrew/homebrew-core.git/",


### PR DESCRIPTION
- combine the two GitHub canonicalisation `sub` calls into one, matching any RFC 3986-ish scheme so forms like `git+https://` are recognised too
- extract the long remote regexes into named constants for readability and to share the scheme/userinfo fragment
- drop `T.must` and the manual `user/repository` split in `remote_to_reference` by reusing the existing `fetch` helper

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 high with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----