### PR TITLE
os/mac/hardware/cpu: fallback to generic CPU detection if sysctl fails

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -20,7 +20,7 @@ module OS
             when MachO::Headers::CPU_TYPE_ARM64
               :arm
             else
-              :dunno
+              super
             end
           end
 

--- a/Library/Homebrew/test/hardware/cpu_spec.rb
+++ b/Library/Homebrew/test/hardware/cpu_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe Hardware::CPU do
     it "returns the current CPU's type as a symbol, or :dunno if it cannot be detected" do
       expect(cpu_types).to include(described_class.type)
     end
+
+    it "falls back when hw.cputype cannot be detected on a Mac", :needs_macos do
+      expect(described_class).to receive(:sysctl_int).with("hw.cputype").and_return(0)
+
+      # Unlike the previous test, we can usually assume this will never be `dunno` on a Mac.
+      expect(described_class.type).not_to eq(:dunno)
+    end
   end
 
   describe "::family" do


### PR DESCRIPTION
This fixes sandboxes misbehaving and doing network requests because it thinks the arch is `:dunno` when sysctl is blocked

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
