### PR TITLE
Retarget redirected tap trust

### DIFF
--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -70,6 +70,10 @@ module Homebrew
             info = "#{tap}: "
             if tap.installed?
               info += "Installed"
+              if Homebrew::EnvConfig.require_tap_trust?
+                require "trust"
+                info += "\n#{Homebrew::Trust.trusted_tap?(tap) ? "Trusted" : "Untrusted"}"
+              end
               info += if (contents = tap.contents).blank?
                 "\nNo commands/casks/formulae"
               else

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -66,6 +66,33 @@ module Homebrew
           install_from_api_message
         end
 
+        if (redirected_remotes_file = ENV.fetch("HOMEBREW_REDIRECTED_REMOTES_FILE", nil)).present?
+          redirected_remotes_path = Pathname(redirected_remotes_file)
+          if redirected_remotes_path.file?
+            begin
+              redirected_remotes_path.each_line do |line|
+                tap_path, redirected_remote = line.chomp.split("\t", 2)
+                next if tap_path.blank? || redirected_remote.blank?
+                next unless (tap = Tap.from_path(tap_path))
+
+                old_repository_var_suffix = tap.repository_var_suffix
+                tap.apply_redirected_remote!(redirected_remote, quiet: args.quiet?)
+                new_repository_var_suffix = tap.repository_var_suffix
+                next if old_repository_var_suffix == new_repository_var_suffix
+
+                ["HOMEBREW_UPDATE_BEFORE", "HOMEBREW_UPDATE_AFTER"].each do |prefix|
+                  old_var = "#{prefix}#{old_repository_var_suffix}"
+                  old_value = ENV.fetch(old_var, nil)
+                  next if old_value.blank?
+
+                  ENV["#{prefix}#{new_repository_var_suffix}"] ||= old_value
+                end
+              end
+            ensure
+              redirected_remotes_path.unlink if redirected_remotes_path.exist?
+            end
+          end
+        end
         tap_or_untap_core_taps_if_necessary
 
         updated = false

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -700,8 +700,10 @@ EOS
 
   local update_failed_file="${HOMEBREW_REPOSITORY}/.git/UPDATE_FAILED"
   local missing_remote_ref_dirs_file="${HOMEBREW_REPOSITORY}/.git/FAILED_FETCH_DIRS"
+  local redirected_remotes_file="${HOMEBREW_REPOSITORY}/.git/REDIRECTED_REMOTES"
   rm -f "${update_failed_file}"
   rm -f "${missing_remote_ref_dirs_file}"
+  rm -f "${redirected_remotes_file}"
 
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
@@ -808,7 +810,8 @@ EOS
         declare UPSTREAM_BRANCH"${TAP_VAR}"="main"
       fi
 
-      if [[ -n "${UPSTREAM_REPOSITORY}" ]]
+      if [[ -n "${UPSTREAM_REPOSITORY}" ]] &&
+         [[ -z "${HOMEBREW_UPDATE_FORCE}" || "${DIR}" == "${HOMEBREW_LIBRARY}"/Taps/*/* ]]
       then
         # UPSTREAM_REPOSITORY_TOKEN is parsed (if exists) from UPSTREAM_REPOSITORY_URL
         # HOMEBREW_GITHUB_API_TOKEN is optionally defined in the user environment.
@@ -838,25 +841,58 @@ EOS
           GITHUB_API_ENDPOINT="commits/${UPSTREAM_BRANCH_DIR}"
         fi
 
+        local upstream_api_url="https://api.github.com/repos/${UPSTREAM_REPOSITORY}/${GITHUB_API_ENDPOINT}"
+
         # HOMEBREW_CURL is set by brew.sh (and isn't misspelt here)
         # shellcheck disable=SC2153
-        UPSTREAM_SHA_HTTP_CODE="$(
+        UPSTREAM_SHA_HTTP_RESPONSE="$(
           curl \
             "${CURL_DISABLE_CURLRC_ARGS[@]}" \
             "${CURL_GITHUB_API_ARGS[@]}" \
             --silent --max-time 3 \
-            --location --no-remote-time --output /dev/null --write-out "%{http_code}" \
+            --location --no-remote-time --output /dev/null --write-out "%{http_code} %{url_effective}" \
             --dump-header "${DIR}/.git/GITHUB_HEADERS" \
             --user-agent "${HOMEBREW_USER_AGENT_CURL}" \
             --header "X-GitHub-Api-Version:2022-11-28" \
             --header "Accept: ${GITHUB_API_ACCEPT}" \
             --header "If-None-Match: \"${GITHUB_API_ETAG}\"" \
-            "https://api.github.com/repos/${UPSTREAM_REPOSITORY}/${GITHUB_API_ENDPOINT}"
+            "${upstream_api_url}"
         )"
+        UPSTREAM_SHA_HTTP_CODE="${UPSTREAM_SHA_HTTP_RESPONSE%% *}"
+        UPSTREAM_SHA_HTTP_EFFECTIVE_URL="${UPSTREAM_SHA_HTTP_RESPONSE#* }"
+
+        if [[ "${DIR}" == "${HOMEBREW_LIBRARY}"/Taps/*/* ]] &&
+           [[ -n "${UPSTREAM_SHA_HTTP_EFFECTIVE_URL}" ]] &&
+           [[ "${UPSTREAM_SHA_HTTP_EFFECTIVE_URL}" != "${upstream_api_url}" ]]
+        then
+          redirected_remote="$(
+            curl \
+              "${CURL_DISABLE_CURLRC_ARGS[@]}" \
+              "${CURL_GITHUB_API_ARGS[@]}" \
+              --silent --max-time 3 \
+              --location --no-remote-time \
+              --user-agent "${HOMEBREW_USER_AGENT_CURL}" \
+              --header "X-GitHub-Api-Version:2022-11-28" \
+              --header "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${UPSTREAM_REPOSITORY}" |
+              sed -n 's/^[[:space:]]*"clone_url": "\(.*\)",$/\1/p' |
+              head -n1
+          )"
+          if [[ -n "${redirected_remote}" ]]
+          then
+            printf "%s\t%s\n" "${DIR}" "${redirected_remote}" >>"${redirected_remotes_file}"
+          fi
+        fi
 
         # Touch FETCH_HEAD to confirm we've checked for an update.
         [[ -f "${DIR}/.git/FETCH_HEAD" ]] && touch "${DIR}/.git/FETCH_HEAD"
-        [[ -z "${HOMEBREW_UPDATE_FORCE}" ]] && [[ "${UPSTREAM_SHA_HTTP_CODE}" == "304" ]] && exit
+        if [[ -z "${HOMEBREW_UPDATE_FORCE}" ]] &&
+           [[ "${UPSTREAM_SHA_HTTP_CODE}" == "304" ]] &&
+           [[ "${DIR}" != "${HOMEBREW_LIBRARY}"/Taps/*/* ||
+              "${UPSTREAM_SHA_HTTP_EFFECTIVE_URL}" == "${upstream_api_url}" ]]
+        then
+          exit
+        fi
       fi
 
       # HOMEBREW_VERBOSE isn't modified here so ignore subshell warning.
@@ -917,6 +953,14 @@ EOS
             echo "${DIR}" >>"${missing_remote_ref_dirs_file}"
           fi
         fi
+      elif [[ "${DIR}" == "${HOMEBREW_LIBRARY}"/Taps/*/* ]] &&
+           [[ -s "${tmp_failure_file}" ]]
+      then
+        redirected_remote="$(sed -n 's/.*redirecting to //p' "${tmp_failure_file}" | tail -n1)"
+        if [[ -n "${redirected_remote}" ]]
+        then
+          printf "%s\t%s\n" "${DIR}" "${redirected_remote}" >>"${redirected_remotes_file}"
+        fi
       fi
 
       if [[ -n "${MAIN_MIGRATION_REQUIRED}" ]]
@@ -936,6 +980,11 @@ EOS
     HOMEBREW_MISSING_REMOTE_REF_DIRS="$(cat "${missing_remote_ref_dirs_file}")"
     rm -f "${missing_remote_ref_dirs_file}"
     export HOMEBREW_MISSING_REMOTE_REF_DIRS
+  fi
+
+  if [[ -f "${redirected_remotes_file}" ]]
+  then
+    export HOMEBREW_REDIRECTED_REMOTES_FILE="${redirected_remotes_file}"
   fi
 
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
@@ -1030,6 +1079,7 @@ EOS
   if [[ -n "${HOMEBREW_UPDATED}" ]] ||
      [[ -n "${HOMEBREW_UPDATE_FAILED}" ]] ||
      [[ -n "${HOMEBREW_MISSING_REMOTE_REF_DIRS}" ]] ||
+     [[ -n "${HOMEBREW_REDIRECTED_REMOTES_FILE}" ]] ||
      [[ -n "${HOMEBREW_UPDATE_FORCE}" ]] ||
      [[ -d "${HOMEBREW_LIBRARY}/LinkedKegs" ]] ||
      [[ ! -f "${HOMEBREW_CACHE}/all_commands_list.txt" ]] ||

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -157,6 +157,8 @@ class Tap
     %r{\A(?:[a-z][a-z0-9+.-]*://(?:[^@/]+@)?github\.com/|(?:[^@/]+@)?github\.com:)}
   # The host of a remote: the first `/`- or `:`-delimited segment after any scheme and userinfo.
   REMOTE_HOST_REGEX = %r{\A#{REMOTE_SCHEME_USERINFO_REGEX.source}([^/:]+)}
+  GIT_REDIRECT_REMOTE_REGEX = /redirecting to (?<remote>\S+)/i
+  private_constant :GIT_REDIRECT_REMOTE_REGEX
 
   # On GitHub the scheme and userinfo are insignificant (any of HTTPS, SSH SCP syntax, `ssh://` or
   # `git://` identify the same repository), so those forms are canonicalised to HTTPS. For hosts in
@@ -533,6 +535,69 @@ class Tap
     false
   end
 
+  sig { params(output: String, quiet: T::Boolean).void }
+  def update_remote_from_git_redirect!(output, quiet: false)
+    output.each_line do |line|
+      next unless (match = line.match(GIT_REDIRECT_REMOTE_REGEX))
+
+      apply_redirected_remote!(T.must(match[:remote]), quiet:)
+      break
+    end
+  end
+
+  sig { params(redirected_remote: String, quiet: T::Boolean).void }
+  def apply_redirected_remote!(redirected_remote, quiet: false)
+    old_name = name
+    old_remote = remote
+    return if old_remote.present? && self.class.same_remote?(old_remote, redirected_remote)
+
+    redirected_reference = self.class.remote_to_reference(redirected_remote)
+    if redirected_reference.present? && !self.class.remote_reference?(redirected_reference)
+      redirected_tap = self.class.fetch(redirected_reference)
+      if redirected_tap.name != name && !redirected_tap.installed?
+        old_path = path
+        redirected_tap.path.dirname.mkpath
+        FileUtils.mv(old_path, redirected_tap.path)
+        old_path.parent.rmdir_if_possible
+
+        @user = redirected_tap.user
+        @repository = redirected_tap.repository
+        @name = redirected_tap.name
+        @full_repository = redirected_tap.full_repository
+        @full_name = redirected_tap.full_name
+        @path = redirected_tap.path
+        @git_repository = GitRepository.new(@path)
+        clear_cache
+      end
+    end
+
+    safe_system "git", "-C", path, "remote", "set-url", "origin", redirected_remote
+    clear_cache
+    Tap.clear_cache
+
+    require "trust"
+    trust_invalidated = Homebrew::Trust.invalidate_tap_references!(old_name, remote: old_remote)
+
+    return if quiet
+
+    $stderr.ohai(
+      if old_name == name
+        "Redirected tap #{name} remote to #{redirected_remote}"
+      else
+        "Redirected tap #{old_name} to tap #{name}"
+      end,
+    )
+    $stderr.puts "#{trust_invalidated ? "Untrusted" : "Not trusted"} tap: #{old_name}"
+  end
+
+  sig { params(args: T::Array[T.any(String, Pathname)], chdir: T.nilable(Pathname)).returns(T.untyped) }
+  def git_command!(args, chdir: nil)
+    require "system_command"
+
+    SystemCommand.run!("git", args:, chdir:, print_stderr: true)
+  end
+  private :git_command!
+
   # Install this {Tap}.
   #
   # @param clone_target If passed, it will be used as the clone remote.
@@ -607,7 +672,8 @@ class Tap
       # Git throws an error when attempting to unshallow a full clone
       args << "--unshallow" if shallow?
       args << "-q" if quiet
-      path.cd { safe_system "git", *args }
+      result = git_command!(args, chdir: path)
+      update_remote_from_git_redirect!(result.stderr, quiet:)
       return
     elsif (core_tap? || core_cask_tap?) && !Homebrew::EnvConfig.no_install_from_api? && !force &&
           worktree_source_tap_path.blank?
@@ -619,7 +685,7 @@ class Tap
     Tap.clear_cache
 
     $stderr.ohai "Tapping #{name}" unless quiet
-    args =  %W[clone #{requested_remote} #{path}]
+    args = %W[clone #{requested_remote} #{path}]
 
     # Override possible user configs like:
     #   git config --global clone.defaultRemoteName notorigin
@@ -639,7 +705,8 @@ class Tap
         worktree_args += ["--detach", path, "HEAD"]
         safe_system "git", *worktree_args
       else
-        safe_system "git", *args
+        result = git_command!(args)
+        update_remote_from_git_redirect!(result.stderr, quiet:)
       end
 
       if verify && !Homebrew::EnvConfig.developer? && !Readall.valid_tap?(self, aliases: true)
@@ -738,7 +805,8 @@ class Tap
     args << "--quiet" if quiet
     args << "origin"
     args << "+refs/heads/*:refs/remotes/origin/*"
-    safe_system "git", "-C", path, *args
+    result = git_command!(args, chdir: path)
+    update_remote_from_git_redirect!(result.stderr, quiet:)
     git_repository.set_head_origin_auto
 
     current_upstream_head ||= T.must(git_repository.origin_branch_name)

--- a/Library/Homebrew/test/cmd/tap-info_spec.rb
+++ b/Library/Homebrew/test/cmd/tap-info_spec.rb
@@ -25,6 +25,62 @@ RSpec.describe Homebrew::Cmd::TapInfo do
       .and not_to_output.to_stderr
   end
 
+  it "prints trusted tap status when tap trust is required" do
+    require "trust"
+
+    tap_path = mktmpdir/"thirdparty/foo"
+    tap_path.mkpath
+    tap = instance_double(
+      Tap,
+      to_s:            "thirdparty/foo",
+      installed?:      true,
+      contents:        [],
+      private?:        false,
+      path:            tap_path,
+      remote:          "https://github.com/thirdparty/homebrew-foo",
+      default_remote:  "https://github.com/thirdparty/homebrew-foo",
+      git_head:        "abc123",
+      git_last_commit: "1 second ago",
+      git_branch:      "main",
+    )
+    tap_info = described_class.new([])
+    allow(tap_info).to receive(:print_tap_listings).with(tap)
+    allow(Homebrew::Trust).to receive(:trusted_tap?).with(tap).and_return(true)
+
+    with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+      expect { tap_info.send(:print_tap_info, [tap]) }
+        .to output(%r{thirdparty/foo: Installed\nTrusted\nNo commands/casks/formulae}).to_stdout
+    end
+  end
+
+  it "prints untrusted tap status when tap trust is required" do
+    require "trust"
+
+    tap_path = mktmpdir/"thirdparty/foo"
+    tap_path.mkpath
+    tap = instance_double(
+      Tap,
+      to_s:            "thirdparty/foo",
+      installed?:      true,
+      contents:        [],
+      private?:        false,
+      path:            tap_path,
+      remote:          "https://github.com/thirdparty/homebrew-foo",
+      default_remote:  "https://github.com/thirdparty/homebrew-foo",
+      git_head:        "abc123",
+      git_last_commit: "1 second ago",
+      git_branch:      "main",
+    )
+    tap_info = described_class.new([])
+    allow(tap_info).to receive(:print_tap_listings).with(tap)
+    allow(Homebrew::Trust).to receive(:trusted_tap?).with(tap).and_return(false)
+
+    with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+      expect { tap_info.send(:print_tap_info, [tap]) }
+        .to output(%r{thirdparty/foo: Installed\nUntrusted\nNo commands/casks/formulae}).to_stdout
+    end
+  end
+
   describe "#decorate_formula" do
     let(:tap_info) { described_class.new([]) }
     let(:tap) { instance_double(Tap, name: "homebrew/foo") }

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -12,6 +12,34 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
 
   it_behaves_like "reinstall_pkgconf_if_needed"
 
+  it "copies update revisions for redirected tap names" do
+    redirected_remotes_file = mktmpdir/"redirected-remotes"
+    redirected_remotes_file.write("/tmp/homebrew-foo\thttps://github.com/new/homebrew-foo.git\n")
+
+    tap = instance_double(Tap, repository_var_suffix: "_OLD_HOMEBREW_FOO")
+    allow(Tap).to receive(:from_path).with("/tmp/homebrew-foo").and_return(tap)
+    allow(tap).to receive(:apply_redirected_remote!)
+      .with("https://github.com/new/homebrew-foo.git", quiet: true) do
+        allow(tap).to receive(:repository_var_suffix).and_return("_NEW_HOMEBREW_FOO")
+      end
+    allow(Homebrew::EnvConfig).to receive_messages(disable_load_formula?: true, no_install_from_api?: true)
+    update_report = described_class.new(["--quiet"])
+    allow(update_report).to receive(:tap_or_untap_core_taps_if_necessary)
+
+    with_env(
+      HOMEBREW_REDIRECTED_REMOTES_FILE:        redirected_remotes_file.to_s,
+      HOMEBREW_UPDATE_BEFORE:                  "abc",
+      HOMEBREW_UPDATE_AFTER:                   "abc",
+      HOMEBREW_UPDATE_BEFORE_OLD_HOMEBREW_FOO: "123",
+      HOMEBREW_UPDATE_AFTER_OLD_HOMEBREW_FOO:  "456",
+    ) do
+      update_report.run
+
+      expect(ENV.fetch("HOMEBREW_UPDATE_BEFORE_NEW_HOMEBREW_FOO")).to eq("123")
+      expect(ENV.fetch("HOMEBREW_UPDATE_AFTER_NEW_HOMEBREW_FOO")).to eq("456")
+    end
+  end
+
   describe Reporter do
     let(:tap) { CoreTap.instance }
     let(:reporter_class) do

--- a/Library/Homebrew/test/cmd/update_spec.rb
+++ b/Library/Homebrew/test/cmd/update_spec.rb
@@ -150,4 +150,332 @@ RSpec.describe Homebrew::Cmd::Update do
     expect(stderr).to be_empty
     expect(args_file.read).to eq("update-report\n--auto-update\n")
   end
+
+  it "does not query redirected remote metadata for no-op tap updates" do
+    args_file = test_root/"brew-args.txt"
+    fetches_file = test_root/"fetches.txt"
+    metadata_queries_file = test_root/"metadata-queries.txt"
+    repository = test_root/"repository"
+    tap_path = test_root/"Library/Taps/old/homebrew-foo"
+    setup_update_utils
+    (repository/".git").mkpath
+    (tap_path/".git").mkpath
+    (test_root/"cache").mkpath
+    (test_root/"cache/all_commands_list.txt").write ""
+
+    _stdout, stderr, status = run_update_shell(
+      <<~SH,
+        source "#{update_script}"
+        brew() { printf '%s\\n' "$@" > "#{args_file}"; return 1; }
+        fetch_api_file() { :; }
+        git_init_if_necessary() { :; }
+        git() {
+          case "$*" in
+            "--version") return 0 ;;
+            "config --local --get remote.origin.url" | "config remote.origin.url")
+              if [[ "$PWD" == "#{tap_path}" ]]
+              then
+                echo "https://github.com/old/homebrew-foo"
+              else
+                echo "https://github.com/Homebrew/brew"
+              fi
+              return 0
+              ;;
+            "symbolic-ref refs/remotes/origin/HEAD")
+              echo "refs/remotes/origin/main"
+              return 0
+              ;;
+            "rev-parse refs/remotes/origin/main" | "rev-parse -q --verify refs/remotes/origin/main" | "rev-parse -q --verify HEAD")
+              echo abc
+              return 0
+              ;;
+            "tag --list")
+              echo "4.0.0"
+              return 0
+              ;;
+            fetch*)
+              echo "$PWD" >> "#{fetches_file}"
+              return 0
+              ;;
+          esac
+          printf 'unexpected git %s\\n' "$*" >&2
+          return 1
+        }
+        curl() {
+          local url
+          for url in "$@"; do :; done
+
+          case "${url}" in
+            "https://api.github.com/repos/Homebrew/brew/tags" | "https://api.github.com/repos/old/homebrew-foo/commits/main")
+              printf '304 %s' "${url}"
+              ;;
+            "https://api.github.com/repos/Homebrew/brew" | "https://api.github.com/repos/old/homebrew-foo")
+              echo "${url}" >> "#{metadata_queries_file}"
+              printf 'unexpected metadata query\\n' >&2
+              return 1
+              ;;
+            *)
+              printf 'unexpected curl %s\\n' "${url}" >&2
+              return 1
+              ;;
+          esac
+        }
+        lock() { :; }
+        odie() { echo "Error: $*" >&2; exit 1; }
+        ohai() { :; }
+        onoe() { echo "Error: $*" >&2; }
+        safe_cd() { cd "$1" &>/dev/null || exit 1; }
+        setup_ca_certificates() { :; }
+        setup_curl() { :; }
+        setup_git() { :; }
+        homebrew-update --auto-update
+      SH
+      {
+        "HOMEBREW_BREW_DEFAULT_GIT_REMOTE" => "https://github.com/Homebrew/brew",
+        "HOMEBREW_BREW_GIT_REMOTE"         => "https://github.com/Homebrew/brew",
+        "HOMEBREW_CACHE"                   => (test_root/"cache").to_s,
+        "HOMEBREW_CASK_REPOSITORY"         => (test_root/"cask").to_s,
+        "HOMEBREW_CELLAR"                  => (test_root/"cellar").to_s,
+        "HOMEBREW_CORE_DEFAULT_GIT_REMOTE" => "https://github.com/Homebrew/homebrew-core",
+        "HOMEBREW_CORE_GIT_REMOTE"         => "https://github.com/Homebrew/homebrew-core",
+        "HOMEBREW_CORE_REPOSITORY"         => (test_root/"core").to_s,
+        "HOMEBREW_LIBRARY"                 => (test_root/"Library").to_s,
+        "HOMEBREW_NO_ENV_HINTS"            => "1",
+        "HOMEBREW_NO_INSTALL_FROM_API"     => "1",
+        "HOMEBREW_PREFIX"                  => (test_root/"prefix").to_s,
+        "HOMEBREW_REPOSITORY"              => repository.to_s,
+        "HOMEBREW_USER_AGENT_CURL"         => "Homebrew/test",
+      },
+    )
+
+    expect(status.success?).to be true
+    expect(stderr).to be_empty
+    expect(args_file).not_to exist
+    expect(fetches_file).not_to exist
+    expect(metadata_queries_file).not_to exist
+  end
+
+  it "treats redirected tap SHA API checks as updates" do
+    args_file = test_root/"brew-args.txt"
+    fetches_file = test_root/"fetches.txt"
+    metadata_queries_file = test_root/"metadata-queries.txt"
+    repository = test_root/"repository"
+    tap_path = test_root/"Library/Taps/old/homebrew-foo"
+    setup_update_utils
+    (repository/".git").mkpath
+    (tap_path/".git").mkpath
+    (test_root/"cache").mkpath
+    (test_root/"cache/all_commands_list.txt").write ""
+
+    _stdout, stderr, status = run_update_shell(
+      <<~SH,
+        source "#{update_script}"
+        brew() { printf '%s\\n' "$@" > "#{args_file}"; }
+        fetch_api_file() { :; }
+        git_init_if_necessary() { :; }
+        git() {
+          case "$*" in
+            "--version") return 0 ;;
+            "config --local --get remote.origin.url" | "config remote.origin.url")
+              if [[ "$PWD" == "#{tap_path}" ]]
+              then
+                echo "https://github.com/old/homebrew-foo"
+              else
+                echo "https://github.com/Homebrew/brew"
+              fi
+              return 0
+              ;;
+            "symbolic-ref refs/remotes/origin/HEAD")
+              echo "refs/remotes/origin/main"
+              return 0
+              ;;
+            "rev-parse refs/remotes/origin/main" | "rev-parse -q --verify refs/remotes/origin/main" | "rev-parse -q --verify HEAD")
+              echo abc
+              return 0
+              ;;
+            "tag --list")
+              echo "4.0.0"
+              return 0
+              ;;
+            "fetch --tags --force -q origin refs/heads/main:refs/remotes/origin/main")
+              echo "$PWD" >> "#{fetches_file}"
+              return 0
+              ;;
+          esac
+          printf 'unexpected git %s\\n' "$*" >&2
+          return 1
+        }
+        curl() {
+          local url
+          for url in "$@"; do :; done
+
+          case "${url}" in
+            "https://api.github.com/repos/Homebrew/brew/tags")
+              printf '304 %s' "${url}"
+              ;;
+            "https://api.github.com/repos/old/homebrew-foo/commits/main")
+              printf '304 https://api.github.com/repositories/456/commits/main'
+              ;;
+            "https://api.github.com/repos/Homebrew/brew")
+              printf 'unexpected brew metadata query\\n' >&2
+              return 1
+              ;;
+            "https://api.github.com/repos/old/homebrew-foo")
+              echo "${url}" >> "#{metadata_queries_file}"
+              printf '{\\n  "clone_url": "https://github.com/new/homebrew-foo.git",\\n  "html_url": "https://github.com/new/homebrew-foo"\\n}\\n'
+              ;;
+            *)
+              printf 'unexpected curl %s\\n' "${url}" >&2
+              return 1
+              ;;
+          esac
+        }
+        lock() { :; }
+        odie() { echo "Error: $*" >&2; exit 1; }
+        ohai() { :; }
+        onoe() { echo "Error: $*" >&2; }
+        safe_cd() { cd "$1" &>/dev/null || exit 1; }
+        setup_ca_certificates() { :; }
+        setup_curl() { :; }
+        setup_git() { :; }
+        homebrew-update --auto-update
+      SH
+      {
+        "HOMEBREW_BREW_DEFAULT_GIT_REMOTE" => "https://github.com/Homebrew/brew",
+        "HOMEBREW_BREW_GIT_REMOTE"         => "https://github.com/Homebrew/brew",
+        "HOMEBREW_CACHE"                   => (test_root/"cache").to_s,
+        "HOMEBREW_CASK_REPOSITORY"         => (test_root/"cask").to_s,
+        "HOMEBREW_CELLAR"                  => (test_root/"cellar").to_s,
+        "HOMEBREW_CORE_DEFAULT_GIT_REMOTE" => "https://github.com/Homebrew/homebrew-core",
+        "HOMEBREW_CORE_GIT_REMOTE"         => "https://github.com/Homebrew/homebrew-core",
+        "HOMEBREW_CORE_REPOSITORY"         => (test_root/"core").to_s,
+        "HOMEBREW_LIBRARY"                 => (test_root/"Library").to_s,
+        "HOMEBREW_NO_ENV_HINTS"            => "1",
+        "HOMEBREW_NO_INSTALL_FROM_API"     => "1",
+        "HOMEBREW_PREFIX"                  => (test_root/"prefix").to_s,
+        "HOMEBREW_REPOSITORY"              => repository.to_s,
+        "HOMEBREW_USER_AGENT_CURL"         => "Homebrew/test",
+      },
+    )
+
+    expect(status.success?).to be true
+    expect(stderr).to be_empty
+    expect(args_file.read).to eq("update-report\n--auto-update\n")
+    expect(fetches_file.read).to eq("#{tap_path}\n")
+    expect((repository/".git/REDIRECTED_REMOTES").read).to eq(
+      "#{tap_path}\thttps://github.com/new/homebrew-foo.git\n",
+    )
+    expect(metadata_queries_file.read).to eq("https://api.github.com/repos/old/homebrew-foo\n")
+  end
+
+  it "queries redirected remote metadata only for taps" do
+    args_file = test_root/"brew-args.txt"
+    metadata_queries_file = test_root/"metadata-queries.txt"
+    repository = test_root/"repository"
+    tap_path = test_root/"Library/Taps/old/homebrew-foo"
+    setup_update_utils
+    (repository/".git").mkpath
+    (tap_path/".git").mkpath
+    (test_root/"cache").mkpath
+    (test_root/"cache/all_commands_list.txt").write ""
+
+    _stdout, stderr, status = run_update_shell(
+      <<~SH,
+        source "#{update_script}"
+        brew() { printf '%s\\n' "$@" > "#{args_file}"; }
+        fetch_api_file() { :; }
+        git_init_if_necessary() { :; }
+        git() {
+          case "$*" in
+            "--version") return 0 ;;
+            "config --local --get remote.origin.url" | "config remote.origin.url")
+              if [[ "$PWD" == "#{tap_path}" ]]
+              then
+                echo "https://github.com/old/homebrew-foo"
+              else
+                echo "https://github.com/Homebrew/brew"
+              fi
+              return 0
+              ;;
+            "symbolic-ref refs/remotes/origin/HEAD")
+              echo "refs/remotes/origin/main"
+              return 0
+              ;;
+            "rev-parse refs/remotes/origin/main" | "rev-parse -q --verify refs/remotes/origin/main" | "rev-parse -q --verify HEAD" | "rev-parse -q --verify main")
+              echo abc
+              return 0
+              ;;
+            "merge-base --is-ancestor abc abc")
+              return 0
+              ;;
+            "tag --list")
+              echo "4.0.0"
+              return 0
+              ;;
+            "fetch --tags --force -q origin refs/heads/main:refs/remotes/origin/main")
+              return 0
+              ;;
+          esac
+          printf 'unexpected git %s\\n' "$*" >&2
+          return 1
+        }
+        curl() {
+          local url
+          for url in "$@"; do :; done
+
+          case "${url}" in
+            "https://api.github.com/repos/Homebrew/brew/tags")
+              printf 'unexpected brew API query\\n' >&2
+              return 1
+              ;;
+            "https://api.github.com/repos/old/homebrew-foo/commits/main")
+              printf '304 https://api.github.com/repositories/456/commits/main'
+              ;;
+            "https://api.github.com/repos/Homebrew/brew" | "https://api.github.com/repos/old/homebrew-foo")
+              echo "${url}" >> "#{metadata_queries_file}"
+              printf '{\\n  "clone_url": "https://github.com/new/homebrew-foo.git",\\n  "html_url": "https://github.com/new/homebrew-foo"\\n}\\n'
+              ;;
+            *)
+              printf 'unexpected curl %s\\n' "${url}" >&2
+              return 1
+              ;;
+          esac
+        }
+        lock() { :; }
+        odie() { echo "Error: $*" >&2; exit 1; }
+        ohai() { :; }
+        onoe() { echo "Error: $*" >&2; }
+        safe_cd() { cd "$1" &>/dev/null || exit 1; }
+        setup_ca_certificates() { :; }
+        setup_curl() { :; }
+        setup_git() { :; }
+        homebrew-update --auto-update --force --simulate-from-current-branch
+      SH
+      {
+        "HOMEBREW_BREW_DEFAULT_GIT_REMOTE" => "https://github.com/Homebrew/brew",
+        "HOMEBREW_BREW_GIT_REMOTE"         => "https://github.com/Homebrew/brew",
+        "HOMEBREW_CACHE"                   => (test_root/"cache").to_s,
+        "HOMEBREW_CASK_REPOSITORY"         => (test_root/"cask").to_s,
+        "HOMEBREW_CELLAR"                  => (test_root/"cellar").to_s,
+        "HOMEBREW_CORE_DEFAULT_GIT_REMOTE" => "https://github.com/Homebrew/homebrew-core",
+        "HOMEBREW_CORE_GIT_REMOTE"         => "https://github.com/Homebrew/homebrew-core",
+        "HOMEBREW_CORE_REPOSITORY"         => (test_root/"core").to_s,
+        "HOMEBREW_DEVELOPER"               => "1",
+        "HOMEBREW_LIBRARY"                 => (test_root/"Library").to_s,
+        "HOMEBREW_NO_ENV_HINTS"            => "1",
+        "HOMEBREW_NO_INSTALL_FROM_API"     => "1",
+        "HOMEBREW_PREFIX"                  => (test_root/"prefix").to_s,
+        "HOMEBREW_REPOSITORY"              => repository.to_s,
+        "HOMEBREW_USER_AGENT_CURL"         => "Homebrew/test",
+      },
+    )
+
+    expect(status.success?).to be true
+    expect(stderr).to be_empty
+    expect(args_file.read).to eq("update-report\n--force\n--simulate-from-current-branch\n")
+    expect((repository/".git/REDIRECTED_REMOTES").read).to eq(
+      "#{tap_path}\thttps://github.com/new/homebrew-foo.git\n",
+    )
+    expect(metadata_queries_file.read).to eq("https://api.github.com/repos/old/homebrew-foo\n")
+  end
 end

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -550,6 +550,62 @@ RSpec.describe Tap do
     end
   end
 
+  describe "#update_remote_from_git_redirect!" do
+    it "moves default GitHub taps to the redirected name and invalidates old trust", :trust_store do
+      require "trust"
+
+      tap = described_class.fetch("oldowner", "foo")
+      old_path = tap.path
+      new_path = described_class.fetch("newowner", "foo").path
+      tap.path.mkpath
+      system "git", "-C", tap.path.to_s, "init"
+      system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://github.com/oldowner/homebrew-foo"
+      Homebrew::Trust.trust!(:tap, "oldowner/foo")
+      Homebrew::Trust.trust!(:tap, "https://github.com/oldowner/homebrew-foo")
+      Homebrew::Trust.trust!(:formula, "oldowner/foo/bar")
+
+      tap.update_remote_from_git_redirect!(
+        "warning: redirecting to https://github.com/newowner/homebrew-foo\n",
+        quiet: true,
+      )
+
+      expect(tap.name).to eq("newowner/foo")
+      expect(tap.path).to eq(new_path)
+      expect(new_path).to be_a_directory
+      expect(old_path).not_to exist
+      expect(Utils.popen_read("git", "-C", tap.path, "config", "remote.origin.url").chomp)
+        .to eq("https://github.com/newowner/homebrew-foo")
+      expect(Homebrew::Trust.trusted_entries(:tap)).to be_empty
+      expect(Homebrew::Trust.trusted_entries(:formula)).to be_empty
+    ensure
+      Homebrew::Trust.clear!(:tap)
+      Homebrew::Trust.clear!(:formula)
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"oldowner"
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"newowner"
+    end
+
+    it "prints tap redirect and untrust messages", :trust_store do
+      require "trust"
+
+      tap = described_class.fetch("oldoutput", "foo")
+      tap.path.mkpath
+      system "git", "-C", tap.path.to_s, "init"
+      system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://github.com/oldoutput/homebrew-foo"
+      Homebrew::Trust.trust!(:tap, "oldoutput/foo")
+
+      expect($stderr).to receive(:ohai).with("Redirected tap oldoutput/foo to tap newoutput/foo")
+      expect($stderr).to receive(:puts).with("Untrusted tap: oldoutput/foo")
+
+      tap.update_remote_from_git_redirect!(
+        "warning: redirecting to https://github.com/newoutput/homebrew-foo\n",
+      )
+    ensure
+      Homebrew::Trust.clear!(:tap)
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"oldoutput"
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"newoutput"
+    end
+  end
+
   specify "Git variant" do
     touch path/"README"
     setup_git_repo
@@ -708,12 +764,13 @@ RSpec.describe Tap do
 
       allow(tap).to receive_messages(command_files: [], formula_files: [], cask_files: [],
                                      formula_names: [], cask_tokens: [], link_completions_and_manpages: nil)
-      expect(tap).to receive(:safe_system)
-        .with("git", "clone", requested_remote, tap.path.to_s, "--origin=origin", "--template=",
-              "--config", "core.fsmonitor=false")
+      expect(tap).to receive(:git_command!)
+        .with(["clone", requested_remote, tap.path.to_s, "--origin=origin", "--template=",
+               "--config", "core.fsmonitor=false"])
         .and_wrap_original do
           tap.path.mkpath
           (tap.path/".git").mkpath
+          double(stderr: "")
         end
 
       tap.install clone_target: requested_remote, force: true

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -67,6 +67,27 @@ RSpec.describe Homebrew::Trust, :trust_store do
     described_class.clear!(:tap)
   end
 
+  it "invalidates old tap trust entries after a redirect" do
+    described_class.trust!(:tap, "thirdparty/foo")
+    described_class.trust!(:tap, "https://gitlab.com/old/repo")
+    described_class.trust!(:formula, "thirdparty/foo/bar")
+    described_class.trust!(:cask, "thirdparty/foo/baz")
+    described_class.trust!(:command, "thirdparty/foo/hello")
+
+    expect(described_class.invalidate_tap_references!("thirdparty/foo",
+                                                      remote: "https://gitlab.com/old/repo")).to be(true)
+
+    expect(described_class.trusted_entries(:tap)).to be_empty
+    expect(described_class.trusted_entries(:formula)).to be_empty
+    expect(described_class.trusted_entries(:cask)).to be_empty
+    expect(described_class.trusted_entries(:command)).to be_empty
+  ensure
+    described_class.clear!(:tap)
+    described_class.clear!(:formula)
+    described_class.clear!(:cask)
+    described_class.clear!(:command)
+  end
+
   it "infers tap type for a remote URL argument" do
     result = described_class.target("https://gitlab.com/other/repo")
     expect(result).to eq([:tap, "https://gitlab.com/other/repo"])

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -60,6 +60,38 @@ module Homebrew
       end
     end
 
+    sig { params(name: String, remote: T.nilable(String)).returns(T::Boolean) }
+    def self.invalidate_tap_references!(name, remote: nil)
+      name = normalise_name(name)
+      references = [name]
+      references << normalise_name(remote) if remote.present?
+      if remote.present? && (remote_reference = Tap.remote_to_reference(remote))
+        references << normalise_name(remote_reference)
+      end
+      references.uniq!
+
+      with_trust_store_lock do
+        store = trust_store
+        changed = T.let(false, T::Boolean)
+        store.keys.each do |key|
+          entries = store.fetch(key)
+          filtered_entries = entries.reject do |entry|
+            references.include?(entry) || entry.start_with?("#{name}/")
+          end
+          next if filtered_entries == entries
+
+          changed = true
+          if filtered_entries.empty?
+            store.delete(key)
+          else
+            store[key] = filtered_entries.sort
+          end
+        end
+        write_trust_store(store) if changed
+        changed
+      end
+    end
+
     sig { params(names: T::Array[String], type: T.nilable(Symbol)).void }
     def self.trust_fully_qualified_items!(names, type: nil)
       names.each do |name|


### PR DESCRIPTION
- Follow GitHub redirects while preventing old tap names from staying trusted
- Update redirected tap remotes so future operations use the new canonical URL
- Remove old `trustedtaps` and per-item trust entries after a tap redirect
- Show tap trust status in `tap-info` when tap trust is required
- Query redirected tap metadata only after tap API redirects
- Keep forced redirect checks limited to taps
- Preserve update-report revisions when a tap redirect renames a tap
- Keep no-op tap updates from querying redirected metadata
- Treat redirected tap SHA API checks as updates
- Print redirected and untrusted tap messages with explicit tap wording

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
