### PR TITLE
Make release cooldown configurable via HOMEBREW_RELEASE_COOLDOWN_DAYS

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -907,7 +907,7 @@ module Homebrew
 
           current_str = current.to_s
           current_is_prerelease = current_str.include?("-")
-          cooldown_interval = (DateTime.now - Homebrew::RELEASE_COOLDOWN_DAYS)
+          cooldown_interval = (DateTime.now - Homebrew.release_cooldown_days)
           release_dates.sort_by { |_, date| date }.reverse_each do |version_str, date|
             version = Version.new(version_str)
             return version if version_str == current_str
@@ -940,7 +940,7 @@ module Homebrew
 
           current_str = current.to_s
           current_is_prerelease = current_str.match?(PYPI_UNSTABLE_VERSION_REGEX)
-          cooldown_interval = (DateTime.now - Homebrew::RELEASE_COOLDOWN_DAYS)
+          cooldown_interval = (DateTime.now - Homebrew.release_cooldown_days)
           releases.sort_by { |k, _| Version.new(k) }.reverse_each do |version_str, assets|
             version = Version.new(version_str)
             return version if version_str == current_str
@@ -972,7 +972,7 @@ module Homebrew
           return unless json.is_a?(Array)
 
           current_str = current.to_s
-          cooldown_interval = (DateTime.now - Homebrew::RELEASE_COOLDOWN_DAYS)
+          cooldown_interval = (DateTime.now - Homebrew.release_cooldown_days)
           json.sort_by { |release| Version.new(release["number"]) }.reverse_each do |release|
             next if release["platform"] != (match[:platform] || "ruby")
 

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -624,6 +624,13 @@ module Homebrew
         description: "If set, use Pry for the `brew irb` command.",
         boolean:     true,
       },
+      HOMEBREW_RELEASE_COOLDOWN_DAYS:            {
+        description: "Number of days a newly published upstream release must have been available before " \
+                     "Homebrew tooling will use it. Applies to npm, PyPI and RubyGems dependency installs " \
+                     "during formula builds and tests, PyPI resource resolution and `brew bump`. " \
+                     "Set to `0` to disable release cooldowns.",
+        default:     1,
+      },
       HOMEBREW_REQUIRE_TAP_TRUST:                {
         # odeprecated: make tap trust checks default in a later release.
         description: "If set, require non-official tap formulae, casks and commands to be trusted with " \
@@ -781,6 +788,7 @@ module Homebrew
       :HOMEBREW_DOWNLOAD_CONCURRENCY,
       :HOMEBREW_FORBID_PACKAGES_FROM_PATHS,
       :HOMEBREW_MAKE_JOBS,
+      :HOMEBREW_RELEASE_COOLDOWN_DAYS,
     ]).freeze, T::Set[Symbol])
 
     # This tracks process-local warnings, so it must remain mutable.
@@ -959,6 +967,14 @@ module Homebrew
       end
 
       [concurrency, 1].max
+    end
+
+    sig { returns(Integer) }
+    def release_cooldown_days
+      days = Integer(ENV.fetch("HOMEBREW_RELEASE_COOLDOWN_DAYS", ""), 10, exception: false)
+      return ENVS.fetch(:HOMEBREW_RELEASE_COOLDOWN_DAYS).fetch(:default) if days.nil?
+
+      [days, 0].max
     end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2218,7 +2218,7 @@ class Formula
     args = ["--verbose", "--no-deps", "--no-binary=:all:", "--ignore-installed", "--no-compile"]
     # Delay packages published in the last day so builds are less likely to
     # install a freshly compromised PyPI release.
-    args << "--uploaded-prior-to=#{(Time.now.utc - Homebrew::RELEASE_COOLDOWN_SECONDS).iso8601(0)}"
+    args << "--uploaded-prior-to=#{(Time.now.utc - Homebrew.release_cooldown_seconds).iso8601(0)}"
     args << "--prefix=#{prefix}" if prefix
     args << "--no-build-isolation" unless build_isolation
     args
@@ -3746,7 +3746,7 @@ class Formula
       GOCACHE:                 "#{HOMEBREW_CACHE}/go_cache",
       GOPATH:                  "#{HOMEBREW_CACHE}/go_mod_cache",
       CARGO_HOME:              "#{HOMEBREW_CACHE}/cargo_cache",
-      BUNDLE_COOLDOWN:         Homebrew::RELEASE_COOLDOWN_DAYS.to_s,
+      BUNDLE_COOLDOWN:         Homebrew.release_cooldown_days.to_s,
       PIP_CACHE_DIR:           "#{HOMEBREW_CACHE}/pip_cache",
       CURL_HOME:               ENV.fetch("CURL_HOME") { home.to_s },
       PYTHONDONTWRITEBYTECODE: "1",

--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -19,7 +19,7 @@ module Language
     sig { params(ignore_scripts: T::Boolean).returns(T::Array[String]) }
     def self.npm_install_security_args(ignore_scripts: true)
       args = %W[
-        --min-release-age=#{Homebrew::RELEASE_COOLDOWN_DAYS}
+        --min-release-age=#{Homebrew.release_cooldown_days}
         --#{npm_cache_config}
       ]
 

--- a/Library/Homebrew/release_cooldown.rb
+++ b/Library/Homebrew/release_cooldown.rb
@@ -2,6 +2,18 @@
 # frozen_string_literal: true
 
 module Homebrew
-  RELEASE_COOLDOWN_DAYS = T.let(1, Integer)
-  RELEASE_COOLDOWN_SECONDS = T.let(RELEASE_COOLDOWN_DAYS * 24 * 60 * 60, Integer)
+  # The number of days a new upstream release must have been published before
+  # Homebrew tooling will use it, configurable with
+  # `$HOMEBREW_RELEASE_COOLDOWN_DAYS`. A value of `0` disables the cooldown.
+  sig { returns(Integer) }
+  def self.release_cooldown_days
+    require "env_config"
+
+    EnvConfig.release_cooldown_days
+  end
+
+  sig { returns(Integer) }
+  def self.release_cooldown_seconds
+    release_cooldown_days * 24 * 60 * 60
+  end
 end

--- a/Library/Homebrew/test/release_cooldown_spec.rb
+++ b/Library/Homebrew/test/release_cooldown_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "release_cooldown"
+
+RSpec.describe Homebrew do
+  describe "::release_cooldown_days" do
+    it "defaults to 1 day" do
+      expect(described_class.release_cooldown_days).to eq 1
+    end
+
+    it "respects HOMEBREW_RELEASE_COOLDOWN_DAYS" do
+      with_env(HOMEBREW_RELEASE_COOLDOWN_DAYS: "7") do
+        expect(described_class.release_cooldown_days).to eq 7
+      end
+    end
+
+    it "treats 0 as disabling the cooldown" do
+      with_env(HOMEBREW_RELEASE_COOLDOWN_DAYS: "0") do
+        expect(described_class.release_cooldown_days).to eq 0
+      end
+    end
+
+    it "clamps negative values to 0" do
+      with_env(HOMEBREW_RELEASE_COOLDOWN_DAYS: "-3") do
+        expect(described_class.release_cooldown_days).to eq 0
+      end
+    end
+
+    it "falls back to the default for non-integer values" do
+      with_env(HOMEBREW_RELEASE_COOLDOWN_DAYS: "soon") do
+        expect(described_class.release_cooldown_days).to eq 1
+      end
+    end
+
+    it "falls back to the default for empty values" do
+      with_env(HOMEBREW_RELEASE_COOLDOWN_DAYS: "") do
+        expect(described_class.release_cooldown_days).to eq 1
+      end
+    end
+  end
+
+  describe "::release_cooldown_seconds" do
+    it "derives from the configured number of days" do
+      with_env(HOMEBREW_RELEASE_COOLDOWN_DAYS: "2") do
+        expect(described_class.release_cooldown_seconds).to eq 2 * 24 * 60 * 60
+      end
+    end
+  end
+end

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -497,7 +497,7 @@ module PyPI
     command = [
       Formula[python_name].opt_libexec/"bin/python", "-m", "pip", "install", "-q", "--disable-pip-version-check",
       "--dry-run", "--ignore-installed",
-      "--uploaded-prior-to=#{(Time.now.utc - Homebrew::RELEASE_COOLDOWN_SECONDS).iso8601(0)}",
+      "--uploaded-prior-to=#{(Time.now.utc - Homebrew.release_cooldown_seconds).iso8601(0)}",
       "--report=/dev/stdout", *packages.map(&:to_s)
     ]
     options = {}

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -4854,6 +4854,15 @@ command execution (e.g. `$(cat file)`).
 
 : If set, use Pry for the `brew irb` command.
 
+`HOMEBREW_RELEASE_COOLDOWN_DAYS`
+
+: Number of days a newly published upstream release must have been available
+  before Homebrew tooling will use it. Applies to npm, PyPI and RubyGems
+  dependency installs during formula builds and tests, PyPI resource resolution
+  and `brew bump`. Set to `0` to disable release cooldowns.
+  
+  *Default:* `1`.
+
 `HOMEBREW_REQUIRE_TAP_TRUST`
 
 : If set, require non-official tap formulae, casks and commands to be trusted

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3165,6 +3165,13 @@ If set, \fBbrew install\fP \fIformula\fP will use this URL to download PyPI pack
 \fBHOMEBREW_PRY\fP
 If set, use Pry for the \fBbrew irb\fP command\.
 .TP
+\fBHOMEBREW_RELEASE_COOLDOWN_DAYS\fP
+Number of days a newly published upstream release must have been available before Homebrew tooling will use it\. Applies to npm, PyPI and RubyGems dependency installs during formula builds and tests, PyPI resource resolution and \fBbrew bump\fP\&\. Set to \fB0\fP to disable release cooldowns\.
+.RS
+.P
+\fIDefault:\fP \fB1\fP\&\.
+.RE
+.TP
 \fBHOMEBREW_REQUIRE_TAP_TRUST\fP
 If set, require non\-official tap formulae, casks and commands to be trusted with \fBbrew trust\fP before Homebrew loads them\. This is the default unless \fB$HOMEBREW_NO_REQUIRE_TAP_TRUST\fP is set\. Also enables commands that evaluate all formulae and casks\.
 .RS


### PR DESCRIPTION
The release cooldown is currently a hardcoded constant. Organisations that manage Homebrew centrally (e.g. via /etc/homebrew/brew.env) may want a longer cooldown than the default, while some workflows may need to disable it entirely.

Replace the RELEASE_COOLDOWN_DAYS/RELEASE_COOLDOWN_SECONDS constants with Homebrew.release_cooldown_days/release_cooldown_seconds, backed by a new HOMEBREW_RELEASE_COOLDOWN_DAYS environment variable parsed by a custom EnvConfig implementation (like HOMEBREW_DOWNLOAD_CONCURRENCY).

The default is unchanged (1 day). Setting 0 disables the cooldown, negative values are clamped to 0 and values that don't parse as an integer fall back to the default rather than silently disabling the cooldown (since that seemed an unfortunate failure mode for a typo in a security-related setting — happy to switch to plain `to_i` if you prefer consistency with the other numeric variables).

Related context: I'm aware #22659 and #21129 asked for blanket/global dependency cooldowns and were declined for the reasons in [Supply Chain Security](https://docs.brew.sh/Supply-Chain-Security). This PR is intentionally not that: it doesn't change which ecosystems get cooldowns, doesn't add a cooldown to bottles/formulae generally, and doesn't change the default. It only makes the duration of the already-existing, narrowly-scoped cooldowns tunable via the same environment variable mechanism used for other behaviour, so organisations that deploy `/etc/homebrew/brew.env` can pick a different trade-off for the ecosystems you've already decided warrant a cooldown. If you'd rather not expose this knob at all, no hard feelings — closing with a pointer to the rationale would still be a useful signal for others searching later.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI usage: this PR was written with the assistance of Claude Code (model: Claude Fable 5). The implementation was developed test-first (the spec was written and observed failing before the implementation), modelled on the existing `EnvConfig` custom implementations (`HOMEBREW_DOWNLOAD_CONCURRENCY`, `HOMEBREW_MAKE_JOBS`). Verification: `brew lgtm` run locally (typecheck, `style --changed` and the relevant tests), the `formula`, `env_config` and `language/node` specs run individually, and the RBI/manpage/completions regenerated with `brew typecheck --update` and `brew generate-man-completions`. I have reviewed the diff myself and will address review comments manually if needed.

-----
