### PR TITLE
Base `--changed` commands on `origin/HEAD`

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -16,6 +16,7 @@ require "digest"
 require "json"
 require "formula_auditor"
 require "tap_auditor"
+require "utils/git"
 
 module Homebrew
   module DevCmd
@@ -128,8 +129,7 @@ module Homebrew
             audit_formulae = []
             audit_casks = []
 
-            changed_files = Utils.popen_read("git", "diff", "--name-only", "--no-relative", "main")
-            changed_files.split("\n").each do |file|
+            Utils::Git.changed_files(tap.path).each do |file|
               next unless file.end_with?(".rb")
 
               absolute_file = File.expand_path(file, tap.path)

--- a/Library/Homebrew/dev-cmd/style.rb
+++ b/Library/Homebrew/dev-cmd/style.rb
@@ -5,6 +5,7 @@ require "abstract_command"
 require "json"
 require "open3"
 require "style"
+require "utils/git"
 
 module Homebrew
   module DevCmd
@@ -91,14 +92,13 @@ module Homebrew
 
       sig { returns(T::Array[Pathname]) }
       def changed_ruby_or_shell_files
-        repo = Utils.popen_read("git", "rev-parse", "--show-toplevel").chomp
+        repository = Utils.popen_read("git", "rev-parse", "--show-toplevel").chomp
         odie "`brew style --changed` must be run inside a git repository!" unless $CHILD_STATUS.success?
 
-        changed_files = Utils.popen_read("git", "diff", "--name-only", "--no-relative", "main")
-        changed_files.split("\n").filter_map do |file|
+        Utils::Git.changed_files(repository).filter_map do |file|
           next if !file.end_with?(".rb", ".sh", ".yml", ".rbi") && file != "bin/brew"
 
-          Pathname(file).expand_path(repo)
+          Pathname(file).expand_path(repository)
         end.select(&:exist?)
       end
     end

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -5,6 +5,7 @@ require "abstract_command"
 require "fileutils"
 require "hardware"
 require "system_command"
+require "utils/git"
 
 module Homebrew
   module DevCmd
@@ -235,15 +236,14 @@ module Homebrew
 
       sig { returns(T::Array[String]) }
       def changed_test_files
-        changed_files = Utils.popen_read("git", "diff", "--name-only", "main")
+        changed_files = Utils::Git.changed_files(HOMEBREW_REPOSITORY)
 
-        odebug "No files have been changed from the `main` branch." if changed_files.blank?
-        return [] if changed_files.blank?
+        odebug "No files have been changed from the default branch." if changed_files.empty?
+        return [] if changed_files.empty?
 
         filestub_regex = %r{Library/Homebrew/([\w/-]+).rb}
-        T.cast(changed_files.scan(filestub_regex), T::Array[T::Array[String]])
-         .map { it.fetch(-1) }
-         .flat_map do |filestub|
+        changed_files.filter_map { |file| file[filestub_regex, 1] }
+                     .flat_map do |filestub|
           shared_context_tests = shared_context_test_files(filestub)
           next shared_context_tests if shared_context_tests.present?
 

--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -62,8 +62,7 @@ RSpec.describe Homebrew::DevCmd::Tests do
       let(:changed_file) { "Library/Homebrew/test/cmd/help_spec.rb\n" }
 
       before do
-        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "main")
-                                            .and_return(changed_file)
+        allow(Utils::Git).to receive(:changed_files).and_return(changed_file.split("\n"))
       end
 
       it "includes the changed spec file" do
@@ -75,8 +74,7 @@ RSpec.describe Homebrew::DevCmd::Tests do
       let(:changed_file) { "Library/Homebrew/cmd/help.rb\n" }
 
       before do
-        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "main")
-                                            .and_return(changed_file)
+        allow(Utils::Git).to receive(:changed_files).and_return(changed_file.split("\n"))
       end
 
       it "maps the file to its corresponding spec" do
@@ -90,8 +88,7 @@ RSpec.describe Homebrew::DevCmd::Tests do
       end
 
       before do
-        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "main")
-                                            .and_return(changed_file)
+        allow(Utils::Git).to receive(:changed_files).and_return(changed_file.split("\n"))
       end
 
       it "includes integration tests and excludes unrelated tests", :aggregate_failures do
@@ -106,8 +103,7 @@ RSpec.describe Homebrew::DevCmd::Tests do
       end
 
       before do
-        allow(Utils).to receive(:popen_read).with("git", "diff", "--name-only", "main")
-                                            .and_return(changed_file)
+        allow(Utils::Git).to receive(:changed_files).and_return(changed_file.split("\n"))
       end
 
       it "includes cask tests and excludes non-cask tests", :aggregate_failures do

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -96,6 +96,20 @@ RSpec.describe Utils::Git do
     end
   end
 
+  describe "::changed_files" do
+    it "diffs against the `origin/HEAD` merge-base, ignoring a stale local default branch" do
+      git = HOMEBREW_SHIMS_PATH/"shared/git"
+      HOMEBREW_CACHE.cd do
+        system git, "checkout", "--quiet", "-b", "feature"
+        system git, "update-ref", "refs/remotes/origin/HEAD", "HEAD" # up-to-date upstream
+        system git, "branch", "--force", "main", "HEAD~2" # stale local default branch
+        File.write("README.md", "changed")
+      end
+
+      expect(described_class.changed_files(HOMEBREW_CACHE)).to eq(["README.md"])
+    end
+  end
+
   describe "#last_revision_commit_of_files" do
     context "when before_commit is nil" do
       it "gives last revision commit" do

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -110,6 +110,18 @@ module Utils
       Utils.popen_read(git, "-C", repo, "show", "#{commit}:#{relative_file}")
     end
 
+    # The paths (relative to `repository`'s root) changed in its working tree
+    # since it diverged from the upstream default branch. The base is the
+    # `origin/HEAD` merge-base rather than the local default branch ref, which
+    # is often stale (e.g. in worktrees and freshly-cloned taps); it falls back
+    # to `main` when `origin/HEAD` is unavailable.
+    sig { params(repository: T.any(Pathname, String)).returns(T::Array[String]) }
+    def self.changed_files(repository)
+      base_ref = Utils.popen_read(git, "-C", repository, "merge-base", "origin/HEAD", "HEAD").chomp.presence
+      base_ref ||= "main"
+      Utils.popen_read(git, "-C", repository, "diff", "--name-only", "--no-relative", base_ref).split("\n")
+    end
+
     sig { void }
     def self.ensure_installed!
       return if available?


### PR DESCRIPTION
- `style`, `tests` and `audit` `--changed` diffed against the local default branch ref, which is often stale (e.g. in worktrees and freshly-cloned taps) where you branch off an up-to-date upstream
- a stale base reports far more as changed, dragging in files that then get linted or "fixed" with the wrong config
- add a shared `Utils::Git.changed_files` that diffs against the `origin/HEAD` merge-base, falling back to `main`, and use it in all three commands so taps and worktrees behave correctly

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 high with local review, tweaking and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
