### PR TITLE
bundle: defer trust to wrapper when under forced wrapper mode

### DIFF
--- a/Library/Homebrew/bundle/brew.rb
+++ b/Library/Homebrew/bundle/brew.rb
@@ -6,7 +6,7 @@ require "tsort"
 require "utils"
 require "utils/output"
 require "bundle/package_type"
-require "trust"
+require "bundle/trust"
 
 module Homebrew
   module Bundle
@@ -145,14 +145,11 @@ module Homebrew
 
           # Reading the formula is needed for authoritative outdated state, so
           # report trust problems before the upgrade check tries to load it.
-          if Utils.full_name?(formula) && Homebrew::EnvConfig.require_tap_trust?
-            require "trust"
-
-            unless Homebrew::Trust.trusted?(:formula, formula)
-              opoo "Cannot check whether #{formula} is outdated because its tap is not trusted. " \
-                   "Run `brew trust --formula #{formula}` to trust it."
-              return true
-            end
+          if Utils.full_name?(formula) && Homebrew::EnvConfig.require_tap_trust? &&
+             !Bundle::Trust.trusted?(:formula, formula)
+            opoo "Cannot check whether #{formula} is outdated because its tap is not trusted. " \
+                 "Run `brew trust --formula #{formula}` to trust it."
+            return true
           end
 
           # Check local cache first and then authoritative Homebrew source.
@@ -250,7 +247,7 @@ module Homebrew
           requested_formula = formulae.select do |f|
             f[:installed_on_request?]
           end
-          trusted_formulae = Homebrew::Trust.trusted_entries(:formula)
+          trusted_formulae = Bundle::Trust.trusted_entries(:formula)
           requested_formula.map do |f|
             brewline = if describe && f[:desc].present?
               f[:desc].split("\n").map { |s| "# #{s}\n" }.join
@@ -558,7 +555,7 @@ module Homebrew
         # triggers the trust check before any later step could grant trust.
         # Only fully-qualified names map to a tap, so unqualified names cannot
         # be meaningfully trusted.
-        Homebrew::Trust.trust!(:formula, @full_name) if @trusted && Utils.full_name?(@full_name)
+        Bundle::Trust.trust!(:formula, @full_name) if @trusted && Utils.full_name?(@full_name)
 
         if (tap_with_name = ::Tap.with_formula_name(@full_name))
           tap, = tap_with_name

--- a/Library/Homebrew/bundle/cask.rb
+++ b/Library/Homebrew/bundle/cask.rb
@@ -4,7 +4,7 @@
 require "utils"
 require "utils/output"
 require "bundle/package_type"
-require "trust"
+require "bundle/trust"
 
 module Homebrew
   module Bundle
@@ -99,7 +99,7 @@ module Homebrew
 
           # Only fully-qualified names map to a tap, so unqualified tokens
           # cannot be meaningfully trusted.
-          Homebrew::Trust.trust!(:cask, full_name) if options[:trusted] && Utils.full_name?(full_name)
+          Bundle::Trust.trust!(:cask, full_name) if options[:trusted] && Utils.full_name?(full_name)
 
           install_result = if cask_installed?(name) && upgrading?(no_upgrade, name, options)
             status = "#{options[:greedy] ? "may not be" : "not"} up-to-date"
@@ -224,7 +224,7 @@ module Homebrew
 
         sig { override.params(describe: T::Boolean).returns(String) }
         def dump(describe: false)
-          trusted_casks = Homebrew::Trust.trusted_entries(:cask)
+          trusted_casks = Bundle::Trust.trusted_entries(:cask)
           casks.map do |cask|
             description = "# #{cask.desc}\n" if describe && cask.desc.present?
             config = ", args: { #{explicit_s(cask.config)} }" if cask.config.present? && cask.config.explicit.present?

--- a/Library/Homebrew/bundle/tap.rb
+++ b/Library/Homebrew/bundle/tap.rb
@@ -3,7 +3,7 @@
 
 require "json"
 require "bundle/package_type"
-require "trust"
+require "bundle/trust"
 
 module Homebrew
   module Bundle
@@ -92,7 +92,7 @@ module Homebrew
               ", \"#{tap_remote}\""
             end
             tapline = "tap \"#{tap.name}\"#{remote}"
-            tapline += ", trusted: true" if Homebrew::Trust.explicitly_trusted_tap?(tap)
+            tapline += ", trusted: true" if Bundle::Trust.explicitly_trusted_tap?(tap)
             tapline
           end.sort.uniq.join("\n")
         end

--- a/Library/Homebrew/bundle/trust.rb
+++ b/Library/Homebrew/bundle/trust.rb
@@ -1,0 +1,51 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "json"
+require "tap"
+require "trust"
+require "utils"
+
+module Homebrew
+  module Bundle
+    module Trust
+      extend Homebrew::Trust::Read
+
+      sig { void }
+      def self.reset!
+        @trust_data = T.let(nil, T.nilable(T::Hash[String, T::Array[String]]))
+      end
+
+      sig { override.params(type: Symbol).returns(T::Array[String]) }
+      def self.trusted_entries(type)
+        return Homebrew::Trust.trusted_entries(type) if Homebrew::EnvConfig.force_brew_wrapper.blank?
+
+        trust_data.fetch(Utils.pluralize(type.to_s, 2), [])
+      end
+
+      sig { params(type: Symbol, name: String).returns(T::Boolean) }
+      def self.trust!(type, name)
+        newly_trusted = Homebrew::Trust.trust!(type, name)
+
+        # In wrapper mode, save the trust to both trust stores.
+        return newly_trusted if Homebrew::EnvConfig.force_brew_wrapper.blank?
+
+        already_trusted = trusted?(type, name)
+        Utils.safe_popen_read(HOMEBREW_BREW_FILE, "trust", "--#{type}", name)
+        reset!
+
+        !already_trusted || newly_trusted
+      end
+
+      sig { returns(T::Hash[String, T::Array[String]]) }
+      private_class_method def self.trust_data
+        @trust_data ||= T.let(begin
+          data = JSON.parse(Utils.safe_popen_read(HOMEBREW_BREW_FILE, "trust", "--json=v1"))
+          raise "Unexpected `brew trust --json=v1` output: #{data.inspect}" unless data.is_a?(Hash)
+
+          data
+        end, T.nilable(T::Hash[String, T::Array[String]]))
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe Homebrew::Bundle::Brew do
           # foobar
           brew "qux/quuz/foo"
         RUBY
-        allow(Homebrew::Trust).to receive(:trusted_entries).with(:formula).and_return(["bazzles/bizzles/baz"])
+        allow(Homebrew::Bundle::Trust).to receive(:trusted_entries).with(:formula).and_return(["bazzles/bizzles/baz"])
         expect(dumper.dump(describe: true)).to eql(expected.chomp)
       end
     end
@@ -599,14 +599,14 @@ RSpec.describe Homebrew::Bundle::Brew do
         tap = instance_double(Tap, ensure_installed!: nil)
         allow(Tap).to receive(:with_formula_name).with(tapped_name).and_return([tap, "baz"])
         allow(tap).to receive(:ensure_installed!) { order << :tap }
-        allow(Homebrew::Trust).to receive(:trust!).with(:formula, tapped_name) { order << :trust }
+        allow(Homebrew::Bundle::Trust).to receive(:trust!).with(:formula, tapped_name) { order << :trust }
         described_class.install!(tapped_name, trusted: true)
         expect(order).to eq([:trust, :tap])
       end
 
       it "does not trust an unqualified formula name" do
         allow(Tap).to receive(:with_formula_name).and_return(nil)
-        expect(Homebrew::Trust).not_to receive(:trust!)
+        expect(Homebrew::Bundle::Trust).not_to receive(:trust!)
         described_class.install!("baz", trusted: true)
       end
     end
@@ -687,7 +687,8 @@ RSpec.describe Homebrew::Bundle::Brew do
         described_class.reset!
         allow(Homebrew::EnvConfig).to receive(:require_tap_trust?).and_return(true)
         allow(Formula).to receive(:installed_formula_names).and_return(["php@7.2"])
-        allow(Homebrew::Trust).to receive(:trusted?).with(:formula, "shivammathur/php/php@7.2").and_return(false)
+        allow(Homebrew::Bundle::Trust).to receive(:trusted?).with(:formula,
+                                                                  "shivammathur/php/php@7.2").and_return(false)
       end
 
       it "warns and marks the formula actionable without loading it" do

--- a/Library/Homebrew/test/bundle/cask_spec.rb
+++ b/Library/Homebrew/test/bundle/cask_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Homebrew::Bundle::Cask do
           # Software
           cask "baz"
         RUBY
-        allow(Homebrew::Trust).to receive(:trusted_entries).with(:cask).and_return(["bar"])
+        allow(Homebrew::Bundle::Trust).to receive(:trusted_entries).with(:cask).and_return(["bar"])
         expect(dumper.dump(describe: true)).to eql(expected.chomp)
       end
 
@@ -260,13 +260,13 @@ RSpec.describe Homebrew::Bundle::Cask do
 
         it "trusts the cask before installing it" do
           allow(Homebrew::Bundle).to receive(:brew).and_return(true)
-          expect(Homebrew::Trust).to receive(:trust!).with(:cask, "puma/puma/puma-cask")
+          expect(Homebrew::Bundle::Trust).to receive(:trust!).with(:cask, "puma/puma/puma-cask")
           described_class.install!("puma-cask", full_name: "puma/puma/puma-cask", trusted: true)
         end
 
         it "does not trust an unqualified cask token" do
           allow(Homebrew::Bundle).to receive(:brew).and_return(true)
-          expect(Homebrew::Trust).not_to receive(:trust!)
+          expect(Homebrew::Bundle::Trust).not_to receive(:trust!)
           described_class.install!("google-chrome", trusted: true)
         end
 

--- a/Library/Homebrew/test/bundle/tap_spec.rb
+++ b/Library/Homebrew/test/bundle/tap_spec.rb
@@ -62,8 +62,9 @@ RSpec.describe Homebrew::Bundle::Tap do
       end
 
       it "dumps trusted taps with trusted true" do
-        allow(Homebrew::Trust).to receive(:trusted_entries).with(:tap)
-                                                           .and_return(["https://bitbucket.org/bitbucket/bar.git"])
+        allow(Homebrew::Bundle::Trust).to receive(:trusted_entries)
+          .with(:tap)
+          .and_return(["https://bitbucket.org/bitbucket/bar.git"])
 
         expect(dumper.dump).to include(
           "tap \"bitbucket/bar\", \"https://bitbucket.org/bitbucket/bar.git\", trusted: true",

--- a/Library/Homebrew/test/bundle/trust_spec.rb
+++ b/Library/Homebrew/test/bundle/trust_spec.rb
@@ -1,0 +1,86 @@
+# typed: true
+# frozen_string_literal: true
+
+require "bundle/trust"
+
+RSpec.describe Homebrew::Bundle::Trust do
+  before do
+    described_class.reset!
+  end
+
+  describe ".trusted_entries" do
+    it "delegates to Homebrew::Trust when wrapper mode is not forced" do
+      allow(Homebrew::EnvConfig).to receive(:force_brew_wrapper).and_return(nil)
+      expect(Homebrew::Trust).to receive(:trusted_entries).with(:formula).and_return(["user/tap/foo"])
+
+      expect(described_class.trusted_entries(:formula)).to eq(["user/tap/foo"])
+    end
+
+    it "reads trusted entries through brew when wrapper mode is forced" do
+      allow(Homebrew::EnvConfig).to receive(:force_brew_wrapper).and_return("/tmp/wrapper/brew")
+      trust_json = <<~JSON
+        {
+          "taps": [],
+          "formulae": ["user/tap/foo"],
+          "casks": [],
+          "commands": []
+        }
+      JSON
+
+      expect(Utils).to receive(:safe_popen_read)
+        .with(HOMEBREW_BREW_FILE, "trust", "--json=v1")
+        .and_return(trust_json)
+
+      expect(described_class.trusted_entries(:formula)).to eq(["user/tap/foo"])
+    end
+  end
+
+  describe ".trusted?" do
+    it "checks trusted taps through brew output when wrapper mode is forced" do
+      allow(Homebrew::EnvConfig).to receive(:force_brew_wrapper).and_return("/tmp/wrapper/brew")
+      trust_json = <<~JSON
+        {
+          "taps": ["https://gitlab.com/user/homebrew-tap"],
+          "formulae": [],
+          "casks": [],
+          "commands": []
+        }
+      JSON
+
+      allow(Utils).to receive(:safe_popen_read)
+        .with(HOMEBREW_BREW_FILE, "trust", "--json=v1")
+        .and_return(trust_json)
+
+      tap = instance_double(Tap)
+      allow(Tap).to receive(:fetch).with("user/tap").and_return(tap)
+      allow(tap).to receive(:implicitly_trusted?).and_return(false)
+      allow(tap).to receive(:matches_reference?).with("https://gitlab.com/user/homebrew-tap").and_return(true)
+
+      expect(described_class.trusted?(:formula, "user/tap/foo")).to be(true)
+    end
+  end
+
+  describe ".trust!" do
+    it "writes trust through brew when wrapper mode is forced" do
+      allow(Homebrew::EnvConfig).to receive(:force_brew_wrapper).and_return("/tmp/wrapper/brew")
+      allow(Homebrew::Trust).to receive(:trust!).and_return(true)
+      allow(described_class).to receive(:trusted?).with(:cask, "user/tap/foo").and_return(false, true)
+      expect(Utils).to receive(:safe_popen_read)
+        .with(HOMEBREW_BREW_FILE, "trust", "--cask", "user/tap/foo")
+        .and_return("Trusted cask: user/tap/foo\n")
+
+      expect(described_class.trust!(:cask, "user/tap/foo")).to be(true)
+    end
+
+    it "returns false when the entry is already trusted" do
+      allow(Homebrew::EnvConfig).to receive(:force_brew_wrapper).and_return("/tmp/wrapper/brew")
+      allow(Homebrew::Trust).to receive(:trust!).and_return(false)
+      allow(described_class).to receive(:trusted?).with(:formula, "user/tap/foo").and_return(true)
+      allow(Utils).to receive(:safe_popen_read)
+        .with(HOMEBREW_BREW_FILE, "trust", "--formula", "user/tap/foo")
+        .and_return("Already trusted formula: user/tap/foo\n")
+
+      expect(described_class.trust!(:formula, "user/tap/foo")).to be(false)
+    end
+  end
+end

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -13,6 +13,46 @@ module Homebrew
   module Trust
     extend Utils::Output::Mixin
 
+    module Read
+      extend T::Helpers
+
+      abstract!
+
+      sig { abstract.params(type: Symbol).returns(T::Array[String]) }
+      def trusted_entries(type); end
+
+      sig { params(type: Symbol, name: String).returns(T::Boolean) }
+      def trusted?(type, name)
+        name = normalise_name(name)
+        return true if trusted_entries(type).include?(name)
+        return false if type == :tap
+        return false unless (tap_name = ::Utils.tap_from_full_name(name))
+
+        trusted_tap?(Tap.fetch(tap_name))
+      rescue Tap::InvalidNameError
+        false
+      end
+
+      sig { params(tap: Tap).returns(T::Boolean) }
+      def trusted_tap?(tap)
+        tap.implicitly_trusted? || explicitly_trusted_tap?(tap)
+      end
+
+      # Whether the tap appears in the trust list, ignoring any implicit official-tap trust. The
+      # entries may be `user/repository` names or remote URLs, so match via {Tap#matches_reference?}.
+      sig { params(tap: Tap).returns(T::Boolean) }
+      def explicitly_trusted_tap?(tap)
+        trusted_entries(:tap).any? { |reference| tap.matches_reference?(reference) }
+      end
+
+      sig { params(name: String).returns(String) }
+      def normalise_name(name)
+        name.downcase
+      end
+    end
+
+    extend Read
+
     SETTING_KEYS = T.let({
       tap:     :trustedtaps,
       formula: :trustedformulae,
@@ -91,30 +131,6 @@ module Homebrew
       store = trust_store
       store.delete(setting_key(type))
       write_trust_store(store)
-    end
-
-    sig { params(type: Symbol, name: String).returns(T::Boolean) }
-    def self.trusted?(type, name)
-      name = normalise_name(name)
-      return true if trusted_entries(type).include?(name)
-      return false if type == :tap
-      return false unless (tap_name = ::Utils.tap_from_full_name(name))
-
-      trusted_tap?(Tap.fetch(tap_name))
-    rescue Tap::InvalidNameError
-      false
-    end
-
-    sig { params(tap: Tap).returns(T::Boolean) }
-    def self.trusted_tap?(tap)
-      tap.implicitly_trusted? || explicitly_trusted_tap?(tap)
-    end
-
-    # Whether the tap appears in the trust list, ignoring any implicit official-tap trust. The
-    # entries may be `user/repository` names or remote URLs, so match via {Tap#matches_reference?}.
-    sig { params(tap: T.untyped).returns(T::Boolean) }
-    def self.explicitly_trusted_tap?(tap)
-      trusted_entries(:tap).any? { |reference| tap.matches_reference?(reference) }
     end
 
     sig { params(name: String, path: Pathname).void }
@@ -202,14 +218,9 @@ module Homebrew
       SETTING_KEYS.fetch(type).to_s
     end
 
-    sig { params(type: Symbol).returns(T::Array[String]) }
+    sig { override.params(type: Symbol).returns(T::Array[String]) }
     def self.trusted_entries(type)
       trust_store.fetch(setting_key(type), [])
-    end
-
-    sig { params(name: String).returns(String) }
-    def self.normalise_name(name)
-      name.downcase
     end
 
     sig { params(name: String, type: T.nilable(Symbol), include_existing: T::Boolean).returns([Symbol, String]) }


### PR DESCRIPTION
When `HOMEBREW_FORCE_BREW_WRAPPER` is set, `brew bundle` might be run in a different user context than the `brew install` commands it issues. Therefore when this mode is active, we need to defer trust to `brew trust` to ensure items are trusted correctly.

This PR has no functional change for the majority of users which do not use `HOMEBREW_FORCE_BREW_WRAPPER`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

For tests only. Verified by running the tests and human code review.

-----
