### PR TITLE
Isolate trust store specs to fix flaky test

### DIFF
--- a/Library/Homebrew/test/cmd/trust_spec.rb
+++ b/Library/Homebrew/test/cmd/trust_spec.rb
@@ -5,7 +5,7 @@ require "cmd/shared_examples/args_parse"
 require "cmd/trust"
 require "trust"
 
-RSpec.describe Homebrew::Cmd::Trust do
+RSpec.describe Homebrew::Cmd::Trust, :trust_store do
   RSpec::Matchers.define :match_json do |expected|
     T.bind(self, T.class_of(RSpec::Matchers::DSL::Matcher))
     match do |actual|

--- a/Library/Homebrew/test/cmd/untrust_spec.rb
+++ b/Library/Homebrew/test/cmd/untrust_spec.rb
@@ -5,7 +5,7 @@ require "cmd/shared_examples/args_parse"
 require "cmd/untrust"
 require "trust"
 
-RSpec.describe Homebrew::Cmd::Untrust do
+RSpec.describe Homebrew::Cmd::Untrust, :trust_store do
   it_behaves_like "parseable arguments"
 
   it "untrusts a given tap", :integration_test do

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -57,6 +57,7 @@ require "test/support/helper/subcommand"
 
 require "test/support/helper/spec/shared_context/homebrew_cask" if OS.mac?
 require "test/support/helper/spec/shared_context/integration_test"
+require "test/support/helper/spec/shared_context/trust_store"
 require "test/support/helper/spec/shared_examples/formulae_exist"
 
 TEST_DIRECTORIES = [

--- a/Library/Homebrew/test/support/helper/spec/shared_context/trust_store.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/trust_store.rb
@@ -1,0 +1,20 @@
+# typed: true
+# frozen_string_literal: true
+
+require "tmpdir"
+
+# Isolate the `Homebrew::Trust` store in a per-example config home so a parallel worker's teardown
+# (which deletes the shared default `trust.json`) cannot clobber it between writing and re-reading.
+RSpec.shared_context "trust store" do # rubocop:disable RSpec/ContextWording
+  T.bind(self, T.class_of(RSpec::Core::ExampleGroup))
+
+  around do |example|
+    Dir.mktmpdir do |config_home|
+      with_env(HOMEBREW_USER_CONFIG_HOME: config_home) { example.run }
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include_context "trust store", :trust_store
+end

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -3,15 +3,8 @@
 
 require "tap"
 require "trust"
-require "tmpdir"
 
-RSpec.describe Homebrew::Trust do
-  around do |example|
-    Dir.mktmpdir do |config_home|
-      with_env(HOMEBREW_USER_CONFIG_HOME: config_home) { example.run }
-    end
-  end
-
+RSpec.describe Homebrew::Trust, :trust_store do
   it "lets HOMEBREW_NO_REQUIRE_TAP_TRUST override HOMEBREW_REQUIRE_TAP_TRUST" do
     with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1", HOMEBREW_NO_REQUIRE_TAP_TRUST: "1") do
       expect(Homebrew::EnvConfig.require_tap_trust?).to be(false)


### PR DESCRIPTION
- The shared default `trust.json` config home is reused by every parallel test worker, and the global spec teardown deletes it after each example.
- The `cmd/trust` "plural switch alias" example wrote then re-read that file, so a sibling worker's teardown could wipe it in between and flip `trusted?` to false intermittently.
- Extract the per-example config-home isolation (already duplicated in `trust_spec`) into a shared `:trust_store` context and apply it to the `trust`, `cmd/trust` and `cmd/untrust` specs.

As spotted by @cho-m.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 high with local review and tweaking.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
