### PR TITLE
Use API bottle metadata for fetch

### DIFF
--- a/Library/Homebrew/api/formula_bottle.rb
+++ b/Library/Homebrew/api/formula_bottle.rb
@@ -1,0 +1,46 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "api/formula_struct"
+require "bottle"
+require "bottle_specification"
+require "pkg_version"
+
+module Homebrew
+  module API
+    module FormulaBottle
+      sig {
+        params(
+          name:           String,
+          formula_struct: Homebrew::API::FormulaStruct,
+          bottle_tag:     Utils::Bottles::Tag,
+        ).returns(T.nilable(::Bottle))
+      }
+      def self.bottle(name:, formula_struct:, bottle_tag: Utils::Bottles.tag)
+        return unless formula_struct.stable?
+        return unless formula_struct.bottle?
+
+        bottle_specification = BottleSpecification.new
+        bottle_specification.root_url(
+          if Homebrew::EnvConfig.bottle_domain == HOMEBREW_BOTTLE_DEFAULT_DOMAIN
+            HOMEBREW_BOTTLE_DEFAULT_DOMAIN
+          else
+            Homebrew::EnvConfig.bottle_domain
+          end,
+        )
+        bottle_specification.rebuild(formula_struct.bottle_rebuild)
+        formula_struct.bottle_checksums.each { |args| bottle_specification.sha256(args) }
+
+        return unless bottle_specification.tag?(bottle_tag)
+
+        ::Bottle.new(
+          nil,
+          bottle_specification,
+          bottle_tag,
+          name:,
+          pkg_version: PkgVersion.new(::Version.new(formula_struct.stable_version), formula_struct.revision),
+        )
+      end
+    end
+  end
+end

--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -81,24 +81,44 @@ class Bottle
   def_delegators :resource, :url, :verify_download_integrity
   def_delegators :resource, :cached_download, :downloader
 
-  sig { params(formula: Formula, spec: BottleSpecification, tag: T.nilable(Utils::Bottles::Tag)).void }
-  def initialize(formula, spec, tag = nil)
+  sig {
+    params(
+      formula:     T.nilable(Formula),
+      spec:        BottleSpecification,
+      tag:         T.nilable(Utils::Bottles::Tag),
+      name:        T.nilable(String),
+      pkg_version: T.nilable(PkgVersion),
+    ).void
+  }
+  def initialize(formula, spec, tag = nil, name: nil, pkg_version: nil)
     super()
 
-    @name = T.let(formula.name, String)
-    @resource = T.let(Resource.new, Resource)
-    @resource.owner = formula
+    resource_name = T.let(nil, T.nilable(String))
+    if formula
+      name = formula.name
+      pkg_version = formula.pkg_version
+    else
+      raise ArgumentError, "Bottle name is required" if name.nil?
+      raise ArgumentError, "Bottle version is required" if pkg_version.nil?
+
+      resource_name = name
+    end
+
+    @name = T.let(name, String)
+    @pkg_version = T.let(pkg_version, PkgVersion)
+    @resource = T.let(Resource.new(resource_name), Resource)
+    @resource.owner = formula if formula
     @spec = spec
 
     tag_spec = spec.tag_specification_for(Utils::Bottles.tag(tag))
 
-    odie "#{formula.name} tag specification for tag #{tag} is nil" if tag_spec.nil?
+    odie "#{@name} tag specification for tag #{tag} is nil" if tag_spec.nil?
 
     @tag = T.let(tag_spec.tag, Utils::Bottles::Tag)
     @cellar = T.let(tag_spec.cellar, T.any(String, Symbol))
     @rebuild = T.let(spec.rebuild, Integer)
 
-    @resource.version(formula.pkg_version.to_s)
+    @resource.version(@pkg_version.to_s)
     @resource.checksum = tag_spec.checksum
 
     @fetch_tab_retried = T.let(false, T::Boolean)
@@ -203,9 +223,7 @@ class Bottle
   end
 
   sig { returns(Filename) }
-  def filename
-    Filename.create(T.cast(resource.owner, Formula), @tag, @spec.rebuild)
-  end
+  def filename = Filename.new(@name, @pkg_version, @tag, @spec.rebuild)
 
   sig { returns(T.nilable(Resource::BottleManifest)) }
   def github_packages_manifest_resource
@@ -215,7 +233,10 @@ class Bottle
       begin
         resource = Resource::BottleManifest.new(self)
 
-        version_rebuild = GitHubPackages.version_rebuild(T.must(@resource.version), rebuild)
+        resource_version = @resource.version
+        odie "resource version is nil" if resource_version.nil?
+
+        version_rebuild = GitHubPackages.version_rebuild(resource_version, rebuild)
         resource.version(version_rebuild)
 
         image_name = GitHubPackages.image_formula_name(@name)
@@ -269,7 +290,7 @@ class Bottle
 
     @root_url = T.let(val, T.nilable(String))
 
-    filename = Filename.create(T.cast(resource.owner, Formula), @tag, @spec.rebuild)
+    filename = self.filename
     resource_checksum = resource.checksum
     odie "resource checksum is nil" if resource_checksum.nil?
 

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -4,6 +4,7 @@
 require "abstract_command"
 require "formula"
 require "fetch"
+require "api/formula_bottle"
 require "cask/config"
 require "cask/download"
 require "download_queue"
@@ -76,6 +77,11 @@ module Homebrew
       sig { override.void }
       def run
         Formulary.enable_factory_cache!
+
+        if enqueue_api_formula_bottles?
+          download_queue.fetch
+          return
+        end
 
         bucket = if args.deps?
           args.named.to_formulae_and_casks.flat_map do |formula_or_cask|
@@ -166,6 +172,58 @@ module Homebrew
       end
 
       private
+
+      sig { returns(T::Boolean) }
+      def enqueue_api_formula_bottles?
+        return false if Homebrew::EnvConfig.no_install_from_api?
+        return false if args.only_formula_or_cask == :cask
+        return false if args.deps? || args.HEAD?
+        return false if args.build_from_source? || args.build_bottle?
+        return false if args.all_platforms? || args.os.present? || args.arch.present? || args.bottle_tag.present?
+        return false if ENV["HOMEBREW_TEST_GENERIC_OS"].present?
+
+        formula_hashes = Homebrew::API::Internal.formula_hashes
+        aliases = Homebrew::API::Internal.formula_aliases
+        renames = Homebrew::API::Internal.formula_renames
+        names = T.let([], T::Array[String])
+
+        args.named.downcased_unique_named.each do |requested_name|
+          name = requested_name[HOMEBREW_DEFAULT_TAP_FORMULA_REGEX, :name]
+          return false if name.blank?
+
+          name = name.downcase
+          name = aliases.fetch(name, name)
+          name = renames.fetch(name, name)
+          return false unless formula_hashes.key?(name)
+
+          names << name
+        end
+
+        bottles = T.let([], T::Array[[String, Bottle]])
+        bottle_tag = Utils::Bottles.tag
+        names.each do |name|
+          formula_struct = Homebrew::API::Internal.formula_struct(name)
+          return false if formula_struct.pour_bottle?
+
+          bottle = Homebrew::API::FormulaBottle.bottle(name:, formula_struct:, bottle_tag:)
+          return false if bottle.nil?
+          return false if !args.force_bottle? && !bottle.compatible_locations?
+
+          bottles << [name, bottle]
+        end
+
+        puts "Fetching: #{names * ", "}" if names.size > 1
+        bottles.each do |name, bottle|
+          ohai "Fetching #{name} from #{CoreTap.instance}"
+          bottle.clear_cache if args.force?
+
+          if (manifest_resource = bottle.github_packages_manifest_resource)
+            download_queue.enqueue(manifest_resource)
+          end
+          download_queue.enqueue(bottle)
+        end
+        true
+      end
 
       sig { params(cask: Cask::Cask).returns(T::Array[Cask::Download]) }
       def cask_downloads(cask)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "formula"
+require "api/formula_bottle"
 require "keg"
 require "tab"
 require "utils/bottles"
@@ -140,6 +141,8 @@ class FormulaInstaller
     @show_summary_heading = T.let(false, T::Boolean)
     @etc_var_preinstall = T.let([], T::Array[Pathname])
     @download_queue = T.let(Homebrew.default_download_queue, Homebrew::DownloadQueue)
+    @api_bottle = T.let(nil, T.nilable(Bottle))
+    @api_bottle_loaded = T.let(false, T::Boolean)
 
     # Take the original formula instance, which might have been swapped from an API instance to a source instance
     @formula = T.let(T.must(previously_fetched_formula), Formula) if previously_fetched_formula
@@ -267,7 +270,7 @@ class FormulaInstaller
 
     return true if formula.local_bottle_path.present?
 
-    bottle = formula.bottle_for_tag(Utils::Bottles.tag)
+    bottle = api_bottle || formula.bottle_for_tag(Utils::Bottles.tag)
     return false if bottle.nil?
 
     unless bottle.compatible_locations?
@@ -1441,7 +1444,7 @@ on_request: installed_on_request?, options:)
     return if @fetch_bottle_tab
     return if formula.local_bottle_path.present?
 
-    if (bottle = formula.bottle) &&
+    if (bottle = api_bottle || formula.bottle) &&
        (manifest_resource = bottle.github_packages_manifest_resource) &&
        enqueue
       download_queue.enqueue(manifest_resource) unless manifest_resource.downloaded_and_valid?
@@ -1510,10 +1513,30 @@ on_request: installed_on_request?, options:)
     if (bottle_path = formula.local_bottle_path)
       Resource::Local.new(bottle_path.to_s)
     elsif pour_bottle?
-      T.must(formula.bottle)
+      bottle = api_bottle || formula.bottle
+      odie "Bottle for #{formula.full_name} is unavailable." if bottle.nil?
+
+      bottle
     else
-      T.must(formula.resource)
+      resource = formula.resource
+      odie "Resource for #{formula.full_name} is unavailable." if resource.nil?
+
+      resource
     end
+  end
+
+  sig { returns(T.nilable(Bottle)) }
+  def api_bottle
+    return @api_bottle if @api_bottle_loaded
+
+    @api_bottle_loaded = true
+    return unless formula.loaded_from_internal_api?
+    return unless formula.core_formula?
+
+    @api_bottle = Homebrew::API::FormulaBottle.bottle(
+      name:           formula.name,
+      formula_struct: Homebrew::API::Internal.formula_struct(formula.name),
+    )
   end
 
   sig { void }

--- a/Library/Homebrew/test/cmd/fetch_spec.rb
+++ b/Library/Homebrew/test/cmd/fetch_spec.rb
@@ -7,6 +7,45 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::FetchCmd do
   it_behaves_like "parseable arguments"
 
+  it "uses API bottle metadata before loading simple core formulae" do
+    cmd = described_class.new(["fast-fetch"])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil)
+    bottle_tag = with_env(HOMEBREW_TEST_GENERIC_OS: nil) { Utils::Bottles.tag }
+    formula_struct = Homebrew::API::FormulaStruct.from_hash(
+      "bottle_checksums"     => [
+        {
+          cellar:            :any_skip_relocation,
+          bottle_tag.to_sym => "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97",
+        },
+      ],
+      "bottle_present"       => true,
+      "desc"                 => "fast fetch",
+      "homepage"             => "https://brew.sh",
+      "license"              => "MIT",
+      "ruby_source_checksum" => "abc123",
+      "stable_present"       => true,
+      "stable_version"       => "1.0",
+    )
+    enqueued_downloads = []
+
+    allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
+    allow(download_queue).to receive(:enqueue) { |download| enqueued_downloads << download }
+    allow(Homebrew::API::Internal).to receive_messages(
+      formula_aliases: {},
+      formula_hashes:  { "fast-fetch" => {} },
+      formula_renames: {},
+      formula_struct:  formula_struct,
+    )
+
+    expect(cmd.args.named).not_to receive(:to_formulae_and_casks)
+    expect(Formulary).not_to receive(:factory)
+    expect(download_queue).to receive(:shutdown)
+
+    with_env(HOMEBREW_TEST_GENERIC_OS: nil) { cmd.run }
+
+    expect(enqueued_downloads).to include(an_instance_of(Bottle))
+  end
+
   it "downloads Formula and Cask URLs concurrently", :cask, :integration_test do
     setup_test_formula "testball1"
     setup_test_formula "testball2"

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -827,6 +827,43 @@ RSpec.describe FormulaInstaller do
   end
 
   describe "#prelude_fetch" do
+    it "uses API bottle metadata for API-loaded formula manifests" do
+      formula = formula("deno") do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/deno-2.7.11.tar.gz"
+      end
+      formula_struct = Homebrew::API::FormulaStruct.new(
+        bottle_checksums:     [
+          {
+            cellar:                  :any_skip_relocation,
+            Utils::Bottles.tag.to_sym => "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97",
+          },
+        ],
+        bottle_present:       true,
+        desc:                 "deno",
+        homepage:             "https://brew.sh",
+        license:              "MIT",
+        ruby_source_checksum: "abc123",
+        stable_present:       true,
+        stable_version:       "2.7.11",
+      )
+      installer = described_class.new(formula, ignore_deps: true)
+      installer.download_queue = instance_double(Homebrew::DownloadQueue)
+
+      allow(formula).to receive_messages(
+        bottle_tag?:               true,
+        core_formula?:             true,
+        loaded_from_internal_api?: true,
+        pour_bottle?:              true,
+      )
+      allow(Homebrew::API::Internal).to receive(:formula_struct).with("deno").and_return(formula_struct)
+      expect(formula).not_to receive(:bottle_for_tag)
+      expect(formula).not_to receive(:bottle)
+      expect(installer.download_queue).to receive(:enqueue).with(an_instance_of(Resource::BottleManifest))
+
+      installer.prelude_fetch
+    end
+
     it "raises on forbidden formula tap before fetching the source from the API" do
       homebrew_forbidden = Tap.fetch("homebrew/forbidden")
       allow(Tap).to receive_messages(allowed_taps: [], forbidden_taps: [homebrew_forbidden.name])


### PR DESCRIPTION
- Avoid inflating simple `homebrew/core` formulae when `brew fetch` can resolve bottle URLs, tags and checksums from `FormulaStruct`.
- Reuse that bottle construction during installer prefetch so API-loaded formulae do not rebuild bottle metadata just to enqueue manifests.
- Keep full `Formula` objects for install decisions, dependency checks and source fallback paths.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->


-----
