### PR TITLE
Limit sandbox home deny rules

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -212,7 +212,7 @@ class Sandbox
   sig { void }
   def deny_read_home
     home = Pathname(Dir.home(ENV.fetch("USER"))).realpath
-    required = [
+    if [
       HOMEBREW_PREFIX,
       HOMEBREW_REPOSITORY,
       HOMEBREW_CACHE,
@@ -223,23 +223,85 @@ class Sandbox
       ENV.fetch("RUNNER_TEMP", nil),
       Homebrew::Trust.trust_file,
       *home_write_paths.select { |path| File.exist?(path) },
-    ].compact.flat_map do |path|
+    ].compact.any? do |path|
       path = Pathname(path)
-      [path.expand_path, (path.realpath if path.exist?)]
+      [path.expand_path, (path.realpath if path.exist?)].compact.any? { |pathname| pathname.ascend.include?(home) }
     end
-    required = required.compact.select { |path| path.ascend.include?(home) }
+      # When Homebrew or CI needs some `$HOME` paths to stay readable, deny only
+      # well-known credential and personal-data paths instead of enumerating all
+      # of `$HOME`.
+      [
+        ".ssh",
+        ".aws",
+        ".azure",
+        ".boto",
+        ".docker",
+        ".config/gh",
+        ".config/gcloud",
+        ".config/huggingface",
+        ".config/pip",
+        ".config/pypoetry",
+        ".config/rclone",
+        ".config/containers/auth.json",
+        ".config/composer/auth.json",
+        ".config/sops/age/keys.txt",
+        ".gnupg",
+        ".git-credentials",
+        ".gitconfig",
+        ".gsutil",
+        ".kube",
+        ".netrc",
+        ".npmrc",
+        ".yarnrc",
+        ".yarnrc.yml",
+        ".pnpmrc",
+        ".bunfig.toml",
+        ".pypirc",
+        ".pip",
+        ".poetry",
+        ".local/share/pypoetry",
+        ".gem/credentials",
+        ".bundle/config",
+        ".cargo/credentials",
+        ".cargo/credentials.toml",
+        ".composer/auth.json",
+        ".condarc",
+        ".m2/settings.xml",
+        ".gradle/gradle.properties",
+        ".sbt/1.0/credentials.sbt",
+        ".terraform.d/credentials.tfrc.json",
+        ".pulumi/credentials.json",
+        ".oci/config",
+        ".huggingface/token",
+        ".cache/huggingface/token",
+        ".claude",
+        ".claude.json",
+        ".kiro",
+        ".bash_history",
+        ".zsh_history",
+        ".python_history",
+        ".mysql_history",
+        ".psql_history",
+        ".env",
+        ".env.local",
+        "Documents",
+        "Movies",
+        "Music",
+        "Pictures",
+        "Library/Keychains",
+        "Library/Mobile Documents",
+        "Library/CloudStorage",
+        "Dropbox",
+        "Google Drive",
+        "OneDrive",
+      ].each do |path|
+        path = home/path
+        deny_read_path path if path.exist?
+      end
+      return
+    end
 
-    # Block as much of `$HOME` as possible so a malicious build or install script
-    # cannot read SSH keys, cloud and package-registry tokens, browser or
-    # crypto-wallet data or any other secret kept in the home directory. When no
-    # Homebrew or CI directory lives inside `$HOME` the whole thing is denied;
-    # otherwise deny every entry except those Homebrew and its build tools must
-    # read, such as `~/Library/Caches/Homebrew`, `~/Library/Logs/Homebrew`, the
-    # `~/.homebrew/trust.json` tap trust store the sandboxed build re-checks and
-    # the `home_write_paths` that builds write to (the Xcode dirs on macOS).
-    return deny_read_path(home) if required.empty?
-
-    deny_read_home_except home, required
+    deny_read_path home
   end
 
   sig { params(path: T.nilable(T.any(String, Pathname)), type: Symbol).void }
@@ -459,26 +521,6 @@ class Sandbox
 
   sig { returns(T.nilable(Time)) }
   attr_reader :start
-
-  sig { params(dir: Pathname, required: T::Array[Pathname]).void }
-  def deny_read_home_except(dir, required)
-    dir.children.each do |child|
-      next if required.include?(child)
-
-      # Only descend into real, non-symlink directories on the way to a path
-      # Homebrew needs, so a non-directory ancestor cannot raise and a symlink
-      # loop cannot cause infinite recursion.
-      if child.directory? && !child.symlink? && required.any? { |path| path.ascend.include?(child) }
-        deny_read_home_except child, required
-      else
-        deny_read_path child
-      end
-    rescue SystemCallError
-      next
-    end
-  rescue SystemCallError
-    # `dir` is unreadable, so there is nothing inside it left to deny.
-  end
 
   # Home directories a build needs to write to, and so must also read;
   # overridden per-OS (e.g. the Xcode directories on macOS).

--- a/Library/Homebrew/test/sandbox_shared_spec.rb
+++ b/Library/Homebrew/test/sandbox_shared_spec.rb
@@ -293,60 +293,120 @@ RSpec.describe Sandbox do
       expect(sandbox.send(:profile).rules).to be_empty
     end
 
-    it "denies every home entry except the directories Homebrew needs" do
+    it "denies known sensitive home paths when Homebrew needs home access" do
       cache = home/"Library/Caches/Homebrew"
       stub_const("HOMEBREW_CACHE", cache)
-      [cache, home/"Library/Preferences", home/".config", home/".ssh", home/"src"].each(&:mkpath)
-      FileUtils.touch home/".netrc"
+      allowed_dirs = [
+        cache,
+        home/"Library/Preferences",
+        home/".config",
+        home/".config/homebrew",
+        home/"src",
+      ]
+      sensitive_dirs = [
+        home/".claude",
+        home/".config/gcloud",
+        home/".config/gh",
+        home/".config/huggingface",
+        home/".config/pip",
+        home/".config/pypoetry",
+        home/".config/rclone",
+        home/".kiro",
+        home/".pip",
+        home/".ssh",
+        home/"Documents",
+      ]
+      sensitive_files = [
+        home/".bash_history",
+        home/".cache/huggingface/token",
+        home/".claude.json",
+        home/".config/composer/auth.json",
+        home/".config/containers/auth.json",
+        home/".config/sops/age/keys.txt",
+        home/".cargo/credentials.toml",
+        home/".gem/credentials",
+        home/".git-credentials",
+        home/".mysql_history",
+        home/".netrc",
+        home/".npmrc",
+        home/".psql_history",
+        home/".pypirc",
+        home/".python_history",
+        home/".terraform.d/credentials.tfrc.json",
+        home/".zsh_history",
+      ]
 
-      sandbox.deny_read_home
-
-      expect(sandbox.send(:profile).rules.map { |rule| rule.filter&.path }).to match_array(
-        [home/".config", home/".netrc", home/".ssh", home/"src", home/"Library/Preferences"]
-          .map { |path| path.realpath.to_s },
-      )
-    end
-
-    it "denies home entries whose names contain parentheses or backslashes without raising" do
-      stub_const("HOMEBREW_LOGS", home/"Library/Logs/Homebrew")
-      teams_log = home/"Library/Logs/Microsoft Teams Helper (Renderer)"
-      backslash_dir = home/"I:\\"
-      [home/"Library/Logs/Homebrew", teams_log, backslash_dir].each(&:mkpath)
+      [*allowed_dirs, *sensitive_dirs].each(&:mkpath)
+      sensitive_files.each do |path|
+        path.dirname.mkpath
+        FileUtils.touch path
+      end
 
       sandbox.deny_read_home
 
       denied = sandbox.send(:profile).rules.map { |rule| rule.filter&.path }
-      expect(denied).to include(teams_log.realpath.to_s, backslash_dir.realpath.to_s)
+      expect(denied).to include(*(sensitive_dirs + sensitive_files).map { |path| path.realpath.to_s })
+      expect(denied).not_to include(*allowed_dirs.map { |path| path.realpath.to_s })
+    end
+
+    it "does not deny arbitrary home entries whose names contain parentheses or backslashes" do
+      stub_const("HOMEBREW_LOGS", home/"Library/Logs/Homebrew")
+      teams_log = home/"Library/Logs/Microsoft Teams Helper (Renderer)"
+      backslash_dir = home/"I:\\"
+      [home/"Library/Logs/Homebrew", teams_log, backslash_dir, home/".ssh"].each(&:mkpath)
+
+      sandbox.deny_read_home
+
+      denied = sandbox.send(:profile).rules.map { |rule| rule.filter&.path }
+      expect(denied).to include((home/".ssh").realpath.to_s)
+      expect(denied).not_to include(teams_log.realpath.to_s, backslash_dir.realpath.to_s)
     end
 
     it "keeps the trust store readable so sandboxed builds can re-check tap trust" do
       stub_const("HOMEBREW_CACHE", home/"Library/Caches/Homebrew")
       config_home = home/".homebrew"
-      [home/"Library/Caches/Homebrew", config_home].each(&:mkpath)
+      [home/"Library/Caches/Homebrew", config_home, home/".ssh"].each(&:mkpath)
       trust_file = config_home/"trust.json"
-      secret = config_home/"secret"
-      [trust_file, secret].each { |file| FileUtils.touch file }
+      FileUtils.touch trust_file
 
       with_env(HOMEBREW_USER_CONFIG_HOME: config_home.to_s) do
         sandbox.deny_read_home
       end
 
       denied = sandbox.send(:profile).rules.map { |rule| rule.filter&.path }
-      expect(denied).to include(secret.realpath.to_s)
+      expect(denied).to include((home/".ssh").realpath.to_s)
+      expect(denied).not_to include(trust_file.realpath.to_s)
+    end
+
+    it "keeps the XDG trust store readable so sandboxed builds can re-check tap trust" do
+      stub_const("HOMEBREW_CACHE", home/"Library/Caches/Homebrew")
+      config_home = home/".config/homebrew"
+      gh_config = home/".config/gh"
+      [home/"Library/Caches/Homebrew", config_home, gh_config, home/".ssh"].each(&:mkpath)
+      trust_file = config_home/"trust.json"
+      FileUtils.touch trust_file
+
+      with_env(HOMEBREW_USER_CONFIG_HOME: config_home.to_s) do
+        sandbox.deny_read_home
+      end
+
+      denied = sandbox.send(:profile).rules.map { |rule| rule.filter&.path }
+      expect(denied).to include(gh_config.realpath.to_s)
+      expect(denied).to include((home/".ssh").realpath.to_s)
+      expect(denied).not_to include((home/".config").realpath.to_s)
       expect(denied).not_to include(trust_file.realpath.to_s)
     end
 
     it "keeps the Xcode directories readable so builds can use them", :needs_macos do
-      stub_const("HOMEBREW_CACHE", home/"Library/Caches/Homebrew")
       developer = home/"Library/Developer"
       swiftpm = home/"Library/Caches/org.swift.swiftpm"
-      [home/"Library/Caches/Homebrew", developer, swiftpm, home/"Library/Preferences"].each(&:mkpath)
+      [developer, swiftpm, home/".ssh"].each(&:mkpath)
 
       sandbox.deny_read_home
 
       denied = sandbox.send(:profile).rules.map { |rule| rule.filter&.path }
       expect(denied).not_to include(developer.realpath.to_s, swiftpm.realpath.to_s)
-      expect(denied).to include((home/"Library/Preferences").realpath.to_s)
+      expect(denied).to include((home/".ssh").realpath.to_s)
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22711 by reverting the approach in https://github.com/Homebrew/brew/pull/22660.

- avoid recursively enumerating large home directories when Homebrew paths need to stay readable inside the sandbox.
- deny common credential and personal-data paths instead.
- keep `.config` and package-manager credential files unreadable to reduce user-specific build behaviour.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
