### PR TITLE
Mark custom-remote taps trusted in bundle dump

### DIFF
--- a/Library/Homebrew/bundle/tap.rb
+++ b/Library/Homebrew/bundle/tap.rb
@@ -82,7 +82,6 @@ module Homebrew
 
         sig { override.returns(String) }
         def dump
-          trusted_taps = Homebrew::Trust.trusted_entries(:tap)
           taps.map do |tap|
             remote = if tap.custom_remote? && (tap_remote = tap.remote)
               if (api_token = ENV.fetch("HOMEBREW_GITHUB_API_TOKEN", false).presence)
@@ -93,7 +92,7 @@ module Homebrew
               ", \"#{tap_remote}\""
             end
             tapline = "tap \"#{tap.name}\"#{remote}"
-            tapline += ", trusted: true" if trusted_taps.include?(tap.name)
+            tapline += ", trusted: true" if Homebrew::Trust.explicitly_trusted_tap?(tap)
             tapline
           end.sort.uniq.join("\n")
         end

--- a/Library/Homebrew/test/bundle/tap_spec.rb
+++ b/Library/Homebrew/test/bundle/tap_spec.rb
@@ -27,13 +27,17 @@ RSpec.describe Homebrew::Bundle::Tap do
 
         bar = instance_double(Tap, name: "bitbucket/bar", custom_remote?: true,
                               remote: "https://bitbucket.org/bitbucket/bar.git")
-        baz = instance_double(Tap, name: "homebrew/baz", custom_remote?: false)
-        foo = instance_double(Tap, name: "homebrew/foo", custom_remote?: false)
+        baz = instance_double(Tap, name: "homebrew/baz", custom_remote?: false, remote: nil)
+        foo = instance_double(Tap, name: "homebrew/foo", custom_remote?: false, remote: nil)
 
         ENV["HOMEBREW_GITHUB_API_TOKEN_BEFORE"] = ENV.fetch("HOMEBREW_GITHUB_API_TOKEN", nil)
         ENV["HOMEBREW_GITHUB_API_TOKEN"] = "some-token"
         private_tap = instance_double(Tap, name: "privatebrew/private", custom_remote?: true,
           remote: "https://#{ENV.fetch("HOMEBREW_GITHUB_API_TOKEN")}@github.com/privatebrew/homebrew-private")
+
+        [bar, baz, foo, private_tap].each do |tap|
+          allow(tap).to receive(:matches_reference?) { |reference| reference == tap.remote }
+        end
 
         allow(Tap).to receive(:select).and_return [bar, baz, foo, private_tap]
       end
@@ -58,7 +62,8 @@ RSpec.describe Homebrew::Bundle::Tap do
       end
 
       it "dumps trusted taps with trusted true" do
-        allow(Homebrew::Trust).to receive(:trusted_entries).with(:tap).and_return(["bitbucket/bar"])
+        allow(Homebrew::Trust).to receive(:trusted_entries).with(:tap)
+                                                           .and_return(["https://bitbucket.org/bitbucket/bar.git"])
 
         expect(dumper.dump).to include(
           "tap \"bitbucket/bar\", \"https://bitbucket.org/bitbucket/bar.git\", trusted: true",

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -104,7 +104,14 @@ module Homebrew
 
     sig { params(tap: T.untyped).returns(T::Boolean) }
     def self.trusted_tap?(tap)
-      tap.implicitly_trusted? || trusted_entries(:tap).any? { |reference| tap.matches_reference?(reference) }
+      tap.implicitly_trusted? || explicitly_trusted_tap?(tap)
+    end
+
+    # Whether the tap appears in the trust list, ignoring any implicit official-tap trust. The
+    # entries may be `user/repository` names or remote URLs, so match via {Tap#matches_reference?}.
+    sig { params(tap: T.untyped).returns(T::Boolean) }
+    def self.explicitly_trusted_tap?(tap)
+      trusted_entries(:tap).any? { |reference| tap.matches_reference?(reference) }
     end
 
     sig { params(name: String, path: Pathname).void }


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22622

- `brew bundle dump` only added `trusted: true` when a tap's `name` was in the trust list, but custom-remote (non-GitHub) taps are stored by their remote URL, so private taps were never recorded as trusted even when `brew trust` listed them.
- match trust entries with `Tap#matches_reference?` instead, reusing the consolidated remote normalisation so URL and name references both resolve.
- extract `Trust.explicitly_trusted_tap?`, shared with `trusted_tap?`, to keep the matching in one place and avoid annotating implicitly trusted official taps.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 with local review, tweaking and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
