### PR TITLE
bottle_specification: add constants for cellar symbols

### DIFF
--- a/Library/Homebrew/bottle_specification.rb
+++ b/Library/Homebrew/bottle_specification.rb
@@ -4,7 +4,15 @@
 class BottleSpecification
   include Utils::Output::Mixin
 
-  RELOCATABLE_CELLARS = [:any, :any_skip_relocation].freeze
+  # Relocatable cellar using placeholders, e.g. `@@HOMEBREW_PREFIX@@`.
+  # Requires relocating text files and binaries.
+  ANY_CELLAR = :any
+
+  # Relocatable cellar using placeholders, e.g. `@@HOMEBREW_PREFIX@@`.
+  # Does not need to relocate binaries but still relocates text files.
+  ANY_SKIP_RELOCATION_CELLAR = :any_skip_relocation
+
+  RELOCATABLE_CELLARS = T.let([ANY_CELLAR, ANY_SKIP_RELOCATION_CELLAR].freeze, T::Array[Symbol])
 
   sig { returns(T.nilable(Tap)) }
   attr_accessor :tap
@@ -97,7 +105,7 @@ class BottleSpecification
   sig { params(tag: Utils::Bottles::Tag, tab: T.nilable(Tab)).returns(T::Boolean) }
   def skip_relocation?(tag: Utils::Bottles.tag, tab: nil)
     spec = collector.specification_for(tag)
-    spec&.cellar == :any_skip_relocation
+    spec&.cellar == ANY_SKIP_RELOCATION_CELLAR
   end
 
   sig { params(tag: Utils::Bottles::Tag, no_older_versions: T::Boolean).returns(T::Boolean) }

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -470,8 +470,8 @@ module Homebrew
 
           tag_spec = Formula[formula.name].bottle_specification
                                           .tag_specification_for(bottle_tag, no_older_versions: true)
-          relocatable = [:any, :any_skip_relocation].include?(tag_spec.cellar)
-          skip_relocation = tag_spec.cellar == :any_skip_relocation
+          relocatable = BottleSpecification::RELOCATABLE_CELLARS.include?(tag_spec.cellar)
+          skip_relocation = tag_spec.cellar == BottleSpecification::ANY_SKIP_RELOCATION_CELLAR
 
           prefix = bottle_tag.default_prefix
           cellar = bottle_tag.default_cellar
@@ -608,9 +608,9 @@ module Homebrew
         bottle.root_url(root_url) if root_url
         bottle_cellar = if relocatable
           if skip_relocation
-            :any_skip_relocation
+            BottleSpecification::ANY_SKIP_RELOCATION_CELLAR
           else
-            :any
+            BottleSpecification::ANY_CELLAR
           end
         else
           cellar
@@ -708,7 +708,7 @@ module Homebrew
       def merge
         bottles_hash = merge_json_files(parse_json_files(args.named))
 
-        any_cellars = ["any", "any_skip_relocation"]
+        any_cellars = BottleSpecification::RELOCATABLE_CELLARS.map(&:to_s)
         bottles_hash.each do |formula_name, bottle_hash|
           ohai formula_name
 

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -228,10 +228,8 @@ module OS
         relocation = super
 
         brewed_perl = runtime_dependencies&.any? do |dep|
-          T.cast(dep,
-                 T::Hash[String,
-                         T.untyped])["full_name"] == "perl" && T.cast(dep,
-                                                                      T::Hash[String, T.untyped])["declared_directly"]
+          dep = T.cast(dep, T::Hash[String, T.untyped])
+          dep["full_name"] == "perl" && dep["declared_directly"]
         end
         perl_path = if brewed_perl || name == "perl"
           "#{HOMEBREW_PREFIX}/opt/perl/bin/perl"

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1566,7 +1566,7 @@ on_request: installed_on_request?, options:)
     keg.replace_placeholders_with_locations(tab.changed_files, skip_linkage:)
 
     cellar = formula.bottle_specification.tag_to_cellar(Utils::Bottles.tag)
-    return if [:any, :any_skip_relocation].include?(cellar)
+    return if BottleSpecification::RELOCATABLE_CELLARS.include?(cellar)
 
     prefix = Pathname(cellar).parent.to_s
     return if cellar == HOMEBREW_CELLAR.to_s && prefix == HOMEBREW_PREFIX.to_s


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

Some minor touch ups.

Was originally looking into replacing placeholder for non-/usr/local default prefix. Applying some simple changes from work on that to avoid the scattered usage of symbols along with adding comments on how current cellars are used (e.g. what gets relocated on `:any` and `:any_skip_relocation`).

---

On topic of exploring default prefix, easiest option may be to introduce new cellar symbols, e.g. something like `:any_default` and `:default`, which will imply the default prefix is used. Still considering some other ideas.