### PR TITLE
which-formula: parse all expected cli options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Do not use conventional commit prefixes such as `feat:`, `fix:`, `chore:`, `refa
 - When adding or tightening tests, verify them with a red/green cycle using the exact `--only=file:line` target for the example you changed.
 - Formula classes created in specs may be frozen; avoid stubbing class methods on them with RSpec mocks and prefer instance-level stubs or test setup that does not require class-method stubbing.
 - Keep comments minimal; prefer self-documenting code through strings, variable names, etc. over more comments.
+- Put a comment immediately above each `shellcheck disable` explaining why it is needed.
 - Aim to wrap human-written user-facing terminal output at around 80 characters; this does not apply to generated output or code.
 
 ## Repository Structure

--- a/Library/Homebrew/cmd/as-console-user.sh
+++ b/Library/Homebrew/cmd/as-console-user.sh
@@ -2,18 +2,28 @@
 
 # `HOMEBREW_*` variables are set by brew.sh before sourcing this command.
 # shellcheck disable=SC2154
+source "${HOMEBREW_LIBRARY}/Homebrew/utils/cmd.sh"
+
 homebrew-as-console-user() {
-  case "${1:-}" in
-    --help | -h | --usage | "-?")
-      "${HOMEBREW_BREW_FILE}" help as-console-user
-      return
-      ;;
-    *) ;;
-  esac
+  while [[ "$#" -gt 0 ]]
+  do
+    if homebrew-command-help as-console-user "$1"
+    then
+      return $?
+    fi
+    if homebrew-command-common-option "$1"
+    then
+      shift
+      continue
+    fi
+    break
+  done
+
+  homebrew-command-enable-debug
 
   if [[ "$#" -eq 0 ]]
   then
-    "${HOMEBREW_BREW_FILE}" help as-console-user
+    brew help as-console-user
     return 1
   fi
 

--- a/Library/Homebrew/cmd/exec.sh
+++ b/Library/Homebrew/cmd/exec.sh
@@ -1,6 +1,7 @@
 # Documentation defined in Library/Homebrew/cmd/exec.rb
 
 # shellcheck disable=SC2154
+source "${HOMEBREW_LIBRARY}/Homebrew/utils/cmd.sh"
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/executables.sh"
 
 exec-formula-name() {
@@ -86,6 +87,16 @@ homebrew-exec() {
 
   while [[ "$#" -gt 0 ]]
   do
+    if homebrew-command-help exec "$1"
+    then
+      return $?
+    fi
+    if homebrew-command-common-option "$1"
+    then
+      shift
+      continue
+    fi
+
     case "$1" in
       --formulae=*)
         formulae_arg="${1#--formulae=}"
@@ -115,10 +126,6 @@ homebrew-exec() {
         deny_network=1
         shift
         ;;
-      --help | -h)
-        "${HOMEBREW_BREW_FILE}" help exec
-        return
-        ;;
       --)
         shift
         break
@@ -136,6 +143,8 @@ homebrew-exec() {
 
   [[ "${sandbox_seen}" -eq 0 || -n "${sandbox_path}" ]] || odie "\`--sandbox\` requires a writable path."
   [[ "${sandbox_seen}" -eq 1 || "${deny_network}" -eq 0 ]] || odie "\`--deny-network\` requires \`--sandbox\`."
+
+  homebrew-command-enable-debug
 
   if [[ "${formulae_seen}" -eq 1 ]]
   then

--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -1,5 +1,9 @@
 # Documentation defined in Library/Homebrew/cmd/update-reset.rb
 
+# HOMEBREW_LIBRARY is set by bin/brew
+# shellcheck disable=SC2154
+source "${HOMEBREW_LIBRARY}/Homebrew/utils/cmd.sh"
+
 # Replaces the function in Library/Homebrew/brew.sh to cache the Git executable to provide
 # speedup when using Git repeatedly and prevent errors if the shim changes mid-update.
 git() {
@@ -23,15 +27,17 @@ homebrew-update-reset() {
 
   for option in "$@"
   do
+    if homebrew-command-help update-reset "${option}"
+    then
+      exit $?
+    fi
+    if homebrew-command-common-option "${option}"
+    then
+      continue
+    fi
+
     case "${option}" in
-      -\? | -h | --help | --usage)
-        brew help update-reset
-        exit $?
-        ;;
-      --debug) HOMEBREW_DEBUG=1 ;;
-      -*)
-        [[ "${option}" == *d* ]] && HOMEBREW_DEBUG=1
-        ;;
+      -*) homebrew-command-common-short-options "${option}" ;;
       *)
         if [[ -d "${option}/.git" ]]
         then
@@ -45,10 +51,7 @@ homebrew-update-reset() {
     esac
   done
 
-  if [[ -n "${HOMEBREW_DEBUG}" ]]
-  then
-    set -x
-  fi
+  homebrew-command-enable-debug
 
   if [[ -z "${REPOS[*]}" ]]
   then

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -11,6 +11,7 @@
 # HOMEBREW_FORCE_BREWED_CURL, HOMEBREW_FORCE_BREWED_GIT,
 # HOMEBREW_SYSTEM_CURL_TOO_OLD, HOMEBREW_USER_AGENT_CURL are set by brew.sh
 # shellcheck disable=SC2154
+source "${HOMEBREW_LIBRARY}/Homebrew/utils/cmd.sh"
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/api.sh"
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/lock.sh"
 
@@ -485,14 +486,16 @@ homebrew-update() {
 
   for option in "$@"
   do
+    if homebrew-command-help update "${option}"
+    then
+      exit $?
+    fi
+    if homebrew-command-common-option "${option}"
+    then
+      continue
+    fi
+
     case "${option}" in
-      -\? | -h | --help | --usage)
-        brew help update
-        exit $?
-        ;;
-      --verbose) HOMEBREW_VERBOSE=1 ;;
-      --debug) HOMEBREW_DEBUG=1 ;;
-      --quiet) HOMEBREW_QUIET=1 ;;
       --merge)
         shift
         HOMEBREW_MERGE=1
@@ -509,9 +512,7 @@ homebrew-update() {
         exit 1
         ;;
       -*)
-        [[ "${option}" == *v* ]] && HOMEBREW_VERBOSE=1
-        [[ "${option}" == *q* ]] && HOMEBREW_QUIET=1
-        [[ "${option}" == *d* ]] && HOMEBREW_DEBUG=1
+        homebrew-command-common-short-options "${option}"
         [[ "${option}" == *f* ]] && HOMEBREW_UPDATE_FORCE=1
         ;;
       *)
@@ -521,10 +522,7 @@ homebrew-update() {
     esac
   done
 
-  if [[ -n "${HOMEBREW_DEBUG}" ]]
-  then
-    set -x
-  fi
+  homebrew-command-enable-debug
 
   if [[ -z "${HOMEBREW_UPDATE_TO_TAG}" ]]
   then

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -7,6 +7,7 @@
 # HOMEBREW_CURL, HOMEBREW_GITHUB_PACKAGES_AUTH, HOMEBREW_LINUX, HOMEBREW_LINUX_MINIMUM_GLIBC_VERSION, HOMEBREW_MACOS,
 # HOMEBREW_PHYSICAL_PROCESSOR, HOMEBREW_PROCESSOR, HOMEBREW_USER_AGENT_CURL are set by brew.sh
 # shellcheck disable=SC2154
+source "${HOMEBREW_LIBRARY}/Homebrew/utils/cmd.sh"
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/lock.sh"
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/ruby.sh"
 
@@ -319,20 +320,18 @@ homebrew-vendor-install() {
 
   for option in "$@"
   do
+    if homebrew-command-help vendor-install "${option}"
+    then
+      exit $?
+    fi
+    if homebrew-command-common-option "${option}"
+    then
+      continue
+    fi
+
     case "${option}" in
-      -\? | -h | --help | --usage)
-        brew help vendor-install
-        exit $?
-        ;;
-      --verbose) HOMEBREW_VERBOSE=1 ;;
-      --quiet) HOMEBREW_QUIET=1 ;;
-      --debug) HOMEBREW_DEBUG=1 ;;
       --*) ;;
-      -*)
-        [[ "${option}" == *v* ]] && HOMEBREW_VERBOSE=1
-        [[ "${option}" == *q* ]] && HOMEBREW_QUIET=1
-        [[ "${option}" == *d* ]] && HOMEBREW_DEBUG=1
-        ;;
+      -*) homebrew-command-common-short-options "${option}" ;;
       *)
         if [[ -n "${VENDOR_NAME}" ]]
         then
@@ -356,7 +355,7 @@ homebrew-vendor-install() {
   done
 
   [[ -z "${VENDOR_NAME}" ]] && odie "This command requires a vendor target!"
-  [[ -n "${HOMEBREW_DEBUG}" ]] && set -x
+  homebrew-command-enable-debug
 
   if [[ "${VENDOR_NAME}" == "brew-rs" ]]
   then

--- a/Library/Homebrew/cmd/which-formula.sh
+++ b/Library/Homebrew/cmd/which-formula.sh
@@ -11,19 +11,36 @@ homebrew-which-formula() {
     case "$1" in
       --explain)
         HOMEBREW_EXPLAIN=1
-        shift
         ;;
+      -\? | -h | --help | --usage)
+        brew help which-formula
+        return $?
+        ;;
+      --verbose) : ;;
+      --debug) HOMEBREW_DEBUG=1 ;;
+      --quiet) : ;;
       --*)
-        echo "Unknown option: $1" >&2
+        onoe "Unknown option: $1"
         brew help which-formula
         return 1
         ;;
-      *)
-        args+=("$1")
-        shift
+      -*)
+        if [[ "$1" == *h* ]]
+        then
+          brew help which-formula
+          return $?
+        fi
+        [[ "$1" == *d* ]] && HOMEBREW_DEBUG=1
         ;;
+      *) args+=("$1") ;;
     esac
+    shift
   done
+
+  if [[ -n "${HOMEBREW_DEBUG}" ]]
+  then
+    set -x
+  fi
 
   if [[ ${#args[@]} -eq 0 ]]
   then

--- a/Library/Homebrew/cmd/which-formula.sh
+++ b/Library/Homebrew/cmd/which-formula.sh
@@ -1,6 +1,7 @@
 # Documentation defined in Library/Homebrew/cmd/which-formula.rb
 
 # shellcheck disable=SC2154
+source "${HOMEBREW_LIBRARY}/Homebrew/utils/cmd.sh"
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/executables.sh"
 
 homebrew-which-formula() {
@@ -8,39 +9,32 @@ homebrew-which-formula() {
 
   while [[ "$#" -gt 0 ]]
   do
+    if homebrew-command-help which-formula "$1"
+    then
+      return $?
+    fi
+    if homebrew-command-common-option "$1"
+    then
+      shift
+      continue
+    fi
+
     case "$1" in
       --explain)
         HOMEBREW_EXPLAIN=1
         ;;
-      -\? | -h | --help | --usage)
-        brew help which-formula
-        return $?
-        ;;
-      --verbose) : ;;
-      --debug) HOMEBREW_DEBUG=1 ;;
-      --quiet) : ;;
       --*)
         onoe "Unknown option: $1"
         brew help which-formula
         return 1
         ;;
-      -*)
-        if [[ "$1" == *h* ]]
-        then
-          brew help which-formula
-          return $?
-        fi
-        [[ "$1" == *d* ]] && HOMEBREW_DEBUG=1
-        ;;
+      -*) homebrew-command-common-short-options "$1" ;;
       *) args+=("$1") ;;
     esac
     shift
   done
 
-  if [[ -n "${HOMEBREW_DEBUG}" ]]
-  then
-    set -x
-  fi
+  homebrew-command-enable-debug
 
   if [[ ${#args[@]} -eq 0 ]]
   then

--- a/Library/Homebrew/test/cmd/as-console-user_spec.rb
+++ b/Library/Homebrew/test/cmd/as-console-user_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Homebrew::Cmd::AsConsoleUser do
         homebrew-as-console-user
       SH
       "HOMEBREW_BREW_FILE" => "brew",
+      "HOMEBREW_LIBRARY"   => (repository_root/"Library").to_s,
     )
 
     expect(status.exitstatus).to eq 1
@@ -83,6 +84,7 @@ RSpec.describe Homebrew::Cmd::AsConsoleUser do
         homebrew-as-console-user install wget
       SH
       "HOMEBREW_BREW_FILE" => "brew",
+      "HOMEBREW_LIBRARY"   => (repository_root/"Library").to_s,
     )
 
     expect(status.exitstatus).to eq 1

--- a/Library/Homebrew/test/cmd/update_spec.rb
+++ b/Library/Homebrew/test/cmd/update_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Homebrew::Cmd::Update do
   def setup_update_utils
     (test_root/"Library/Homebrew/utils").mkpath
     FileUtils.ln_s repository_root/"Library/Homebrew/utils.sh", test_root/"Library/Homebrew/utils.sh"
-    %w[api executables formatter lock tty].each do |name|
+    %w[api cmd executables formatter lock tty].each do |name|
       FileUtils.ln_s repository_root/"Library/Homebrew/utils/#{name}.sh",
                      test_root/"Library/Homebrew/utils/#{name}.sh"
     end

--- a/Library/Homebrew/test/cmd/which-formula_spec.rb
+++ b/Library/Homebrew/test/cmd/which-formula_spec.rb
@@ -88,6 +88,30 @@ RSpec.describe Homebrew::Cmd::WhichFormula do
           HOMEBREW_NO_EMOJI=1 check "non-emoji output" 0 $'foo\\n' "" homebrew-which-formula foo2
           check "missing executable" 1 "" "" homebrew-which-formula bar
 
+          long_verbose_option() {
+            unset HOMEBREW_VERBOSE
+            homebrew-which-formula --verbose bar
+            local status="$?"
+            [[ -n "${HOMEBREW_VERBOSE}" ]] || {
+              echo "long verbose option: HOMEBREW_VERBOSE was not set" >&2
+              return 2
+            }
+            return "${status}"
+          }
+          check "long verbose option" 1 "" "" long_verbose_option
+
+          short_verbose_option() {
+            unset HOMEBREW_VERBOSE
+            homebrew-which-formula -v bar
+            local status="$?"
+            [[ -n "${HOMEBREW_VERBOSE}" ]] || {
+              echo "short verbose option: HOMEBREW_VERBOSE was not set" >&2
+              return 2
+            }
+            return "${status}"
+          }
+          check "short verbose option" 1 "" "" short_verbose_option
+
           rm -f "$(executables_txt_cache_file)"
           HOMEBREW_NO_INSTALL_FROM_API=1 check "disabled API without database" 1 "" \\
             $'Error: HOMEBREW_NO_INSTALL_FROM_API must be unset to use `brew which-formula` or `brew exec`.\\n' \\

--- a/Library/Homebrew/utils/cmd.sh
+++ b/Library/Homebrew/utils/cmd.sh
@@ -1,0 +1,84 @@
+# Helpers for Homebrew's Bash command option parsing.
+
+# HOMEBREW_LIBRARY is set by bin/brew.
+# shellcheck disable=SC2154
+source "${HOMEBREW_LIBRARY}/Homebrew/utils.sh"
+
+homebrew-command-help() {
+  local command="$1"
+  local option="$2"
+
+  case "${option}" in
+    -\? | -h | --help | --usage)
+      brew help "${command}"
+      ;;
+    --*)
+      return 1
+      ;;
+    -*h*)
+      brew help "${command}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+homebrew-command-common-option() {
+  local option="$1"
+
+  case "${option}" in
+    --verbose)
+      HOMEBREW_VERBOSE=1
+      ;;
+    --quiet)
+      HOMEBREW_QUIET=1
+      ;;
+    --debug)
+      HOMEBREW_DEBUG=1
+      ;;
+    --*)
+      return 1
+      ;;
+    -*)
+      local other_options="${option#-}"
+      other_options="${other_options//[dqv]/}"
+      [[ -n "${option#-}" && -z "${other_options}" ]] || return 1
+
+      # `HOMEBREW_VERBOSE` is read by caller command code after this helper returns.
+      # shellcheck disable=SC2034
+      [[ "${option#-}" == *v* ]] && HOMEBREW_VERBOSE=1
+      # `HOMEBREW_QUIET` is read by caller command code after this helper returns.
+      # shellcheck disable=SC2034
+      [[ "${option#-}" == *q* ]] && HOMEBREW_QUIET=1
+      [[ "${option#-}" == *d* ]] && HOMEBREW_DEBUG=1
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+homebrew-command-common-short-options() {
+  local options="$1"
+
+  case "${options}" in
+    --*)
+      return 1
+      ;;
+    -*) ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  options="${options#-}"
+  [[ -n "${options}" ]] || return 1
+  options="${options//[!dqv]/}"
+  [[ -z "${options}" ]] || homebrew-command-common-option "-${options}"
+}
+
+homebrew-command-enable-debug() {
+  [[ -n "${HOMEBREW_DEBUG:-}" ]] && set -x
+}


### PR DESCRIPTION
Currently, `brew which-formula --help` errors out (but does print usage, if incidentally). Other long form options which-formula claims to support (per `brew help which-formula`) also error out and print usage. All single letter options fail, as they are parsed as arguments rather than options. This behavior is confusing and inconsistant with other brew commands.

PR handles these options consistant with the behavior and implementation of `update` and other bash commands.

- Add parsing for the short and long forms of all options that `which-formula` claims to support :  --debug, --quiet, --verbose, --help
- Add handling of --help (print help)
- Add handling of --debug (print bash debug log with `set -x`, similar behavior to `brew upgrade -d`)
- --quiet and --verbose are noops, but no longer produce errors (could set HOMEBREW_QUIET/HOMEBREW_VERBOSE here, but setting it and not using it upsets `shellcheck`)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
