### PR TITLE
Remove dead code in Library/Homebrew/utils/

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -93,6 +93,7 @@ Style/Documentation:
     - os/mac.rb
     - resource.rb
     - startup/config.rb
+    - utils/gzip.rb
     - utils/inreplace.rb
     - utils/output.rb
     - utils/shebang.rb

--- a/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
@@ -88,30 +88,6 @@ RSpec.describe Utils::AST::FormulaAST do
     end
   end
 
-  describe "#remove_stanzas" do
-    subject(:formula_ast) do
-      described_class.new <<~RUBY
-        class Foo < Formula
-          url "https://brew.sh/foo-1.0.tar.gz"
-          mirror "https://example.com/foo-1.0.tar.gz"
-          mirror "https://mirror.example.com/foo-1.0.tar.gz"
-          sha256 "#{"e" * 64}"
-        end
-      RUBY
-    end
-
-    it "removes all matching stanzas" do
-      formula_ast.remove_stanzas(:mirror)
-
-      expect(formula_ast.process).to eq <<~RUBY
-        class Foo < Formula
-          url "https://brew.sh/foo-1.0.tar.gz"
-          sha256 "#{"e" * 64}"
-        end
-      RUBY
-    end
-  end
-
   describe "#add_stanzas_after" do
     it "adds multiple stanzas after the specified stanza" do
       formula_ast.add_stanzas_after(:url, [[:mirror, "https://example.com/foo-1.0.tar.gz"], [:version, "1.0"]])

--- a/Library/Homebrew/test/utils/git_repository_spec.rb
+++ b/Library/Homebrew/test/utils/git_repository_spec.rb
@@ -83,17 +83,4 @@ RSpec.describe Utils do
       end
     end
   end
-
-  describe "::git_commit_message" do
-    include_examples "git_repository helper function", :git_commit_message
-
-    it "returns the commit message of HEAD" do
-      expect(described_class.git_commit_message(HOMEBREW_CACHE)).to eq(commit_message)
-      expect(described_class.git_commit_message(HOMEBREW_CACHE, commit: head_revision)).to eq(commit_message)
-      HOMEBREW_CACHE.cd do
-        expect(described_class.git_commit_message).to eq(commit_message)
-        expect(described_class.git_commit_message(commit: head_revision)).to eq(commit_message)
-      end
-    end
-  end
 end

--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -47,13 +47,6 @@ RSpec.describe GitHub do
     end
   end
 
-  describe "::public_member_usernames", :needs_network do
-    it "gets the usernames of all publicly visible members of the organisation" do
-      response = described_class.public_member_usernames("Homebrew")
-      expect(response).to be_a(Array)
-    end
-  end
-
   describe "::get_artifact_urls", :needs_network do
     it "fails to find a nonexistent workflow" do
       expect do

--- a/Library/Homebrew/test/utils/gzip_spec.rb
+++ b/Library/Homebrew/test/utils/gzip_spec.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "utils/gzip"

--- a/Library/Homebrew/test/utils/inreplace_spec.rb
+++ b/Library/Homebrew/test/utils/inreplace_spec.rb
@@ -82,49 +82,4 @@ RSpec.describe Utils::Inreplace do
       EOS
     end
   end
-
-  describe ".inreplace_pairs" do
-    it "raises error if there is no old value" do
-      inreplace = T.let(described_class, T.untyped)
-      expect { inreplace.inreplace_pairs(file.path, [[nil, "f"]]) }.to raise_error(TypeError)
-    end
-
-    it "substitutes returned string but not file when `read_only_run: true`" do
-      expect(described_class.inreplace_pairs(file.path, [["a", "foo"]], read_only_run: true)).to eq <<~EOS
-        foo
-        b
-        c
-        foofoo
-      EOS
-      expect(File.binread(file)).to eq <<~EOS
-        a
-        b
-        c
-        aa
-      EOS
-    end
-
-    it "substitutes both returned string and file when `read_only_run: false`" do
-      replace_result = <<~TEXT
-        foo
-        b
-        c
-        foofoo
-      TEXT
-      expect(described_class.inreplace_pairs(file.path, [["a", "foo"]])).to eq replace_result
-      expect(File.binread(file)).to eq replace_result
-    end
-
-    it "substitutes multiple pairs in order" do
-      pairs = [["a", "b"], ["bb", "test"], ["b", "z"]]
-      replace_result = <<~TEXT
-        z
-        z
-        c
-        test
-      TEXT
-      expect(described_class.inreplace_pairs(file.path, pairs)).to eq replace_result
-      expect(File.binread(file)).to eq replace_result
-    end
-  end
 end

--- a/Library/Homebrew/test/utils/svn_spec.rb
+++ b/Library/Homebrew/test/utils/svn_spec.rb
@@ -9,8 +9,15 @@ RSpec.describe Utils::Svn do
     instance_double(SystemCommand::Result, to_a: [stdout, stderr, status])
   end
 
+  def clear_version_cache
+    return unless described_class.instance_variable_defined?(:@version)
+
+    described_class.send(:remove_instance_variable,
+                         :@version)
+  end
+
   before do
-    described_class.clear_version_cache
+    clear_version_cache
   end
 
   describe "::available?" do
@@ -33,7 +40,7 @@ RSpec.describe Utils::Svn do
 
       expect(described_class.version).to eq("1.14.5")
 
-      described_class.clear_version_cache
+      clear_version_cache
       expect(described_class).to receive(:system_command)
         .with(HOMEBREW_SHIMS_PATH/"shared/svn", args: ["--version"], print_stderr: false)
         .and_return(svn_result("", success: false))

--- a/Library/Homebrew/test/utils/tar_spec.rb
+++ b/Library/Homebrew/test/utils/tar_spec.rb
@@ -4,8 +4,15 @@
 require "utils/tar"
 
 RSpec.describe Utils::Tar do
+  def clear_executable_cache
+    return unless described_class.instance_variable_defined?(:@executable)
+
+    described_class.send(:remove_instance_variable,
+                         :@executable)
+  end
+
   before do
-    described_class.clear_executable_cache
+    clear_executable_cache
   end
 
   describe ".available?" do

--- a/Library/Homebrew/utils/ast.rb
+++ b/Library/Homebrew/utils/ast.rb
@@ -250,14 +250,6 @@ module Utils
         remove_stanza_node(stanza_node)
       end
 
-      sig { params(name: Symbol, type: T.nilable(Symbol)).void }
-      def remove_stanzas(name, type: nil)
-        stanza_nodes = stanzas(name, type:)
-        raise "Could not find '#{name}' stanza!" if stanza_nodes.empty?
-
-        stanza_nodes.each { |stanza_node| remove_stanza_node(stanza_node) }
-      end
-
       sig { params(name: Symbol, replacement: T.any(Numeric, String, Symbol), type: T.nilable(Symbol)).void }
       def replace_stanza(name, replacement, type: nil)
         stanza_node = stanza(name, type:)

--- a/Library/Homebrew/utils/git_repository.rb
+++ b/Library/Homebrew/utils/git_repository.rb
@@ -38,16 +38,4 @@ module Utils
   def self.git_branch(repo = Pathname.pwd, safe: true)
     GitRepository.new(Pathname(repo)).branch_name(safe:)
   end
-
-  # Gets the full commit message of the specified commit, or of the HEAD commit if unspecified.
-  sig {
-    params(
-      repo:   T.any(String, Pathname),
-      commit: String,
-      safe:   T::Boolean,
-    ).returns(T.nilable(String))
-  }
-  def self.git_commit_message(repo = Pathname.pwd, commit: "HEAD", safe: true)
-    GitRepository.new(Pathname(repo)).commit_message(commit, safe:)
-  end
 end

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -71,11 +71,6 @@ module GitHub
     @user ||= T.let(API.open_rest("#{API_URL}/user"), T.nilable(T::Hash[String, T.untyped]))
   end
 
-  sig { params(repo: String, user: String).returns(T::Hash[String, T.untyped]) }
-  def self.permission(repo, user)
-    API.open_rest("#{API_URL}/repos/#{repo}/collaborators/#{user}/permission")
-  end
-
   sig { params(query: String, only: T.nilable(T.any(Symbol, String))).void }
   def self.print_pull_requests_matching(query, only = nil)
     open_or_closed_prs = search_issues(query, is: only, type: "pr", user: "Homebrew")
@@ -379,21 +374,6 @@ module GitHub
     end
 
     matching_artifacts.map { |art| art["archive_download_url"] }
-  end
-
-  sig { params(org: String, per_page: Integer).returns(T::Array[String]) }
-  def self.public_member_usernames(org, per_page: MAX_PER_PAGE)
-    url = "#{API_URL}/orgs/#{org}/public_members"
-    members = []
-
-    API.paginate_rest(url, per_page:) do |result|
-      result = result.map { |member| member["login"] }
-      members.concat(result)
-
-      return members if result.length < per_page
-    end
-
-    members
   end
 
   sig { params(org: String, team: String).returns(T::Hash[String, String]) }

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -46,9 +46,6 @@ module GitHub
     class Error < RuntimeError
       include Utils::Output::Mixin
 
-      sig { returns(T.nilable(String)) }
-      attr_reader :github_message
-
       sig { params(message: T.nilable(String), github_message: String).void }
       def initialize(message = nil, github_message = T.unsafe(nil))
         @github_message = T.let(github_message, T.nilable(String))

--- a/Library/Homebrew/utils/gzip.rb
+++ b/Library/Homebrew/utils/gzip.rb
@@ -53,6 +53,14 @@ module Utils
       Pathname.new(output)
     end
 
+    # Compress one or more files with `gzip`, reproducibly by default.
+    #
+    # Unlike the system `gzip`, this avoids recording the build-time modification
+    # time so that the output is deterministic (see {https://docs.brew.sh/Reproducible-Builds}).
+    # Each file is compressed in place, placing the result next to the original
+    # with a `.gz` suffix, and the resulting paths are returned.
+    #
+    # @api public
     sig {
       params(
         paths:        T.any(String, Pathname),

--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -82,30 +82,5 @@ module Utils
 
       raise Utils::Inreplace::Error, errors if errors.present?
     end
-
-    sig {
-      params(
-        path:              T.any(String, Pathname),
-        replacement_pairs: T::Array[[T.any(Regexp, Pathname, String), T.any(Pathname, String)]],
-        read_only_run:     T::Boolean,
-        silent:            T::Boolean,
-      ).returns(String)
-    }
-    def self.inreplace_pairs(path, replacement_pairs, read_only_run: false, silent: false)
-      str = File.binread(path)
-      contents = StringInreplaceExtension.new(str)
-      replacement_pairs.each do |old, new|
-        if old.blank?
-          contents.errors << "No old value for new value #{new}! Did you pass the wrong arguments?"
-          next
-        end
-
-        contents.gsub!(old, new)
-      end
-      raise Utils::Inreplace::Error, path => contents.errors if contents.errors.present?
-
-      Pathname(path).atomic_write(contents.inreplace_string) unless read_only_run
-      contents.inreplace_string
-    end
   end
 end

--- a/Library/Homebrew/utils/linkage.rb
+++ b/Library/Homebrew/utils/linkage.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 module Utils
+  # @api internal
   sig {
     params(binary: T.any(String, Pathname), library: T.any(String, Pathname)).returns(T::Boolean)
   }

--- a/Library/Homebrew/utils/output.rb
+++ b/Library/Homebrew/utils/output.rb
@@ -263,17 +263,6 @@ module Utils
       end
 
       sig { params(string: String).returns(String) }
-      def pretty_outdated(string)
-        if !$stdout.tty?
-          string
-        elsif Homebrew::EnvConfig.no_emoji?
-          Formatter.error("#{Tty.bold}#{string} (outdated)#{Tty.reset}")
-        else
-          "#{Tty.bold}#{string} #{Formatter.warning("⚠")}#{Tty.reset}"
-        end
-      end
-
-      sig { params(string: String).returns(String) }
       def pretty_upgradable(string)
         if !$stdout.tty?
           string

--- a/Library/Homebrew/utils/repology.rb
+++ b/Library/Homebrew/utils/repology.rb
@@ -10,8 +10,6 @@ module Repology
 
   HOMEBREW_CORE = "homebrew"
   HOMEBREW_CASK = "homebrew_casks"
-  MAX_PAGINATION = 15
-  private_constant :MAX_PAGINATION
 
   sig { params(last_package_in_response: T.nilable(String), repository: String).returns(T::Hash[String, T.untyped]) }
   def self.query_api(last_package_in_response = "", repository:)

--- a/Library/Homebrew/utils/svn.rb
+++ b/Library/Homebrew/utils/svn.rb
@@ -46,11 +46,6 @@ module Utils
         end
         args
       end
-
-      sig { void }
-      def clear_version_cache
-        remove_instance_variable(:@version) if defined?(@version)
-      end
     end
   end
 end

--- a/Library/Homebrew/utils/tar.rb
+++ b/Library/Homebrew/utils/tar.rb
@@ -38,11 +38,6 @@ module Utils
                                                                print_stderr: false).to_a
         odie "#{path} is not a valid tar file!" if !status.success? || stdout.blank?
       end
-
-      sig { void }
-      def clear_executable_cache
-        remove_instance_variable(:@executable) if defined?(@executable)
-      end
     end
   end
 end

--- a/Library/Homebrew/utils/topological_hash.rb
+++ b/Library/Homebrew/utils/topological_hash.rb
@@ -56,12 +56,12 @@ module Utils
 
     private
 
-    sig { params(block: T.proc.params(arg0: K).void).void }
+    sig { override.params(block: T.proc.params(arg0: K).void).void }
     def tsort_each_node(&block)
       each_key(&block)
     end
 
-    sig { params(node: K, block: T.proc.params(arg0: CaskOrFormula).void).returns(V) }
+    sig { override.params(node: K, block: T.proc.params(arg0: CaskOrFormula).void).returns(V) }
     def tsort_each_child(node, &block)
       fetch(node).each(&block)
     end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

## Overview

I'm experimenting with a custom `brew deadcode` command backed by [Spoom's dead code removal](https://github.com/shopify/spoom?tab=readme-ov-file#dead-code-removal), extended to respect Sorbet `override` signatures and `@api` annotations so that dynamically-dispatched and externally-consumed code isn't flagged. **This PR is an extraction of that work limited to `Library/Homebrew/utils/`**, to evaluate viability on a small, low-risk surface before proposing anything larger.

## What's here

- Removes unused methods in `Library/Homebrew/utils/` identified by the deadcode pass (`Inreplace.inreplace_pairs`, `GitRepository.git_commit_message`, `GitHub.permission`, `GitHub.public_member_usernames`, `AST::FormulaAST#remove_stanzas`, …) and their now-orphaned specs.
- Marks `TopologicalHash#tsort_each_node` / `#tsort_each_child` as `override`, since they override `TSort`'s abstract methods.
- **Relocates test-only code to specs**: `Svn.clear_version_cache` and `Tar.clear_executable_cache` existed solely to reset memoized state from their specs. They're moved into the specs (resetting the ivar directly). This arguably makes more sense and keeps the source focused on shipped behavior.
- **Keeps externally-consumed methods, marked `# @api internal`** rather than removing them, since nothing in `brew` itself calls them but `homebrew-core` does:
  - `Utils.binary_linked_to_library?` — ~58 call sites in `homebrew-core`.
  - `Utils::Gzip.compress` — ~31 call sites in `homebrew-core`, and documented in [Reproducible Builds](https://docs.brew.sh/Reproducible-Builds).

  These are exactly the cases the `@api`-aware deadcode pass is meant to preserve.

## AI disclosure

- [x] AI was used to generate or assist with generating this PR.

AI (Claude Code) drove the spoom-backed removal and this extraction. Every removal was checked for live callers in `brew` (static + dynamic/symbol references) and in `homebrew-core`; `binary_linked_to_library?` and `Gzip.compress` were caught this way and kept. Verified locally: `brew typecheck` is clean, `brew style` passes, and the full `brew tests` suite passes.