### PR TITLE
Defer HOMEBREW_ env secrets to download time

### DIFF
--- a/Library/Homebrew/download_strategy/curl_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/curl_download_strategy.rb
@@ -74,8 +74,15 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
         end
         @last_modified = last_modified
 
-        # Authorization is no longer valid after redirects
-        meta[:headers]&.delete_if { |header| header.start_with?("Authorization") } if is_redirection
+        # Caller-supplied headers (e.g. tokens) are no longer valid after a
+        # redirect to another host, and `Authorization` after any redirect.
+        if is_redirection
+          if resolved_url && URI(url).host != URI(resolved_url).host
+            meta.delete(:headers)
+          else
+            meta[:headers]&.delete_if { |header| header.start_with?("Authorization") }
+          end
+        end
 
         # The cached location is no longer fresh if either:
         # - Last-Modified value is newer than the file's timestamp
@@ -266,7 +273,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     args += ["--user", meta.fetch(:user)] if meta.key?(:user)
 
-    args += meta.fetch(:headers, []).flat_map { |h| ["--header", h.strip] }
+    args += meta.fetch(:headers, []).flat_map { |h| ["--header", ENV.expand_deferred_environment(h).strip] }
 
     args
   end

--- a/Library/Homebrew/extend/ENV/sensitive.rb
+++ b/Library/Homebrew/extend/ENV/sensitive.rb
@@ -8,6 +8,14 @@ module EnvSensitive
 
   requires_ancestor { Sorbet::Private::Static::ENVClass }
 
+  # `bin/brew` re-execs with only `HOMEBREW_*` variables (plus a fixed
+  # non-secret allowlist) in the environment, so every secret reaching
+  # formula/cask evaluation is `HOMEBREW_*`. These markers wrap a deferred
+  # secret name interpolated into the DSL in place of the real value; the real
+  # value is swapped back in at download time by `expand_deferred_environment`.
+  DEFERRED_PLACEHOLDER_PREFIX = "{{HOMEBREW_DEFERRED_ENV:"
+  DEFERRED_PLACEHOLDER_SUFFIX = "}}"
+
   sig { params(key: T.any(String, Symbol)).returns(T::Boolean) }
   def sensitive?(key)
     key.match?(/(cookie|key|token|password|passphrase|auth)/i)
@@ -18,16 +26,31 @@ module EnvSensitive
     select { |key, _| sensitive?(key) }
   end
 
-  sig { params(except: T::Array[String], block: T.nilable(T.proc.returns(T.untyped))).returns(T.untyped) }
-  def clear_sensitive_environment!(except: [], &block)
+  sig {
+    params(
+      except: T::Array[String],
+      defer:  T::Boolean,
+      block:  T.nilable(T.proc.returns(T.untyped)),
+    ).returns(T.untyped)
+  }
+  def clear_sensitive_environment!(except: [], defer: false, &block)
     unless block
-      each_key { |key| delete key if sensitive?(key) && except.exclude?(key) }
+      each_key do |key|
+        next unless sensitive?(key)
+        next if except.include?(key)
+
+        if defer
+          self[key] = "#{DEFERRED_PLACEHOLDER_PREFIX}#{key}#{DEFERRED_PLACEHOLDER_SUFFIX}"
+        else
+          delete key
+        end
+      end
       return
     end
 
     old_env = to_hash.dup
     begin
-      clear_sensitive_environment!(except:)
+      clear_sensitive_environment!(except:, defer:)
       yield
     ensure
       replace(old_env)
@@ -36,7 +59,22 @@ module EnvSensitive
 
   sig { params(block: T.proc.returns(T.untyped)).returns(T.untyped) }
   def clear_sensitive_environment_for_eval!(&block)
-    clear_sensitive_environment!(except: ["HOMEBREW_GITHUB_API_TOKEN"], &block)
+    clear_sensitive_environment!(except: ["HOMEBREW_GITHUB_API_TOKEN"], defer: true, &block)
+  end
+
+  # Only the download path (a URL's `header:`/specs) calls this, so a masked
+  # secret is resolved to its real value solely when fetching, never elsewhere
+  # in the DSL.
+  sig { params(value: String).returns(String) }
+  def expand_deferred_environment(value)
+    return value unless value.include?(DEFERRED_PLACEHOLDER_PREFIX)
+
+    prefix = Regexp.escape(DEFERRED_PLACEHOLDER_PREFIX)
+    suffix = Regexp.escape(DEFERRED_PLACEHOLDER_SUFFIX)
+    value.gsub(/#{prefix}(HOMEBREW_\w+)#{suffix}/) do
+      name = Regexp.last_match(1)
+      name ? fetch(name, "") : ""
+    end
   end
 end
 

--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -186,6 +186,43 @@ RSpec.describe "ENV" do
         expect(subject).not_to include("OTHER_TOKEN")
       end
     end
+
+    describe "#clear_sensitive_environment_for_eval!" do
+      it "defers HOMEBREW_ secrets to a placeholder that expands to the real value" do
+        subject["HOMEBREW_PRIVATE_TOKEN"] = "glpat-secret"
+
+        deferred = subject.clear_sensitive_environment_for_eval! { subject["HOMEBREW_PRIVATE_TOKEN"] }
+
+        expect(deferred).not_to eq("glpat-secret")
+        expect(deferred).not_to be_empty
+        expect(subject.expand_deferred_environment("PRIVATE-TOKEN: #{deferred}")).to eq("PRIVATE-TOKEN: glpat-secret")
+      end
+
+      it "never expands a non-HOMEBREW_ secret back to its real value" do
+        subject["SECRET_TOKEN"] = "password"
+        deferred = subject.clear_sensitive_environment_for_eval! { subject["SECRET_TOKEN"] }
+        expect(subject.expand_deferred_environment("X: #{deferred}")).not_to include("password")
+      end
+
+      it "keeps HOMEBREW_GITHUB_API_TOKEN readable during eval" do
+        subject["HOMEBREW_GITHUB_API_TOKEN"] = "gh-token"
+        expect(subject.clear_sensitive_environment_for_eval! do
+          subject["HOMEBREW_GITHUB_API_TOKEN"]
+        end).to eq("gh-token")
+      end
+
+      it "restores the environment after yielding" do
+        subject["HOMEBREW_PRIVATE_TOKEN"] = "glpat-secret"
+        subject.clear_sensitive_environment_for_eval! { nil }
+        expect(subject["HOMEBREW_PRIVATE_TOKEN"]).to eq("glpat-secret")
+      end
+    end
+
+    describe "#expand_deferred_environment" do
+      it "leaves values without a deferred placeholder unchanged" do
+        expect(subject.expand_deferred_environment("PRIVATE-TOKEN: plain")).to eq("PRIVATE-TOKEN: plain")
+      end
+    end
   end
 
   describe Stdenv do

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe Cask::CaskLoader, :cask do
   end
 
   describe "FromPathLoader" do
-    it "clears sensitive environment variables while evaluating casks" do
+    it "masks sensitive environment variables while evaluating casks" do
       cask_token = "sensitive-env"
       cask_file = mktmpdir/"#{cask_token}.rb"
       cask_file.write <<~RUBY
@@ -283,18 +283,18 @@ RSpec.describe Cask::CaskLoader, :cask do
 
           url "https://example.com/app.dmg"
           name "Sensitive Env"
-          desc ENV.key?("SECRET_TOKEN") ? "Secret present" : "Secret absent"
+          desc ENV.fetch("HOMEBREW_SECRET_TOKEN", "") == "password" ? "Secret leaked" : "Secret masked"
           homepage "https://example.com"
 
           app "App.app"
         end
       RUBY
 
-      with_env(SECRET_TOKEN: "password") do
+      with_env(HOMEBREW_SECRET_TOKEN: "password") do
         cask = Cask::CaskLoader::FromPathLoader.new(cask_file).load(config: nil)
 
-        expect(cask.desc).to eq("Secret absent")
-        expect(ENV.fetch("SECRET_TOKEN", nil)).to eq("password")
+        expect(cask.desc).to eq("Secret masked")
+        expect(ENV.fetch("HOMEBREW_SECRET_TOKEN", nil)).to eq("password")
       end
     end
 

--- a/Library/Homebrew/test/download_strategies/curl_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_spec.rb
@@ -27,6 +27,20 @@ RSpec.describe CurlDownloadStrategy do
     expect(strategy.send(:_curl_args)).to eq(["--user", "download:123456"])
   end
 
+  context "with a deferred HOMEBREW_ secret in a header" do
+    let(:specs) { { headers: [header] } }
+    let(:header) do
+      ENV["HOMEBREW_PRIVATE_TOKEN"] = "glpat-secret"
+      ENV.clear_sensitive_environment_for_eval! { "PRIVATE-TOKEN: #{ENV.fetch("HOMEBREW_PRIVATE_TOKEN", nil)}" }
+    end
+
+    after { ENV.delete("HOMEBREW_PRIVATE_TOKEN") }
+
+    it "expands the placeholder to the real value at download time" do
+      expect(strategy.send(:_curl_args)).to include("PRIVATE-TOKEN: glpat-secret")
+    end
+  end
+
   describe "#fetch" do
     before do
       allow(Homebrew::EnvConfig).to receive(:artifact_domain).and_return(artifact_domain)
@@ -140,6 +154,24 @@ RSpec.describe CurlDownloadStrategy do
           )
           .at_least(:once)
           .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "", assert_success!: nil))
+
+        strategy.fetch
+      end
+    end
+
+    context "when a redirect crosses to another host" do
+      let(:specs) { { headers: ["PRIVATE-TOKEN: glpat-secret"] } }
+
+      before do
+        allow(strategy).to receive(:resolve_url_basename_time_file_size)
+          .and_return(["https://other.example.org/foo.tar.gz", "foo.tar.gz", nil, 0, nil, true])
+      end
+
+      it "does not forward caller-supplied headers to the new host" do
+        expect(strategy).to receive(:system_command) do |_command, options|
+          expect(options[:args]).not_to include("PRIVATE-TOKEN: glpat-secret")
+          instance_double(SystemCommand::Result, success?: true, stdout: "", assert_success!: nil)
+        end.at_least(:once)
 
         strategy.fetch
       end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -56,14 +56,14 @@ RSpec.describe Formulary do
   end
 
   describe "::load_formula" do
-    it "clears sensitive environment variables while evaluating formulae" do
-      with_env(SECRET_TOKEN: "password") do
+    it "masks sensitive environment variables while evaluating formulae" do
+      with_env(HOMEBREW_SECRET_TOKEN: "password") do
         formula_class = described_class.load_formula(
           "sensitive-env",
           mktmpdir/"sensitive-env.rb",
           <<~RUBY,
             class SensitiveEnv < Formula
-              SECRET_TOKEN_PRESENT = ENV.key?("SECRET_TOKEN")
+              SECRET_TOKEN_VALUE = ENV.fetch("HOMEBREW_SECRET_TOKEN", nil)
               url "https://brew.sh/sensitive-env-1.0.tar.gz"
             end
           RUBY
@@ -72,8 +72,8 @@ RSpec.describe Formulary do
           ignore_errors: false,
         )
 
-        expect(formula_class::SECRET_TOKEN_PRESENT).to be(false)
-        expect(ENV.fetch("SECRET_TOKEN", nil)).to eq("password")
+        expect(formula_class::SECRET_TOKEN_VALUE).not_to eq("password")
+        expect(ENV.fetch("HOMEBREW_SECRET_TOKEN", nil)).to eq("password")
       end
     end
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22619

- Mask sensitive `HOMEBREW_*` environment variables with an opaque placeholder while a formula/cask is evaluated, then swap the real value back in only when curl fetches a URL.
- Evaluating a formula/cask scrubs token-like environment variables so untrusted top-level DSL cannot read and exfiltrate them. That same scrubbing broke the legitimate pattern of authenticating a private download, e.g. a `PRIVATE-TOKEN` header interpolating `#{ENV["HOMEBREW_PRIVATE_TOKEN"]}`, which silently resolved to an empty token and failed.
- `HOMEBREW_NO_EVAL_ENV_SCRUBBING` was the only workaround and is now deprecated, leaving private taps with no supported path.
- The header string is interpolated eagerly at eval time, which is exactly when secrets are hidden, so the empty value was baked in long before the download ran. Masking keeps a resolvable marker through eval; resolution happens later, at fetch time, once the real environment is restored.
- `bin/brew` already re-execs with only `HOMEBREW_*` (plus a fixed non-secret allowlist) in the environment, so every secret that can reach evaluation is `HOMEBREW_*`. Each is masked to a placeholder rather than deleted, so interpolation captures the marker, not an empty string, and the DSL still cannot read the real value.
- `expand_deferred_environment` runs in `_curl_args` only, so the real value is restored solely on the download path and never for other stanzas such as `desc`. It is restricted to `HOMEBREW_` names, so a non-`HOMEBREW_` secret can never be resolved.
- `HOMEBREW_GITHUB_API_TOKEN` is still read through unchanged.
- Caller-supplied headers are now dropped across a cross-host redirect (previously only `Authorization`), so a resolved token cannot leak to a redirect target such as object storage.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 with local review, testing, tweaking and editing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
