### PR TITLE
Trust qualified tap items before install

### DIFF
--- a/Library/Homebrew/description_cache_store.rb
+++ b/Library/Homebrew/description_cache_store.rb
@@ -80,7 +80,7 @@ class DescriptionCacheStore < CacheStore
 
     formula_names.each do |name|
       update!(name, Formula[name].desc)
-    rescue FormulaUnavailableError, *FormulaVersions::IGNORED_EXCEPTIONS
+    rescue FormulaUnavailableError, Homebrew::UntrustedTapError, *FormulaVersions::IGNORED_EXCEPTIONS
       delete!(name)
     end
   end

--- a/Library/Homebrew/test/description_cache_store_spec.rb
+++ b/Library/Homebrew/test/description_cache_store_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe DescriptionCacheStore do
       expect(database).to receive(:set).with(f.name, f.desc)
       cache_store.update_from_formula_names!([f.name])
     end
+
+    it "deletes untrusted formulae descriptions" do
+      expect(Formulary).to receive(:factory).with(formula_name).and_raise(Homebrew::UntrustedTapError)
+      expect(database).to receive(:empty?).and_return(false)
+      expect(database).to receive(:delete).with(formula_name)
+
+      cache_store.update_from_formula_names!([formula_name])
+    end
   end
 
   describe "#delete_from_formula_names!" do

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -165,7 +165,12 @@ RSpec.describe Homebrew::Trust do
     (tap.formula_dir/"bar.rb").write("class Bar < Formula; end\n")
     (tap.cask_dir/"baz.rb").write("cask 'baz'\n")
 
-    described_class.trust_fully_qualified_items!(["qualified/foo/bar", "qualified/foo/baz"])
+    without_partial_double_verification do
+      expect($stderr).to receive(:ohai).with("Trusted formula qualified/foo/bar").ordered
+      expect($stderr).to receive(:ohai).with("Trusted cask qualified/foo/baz").ordered
+
+      described_class.trust_fully_qualified_items!(["qualified/foo/bar", "qualified/foo/baz"])
+    end
 
     expect(described_class.trusted?(:formula, "qualified/foo/bar")).to be(true)
     expect(described_class.trusted?(:cask, "qualified/foo/baz")).to be(true)

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -77,7 +77,10 @@ module Homebrew
         else
           []
         end
-        types.each { |item_type| trust!(item_type, "#{tap.name}/#{item_name}") }
+        types.each do |item_type|
+          full_name = "#{tap.name}/#{item_name}"
+          $stderr.ohai "Trusted #{item_type} #{full_name}" if trust!(item_type, full_name)
+        end
       rescue Tap::InvalidNameError
         nil
       end


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22618

- Keep tap description cache updates from failing on unrelated untrusted formulae during an automatic tap.
- Announce implicit trust when a fully-qualified tap item is named.
- Cover untrusted cache entries and qualified-item trust output.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review, editing and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
