### PR TITLE
bundle/parallel_installer: install taps before packages

### DIFF
--- a/Library/Homebrew/bundle/parallel_installer.rb
+++ b/Library/Homebrew/bundle/parallel_installer.rb
@@ -37,13 +37,19 @@ module Homebrew
 
       sig { returns([Integer, Integer]) }
       def run!
-        dependency_map = build_dependency_map
-
         success = 0
         failure = 0
-        pending_entries = T.let(@entries.dup, T::Array[Installer::InstallableEntry])
-        completed = T.let(Set.new, T::Set[String])
 
+        tap_entries, pending_entries = @entries.partition { |entry| entry.cls == Homebrew::Bundle::Tap }
+        tap_entries.each_slice(@jobs) do |batch|
+          tap_success, tap_failure = install_entries_parallel!(batch)
+          success += tap_success
+          failure += tap_failure
+        end
+        ::Tap.clear_cache if tap_entries.present?
+
+        dependency_map = build_dependency_map(pending_entries)
+        completed = T.let(Set.new, T::Set[String])
         until pending_entries.empty?
           ready_entries = pending_entries.select do |entry|
             dependency_map.fetch(entry.name, Set.new).all? { |dependency| completed.include?(dependency) }
@@ -63,29 +69,12 @@ module Homebrew
           end
 
           batch = ready_entries.take(@jobs)
-          futures = batch.to_h do |entry|
-            [entry, Concurrent::Promises.future_on(@pool, entry) do |install_entry|
-              install_entry!(install_entry)
-            end]
-          end
+          batch_success, batch_failure = install_entries_parallel!(batch)
+          success += batch_success
+          failure += batch_failure
 
-          batch.each do |entry|
-            installed = begin
-              !futures.fetch(entry).value!.nil?
-            rescue => e
-              write_output(Formatter.error("Installing #{entry.name} has failed!"), stream: $stderr)
-              write_output("[#{entry.name}] #{e.message}", stream: $stderr) if @verbose
-              false
-            end
-
-            pending_entries.delete(entry)
-            completed << entry.name
-            if installed
-              success += 1
-            else
-              failure += 1
-            end
-          end
+          pending_entries -= batch
+          completed.merge(batch.map(&:name))
         end
 
         [success, failure]
@@ -96,12 +85,12 @@ module Homebrew
 
       private
 
-      sig { returns(T::Hash[String, T::Set[String]]) }
-      def build_dependency_map
+      sig { params(entries: T::Array[Installer::InstallableEntry]).returns(T::Hash[String, T::Set[String]]) }
+      def build_dependency_map(entries)
         installed_taps = Homebrew::Bundle::Tap.installed_taps
 
         # Phase 1: Map both full and short names so dep lookups work either way.
-        entry_name_map = @entries.each_with_object({}) do |entry, map|
+        entry_name_map = entries.each_with_object({}) do |entry, map|
           map[entry.name] = entry.name
           map[normalize_formula_name(entry.name)] = entry.name
         end
@@ -109,7 +98,7 @@ module Homebrew
         # Phase 2: Direct dependencies declared in the Brewfile. Determines
         # install ordering (entry A must finish before entry B starts).
         brewfile_deps = T.let({}, T::Hash[String, T::Array[String]])
-        @entries.each do |entry|
+        entries.each do |entry|
           deps = case entry.cls.name
           when "Homebrew::Bundle::Brew"
             Homebrew::Bundle::Brew.formula_dep_names(entry.name)
@@ -120,7 +109,7 @@ module Homebrew
           end
 
           # Entries from non-default taps depend on the tap being installed first.
-          deps += Homebrew::Bundle::Installer.tap_dependencies(entry, entries: @entries, installed_taps:)
+          deps += Homebrew::Bundle::Installer.tap_dependencies(entry, entries:, installed_taps:)
 
           brewfile_deps[entry.name] = deps
         end
@@ -128,9 +117,9 @@ module Homebrew
         # Phase 3: Recursive dependency sets for lock conflict detection.
         # `FormulaInstaller#lock` locks all recursive dependencies before
         # installing, even when pouring bottles.
-        cask_names = T.let(@entries.select { |e| e.cls == Homebrew::Bundle::Cask }.to_set(&:name), T::Set[String])
+        cask_names = T.let(entries.select { |e| e.cls == Homebrew::Bundle::Cask }.to_set(&:name), T::Set[String])
         recursive_deps = T.let({}, T::Hash[String, T::Set[String]])
-        @entries.each do |entry|
+        entries.each do |entry|
           recursive_deps[entry.name] = case entry.cls.name
           when "Homebrew::Bundle::Brew"
             Homebrew::Bundle::Brew.recursive_dep_names(entry.name)
@@ -142,7 +131,7 @@ module Homebrew
         end
 
         # Phase 4: Merge explicit ordering and implicit lock conflicts.
-        @entries.each_with_object({}) do |entry, map|
+        entries.each_with_object({}) do |entry, map|
           depends_on = brewfile_deps.fetch(entry.name).each_with_object(Set.new) do |dep, set|
             name = entry_name_map[dep] || entry_name_map[normalize_formula_name(dep)]
             set << name if name.present? && name != entry.name
@@ -150,7 +139,7 @@ module Homebrew
 
           # Later entries wait for earlier ones when they share any recursive dep.
           entry_rdeps = recursive_deps.fetch(entry.name)
-          @entries.each do |earlier|
+          entries.each do |earlier|
             break if earlier.name == entry.name
             next if depends_on.include?(earlier.name)
 
@@ -180,6 +169,35 @@ module Homebrew
         direct & cask_names
       rescue ::Cask::CaskUnavailableError
         Set.new
+      end
+
+      sig { params(entries: T::Array[Installer::InstallableEntry]).returns([Integer, Integer]) }
+      def install_entries_parallel!(entries)
+        futures = entries.to_h do |entry|
+          [entry, Concurrent::Promises.future_on(@pool, entry) do |install_entry|
+            install_entry!(install_entry)
+          end]
+        end
+
+        success = 0
+        failure = 0
+        entries.each do |entry|
+          installed = begin
+            !futures.fetch(entry).value!.nil?
+          rescue => e
+            write_output(Formatter.error("Installing #{entry.name} has failed!"), stream: $stderr)
+            write_output("[#{entry.name}] #{e.message}", stream: $stderr) if @verbose
+            false
+          end
+
+          if installed
+            success += 1
+          else
+            failure += 1
+          end
+        end
+
+        [success, failure]
       end
 
       sig { params(entry: Installer::InstallableEntry).returns(T::Boolean) }
@@ -239,7 +257,7 @@ module Homebrew
       sig { void }
       def clear_tty_line
         File.open("/dev/tty", "w") { |f| f.print("\r\e[K") }
-      rescue Errno::ENXIO, Errno::ENOENT
+      rescue Errno::ENXIO, Errno::ENOENT, Errno::EACCES, Errno::EPERM
         # No TTY available (CI, piped output) - nothing to clean up.
         nil
       end

--- a/Library/Homebrew/bundle/tap.rb
+++ b/Library/Homebrew/bundle/tap.rb
@@ -71,6 +71,8 @@ module Homebrew
             return false
           end
 
+          require "tap"
+          ::Tap.fetch(name).clear_cache
           installed_taps << name
           true
         end

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -287,10 +287,11 @@ RSpec.describe Homebrew::Bundle::Installer do
       allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("alpha").and_return(Set["shared-build-dep"])
       allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("beta").and_return(Set["shared-build-dep"])
 
+      entries = [alpha_entry, beta_entry]
       dependency_map = Homebrew::Bundle::ParallelInstaller.new(
-        [alpha_entry, beta_entry],
+        entries,
         jobs: 2, no_upgrade: false, verbose: false, force: false, quiet: true,
-      ).send(:build_dependency_map)
+      ).send(:build_dependency_map, entries)
 
       expect(dependency_map.fetch("beta")).to eq(Set["alpha"])
     end
@@ -329,6 +330,54 @@ RSpec.describe Homebrew::Bundle::Installer do
       expect(success).to eq(2)
       expect(failure).to eq(0)
       expect(install_order).to eq(["homebrew/foo", "bar"])
+    end
+
+    it "reads fully qualified formulae after installing their Brewfile taps" do
+      tap_entry = Homebrew::Bundle::Installer::InstallableEntry.new(
+        name:    "thirdparty/rootformula",
+        options: {},
+        verb:    "Tapping",
+        cls:     Homebrew::Bundle::Tap,
+      )
+      tapped_formula_entry = Homebrew::Bundle::Installer::InstallableEntry.new(
+        name:    "thirdparty/rootformula/foo",
+        options: {},
+        verb:    "Installing",
+        cls:     Homebrew::Bundle::Brew,
+      )
+      install_order = []
+      event_order = []
+
+      allow(Homebrew::Bundle::Brew).to receive(:formula_dep_names) do |name|
+        event_order << :formula_dep_names
+        expect(name).to eq("thirdparty/rootformula/foo")
+        []
+      end
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names) do |name|
+        event_order << :recursive_dep_names
+        expect(name).to eq("thirdparty/rootformula/foo")
+        Set.new
+      end
+      allow(Homebrew::Bundle::Tap).to receive(:install!) do |name, **_options|
+        install_order << name
+        event_order << :tap_install
+        true
+      end
+      allow(Homebrew::Bundle::Brew).to receive(:install!) do |name, **_options|
+        install_order << name
+        event_order << :formula_install
+        true
+      end
+
+      success, failure = Homebrew::Bundle::ParallelInstaller.new(
+        [tap_entry, tapped_formula_entry],
+        jobs: 2, no_upgrade: false, verbose: false, force: false, quiet: true,
+      ).run!
+
+      expect(success).to eq(2)
+      expect(failure).to eq(0)
+      expect(install_order).to eq(["thirdparty/rootformula", "thirdparty/rootformula/foo"])
+      expect(event_order).to eq([:tap_install, :formula_dep_names, :recursive_dep_names, :formula_install])
     end
 
     it "installs unqualified casks after Brewfile taps" do

--- a/Library/Homebrew/test/bundle/tap_spec.rb
+++ b/Library/Homebrew/test/bundle/tap_spec.rb
@@ -106,6 +106,30 @@ RSpec.describe Homebrew::Bundle::Tap do
         expect(described_class.install!("homebrew/cask")).to be(true)
       end
 
+      it "clears cached tap contents after tapping" do
+        tap = Tap.fetch("bundle-test/rootformula")
+        FileUtils.rm_rf(tap.path)
+        tap.clear_cache
+
+        expect(tap.formula_dir).to eq(tap.path/"Formula")
+
+        expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "tap", tap.name,
+                                                          verbose: false) do
+          tap.path.mkpath
+          FileUtils.touch tap.path/"foo.rb"
+          true
+        end
+
+        expect(described_class.install!(tap.name)).to be(true)
+        expect(tap.formula_dir).to eq(tap.path)
+        expect(tap.formula_files_by_name).to include("foo" => tap.path/"foo.rb")
+      ensure
+        if tap
+          FileUtils.rm_rf(tap.path)
+          tap.path.parent.rmdir_if_possible
+        end
+      end
+
       context "with clone target" do
         it "taps" do
           expect(Homebrew::Bundle).to \


### PR DESCRIPTION
Fixes #22672

`build_dependency_map` does not work and spams errors if you don't already have the tap installed. Therefore we need to install the taps before we can correctly check the package dependency tree.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

For tests etc

-----
