### PR TITLE
bundle: preserve trusted tap option without remote

### DIFF
--- a/Library/Homebrew/bundle/dsl.rb
+++ b/Library/Homebrew/bundle/dsl.rb
@@ -83,8 +83,21 @@ module Homebrew
         @entries << Entry.new(:cask, name, options)
       end
 
-      sig { params(name: String, clone_target: T.nilable(String), options: Homebrew::Bundle::EntryOptions).void }
-      def tap(name, clone_target = nil, options = {})
+      sig {
+        params(
+          name:               String,
+          clone_target:       T.nilable(T.any(String, Homebrew::Bundle::EntryOptions)),
+          positional_options: Homebrew::Bundle::EntryOptions,
+          options:            T.untyped,
+        ).void
+      }
+      def tap(name, clone_target = nil, positional_options = {}, **options)
+        if clone_target.is_a?(Hash)
+          positional_options = clone_target
+          clone_target = nil
+        end
+
+        options = positional_options.merge(options)
         options[:clone_target] = clone_target
         name = Homebrew::Bundle::Dsl.sanitize_tap_name(name)
         @entries << Entry.new(:tap, name, options)

--- a/Library/Homebrew/test/bundle/dsl_spec.rb
+++ b/Library/Homebrew/test/bundle/dsl_spec.rb
@@ -80,6 +80,36 @@ RSpec.describe Homebrew::Bundle::Dsl do
     end
   end
 
+  context "with tap entries" do
+    it "processes trusted taps without a clone target" do
+      dsl = dsl_from_string 'tap "oven-sh/bun", trusted: true'
+
+      expect(dsl.entries[0]).to have_attributes(
+        name:    "oven-sh/bun",
+        options: { trusted: true, clone_target: nil },
+      )
+    end
+
+    it "processes trusted taps with a clone target" do
+      dsl = dsl_from_string 'tap "oven-sh/bun", "https://github.com/oven-sh/homebrew-bun", trusted: true'
+
+      expect(dsl.entries[0]).to have_attributes(
+        name:    "oven-sh/bun",
+        options: { clone_target: "https://github.com/oven-sh/homebrew-bun", trusted: true },
+      )
+    end
+
+    it "processes legacy positional tap options" do
+      dsl = described_class.new(StringIO.new(""))
+      dsl.tap("oven-sh/bun", nil, { trusted: true })
+
+      expect(dsl.entries[0]).to have_attributes(
+        name:    "oven-sh/bun",
+        options: { trusted: true, clone_target: nil },
+      )
+    end
+  end
+
   context "with flatpak entries" do
     it "processes flatpak without options" do
       dsl = dsl_from_string 'flatpak "org.gnome.Calculator"'


### PR DESCRIPTION
## What does this PR do?

Fixes #22668.

This updates the Brewfile DSL so that `tap "owner/name", trusted: true` correctly preserves the `trusted: true` option. Previously, without a custom remote URL, the `trusted:` hash was being mis-parsed as the `clone_target` argument. The fix changes `Dsl#tap` to accept keyword arguments (so `options[:trusted]` is set properly) and adds parser-level tests in `dsl_spec.rb` to verify both “tap by name” and “tap with URL” cases. 

## Why is this useful?

It makes declarative tap trust work consistently. Now a Brewfile entry like `tap "oven-sh/bun", trusted: true` will behave like running `brew tap oven-sh/bun` plus `brew trust --tap oven-sh/bun`, avoiding trust warnings and ensuring the tap is recorded in `trust.json`. This matches the existing working case when a URL is provided, and it fixes round-trip issues when using `brew bundle dump`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->
I used GPT 5.5 and Gemini 3.5 flash in oh-my-pi to generate code for this PR.

-----
