### PR TITLE
livecheck/strategy/extract_plist: fix runtime type issue

### DIFF
--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -104,9 +104,8 @@ module Homebrew
         def self.cask_with_url(cask, url, url_options)
           # Collect the `Cask::URL` initializer keyword parameter symbols
           @cask_url_kw_params ||= T.let(
-            T::Utils.signature_for_method(
-              Cask::URL.instance_method(:initialize),
-            ).parameters.filter_map { |type, sym| sym if type == :key },
+            (T::Utils.signature_for_method(Cask::URL.instance_method(:initialize))&.parameters ||
+             Cask::URL.instance_method(:initialize).parameters).filter_map { |type, sym| sym if type == :key },
             T.nilable(T::Array[Symbol]),
           )
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----

At runtime, the type signature can be `nil` causing the method to fail. Claude was used to help resolve the issue.

Unblocks https://github.com/Homebrew/homebrew-cask/pull/267990 (and other `ExtractPlist` livecheck blocks).