### PR TITLE
Trust taps with scp-style remotes without a user

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -134,12 +134,12 @@ class Tap
 
   # Whether an allow/forbid/trust list reference is a remote URL or local path rather than a
   # `user/repository` tap name (which can only match a tap on its default GitHub remote).
-  # A genuine remote reference is a URL (contains `://`), scp-like syntax (`user@host:path`,
-  # i.e. an `@` followed later by a `:`) or a local path (starts with `/`, `.` or `~`).
-  # A bare `@`-containing string such as `foo@bar` is not a remote reference.
+  # A genuine remote reference is a URL (contains `://`), scp-like syntax (`[user@]host:path`,
+  # i.e. a non-empty path after a `:` before any `/`, the same way Git itself detects scp syntax)
+  # or a local path (starts with `/`, `.` or `~`). A bare `foo@bar` or `host:` is not one.
   sig { params(reference: String).returns(T::Boolean) }
   def self.remote_reference?(reference)
-    reference.include?("://") || reference.match?(/@[^@]+:/) || reference.start_with?("/", ".", "~")
+    reference.match?(%r{\A[^/]+:.}) || reference.start_with?("/", ".", "~")
   end
 
   # Hosts where a `.git` suffix and trailing slashes are known not to change which repository a

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -172,6 +172,28 @@ RSpec.describe Tap do
     end
   end
 
+  describe "::remote_reference?" do
+    it "recognises scp-like syntax without a `user@`" do
+      expect(described_class.remote_reference?("ssh_host:/srv/git/homebrew-custom_tap")).to be true
+    end
+
+    it "recognises scp-like syntax with a `user@`" do
+      expect(described_class.remote_reference?("git@github.com:user/homebrew-repo")).to be true
+    end
+
+    it "treats a `user/repository` tap name as not a remote reference" do
+      expect(described_class.remote_reference?("user/repo")).to be false
+    end
+
+    it "treats a bare `@`-containing string as not a remote reference" do
+      expect(described_class.remote_reference?("foo@bar")).to be false
+    end
+
+    it "treats a `host:` with an empty path as not a remote reference" do
+      expect(described_class.remote_reference?("host:")).to be false
+    end
+  end
+
   describe "::normalize_remote" do
     it "keeps an explicit port on a GitHub remote rather than turning it into a path" do
       expect(described_class.normalize_remote("https://github.com:443/Homebrew/homebrew-core"))


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22651

- `brew trust user/tap` resolved a custom remote to its scp URL (`host:/srv/...`) but `remote_reference?` only matched scp syntax with an explicit `user@`, so the bare `host:path` form was treated as a tap name and raised `Invalid tap name`
- detect scp syntax the way Git does, a `:` before any `/`, so both `host:path` and `user@host:path` count as remote references

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 high with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. -->

-----
