### PR TITLE
formula_installer: simplify bubblewrap handling

### DIFF
--- a/Library/Homebrew/extend/os/linux/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/linux/dependency_collector.rb
@@ -59,7 +59,10 @@ module OS
                   (!build_formulae_tree_needed || (global_dep_tree.key?(GLIBC) && global_dep_tree.key?(GCC)))
 
         building_global_dep_tree!
-        global_dep_tree[BUBBLEWRAP] = Set.new(global_deps_for(BUBBLEWRAP)) if sandbox_tree_needed
+        if sandbox_tree_needed
+          include_build = OS.not_tier_one_configuration? || build_formulae_tree_needed
+          global_dep_tree[BUBBLEWRAP] = Set.new(global_deps_for(BUBBLEWRAP, include_build:))
+        end
         if build_formulae_tree_needed
           global_dep_tree[GLIBC] = Set.new(global_deps_for(GLIBC))
           # gcc depends on glibc
@@ -86,16 +89,19 @@ module OS
         ::Sandbox.executable.blank?
       end
 
-      sig { params(name: String).returns(T::Array[String]) }
-      def global_deps_for(name)
+      sig { params(name: String, include_build: T::Boolean).returns(T::Array[String]) }
+      def global_deps_for(name, include_build: true)
         @global_deps_for ||= T.let({}, T.nilable(T::Hash[String, T::Array[String]]))
         # Always strip out glibc and gcc from all parts of dependency tree when
         # we're calculating their dependency trees. Other parts of Homebrew will
         # catch any circular dependencies.
-        @global_deps_for[name] ||= if (formula = formula_for(name))
-          formula.deps.map(&:name).flat_map do |dep|
-            [dep, *global_deps_for(dep)].compact
-          end.uniq
+        @global_deps_for["#{name}|#{include_build}"] ||= if (formula = formula_for(name))
+          formula.deps.filter_map do |dep|
+            next if dep.test? && !dep.build?
+            next if dep.build? && !include_build
+
+            [dep.name, *global_deps_for(dep.name, include_build:)].compact
+          end.flatten.uniq
         else
           []
         end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -435,7 +435,20 @@ class FormulaInstaller
     if Homebrew::EnvConfig.developer?
       # `recursive_dependencies` trims cyclic dependencies, so we do one level and take the recursive deps of that.
       # Mapping direct dependencies to deeper dependencies in a hash is also useful for the cyclic output below.
-      recursive_dep_map = formula.deps.to_h { |dep| [dep, dep.to_formula.recursive_dependencies] }
+      recursive_dep_map = formula.deps.to_h do |dep|
+        # We cheat a bit with bubblewrap. We eagerly add it to build dependencies on tier-one systems.
+        # But this cyclic dependency check is (intentionally) overly strict and forbids cyclic build dependencies,
+        # to help prevent cases that would break, for example, mass bottling.
+        recursive_deps = if dep.name == "bubblewrap" && dep.implicit?
+          []
+        else
+          dep.to_formula.recursive_dependencies do |_dependent, recursive_dep|
+            Dependable::PRUNE if recursive_dep.name == "bubblewrap" && recursive_dep.implicit?
+          end
+        end
+
+        [dep, recursive_deps]
+      end
 
       cyclic_dependencies = []
       recursive_dep_map.each do |dep, recursive_deps|
@@ -807,14 +820,7 @@ on_request: installed_on_request?, options:)
             "#{deps.map { Formatter.identifier(it) }.to_sentence}",
             truncate: false
       end
-      bubblewrap_dependency_index = deps.index { |dep| dep.name == "bubblewrap" && dep.implicit? }
-      deps.each_with_index do |dep, index|
-        if formula.name == "bubblewrap" || (bubblewrap_dependency_index && index <= bubblewrap_dependency_index)
-          with_env(HOMEBREW_INSTALLING_BUBBLEWRAP: "1") { install_dependency(dep) }
-        else
-          install_dependency(dep)
-        end
-      end
+      deps.each { install_dependency(it) }
     end
 
     @show_header = true if deps.length > 1
@@ -1128,7 +1134,6 @@ on_request: installed_on_request?, options:)
       formula_path,
     ].concat(build_argv)
 
-    Sandbox.ensure_sandbox_installed!
     if Sandbox.available?
       sandbox = Sandbox.new
       sandbox.allow_read_if_exists path: formula_path
@@ -1148,6 +1153,7 @@ on_request: installed_on_request?, options:)
       sandbox.deny_all_network unless formula.network_access_allowed?(:build)
       sandbox.run(*args)
     else
+      opoo "Sandbox unavailable: building without sandboxing!"
       Utils.safe_fork do
         exec(*args)
       end
@@ -1376,7 +1382,6 @@ on_request: installed_on_request?, options:)
 
     args << post_install_formula_path
 
-    Sandbox.ensure_sandbox_installed!
     if Sandbox.available?
       sandbox = Sandbox.new
       formula.logs.mkpath
@@ -1393,6 +1398,7 @@ on_request: installed_on_request?, options:)
       end
       sandbox.run(*args)
     else
+      opoo "Sandbox unavailable: running post-install without sandboxing!"
       Utils.safe_fork do
         exec(*args)
       end

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -237,32 +237,6 @@ RSpec.describe FormulaInstaller do
       expect(child_installer).not_to be_installed_on_request
       expect(child_installer&.link_keg).to be true
     end
-
-    it "disables Bubblewrap auto-install until the implicit Bubblewrap dependency is installed" do
-      formula = formula "homebrew-bubblewrap-bootstrap-target" do
-        T.bind(self, T.class_of(Formula))
-        url "foo-1.0"
-      end
-      installer = described_class.new(formula)
-      dependency_names = %w[libcap bubblewrap zlib]
-      dependencies = dependency_names.map do |name|
-        instance_double(Dependency, name:, implicit?: name == "bubblewrap")
-      end
-      installing_bubblewrap_env = []
-
-      allow(installer).to receive(:oh1)
-      allow(installer).to receive(:install_dependency) do |dependency|
-        installing_bubblewrap_env << [dependency.name, ENV.fetch("HOMEBREW_INSTALLING_BUBBLEWRAP", nil)]
-      end
-
-      installer.send(:install_dependencies, dependencies)
-
-      expect(installing_bubblewrap_env).to eq([
-        ["libcap", "1"],
-        ["bubblewrap", "1"],
-        ["zlib", nil],
-      ])
-    end
   end
 
   describe "versioned keg-only linking defaults" do
@@ -514,6 +488,78 @@ RSpec.describe FormulaInstaller do
       Formulary.cache.delete(formula2_path)
 
       fi = described_class.new(formula1)
+
+      expect do
+        fi.check_install_sanity
+      end.to raise_error(CannotInstallFormulaError)
+    end
+
+    it "does not raise on cyclic dependency through direct implicit Bubblewrap" do
+      ENV["HOMEBREW_DEVELOPER"] = "1"
+
+      formula_name = "homebrew-test-formula"
+      f = formula formula_name do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      dep = Dependency.new("bubblewrap", [:implicit])
+
+      allow(f).to receive_messages(deps: [dep], recursive_dependencies: [])
+
+      fi = described_class.new(f)
+
+      expect do
+        fi.check_install_sanity
+      end.not_to raise_error
+    end
+
+    it "does not raise on cyclic dependency through recursive implicit Bubblewrap" do
+      ENV["HOMEBREW_DEVELOPER"] = "1"
+
+      formula_name = "homebrew-test-formula"
+      f = formula formula_name do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      dep = Dependency.new("cmake", [:build])
+      implicit_bubblewrap = Dependency.new("bubblewrap", [:implicit])
+      recursive_dep = Dependency.new(formula_name)
+      dep_formula = instance_double(Formula)
+
+      allow(f).to receive_messages(deps: [dep], recursive_dependencies: [])
+      allow(dep).to receive(:to_formula).and_return(dep_formula)
+      allow(dep_formula).to receive(:recursive_dependencies) do |&block|
+        (block&.call(dep_formula, implicit_bubblewrap) == Dependable::PRUNE) ? [] : [recursive_dep]
+      end
+
+      fi = described_class.new(f)
+
+      expect do
+        fi.check_install_sanity
+      end.not_to raise_error
+    end
+
+    it "raises on cyclic dependency through recursive explicit Bubblewrap" do
+      ENV["HOMEBREW_DEVELOPER"] = "1"
+
+      formula_name = "homebrew-test-formula"
+      f = formula formula_name do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      dep = Dependency.new("cmake", [:build])
+      explicit_bubblewrap = Dependency.new("bubblewrap")
+      recursive_dep = Dependency.new(formula_name)
+      dep_formula = instance_double(Formula)
+
+      allow(f).to receive_messages(deps: [dep], recursive_dependencies: [])
+      allow(dep).to receive(:to_formula).and_return(dep_formula)
+      allow(dep_formula).to receive(:recursive_dependencies) do |&block|
+        block&.call(dep_formula, explicit_bubblewrap)
+        [recursive_dep]
+      end
+
+      fi = described_class.new(f)
 
       expect do
         fi.check_install_sanity

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe DependencyCollector do
   end
 
   describe "#bubblewrap_dep_if_needed" do
+    let(:formulae) do
+      Hash.new { |hash, name| hash[name] = instance_double(Formula, deps: []) }
+    end
+
     around do |example|
       with_env(HOMEBREW_TESTS: nil) { example.run }
     end
@@ -62,12 +66,17 @@ RSpec.describe DependencyCollector do
       allow(Homebrew::EnvConfig).to receive(:sandbox_linux?).and_return(true)
       allow(DevelopmentTools).to receive(:needs_build_formulae?).and_return(false)
       allow(Sandbox).to receive(:executable)
-      allow(Formula).to receive(:[]).with("bubblewrap").and_return(instance_double(Formula, deps: []))
-      collector.send(:global_dep_tree).clear
+      allow(OS).to receive(:not_tier_one_configuration?).and_return(false)
+      allow(Formula).to receive(:[]) { |name| formulae[name] }
+      global_dep_tree.clear
     end
 
     after do
-      collector.send(:global_dep_tree).clear
+      global_dep_tree.clear
+    end
+
+    def global_dep_tree
+      OS::Linux::DependencyCollector.module_eval { class_variable_get(:@@global_dep_tree) }
     end
 
     it "returns a Bubblewrap implicit dependency when the Linux sandbox needs one" do
@@ -85,6 +94,36 @@ RSpec.describe DependencyCollector do
 
       expect(collector.bubblewrap_dep_if_needed(Set["bubblewrap"])).to be_nil
       expect(collector.bubblewrap_dep_if_needed(Set["libcap"])).to be_nil
+    end
+
+    it "returns nil when Bubblewrap is already in the dependency tree" do
+      expect(collector.bubblewrap_dep_if_needed(Set["bubblewrap"])).to be_nil
+    end
+
+    it "returns nil when a Bubblewrap runtime dependency is already in the dependency tree" do
+      formulae["bubblewrap"] = instance_double(Formula, deps: [Dependency.new("libcap")])
+
+      expect(collector.bubblewrap_dep_if_needed(Set["libcap"])).to be_nil
+    end
+
+    it "ignores Bubblewrap build dependencies when build formulae are not needed" do
+      formulae["bubblewrap"] = instance_double(Formula, deps: [
+        Dependency.new("libcap"),
+        Dependency.new("pkgconf", [:build]),
+      ])
+
+      expect(collector.bubblewrap_dep_if_needed(Set["pkgconf"])).to eq(Dependency.new("bubblewrap", [:implicit]))
+    end
+
+    it "includes Bubblewrap build dependencies when build formulae are needed" do
+      allow(DevelopmentTools).to receive(:needs_build_formulae?).and_return(true)
+      formulae["bubblewrap"] = instance_double(Formula, deps: [
+        Dependency.new("pkgconf", [:build]),
+      ])
+      formulae["glibc"]
+      formulae[OS::LINUX_PREFERRED_GCC_RUNTIME_FORMULA]
+
+      expect(collector.bubblewrap_dep_if_needed(Set["pkgconf"])).to be_nil
     end
   end
 end


### PR DESCRIPTION
* Fixes sandbox not being used on tier 1 systems when installing certain formulae
* Fixes `brew install ca-certificates` not working at all - i.e. fixes double install of bubblewrap (dependency collector adds it as a dependency)
* Adds a warning when the sandbox isn't enabled

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Specs only. Hand written bug fix and hand tested a `brew install` flow.

-----
