### PR TITLE
Support macOS 27 as current beta release

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -646,9 +646,9 @@ HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://ghcr.io/v2/homebrew/core"
 # - Library/Homebrew/os/mac/xcode.rb (latest_version), (minimum_version)
 # and, if needed:
 # - MacOSVersion::SYMBOLS
-HOMEBREW_MACOS_NEWEST_UNSUPPORTED="27"
+HOMEBREW_MACOS_NEWEST_UNSUPPORTED="28"
 # TODO: bump version when new macOS is released
-HOMEBREW_MACOS_NEWEST_SUPPORTED="26"
+HOMEBREW_MACOS_NEWEST_SUPPORTED="27"
 # TODO: bump version when new macOS is released and update references in:
 # - docs/Installation.md
 # - HOMEBREW_MACOS_OLDEST_SUPPORTED in .github/workflows/release.yml

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -60,7 +60,7 @@ module OS
     def self.latest_sdk_version
       # TODO: bump version when new Xcode macOS SDK is released
       # NOTE: We only track the major version of the SDK.
-      ::Version.new("26")
+      ::Version.new("27")
     end
 
     sig { returns(String) }

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -17,6 +17,7 @@ module OS
       def self.latest_version(macos: MacOS.version)
         macos = macos.strip_patch
         case macos
+        when "27" then "27.0"
         when "26", "15" then "26.3"
         when "14" then "16.2"
         when "13" then "15.2"
@@ -39,6 +40,7 @@ module OS
       def self.minimum_version
         macos = MacOS.version
         case macos
+        when "27" then "27.0"
         when "15" then "16.0"
         when "14" then "15.0"
         when "13" then "14.1"
@@ -228,6 +230,7 @@ module OS
         when "14.0.3" then "14.3.1"
         when "15.0.0" then "15.4"
         when "16.0.0" then "16.2"
+        when "21.0.0" then "27.0"
         else               "26.3"
         end
       end


### PR DESCRIPTION
## Summary

Support the current macOS 27 (Golden Gate) beta in Homebrew startup/version checks by:

- Bumping `HOMEBREW_MACOS_NEWEST_SUPPORTED` to `27` and `HOMEBREW_MACOS_NEWEST_UNSUPPORTED` to `28`.
- Updating `OS::Mac.latest_sdk_version` to `27`.
- Adding explicit macOS 27 Xcode mappings in `OS::Mac::Xcode`:
  - `latest_version` -> `27.0`
  - `minimum_version` -> `27.0`
  - Clang fallback map for `21.0.0` -> `27.0`

This builds on the earlier preliminary macOS 27 support and moves it to supported for users on the beta release line.

## Notes

No tests were run in this pass; changes are limited to the version support path.
