### PR TITLE
Handle split cask bundle versions

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -748,6 +748,16 @@ module Cask
       installed_short_version = nil if AUTO_UPDATES_BAD_BUNDLE_VERSIONS.include?(installed_short_version)
       return false if installed_short_version.nil? && installed_bundle_version.nil?
 
+      # Some apps split a cask version like 2.61-2057 across the short
+      # version and bundle version fields.
+      if installed_short_version && installed_bundle_version
+        combined_version_comparisons = version.csv.filter_map do |candidate|
+          compare_version_strings("#{installed_short_version}-#{installed_bundle_version}", candidate.to_s)
+        end
+        return false if combined_version_comparisons.include?(0)
+        return false if combined_version_comparisons.present? && combined_version_comparisons.exclude?(-1)
+      end
+
       return false if [installed_short_version, installed_bundle_version].any? do |installed_plist_version|
         compare_version_strings(installed_plist_version, tap_short_version)&.zero?
       end

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -333,6 +333,24 @@ RSpec.describe Cask::Cask, :cask do
         expect(cask.outdated_version).to be_nil
       end
 
+      it "is not outdated when the installed short and bundle versions combine to the tap version" do
+        tap_version = "2.61-2057"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.57-2056")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.61", bundle_version: "2057")
+
+        expect(cask.outdated_version).to be_nil
+      end
+
+      it "is not outdated when the combined installed version is higher than the tap version" do
+        tap_version = "2.61-2057"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.57-2056")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.61", bundle_version: "2058")
+
+        expect(cask.outdated_version).to be_nil
+      end
+
       it "is not outdated when the installed short version matches a CSV build candidate" do
         tap_version = "2.61,2057"
         cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22663

- Avoid reinstalling self-updating casks when `Info.plist` splits marketing and build versions across separate fields.
- Cover stale `installed_version` metadata matching a current bundle.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
