### PR TITLE
Handle mksh in Utils::Shell.set_variable_in_profile

### DIFF
--- a/Library/Homebrew/test/utils/shell_spec.rb
+++ b/Library/Homebrew/test/utils/shell_spec.rb
@@ -107,6 +107,14 @@ RSpec.describe Utils::Shell do
     end
   end
 
+  describe "::set_variable_in_profile" do
+    it "supports mksh" do
+      ENV["SHELL"] = "/bin/mksh"
+      expect(described_class.set_variable_in_profile("HOMEBREW_FOO", "bar"))
+        .to eq("echo 'export HOMEBREW_FOO=bar' >> #{described_class.profile}")
+    end
+  end
+
   describe "::shell_with_prompt" do
     let(:home) { HOMEBREW_TEMP }
     let(:notice) { "" }

--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -79,7 +79,7 @@ module Utils
     sig { params(variable: String, value: String).returns(T.nilable(String)) }
     def set_variable_in_profile(variable, value)
       case preferred
-      when :bash, :ksh, :sh, :zsh, nil
+      when :bash, :ksh, :mksh, :sh, :zsh, nil
         "echo 'export #{variable}=#{sh_quote(value)}' >> #{profile}"
       when :pwsh
         "$env:#{variable}='#{value}' >> #{profile}"


### PR DESCRIPTION
mksh users were shown a blank line in place of the `echo 'export ...'`
instruction whenever `Utils::Shell.set_variable_in_profile` was used
(e.g. the `HOMEBREW_GITHUB_API_TOKEN` blurb shown by `brew gist-logs`
and on GitHub API errors, or the Linux `brew doctor` `HOMEBREW_TEMP`
suggestion).

`set_variable_in_profile` returned `nil` for `:mksh` because, unlike its
sibling methods `export_value` and `prepend_path_in_profile`, its `case`
omitted `:mksh`. The 2019 commit that taught brew about mksh (6e691320f8)
added it everywhere else but missed this method.

Added `:mksh` to the Bourne-compatible branch (mksh already maps to
`~/.kshrc`, identical to ksh) and added a test.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for asmooth review process. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

This PR was written with assistance from Claude Code (Claude Opus 4.8). I
reviewed all generated changes, verified the bug with a red/green test and by
reproducing the `nil` output under `SHELL=/bin/mksh`, and ran `brew lgtm`
locally (all green).

-----