### PR TITLE
Allow tap trust in build sandbox

### DIFF
--- a/Library/Homebrew/extend/os/linux/sandbox.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox.rb
@@ -236,7 +236,7 @@ module OS
           ohai "Configuring Bubblewrap..."
           command = [HOMEBREW_BREW_FILE, "setup-sandbox"]
           command.unshift("sudo") unless Process.euid.zero?
-          raise ErrorDuringExecution.new(command, status: $CHILD_STATUS) unless system(*command)
+          raise ErrorDuringExecution.new(command, status: $CHILD_STATUS || 1) unless system(*command)
 
           reset_state!
         end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1142,6 +1142,10 @@ on_request: installed_on_request?, options:)
     if Sandbox.available?
       sandbox = Sandbox.new
       sandbox.allow_read_if_exists path: formula_path
+      if Homebrew::EnvConfig.require_tap_trust?
+        require "trust"
+        sandbox.allow_read_if_exists path: Homebrew::Trust.trust_file
+      end
       formula.logs.mkpath
       sandbox.record_log(formula.logs/"build.sandbox.log")
       if interactive?

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -6,6 +6,7 @@ require "formula_installer"
 require "keg"
 require "sandbox"
 require "tab"
+require "trust"
 require "cmd/install"
 require "test/support/fixtures/testball"
 require "test/support/fixtures/testball_bottle"
@@ -1119,7 +1120,7 @@ RSpec.describe FormulaInstaller do
       end.to raise_error(CannotInstallFormulaError, /source code not found/)
     end
 
-    it "exposes local formula paths to the sandbox" do
+    it "exposes local formula and trust paths to the sandbox" do
       formula_path = mktmpdir/"homebrew-local-formula.rb"
       FileUtils.touch formula_path
       formula = formula("homebrew-local-formula", path: formula_path) do
@@ -1140,9 +1141,12 @@ RSpec.describe FormulaInstaller do
                                          network_access_allowed?: true)
       allow(Keg).to receive(:new).and_return(instance_double(Keg, empty_installation?: false))
 
-      expect(sandbox).to receive(:allow_read_if_exists).with(path: formula_path)
+      expect(sandbox).to receive(:allow_read_if_exists).with(path: formula_path).ordered
+      expect(sandbox).to receive(:allow_read_if_exists).with(path: Homebrew::Trust.trust_file).ordered
 
-      installer.build
+      with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+        installer.build
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22748

- Keep `trust.json` readable during sandboxed formula builds.
- Avoid trusted tapped formulae failing when `build.rb` reloads them.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
