### PR TITLE
utils/ast: find resources if they are in `stable` block

### DIFF
--- a/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
@@ -17,6 +17,52 @@ RSpec.describe Utils::AST::FormulaAST do
     RUBY
   end
 
+  describe "#resource" do
+    it "finds resource block in a formula" do
+      formula_ast = described_class.new <<~RUBY
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tar.gz"
+
+          resource "foo" do
+            url "https://brew.sh/foo-1.0.tar.gz"
+          end
+        end
+      RUBY
+
+      expect(formula_ast.resource("foo").children[2].children[2].value).to eq("https://brew.sh/foo-1.0.tar.gz")
+    end
+
+    it "finds resource in `stable` block" do
+      formula_ast = described_class.new <<~RUBY
+        class Foo < Formula
+          stable do
+            url "https://brew.sh/foo-1.0.tar.gz"
+
+            resource "foo" do
+              url "https://brew.sh/foo-1.1.tar.gz"
+            end
+          end
+
+          resource "foo" do
+            url "https://brew.sh/foo-1.0.tar.gz"
+          end
+        end
+      RUBY
+
+      expect(formula_ast.resource("foo").children[2].children[2].value).to eq("https://brew.sh/foo-1.1.tar.gz")
+    end
+
+    it "raises an exception when resource block does not exist" do
+      formula_ast = described_class.new <<~RUBY
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tar.gz"
+        end
+      RUBY
+
+      expect { formula_ast.resource("foo") }.to raise_error("Could not find resource 'foo' block!")
+    end
+  end
+
   describe "#replace_stanza" do
     it "replaces the specified stanza in a formula" do
       formula_ast.replace_stanza(:license, :public_domain)

--- a/Library/Homebrew/utils/ast.rb
+++ b/Library/Homebrew/utils/ast.rb
@@ -118,7 +118,14 @@ module Utils
 
       sig { params(name: String).returns(BlockNode) }
       def resource(name)
-        resource = stanzas(:resource, type: :block_call).find do |resource_node|
+        possible_resource_stanzas = if stanza(:stable, type: :block_call).present?
+          # Needed resource block may be either in `stable` or in formula body, hence appending
+          # `children` nodes
+          stable_children + children
+        else
+          children
+        end
+        resource = matching_stanzas(possible_resource_stanzas, :resource, type: :block_call).find do |resource_node|
           T.cast(resource_node, BlockNode).send_node.first_argument&.str_content == name
         end
         raise "Could not find resource '#{name}' block!" if resource.blank?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
There is a problem with `brew bump-formula-pr` that fails to update formula resources if they are in `stable` block. It fails with `Could not find resource 'src' block!` even if the resource exists

See https://github.com/Homebrew/homebrew-core/pull/286987 (`audacious`) and https://github.com/Homebrew/homebrew-core/actions/runs/27274309956/job/80551518696#step:6:6739 (`dotnet`)
