### PR TITLE
Start install downloads earlier

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -304,22 +304,35 @@ module Homebrew
           skip_link:                  args.skip_link?,
         )
 
-        dependants = Upgrade.dependants(
-          installed_formulae,
-          flags:                      args.flags_only,
-          ask:                        ask,
-          installed_on_request:       !args.as_dependency?,
-          force_bottle:               args.force_bottle?,
-          build_from_source_formulae: args.build_from_source_formulae,
-          interactive:                args.interactive?,
-          keep_tmp:                   args.keep_tmp?,
-          debug_symbols:              args.debug_symbols?,
-          force:                      args.force?,
-          debug:                      args.debug?,
-          quiet:                      args.quiet?,
-          verbose:                    args.verbose?,
-          dry_run:                    args.dry_run?,
-        )
+        shared_download_queue = T.let(nil, T.nilable(Homebrew::DownloadQueue))
+        if !ask && !args.dry_run? && formulae_installer.any?
+          shared_download_queue = Homebrew::DownloadQueue.new(pour: true)
+          formulae_installer = Install.prelude_fetch_formulae(formulae_installer,
+                                                              download_queue: shared_download_queue)
+        end
+
+        dependants = begin
+          Upgrade.dependants(
+            installed_formulae,
+            flags:                      args.flags_only,
+            ask:                        ask,
+            installed_on_request:       !args.as_dependency?,
+            force_bottle:               args.force_bottle?,
+            build_from_source_formulae: args.build_from_source_formulae,
+            interactive:                args.interactive?,
+            keep_tmp:                   args.keep_tmp?,
+            debug_symbols:              args.debug_symbols?,
+            force:                      args.force?,
+            debug:                      args.debug?,
+            quiet:                      args.quiet?,
+            verbose:                    args.verbose?,
+            dry_run:                    args.dry_run?,
+          )
+        # Ensure the early download queue is shut down on interrupts.
+        rescue Exception # rubocop:disable Lint/RescueException
+          shared_download_queue&.shutdown
+          raise
+        end
 
         # Main block: if asking the user is enabled, show dry-run information.
         if ask
@@ -340,7 +353,9 @@ module Homebrew
         end
 
         if !args.dry_run? && (formulae_installer.any? || fetch_casks.any?)
-          download_queue = Homebrew::DownloadQueue.new(pour: true)
+          download_queue = T.let(shared_download_queue || Homebrew::DownloadQueue.new(pour: true),
+                                 Homebrew::DownloadQueue)
+          shared_download_queue = nil
           begin
             Cask::Upgrade.show_upgrade_summary(
               upgrade_casks.map { |cask| "#{cask.full_name} #{cask.installed_version} -> #{cask.version}" },
@@ -376,6 +391,7 @@ module Homebrew
             download_queue.shutdown
           end
         end
+        shared_download_queue&.shutdown
 
         exit 1 if Homebrew.failed?
 

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -193,22 +193,33 @@ module Homebrew
             )
           end
 
-          dependants = Upgrade.dependants(
-            formulae,
-            flags:                      args.flags_only,
-            ask:                        ask,
-            force_bottle:               args.force_bottle?,
-            build_from_source_formulae: args.build_from_source_formulae,
-            interactive:                args.interactive?,
-            keep_tmp:                   args.keep_tmp?,
-            debug_symbols:              args.debug_symbols?,
-            force:                      args.force?,
-            debug:                      args.debug?,
-            quiet:                      args.quiet?,
-            verbose:                    args.verbose?,
-          )
-
           formulae_installers = reinstall_contexts.map(&:formula_installer)
+          if !ask && formulae_installers.any?
+            download_queue = Homebrew::DownloadQueue.new(pour: true)
+            shared_download_queue = download_queue
+            formulae_installers = Install.prelude_fetch_formulae(formulae_installers, download_queue:)
+          end
+
+          dependants = begin
+            Upgrade.dependants(
+              formulae,
+              flags:                      args.flags_only,
+              ask:                        ask,
+              force_bottle:               args.force_bottle?,
+              build_from_source_formulae: args.build_from_source_formulae,
+              interactive:                args.interactive?,
+              keep_tmp:                   args.keep_tmp?,
+              debug_symbols:              args.debug_symbols?,
+              force:                      args.force?,
+              debug:                      args.debug?,
+              quiet:                      args.quiet?,
+              verbose:                    args.verbose?,
+            )
+          # Ensure the early download queue is shut down on interrupts.
+          rescue Exception # rubocop:disable Lint/RescueException
+            shared_download_queue&.shutdown
+            raise
+          end
 
           # Main block: if asking the user is enabled, show dry-run information.
           if ask
@@ -230,7 +241,8 @@ module Homebrew
           end
 
           valid_formula_installers = if casks.any?
-            shared_download_queue = Homebrew::DownloadQueue.new(pour: true)
+            shared_download_queue ||= Homebrew::DownloadQueue.new(pour: true)
+            download_queue = shared_download_queue
             begin
               Install.show_combined_fetch_downloads_heading(
                 formula_names: formulae_installers.map { |fi| fi.formula.name },
@@ -238,7 +250,7 @@ module Homebrew
               )
 
               valid_formula_installers = Install.enqueue_formulae(formulae_installers,
-                                                                  download_queue: shared_download_queue)
+                                                                  download_queue:)
 
               require "cask/installer"
               fetch_cask_installers = casks.map do |cask|
@@ -251,16 +263,25 @@ module Homebrew
                   require_sha:    args.require_sha?,
                   reinstall:      true,
                   zap:            args.zap?,
-                  download_queue: shared_download_queue,
+                  download_queue:,
                   defer_fetch:    true,
                 )
               end
-              Install.enqueue_cask_installers(fetch_cask_installers, download_queue: shared_download_queue)
-              shared_download_queue.fetch
+              Install.enqueue_cask_installers(fetch_cask_installers, download_queue:)
+              download_queue.fetch
               casks_prefetched = true
               valid_formula_installers
             ensure
-              shared_download_queue.shutdown
+              download_queue.shutdown
+            end
+          elsif shared_download_queue
+            download_queue = shared_download_queue
+            begin
+              Install.fetch_formulae(formulae_installers,
+                                     download_queue:,
+                                     shutdown_download_queue: false)
+            ensure
+              download_queue.shutdown
             end
           else
             Install.fetch_formulae(formulae_installers)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -303,6 +303,8 @@ class FormulaInstaller
 
   sig { void }
   def prelude_fetch
+    return if @ran_prelude_fetch
+
     deprecate_disable_type = DeprecateDisable.type(formula)
     if deprecate_disable_type.present?
       message = "#{formula.full_name} has been #{DeprecateDisable.message(formula)}"

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -353,14 +353,12 @@ module Homebrew
           formula_sentence = formulae_names_to_install.map { |name| Formatter.identifier(name) }.to_sentence
           oh1 "Fetching downloads for: #{formula_sentence}", truncate: false
         end
-        formula_installers.each do |fi|
-          fi.download_queue = download_queue
-        end
-
-        valid_formula_installers = formula_installers.dup
 
         begin
-          [:prelude_fetch, :prelude, :enqueue_fetch].each do |step|
+          valid_formula_installers = prelude_fetch_formulae(formula_installers, download_queue:)
+          download_queue.fetch
+
+          [:prelude, :enqueue_fetch].each do |step|
             valid_formula_installers.select! do |fi|
               fi.public_send(step)
               true
@@ -380,6 +378,29 @@ module Homebrew
         end
 
         valid_formula_installers
+      end
+
+      sig {
+        params(
+          formula_installers: T::Array[FormulaInstaller],
+          download_queue:     Homebrew::DownloadQueue,
+        ).returns(T::Array[FormulaInstaller])
+      }
+      def prelude_fetch_formulae(formula_installers, download_queue:)
+        formula_installers.each do |fi|
+          fi.download_queue = download_queue
+        end
+
+        formula_installers.select do |fi|
+          fi.prelude_fetch
+          true
+        rescue CannotInstallFormulaError => e
+          ofail e.message
+          false
+        rescue UnsatisfiedRequirements, DownloadError, ChecksumMismatchError => e
+          ofail "#{fi.formula}: #{e}"
+          false
+        end
       end
 
       sig { params(formula_installers: T::Array[FormulaInstaller], download_queue: Homebrew::DownloadQueue).returns(T::Array[FormulaInstaller]) }

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -278,6 +278,40 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     expect(Homebrew).to have_failed
   end
 
+  it "starts formula prelude fetches before dependant checks when not asking" do
+    cmd = described_class.new(["--yes", "testball"])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil)
+    formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/testball-0.1.tar.gz"
+    end
+    formula_installer = instance_double(FormulaInstaller, formula:)
+    dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
+
+    allow(Tap).to receive_messages(with_formula_name: nil, with_cask_token: nil)
+    allow(Homebrew::Trust).to receive(:trust_fully_qualified_items!)
+    allow(cmd.args.named).to receive(:to_formulae_and_casks).with(warn: false).and_return([formula])
+    allow(Homebrew::Install).to receive(:perform_preinstall_checks_once)
+    allow(Homebrew::Install).to receive(:check_cc_argv)
+    allow(Homebrew::Install).to receive_messages(install_formula?: true, formula_installers: [formula_installer])
+    allow(Homebrew::Install).to receive(:install_formulae)
+    allow(Homebrew::Upgrade).to receive(:upgrade_dependents)
+    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
+    allow(Homebrew.messages).to receive(:display_messages)
+    expect(Homebrew::DownloadQueue).to receive(:new).ordered.and_return(download_queue)
+    expect(formula_installer).to receive(:download_queue=).with(download_queue).ordered
+    expect(formula_installer).to receive(:prelude_fetch).ordered
+    expect(Homebrew::Upgrade).to receive(:dependants).ordered.and_return(dependants)
+    expect(Homebrew::Install).to receive(:enqueue_formulae)
+      .with([formula_installer], download_queue:)
+      .ordered
+      .and_return([formula_installer])
+    expect(download_queue).to receive(:fetch).ordered
+    expect(download_queue).to receive(:shutdown).ordered
+
+    cmd.run
+  end
+
   it "does not install `homebrew/cask` when a cask remains unavailable" do
     cmd = described_class.new(["foo"])
     cask_tap = CoreCaskTap.instance
@@ -407,6 +441,8 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
       formula_installers: [formula_installer],
       enqueue_formulae:   [formula_installer],
     )
+    allow(formula_installer).to receive(:download_queue=)
+    allow(formula_installer).to receive(:prelude_fetch)
     allow(Cask::Installer).to receive(:new).and_return(installer)
     allow(Homebrew::Install).to receive(:install_formulae)
     allow(Homebrew::Upgrade).to receive(:upgrade_dependents)

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -86,6 +86,47 @@ RSpec.describe Homebrew::Cmd::Reinstall do
     cmd.run
   end
 
+  it "starts formula prelude fetches before dependant checks when not asking" do
+    cmd = described_class.new(["--yes", "testball"])
+    download_queue = instance_double(Homebrew::DownloadQueue, shutdown: nil)
+    formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/testball-0.1.tar.gz"
+    end
+    formula_installer = FormulaInstaller.new(formula)
+    dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
+    reinstall_context = Homebrew::Reinstall::InstallationContext.new(
+      formula_installer:,
+      formula:,
+      keg:               nil,
+      options:           Options.create([]),
+    )
+
+    allow(Homebrew::Trust).to receive(:trust_fully_qualified_items!)
+    allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable)
+      .with(method: :resolve)
+      .and_return([formula])
+    allow(formula).to receive_messages(latest_formula: formula, pinned?: false)
+    allow(Migrator).to receive(:migrate_if_needed)
+    allow(Homebrew::Install).to receive(:perform_preinstall_checks_once)
+    allow(Homebrew::Reinstall).to receive(:build_install_context).and_return(reinstall_context)
+    allow(Homebrew::Reinstall).to receive(:reinstall_formula)
+    allow(Homebrew::Upgrade).to receive(:upgrade_dependents)
+    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
+    allow(Homebrew.messages).to receive(:display_messages)
+    expect(Homebrew::DownloadQueue).to receive(:new).ordered.and_return(download_queue)
+    expect(formula_installer).to receive(:download_queue=).with(download_queue).ordered
+    expect(formula_installer).to receive(:prelude_fetch).ordered
+    expect(Homebrew::Upgrade).to receive(:dependants).ordered.and_return(dependants)
+    expect(Homebrew::Install).to receive(:fetch_formulae)
+      .with([formula_installer], download_queue:, shutdown_download_queue: false)
+      .ordered
+      .and_return([formula_installer])
+    expect(download_queue).to receive(:shutdown).ordered
+
+    cmd.run
+  end
+
   it "reinstalls a Formula", :aggregate_failures, :integration_test do
     formula_name = "testball_bottle"
     formula_prefix = HOMEBREW_CELLAR/formula_name/"0.1"

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -910,6 +910,23 @@ RSpec.describe FormulaInstaller do
       installer.prelude_fetch
     end
 
+    it "does not repeat source download prelude work" do
+      f = formula("homebrew-prelude-fetch-once") do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/prelude-fetch-once-0.1.tar.gz"
+      end
+      allow(f).to receive(:loaded_from_api?).and_return(true)
+      fi = described_class.new(f, ignore_deps: true)
+      fi.download_queue = instance_double(Homebrew::DownloadQueue)
+
+      expect(Homebrew::API::Formula).to receive(:source_download)
+        .with(f, download_queue: fi.download_queue, enqueue: true)
+        .once
+
+      fi.prelude_fetch
+      fi.prelude_fetch
+    end
+
     it "raises on forbidden formula tap before fetching the source from the API" do
       homebrew_forbidden = Tap.fetch("homebrew/forbidden")
       allow(Tap).to receive_messages(allowed_taps: [], forbidden_taps: [homebrew_forbidden.name])


### PR DESCRIPTION
- Start formula prelude fetches before dependant checks when no prompt can block.
- Share prelude-fetch queueing across install, reinstall and upgrade.
- Reuse the early queue later to avoid changing pour/link behaviour.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
