### PR TITLE
Handle pinned dependency failures in upgrade previews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,5 +62,6 @@ Do not use conventional commit prefixes such as `feat:`, `fix:`, `chore:`, `refa
 9. Inline new or existing methods as methods or local variables unless they are reused 2+ times or needed for unit tests.
 10. Avoid `T.must`; prefer explicit nil checks or APIs that return non-nil values.
 11. Avoid `T.unsafe(self)` whenever possible; prefer `requires_ancestor` or similar typed module patterns.
-12. Keep `extend/os/*` prepends as thin as possible; put the `prepend` in the OS-specific `linux` or `macos` file rather than the shared `extend/os/*` loader with an inline `if`, and prefer putting substantive logic in shared code outside `extend/` when practical so it can be tested on all platforms instead of relying on `:needs_linux` or `:needs_macos` specs.
-13. When Bash logic mirrors Ruby logic, keep both implementations in sync and add two-way comments naming the matching Ruby and Bash locations; keep matching helper filenames aligned where practical.
+12. Avoid `.send` in tests; call methods directly and make the method public or, for dynamic calls, use `.public_send`.
+13. Keep `extend/os/*` prepends as thin as possible; put the `prepend` in the OS-specific `linux` or `macos` file rather than the shared `extend/os/*` loader with an inline `if`, and prefer putting substantive logic in shared code outside `extend/` when practical so it can be tested on all platforms instead of relying on `:needs_linux` or `:needs_macos` specs.
+14. When Bash logic mirrors Ruby logic, keep both implementations in sync and add two-way comments naming the matching Ruby and Bash locations; keep matching helper filenames aligned where practical.

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -184,6 +184,7 @@ module Homebrew
         @final_upgrade_summary = T.let(FinalUpgradeSummary.new, T.nilable(FinalUpgradeSummary))
         @ask_prompt_required = false
         ask = !args.no_ask?
+        skip_upgrades_after_failed_ask_preview = T.let(false, T::Boolean)
 
         if args.named.present?
           Homebrew::Trust.trust_fully_qualified_items!(args.named, type: args.only_formula_or_cask)
@@ -251,6 +252,7 @@ module Homebrew
             Cask::Upgrade.show_upgrade_summary(final_upgrade_summary.version_changes)
           end
           ask_upgrade_planned = final_upgrade_summary.version_changes.present?
+          skip_upgrades_after_failed_ask_preview = Homebrew.failed? && !ask_upgrade_planned
           @final_upgrade_summary = FinalUpgradeSummary.new
         end
 
@@ -293,14 +295,14 @@ module Homebrew
           end
         end
 
-        unless only_upgrade_casks
+        if !only_upgrade_casks && !skip_upgrades_after_failed_ask_preview
           upgrade_outdated_formulae!(
             formulae,
             use_prefetched:       formulae_prefetched,
             show_upgrade_summary: prefetched_formulae_upgrades.blank? && !args.dry_run? && !ask,
           )
         end
-        unless only_upgrade_formulae
+        if !only_upgrade_formulae && !skip_upgrades_after_failed_ask_preview
           upgrade_outdated_casks!(
             casks,
             skip_prefetch:        prefetched_casks,
@@ -416,17 +418,6 @@ module Homebrew
           end
         end
 
-        if pinned.any?
-          message = "Not upgrading #{pinned.count} pinned #{Utils.pluralize("package", pinned.count)}:"
-          # only fail when pinned formulae are named explicitly
-          if formulae.any?
-            ofail message
-          else
-            opoo message
-          end
-          puts pinned.map { |f| "#{f.full_specified_name} #{f.pkg_version}" } * ", "
-        end
-
         if formulae_to_install.empty?
           oh1 "No packages to upgrade" if show_upgrade_summary
         elsif show_upgrade_summary
@@ -461,8 +452,22 @@ module Homebrew
         )
 
         if formulae_installer.blank?
+          return if formulae_to_install.present?
           return if pinned.blank?
+        end
 
+        if pinned.any?
+          message = "Not upgrading #{pinned.count} pinned #{Utils.pluralize("package", pinned.count)}:"
+          # only fail when pinned formulae are named explicitly
+          if formulae.any?
+            ofail message
+          else
+            opoo message
+          end
+          puts pinned.map { |f| "#{f.full_specified_name} #{f.pkg_version}" } * ", "
+        end
+
+        if formulae_installer.blank?
           return FormulaeUpgradeContext.new(
             formulae_to_install:,
             formulae_installer:  formulae_installer,

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     end
   end
 
+  def setup_pinned_dependency_upgrade
+    write_formula "pinned-dep", <<~RUBY
+      url "https://brew.sh/pinned-dep-2.0"
+    RUBY
+    install_formula_version "pinned-dep", "1.0", optlinked: true
+    Formula["pinned-dep"].pin
+
+    write_formula "needs-pinned-dep", <<~RUBY
+      url "https://brew.sh/needs-pinned-dep-2.0"
+      depends_on "pinned-dep"
+    RUBY
+    install_formula_version "needs-pinned-dep", "1.0", optlinked: true
+  end
+
   it "upgrades a Formula and Cask", :cask, :integration_test do
     formula_name = "testball_bottle"
     formula_rack = HOMEBREW_CELLAR/formula_name
@@ -149,29 +163,32 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   end
 
   it "does not summarize dry-run formula upgrades blocked by pinned dependencies" do
-    write_formula "pinned-dep", <<~RUBY
-      url "https://brew.sh/pinned-dep-2.0"
-    RUBY
-    install_formula_version "pinned-dep", "1.0", optlinked: true
-    Formula["pinned-dep"].pin
-
-    write_formula "needs-pinned-dep", <<~RUBY
-      url "https://brew.sh/needs-pinned-dep-2.0"
-      depends_on "pinned-dep"
-    RUBY
-    install_formula_version "needs-pinned-dep", "1.0", optlinked: true
-
-    cmd = described_class.new(["--dry-run"])
-    pinned_dependency_error =
-      /You must `brew unpin pinned-dep` as installing needs-pinned-dep requires the latest version/
+    setup_pinned_dependency_upgrade
 
     expect do
-      cmd.send(:upgrade_outdated_formulae!, [Formula["needs-pinned-dep"]], dry_run: true, show_upgrade_summary: false)
+      described_class.new(["--dry-run", "--yes", "--formula"]).run
     end
-      .to not_to_output(/Would upgrade.*needs-pinned-dep/m).to_stdout
-      .and output(pinned_dependency_error).to_stderr
+      .to not_to_output(/Pinned formula|needs-pinned-dep/).to_stdout
+      .and output(/You must `brew unpin pinned-dep` as installing needs-pinned-dep requires the latest version/)
+      .to_stderr
 
-    expect(cmd.send(:final_upgrade_summary).version_changes).to be_empty
+    expect(Homebrew).to have_failed
+  ensure
+    Formula["pinned-dep"].unpin if Formula["pinned-dep"].pinned?
+  end
+
+  it "does not warn about pinned formulae before ask-mode pinned dependency failures" do
+    setup_pinned_dependency_upgrade
+
+    expect do
+      described_class.new(["--formula"]).run
+    end
+      .to not_to_output(/Pinned formula|needs-pinned-dep/).to_stdout
+      .and output(a_string_matching(
+                    /\A(?=.*You must `brew unpin pinned-dep`)(?!.*Not upgrading \d+ pinned package).*\z/m,
+                  )).to_stderr
+
+    expect(Homebrew).to have_failed
   ensure
     Formula["pinned-dep"].unpin if Formula["pinned-dep"].pinned?
   end

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -148,6 +148,34 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       ).to_stderr
   end
 
+  it "does not summarize dry-run formula upgrades blocked by pinned dependencies" do
+    write_formula "pinned-dep", <<~RUBY
+      url "https://brew.sh/pinned-dep-2.0"
+    RUBY
+    install_formula_version "pinned-dep", "1.0", optlinked: true
+    Formula["pinned-dep"].pin
+
+    write_formula "needs-pinned-dep", <<~RUBY
+      url "https://brew.sh/needs-pinned-dep-2.0"
+      depends_on "pinned-dep"
+    RUBY
+    install_formula_version "needs-pinned-dep", "1.0", optlinked: true
+
+    cmd = described_class.new(["--dry-run"])
+    pinned_dependency_error =
+      /You must `brew unpin pinned-dep` as installing needs-pinned-dep requires the latest version/
+
+    expect do
+      cmd.send(:upgrade_outdated_formulae!, [Formula["needs-pinned-dep"]], dry_run: true, show_upgrade_summary: false)
+    end
+      .to not_to_output(/Would upgrade.*needs-pinned-dep/m).to_stdout
+      .and output(pinned_dependency_error).to_stderr
+
+    expect(cmd.send(:final_upgrade_summary).version_changes).to be_empty
+  ensure
+    Formula["pinned-dep"].unpin if Formula["pinned-dep"].pinned?
+  end
+
   it "requires one named argument with --minimum-version" do
     expect { described_class.new(["--minimum-version=1.2.3"]).run }
       .to raise_error(UsageError, /`--minimum-version` requires exactly one formula or cask argument/)

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -112,17 +112,28 @@ module Homebrew
         installers.filter_map do |fi|
           fi.determine_bottle_tab_attributes
 
-          all_runtime_deps_installed = fi.bottle_tab_runtime_dependencies.presence&.all? do |dependency, hash|
-            minimum_version = if (version = hash["version"])
-              Version.new(version)
+          if !dry_run && dependents
+            all_runtime_deps_installed = fi.bottle_tab_runtime_dependencies.presence&.all? do |dependency, hash|
+              minimum_version = if (version = hash["version"])
+                Version.new(version)
+              end
+              Dependency.new(dependency).installed?(minimum_version:, minimum_revision: hash["revision"].to_i)
             end
-            Dependency.new(dependency).installed?(minimum_version:, minimum_revision: hash["revision"].to_i)
+
+            if all_runtime_deps_installed
+              # Don't need to install this bottle if all of the runtime
+              # dependencies have the same or newer version already installed.
+              next
+            end
           end
 
-          if !dry_run && dependents && all_runtime_deps_installed
-            # Don't need to install this bottle if all of the runtime
-            # dependencies have the same or newer version already installed.
-            next
+          if dry_run
+            begin
+              fi.check_install_sanity
+            rescue CannotInstallFormulaError => e
+              ofail e.message
+              next
+            end
           end
 
           fi


### PR DESCRIPTION
Closes #22676.

This fixes brew upgrade --dry-run/--ask output when a formula upgrade is bloxked by an unsatisfied pinned dependency.

Previously, the dry-run/ask preview could still include a formula in the upgrade summary even though the real upgrade would later fail with CannotInstallFormulaError because one of its required dependencies was pinned. This made the preview misleading because Homebrew said it would install/upgrade packages that would not actually be installed.

This PR makes the dry-run formula installer path run the existing install sanity checks and skip installers that fail with CannotInstallFormulaError, so the pinned dependency error is shown instead of recording an impossible upgrade in the final summary.


-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.


Oh-my-pi with GPT 5.5 (high) were used to generate code for this commit.
<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
