### PR TITLE
cask/caskroom: handle untrusted errors better

### DIFF
--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -90,9 +90,19 @@ module Cask
     sig { params(config: T.nilable(Config)).returns(T::Array[Cask]) }
     def self.casks(config: nil)
       tokens.sort.filter_map do |token|
-        CaskLoader.load_prefer_installed(token, config:, warn: false)
-      rescue TapCaskAmbiguityError => e
-        e.loaders.fetch(0).load(config:)
+        # This is nested so that the rescue can catch errors from both branches
+        begin
+          CaskLoader.load_prefer_installed(token, config:, warn: false)
+        rescue TapCaskAmbiguityError => e
+          e.loaders.fetch(0).load(config:)
+        end
+      rescue Homebrew::UntrustedTapError
+        # If the tap is untrusted the only place we can load the cask from is the installed cask file, if it exists.
+        begin
+          CaskLoader::FromInstalledPathLoader.try_new(token, warn: false)&.load(config:)
+        rescue
+          nil
+        end
       rescue
         # Don't blow up because of a single unavailable cask.
         nil

--- a/Library/Homebrew/test/cask/caskroom_spec.rb
+++ b/Library/Homebrew/test/cask/caskroom_spec.rb
@@ -101,6 +101,81 @@ RSpec.describe Cask::Caskroom do
     end
   end
 
+  describe ".casks" do
+    sig { params(dir: Pathname, token: String, tap: T.nilable(Tap), version: String).void }
+    def setup_cask_metadata(dir, token, tap: nil, version: "1.0")
+      casks_dir = dir/token/".metadata"/version/"20250101000000.000"/"Casks"
+      casks_dir.mkpath
+      (casks_dir/"#{token}.rb").write <<~RUBY
+        cask "#{token}" do
+          version "#{version}"
+        end
+      RUBY
+
+      receipt = dir/token/".metadata"/AbstractTab::FILENAME
+      receipt.write JSON.generate({
+        source: {
+          tap:     tap&.name,
+          version: version,
+        },
+      })
+    end
+
+    it "includes casks installed from untrusted taps without loading cask files" do
+      token = "untrusted-cask"
+      tap = Tap.fetch("thirdparty", "foo")
+      cask_path = tap.cask_dir/"#{token}.rb"
+      cask_path.dirname.mkpath
+      cask_path.write <<~RUBY
+        raise "untrusted cask evaluated"
+      RUBY
+
+      Dir.mktmpdir do |dir|
+        allow(described_class).to receive(:path).and_return(Pathname(dir))
+
+        setup_cask_metadata(Pathname(dir), token, tap:, version: "1.0")
+
+        with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+          casks = described_class.casks
+          expect(casks.map(&:token)).to eq([token])
+
+          cask = casks.first
+          expect(cask&.installed_version).to eq("1.0")
+          expect(cask&.tap).to eq(tap)
+        end
+      end
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+
+    it "does not error for ambiguous installed casks when an ambiguous tap is untrusted" do
+      token = "ambiguous-untrusted-cask"
+      taps = [Tap.fetch("thirdparty", "foo"), Tap.fetch("thirdparty", "bar")]
+      taps.each do |tap|
+        cask_path = tap.cask_dir/"#{token}.rb"
+        cask_path.dirname.mkpath
+        cask_path.write <<~RUBY
+          cask "#{token}" do
+            version "2.0"
+          end
+        RUBY
+      end
+      Dir.mktmpdir do |dir|
+        allow(described_class).to receive(:path).and_return(Pathname(dir))
+
+        setup_cask_metadata(Pathname(dir), token, version: "1.0")
+
+        with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+          casks = described_class.casks
+          expect(casks.map(&:token)).to eq([token])
+          expect(casks.first&.installed_version).to eq("1.0")
+        end
+      end
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+  end
+
   describe ".corrupt_cask_dirs" do
     it "returns tokens for directories without valid caskfiles" do
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
There were two issues here:

* If you had a cask installed which had an ambiguous name but did not have tap information available (older casks usually), `brew info --json=v2 --installed` would incorrectly hard fail if one of the taps the cask could be was untrusted.
* Even if you didn't hit the first point, listing installed casks would silently skip any cask that does not have its tap trusted.

This PR fixes the above two issues by:

* Correcting the nesting of `rescue` blocks so it never hard fails.
* Falling back to the installed cask in the Caskroom if taps are untrusted.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

Tests only, but with parts rewritten for correctness and coverage.

-----
