### PR TITLE
Source utils.sh in items.sh for opoo

### DIFF
--- a/Library/Homebrew/items.sh
+++ b/Library/Homebrew/items.sh
@@ -1,3 +1,9 @@
+# `opoo` is defined in utils.sh, which the early `formulae`/`casks` dispatch in
+# brew.sh runs before sourcing, so source it here for these commands.
+# HOMEBREW_LIBRARY is set by bin/brew
+# shellcheck disable=SC2154
+source "${HOMEBREW_LIBRARY}/Homebrew/utils.sh"
+
 homebrew-items() {
   local items
   local find_include_filter="$1"


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22740

- the early `formulae`/`casks` dispatch in `brew.sh` exits before `utils.sh` is sourced, so `opoo` was undefined when warning about untrusted taps, printing `opoo: command not found`
- source `utils.sh` from the shared `items.sh` to define `opoo` for the untrusted-tap and jq-fallback warnings in both commands

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Opus 4.8 high with local review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
