### PR TITLE
help: run an external command's own `--help` when undocumented

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -89,8 +89,15 @@ begin
   # - no arguments are passed
   if empty_argv || help_flag
     require "help"
+    # `Homebrew::Help.help` may defer to a self-documenting external command's own
+    # `--help` (e.g. `brew help <cmd>`). Pass `--help`, not the Homebrew help flag
+    # that triggered this (`-h`, `--usage`, `-?`), which the command may not know.
+    if external_cmd_path
+      ARGV.reject! { |arg| help_flag_list.include?(arg) }
+      ARGV.push("--help")
+    end
     Homebrew::Help.help cmd, remaining_args: args.remaining, empty_argv:
-    # `Homebrew::Help.help` never returns, except for unknown commands.
+    # `Homebrew::Help.help` never returns, except for unknown and deferred commands.
   end
 
   if cmd.nil?

--- a/Library/Homebrew/help.rb
+++ b/Library/Homebrew/help.rb
@@ -46,6 +46,15 @@ module Homebrew
       # Resume execution in `brew.rb` for unknown commands.
       return if path.nil?
 
+      # An external command with no `#:` comments documents itself by running its
+      # own `--help`, so resume execution in `brew.rb` to do that. Internal commands
+      # and Ruby commands (`*.rb`, which generate their own help) are excluded.
+      undocumented_external_cmd = !Commands.valid_internal_cmd?(cmd) &&
+                                  !Commands.valid_internal_dev_cmd?(cmd) &&
+                                  path.extname != ".rb" &&
+                                  command_help_lines(path).blank?
+      return if undocumented_external_cmd
+
       # Display help for internal command (or generic help if undocumented).
       puts command_help(cmd, path, remaining_args:, usage_error: false)
       exit 0

--- a/Library/Homebrew/test/cmd/help_spec.rb
+++ b/Library/Homebrew/test/cmd/help_spec.rb
@@ -144,6 +144,40 @@ RSpec.describe Homebrew::Cmd::HelpCmd, :integration_test do
       expect { brew "help", "hello-tap" }
         .not_to output(/^From tap:/).to_stdout
     end
+
+    it "runs an external command's own `--help` when it has no `#:` comments" do
+      tap_path = setup_test_tap
+      cmd_path = tap_path/"cmd/brew-selfdoc"
+      cmd_path.dirname.mkpath
+      cmd_path.write <<~SH
+        #!/bin/bash
+        [[ "$*" == *--help* ]] || { echo "expected --help, got: $*" >&2; exit 1; }
+        echo "Usage: brew selfdoc [options]"
+      SH
+      cmd_path.chmod(0755)
+
+      expect { brew "help", "selfdoc" }
+        .to output(/^Usage: brew selfdoc/).to_stdout
+        .and be_a_success
+    end
+
+    it "renders `#:` help for an external command rather than running it" do
+      tap_path = setup_test_tap
+      cmd_path = tap_path/"cmd/brew-commented"
+      cmd_path.dirname.mkpath
+      cmd_path.write <<~SH
+        #!/bin/bash
+        #:  * `commented`:
+        #:    Documented via comments.
+        echo "the command body should not have run" >&2
+        exit 1
+      SH
+      cmd_path.chmod(0755)
+
+      expect { brew "help", "commented" }
+        .to output(/Documented via comments\./).to_stdout
+        .and be_a_success
+    end
   end
 
   describe "cat" do


### PR DESCRIPTION
`brew <cmd> --help` and `brew help <cmd>` print the generic top-level `brew --help` page for an external command that ships no `#:` help comments — even when that command implements its own `--help`. That makes `--help` useless for those commands.

Fixes https://github.com/Homebrew/homebrew-brew-vulns/issues/85.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Opus 4.8 with manual testing and verification.

-----