### PR TITLE
pathname: change `write_env_script` type

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -325,10 +325,9 @@ class Pathname
       args_or_env: T.any(
         String, Pathname,
         T::Array[T.any(String, Pathname)],
-        T::Hash[String, T.any(String, Pathname)],
-        T::Hash[Symbol, T.any(String, Pathname)]
+        T::Hash[T.any(String, Symbol), T.any(String, Pathname)]
       ),
-      env:         T.any(T::Hash[String, T.any(String, Pathname)], T::Hash[Symbol, T.any(String, Pathname)]),
+      env:         T::Hash[T.any(String, Symbol), T.any(String, Pathname)],
     ).void
   }
   def write_env_script(target, args_or_env, env = T.unsafe(nil))

--- a/Library/Homebrew/test/extend/pathname_spec.rb
+++ b/Library/Homebrew/test/extend/pathname_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe Pathname do
 
     it "creates script without arguments" do
       mktmpdir do |tmpdir|
-        (tmpdir/"wrapper_script").write_env_script "test", TEST: "bar", TEST2: tmpdir/"baz"
+        env = { TEST: "bar" }
+        env["TEST2"] = tmpdir/"baz"
+        (tmpdir/"wrapper_script").write_env_script "test", env
         expect((tmpdir/"wrapper_script").read).to eq(<<~BASH)
           #!/bin/bash
           TEST="bar" TEST2="#{tmpdir}/baz" exec "test"  "$@"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
Allow to mix strings and symbols keys in the same hash. This is useful when adding new entries to a hash that uses symbols as keys, f.e:
```ruby
env = Language::Java.overridable_java_home_env
env["FOO"] = "bar"
(bin/"test-script").write_env_script libexec/"test-script", env
```

Found in https://github.com/Homebrew/homebrew-core/actions/runs/27268992443/job/80534529987