### PR TITLE
Document Brewfile tap trust

### DIFF
--- a/docs/Brew-Bundle-and-Brewfile.md
+++ b/docs/Brew-Bundle-and-Brewfile.md
@@ -304,6 +304,12 @@ brew "postgresql@16",
 # Runs `brew install ruby` and, afterwards, writes the installed version to the '.ruby-version` file.
 brew "ruby", version_file: ".ruby-version"
 
+# Trusts the tap, formula or cask so Homebrew loads it when tap trust is required.
+# This works on `tap`, `brew` and `cask` entries.
+tap "user/repo", trusted: true
+brew "user/repo/formula", trusted: true
+cask "user/repo/cask", trusted: true
+
 # Runs `brew install gnupg` or `brew install glibc` only on the specified OS.
 # Note: `brew bundle list` will not output `gnupg` on Linux or `glibc` on macOS` in this case:
 # the Ruby logic means they are "hidden" on other platforms.
@@ -339,6 +345,22 @@ This is useful when a project wants Homebrew to install a runtime and keep a con
 ```ruby
 brew "ruby", version_file: ".ruby-version"
 ```
+
+### `trusted`
+
+`tap`, `brew` and `cask` entries support `trusted: true` to declaratively
+[trust](Tap-Trust.md) a non-official tap, formula or cask. Homebrew trusts the
+entry before installing it, so it loads even when tap trust is required.
+
+```ruby
+tap "user/repo", trusted: true
+brew "user/repo/formula", trusted: true
+cask "user/repo/cask", trusted: true
+```
+
+As with `brew trust`, prefer trusting the specific formula or cask you need over
+trusting a whole tap. `brew bundle dump` writes `trusted: true` for entries you
+have already trusted.
 
 ## Versions
 

--- a/docs/Tap-Trust.md
+++ b/docs/Tap-Trust.md
@@ -68,6 +68,22 @@ tap you administer or rely on heavily, but for one-off installs, automation or
 software from a vendor you do not fully control, prefer trusting only the item
 you need.
 
+## Trusting in a `Brewfile`
+
+You can declare trust in a [`Brewfile`](Brew-Bundle-and-Brewfile.md) with
+`trusted: true` on `tap`, `brew` and `cask` entries:
+
+```ruby
+tap "user/repo", trusted: true
+brew "user/repo/formula", trusted: true
+cask "user/repo/cask", trusted: true
+```
+
+`brew bundle` trusts each entry before installing it, so non-official taps,
+formulae and casks load even when tap trust is required. As on the command line,
+prefer trusting the specific formula or cask you need over the whole tap.
+`brew bundle dump` writes `trusted: true` for entries you have already trusted.
+
 ## Managing trust
 
 List trusted entries:


### PR DESCRIPTION
- explain the `trusted: true` option for `tap`, `brew` and `cask` entries so users can declare tap trust declaratively
- cross-link the Brewfile and Tap Trust pages now that trust can be expressed in a `Brewfile`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 with local review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
