### PR TITLE
workflows/tests: speed up glibc test runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -405,14 +405,12 @@ jobs:
           uninstall: true
 
       - name: Setup environment variables
+        if: matrix.name == 'test-bot (Linux Homebrew glibc)'
         run: |
-          # Set environment variables to bypass `brew doctor` failures on Tier >=2 configurations
-          if [[ "${MATRIX_NAME}" == "test-bot (Linux Homebrew glibc)" ]]; then
-            echo "HOMEBREW_GLIBC_TESTING=1" >> "$GITHUB_ENV"
-            echo "HOMEBREW_SORBET_RECURSIVE=0" >> "$GITHUB_ENV"
-          fi
-        env:
-          MATRIX_NAME: ${{ matrix.name }}
+          # Set environment variables to bypass `brew doctor` failures and disable
+          # recursive Sorbet runtime checks for speed on Tier >=2 configurations
+          echo "HOMEBREW_GLIBC_TESTING=1" >> "$GITHUB_ENV"
+          echo "HOMEBREW_SORBET_RECURSIVE=0" >> "$GITHUB_ENV"
 
       - run: brew test-bot --only-cleanup-before
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -409,6 +409,7 @@ jobs:
           # Set environment variables to bypass `brew doctor` failures on Tier >=2 configurations
           if [[ "${MATRIX_NAME}" == "test-bot (Linux Homebrew glibc)" ]]; then
             echo "HOMEBREW_GLIBC_TESTING=1" >> "$GITHUB_ENV"
+            echo "HOMEBREW_SORBET_RECURSIVE=0" >> "$GITHUB_ENV"
           fi
         env:
           MATRIX_NAME: ${{ matrix.name }}


### PR DESCRIPTION
PR to experiment with some changes to see impact on glibc runner times.

Baseline:
- `brew test-bot --only-setup` old runs took 1m and now are around 6-7m
- `brew test-bot --only-formulae --only-json-tab --test-default-formula` old runs took 2.5m and now around 12-14m

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
