### PR TITLE
Loosen issue/PR template completeness checks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -14,7 +14,7 @@ body:
   - type: checkboxes
     attributes:
       label: Verification
-      description: Please verify that you've followed these steps. If you cannot truthfully check these boxes, open a discussion at https://github.com/orgs/Homebrew/discussions instead.
+      description: Please verify that you've followed these steps. If you cannot truthfully check these boxes, open a discussion at https://github.com/orgs/Homebrew/discussions instead. Do not delete these checkboxes or your issue will be closed automatically.
       options:
         - label: I ran `brew update` twice and am still able to reproduce my issue.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -8,7 +8,7 @@ body:
   - type: checkboxes
     attributes:
       label: Verification
-      description: Please verify that you've followed these steps.
+      description: Please verify that you've followed these steps. Do not delete these checkboxes or your issue will be closed automatically.
       options:
         - label: This issue's title and/or description do not reference a single formula e.g. `brew install wget`. If they do, open an issue at https://github.com/Homebrew/homebrew-core/issues/new/choose instead.
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@
 
 <!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
 <!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
+<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->
 
 - [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
 - [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?

--- a/.github/scripts/check_template.rb
+++ b/.github/scripts/check_template.rb
@@ -2,12 +2,12 @@
 
 require "yaml"
 
+AI_MENTION = /\b(?:AI|LLM)\b/i
 CHECKBOX_MARKER = /\A- \[[ xX]\] /
-CHECKED_CHECKBOX_MARKER = /\A- \[[xX]\] /
 HTML_COMMENT_LINE = /\A<!--.*-->\z/
-ISSUE_FORM_HEADING = /\A### /
+ISSUE_FORM_HEADING_MARKER = "### "
+MARKDOWN_HEADING = /\A#+ /
 MARKDOWN_HORIZONTAL_LINE = /\A-+\z/
-NO_RESPONSE = "_No response_"
 NORMALISED_CHECKBOX_MARKER = "- [ ] "
 REQUIRED_TEMPLATE_PERCENTAGE = 75
 PERCENTAGE_SCALE = 100
@@ -31,57 +31,57 @@ end
 
 case ARGV.fetch(0)
 when "pull-request"
-  pr_body_path = ARGV.fetch(1)
-  template_path = ARGV.fetch(2)
-  pr_lines = normalised_lines.call(pr_body_path)
-  template_lines = normalised_lines.call(template_path)
-  matching_template_lines = template_lines.count { |line| pr_lines.include?(line) }
-  scaled_matching_percentage = matching_template_lines * PERCENTAGE_SCALE
-  scaled_required_percentage = template_lines.count * REQUIRED_TEMPLATE_PERCENTAGE
-  preserves_template = scaled_matching_percentage >= scaled_required_percentage
-  has_checked_checkbox = lines.call(pr_body_path).any? { |line| line.match?(CHECKED_CHECKBOX_MARKER) }
-  has_non_template_content = (pr_lines - template_lines).any?
+  # Pass when the body keeps at least REQUIRED_TEMPLATE_PERCENTAGE of the template's
+  # headings and checkboxes combined (ticked or not) and still discloses AI usage:
+  # either the template's AI disclosure checkbox (whose label mentions AI) or any
+  # mention of AI/LLM in the text. This blocks bodies that strip out the template
+  # (e.g. AI-generated pull requests) without caring whether boxes are ticked.
+  body_lines = lines.call(ARGV.fetch(1))
+  normalised_body = normalised_lines.call(ARGV.fetch(1))
+  template_items = normalised_lines.call(ARGV.fetch(2)).select do |line|
+    line.start_with?(NORMALISED_CHECKBOX_MARKER) || line.match?(MARKDOWN_HEADING)
+  end
+  present_count = template_items.count { |item| normalised_body.include?(item) }
+  preserves_template = present_count * PERCENTAGE_SCALE >= template_items.count * REQUIRED_TEMPLATE_PERCENTAGE
+  discloses_ai = body_lines.any? { |line| line.match?(AI_MENTION) }
 
-  puts preserves_template && (has_checked_checkbox || has_non_template_content)
+  puts preserves_template && discloses_ai
 when "issue"
-  issue_body = File.read(ARGV.fetch(1), mode: "rb")
-                   .encode("UTF-8", invalid: :replace, undef: :replace)
-  issue_lines = issue_body.lines(chomp: true)
-  issue_field_responses = {}
-  issue_lines.each do |line|
-    if line.match?(ISSUE_FORM_HEADING)
-      issue_field_responses[line.delete_prefix("### ").strip] = []
-    elsif issue_field_responses.any?
-      issue_field_responses.fetch(issue_field_responses.keys.last) << line
+  # Pass when the body keeps at least REQUIRED_TEMPLATE_PERCENTAGE of some template's
+  # headings and checkboxes combined (ticked or not). Counting headings as well as
+  # checkboxes lets the feature template (a single checkbox) be told apart from a
+  # stripped body. The missing items from the closest template are reported on stderr.
+  body_lines = lines.call(ARGV.fetch(1))
+
+  templates = Dir.glob("#{ARGV.fetch(2)}/*.{yml,yaml}").filter_map do |template_path|
+    fields = YAML.safe_load_file(template_path).fetch("body", [])
+    headings = fields.filter_map { |field| field.dig("attributes", "label") if field["type"] != "markdown" }
+    checkboxes = fields.flat_map do |field|
+      next [] if field["type"] != "checkboxes"
+
+      field.fetch("attributes", {}).fetch("options", []).map { |option| option.fetch("label") }
     end
+    items = headings.map { |label| [:heading, label] } + checkboxes.map { |label| [:checkbox, label] }
+    next if items.empty?
+
+    missing = items.reject { |_kind, label| body_lines.any? { |line| line.include?(label) } }
+    present_count = items.length - missing.length
+    { total: items.length, present_count: present_count, missing: missing }
   end
 
-  puts(Dir.glob("#{ARGV.fetch(2)}/*.{yml,yaml}").any? do |template_path|
-    required_fields = []
-    required_checkboxes = []
+  preserves_template = templates.any? do |template|
+    template[:present_count] * PERCENTAGE_SCALE >= template[:total] * REQUIRED_TEMPLATE_PERCENTAGE
+  end
 
-    YAML.safe_load_file(template_path).fetch("body", []).each do |field|
-      attributes = field.fetch("attributes", {})
-      case field["type"]
-      when "checkboxes"
-        attributes.fetch("options", []).each do |option|
-          required_checkboxes << option.fetch("label") if option["required"]
-        end
-      when "dropdown", "input", "textarea"
-        required_fields << attributes.fetch("label") if field.dig("validations", "required")
-      end
+  if preserves_template
+    puts true
+  else
+    puts false
+    closest_missing = templates.min_by { |template| template[:missing].length }&.fetch(:missing)
+    closest_missing&.each do |kind, label|
+      warn((kind == :checkbox) ? "- [ ] #{label}" : "- `#{ISSUE_FORM_HEADING_MARKER}#{label}` section")
     end
-    next false if required_fields.empty? && required_checkboxes.empty?
-
-    required_fields.all? do |field|
-      issue_field_responses.fetch(field, []).any? do |line|
-        !line.strip.empty? && line.strip != NO_RESPONSE
-      end
-    end &&
-      required_checkboxes.all? do |checkbox|
-        issue_lines.any? { |line| line.match?(CHECKED_CHECKBOX_MARKER) && line.include?(checkbox) }
-      end
-  end)
+  end
 else
   warn "Usage: check_template.rb pull-request BODY TEMPLATE"
   warn "       check_template.rb issue BODY TEMPLATE_DIRECTORY"

--- a/.github/workflows/check-issues.yml
+++ b/.github/workflows/check-issues.yml
@@ -4,6 +4,8 @@ on:
   issues:
     types:
       - opened
+      - edited
+      - reopened
 
 permissions: {}
 
@@ -31,6 +33,7 @@ jobs:
       issues: write
     env:
       GH_TOKEN: ${{ github.token }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
     steps:
       - name: Verify no checkout
         run: |
@@ -51,14 +54,20 @@ jobs:
 
       - name: Fetch issue templates
         run: |
-          gh api "repos/${GITHUB_REPOSITORY:?}/contents/.github/ISSUE_TEMPLATE?ref=main" \
-            --jq '.[] | select(.type == "file" and (.name | test("\\.ya?ml$")) and .name != "config.yml") | .path' |
-            while IFS= read -r template_path
-            do
-              gh api "repos/${GITHUB_REPOSITORY:?}/contents/${template_path}?ref=main" \
-                --jq ".content" |
-                base64 --decode >"${RUNNER_TEMP}/check-issues/templates/${template_path##*/}"
-            done
+          # Validate against the brew, homebrew-core and homebrew-cask templates so
+          # issues transferred between these repositories are not closed for using a
+          # sibling repository's (valid) template.
+          for repo in "${GITHUB_REPOSITORY:?}" Homebrew/homebrew-core Homebrew/homebrew-cask
+          do
+            gh api "repos/${repo}/contents/.github/ISSUE_TEMPLATE?ref=main" \
+              --jq '.[] | select(.type == "file" and (.name | test("\\.ya?ml$")) and .name != "config.yml") | .path' |
+              while IFS= read -r template_path
+              do
+                gh api "repos/${repo}/contents/${template_path}?ref=main" \
+                  --jq ".content" |
+                  base64 --decode >"${RUNNER_TEMP}/check-issues/templates/${repo//\//-}-${template_path##*/}"
+              done
+          done
 
       - name: Fetch template checker
         run: |
@@ -72,7 +81,8 @@ jobs:
           complete_template="$(
             ruby "${RUNNER_TEMP:?}/check_template.rb" issue \
               "${RUNNER_TEMP}/check-issues/body" \
-              "${RUNNER_TEMP}/check-issues/templates"
+              "${RUNNER_TEMP}/check-issues/templates" \
+              2>"${RUNNER_TEMP}/check-issues/missing-checkboxes"
           )"
           case "${complete_template}" in
             true | false) ;;
@@ -84,18 +94,69 @@ jobs:
 
           echo "complete_template=${complete_template}" >>"${GITHUB_OUTPUT:?}"
 
-      - name: Close incomplete issue
-        if: steps.template.outputs.complete_template == 'false'
+      - name: Find incomplete template comment
+        id: comments
+        if: >-
+          (github.event.issue.state == 'closed' &&
+          steps.template.outputs.complete_template == 'true') ||
+          (github.event.issue.state != 'closed' &&
+          steps.template.outputs.complete_template == 'false')
         run: |
-          gh api --method POST "repos/${GITHUB_REPOSITORY:?}/issues/${{ github.event.issue.number }}/comments" \
+          comment_ids="$(
+            gh api --paginate "repos/${GITHUB_REPOSITORY:?}/issues/${ISSUE_NUMBER:?}/comments" \
+              --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- incomplete-issue-template -->"))) | .id'
+          )"
+          if [[ -n "${comment_ids}" ]]
+          then
+            echo "has_incomplete_template_comment=true" >>"${GITHUB_OUTPUT:?}"
+          else
+            echo "has_incomplete_template_comment=false" >>"${GITHUB_OUTPUT:?}"
+          fi
+
+      - name: Find issue closer
+        id: closer
+        if: >-
+          github.event.issue.state == 'closed' &&
+          steps.template.outputs.complete_template == 'true'
+        run: |
+          closed_by="$(gh api "repos/${GITHUB_REPOSITORY:?}/issues/${ISSUE_NUMBER:?}" --jq ".closed_by.login // \"\"")"
+          echo "closed_by=${closed_by}" >>"${GITHUB_OUTPUT:?}"
+
+      - name: Reopen completed issue
+        if: >-
+          github.event.issue.state == 'closed' &&
+          steps.template.outputs.complete_template == 'true' &&
+          steps.closer.outputs.closed_by == 'github-actions[bot]' &&
+          steps.comments.outputs.has_incomplete_template_comment == 'true'
+        run: |
+          gh api --method PATCH "repos/${GITHUB_REPOSITORY:?}/issues/${ISSUE_NUMBER:?}" \
+            -f state=open
+
+      - name: Comment on incomplete issue
+        if: >-
+          github.event.issue.state != 'closed' &&
+          steps.template.outputs.complete_template == 'false' &&
+          steps.comments.outputs.has_incomplete_template_comment != 'true'
+        run: |
+          gh api --method POST "repos/${GITHUB_REPOSITORY:?}/issues/${ISSUE_NUMBER:?}/comments" \
             --raw-field body="$(
               cat <<COMMENT
+          <!-- incomplete-issue-template -->
           Thanks for your issue. This has been closed because it appears to use an incomplete or outdated issue template.
 
-          Please edit and reopen this issue once you have filled in the current issue template. **Do not create a new issue for this.**
+          Please edit this issue to restore the following sections and checkboxes from the current issue template (you do not need to tick the checkboxes):
+
+          $(cat "${RUNNER_TEMP:?}/check-issues/missing-checkboxes")
+
+          This workflow will reopen this issue automatically once they are present. **Do not create a new issue for this.**
           COMMENT
             )"
 
-          gh api --method PATCH "repos/${GITHUB_REPOSITORY:?}/issues/${{ github.event.issue.number }}" \
+      - name: Close incomplete issue
+        if: >-
+          github.event.issue.state != 'closed' &&
+          steps.template.outputs.complete_template == 'false'
+        run: |
+          gh api --method PATCH "repos/${GITHUB_REPOSITORY:?}/issues/${ISSUE_NUMBER:?}" \
             -f state=closed \
             -f state_reason=not_planned

--- a/.github/workflows/check-prs.yml
+++ b/.github/workflows/check-prs.yml
@@ -36,7 +36,6 @@ jobs:
       pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
-      INCOMPLETE_TEMPLATE_COMMENT_MARKER: "<!-- incomplete-pr-template -->"
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_TEMPLATE_URL: ${{ github.server_url }}/${{ github.repository }}/blob/main/.github/PULL_REQUEST_TEMPLATE.md
     steps:
@@ -103,7 +102,7 @@ jobs:
         run: |
           comment_ids="$(
             gh api --paginate "repos/${GITHUB_REPOSITORY:?}/issues/${PR_NUMBER:?}/comments" \
-              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${INCOMPLETE_TEMPLATE_COMMENT_MARKER:?}\"))) | .id"
+              --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- incomplete-pr-template -->"))) | .id'
           )"
           if [[ -n "${comment_ids}" ]]
           then
@@ -140,7 +139,7 @@ jobs:
           gh api --method POST "repos/${GITHUB_REPOSITORY:?}/issues/${PR_NUMBER:?}/comments" \
             --raw-field body="$(
               cat <<COMMENT
-          ${INCOMPLETE_TEMPLATE_COMMENT_MARKER}
+          <!-- incomplete-pr-template -->
           Thanks for your pull request. This has been closed because it appears to use an incomplete or outdated pull request template.
 
           Please edit this pull request to fill in the current [pull request template](${PR_TEMPLATE_URL:?}). This workflow will reopen this pull request automatically once the template is complete. **Do not open a new pull request for this.**


### PR DESCRIPTION
- Validate that issues and pull requests keep at least 75% of a template's headings and checkboxes (ticked or not) instead of requiring every field, so valid reports are not autoclosed.
- Block bodies that strip the template (e.g. AI-generated ones) and require pull requests to disclose AI/LLM usage.
- Auto-reopen issues on edit once the template is restored and list the missing sections and checkboxes in the close comment.
- Validate issues against `homebrew-core` and `homebrew-cask` templates too so transferred issues are not closed.
- Warn in the issue and pull request templates not to delete the checkboxes.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 with local review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
