### PR TITLE
macOS: make latest SDK floor follow prerelease marker

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -60,6 +60,8 @@ module OS
     def self.latest_sdk_version
       # TODO: bump version when new Xcode macOS SDK is released
       # NOTE: We only track the major version of the SDK.
+      return ::Version.new(HOMEBREW_MACOS_NEWEST_UNSUPPORTED) if version.prerelease?
+
       ::Version.new("26")
     end
 

--- a/Library/Homebrew/test/os/mac_spec.rb
+++ b/Library/Homebrew/test/os/mac_spec.rb
@@ -5,6 +5,18 @@ require "locale"
 require "os/mac"
 
 RSpec.describe OS::Mac do
+  describe "::latest_sdk_version" do
+    it "uses the beta floor for prerelease macOS versions" do
+      allow(described_class).to receive(:version).and_return(MacOSVersion.new("27"))
+      expect(described_class.latest_sdk_version).to eq(Version.new("27"))
+    end
+
+    it "uses the current stable floor on supported macOS versions" do
+      allow(described_class).to receive(:version).and_return(MacOSVersion.new("26"))
+      expect(described_class.latest_sdk_version).to eq(Version.new("26"))
+    end
+  end
+
   describe "::languages" do
     it "returns a list of all languages" do
       expect(described_class.languages).not_to be_empty


### PR DESCRIPTION
## Summary

Handle macOS prerelease (beta) SDK floor dynamically by using `HOMEBREW_MACOS_NEWEST_UNSUPPORTED` when `OS::Mac.version` is prerelease, while keeping current supported/unsupported version policy intact.

## Changes

- Update `OS::Mac.latest_sdk_version` to return `HOMEBREW_MACOS_NEWEST_UNSUPPORTED` on prerelease macOS versions.
- Keep stable floor at `26` as-is until normal release/SDK bump cycles.
- Add focused specs in `Library/Homebrew/test/os/mac_spec.rb` for both prerelease and supported-version behavior.

## Rationale

This aligns with maintainer feedback on PR #22643 (`"unsupported deliberately until it is released"`) by avoiding an early supported-version bump while still avoiding false SDK-version regressions on macOS 27 beta systems.

## Notes

I did not run tests in this pass.
