### PR TITLE
description_cache_store/cask: require formula_versions

### DIFF
--- a/Library/Homebrew/description_cache_store/cask_description_cache_store.rb
+++ b/Library/Homebrew/description_cache_store/cask_description_cache_store.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "formula_versions"
+
 #
 # {CaskDescriptionCacheStore} provides methods to fetch and mutate cask descriptions used
 # by the `brew desc` and `brew search` commands.


### PR DESCRIPTION
Follow-up to #22610 (merged), which added `require "formula_versions"` to `description_cache_store.rb`.

Its sibling, `description_cache_store/cask_description_cache_store.rb`, makes the **same** reference —

```ruby
rescue Cask::CaskUnavailableError, *FormulaVersions::IGNORED_EXCEPTIONS
```

— but has no `require "formula_versions"` of its own. Today it resolves only because `description_cache_store.rb` does `require "formula_versions"` *before* `require "description_cache_store/cask_description_cache_store"`, so the constant happens to already be loaded. That's the identical latent bug #22610 fixed, still present here and masked purely by require **ordering**: if the parent's requires were ever reordered (or this file reached by another path), the same lazily-evaluated `rescue` would raise `uninitialized constant FormulaVersions` and abort the command.

This declares the dependency explicitly so it no longer depends on load order. One line, no behaviour change.

(Note: full self-containment isn't possible here — the class subclasses `DescriptionCacheStore`, so requiring the parent would be circular — but the `FormulaVersions` dependency can and should be declared, matching #22610.)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Diagnosed and written with AI assistance (Claude / Claude Code). **What/why:** mirrors the merged #22610 fix for the sibling cache store, which references `FormulaVersions::IGNORED_EXCEPTIONS` without requiring `formula_versions` and currently relies on the parent file's require ordering. **How verified:** confirmed the file makes the reference and has no `require "formula_versions"`; confirmed `require "formula_versions"` is the exact form used in the parent and elsewhere in `Library/Homebrew`; placed it after the magic comments per convention. I did **not** run `brew lgtm` locally (those boxes left unticked) — relying on CI.

-----
