### PR TITLE
Fix `brew bundle` failures for trusted taps

### DIFF
--- a/Library/Homebrew/bundle/installer.rb
+++ b/Library/Homebrew/bundle/installer.rb
@@ -65,6 +65,8 @@ module Homebrew
           InstallableEntry.new(name:, options:, verb: cls.install_verb(name, options), cls:)
         end
 
+        apply_trust!(installable_entries)
+
         if (fetchable_names = fetchable_formulae_and_casks(installable_entries, no_upgrade:).presence)
           fetchable_names_joined = fetchable_names.join(", ")
           puts Formatter.success("Fetching #{fetchable_names_joined}") unless quiet
@@ -108,6 +110,39 @@ module Homebrew
 
         true
       end
+
+      # Apply `trusted: true` Brewfile options before anything fetches or
+      # loads the entries: the fetch phase and upgrade checks load formulae
+      # and casks, which triggers the tap trust check before the per-entry
+      # install step could grant trust.
+      sig { params(entries: T::Array[InstallableEntry]).void }
+      def self.apply_trust!(entries)
+        entries.each do |entry|
+          next unless entry.options[:trusted]
+
+          require "trust"
+
+          if entry.cls == Tap
+            clone_target = entry.options[:clone_target].presence
+            reference = if clone_target
+              require "tap"
+              ::Tap.remote_to_reference(clone_target.to_s) || clone_target.to_s
+            else
+              entry.name
+            end
+            Homebrew::Trust.trust!(:tap, reference)
+          elsif ::Utils.full_name?(entry.full_name)
+            # Only fully-qualified names map to a tap, so unqualified names
+            # cannot be meaningfully trusted.
+            if entry.cls == Brew
+              Homebrew::Trust.trust!(:formula, entry.full_name)
+            elsif entry.cls == Cask
+              Homebrew::Trust.trust!(:cask, entry.full_name)
+            end
+          end
+        end
+      end
+      private_class_method :apply_trust!
 
       sig {
         params(

--- a/Library/Homebrew/description_cache_store/cask_description_cache_store.rb
+++ b/Library/Homebrew/description_cache_store/cask_description_cache_store.rb
@@ -58,8 +58,8 @@ class CaskDescriptionCacheStore < DescriptionCacheStore
     cask_tokens.each do |token|
       c = Cask::CaskLoader.load(token)
       update!(c.full_name, [c.name.join(", "), c.desc.presence])
-    rescue Cask::CaskUnavailableError, *FormulaVersions::IGNORED_EXCEPTIONS
-      delete!(c.full_name) if c.present?
+    rescue Cask::CaskUnavailableError, Homebrew::UntrustedTapError, *FormulaVersions::IGNORED_EXCEPTIONS
+      delete!(token)
     end
   end
 end

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -5,6 +5,7 @@ require "bundle"
 require "bundle/dsl"
 require "bundle/installer"
 require "bundle/parallel_installer"
+require "trust"
 
 RSpec.describe Homebrew::Bundle::Installer do
   let(:formula_entry) { Homebrew::Bundle::Dsl::Entry.new(:brew, "mysql") }
@@ -77,6 +78,61 @@ RSpec.describe Homebrew::Bundle::Installer do
     expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
 
     described_class.install!([tap_entry, tapped_formula_entry], quiet: true)
+  end
+
+  it "trusts `trusted: true` formulae before fetching them" do
+    trusted_formula_entry = Homebrew::Bundle::Dsl::Entry.new(:brew, "thirdparty/tap/bar", { trusted: true })
+
+    allow(Homebrew::Bundle::Tap).to receive(:installed_taps).and_return(["thirdparty/tap"])
+
+    expect(Homebrew::Trust).to receive(:trust!).with(:formula, "thirdparty/tap/bar").ordered.and_return(true)
+    expect(Homebrew::Bundle).to receive(:brew)
+      .with("fetch", "thirdparty/tap/bar", verbose: false)
+      .ordered
+      .and_return(true)
+
+    described_class.install!([trusted_formula_entry], quiet: true)
+  end
+
+  it "trusts `trusted: true` casks before fetching them" do
+    options = { args: {}, full_name: "thirdparty/tap/baz", trusted: true }
+    trusted_cask_entry = Homebrew::Bundle::Dsl::Entry.new(:cask, "baz", options)
+
+    allow(Homebrew::Bundle::Tap).to receive(:installed_taps).and_return(["thirdparty/tap"])
+
+    expect(Homebrew::Trust).to receive(:trust!).with(:cask, "thirdparty/tap/baz").ordered.and_return(true)
+    expect(Homebrew::Bundle).to receive(:brew)
+      .with("fetch", "thirdparty/tap/baz", verbose: false)
+      .ordered
+      .and_return(true)
+
+    described_class.install!([trusted_cask_entry], quiet: true)
+  end
+
+  it "trusts `trusted: true` taps by name" do
+    tap_entry = Homebrew::Bundle::Dsl::Entry.new(:tap, "thirdparty/tap", { trusted: true })
+
+    expect(Homebrew::Trust).to receive(:trust!).with(:tap, "thirdparty/tap").and_return(true)
+
+    described_class.install!([tap_entry], quiet: true)
+  end
+
+  it "trusts `trusted: true` taps with a clone target by their remote reference" do
+    tap_entry = Homebrew::Bundle::Dsl::Entry.new(
+      :tap, "thirdparty/custom", { clone_target: "https://github.com/thirdparty/homebrew-custom", trusted: true }
+    )
+
+    expect(Homebrew::Trust).to receive(:trust!).with(:tap, "thirdparty/custom").and_return(true)
+
+    described_class.install!([tap_entry], quiet: true)
+  end
+
+  it "does not trust unqualified `trusted: true` names" do
+    trusted_formula_entry = Homebrew::Bundle::Dsl::Entry.new(:brew, "mysql", { trusted: true })
+
+    expect(Homebrew::Trust).not_to receive(:trust!)
+
+    described_class.install!([trusted_formula_entry], quiet: true)
   end
 
   it "skips fetching formulae from fully qualified untapped taps" do

--- a/Library/Homebrew/test/description_cache_store_spec.rb
+++ b/Library/Homebrew/test/description_cache_store_spec.rb
@@ -93,6 +93,15 @@ RSpec.describe DescriptionCacheStore do
         expect(database).to receive(:set).with(c.full_name, [c.name.join(", "), c.desc.presence])
         cache_store.update_from_cask_tokens!([c.token])
       end
+
+      it "deletes untrusted cask descriptions" do
+        token = "thirdparty/tap/untrusted-cask"
+        expect(Cask::CaskLoader).to receive(:load).with(token, any_args).and_raise(Homebrew::UntrustedTapError)
+        expect(database).to receive(:empty?).and_return(false)
+        expect(database).to receive(:delete).with(token)
+
+        cache_store.update_from_cask_tokens!([token])
+      end
     end
   end
 end

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -158,6 +158,18 @@ RSpec.describe Homebrew::Trust do
     described_class.clear!(:tap)
   end
 
+  it "does not lose entries when trusting concurrently" do
+    names = Array.new(10) { |i| "thirdparty/foo/formula#{i}" }
+
+    names.map do |name|
+      Thread.new { described_class.trust!(:formula, name) }
+    end.each(&:join)
+
+    expect(described_class.trusted_entries(:formula)).to match_array(names)
+  ensure
+    described_class.clear!(:formula)
+  end
+
   it "trusts fully-qualified formulae and casks" do
     tap = Tap.fetch("qualified", "foo")
     tap.formula_dir.mkpath

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -29,31 +29,35 @@ module Homebrew
     sig { params(type: Symbol, name: String).returns(T::Boolean) }
     def self.trust!(type, name)
       key = setting_key(type)
-      entries = trusted_entries(type)
       name = normalise_name(name)
-      return false if entries.include?(name)
+      with_trust_store_lock do
+        store = trust_store
+        entries = store.fetch(key, [])
+        next false if entries.include?(name)
 
-      store = trust_store
-      store[key] = (entries + [name]).sort
-      write_trust_store(store)
-      true
+        store[key] = (entries + [name]).sort
+        write_trust_store(store)
+        true
+      end
     end
 
     sig { params(type: Symbol, name: String).returns(T::Boolean) }
     def self.untrust!(type, name)
       key = setting_key(type)
-      entries = trusted_entries(type)
       name = normalise_name(name)
-      return false unless entries.delete(name)
+      with_trust_store_lock do
+        store = trust_store
+        entries = store.fetch(key, [])
+        next false unless entries.delete(name)
 
-      store = trust_store
-      if entries.empty?
-        store.delete(key)
-      else
-        store[key] = entries.sort
+        if entries.empty?
+          store.delete(key)
+        else
+          store[key] = entries.sort
+        end
+        write_trust_store(store)
+        true
       end
-      write_trust_store(store)
-      true
     end
 
     sig { params(names: T::Array[String], type: T.nilable(Symbol)).void }
@@ -88,9 +92,11 @@ module Homebrew
 
     sig { params(type: Symbol).void }
     def self.clear!(type)
-      store = trust_store
-      store.delete(setting_key(type))
-      write_trust_store(store)
+      with_trust_store_lock do
+        store = trust_store
+        store.delete(setting_key(type))
+        write_trust_store(store)
+      end
     end
 
     sig { params(type: Symbol, name: String).returns(T::Boolean) }
@@ -335,6 +341,22 @@ module Homebrew
       trust_path.chmod(0600)
     end
     private_class_method :write_trust_store
+
+    # Serialises trust store mutations so concurrent processes or threads
+    # (e.g. parallel `brew bundle` installs) cannot lose entries in the
+    # read-modify-write cycle.
+    sig {
+      type_parameters(:U).params(_block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U))
+    }
+    def self.with_trust_store_lock(&_block)
+      lock_path = Pathname.new("#{trust_file}.lock")
+      lock_path.dirname.mkpath
+      File.open(lock_path, File::RDWR | File::CREAT, 0600) do |lock_file|
+        lock_file.flock(File::LOCK_EX)
+        yield
+      end
+    end
+    private_class_method :with_trust_store_lock
 
     sig { params(path: Pathname).returns(T.untyped) }
     def self.tap_from_path(path)


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

As an experiment, this PR was done end to end by Claude Fable 5 using Max reasoning effort: picking the issue, root-causing, writing the fixes and tests, and validating them. It took ~35 minutes and used ~1600 AI credits. Verification: `brew lgtm` passes locally (typecheck, style and the three changed spec files) and each new regression test was confirmed to fail on `main` without its corresponding fix.

-----

Fixes #22631.

`brew bundle` was failing for `trusted: true` Brewfile entries. Three root causes, one commit each:

1. **Tapping aborts when the tap contains untrusted casks.** `Tap#install` refreshes the cask description cache, which loads every cask in the tap. The cask-side rescue didn't catch `Homebrew::UntrustedTapError` (the formula side was fixed in 8efa9df45d), so `brew 'hashicorp/tap/terraform', trusted: true` died refreshing the cache for `hashicorp/tap`'s casks. Also makes the rescue actually delete the stale cache entry: `c` is always `nil` when the load raises, so `delete!(c.full_name) if c.present?` never ran.

2. **The bundle fetch phase runs before trust is applied.** Trust entries for `trusted: true` were only written in the per-entry install steps, but the upfront fetch and upgradability checks load formulae/casks first and raised `UntrustedTapError` on re-runs. `Bundle::Installer` now applies all `trusted: true` options before fetching. This also makes `tap "user/repo", trusted: true` work at all: `brew bundle dump` emits it but `Bundle::Tap.install!` silently discarded it. Taps with a clone target are trusted by their remote reference, matching `brew trust` behaviour for custom remotes.

3. **Parallel installs lose `trust.json` entries.** `Trust.trust!`/`untrust!`/`clear!` did unlocked read-modify-write cycles, so concurrent bundle jobs could drop each other's writes — as reported in the issue, where a previously trusted tap vanished from `trust.json`. Mutations now take a blocking exclusive `flock` on `trust.json.lock` (the existing `LockFile` class is non-blocking and raises on contention, so it isn't suitable here).
