### PR TITLE
cmd/trust: add `--json=v1` flag

### DIFF
--- a/Library/Homebrew/cmd/trust.rb
+++ b/Library/Homebrew/cmd/trust.rb
@@ -2,11 +2,14 @@
 # frozen_string_literal: true
 
 require "abstract_command"
+require "json"
 require "trust"
 
 module Homebrew
   module Cmd
     class Trust < AbstractCommand
+      VALID_TYPES = [:tap, :formula, :cask, :command].freeze
+
       cmd_args do
         description <<~EOS
           Trust non-official tap formulae, casks or commands so Homebrew may load them when
@@ -22,6 +25,9 @@ module Homebrew
                description: "Trust the named cask."
         switch "--command", "--commands",
                description: "Trust the named external command."
+        flag "--json=",
+             description: "Print trusted entries as JSON. A <version> number is required. " \
+                          "The only accepted value for <version> is `v1`."
 
         conflicts "--tap", "--formula", "--cask", "--command"
 
@@ -30,21 +36,22 @@ module Homebrew
 
       sig { override.void }
       def run
+        if args.json
+          raise UsageError, "invalid JSON version: #{args.json}" if args.json != "v1"
+          raise UsageError, "`--json=v1` requires no named arguments." if args.named.present?
+
+          print_json
+          return
+        end
+
         if args.no_named?
           puts "All official taps and commands are trusted."
-          types = selected_type ? [selected_type] : [:tap, :formula, :cask, :command]
           printed = T.let(false, T::Boolean)
           types.each do |type|
             values = Homebrew::Trust.trusted_entries(type)
             next if values.empty?
 
-            label = case type
-            when :tap then "taps"
-            when :formula then "formulae"
-            when :cask then "casks"
-            when :command then "commands"
-            else raise "Unsupported trust type: #{type}"
-            end
+            label = Utils.pluralize(type.to_s, 2)
             puts "Trusted #{label}:"
             values.each { |value| puts "  #{value}" }
             printed = true
@@ -68,6 +75,31 @@ module Homebrew
       end
 
       private
+
+      sig { void }
+      def print_json
+        if (type = selected_type)
+          puts JSON.pretty_generate(Homebrew::Trust.trusted_entries(type))
+          return
+        end
+
+        json = T.let({}, T::Hash[String, T::Array[String]])
+
+        types.each do |type|
+          key = Utils.pluralize(type.to_s, 2)
+          json[key] = Homebrew::Trust.trusted_entries(type)
+        end
+
+        puts JSON.pretty_generate(json)
+      end
+
+      sig { returns(T::Array[Symbol]) }
+      def types
+        type = selected_type
+        return [type] if type
+
+        VALID_TYPES
+      end
 
       sig { returns(T.nilable(Symbol)) }
       def selected_type

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/trust.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/trust.rbi
@@ -29,6 +29,9 @@ class Homebrew::Cmd::Trust::Args < Homebrew::CLI::Args
   sig { returns(T::Boolean) }
   def formulae?; end
 
+  sig { returns(T.nilable(String)) }
+  def json; end
+
   sig { returns(T::Boolean) }
   def tap?; end
 end

--- a/Library/Homebrew/sorbet/rbi/dsl/r_spec/matchers.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/r_spec/matchers.rbi
@@ -397,6 +397,9 @@ module RSpec::Matchers
   def have_valid_bash_syntax(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def match_json(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def miss_apply(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }

--- a/Library/Homebrew/test/cmd/trust_spec.rb
+++ b/Library/Homebrew/test/cmd/trust_spec.rb
@@ -6,6 +6,15 @@ require "cmd/trust"
 require "trust"
 
 RSpec.describe Homebrew::Cmd::Trust do
+  RSpec::Matchers.define :match_json do |expected|
+    T.bind(self, T.class_of(RSpec::Matchers::DSL::Matcher))
+    match do |actual|
+      JSON.parse(actual) == expected
+    rescue JSON::ParserError
+      false
+    end
+  end
+
   it_behaves_like "parseable arguments"
 
   it "notes official taps are always trusted", :integration_test do
@@ -88,5 +97,41 @@ RSpec.describe Homebrew::Cmd::Trust do
         Trusted formulae:
           thirdparty/foo/bar
       EOS
+  end
+
+  it "lists trusted entries as json with no arguments" do
+    allow(Homebrew::Trust).to receive(:trusted_entries).with(:tap).and_return(["thirdparty/foo"])
+    allow(Homebrew::Trust).to receive(:trusted_entries).with(:formula).and_return(["thirdparty/foo/bar"])
+    allow(Homebrew::Trust).to receive(:trusted_entries).with(:cask).and_return([])
+    allow(Homebrew::Trust).to receive(:trusted_entries).with(:command).and_return([])
+
+    expect { described_class.new(["--json=v1"]).run }
+      .to output(
+        match_json(
+          {
+            "taps"     => ["thirdparty/foo"],
+            "formulae" => ["thirdparty/foo/bar"],
+            "casks"    => [],
+            "commands" => [],
+          },
+        ),
+      ).to_stdout
+  end
+
+  it "lists trusted entries as a json array for a selected type" do
+    allow(Homebrew::Trust).to receive(:trusted_entries).with(:formula).and_return(["thirdparty/foo/bar"])
+
+    expect { described_class.new(["--json=v1", "--formula"]).run }
+      .to output(match_json(["thirdparty/foo/bar"])).to_stdout
+  end
+
+  it "rejects json output with named arguments" do
+    expect { described_class.new(["--json=v1", "thirdparty/foo"]).run }
+      .to raise_error(UsageError, /requires no named arguments/)
+  end
+
+  it "rejects json without an explicit version" do
+    expect { described_class.new(["--json"]).run }
+      .to raise_error(OptionParser::MissingArgument, /--json/)
   end
 end

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -2997,6 +2997,7 @@ _brew_trust() {
       --debug
       --formula
       --help
+      --json
       --quiet
       --tap
       --verbose

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1908,6 +1908,7 @@ __fish_brew_complete_arg 'trust' -l command -d 'Trust the named external command
 __fish_brew_complete_arg 'trust' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'trust' -l formula -d 'Trust the named formula'
 __fish_brew_complete_arg 'trust' -l help -d 'Show this message'
+__fish_brew_complete_arg 'trust' -l json -d 'Print trusted entries as JSON. A version number is required. The only accepted value for version is `v1`'
 __fish_brew_complete_arg 'trust' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'trust' -l tap -d 'Trust the named tap'
 __fish_brew_complete_arg 'trust' -l verbose -d 'Make some output more verbose'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -2447,6 +2447,7 @@ _brew_trust() {
     '--debug[Display any debugging information]' \
     '(--tap --cask --command)--formula[Trust the named formula]' \
     '--help[Show this message]' \
+    '--json[Print trusted entries as JSON. A version number is required. The only accepted value for version is `v1`]' \
     '--quiet[Make some output more quiet]' \
     '(--formula --cask --command)--tap[Trust the named tap]' \
     '--verbose[Make some output more verbose]'

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2195,6 +2195,11 @@ when `$HOMEBREW_REQUIRE_TAP_TRUST` is set. Trusted entries are stored in
 
 : Trust the named external command.
 
+`--json`
+
+: Print trusted entries as JSON. A *`version`* number is required. The only
+  accepted value for *`version`* is `v1`.
+
 ### `unalias` *`alias`* \[...\]
 
 Remove aliases.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1384,6 +1384,9 @@ Trust the named cask\.
 .TP
 \fB\-\-command\fP
 Trust the named external command\.
+.TP
+\fB\-\-json\fP
+Print trusted entries as JSON\. A \fIversion\fP number is required\. The only accepted value for \fIversion\fP is \fBv1\fP\&\.
 .SS "\fBunalias\fP \fIalias\fP \fR[\.\.\.]"
 Remove aliases\.
 .SS "\fBuninstall\fP, \fBremove\fP, \fBrm\fP \fR[\fIoptions\fP] \fIinstalled_formula\fP|\fIinstalled_cask\fP \fR[\.\.\.]"


### PR DESCRIPTION
`brew trust` prints everything that is trusted but this isn't really machine parsable. This flag provides a way to do that (given the underlying `trust.json` is private API).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

For tests only. Verified by running the tests and human code review.

-----
