### PR TITLE
untap: continue processing remaining taps on failure

### DIFF
--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -26,7 +26,10 @@ module Homebrew
         end
 
         taps.each do |tap|
-          odie "Untapping #{tap} is not allowed" if tap.core_tap? && Homebrew::EnvConfig.no_install_from_api?
+          if tap.core_tap? && Homebrew::EnvConfig.no_install_from_api?
+            ofail "Untapping #{tap} is not allowed"
+            next
+          end
 
           if Homebrew::EnvConfig.no_install_from_api? || (!tap.core_tap? && !tap.core_cask_tap?)
             installed_tap_formulae = installed_formulae_for(tap:)
@@ -40,10 +43,11 @@ module Homebrew
                   #{installed_names}
                 EOS
               else
-                odie <<~EOS
+                ofail <<~EOS
                   Refusing to untap #{tap} because it contains the following installed formulae or casks:
                   #{installed_names}
                 EOS
+                next
               end
             end
           end

--- a/Library/Homebrew/test/cmd/untap_spec.rb
+++ b/Library/Homebrew/test/cmd/untap_spec.rb
@@ -24,6 +24,27 @@ RSpec.describe Homebrew::Cmd::Untap do
       .and raise_error(SystemExit)
   end
 
+  it "continues untapping remaining taps when one has installed formulae" do
+    tap1 = Tap.fetch("homebrew", "foo")
+    tap2 = Tap.fetch("homebrew", "bar")
+
+    cmd = described_class.new(["homebrew/foo", "homebrew/bar"])
+    allow(cmd.args.named).to receive(:to_installed_taps).and_return([tap1, tap2])
+
+    allow(cmd).to receive(:installed_formulae_for).with(tap: tap1).and_return(["homebrew/foo/testball"])
+    allow(cmd).to receive(:installed_formulae_for).with(tap: tap2).and_return([])
+    allow(cmd).to receive(:installed_casks_for).with(tap: tap1).and_return([])
+    allow(cmd).to receive(:installed_casks_for).with(tap: tap2).and_return([])
+
+    expect(tap1).not_to receive(:uninstall)
+    expect(tap2).to receive(:uninstall).with(manual: true)
+
+    expect { cmd.run }.to output(/Refusing to untap/).to_stderr
+    expect(Homebrew).to have_failed
+  ensure
+    Homebrew.failed = false
+  end
+
   describe "#installed_formulae_for" do
     shared_examples "finds installed formulae in tap", :no_api do
       def load_formula(name:, with_formula_file: false, mock_install: false)


### PR DESCRIPTION
-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

AI (opencode) assisted with implementing the code changes and writing the test. I reviewed every edit, ran `brew lgtm` locally, and verified all checks pass.

-----

## Summary

`brew untap x y` was exiting on the first failure (`odie` calls `exit 1`), so remaining taps were never processed. This replaces the two `odie` calls inside the `taps.each` loop with `ofail` + `next`, matching the collect-errors-and-continue pattern already used by `brew uninstall`, `brew reinstall`, and `brew install`.

The two cases changed:

1. **Core tap with `no_install_from_api`** — now reports the error and skips to the next tap instead of exiting immediately.
2. **Installed formulae/casks without `--force`** — same: reports and skips instead of exiting.

Added a unit test verifying that when one tap has installed formulae (causing a failure), the second tap is still untapped and `Homebrew.failed` is set.