### PR TITLE
Avoid sandbox user config reads

### DIFF
--- a/Library/Homebrew/download_strategy/git_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/git_download_strategy.rb
@@ -47,6 +47,12 @@ class GitDownloadStrategy < VCSDownloadStrategy
 
   private
 
+  # Avoid user Git config reads; sandbox-denied config files make Git exit.
+  sig { override.returns(T::Hash[String, String]) }
+  def env
+    { "GIT_CONFIG_GLOBAL" => File::NULL }
+  end
+
   sig { override.returns(String) }
   def cache_tag
     if partial_clone_sparse_checkout?

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1662,7 +1662,6 @@ class Formula
         TMPDIR:        HOMEBREW_TEMP,
         TEMP:          HOMEBREW_TEMP,
         TMP:           HOMEBREW_TEMP,
-        _JAVA_OPTIONS: "-Djava.io.tmpdir=#{HOMEBREW_TEMP}",
         HOMEBREW_PATH: nil,
         PATH:          PATH.new(ORIGINAL_PATHS),
       }
@@ -1670,6 +1669,10 @@ class Formula
       Dir.mktmpdir("#{name}-postinstall-") do |home|
         postinstall_home = Pathname(home)
         new_env[:HOME] = postinstall_home.to_s
+        new_env.merge!(common_sandbox_env(postinstall_home))
+        # Keep postinstall Java temp files in Homebrew temp while the common
+        # sandbox environment points Java's user home at the cache.
+        new_env[:_JAVA_OPTIONS] += " -Djava.io.tmpdir=#{HOMEBREW_TEMP}"
         setup_home postinstall_home
 
         with_env(new_env) do
@@ -3284,11 +3287,14 @@ class Formula
 
     mktemp("#{name}-test") do |staging|
       staging.retain! if keep_tmp
-      @testpath = T.let(staging.tmpdir, T.nilable(Pathname))
-      test_env[:HOME] = @testpath
-      test_env.merge!(common_stage_test_env(T.must(@testpath)))
+      testpath = staging.tmpdir
+      raise "Test path is unexpectedly unset." if testpath.nil?
+
+      @testpath = T.let(testpath, T.nilable(Pathname))
+      test_env[:HOME] = testpath
+      test_env.merge!(common_sandbox_env(testpath))
       test_env[:_JAVA_OPTIONS] += " -Djava.io.tmpdir=#{HOMEBREW_TEMP}"
-      setup_home T.must(@testpath)
+      setup_home testpath
       begin
         with_logging("test") do
           with_env(test_env) do
@@ -3738,18 +3744,23 @@ class Formula
     exit! 1 # never gets here unless exec threw or failed
   end
 
-  # Common environment variables used at both build and test time.
+  # Common environment variables used by sandboxed build, test and postinstall phases.
   sig { params(home: Pathname).returns(T::Hash[Symbol, String]) }
-  def common_stage_test_env(home)
+  def common_sandbox_env(home)
     {
       _JAVA_OPTIONS:           "-Duser.home=#{HOMEBREW_CACHE}/java_cache",
       GOCACHE:                 "#{HOMEBREW_CACHE}/go_cache",
+      GIT_CONFIG_GLOBAL:       File::NULL,
+      GOENV:                   "off",
       GOPATH:                  "#{HOMEBREW_CACHE}/go_mod_cache",
       CARGO_HOME:              "#{HOMEBREW_CACHE}/cargo_cache",
       BUNDLE_COOLDOWN:         Homebrew::RELEASE_COOLDOWN_DAYS.to_s,
       PIP_CACHE_DIR:           "#{HOMEBREW_CACHE}/pip_cache",
+      PIP_CONFIG_FILE:         File::NULL,
+      NPM_CONFIG_USERCONFIG:   File::NULL,
       CURL_HOME:               ENV.fetch("CURL_HOME") { home.to_s },
       PYTHONDONTWRITEBYTECODE: "1",
+      XDG_CONFIG_HOME:         "#{home}/.config",
     }
   end
 
@@ -3767,7 +3778,7 @@ class Formula
 
       unless interactive
         stage_env[:HOME] = env_home
-        stage_env.merge!(common_stage_test_env(env_home))
+        stage_env.merge!(common_sandbox_env(env_home))
       end
 
       setup_home env_home

--- a/Library/Homebrew/test/download_strategies/git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/git_spec.rb
@@ -39,6 +39,19 @@ RSpec.describe GitDownloadStrategy do
       end
       expect(strategy.source_modified_time.to_i).to eq(1_485_115_153)
     end
+
+    it "does not read user Git configuration" do
+      expect(strategy).to receive(:system_command)
+        .with(
+          "git",
+          args:         ["--git-dir", cached_location/".git", "show", "-s", "--format=%cD"],
+          env:          { "GIT_CONFIG_GLOBAL" => File::NULL },
+          print_stderr: false,
+        )
+        .and_return(instance_double(SystemCommand::Result, stdout: "Fri, 12 Jun 2026 06:12:11 -0700"))
+
+      expect(strategy.source_modified_time).to eq(Time.parse("Fri, 12 Jun 2026 06:12:11 -0700"))
+    end
   end
 
   specify "#last_commit" do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1140,6 +1140,27 @@ RSpec.describe Formula do
     expect(f2).not_to have_post_install_defined
   end
 
+  specify "#run_post_install prevents build tools from reading user configuration" do
+    env = {}
+    f = formula do
+      T.bind(self, T.class_of(Formula))
+      url "foo-1.0"
+    end
+
+    allow(Tab).to receive(:for_formula).with(f).and_return(f.build)
+    allow(f).to receive(:post_install) { env = ENV.to_hash }
+
+    f.run_post_install
+
+    expect(env).to include(
+      "GIT_CONFIG_GLOBAL"     => File::NULL,
+      "GOENV"                 => "off",
+      "NPM_CONFIG_USERCONFIG" => File::NULL,
+      "PIP_CONFIG_FILE"       => File::NULL,
+      "XDG_CONFIG_HOME"       => "#{env.fetch("HOME")}/.config",
+    )
+  end
+
   specify "#post_install_steps" do
     f = formula do
       T.bind(self, T.class_of(Formula))
@@ -3085,7 +3106,7 @@ RSpec.describe Formula do
     end
   end
 
-  describe "#common_stage_test_env" do
+  describe "#common_sandbox_env" do
     let(:f) do
       formula do
         url "foo-1.0"
@@ -3093,7 +3114,19 @@ RSpec.describe Formula do
     end
 
     it "sets Bundler cooldown for RubyGems dependencies" do
-      expect(f.send(:common_stage_test_env, mktmpdir)[:BUNDLE_COOLDOWN]).to eq("1")
+      expect(f.send(:common_sandbox_env, mktmpdir)[:BUNDLE_COOLDOWN]).to eq("1")
+    end
+
+    it "prevents build tools from reading user configuration" do
+      home = mktmpdir
+
+      expect(f.send(:common_sandbox_env, home)).to include(
+        GIT_CONFIG_GLOBAL:     File::NULL,
+        GOENV:                 "off",
+        NPM_CONFIG_USERCONFIG: File::NULL,
+        PIP_CONFIG_FILE:       File::NULL,
+        XDG_CONFIG_HOME:       (home/".config").to_s,
+      )
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22710
Fixes https://github.com/Homebrew/brew/issues/22711

- `git` treats sandbox-denied global config reads as fatal.
- Keep build, test and postinstall tools away from user config.
- Cover Git downloads and shared sandbox phase environment.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and manual testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
