### PR TITLE
bundle/dsl: fix kwargs handling for taps

### DIFF
--- a/Library/Homebrew/bundle/dsl.rb
+++ b/Library/Homebrew/bundle/dsl.rb
@@ -83,8 +83,16 @@ module Homebrew
         @entries << Entry.new(:cask, name, options)
       end
 
-      sig { params(name: String, clone_target: T.nilable(String), options: Homebrew::Bundle::EntryOptions).void }
-      def tap(name, clone_target = nil, options = {})
+      sig {
+        params(
+          name:            String,
+          clone_target:    T.nilable(String),
+          options:         Homebrew::Bundle::EntryOptions,
+          keyword_options: Homebrew::Bundle::EntryOption,
+        ).void
+      }
+      def tap(name, clone_target = nil, options = {}, **keyword_options)
+        options.merge!(keyword_options)
         options[:clone_target] = clone_target
         name = Homebrew::Bundle::Dsl.sanitize_tap_name(name)
         @entries << Entry.new(:tap, name, options)

--- a/Library/Homebrew/test/bundle/dsl_spec.rb
+++ b/Library/Homebrew/test/bundle/dsl_spec.rb
@@ -66,6 +66,13 @@ RSpec.describe Homebrew::Bundle::Dsl do
     end
   end
 
+  context "with tap entries" do
+    it "processes trusted options without a clone target" do
+      dsl = dsl_from_string 'tap "thirdparty/tap", trusted: true'
+      expect(dsl.entries[0].options).to eql(clone_target: nil, trusted: true)
+    end
+  end
+
   context "with multiple cask_args" do
     subject(:dsl) do
       dsl_from_string <<~RUBY


### PR DESCRIPTION
Fixes #22668.

For backwards compatibility reasons, the hash positional argument is still accepted. I'll follow up with a deprecation plan for that.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
