### PR TITLE
which-formula: parse all expected cli options

### DIFF
--- a/Library/Homebrew/cmd/which-formula.sh
+++ b/Library/Homebrew/cmd/which-formula.sh
@@ -13,10 +13,23 @@ homebrew-which-formula() {
         HOMEBREW_EXPLAIN=1
         shift
         ;;
+      -\? | -h | --help | --usage)
+        brew help which-formula
+        exit $?
+        ;;
+      --verbose) HOMEBREW_VERBOSE=1 ;;
+      --debug) HOMEBREW_DEBUG=1 ;;
+      --quiet) HOMEBREW_QUIET=1 ;;
       --*)
-        echo "Unknown option: $1" >&2
+        onoe "Unknown option: $1"
         brew help which-formula
         return 1
+        ;;
+      -*)
+        [[ "$1" == *v* ]] && HOMEBREW_VERBOSE=1
+        [[ "$1" == *q* ]] && HOMEBREW_QUIET=1
+        [[ "$1" == *d* ]] && HOMEBREW_DEBUG=1
+        shift
         ;;
       *)
         args+=("$1")
@@ -24,6 +37,11 @@ homebrew-which-formula() {
         ;;
     esac
   done
+
+  if [[ -n "${HOMEBREW_DEBUG}" ]]
+  then
+    set -x
+  fi
 
   if [[ ${#args[@]} -eq 0 ]]
   then


### PR DESCRIPTION
Currently, `brew which-formula --help` errors out (but does print usage, if incidentally), and all single letter options are silently ignored. This behavior is confusing and inconsistant with other brew commands.

PR handles these options consistant with the behavior and implementation of update.sh and other bash commands.

- Add parsing for the short and long forms of all options that which-formula claims to support (per `brew help which-formula`):  --debug, --quiet, --verbose, --help
- Add handling of --help (print help)
- Add handling of --debug (print bash debug log with `set -x`, similar behavior to `brew upgrade -d`)
- --quiet and --verbose are noops, but no longer produce errors

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
