### PR TITLE
Emit Linux variations for casks with Linux checksums

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -616,7 +616,7 @@ module Cask
       if dsl!.on_system_blocks_exist?
         begin
           OnSystem::VALID_OS_ARCH_TAGS.each do |bottle_tag|
-            next if bottle_tag.linux? && dsl!.os.nil?
+            next if bottle_tag.linux? && dsl!.os.nil? && !dsl!.sha256_set_for_linux?
 
             macos_requirements = [depends_on.macos, depends_on.maximum_macos].compact
             next if bottle_tag.macos? &&

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -241,6 +241,7 @@ module Cask
       @os_set_in_block = T.let(false, T::Boolean)
       @rename = T.let([], T::Array[DSL::Rename])
       @sha256 = T.let(nil, T.nilable(T.any(Checksum, Symbol)))
+      @sha256_set_for_linux = T.let(false, T::Boolean)
       @sha256_set_in_block = T.let(false, T::Boolean)
       @staged_path = T.let(nil, T.nilable(Pathname))
       @token = T.let(cask.token, String)
@@ -267,6 +268,9 @@ module Cask
 
     sig { returns(T::Boolean) }
     def on_os_blocks_exist? = @on_os_blocks_exist
+
+    sig { returns(T::Boolean) }
+    def sha256_set_for_linux? = @sha256_set_for_linux
 
     # Specifies the cask's name.
     #
@@ -531,6 +535,7 @@ module Cask
         if arm.present? || x86_64.present? || x86_64_linux.present? || arm64_linux.present?
           @on_system_blocks_exist = true
         end
+        @sha256_set_for_linux = true if x86_64_linux.present? || arm64_linux.present?
 
         val = arg || on_system_conditional(
           macos: on_arch_conditional(arm:, intel: x86_64),

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -817,6 +817,13 @@ RSpec.describe Cask::Cask, :cask do
       expect(h["variations"]).not_to include(:arm64_linux)
     end
 
+    it "emits Linux variations for a cask with Linux checksums but no `os` stanza" do
+      c = Cask::CaskLoader.load("sha256-linux")
+      h = c.to_hash_with_variations
+
+      expect(h["variations"]).to include(:x86_64_linux, :arm64_linux)
+    end
+
     # NOTE: The calls to `Cask.generating_hash!` and `Cask.generated_hash!`
     #       are not idempotent so they can only be used in one test.
     it "returns the correct hash placeholders" do

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-linux.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-linux.rb
@@ -1,0 +1,16 @@
+# typed: false
+
+cask "sha256-linux" do
+  arch arm: "arm", intel: "intel"
+
+  version "1.2.3"
+  sha256 arm:          "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",
+         intel:        "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b",
+         x86_64_linux: "244d413861cecb3707cfbcc5c4346d5367daa827da5ea08fb3f3bc2b6276d239",
+         arm64_linux:  "9a1c0967baa46828930ccbbc88668d1b0db07e6edf778800ed4da073c00054f8"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine-#{arch}.zip"
+  homepage "https://brew.sh/"
+
+  app "Caffeine.app"
+end


### PR DESCRIPTION
`Cask#to_hash_with_variations` only emits Linux variations to the JSON API when a cask sets an `os` stanza. A cask that declares Linux checksums (`sha256 x86_64_linux:`/`arm64_linux:`) but no `os` stanza therefore ships no Linux variations, so installing it on Linux falls back to the cask's macOS artifacts and fails as macOS-only — even when it already has a working `on_linux`/`app_image` block. `zettlr` is one such cask.

This tracks when `sha256` is given Linux values and emits Linux variations in that case too, alongside the existing `os`-stanza signal.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

Claude drafted the change and regression test; I reviewed the logic in `to_hash_with_variations`, confirmed the test fails without the fix and passes with it, and verified end-to-end that the real `zettlr` cask now produces `x86_64_linux`/`arm64_linux` variations. `brew lgtm` passes locally.

-----
