### PR TITLE
sandbox: deny all of $HOME except Homebrew dirs

### DIFF
--- a/Library/Homebrew/extend/os/mac/sandbox.rb
+++ b/Library/Homebrew/extend/os/mac/sandbox.rb
@@ -53,8 +53,7 @@ module OS
       # Xcode projects expect access to certain cache/archive dirs.
       sig { void }
       def allow_write_xcode
-        allow_write_path "#{Dir.home(ENV.fetch("USER"))}/Library/Developer"
-        allow_write_path "#{Dir.home(ENV.fetch("USER"))}/Library/Caches/org.swift.swiftpm"
+        home_write_paths.each { |path| allow_write_path path }
       end
 
       module ClassMethods
@@ -74,6 +73,12 @@ module OS
       end
 
       private
+
+      sig { returns(T::Array[String]) }
+      def home_write_paths
+        home = Dir.home(ENV.fetch("USER"))
+        ["#{home}/Library/Developer", "#{home}/Library/Caches/org.swift.swiftpm"]
+      end
 
       sig { params(args: T::Array[T.any(String, ::Pathname)], tmpdir: String).returns(T::Array[T.any(String, ::Pathname)]) }
       def sandbox_command(args, tmpdir)

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -190,7 +190,7 @@ class Sandbox
   sig { void }
   def deny_read_home
     home = Pathname(Dir.home(ENV.fetch("USER"))).realpath
-    if [
+    required = [
       HOMEBREW_PREFIX,
       HOMEBREW_REPOSITORY,
       HOMEBREW_CACHE,
@@ -199,40 +199,23 @@ class Sandbox
       ENV.fetch("GITHUB_WORKSPACE", nil),
       ENV.fetch("RUNNER_WORKSPACE", nil),
       ENV.fetch("RUNNER_TEMP", nil),
-    ].compact.any? do |path|
+      *home_write_paths.select { |path| File.exist?(path) },
+    ].compact.flat_map do |path|
       path = Pathname(path)
-      [path.expand_path, path.exist? ? path.realpath : nil].compact.any? { |pathname| pathname.ascend.include?(home) }
+      [path.expand_path, (path.realpath if path.exist?)]
     end
-      [
-        ".ssh",
-        ".aws",
-        ".azure",
-        ".config/gcloud",
-        ".docker",
-        ".gnupg",
-        ".kube",
-        ".netrc",
-        ".npmrc",
-        ".pypirc",
-        ".gem/credentials",
-        "Documents",
-        "Movies",
-        "Music",
-        "Pictures",
-        "Library/Keychains",
-        "Library/Mobile Documents",
-        "Library/CloudStorage",
-        "Dropbox",
-        "Google Drive",
-        "OneDrive",
-      ].each do |path|
-        path = home/path
-        deny_read_path path if path.exist?
-      end
-      return
-    end
+    required = required.compact.select { |path| path.ascend.include?(home) }
 
-    deny_read_path home
+    # Block as much of `$HOME` as possible so a malicious build or install script
+    # cannot read SSH keys, cloud and package-registry tokens, browser or
+    # crypto-wallet data or any other secret kept in the home directory. When no
+    # Homebrew or CI directory lives inside `$HOME` the whole thing is denied;
+    # otherwise deny every entry except those Homebrew and its build tools must
+    # read, such as `~/Library/Caches/Homebrew`, `~/Library/Logs/Homebrew` and
+    # the `home_write_paths` that builds write to (the Xcode dirs on macOS).
+    return deny_read_path(home) if required.empty?
+
+    deny_read_home_except home, required
   end
 
   sig { params(path: T.nilable(T.any(String, Pathname)), type: Symbol).void }
@@ -453,6 +436,31 @@ class Sandbox
 
   sig { returns(T.nilable(Time)) }
   attr_reader :start
+
+  sig { params(dir: Pathname, required: T::Array[Pathname]).void }
+  def deny_read_home_except(dir, required)
+    dir.children.each do |child|
+      next if required.include?(child)
+
+      # Only descend into real, non-symlink directories on the way to a path
+      # Homebrew needs, so a non-directory ancestor cannot raise and a symlink
+      # loop cannot cause infinite recursion.
+      if child.directory? && !child.symlink? && required.any? { |path| path.ascend.include?(child) }
+        deny_read_home_except child, required
+      else
+        deny_read_path child
+      end
+    rescue SystemCallError
+      next
+    end
+  rescue SystemCallError
+    # `dir` is unreadable, so there is nothing inside it left to deny.
+  end
+
+  # Home directories a build needs to write to, and so must also read;
+  # overridden per-OS (e.g. the Xcode directories on macOS).
+  sig { returns(T::Array[String]) }
+  def home_write_paths = []
 
   sig { params(_args: T::Array[T.any(String, Pathname)], _tmpdir: String).returns(T::Array[T.any(String, Pathname)]) }
   def sandbox_command(_args, _tmpdir)

--- a/Library/Homebrew/test/sandbox_shared_spec.rb
+++ b/Library/Homebrew/test/sandbox_shared_spec.rb
@@ -225,24 +225,31 @@ RSpec.describe Sandbox do
       expect(sandbox.send(:profile).rules).to be_empty
     end
 
-    it "denies sensitive home paths when the real home cannot be denied" do
-      [".ssh", "Documents", "Library/Keychains", "Library/Mobile Documents", "Dropbox"].each do |directory|
-        (home/directory).mkpath
-      end
+    it "denies every home entry except the directories Homebrew needs" do
+      cache = home/"Library/Caches/Homebrew"
+      stub_const("HOMEBREW_CACHE", cache)
+      [cache, home/"Library/Preferences", home/".config", home/".ssh", home/"src"].each(&:mkpath)
+      FileUtils.touch home/".netrc"
 
-      with_env(GITHUB_WORKSPACE: (home/"workspace").to_s) do
-        sandbox.deny_read_home
-      end
+      sandbox.deny_read_home
 
-      expect(sandbox.send(:profile).rules.map { |rule| rule.filter&.path }).to eq(
-        [
-          home/".ssh",
-          home/"Documents",
-          home/"Library/Keychains",
-          home/"Library/Mobile Documents",
-          home/"Dropbox",
-        ].map { |path| path.realpath.to_s },
+      expect(sandbox.send(:profile).rules.map { |rule| rule.filter&.path }).to match_array(
+        [home/".config", home/".netrc", home/".ssh", home/"src", home/"Library/Preferences"]
+          .map { |path| path.realpath.to_s },
       )
+    end
+
+    it "keeps the Xcode directories readable so builds can use them", :needs_macos do
+      stub_const("HOMEBREW_CACHE", home/"Library/Caches/Homebrew")
+      developer = home/"Library/Developer"
+      swiftpm = home/"Library/Caches/org.swift.swiftpm"
+      [home/"Library/Caches/Homebrew", developer, swiftpm, home/"Library/Preferences"].each(&:mkpath)
+
+      sandbox.deny_read_home
+
+      denied = sandbox.send(:profile).rules.map { |rule| rule.filter&.path }
+      expect(denied).not_to include(developer.realpath.to_s, swiftpm.realpath.to_s)
+      expect(denied).to include((home/"Library/Preferences").realpath.to_s)
     end
   end
 


### PR DESCRIPTION
- `HOMEBREW_CACHE` and `HOMEBREW_LOGS` live under `$HOME` by
  default, so `deny_read_home` always took its selective branch
  and left most of `$HOME` readable to build and install scripts
- enumerating individual secret files cannot keep pace with what
  supply-chain attacks steal (SSH keys, cloud and registry
  tokens, AI agent configs, crypto wallets and more)
- instead deny every `$HOME` entry except the Homebrew and CI
  directories that must stay readable, such as
  `~/Library/Caches/Homebrew` and `~/Library/Logs/Homebrew`
- keep the per-OS `home_write_paths` readable too (the Xcode dirs
  `~/Library/Developer` and the swiftpm cache on macOS), since
  builds already write there and must read them back
- `deny_read_home` is shared and unoverridden, so this hardens
  the macOS and Linux formula and cask sandboxes alike
- only descend into real, non-symlink directories and tolerate
  unreadable ones, so a non-directory ancestor cannot raise and
  a symlink loop cannot cause infinite recursion

Avoided this in Homebrew 6.0.0 because feels like a non-zero chance this goes 💥 so want it to have a run on `main` before a stable release.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
