### PR TITLE
Report only successful upgrades

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -213,7 +213,7 @@ module Cask
       cask_upgrades = upgradable_casks.map do |(old_cask, new_cask)|
         "#{new_cask.full_name} #{old_cask.version} -> #{new_cask.version}"
       end
-      summary_upgrades&.concat(cask_upgrades)
+      summary_upgrades&.concat(cask_upgrades) if dry_run
       summary_deprecated&.concat(upgradable_casks.filter_map do |(_, new_cask)|
         new_cask.full_name if new_cask.deprecated?
       end)
@@ -255,12 +255,13 @@ module Cask
 
       download_queue ||= Homebrew.default_download_queue
 
-      upgradable_casks.each do |(old_cask, new_cask)|
+      upgradable_casks.each_with_index do |(old_cask, new_cask), index|
         upgrade_cask(
           old_cask, new_cask,
           binaries:, force:, skip_cask_deps:, verbose:,
           quarantine:, require_sha:, quit:, download_queue:
         )
+        summary_upgrades&.push(cask_upgrades.fetch(index))
       rescue => e
         new_exception = e.exception("#{new_cask.full_name}: #{e}")
         new_exception.set_backtrace(e.backtrace)

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -506,13 +506,23 @@ module Homebrew
         @final_upgrade_summary
       end
 
-      sig { params(context: FormulaeUpgradeContext, include_sizes: T::Boolean).void }
-      def record_formula_upgrade_summary(context, include_sizes: false)
+      sig {
+        params(
+          context:            FormulaeUpgradeContext,
+          include_sizes:      T::Boolean,
+          formulae_installer: T.nilable(T::Array[FormulaInstaller]),
+          version_changes:    T.nilable(T::Array[String]),
+        ).void
+      }
+      def record_formula_upgrade_summary(context, include_sizes: false, formulae_installer: nil, version_changes: nil)
         summary = final_upgrade_summary
-        upgrade_formulae = context.formulae_installer.map(&:formula)
+        formulae_installer ||= context.formulae_installer
+        upgrade_formulae = formulae_installer.map(&:formula)
         dependent_formulae = context.dependants.upgradeable
-        summary.version_changes.concat(formula_upgrade_descriptions(upgrade_formulae, include_sizes:))
-        summary.version_changes.concat(formula_upgrade_descriptions(dependent_formulae, include_sizes:))
+        summary.version_changes.concat(
+          version_changes || (formula_upgrade_descriptions(upgrade_formulae, include_sizes:) +
+            formula_upgrade_descriptions(dependent_formulae, include_sizes:)),
+        )
         summary.pinned_formulae.concat((context.pinned_formulae + context.dependants.pinned).map do |formula|
           "#{formula.full_specified_name} #{formula.pkg_version}"
         end)
@@ -525,7 +535,7 @@ module Homebrew
         summary.disabled.concat(formulae.filter_map do |formula|
           formula.full_specified_name if formula.disabled?
         end)
-        summary.source_build_formulae.concat(context.formulae_installer.filter_map do |formula_installer|
+        summary.source_build_formulae.concat(formulae_installer.filter_map do |formula_installer|
           formula = formula_installer.formula
           next unless formula.core_formula?
           next if formula_installer.pour_bottle?
@@ -674,7 +684,14 @@ module Homebrew
           return valid_formula_installers.present?
         end
 
-        record_formula_upgrade_summary(context, include_sizes: dry_run)
+        formula_version_changes = formula_upgrade_descriptions(context.formulae_installer.map(&:formula),
+                                                               include_sizes: dry_run)
+        dependent_version_changes = formula_upgrade_descriptions(context.dependants.upgradeable,
+                                                                 include_sizes: dry_run)
+        if dry_run
+          record_formula_upgrade_summary(context,
+                                         version_changes: formula_version_changes + dependent_version_changes)
+        end
         if !args.no_ask? && dry_run && args.named.present? &&
            Install.formulae_ask_prompt_needed?(context.formulae_installer, context.dependants)
           @ask_prompt_required = true
@@ -688,7 +705,7 @@ module Homebrew
           []
         end
 
-        Upgrade.upgrade_formulae(
+        upgraded_formula_installers = Upgrade.upgrade_formulae(
           context.formulae_installer,
           dry_run:,
           verbose:            args.verbose?,
@@ -711,6 +728,21 @@ module Homebrew
           verbose:                    args.verbose?,
           skip_formula_names:
         )
+
+        unless dry_run
+          upgraded_formula_installers_by_identity = T.let({}.compare_by_identity,
+                                                          T::Hash[FormulaInstaller, T::Boolean])
+          upgraded_formula_installers.each do |formula_installer|
+            upgraded_formula_installers_by_identity[formula_installer] = true
+          end
+          record_formula_upgrade_summary(
+            context,
+            formulae_installer: upgraded_formula_installers,
+            version_changes:    context.formulae_installer.each_with_index.filter_map do |formula_installer, index|
+              formula_version_changes.fetch(index) if upgraded_formula_installers_by_identity.key?(formula_installer)
+            end + dependent_version_changes,
+          )
+        end
 
         @prefetched_formulae_upgrade_context = nil if use_prefetched_context
         true

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -643,6 +643,7 @@ RSpec.describe Cask::Upgrade, :cask do
     end
 
     it "does not end the upgrade process" do
+      summary_upgrades = []
       upgraded_tokens = []
       bad_checksum = Cask::CaskLoader.load("bad-checksum")
       bad_checksum_path = Pathname(bad_checksum.config.appdir).join("Caffeine.app")
@@ -670,10 +671,11 @@ RSpec.describe Cask::Upgrade, :cask do
       end
 
       expect do
-        described_class.upgrade_casks!(args:, skip_prefetch: true)
+        described_class.upgrade_casks!(args:, skip_prefetch: true, summary_upgrades:)
       end.to raise_error(Cask::MultipleCaskErrors)
 
       expect(upgraded_tokens).to contain_exactly("bad-checksum", "bad-checksum2", "local-transmission-zip")
+      expect(summary_upgrades).to contain_exactly("local-transmission-zip 2.60 -> 2.61")
 
       expect(bad_checksum).to be_installed
       expect(bad_checksum_path).to be_a_directory

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -924,23 +924,63 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     old_keg.mkpath
     new_keg.mkpath
     allow(formula).to receive_messages(optlinked?: true, opt_prefix: old_keg)
+    formula_installer = FormulaInstaller.new(formula)
     cmd = described_class.new([])
 
     allow(cmd).to receive(:formulae_upgrade_context).and_return(
       Homebrew::Cmd::UpgradeCmd::FormulaeUpgradeContext.new(
         formulae_to_install: [formula],
-        formulae_installer:  [FormulaInstaller.new(formula)],
+        formulae_installer:  [formula_installer],
         dependants:          Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: []),
       ),
     )
     allow(Homebrew::Upgrade).to receive(:upgrade_formulae) do
       allow(formula).to receive(:opt_prefix).and_return(new_keg)
+      [formula_installer]
     end
     allow(Homebrew::Upgrade).to receive(:upgrade_dependents)
 
     cmd.send(:upgrade_outdated_formulae!, [])
 
     expect(cmd.send(:final_upgrade_summary).version_changes).to include("testball 0.1 -> 0.2")
+  end
+
+  it "omits failed formula version changes from the final summary" do
+    successful_formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/testball-0.2"
+    end
+    failed_formula = formula("failball") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/failball-0.2"
+      deprecate! date: "2020-01-01", because: :unmaintained
+    end
+    successful_formula_installer = FormulaInstaller.new(successful_formula)
+    failed_formula_installer = FormulaInstaller.new(failed_formula)
+    old_successful_keg = HOMEBREW_CELLAR/"testball/0.1"
+    old_failed_keg = HOMEBREW_CELLAR/"failball/0.1"
+    old_successful_keg.mkpath
+    old_failed_keg.mkpath
+    allow(successful_formula).to receive_messages(optlinked?: true, opt_prefix: old_successful_keg)
+    allow(failed_formula).to receive_messages(optlinked?: true, opt_prefix: old_failed_keg)
+    cmd = described_class.new([])
+
+    allow(cmd).to receive(:formulae_upgrade_context).and_return(
+      Homebrew::Cmd::UpgradeCmd::FormulaeUpgradeContext.new(
+        formulae_to_install: [successful_formula, failed_formula],
+        formulae_installer:  [successful_formula_installer, failed_formula_installer],
+        dependants:          Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: []),
+      ),
+    )
+    allow(Homebrew::Upgrade).to receive(:upgrade_formulae).and_return([successful_formula_installer])
+    allow(Homebrew::Upgrade).to receive(:upgrade_dependents)
+
+    cmd.send(:upgrade_outdated_formulae!, [])
+
+    expect(cmd.send(:final_upgrade_summary)).to have_attributes(
+      version_changes: contain_exactly("testball 0.1 -> 0.2"),
+      deprecated:      contain_exactly("failball"),
+    )
   end
 
   it_behaves_like "reinstall_pkgconf_if_needed"

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -142,7 +142,7 @@ module Homebrew
 
       sig {
         params(formula_installers: T::Array[FormulaInstaller], dry_run: T::Boolean, verbose: T::Boolean,
-               fetch: T::Boolean, skip_formula_names: T::Array[String]).void
+               fetch: T::Boolean, skip_formula_names: T::Array[String]).returns(T::Array[FormulaInstaller])
       }
       def upgrade_formulae(formula_installers, dry_run: false, verbose: false, fetch: true, skip_formula_names: [])
         valid_formula_installers = if dry_run || !fetch
@@ -151,17 +151,19 @@ module Homebrew
           Install.fetch_formulae(formula_installers)
         end
 
-        valid_formula_installers.each do |fi|
-          upgrade_formula(fi, dry_run:, verbose:, skip_formula_names:)
-          Cleanup.install_formula_clean!(fi.formula) unless dry_run
+        upgraded_formula_installers = valid_formula_installers.select do |fi|
+          upgraded = upgrade_formula(fi, dry_run:, verbose:, skip_formula_names:)
+          Cleanup.install_formula_clean!(fi.formula) if upgraded && !dry_run
+          upgraded
         end
-        return unless dry_run
+        return upgraded_formula_installers unless dry_run
 
-        formulae_to_clean = Cleanup.install_cleanup_formulae(valid_formula_installers.map(&:formula))
+        formulae_to_clean = Cleanup.install_cleanup_formulae(upgraded_formula_installers.map(&:formula))
         if formulae_to_clean.present? &&
            Cleanup.printed_dry_run_output?(Cleanup.dry_run_output(formulae: formulae_to_clean), ohai: true)
           Cleanup.puts_no_install_cleanup_disable_message_if_not_already!
         end
+        upgraded_formula_installers
       end
 
       sig { params(formula: Formula).returns(T::Array[Keg]) }
@@ -417,7 +419,7 @@ module Homebrew
 
       sig {
         params(formula_installer: FormulaInstaller, dry_run: T::Boolean, verbose: T::Boolean,
-               skip_formula_names: T::Array[String]).void
+               skip_formula_names: T::Array[String]).returns(T::Boolean)
       }
       def upgrade_formula(formula_installer, dry_run: false, verbose: false, skip_formula_names: [])
         formula = formula_installer.formula
@@ -432,14 +434,16 @@ module Homebrew
               "#{name} #{f.pkg_version}"
             end
           end
-          return
+          return true
         end
 
         Install.install_formula(formula_installer, upgrade: true)
+        true
       rescue BuildError => e
         e.dump(verbose:)
         puts
         Homebrew.failed = true
+        false
       end
 
       sig { params(installed_formulae: T::Array[Formula]).returns(T::Array[Formula]) }


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22698

- Fixes the final `brew upgrade` summary for partial failures.
- Records only successful cask and formula upgrades after real runs.
- Covers failed cask and formula upgrades with regression tests.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
