### PR TITLE
Don't warn for partially trusted skipped taps

### DIFF
--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -357,6 +357,24 @@ RSpec.describe Homebrew::Trust, :trust_store do
     FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
   end
 
+  it "does not warn about a partially trusted tap when other files are untrusted" do
+    tap = Tap.fetch("thirdparty", "foo")
+    trusted_path = tap.formula_dir/"trusted.rb"
+    untrusted_path = tap.formula_dir/"untrusted.rb"
+    trusted_path.dirname.mkpath
+    FileUtils.touch [trusted_path, untrusted_path]
+    described_class.trust!(:formula, "thirdparty/foo/trusted")
+
+    with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+      expect { expect(described_class.trusted_formula_files([trusted_path, untrusted_path])).to eq([trusted_path]) }
+        .not_to output.to_stderr
+    end
+  ensure
+    described_class.clear!(:tap)
+    described_class.clear!(:formula)
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
   it "does not store default trust when trust checks are disabled" do
     tap = Tap.fetch("thirdparty", "foo")
     formula_path = tap.formula_dir/"default-trust.rb"

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -255,12 +255,16 @@ module Homebrew
 
     sig { returns(T::Array[Tap]) }
     def self.wholly_untrusted_taps
-      untrusted_taps.reject do |tap|
-        trusted_entry_prefix?(:formula, tap) ||
-          trusted_entry_prefix?(:cask, tap) ||
-          trusted_entry_prefix?(:command, tap)
-      end
+      untrusted_taps.reject { |tap| partially_trusted_tap?(tap) }
     end
+
+    sig { params(tap: Tap).returns(T::Boolean) }
+    def self.partially_trusted_tap?(tap)
+      trusted_entry_prefix?(:formula, tap) ||
+        trusted_entry_prefix?(:cask, tap) ||
+        trusted_entry_prefix?(:command, tap)
+    end
+    private_class_method :partially_trusted_tap?
 
     sig { params(type: Symbol).returns(String) }
     def self.setting_key(type)
@@ -455,6 +459,8 @@ module Homebrew
 
       skipped_taps = (files - trusted_files).filter_map { |file| tap_from_path(file) }.uniq.sort_by(&:name)
       skipped_taps.each do |tap|
+        next if partially_trusted_tap?(tap)
+
         opoo "Skipping #{tap.name} because it is not trusted. Run `brew trust #{tap.name}` to trust it."
       end
 


### PR DESCRIPTION
Fixes https://github.com/orgs/Homebrew/discussions/6898

- `brew update`/`upgrade` warned that a tap was untrusted even when the user had trusted a specific formula from it, contradicting the recommended per-item trust workflow and `brew doctor`
- skip the warning for taps with any per-item trust entry, matching the `wholly_untrusted_taps` logic `brew doctor` already uses

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
