### PR TITLE
generate-zap: search app bundle identifiers

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-zap.rb
+++ b/Library/Homebrew/dev-cmd/generate-zap.rb
@@ -134,10 +134,7 @@ module Homebrew
 
       sig { params(patterns: T::Array[String]).returns(String) }
       def format_patterns(patterns)
-        quoted_patterns = patterns.map { |pattern| "\"#{pattern}\"" }
-        return quoted_patterns.fetch(0) if quoted_patterns.one?
-
-        "#{quoted_patterns.take(quoted_patterns.size - 1).join(", ")} and #{quoted_patterns.fetch(-1)}"
+        patterns.map { |pattern| "\"#{pattern}\"" }.to_sentence
       end
 
       sig { params(app_artifact: Cask::Artifact::App).returns(T::Array[String]) }

--- a/Library/Homebrew/dev-cmd/generate-zap.rb
+++ b/Library/Homebrew/dev-cmd/generate-zap.rb
@@ -96,14 +96,10 @@ module Homebrew
           resolve_patterns_from_cask(input)
         end
 
-        ohai "Scanning for files matching #{patterns.map { |pattern| "\"#{pattern}\"" }.to_sentence}..."
+        ohai "Scanning for files matching #{format_patterns(patterns)}..."
 
-        trash_paths = patterns.flat_map do |pattern|
-          scan_directories(USER_TRASH_PATHS, home_relative: true, pattern:) + scan_home_root(pattern)
-        end
-        delete_paths = patterns.flat_map do |pattern|
-          scan_directories(SYSTEM_DELETE_PATHS, home_relative: false, pattern:)
-        end
+        trash_paths = scan_directories(USER_TRASH_PATHS, home_relative: true, patterns:) + scan_home_root(patterns)
+        delete_paths = scan_directories(SYSTEM_DELETE_PATHS, home_relative: false, patterns:)
 
         trash_paths  = replace_uuids(collapse_to_wildcards(trash_paths))
         delete_paths = replace_uuids(collapse_to_wildcards(delete_paths))
@@ -111,7 +107,7 @@ module Homebrew
         rmdir_paths = derive_rmdir_candidates(trash_paths + delete_paths)
 
         if trash_paths.empty? && delete_paths.empty?
-          opoo "No files found matching #{patterns.map { |pattern| "\"#{pattern}\"" }.to_sentence}."
+          opoo "No files found matching #{format_patterns(patterns)}."
           puts "# No zap stanza required"
           return
         end
@@ -136,6 +132,14 @@ module Homebrew
         end
       end
 
+      sig { params(patterns: T::Array[String]).returns(String) }
+      def format_patterns(patterns)
+        quoted_patterns = patterns.map { |pattern| "\"#{pattern}\"" }
+        return quoted_patterns.fetch(0) if quoted_patterns.one?
+
+        "#{quoted_patterns.take(quoted_patterns.size - 1).join(", ")} and #{quoted_patterns.fetch(-1)}"
+      end
+
       sig { params(app_artifact: Cask::Artifact::App).returns(T::Array[String]) }
       def bundle_identifiers(app_artifact)
         info_plist = app_artifact.target/"Contents/Info.plist"
@@ -152,11 +156,12 @@ module Homebrew
         params(
           directories:   T::Array[String],
           home_relative: T::Boolean,
-          pattern:       String,
+          patterns:      T::Array[String],
         ).returns(T::Array[String])
       }
-      def scan_directories(directories, home_relative:, pattern:)
+      def scan_directories(directories, home_relative:, patterns:)
         home = Dir.home
+        downcased_patterns = patterns.map(&:downcase)
         matches = []
 
         directories.each do |dir|
@@ -164,7 +169,8 @@ module Homebrew
           next unless File.directory?(full_dir)
 
           Dir.each_child(full_dir) do |entry|
-            next unless entry.downcase.include?(pattern.downcase)
+            downcased_entry = entry.downcase
+            next unless downcased_patterns.any? { |pattern| downcased_entry.include?(pattern) }
 
             full_path = File.join(full_dir, entry)
             matches << normalize_path(full_path)
@@ -174,14 +180,17 @@ module Homebrew
         matches.uniq.sort
       end
 
-      sig { params(pattern: String).returns(T::Array[String]) }
-      def scan_home_root(pattern)
+      sig { params(patterns: T::Array[String]).returns(T::Array[String]) }
+      def scan_home_root(patterns)
         home = Dir.home
+        downcased_patterns = patterns.map(&:downcase)
         matches = []
 
         Dir.each_child(home) do |entry|
           next unless entry.start_with?(".")
-          next unless entry.downcase.include?(pattern.downcase)
+
+          downcased_entry = entry.downcase
+          next unless downcased_patterns.any? { |pattern| downcased_entry.include?(pattern) }
 
           matches << normalize_path(File.join(home, entry))
         end

--- a/Library/Homebrew/dev-cmd/generate-zap.rb
+++ b/Library/Homebrew/dev-cmd/generate-zap.rb
@@ -3,10 +3,13 @@
 
 require "abstract_command"
 require "cask/cask_loader"
+require "system_command"
 
 module Homebrew
   module DevCmd
     class GenerateZap < AbstractCommand
+      include SystemCommand::Mixin
+
       cmd_args do
         description <<~EOS
           Generate a `zap` stanza for a cask by scanning the system for associated
@@ -87,17 +90,20 @@ module Homebrew
       def run
         input = args.named.fetch(0)
 
-        app_name = if args.name?
-          input
+        patterns = if args.name?
+          [input]
         else
-          resolve_app_name_from_cask(input)
+          resolve_patterns_from_cask(input)
         end
 
-        ohai "Scanning for files matching \"#{app_name}\"..."
+        ohai "Scanning for files matching #{patterns.map { |pattern| "\"#{pattern}\"" }.to_sentence}..."
 
-        trash_paths  = scan_directories(USER_TRASH_PATHS, home_relative: true, pattern: app_name)
-        trash_paths += scan_home_root(app_name)
-        delete_paths = scan_directories(SYSTEM_DELETE_PATHS, home_relative: false, pattern: app_name)
+        trash_paths = patterns.flat_map do |pattern|
+          scan_directories(USER_TRASH_PATHS, home_relative: true, pattern:) + scan_home_root(pattern)
+        end
+        delete_paths = patterns.flat_map do |pattern|
+          scan_directories(SYSTEM_DELETE_PATHS, home_relative: false, pattern:)
+        end
 
         trash_paths  = replace_uuids(collapse_to_wildcards(trash_paths))
         delete_paths = replace_uuids(collapse_to_wildcards(delete_paths))
@@ -105,7 +111,7 @@ module Homebrew
         rmdir_paths = derive_rmdir_candidates(trash_paths + delete_paths)
 
         if trash_paths.empty? && delete_paths.empty?
-          opoo "No files found matching \"#{app_name}\"."
+          opoo "No files found matching #{patterns.map { |pattern| "\"#{pattern}\"" }.to_sentence}."
           puts "# No zap stanza required"
           return
         end
@@ -115,17 +121,31 @@ module Homebrew
 
       private
 
-      sig { params(token: String).returns(String) }
-      def resolve_app_name_from_cask(token)
+      sig { params(token: String).returns(T::Array[String]) }
+      def resolve_patterns_from_cask(token)
         cask = Cask::CaskLoader.load(token)
 
         app_artifact = cask.artifacts.find { |a| a.is_a?(Cask::Artifact::App) }
         if app_artifact
-          app_artifact.target.basename(".app").to_s
+          patterns = [app_artifact.target.basename(".app").to_s]
+          patterns.concat(bundle_identifiers(app_artifact))
+          patterns.uniq
         else
           ohai "No app artifact found in cask \"#{token}\"; using token as app name."
-          token.tr("-", " ").split.map(&:capitalize).join(" ")
+          [token.tr("-", " ").split.map(&:capitalize).join(" ")]
         end
+      end
+
+      sig { params(app_artifact: Cask::Artifact::App).returns(T::Array[String]) }
+      def bundle_identifiers(app_artifact)
+        info_plist = app_artifact.target/"Contents/Info.plist"
+        return [] if !info_plist.exist? || !info_plist.readable?
+
+        plist = system_command!("plutil", args: ["-convert", "xml1", "-o", "-", info_plist]).plist
+        bundle_identifier = plist["CFBundleIdentifier"]
+        return [] unless bundle_identifier.is_a?(String)
+
+        [bundle_identifier]
       end
 
       sig {

--- a/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
         allow(Dir).to receive(:home).and_return(tmpdir)
 
         results = generate_zap.send(:scan_directories, ["Library/Preferences"],
-                                    home_relative: true, pattern: "foo")
+                                    home_relative: true, patterns: ["foo"])
 
         expect(results.size).to eq(1)
         expect(results.first).to include("com.example.Foo.plist")
@@ -69,8 +69,23 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
 
     it "returns empty array when directory does not exist" do
       results = generate_zap.send(:scan_directories, ["nonexistent/path"],
-                                  home_relative: true, pattern: "test")
+                                  home_relative: true, patterns: ["test"])
       expect(results).to be_empty
+    end
+
+    it "finds entries matching any pattern with one directory scan" do
+      Dir.mktmpdir do |tmpdir|
+        FileUtils.mkdir_p("#{tmpdir}/Library/Preferences")
+        FileUtils.touch("#{tmpdir}/Library/Preferences/com.example.foo.plist")
+        FileUtils.touch("#{tmpdir}/Library/Preferences/com.example.bar.plist")
+
+        allow(Dir).to receive(:home).and_return(tmpdir)
+
+        results = generate_zap.send(:scan_directories, ["Library/Preferences"],
+                                    home_relative: true, patterns: ["foo", "bar"])
+
+        expect(results.size).to eq(2)
+      end
     end
   end
 
@@ -83,10 +98,46 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
 
         allow(Dir).to receive(:home).and_return(tmpdir)
 
-        results = generate_zap.send(:scan_home_root, "foo")
+        results = generate_zap.send(:scan_home_root, ["foo"])
 
         expect(results.size).to eq(1)
         expect(results.first).to include(".foo")
+      end
+    end
+  end
+
+  describe "#bundle_identifiers" do
+    it "returns empty array when Info.plist is missing" do
+      app = instance_double(Cask::Artifact::App, target: Pathname.new("TestCask.app"))
+
+      expect(generate_zap.send(:bundle_identifiers, app)).to eq([])
+    end
+
+    it "returns empty array when Info.plist is unreadable" do
+      info_plist = instance_double(Pathname, exist?: true, readable?: false)
+      app_path = instance_double(Pathname)
+      app = instance_double(Cask::Artifact::App, target: app_path)
+
+      allow(app_path).to receive(:/).with("Contents/Info.plist").and_return(info_plist)
+
+      expect(generate_zap.send(:bundle_identifiers, app)).to eq([])
+    end
+
+    it "returns empty array when CFBundleIdentifier is not a string" do
+      Dir.mktmpdir do |tmpdir|
+        app_path = Pathname.new("#{tmpdir}/TestCask.app")
+        info_plist = app_path/"Contents/Info.plist"
+        info_plist.dirname.mkpath
+        info_plist.write("")
+
+        app = instance_double(Cask::Artifact::App, target: app_path)
+        result = instance_double(SystemCommand::Result, plist: { "CFBundleIdentifier" => [] })
+
+        allow(generate_zap).to receive(:system_command!)
+          .with("plutil", args: ["-convert", "xml1", "-o", "-", info_plist])
+          .and_return(result)
+
+        expect(generate_zap.send(:bundle_identifiers, app)).to eq([])
       end
     end
   end

--- a/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
@@ -9,14 +9,36 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
 
   it_behaves_like "parseable arguments"
 
-  describe "#resolve_app_name_from_cask" do
+  describe "#resolve_patterns_from_cask" do
     it "resolves app name from a cask with an app artifact" do
       app = instance_double(Cask::Artifact::App, target: Pathname.new("TestCask.app"))
       allow(app).to receive(:is_a?).with(Cask::Artifact::App).and_return(true)
       cask = instance_double(Cask::Cask, artifacts: [app])
       allow(Cask::CaskLoader).to receive(:load).with("test-cask").and_return(cask)
 
-      expect(generate_zap.send(:resolve_app_name_from_cask, "test-cask")).to eq("TestCask")
+      expect(generate_zap.send(:resolve_patterns_from_cask, "test-cask")).to eq(["TestCask"])
+    end
+
+    it "resolves bundle identifier from an installed app artifact" do
+      Dir.mktmpdir do |tmpdir|
+        app_path = Pathname.new("#{tmpdir}/TestCask.app")
+        info_plist = app_path/"Contents/Info.plist"
+        info_plist.dirname.mkpath
+        info_plist.write("")
+
+        app = instance_double(Cask::Artifact::App, target: app_path)
+        result = instance_double(SystemCommand::Result, plist: { "CFBundleIdentifier" => "com.example.testcask" })
+        cask = instance_double(Cask::Cask, artifacts: [app])
+
+        allow(app).to receive(:is_a?).with(Cask::Artifact::App).and_return(true)
+        allow(Cask::CaskLoader).to receive(:load).with("test-cask").and_return(cask)
+        allow(generate_zap).to receive(:system_command!)
+          .with("plutil", args: ["-convert", "xml1", "-o", "-", info_plist])
+          .and_return(result)
+
+        expect(generate_zap.send(:resolve_patterns_from_cask, "test-cask"))
+          .to eq(["TestCask", "com.example.testcask"])
+      end
     end
 
     it "falls back to title-cased token when no app artifact exists" do
@@ -24,7 +46,7 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
 
       allow(Cask::CaskLoader).to receive(:load).with("test-cask").and_return(cask)
 
-      expect(generate_zap.send(:resolve_app_name_from_cask, "test-cask")).to eq("Test Cask")
+      expect(generate_zap.send(:resolve_patterns_from_cask, "test-cask")).to eq(["Test Cask"])
     end
   end
 


### PR DESCRIPTION
-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

I used GitHub Copilot CLI to help investigate the issue, edit the implementation and tests, and draft this PR. I verified the change locally with `brew lgtm --online`.

-----

`brew generate-zap` currently scans for files matching the app artifact name. Some apps store their support files under the app bundle identifier instead. For example, GitHub Copilot installs `GitHub Copilot.app`, but its support files use `com.github.githubapp`, so a display-name-only scan misses them and reports that no zap stanza is needed.

This changes `generate-zap` to scan both the app artifact name and the installed app's `CFBundleIdentifier` when an installed `Info.plist` is available. The command still falls back to the existing app-name behavior when the bundle identifier cannot be read.

A new test covers extracting the bundle identifier from an installed app artifact.
