### PR TITLE
Remove dead Formula methods and annotate public DSL

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -519,12 +519,6 @@ class Formula
     full_alias_name || full_name
   end
 
-  # The name specified to install this formula.
-  sig { returns(String) }
-  def installed_specified_name
-    installed_alias_name || name
-  end
-
   # The name (including tap) specified to install this formula.
   sig { returns(String) }
   def full_installed_specified_name
@@ -748,16 +742,6 @@ class Formula
     end
 
     formula_names_for_glob("#{sibling_name}.rb")
-  end
-
-  # Returns sibling `-full` or non-`-full` Formula objects for any Formula.
-  sig { returns(T::Array[Formula]) }
-  def full_formulae
-    full_formulae_names.filter_map do |formula_name|
-      Formula[formula_name]
-    rescue FormulaUnavailableError
-      nil
-    end.sort_by(&:version).reverse
   end
 
   sig { returns(T.nilable(String)) }
@@ -1069,14 +1053,6 @@ class Formula
   # Is the formula linked to `opt`?
   sig { returns(T::Boolean) }
   def optlinked? = opt_prefix.symlink?
-
-  # If a formula's linked keg points to the prefix.
-  sig { params(version: T.any(String, PkgVersion)).returns(T::Boolean) }
-  def prefix_linked?(version = pkg_version)
-    return false unless linked?
-
-    linked_keg.resolved_path == versioned_prefix(version)
-  end
 
   # {PkgVersion} of the linked keg for the formula.
   sig { returns(T.nilable(PkgVersion)) }
@@ -2624,12 +2600,6 @@ class Formula
     installed.select { |f| f.installed_alias_path == alias_path }
   end
 
-  # An array of all alias files of core {Formula}e.
-  sig { returns(T::Array[Pathname]) }
-  def self.core_alias_files
-    CoreTap.instance.alias_files
-  end
-
   # An array of all core aliases.
   sig { returns(T::Array[String]) }
   def self.core_aliases
@@ -3244,25 +3214,6 @@ class Formula
     hash
   end
 
-  sig { params(spec_symbol: Symbol).returns(T.nilable(T::Hash[String, T.untyped])) }
-  def internal_dependencies_hash(spec_symbol)
-    raise ArgumentError, "Unsupported spec: #{spec_symbol}" unless [:stable, :head].include?(spec_symbol)
-    return unless (spec = public_send(spec_symbol))
-
-    spec.declared_deps.each_with_object({}) do |dep, dep_hash|
-      # Implicit dependencies are only needed when installing from source
-      # since they are only used to download and unpack source files.
-      # @see DependencyCollector
-      next if dep.implicit?
-
-      metadata_hash = {}
-      metadata_hash[:tags] = dep.tags if dep.tags.present?
-      metadata_hash[:uses_from_macos] = dep.bounds.presence if dep.uses_from_macos?
-
-      dep_hash[dep.name] = metadata_hash.presence
-    end
-  end
-
   sig { returns(T.nilable(T::Boolean)) }
   def on_system_blocks_exist?
     self.class.on_system_blocks_exist? || @on_system_blocks_exist
@@ -3330,6 +3281,9 @@ class Formula
   }
   def test; end
 
+  # Returns the path to a fixture file for use in formula tests.
+  #
+  # @api public
   sig { params(file: T.any(Pathname, String)).returns(Pathname) }
   def test_fixtures(file)
     HOMEBREW_LIBRARY_PATH/"test/support/fixtures"/file
@@ -3662,6 +3616,8 @@ class Formula
   end
 
   # Runs `xcodebuild` without Homebrew's compiler environment variables set.
+  #
+  # @api public
   sig { params(args: T.any(String, Integer, Pathname, Symbol)).void }
   def xcodebuild(*args)
     removed = ENV.remove_cc_etc
@@ -3967,6 +3923,8 @@ class Formula
     # ```ruby
     # allow_network_access! [:build, :test]
     # ```
+    #
+    # @api public
     sig { params(phases: T.any(Symbol, T::Array[Symbol])).void }
     def allow_network_access!(phases = [])
       phases_array = Array(phases)
@@ -3999,6 +3957,8 @@ class Formula
     # ```ruby
     # deny_network_access! [:build, :test]
     # ```
+    #
+    # @api public
     sig { params(phases: T.any(Symbol, T::Array[Symbol])).void }
     def deny_network_access!(phases = [])
       phases_array = Array(phases)
@@ -4372,6 +4332,8 @@ class Formula
     # # Special case: empty `package_name` allows to skip resource updates for non-extra packages
     # pypi_packages package_name: "", extra_packages: "setuptools"
     # ```
+    #
+    # @api public
     sig {
       params(
         package_name:     T.nilable(String),

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -261,34 +261,6 @@ RSpec.describe Formula do
     end
   end
 
-  describe "#full_formulae" do
-    let(:f) do
-      formula "foo" do
-        T.bind(self, T.class_of(Formula))
-        url "foo-1.0"
-      end
-    end
-
-    let(:f_full) do
-      formula "foo-full" do
-        T.bind(self, T.class_of(Formula))
-        url "foo-full-1.0"
-      end
-    end
-
-    before do
-      allow(Formulary).to receive(:load_formula_from_path).with(f_full.name, f_full.path).and_return(f_full)
-      allow(Formulary).to receive(:factory).with(f_full.name).and_return(f_full)
-      allow(f).to receive(:full_formulae_names).and_return([f_full.name])
-    end
-
-    it "returns array with sibling full formulae" do
-      FileUtils.touch f.path
-      FileUtils.touch f_full.path
-      expect(f.full_formulae).to eq [f_full]
-    end
-  end
-
   describe "#unversioned_formula_name" do
     let(:f) do
       formula "foo" do
@@ -565,7 +537,6 @@ RSpec.describe Formula do
       expect(f.installed_alias_path).to be_nil
       expect(f.installed_alias_name).to be_nil
       expect(f.full_installed_alias_name).to be_nil
-      expect(f.installed_specified_name).to eq(f.name)
       expect(f.full_installed_specified_name).to eq(f.name)
     end
 
@@ -579,7 +550,6 @@ RSpec.describe Formula do
     expect(f.installed_alias_path).to eq(alias_path)
     expect(f.installed_alias_name).to eq(alias_name)
     expect(f.full_installed_alias_name).to eq(alias_name)
-    expect(f.installed_specified_name).to eq(alias_name)
     expect(f.full_installed_specified_name).to eq(alias_name)
   end
 
@@ -601,7 +571,6 @@ RSpec.describe Formula do
       expect(f.installed_alias_path).to be_nil
       expect(f.installed_alias_name).to be_nil
       expect(f.full_installed_alias_name).to be_nil
-      expect(f.installed_specified_name).to eq(f.name)
       expect(f.full_installed_specified_name).to eq(f.full_name)
     end
 
@@ -616,7 +585,6 @@ RSpec.describe Formula do
     expect(f.installed_alias_path).to eq(alias_path)
     expect(f.installed_alias_name).to eq(alias_name)
     expect(f.full_installed_alias_name).to eq(full_alias_name)
-    expect(f.installed_specified_name).to eq(alias_name)
     expect(f.full_installed_specified_name).to eq(full_alias_name)
 
     FileUtils.rm_rf HOMEBREW_LIBRARY/"Taps/user"


### PR DESCRIPTION
This is an **extraction** from an experimental branch where I'm trialling a custom `brew deadcode` command (backed by [Spoom](https://github.com/Shopify/spoom)) that removes dead code while respecting `@api` annotations, `override` signatures and dynamic-dispatch markers. This PR is the `Library/Homebrew/formula.rb` slice of that work, split out so it can be reviewed on its own.

### What this does

**Removes `Formula` methods with no callers** in Homebrew or the taps (homebrew-core/homebrew-cask), plus their now-dead specs:

| method | homebrew-core | brew (non-test) | notes |
|---|---|---|---|
| `installed_specified_name` | 0 | 0 | test-only |
| `full_formulae` | 0 | 0 | test-only (`full_formulae_names` is kept and still used) |
| `prefix_linked?` | 0 | 0 | no references anywhere |
| `core_alias_files` | 0 | 0 | no references anywhere |
| `internal_dependencies_hash` | 0 | 0 | no references anywhere |

A global GitHub search confirmed none of these are used in any third-party tap either.

`specified_name` was initially in this list, but a global search found it's used in third-party taps (e.g. [homebrew-gimp](https://github.com/edegp/homebrew-gimp/blob/HEAD/Formula/resynthesizer.rb) caveats), so it's **kept**. It's left unannotated, i.e. private by default.

**Annotates the formula DSL methods the official taps rely on but which lacked an `@api` tag** as `@api public`:

| method | homebrew-core call sites |
|---|---|
| `pypi_packages` | 377 |
| `test_fixtures` | 263 |
| `deny_network_access!` | 58 |
| `xcodebuild` | 46 (+5 in brew) |
| `allow_network_access!` | 0 |

`allow_network_access!` is unused in the taps today, but per review feedback it's **kept** (to allow flipping the default one day) and annotated `@api public` to match `deny_network_access!`.

### How the `@api` designations were decided

`formula.rb` is one of `ApiAnnotationHelper::API_SOURCE_FILES`, so `@api` tags here are enforced against formulae by `FormulaAudit/NonPublicApiUsage`: that cop flags **implicit-receiver** calls (`foo` not `x.foo`) to `@api internal`/`@api private` methods in official-tap formulae.

All of the annotated methods are author-facing DSL called bare in formula bodies (e.g. `pypi_packages package_name: "…"`, `deny_network_access! :build`, `test_fixtures "x"`, `xcodebuild "-arch", …`). Marking any of them `@api internal` would make `brew audit` reject the formulae that use them, so they are all `@api public`. (None of the methods in this file qualify for `@api internal`: that level is for APIs invoked with an explicit receiver, e.g. `MacOSVersion.kernel_major_version`, or used only inside Homebrew, none of which are in this extraction.)

Counts above are from `grep` over `Library/Taps/homebrew/homebrew-core/Formula`, the homebrew-cask casks, and `git grep` over `Library/Homebrew` (excluding `test/`).

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI (Claude Code) assisted with this PR: it ran the dead-code analysis, made the edits, and computed the usage counts. I reviewed every removal and annotation, confirmed the call-site counts against homebrew-core and homebrew-cask plus a global GitHub search, verified the `@api` reasoning against `FormulaAudit/NonPublicApiUsage`, and ran `brew typecheck`, `brew style` and the `formula` specs locally.
