### PR TITLE
Trust custom remote items

### DIFF
--- a/Library/Homebrew/items.sh
+++ b/Library/Homebrew/items.sh
@@ -45,10 +45,12 @@ homebrew-trusted-items() {
     select(. != null) |
     "\(.user)/\(.tap)/\(.name)" as $item |
     ($item | split("/") | .[0:2] | join("/")) as $tap |
+    ($tap_references[$tap] // $tap) as $tap_reference |
+    "\($tap_reference)/\(.name)" as $remote_item |
     select(
       $tap == $official_tap or
-      (($store.trustedtaps // []) | index($tap)) or
-      (($store[$trust_key] // []) | index($item))
+      (($store.trustedtaps // []) | (index($tap) or index($tap_reference))) or
+      (($store[$trust_key] // []) | (index($item) or index($remote_item)))
     ) |
     $item
   '
@@ -59,10 +61,12 @@ homebrew-trusted-items() {
     select(. != null) |
     "\(.user)/\(.tap)/\(.name)" as $item |
     ($item | split("/") | .[0:2] | join("/")) as $tap |
+    ($tap_references[$tap] // $tap) as $tap_reference |
+    "\($tap_reference)/\(.name)" as $remote_item |
     select(
       $tap != $official_tap and
-      (($store.trustedtaps // []) | index($tap) | not) and
-      (($store[$trust_key] // []) | index($item) | not)
+      (($store.trustedtaps // []) | (index($tap) or index($tap_reference)) | not) and
+      (($store[$trust_key] // []) | (index($item) or index($remote_item)) | not)
     ) |
     $tap
   '
@@ -82,6 +86,35 @@ homebrew-trusted-items() {
     store="$("${jq}" -c 'if type == "object" then . else {} end' "${trust_file}")" || store='{}'
   fi
 
+  local tap_references
+  # The JQ programs below need literal `$...` variables for JQ, not shell expansions.
+  # shellcheck disable=SC2016
+  tap_references="$(
+    while IFS=$'\t' read -r tap tap_path
+    do
+      [[ -n "${tap}" && -d "${tap_path}" ]] || continue
+
+      local remote
+      if remote="$(git -C "${tap_path}" config --get remote.origin.url 2>/dev/null)"
+      then
+        printf "%s\t%s\n" "${tap}" "${remote}" | tr "[:upper:]" "[:lower:]"
+      else
+        printf "%s\t%s\n" "${tap}" "${tap}"
+      fi
+    done < <(
+      echo "${items}" | "${jq}" -Rr --arg item_dir "${item_dir}" '
+        capture("(?<path>.*/Taps/(?<user>[^/]+)/(?:home|linux)brew-(?<tap>[^/]+))/" + $item_dir + "/.*")? |
+        select(. != null) |
+        "\(.user)/\(.tap)\t\(.path)"
+      ' | sort -u
+    ) | "${jq}" -Rnc '
+      reduce inputs as $line ({};
+        ($line | split("\t")) as $parts |
+        .[$parts[0]] = $parts[1]
+      )
+    '
+  )"
+
   if [[ -z "${HOMEBREW_COMPLETION:-}" ]]
   then
     local tap
@@ -90,12 +123,14 @@ homebrew-trusted-items() {
       [[ -n "${tap}" ]] || continue
       opoo "Skipping ${tap} because it is not trusted. Run \`brew trust ${tap}\` to trust it."
     done < <(echo "${items}" | "${jq}" -Rr --argjson store "${store}" --arg trust_key "${trust_key}" \
-      --arg official_tap "${official_tap}" --arg item_dir "${item_dir}" "${untrusted_tap_filter}" | sort -u)
+      --arg official_tap "${official_tap}" --arg item_dir "${item_dir}" \
+      --argjson tap_references "${tap_references}" "${untrusted_tap_filter}" | sort -u)
   fi
 
   local trusted
   trusted="$(echo "${items}" | "${jq}" -Rr --argjson store "${store}" --arg trust_key "${trust_key}" \
-    --arg official_tap "${official_tap}" --arg item_dir "${item_dir}" "${trust_filter}")"
+    --arg official_tap "${official_tap}" --arg item_dir "${item_dir}" \
+    --argjson tap_references "${tap_references}" "${trust_filter}")"
   local shortnames
   shortnames="$(echo "${trusted}" | cut -d "/" -f 3)"
   echo -e "${trusted}\n${shortnames}" | sort -uf

--- a/Library/Homebrew/test/cmd/trust_spec.rb
+++ b/Library/Homebrew/test/cmd/trust_spec.rb
@@ -53,9 +53,10 @@ RSpec.describe Homebrew::Cmd::Trust, :trust_store do
       expect(Homebrew::Trust.trusted_entries(:tap)).to contain_exactly("https://gitlab.com/other/repo")
     end
 
-    it "refuses to trust an individual formula" do
+    it "trusts an individual formula by its remote-qualified entry" do
       expect { described_class.new(["--formula", "thirdparty/custom/bar"]).run }
-        .to raise_error(UsageError, /custom remote/)
+        .to output("Trusted formula: https://gitlab.com/other/repo/bar\n").to_stdout
+      expect(Homebrew::Trust.trusted_entries(:formula)).to contain_exactly("https://gitlab.com/other/repo/bar")
     end
   end
 

--- a/Library/Homebrew/test/cmd/untrust_spec.rb
+++ b/Library/Homebrew/test/cmd/untrust_spec.rb
@@ -40,6 +40,23 @@ RSpec.describe Homebrew::Cmd::Untrust, :trust_store do
       .to output("Untrusted command: thirdparty/foo/hello\n").to_stdout
   end
 
+  it "untrusts legacy and remote-qualified entries for custom-remote tap items" do
+    tap = Tap.fetch("thirdparty", "custom")
+    tap.path.mkpath
+    system "git", "-C", tap.path.to_s, "init"
+    system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://gitlab.com/other/repo"
+    Homebrew::Trust.trust!(:formula, "thirdparty/custom/bar")
+    Homebrew::Trust.trust!(:formula, "https://gitlab.com/other/repo/bar")
+
+    expect { described_class.new(["--formula", "thirdparty/custom/bar"]).run }
+      .to output("Untrusted formula: thirdparty/custom/bar\n").to_stdout
+    expect(Homebrew::Trust.trusted_entries(:formula)).to be_empty
+    expect(Homebrew::Trust.trusted?(:formula, "thirdparty/custom/bar")).to be(false)
+  ensure
+    Homebrew::Trust.clear!(:formula)
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
   it "untrusts trusted items from a tap" do
     expect(Homebrew::Trust).to receive(:untrust!).with(:tap, "thirdparty/foo").and_return(false)
     allow(Homebrew::Trust).to receive(:trusted_entries).with(:formula).and_return(["thirdparty/foo/bar"])

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -89,17 +89,22 @@ RSpec.describe Homebrew::Trust, :trust_store do
     expect(described_class.trusted_entries(:tap)).to be_empty
   end
 
-  it "refuses new per-item trust for a custom-remote tap but still resolves existing entries to untrust" do
+  it "trusts custom-remote tap items by remote but still resolves existing entries to untrust" do
     tap = Tap.fetch("thirdparty", "custom")
     tap.path.mkpath
     system "git", "-C", tap.path.to_s, "init"
     system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://gitlab.com/other/repo"
 
-    expect { described_class.target("thirdparty/custom/bar", type: :formula) }
-      .to raise_error(UsageError, /custom remote/)
-    expect(described_class.target("thirdparty/custom/bar", type: :formula, include_existing: true))
-      .to eq([:formula, "thirdparty/custom/bar"])
+    described_class.trust!(*described_class.target("thirdparty/custom/bar", type: :formula))
+
+    expect(described_class.trusted?(:formula, "thirdparty/custom/bar")).to be(true)
+    expect(described_class.trusted_entries(:formula)).to contain_exactly("https://gitlab.com/other/repo/bar")
+
+    described_class.trust!(:formula, "thirdparty/custom/legacy")
+    expect(described_class.target("thirdparty/custom/legacy", type: :formula, include_existing: true))
+      .to eq([:formula, "thirdparty/custom/legacy"])
   ensure
+    described_class.clear!(:formula)
     FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
   end
 
@@ -201,7 +206,9 @@ RSpec.describe Homebrew::Trust, :trust_store do
 
   it "does not report taps with trusted entries as wholly untrusted" do
     allow(described_class).to receive(:untrusted_taps)
-      .and_return([instance_double(Tap, name: "thirdparty/foo")])
+      .and_return([
+        instance_double(Tap, name: "thirdparty/foo", reference: "thirdparty/foo", uses_custom_remote?: false),
+      ])
     described_class.trust!(:formula, "thirdparty/foo/bar")
 
     expect(described_class.wholly_untrusted_taps).to be_empty

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -45,10 +45,18 @@ module Homebrew
     def self.untrust!(type, name)
       key = setting_key(type)
       name = normalise_name(name)
+      entries_to_delete = T.let([name], T::Array[String])
+      if type != :tap && ::Utils.full_name?(name) && (tap_name = ::Utils.tap_from_full_name(name))
+        tap = Tap.fetch(tap_name)
+        entries_to_delete << item_trust_name(type, tap, ::Utils.name_from_full_name(name)) if tap.uses_custom_remote?
+      end
+
       with_trust_store_lock do
         store = trust_store
         entries = store.fetch(key, [])
-        next false unless entries.delete(name)
+        removed = T.let(false, T::Boolean)
+        entries_to_delete.uniq.each { |entry| removed = true if entries.delete(entry) }
+        next false unless removed
 
         if entries.empty?
           store.delete(key)
@@ -68,7 +76,7 @@ module Homebrew
         tap_name = name.split("/").first(2).join("/")
         item_name = ::Utils.name_from_full_name(name)
         tap = Tap.fetch(tap_name)
-        next if tap.official? || tap.uses_custom_remote?
+        next if tap.official?
 
         types = if type == :formula
           tap.formula_files_by_name.key?(item_name) ? [:formula] : []
@@ -83,7 +91,9 @@ module Homebrew
         end
         types.each do |item_type|
           full_name = "#{tap.name}/#{item_name}"
-          $stderr.ohai "Trusted #{item_type} #{full_name}" if trust!(item_type, full_name)
+          if trust!(item_type, item_trust_name(item_type, tap, item_name))
+            $stderr.ohai "Trusted #{item_type} #{full_name}"
+          end
         end
       rescue Tap::InvalidNameError
         nil
@@ -102,11 +112,28 @@ module Homebrew
     sig { params(type: Symbol, name: String).returns(T::Boolean) }
     def self.trusted?(type, name)
       name = normalise_name(name)
-      return true if trusted_entries(type).include?(name)
-      return false if type == :tap
+      entries = trusted_entries(type)
+      return true if entries.include?(name)
+
+      if type == :tap
+        return false if Tap.remote_reference?(name)
+
+        return explicitly_trusted_tap?(Tap.fetch(name))
+      end
       return false unless (tap_name = ::Utils.tap_from_full_name(name))
 
-      trusted_tap?(Tap.fetch(tap_name))
+      tap = Tap.fetch(tap_name)
+      return true if trusted_tap?(tap)
+
+      item_name = normalise_name(::Utils.name_from_full_name(name))
+      return true if entries.include?(item_trust_name(type, tap, item_name))
+      return false unless tap.uses_custom_remote?
+
+      entries.any? do |entry|
+        next false unless entry.end_with?("/#{item_name}")
+
+        Tap.same_remote?(entry.delete_suffix("/#{item_name}"), tap.remote)
+      end
     rescue Tap::InvalidNameError
       false
     end
@@ -130,7 +157,7 @@ module Homebrew
       return if trusted_tap?(tap)
 
       full_name = "#{tap.name}/#{::Utils.name_from_full_name(name)}"
-      return if !tap.uses_custom_remote? && trusted?(:formula, full_name)
+      return if trusted?(:formula, full_name)
       return if explicitly_allowed?(:formula, full_name, tap)
       return unless Homebrew::EnvConfig.require_tap_trust?
 
@@ -144,7 +171,7 @@ module Homebrew
       return if trusted_tap?(tap)
 
       full_name = "#{tap.name}/#{::Utils.name_from_full_name(token)}"
-      return if !tap.uses_custom_remote? && trusted?(:cask, full_name)
+      return if trusted?(:cask, full_name)
       return if explicitly_allowed?(:cask, full_name, tap)
       return unless Homebrew::EnvConfig.require_tap_trust?
 
@@ -158,7 +185,7 @@ module Homebrew
       return if trusted_tap?(tap)
 
       full_name = "#{tap.name}/#{command || path.basename(path.extname).to_s.delete_prefix("brew-")}"
-      return if !tap.uses_custom_remote? && trusted?(:command, full_name)
+      return if trusted?(:command, full_name)
       return unless Homebrew::EnvConfig.require_tap_trust?
 
       raise_untrusted!(:command, full_name, tap)
@@ -197,9 +224,9 @@ module Homebrew
     sig { returns(T::Array[Tap]) }
     def self.wholly_untrusted_taps
       untrusted_taps.reject do |tap|
-        trusted_entry_prefix?(:formula, tap.name) ||
-          trusted_entry_prefix?(:cask, tap.name) ||
-          trusted_entry_prefix?(:command, tap.name)
+        trusted_entry_prefix?(:formula, tap) ||
+          trusted_entry_prefix?(:cask, tap) ||
+          trusted_entry_prefix?(:command, tap)
       end
     end
 
@@ -236,18 +263,22 @@ module Homebrew
       end
 
       tap, token = tap_with_name
-      full_name = "#{tap.name}/#{token}"
-      candidates = T.let([], T::Array[[Symbol, String]])
-      candidates << [:formula, full_name] if tap.formula_files_by_name.key?(token)
-      candidates << [:cask, full_name] if tap.cask_files_by_name.key?(token)
-      candidates << [:command, full_name] if command_file?(tap, token)
-      if include_existing
-        candidates << [:formula, full_name] if trusted?(:formula, full_name)
-        candidates << [:cask, full_name] if trusted?(:cask, full_name)
-        candidates << [:command, full_name] if trusted?(:command, full_name)
+      candidate_types = T.let([], T::Array[Symbol])
+      candidate_types << :formula if tap.formula_files_by_name.key?(token)
+      candidate_types << :cask if tap.cask_files_by_name.key?(token)
+      if tap.command_files.any? { |path| path.basename(path.extname).to_s.delete_prefix("brew-") == token }
+        candidate_types << :command
       end
-      candidates.uniq!
-
+      if include_existing
+        full_name = "#{tap.name}/#{token}"
+        candidate_types << :formula if trusted?(:formula, full_name)
+        candidate_types << :cask if trusted?(:cask, full_name)
+        candidate_types << :command if trusted?(:command, full_name)
+      end
+      candidates = T.let([], T::Array[[Symbol, String]])
+      candidate_types.uniq.each do |candidate_type|
+        candidates << [candidate_type, item_trust_name(candidate_type, tap, token, include_existing:)]
+      end
       return candidates.fetch(0) if candidates.one?
 
       raise UsageError, "No formula, cask or command found for #{name}." if candidates.empty?
@@ -270,16 +301,13 @@ module Homebrew
         end
       when :formula
         tap, formula_name = fully_qualified_package_name(name, "Formulae")
-        require_default_remote_item!(tap) unless include_existing
-        "#{tap.name}/#{formula_name}"
+        item_trust_name(type, tap, formula_name, include_existing:)
       when :cask
         tap, token = fully_qualified_package_name(name, "Casks")
-        require_default_remote_item!(tap) unless include_existing
-        "#{tap.name}/#{token}"
+        item_trust_name(type, tap, token, include_existing:)
       when :command
         tap, command_name = fully_qualified_package_name(name, "Commands")
-        require_default_remote_item!(tap) unless include_existing
-        "#{tap.name}/#{command_name}"
+        item_trust_name(type, tap, command_name, include_existing:)
       else
         raise UsageError, "Unsupported trust target type: #{type}"
       end
@@ -288,16 +316,16 @@ module Homebrew
     end
     private_class_method :trust_name
 
-    # Per-item trust cannot be created for custom-remote taps (trust the whole tap by URL); existing
-    # entries are still resolvable so `brew untrust` (`include_existing`) can remove legacy ones.
-    sig { params(tap: Tap).void }
-    def self.require_default_remote_item!(tap)
-      return unless tap.uses_custom_remote?
+    sig { params(type: Symbol, tap: Tap, item_name: String, include_existing: T::Boolean).returns(String) }
+    def self.item_trust_name(type, tap, item_name, include_existing: false)
+      item_name = normalise_name(item_name)
+      full_name = "#{tap.name}/#{item_name}"
+      return full_name if include_existing && trusted_entries(type).include?(normalise_name(full_name))
+      return full_name unless tap.uses_custom_remote?
 
-      raise UsageError, "Cannot trust individual items in #{tap.name} as it uses a custom remote.\n" \
-                        "Run `brew trust #{tap.name}` to trust the whole tap instead."
+      "#{normalise_name(tap.reference)}/#{item_name}"
     end
-    private_class_method :require_default_remote_item!
+    private_class_method :item_trust_name
 
     sig { params(name: String, noun: String).returns([Tap, String]) }
     def self.fully_qualified_package_name(name, noun)
@@ -307,12 +335,6 @@ module Homebrew
       tap_with_name
     end
     private_class_method :fully_qualified_package_name
-
-    sig { params(tap: Tap, command_name: String).returns(T::Boolean) }
-    def self.command_file?(tap, command_name)
-      tap.command_files.any? { |path| path.basename(path.extname).to_s.delete_prefix("brew-") == command_name }
-    end
-    private_class_method :command_file?
 
     sig { returns(T::Hash[String, T::Array[String]]) }
     def self.trust_store
@@ -373,7 +395,7 @@ module Homebrew
       name = path.basename(path.extname).to_s
       name = name.delete_prefix("brew-") if type == :command
       full_name = "#{tap.name}/#{name}"
-      return true if !tap.uses_custom_remote? && trusted?(type, full_name)
+      return true if trusted?(type, full_name)
       return true if explicitly_allowed?(type, full_name, tap)
 
       !Homebrew::EnvConfig.require_tap_trust?
@@ -408,10 +430,13 @@ module Homebrew
     end
     private_class_method :trusted_files
 
-    sig { params(type: Symbol, tap_name: String).returns(T::Boolean) }
-    def self.trusted_entry_prefix?(type, tap_name)
-      prefix = "#{tap_name}/"
-      trusted_entries(type).any? { |entry| entry.start_with?(prefix) }
+    sig { params(type: Symbol, tap: Tap).returns(T::Boolean) }
+    def self.trusted_entry_prefix?(type, tap)
+      prefixes = T.let([normalise_name(tap.reference)], T::Array[String])
+      prefixes << tap.name if tap.uses_custom_remote?
+      trusted_entries(type).any? do |entry|
+        prefixes.any? { |prefix| entry.start_with?("#{prefix}/") }
+      end
     end
     private_class_method :trusted_entry_prefix?
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22685

- Allow per-item trust for custom remote taps without trusting the whole tap.
- Store custom remote item trust against the remote reference so a reused tap name does not broaden trust.
- Keep the Bash item listing path aligned with Ruby trust checks.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
