### PR TITLE
Allow Bubblewrap auto-install

### DIFF
--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -28,13 +28,6 @@ module OS
         end
 
         sig { returns(T::Array[String]) }
-        def fatal_build_from_source_checks
-          (super + %w[
-            check_linux_sandbox
-          ]).freeze
-        end
-
-        sig { returns(T::Array[String]) }
         def supported_configuration_checks
           %w[
             check_glibc_minimum_version

--- a/Library/Homebrew/test/os/linux/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/linux/diagnostic_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Homebrew::Diagnostic::Checks do
   end
 
   specify "#fatal_build_from_source_checks" do
-    expect(checks.fatal_build_from_source_checks).to include("check_linux_sandbox")
+    expect(checks.fatal_build_from_source_checks).not_to include("check_linux_sandbox")
   end
 
   specify "#check_linux_sandbox returns nil when Linux sandboxing is disabled" do


### PR DESCRIPTION
- `check_linux_sandbox` blocked source builds before the implicit `bubblewrap` install path could run.
- Keeping it out of fatal checks lets source installs reach the sandbox setup path.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
