### PR TITLE
Avoid loading tap commands on completion rebuild

### DIFF
--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -227,8 +227,9 @@ module Commands
     # Ensure that the cache exists so we can build the commands list
     HOMEBREW_CACHE.mkpath
 
+    # Don't reject `command_hidden_from_manpage?` commands here: internal ones
+    # are already excluded and checking externals loads every tap command file.
     cmds = commands - Homebrew::Completions::COMPLETIONS_EXCLUSION_LIST
-    cmds.reject! { |cmd| Homebrew::Completions.command_hidden_from_manpage?(cmd) }
 
     all_commands_file = HOMEBREW_CACHE/"all_commands_list.txt"
     external_commands_file = HOMEBREW_CACHE/"external_commands_list.txt"

--- a/Library/Homebrew/test/commands_spec.rb
+++ b/Library/Homebrew/test/commands_spec.rb
@@ -144,6 +144,17 @@ RSpec.describe Commands do
         expect(commands).not_to include("rbcmd")
       end
     end
+
+    it "does not load external command files" do
+      mktmpdir do |cache|
+        stub_const("HOMEBREW_CACHE", cache)
+        allow(described_class).to receive(:external_commands).and_return(["external"])
+
+        expect(described_class).not_to receive(:external_ruby_v2_cmd_path)
+
+        described_class.rebuild_commands_completion_list
+      end
+    end
   end
 
   describe "::path" do


### PR DESCRIPTION
- `rebuild_commands_completion_list` runs on every `brew update` and `tap`/`untap`. The hidden-command filter added in `e2dc82ec5d` resolved each command via `Commands.path`, which loads and runs every external Ruby command in every tap.
- Internal and developer commands are already filtered for `hide_from_man_page` by `find_internal_commands`, so the extra filter only added the external-command loading regression.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Opus 4.8 max with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
