### PR TITLE
sandbox: scope `require "trust"` to avoid `brew irb` failure

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -5,7 +5,6 @@ require "io/console"
 require "pty"
 require "tempfile"
 require "exceptions"
-require "trust"
 require "utils/fork"
 require "utils/output"
 
@@ -211,6 +210,8 @@ class Sandbox
 
   sig { void }
   def deny_read_home
+    require "trust"
+
     home = Pathname(Dir.home(ENV.fetch("USER"))).realpath
     if [
       HOMEBREW_PREFIX,


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

This helps avoid an require loop resulting in
```
Error: uninitialized constant Cask::DSL::Artifact
```

Started happening after 677b433222972287ff113b680e32c30a03d24897