### PR TITLE
cmd/trust: add `--taps`

### DIFF
--- a/Library/Homebrew/cmd/trust.rb
+++ b/Library/Homebrew/cmd/trust.rb
@@ -17,7 +17,7 @@ module Homebrew
           Trusted entries are stored in `${XDG_CONFIG_HOME}/homebrew/trust.json` if
           `$XDG_CONFIG_HOME` is set or `~/.homebrew/trust.json` otherwise.
         EOS
-        switch "--tap",
+        switch "--tap", "--taps",
                description: "Trust the named tap."
         switch "--formula", "--formulae",
                description: "Trust the named formula."

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/trust.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/trust.rbi
@@ -34,4 +34,7 @@ class Homebrew::Cmd::Trust::Args < Homebrew::CLI::Args
 
   sig { returns(T::Boolean) }
   def tap?; end
+
+  sig { returns(T::Boolean) }
+  def taps?; end
 end


### PR DESCRIPTION
Each of the trust types had a plural form except taps, which was annoying me

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
