### PR TITLE
Preserve tap remotes in bundle dumps

### DIFF
--- a/Library/Homebrew/bundle/tap.rb
+++ b/Library/Homebrew/bundle/tap.rb
@@ -85,7 +85,7 @@ module Homebrew
         sig { override.returns(String) }
         def dump
           taps.map do |tap|
-            remote = if tap.custom_remote? && (tap_remote = tap.remote)
+            remote = if (tap_remote = tap.remote) && tap_remote != tap.default_remote
               if (api_token = ENV.fetch("HOMEBREW_GITHUB_API_TOKEN", false).presence)
                 # Replace the API token in the remote URL with interpolation.
                 # Keep the interpolation unevaluated until the Brewfile is evaluated.

--- a/Library/Homebrew/test/bundle/tap_spec.rb
+++ b/Library/Homebrew/test/bundle/tap_spec.rb
@@ -26,14 +26,16 @@ RSpec.describe Homebrew::Bundle::Tap do
         described_class.reset!
 
         bar = instance_double(Tap, name: "bitbucket/bar", custom_remote?: true,
-                              remote: "https://bitbucket.org/bitbucket/bar.git")
+                              remote: "https://bitbucket.org/bitbucket/bar.git",
+                              default_remote: "https://github.com/bitbucket/homebrew-bar")
         baz = instance_double(Tap, name: "homebrew/baz", custom_remote?: false, remote: nil)
         foo = instance_double(Tap, name: "homebrew/foo", custom_remote?: false, remote: nil)
 
         ENV["HOMEBREW_GITHUB_API_TOKEN_BEFORE"] = ENV.fetch("HOMEBREW_GITHUB_API_TOKEN", nil)
         ENV["HOMEBREW_GITHUB_API_TOKEN"] = "some-token"
         private_tap = instance_double(Tap, name: "privatebrew/private", custom_remote?: true,
-          remote: "https://#{ENV.fetch("HOMEBREW_GITHUB_API_TOKEN")}@github.com/privatebrew/homebrew-private")
+          remote: "https://#{ENV.fetch("HOMEBREW_GITHUB_API_TOKEN")}@github.com/privatebrew/homebrew-private",
+          default_remote: "https://github.com/privatebrew/homebrew-private")
 
         [bar, baz, foo, private_tap].each do |tap|
           allow(tap).to receive(:matches_reference?) { |reference| reference == tap.remote }
@@ -67,6 +69,20 @@ RSpec.describe Homebrew::Bundle::Tap do
 
         expect(dumper.dump).to include(
           "tap \"bitbucket/bar\", \"https://bitbucket.org/bitbucket/bar.git\", trusted: true",
+        )
+      end
+
+      it "dumps GitHub clone targets matching a tap's default repository" do
+        described_class.reset!
+        tap = instance_double(Tap, name: "alternatert/tap", custom_remote?: false,
+          remote: "git@github.com:AlternateRT/homebrew-tap.git",
+          default_remote: "https://github.com/alternatert/homebrew-tap")
+
+        allow(tap).to receive(:matches_reference?) { |reference| reference == tap.remote }
+        allow(Tap).to receive(:select).and_return [tap]
+
+        expect(dumper.dump).to eql(
+          "tap \"alternatert/tap\", \"git@github.com:AlternateRT/homebrew-tap.git\"",
         )
       end
     end


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22753

- `brew bundle dump` must recreate taps that use SSH or other non-default clone targets even when trust compares the repositories as equivalent.
- The regression covers a GitHub SSH origin whose canonical repository matches the tap name's default repository.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
