### PR TITLE
Keep tap remotes visible in builds

### DIFF
--- a/Library/Homebrew/download_strategy/git_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/git_download_strategy.rb
@@ -50,7 +50,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
   # Avoid user Git config reads; sandbox-denied config files make Git exit.
   sig { override.returns(T::Hash[String, String]) }
   def env
-    { "GIT_CONFIG_GLOBAL" => File::NULL }
+    Utils::Git.no_global_config_env
   end
 
   sig { override.returns(String) }

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3750,7 +3750,7 @@ class Formula
     {
       _JAVA_OPTIONS:           "-Duser.home=#{HOMEBREW_CACHE}/java_cache",
       GOCACHE:                 "#{HOMEBREW_CACHE}/go_cache",
-      GIT_CONFIG_GLOBAL:       File::NULL,
+      GIT_CONFIG_GLOBAL:       Utils::Git.no_global_config_file,
       GOENV:                   "off",
       GOPATH:                  "#{HOMEBREW_CACHE}/go_mod_cache",
       CARGO_HOME:              "#{HOMEBREW_CACHE}/cargo_cache",

--- a/Library/Homebrew/git_repository.rb
+++ b/Library/Homebrew/git_repository.rb
@@ -23,7 +23,7 @@ class GitRepository
   # Gets the URL of the Git origin remote.
   sig { returns(T.nilable(String)) }
   def origin_url
-    popen_git("config", "--get", "remote.origin.url")
+    popen_git("config", "--local", "--get", "remote.origin.url", no_global_config: true)
   end
 
   # Gets the full commit hash of the HEAD commit.
@@ -116,8 +116,11 @@ class GitRepository
 
   private
 
-  sig { params(args: T.untyped, safe: T::Boolean, err: T.nilable(Symbol)).returns(T.nilable(String)) }
-  def popen_git(*args, safe: false, err: nil)
+  sig {
+    params(args: T.untyped, safe: T::Boolean, err: T.nilable(Symbol), no_global_config: T::Boolean)
+      .returns(T.nilable(String))
+  }
+  def popen_git(*args, safe: false, err: nil, no_global_config: false)
     unless git_repository?
       return unless safe
 
@@ -130,6 +133,8 @@ class GitRepository
       raise "Git is unavailable"
     end
 
-    Utils.popen_read(Utils::Git.git, *args, safe:, chdir: pathname, err:).chomp.presence
+    command = [Utils::Git.git, *args]
+    command.unshift(Utils::Git.no_global_config_env) if no_global_config
+    Utils.popen_read(*command, safe:, chdir: pathname, err:).chomp.presence
   end
 end

--- a/Library/Homebrew/test/download_strategies/git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/git_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe GitDownloadStrategy do
         .with(
           "git",
           args:         ["--git-dir", cached_location/".git", "show", "-s", "--format=%cD"],
-          env:          { "GIT_CONFIG_GLOBAL" => File::NULL },
+          env:          Utils::Git.no_global_config_env,
           print_stderr: false,
         )
         .and_return(instance_double(SystemCommand::Result, stdout: "Fri, 12 Jun 2026 06:12:11 -0700"))

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1153,7 +1153,7 @@ RSpec.describe Formula do
     f.run_post_install
 
     expect(env).to include(
-      "GIT_CONFIG_GLOBAL"     => File::NULL,
+      "GIT_CONFIG_GLOBAL"     => Utils::Git.no_global_config_file,
       "GOENV"                 => "off",
       "NPM_CONFIG_USERCONFIG" => File::NULL,
       "PIP_CONFIG_FILE"       => File::NULL,
@@ -3121,7 +3121,7 @@ RSpec.describe Formula do
       home = mktmpdir
 
       expect(f.send(:common_sandbox_env, home)).to include(
-        GIT_CONFIG_GLOBAL:     File::NULL,
+        GIT_CONFIG_GLOBAL:     Utils::Git.no_global_config_file,
         GOENV:                 "off",
         NPM_CONFIG_USERCONFIG: File::NULL,
         PIP_CONFIG_FILE:       File::NULL,

--- a/Library/Homebrew/test/git_repository_spec.rb
+++ b/Library/Homebrew/test/git_repository_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe GitRepository do
     end
   end
 
+  it "reads the origin URL when the global Git config is unusable" do
+    global_config = repo_root/"global.gitconfig"
+    global_config.write("[broken\n")
+
+    with_env(GIT_CONFIG_GLOBAL: global_config.to_s) do
+      expect(git_repo.origin_url).to eq(remote_path.to_s)
+    end
+  end
+
   describe "when the origin has a branch and tag with the same name" do
     it "disambiguates branch_name, origin_branch_name, and default_origin_branch?" do
       expect(git_repo.branch_name).to eq(branch_name)

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -15,10 +15,21 @@ module Utils
       !version.null?
     end
 
+    sig { returns(T::Hash[String, String]) }
+    def self.no_global_config_env
+      { "GIT_CONFIG_GLOBAL" => no_global_config_file }
+    end
+
+    sig { returns(String) }
+    def self.no_global_config_file
+      File::NULL
+    end
+
     sig { returns(Version) }
     def self.version
       @version ||= T.let(begin
-        stdout, _, status = system_command(git, args: ["--version"], verbose: false, print_stderr: false).to_a
+        stdout, _, status = system_command(git, args: ["--version"], env: no_global_config_env,
+                                                verbose: false, print_stderr: false).to_a
         version_str = status.success? ? stdout.chomp[/git version (\d+(?:\.\d+)*)/, 1] : nil
         version_str.nil? ? Version::NULL : Version.new(version_str)
       end, T.nilable(Version))


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22719

- `build.rb` trust checks need tap remotes inside the sandbox.
- Global Git config reads can fail before local tap config is read.
- Shared Git helpers keep sandbox and fetch behaviour aligned.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local testing, tweaking and review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
