### PR TITLE
formula: restore missing finding aliases for old tabs

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2893,7 +2893,8 @@ class Formula
       # A dep is "missing" if it's in the hide list (pretend uninstalled) or
       # genuinely not installed in the cellar.
       base_name = Utils.name_from_full_name(full_name)
-      next if hide.exclude?(base_name) && (HOMEBREW_CELLAR/base_name).directory?
+      next if hide.exclude?(base_name) && ((HOMEBREW_CELLAR/base_name).directory? ||
+                                           (HOMEBREW_PREFIX/"opt"/base_name).directory?)
 
       Dependency.new(full_name)
     end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1567,6 +1567,14 @@ RSpec.describe Formula do
       expect(f.missing_dependencies).to be_empty
     end
 
+    it "returns empty when dep is present as alias or oldname" do
+      (HOMEBREW_CELLAR/"bar@2/2.0").mkpath
+      (HOMEBREW_PREFIX/"opt").mkpath
+      FileUtils.ln_sf HOMEBREW_CELLAR/"bar@2/2.0", HOMEBREW_PREFIX/"opt/bar"
+      allow(keg).to receive(:runtime_dependencies).and_return([{ "full_name" => "bar" }])
+      expect(f.missing_dependencies).to be_empty
+    end
+
     it "returns dep when not present in cellar" do
       allow(keg).to receive(:runtime_dependencies).and_return([{ "full_name" => "baz" }])
       expect(f.missing_dependencies.map(&:name)).to eq(["baz"])


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-core/issues/287502

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Regression from https://github.com/Homebrew/brew/commit/1e8f1eeb0366f0ded2b062e8df4402b3fc3c6d3f where we now claim a dependency is missing for some old tabs that may use an old name (e.g. prior to versioned/unversioned flip like ICU or for rename)
- Fixes https://github.com/Homebrew/homebrew-core/issues/287502

Note that the behavior is not 100% identical as previously we would load formula and thus find the alternative names to search inside Cellar. But this isn't possible without loading formula and taking performance hit.

This instead uses an alternative to assume base_name could be an alias/oldnames and search within opt path.