### PR TITLE
Use API cask metadata for fetch

### DIFF
--- a/Library/Homebrew/api/cask_download.rb
+++ b/Library/Homebrew/api/cask_download.rb
@@ -1,0 +1,39 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "api/cask_struct"
+require "cask/cask"
+require "cask/download"
+
+module Homebrew
+  module API
+    module CaskDownload
+      sig {
+        params(
+          token:       String,
+          cask_struct: Homebrew::API::CaskStruct,
+          quarantine:  T.nilable(T::Boolean),
+          require_sha: T::Boolean,
+        ).returns(T.nilable(::Cask::Download))
+      }
+      def self.download(token:, cask_struct:, quarantine: nil, require_sha: false)
+        return if cask_struct.languages.any?
+        return if cask_struct.url_args.empty?
+
+        cask = ::Cask::Cask.new(
+          token,
+          tap:                      CoreCaskTap.instance,
+          loaded_from_api:          true,
+          loaded_from_internal_api: true,
+        ) do
+          version cask_struct.version
+          sha256 cask_struct.sha256
+          url(*cask_struct.url_args, **cask_struct.url_kwargs)
+          homepage cask_struct.homepage if cask_struct.homepage?
+        end
+
+        ::Cask::Download.new(cask, quarantine:, require_sha:)
+      end
+    end
+  end
+end

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -7,6 +7,7 @@ require "utils/topological_hash"
 require "utils/analytics"
 require "utils/output"
 
+require "api/cask_download"
 require "cask/config"
 require "cask/download"
 require "cask/migrator"
@@ -239,7 +240,14 @@ on_request: true)
     sig { returns(Download) }
     def downloader
       @downloader ||= T.let(
-        Download.new(@cask, quarantine: quarantine?, require_sha: require_sha? && !force?),
+        (if @cask.loaded_from_internal_api? && !@cask.caskfile_only?
+           Homebrew::API::CaskDownload.download(
+             token:       @cask.token,
+             cask_struct: Homebrew::API::Internal.cask_struct(@cask.token),
+             quarantine:  quarantine?,
+             require_sha: require_sha? && !force?,
+           )
+        end) || Download.new(@cask, quarantine: quarantine?, require_sha: require_sha? && !force?),
         T.nilable(Download),
       )
     end

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -4,6 +4,7 @@
 require "abstract_command"
 require "formula"
 require "fetch"
+require "api/cask_download"
 require "api/formula_bottle"
 require "cask/config"
 require "cask/download"
@@ -78,7 +79,7 @@ module Homebrew
       def run
         Formulary.enable_factory_cache!
 
-        if enqueue_api_formula_bottles?
+        if enqueue_api_formula_bottles? || enqueue_api_cask_downloads?
           download_queue.fetch
           return
         end
@@ -175,29 +176,20 @@ module Homebrew
 
       sig { returns(T::Boolean) }
       def enqueue_api_formula_bottles?
-        return false if Homebrew::EnvConfig.no_install_from_api?
+        return false unless api_fetchable?
         return false if args.only_formula_or_cask == :cask
         return false if args.deps? || args.HEAD?
         return false if args.build_from_source? || args.build_bottle?
-        return false if args.all_platforms? || args.os.present? || args.arch.present? || args.bottle_tag.present?
-        return false if ENV["HOMEBREW_TEST_GENERIC_OS"].present?
+        return false if args.bottle_tag.present?
 
-        formula_hashes = Homebrew::API::Internal.formula_hashes
-        aliases = Homebrew::API::Internal.formula_aliases
-        renames = Homebrew::API::Internal.formula_renames
-        names = T.let([], T::Array[String])
-
-        args.named.downcased_unique_named.each do |requested_name|
-          name = requested_name[HOMEBREW_DEFAULT_TAP_FORMULA_REGEX, :name]
-          return false if name.blank?
-
-          name = name.downcase
-          name = aliases.fetch(name, name)
-          name = renames.fetch(name, name)
-          return false unless formula_hashes.key?(name)
-
-          names << name
-        end
+        names = api_fetch_names(
+          regex:   HOMEBREW_DEFAULT_TAP_FORMULA_REGEX,
+          capture: :name,
+          hashes:  Homebrew::API::Internal.formula_hashes,
+          aliases: Homebrew::API::Internal.formula_aliases,
+          renames: Homebrew::API::Internal.formula_renames,
+        )
+        return false if names.nil?
 
         bottles = T.let([], T::Array[[String, Bottle]])
         bottle_tag = Utils::Bottles.tag
@@ -223,6 +215,77 @@ module Homebrew
           download_queue.enqueue(bottle)
         end
         true
+      end
+
+      sig { returns(T::Boolean) }
+      def enqueue_api_cask_downloads?
+        return false unless api_fetchable?
+        return false if args.only_formula_or_cask != :cask
+
+        tokens = api_fetch_names(
+          regex:   HOMEBREW_DEFAULT_TAP_CASK_REGEX,
+          capture: :token,
+          hashes:  Homebrew::API::Internal.cask_hashes,
+          aliases: {},
+          renames: Homebrew::API::Internal.cask_renames,
+        )
+        return false if tokens.nil?
+
+        downloads = T.let([], T::Array[[String, Cask::Download]])
+        tokens.each do |token|
+          download = Homebrew::API::CaskDownload.download(
+            token:,
+            cask_struct: Homebrew::API::Internal.cask_struct(token),
+            quarantine:  true,
+            require_sha: Homebrew::EnvConfig.cask_opts_require_sha?,
+          )
+          return false if download.nil?
+
+          downloads << [token, download]
+        end
+
+        puts "Fetching: #{tokens * ", "}" if tokens.size > 1
+        downloads.each do |token, download|
+          ohai "Fetching #{token} from #{CoreCaskTap.instance}"
+          download_queue.enqueue(download)
+        end
+        true
+      end
+
+      sig { returns(T::Boolean) }
+      def api_fetchable?
+        return false if Homebrew::EnvConfig.no_install_from_api?
+        return false if args.all_platforms? || args.os.present? || args.arch.present?
+        return false if ENV["HOMEBREW_TEST_GENERIC_OS"].present?
+
+        true
+      end
+
+      sig {
+        params(
+          regex:   Regexp,
+          capture: Symbol,
+          hashes:  T::Hash[String, T::Hash[String, T.untyped]],
+          aliases: T::Hash[String, String],
+          renames: T::Hash[String, String],
+        ).returns(T.nilable(T::Array[String]))
+      }
+      def api_fetch_names(regex:, capture:, hashes:, aliases:, renames:)
+        requested_names = args.named.downcased_unique_named
+        names = T.let(requested_names.filter_map do |requested_name|
+          name = requested_name[regex, capture]
+          next if name.blank?
+
+          name = name.downcase
+          name = aliases.fetch(name, name)
+          name = renames.fetch(name, name)
+          next unless hashes.key?(name)
+
+          name
+        end, T::Array[String])
+        return if names.length != requested_names.length
+
+        names
       end
 
       sig { params(cask: Cask::Cask).returns(T::Array[Cask::Download]) }

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -555,6 +555,30 @@ RSpec.describe Cask::Installer, :cask do
   end
 
   describe "#prelude_fetch" do
+    it "uses API cask metadata for API-loaded cask downloads" do
+      cask = Cask::Cask.new("api-cask", loaded_from_api: true, loaded_from_internal_api: true) do
+        url "https://example.com/source-cask.zip"
+        version "0.9"
+        sha256 "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97"
+      end
+      cask_struct = Homebrew::API::CaskStruct.new(
+        sha256:   "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97",
+        url_args: ["https://example.com/api-cask.zip"],
+        version:  "1.0",
+      )
+      download_queue = instance_double(Homebrew::DownloadQueue)
+      installer = described_class.new(cask, download_queue:)
+
+      allow(Homebrew::API::Internal).to receive(:cask_struct).with("api-cask").and_return(cask_struct)
+      expect(Homebrew::API::Cask).not_to receive(:source_download)
+      expect(download_queue).to receive(:enqueue) do |download|
+        expect(download).to be_a(Cask::Download)
+        expect(download.url.to_s).to eq("https://example.com/api-cask.zip")
+      end
+
+      installer.enqueue_downloads
+    end
+
     it "enqueues source API caskfiles before the main cask download" do
       cask = Cask::Cask.new("source-api-cask") do
         url "file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz"

--- a/Library/Homebrew/test/cmd/fetch_spec.rb
+++ b/Library/Homebrew/test/cmd/fetch_spec.rb
@@ -46,6 +46,33 @@ RSpec.describe Homebrew::Cmd::FetchCmd do
     expect(enqueued_downloads).to include(an_instance_of(Bottle))
   end
 
+  it "uses API cask metadata before loading simple core casks" do
+    cmd = described_class.new(["--cask", "fast-cask"])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil)
+    cask_struct = Homebrew::API::CaskStruct.new(
+      sha256:   "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97",
+      url_args: ["https://example.com/fast-cask.zip"],
+      version:  "1.0",
+    )
+    enqueued_downloads = []
+
+    allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
+    allow(download_queue).to receive(:enqueue) { |download| enqueued_downloads << download }
+    allow(Homebrew::API::Internal).to receive_messages(
+      cask_hashes:  { "fast-cask" => {} },
+      cask_renames: {},
+      cask_struct:  cask_struct,
+    )
+
+    expect(cmd.args.named).not_to receive(:to_formulae_and_casks)
+    expect(Cask::CaskLoader).not_to receive(:load)
+    expect(download_queue).to receive(:shutdown)
+
+    with_env(HOMEBREW_TEST_GENERIC_OS: nil) { cmd.run }
+
+    expect(enqueued_downloads).to include(an_instance_of(Cask::Download))
+  end
+
   it "downloads Formula and Cask URLs concurrently", :cask, :integration_test do
     setup_test_formula "testball1"
     setup_test_formula "testball2"


### PR DESCRIPTION
- Avoid loading simple `homebrew/cask` entries when `brew fetch --cask` can resolve URL, version and checksum data from `CaskStruct`.
- Reuse that API-backed download construction for internal-API casks during installer download enqueueing.
- Keep source-backed cask loading for language-specific casks and other caskfile-only install paths.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
