### PR TITLE
Restore user alias completions

### DIFF
--- a/Library/Homebrew/completions/bash.erb
+++ b/Library/Homebrew/completions/bash.erb
@@ -114,6 +114,7 @@ __brew_complete_commands() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local cmds
   local maintainer_cmds
+  local user_aliases
 
   if [[ -n ${__HOMEBREW_COMMANDS} ]]
   then
@@ -129,11 +130,12 @@ __brew_complete_commands() {
   then
     maintainer_cmds="<%= maintainer_commands.join(" ") %>"
   fi
+  user_aliases="$(__brew_list_aliases)"
   while read -r line
   do
     [[ $(__brew_internal_command_alias "${line}") == "${line}" ]] || continue
     COMPREPLY+=("${line}")
-  done < <(compgen -W "${cmds} ${maintainer_cmds}" -- "${cur}")
+  done < <(compgen -W "${cmds} ${maintainer_cmds} ${user_aliases}" -- "${cur}")
   export __HOMEBREW_COMMANDS=${cmds}
 }
 
@@ -160,20 +162,24 @@ __brew_internal_command_alias() {
 
 # https://github.com/Homebrew/homebrew-aliases
 __brew_list_aliases() {
-  local aliases_dir="${HOME}/.brew-aliases"
-  local pattern="^# alias: brew ([[:alnum:]-]+)$"
+  local aliases_dir="${HOME}/.config/brew-aliases"
+  local pattern="alias: brew ([^[:space:]]+)"
+  local alias_name line
   local -a aliases
 
+  [[ ! -d ${aliases_dir} ]] && aliases_dir="${HOME}/.brew-aliases"
   [[ ! -d ${aliases_dir} ]] && return
 
   for file in "${aliases_dir}"/*; do
-    [[ ! -f ${file} ]] && continue
-    while read -r line; do
-      if [[ ${line} =~ ${pattern} ]]; then
-        aliases+=("${BASH_REMATCH[1]}")
-        break
+    [[ ! -f ${file} || ${file} == *~ ]] && continue
+    alias_name="${file##*/}"
+    {
+      read -r line
+      if read -r line && [[ ${line} =~ ${pattern} ]]; then
+        alias_name="${BASH_REMATCH[1]}"
       fi
-    done < "${file}"
+    } < "${file}"
+    aliases+=("${alias_name}")
   done
   [[ -n ${aliases[*]+"${aliases[*]}"} ]] && echo "${aliases[@]}"
 }

--- a/Library/Homebrew/completions/fish.erb
+++ b/Library/Homebrew/completions/fish.erb
@@ -156,6 +156,25 @@ function __fish_brew_suggest_taps_installed -d "List all available taps"
     | string replace (brew --repo)/Library/Taps/ ""
 end
 
+function __fish_brew_suggest_aliases -d "Lists user-defined aliases"
+    set -l aliases_dir "$HOME/.config/brew-aliases"
+    test -d $aliases_dir; or set aliases_dir "$HOME/.brew-aliases"
+    test -d $aliases_dir; or return
+
+    for file in $aliases_dir/*
+        test -f $file; and not string match -q '*~' -- $file; or continue
+        set -l alias_name (string replace -r '^.*/' '' -- $file)
+        begin
+            read -l line
+            if read -l line
+                set -l match (string match -rg 'alias: brew ([^[:space:]]+)' -- $line)
+                test -n "$match"; and set alias_name $match[1]
+            end
+        end < $file
+        echo $alias_name
+    end
+end
+
 function __fish_brew_suggest_commands -d "Lists all command names"
     set -l commands
     if test -f (brew --cache)/all_commands_list.txt
@@ -167,6 +186,7 @@ function __fish_brew_suggest_commands -d "Lists all command names"
         set -l expanded_command (__fish_brew_expand_alias $command)
         test "$expanded_command" = "$command"; and echo $command
     end
+    __fish_brew_suggest_aliases
 end
 
 function __fish_brew_suggest_diagnostic_checks -d "List available diagnostic checks"

--- a/Library/Homebrew/completions/zsh.erb
+++ b/Library/Homebrew/completions/zsh.erb
@@ -35,6 +35,29 @@ __brew_list_aliases() {
   echo "${aliases}"
 }
 
+__brew_user_aliases() {
+  local aliases_dir="${HOME}/.config/brew-aliases"
+  local pattern="alias: brew ([^[:space:]]+)"
+  local file line alias_name
+  local -a aliases
+
+  [[ ! -d ${aliases_dir} ]] && aliases_dir="${HOME}/.brew-aliases"
+  [[ ! -d ${aliases_dir} ]] && return
+
+  for file in "${aliases_dir}"/*(N); do
+    [[ ! -f ${file} || ${file} == *~ ]] && continue
+    alias_name="${file:t}"
+    {
+      read -r line
+      if read -r line && [[ ${line} =~ ${pattern} ]]; then
+        alias_name="${match[1]}"
+      fi
+    } < "${file}"
+    aliases+=("${alias_name}")
+  done
+  (( ${#aliases} )) && _describe -t user-aliases 'user aliases' aliases
+}
+
 __brew_formulae_or_ruby_files() {
   _alternative 'files:files:{_files -g "*.rb"}'
 }
@@ -155,7 +178,8 @@ __brew_external_commands() {
 __brew_commands() {
   _alternative \
     'internal-commands:command:__brew_internal_commands' \
-    'external-commands:command:__brew_external_commands'
+    'external-commands:command:__brew_external_commands' \
+    'user-aliases:alias:__brew_user_aliases'
 }
 
 __brew_diagnostic_checks() {

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -395,13 +395,18 @@ RSpec.describe Homebrew::Completions do
         expect(file).to match(/^complete -o bashdefault -o default -F _brew brew$/)
       end
 
-      it "doesn't add aliases to command completions" do
+      it "doesn't add internal aliases to command completions" do
         file = described_class.generate_bash_completion_file(%w[install missing up update])
         expect(file).not_to include("cmd_aliases")
+        expect(file).to include('user_aliases="$(__brew_list_aliases)"')
+        expect(file).to include('local pattern="alias: brew ([^[:space:]]+)"')
+        expect(file).to include('alias_name="${file##*/}"')
+        expect(file).to include("if read -r line && [[ ${line} =~ ${pattern} ]]; then")
         expect(file).not_to match(/^_brew_up\(\) {$/)
         expect(file).not_to match(/^ {4}up\) _brew_up ;;/)
         expect(file).to include('[[ $(__brew_internal_command_alias "${line}") == "${line}" ]] || continue')
         expect(file).to include('cmd="$(__brew_internal_command_alias "${cmd}")"')
+        expect(file).to include('compgen -W "${cmds} ${maintainer_cmds} ${user_aliases}" -- "${cur}"')
         expect(file).to match(/^ {4}up\) echo "update" ;;$/)
         expect(file).to match(/^ {4}update\) _brew_update ;;$/)
       end
@@ -481,11 +486,16 @@ RSpec.describe Homebrew::Completions do
         expect(completion).to include("*:service:__brew_services")
       end
 
-      it "doesn't generate alias completion functions" do
+      it "doesn't generate internal alias completion functions" do
         file = described_class.generate_zsh_completion_file(%w[up update])
         expect(file).not_to match(/^# brew up$/)
         expect(file).not_to match(/^_brew_up\(\) {$/)
         expect(file).to match(/^    up update$/)
+        expect(file).to match(/^__brew_user_aliases\(\) {$/)
+        expect(file).to include('local pattern="alias: brew ([^[:space:]]+)"')
+        expect(file).to include('alias_name="${file:t}"')
+        expect(file).to include("if read -r line && [[ ${line} =~ ${pattern} ]]; then")
+        expect(file).to include("'user-aliases:alias:__brew_user_aliases'")
         expect(file).to include('command="${aliases[$command_or_alias]:-$command_or_alias}"')
         expect(file).to include('local completion_func="_brew_${command//-/_}"')
       end
@@ -591,10 +601,14 @@ RSpec.describe Homebrew::Completions do
         expect(file).to match(/^__fish_brew_complete_cmd 'update' 'Fetch the newest version of Homebrew .*'$/)
       end
 
-      it "omits aliases from command completions" do
+      it "omits internal aliases from command completions" do
         file = described_class.generate_fish_completion_file(%w[up update])
         expect(file).not_to match(/^__fish_brew_complete_cmd 'up'/)
         expect(file).not_to match(/^__fish_brew_complete_arg 'up'/)
+        expect(file).to match(/^function __fish_brew_suggest_aliases/)
+        expect(file).to include("set -l alias_name (string replace -r '^.*/' '' -- $file)")
+        expect(file).to include("set -l match (string match -rg 'alias: brew ([^[:space:]]+)' -- $line)")
+        expect(file).to include("    __fish_brew_suggest_aliases\nend")
         expect(file).to match(/^        case 'up'$/)
         expect(file).to match(/^            echo 'update'$/)
         expect(file).to include("set -l cmd (__fish_brew_expand_alias $args[1])")

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -99,6 +99,7 @@ __brew_complete_commands() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local cmds
   local maintainer_cmds
+  local user_aliases
 
   if [[ -n ${__HOMEBREW_COMMANDS} ]]
   then
@@ -114,11 +115,12 @@ __brew_complete_commands() {
   then
     maintainer_cmds="analytics determine-test-runners dispatch-build-bottle formula-analytics generate-analytics-api generate-cask-api generate-cask-ci-matrix generate-formula-api generate-internal-api pr-automerge pr-publish pr-pull pr-upload release update-license-data update-maintainers update-portable-ruby update-report update-sponsors vendor-install"
   fi
+  user_aliases="$(__brew_list_aliases)"
   while read -r line
   do
     [[ $(__brew_internal_command_alias "${line}") == "${line}" ]] || continue
     COMPREPLY+=("${line}")
-  done < <(compgen -W "${cmds} ${maintainer_cmds}" -- "${cur}")
+  done < <(compgen -W "${cmds} ${maintainer_cmds} ${user_aliases}" -- "${cur}")
   export __HOMEBREW_COMMANDS=${cmds}
 }
 
@@ -163,20 +165,24 @@ __brew_internal_command_alias() {
 
 # https://github.com/Homebrew/homebrew-aliases
 __brew_list_aliases() {
-  local aliases_dir="${HOME}/.brew-aliases"
-  local pattern="^# alias: brew ([[:alnum:]-]+)$"
+  local aliases_dir="${HOME}/.config/brew-aliases"
+  local pattern="alias: brew ([^[:space:]]+)"
+  local alias_name line
   local -a aliases
 
+  [[ ! -d ${aliases_dir} ]] && aliases_dir="${HOME}/.brew-aliases"
   [[ ! -d ${aliases_dir} ]] && return
 
   for file in "${aliases_dir}"/*; do
-    [[ ! -f ${file} ]] && continue
-    while read -r line; do
-      if [[ ${line} =~ ${pattern} ]]; then
-        aliases+=("${BASH_REMATCH[1]}")
-        break
+    [[ ! -f ${file} || ${file} == *~ ]] && continue
+    alias_name="${file##*/}"
+    {
+      read -r line
+      if read -r line && [[ ${line} =~ ${pattern} ]]; then
+        alias_name="${BASH_REMATCH[1]}"
       fi
-    done < "${file}"
+    } < "${file}"
+    aliases+=("${alias_name}")
   done
   [[ -n ${aliases[*]+"${aliases[*]}"} ]] && echo "${aliases[@]}"
 }

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -178,6 +178,25 @@ function __fish_brew_suggest_taps_installed -d "List all available taps"
     | string replace (brew --repo)/Library/Taps/ ""
 end
 
+function __fish_brew_suggest_aliases -d "Lists user-defined aliases"
+    set -l aliases_dir "$HOME/.config/brew-aliases"
+    test -d $aliases_dir; or set aliases_dir "$HOME/.brew-aliases"
+    test -d $aliases_dir; or return
+
+    for file in $aliases_dir/*
+        test -f $file; and not string match -q '*~' -- $file; or continue
+        set -l alias_name (string replace -r '^.*/' '' -- $file)
+        begin
+            read -l line
+            if read -l line
+                set -l match (string match -rg 'alias: brew ([^[:space:]]+)' -- $line)
+                test -n "$match"; and set alias_name $match[1]
+            end
+        end < $file
+        echo $alias_name
+    end
+end
+
 function __fish_brew_suggest_commands -d "Lists all command names"
     set -l commands
     if test -f (brew --cache)/all_commands_list.txt
@@ -189,6 +208,7 @@ function __fish_brew_suggest_commands -d "Lists all command names"
         set -l expanded_command (__fish_brew_expand_alias $command)
         test "$expanded_command" = "$command"; and echo $command
     end
+    __fish_brew_suggest_aliases
 end
 
 function __fish_brew_suggest_diagnostic_checks -d "List available diagnostic checks"

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -38,6 +38,29 @@ __brew_list_aliases() {
   echo "${aliases}"
 }
 
+__brew_user_aliases() {
+  local aliases_dir="${HOME}/.config/brew-aliases"
+  local pattern="alias: brew ([^[:space:]]+)"
+  local file line alias_name
+  local -a aliases
+
+  [[ ! -d ${aliases_dir} ]] && aliases_dir="${HOME}/.brew-aliases"
+  [[ ! -d ${aliases_dir} ]] && return
+
+  for file in "${aliases_dir}"/*(N); do
+    [[ ! -f ${file} || ${file} == *~ ]] && continue
+    alias_name="${file:t}"
+    {
+      read -r line
+      if read -r line && [[ ${line} =~ ${pattern} ]]; then
+        alias_name="${match[1]}"
+      fi
+    } < "${file}"
+    aliases+=("${alias_name}")
+  done
+  (( ${#aliases} )) && _describe -t user-aliases 'user aliases' aliases
+}
+
 __brew_formulae_or_ruby_files() {
   _alternative 'files:files:{_files -g "*.rb"}'
 }
@@ -286,7 +309,8 @@ __brew_external_commands() {
 __brew_commands() {
   _alternative \
     'internal-commands:command:__brew_internal_commands' \
-    'external-commands:command:__brew_external_commands'
+    'external-commands:command:__brew_external_commands' \
+    'user-aliases:alias:__brew_user_aliases'
 }
 
 __brew_diagnostic_checks() {


### PR DESCRIPTION
- Keep internal aliases out of first-word completion suggestions.
- Add user aliases by reading the alias command files that `brew alias` manages.
- Match `brew alias` lookup order and alias-name parsing so edited files still complete consistently.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
