### PR TITLE
formula: add Zig CPU to `std_zig_args`

### DIFF
--- a/Library/Homebrew/extend/os/mac/formula.rb
+++ b/Library/Homebrew/extend/os/mac/formula.rb
@@ -33,9 +33,10 @@ module OS
         params(
           prefix:       T.any(String, ::Pathname),
           release_mode: Symbol,
+          cpu:          T.nilable(Symbol),
         ).returns(T::Array[String])
       }
-      def std_zig_args(prefix: self.prefix, release_mode: :fast)
+      def std_zig_args(prefix: self.prefix, release_mode: :fast, cpu: nil)
         args = super
         args << "-fno-rosetta" if ::Hardware::CPU.arm?
         args

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2234,19 +2234,24 @@ class Formula
   #
   # @api public
   sig {
-    params(prefix:       T.any(String, Pathname),
-           release_mode: Symbol).returns(T::Array[String])
+    params(
+      prefix:       T.any(String, Pathname),
+      release_mode: Symbol,
+      cpu:          T.nilable(Symbol),
+    ).returns(T::Array[String])
   }
-  def std_zig_args(prefix: self.prefix, release_mode: :fast)
+  def std_zig_args(prefix: self.prefix, release_mode: :fast, cpu: nil)
     raise ArgumentError, "Invalid Zig release mode: #{release_mode}" if [:safe, :fast, :small].exclude?(release_mode)
 
+    cpu ||= Hardware.zig_cpu(ENV.effective_arch)
     release_mode_downcased = release_mode.to_s.downcase
     release_mode_capitalized = release_mode.to_s.capitalize
     [
       "--prefix", prefix.to_s,
       "--release=#{release_mode_downcased}",
       "-Doptimize=Release#{release_mode_capitalized}",
-      "--summary", "all"
+      "--summary", "all",
+      "-Dcpu=#{cpu}"
     ]
   end
 

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -268,6 +268,22 @@ module Hardware
 
       "--codegen target-cpu=#{@target_cpu}"
     end
+
+    # Returns the closest Zig target CPU for the requested brew-supported
+    # architecture symbol. See `zig targets` for available CPUs.
+    #
+    # @see https://github.com/Homebrew/homebrew-core/issues/92282
+    sig { params(arch: Symbol).returns(Symbol) }
+    def zig_cpu(arch)
+      case arch
+      when :arm_vortex_tempest then :apple_m1
+      when :armv6 then :arm1136j_s
+      when :armv8 then :xgene1
+      when :core  then :prescott
+      when :dunno then :baseline
+      else arch.to_s.tr("-", "_").to_sym
+      end
+    end
   end
 end
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -3114,6 +3114,27 @@ RSpec.describe Formula do
     end
   end
 
+  describe "#std_zig_args" do
+    let(:f) do
+      formula do
+        url "foo-1.0"
+      end
+    end
+
+    it "raises an error when provided an unknown release mode" do
+      expect { f.std_zig_args(release_mode: :test) }.to raise_error(ArgumentError)
+    end
+
+    it "includes equivalent Zig CPU for known target arch" do
+      allow(ENV).to receive(:effective_arch).and_return(:arm_vortex_tempest)
+      expect(f.std_zig_args).to include("-Dcpu=apple_m1")
+    end
+
+    it "allows overriding Zig CPU" do
+      expect(f.std_zig_args(cpu: :generic)).to include("-Dcpu=generic")
+    end
+  end
+
   describe "#common_sandbox_env" do
     let(:f) do
       formula do

--- a/Library/Homebrew/test/hardware_spec.rb
+++ b/Library/Homebrew/test/hardware_spec.rb
@@ -1,0 +1,24 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "hardware"
+
+RSpec.describe Hardware do
+  describe ".zig_cpu" do
+    it "returns a specific Zig target CPU for known archs" do
+      Hardware::CPU.optimization_flags.each_key do |arch|
+        next if arch == :dunno
+
+        expect(described_class.zig_cpu(arch)).not_to be :baseline
+      end
+    end
+
+    it "returns baseline Zig target CPU for unknown arch" do
+      expect(described_class.zig_cpu(:dunno)).to be :baseline
+    end
+
+    it "converts GCC -march with dashes to Zig-equivalent target CPU" do
+      expect(described_class.zig_cpu(:"x86-64-v4")).to be :x86_64_v4
+    end
+  end
+end

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -578,6 +578,7 @@ prefix
 "-Doptimize=Release#{release_mode}"
 "--summary"
 "all"
+"-Dcpu=#{Hardware.zig_cpu(ENV.effective_arch)}"
 ```
 
 `release_mode` is a symbol that accepts only `:fast`, `:safe`, and `:small` values (with `:fast` being default).


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Moves duplicate CPU handling in Homebrew/core formulae to brew, e.g.
- https://github.com/Homebrew/homebrew-core/blob/67be52c1fea271b9609e802bbaf54ca05fe08e42/Formula/n/ncdu.rb#L30-L40

This does impact usage of `std_zig_args` as Zig doesn't allow duplicate arg so any formula already passing `-Dcpu=` will need to remove it after this is merged. We could defer impact to a minor release if necessary. From general glance, I didn't see external tap usage of `-Dcpu=`.

A couple differences from previous formula-specific handling:
1. Align all builds to effective arch. Previously we left argument out of Zig build, but this doesn't align to how our superenv handles other languages, e.g. RUSTFLAGS and `-march=` (we always pass `-march=westmere` on Intel macOS for both `--build-from-source` and `--build-bottle`)
2. Provide valid target CPU for defined `armv6` and `core` 
3. Make sure to translate all `-` to `_`. This mainly impacts usage of `--build-bottle --bottle-arch=x86-64-v4` as GCC/Clang uses `-march=x86-64-v4` while Zig uses `-Dcpu=x86_64_v4` (similarly `-mcpu=apple-m4` would be `-Dcpu=apple_m4`)

Also provide an override if we need to cross-compile or a formula is incompatible with targets.