### PR TITLE
livecheck: add compressed option

### DIFF
--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -186,6 +186,7 @@ class Livecheck
     params(
       # URL to check for version information.
       url:           T.any(String, Symbol),
+      compressed:    T.nilable(T::Boolean),
       cookies:       T.nilable(T::Hash[String, String]),
       header:        T.nilable(T.any(String, T::Array[String])),
       homebrew_curl: T.nilable(T::Boolean),
@@ -197,6 +198,7 @@ class Livecheck
   }
   def url(
     url = T.unsafe(nil),
+    compressed: nil,
     cookies: nil,
     header: nil,
     homebrew_curl: nil,
@@ -207,6 +209,7 @@ class Livecheck
   )
     raise ArgumentError, "Only use `post_form` or `post_json`, not both" if post_form && post_json
 
+    @options.compressed = compressed unless compressed.nil?
     @options.cookies = cookies unless cookies.nil?
     @options.header = header unless header.nil?
     @options.homebrew_curl = homebrew_curl unless homebrew_curl.nil?

--- a/Library/Homebrew/livecheck/options.rb
+++ b/Library/Homebrew/livecheck/options.rb
@@ -9,6 +9,9 @@ module Homebrew
     # Option values use a `nil` default to indicate that the value has not been
     # set.
     class Options < T::Struct
+      # Whether to request a compressed response.
+      prop :compressed, T.nilable(T::Boolean)
+
       # Cookies for curl to use when making a request.
       prop :cookies, T.nilable(T::Hash[String, String])
 
@@ -35,6 +38,7 @@ module Homebrew
       sig { returns(T::Hash[Symbol, T.untyped]) }
       def url_options
         {
+          compressed:,
           cookies:,
           header:,
           homebrew_curl:,
@@ -104,7 +108,8 @@ module Homebrew
       def ==(other)
         return false unless other.is_a?(Options)
 
-        @cookies == other.cookies &&
+        @compressed == other.compressed &&
+          @cookies == other.cookies &&
           @header == other.header &&
           @homebrew_curl == other.homebrew_curl &&
           @post_form == other.post_form &&

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -56,7 +56,6 @@ module Homebrew
 
       # `curl` arguments used in `Strategy#page_content` method.
       PAGE_CONTENT_CURL_ARGS = T.let(([
-        "--compressed",
         # Return an error when the HTTP response code is 400 or greater but
         # continue to return body content
         "--fail-with-body",
@@ -267,6 +266,12 @@ module Homebrew
           )]
         end
 
+        args = if options.compressed == false
+          PAGE_CONTENT_CURL_ARGS
+        else
+          PAGE_CONTENT_CURL_ARGS + ["--compressed"]
+        end
+
         user_agents = if options.user_agent
           [options.user_agent]
         else
@@ -277,7 +282,8 @@ module Homebrew
         user_agents.each do |user_agent|
           stdout, stderr, status = curl_output(
             *curl_post_args,
-            *PAGE_CONTENT_CURL_ARGS, url,
+            *args,
+            url,
             **DEFAULT_CURL_OPTIONS,
             use_homebrew_curl: options.homebrew_curl ||
                                !curl_supports_fail_with_body? ||
@@ -285,7 +291,7 @@ module Homebrew
             cookies:           options.cookies,
             header:            options.header,
             referer:           options.referer,
-            user_agent:
+            user_agent:,
           )
           next unless status.success?
 

--- a/Library/Homebrew/test/livecheck/options_spec.rb
+++ b/Library/Homebrew/test/livecheck/options_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Homebrew::Livecheck::Options do
   end
   let(:args) do
     {
+      compressed:    false,
       cookies:       cookies,
       header:        header_string,
       homebrew_curl: true,
@@ -41,6 +42,7 @@ RSpec.describe Homebrew::Livecheck::Options do
   describe "#url_options" do
     it "returns a Hash of the options that are provided as arguments to the `url` DSL method" do
       expect(options.new.url_options).to eq({
+        compressed:    nil,
         cookies:       nil,
         header:        nil,
         homebrew_curl: nil,

--- a/Library/Homebrew/test/livecheck/strategy_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy_spec.rb
@@ -282,6 +282,30 @@ RSpec.describe Homebrew::Livecheck::Strategy do
       expect(strategy.page_content(url)).to eq({ content: body })
     end
 
+    it "handles `compressed` `url` option" do
+      allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
+      allow_any_instance_of(Utils::Curl).to receive(:curl_output).and_return(
+        [response_text[:ok], nil, success_status],
+      )
+
+      expect_any_instance_of(Utils::Curl).to receive(:curl_output).with(
+        *Homebrew::Livecheck::Strategy::PAGE_CONTENT_CURL_ARGS,
+        url,
+        **Homebrew::Livecheck::Strategy::DEFAULT_CURL_OPTIONS,
+        use_homebrew_curl: false,
+        cookies:           nil,
+        header:            nil,
+        referer:           nil,
+        user_agent:        :default,
+      )
+      expect(
+        strategy.page_content(
+          url,
+          options: Homebrew::Livecheck::Options.new(compressed: false),
+        ),
+      ).to eq({ content: body })
+    end
+
     it "handles `cookies` `url` option" do
       allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
       allow(strategy).to receive(:curl_output).and_return([response_text[:ok], nil, success_status])

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -174,6 +174,7 @@ RSpec.describe Livecheck do
       # implemented.]
       livecheck_f.url(
         url_string,
+        compressed:    false,
         cookies:       { "cookie_key" => "cookie_value" },
         header:        "Accept: */*",
         homebrew_curl: true,
@@ -182,6 +183,7 @@ RSpec.describe Livecheck do
         user_agent:    :browser,
       )
       livecheck_f.url(url_string, post_json: post_hash)
+      expect(livecheck_f.options.compressed).to be(false)
       expect(livecheck_f.options.homebrew_curl).to be(true)
       expect(livecheck_f.options.post_form).to eq(post_hash)
       expect(livecheck_f.options.post_json).to eq(post_hash)

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -167,6 +167,9 @@ RSpec.describe Livecheck do
     end
 
     it "sets `url` options when provided" do
+      cookies = { "cookie_key" => "cookie_value" }
+      header_str = "Accept: */*"
+
       # This test makes sure that we can set multiple options at once and
       # options from subsequent `url` calls are merged with existing values
       # (i.e. existing values aren't reset to `nil`). [We only call `url` once
@@ -175,8 +178,8 @@ RSpec.describe Livecheck do
       livecheck_f.url(
         url_string,
         compressed:    false,
-        cookies:       { "cookie_key" => "cookie_value" },
-        header:        "Accept: */*",
+        cookies:,
+        header:        header_str,
         homebrew_curl: true,
         post_form:     post_hash,
         referer:       referer_url,
@@ -184,6 +187,8 @@ RSpec.describe Livecheck do
       )
       livecheck_f.url(url_string, post_json: post_hash)
       expect(livecheck_f.options.compressed).to be(false)
+      expect(livecheck_f.options.cookies).to eq(cookies)
+      expect(livecheck_f.options.header).to eq(header_str)
       expect(livecheck_f.options.homebrew_curl).to be(true)
       expect(livecheck_f.options.post_form).to eq(post_hash)
       expect(livecheck_f.options.post_json).to eq(post_hash)


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

This adds a `compressed` `url` option for `livecheck` blocks, so we can selectively omit the curl `--compressed` argument that we use by default for `Strategy.page_content` requests. We almost never want to do this but there are a small number of files (e.g., appcasts) hosted on AWS where the response uses a `Content-Encoding: aws-chunked` header instead of the actual encoding (e.g., gzip). This causes a curl error (`curl: (56) Unrecognized content encoding type. libcurl understands deflate, gzip content encodings`) but we can avoid this if we don't request a compressed response. It's not ideal but it's necessary in these cases (and thankfully the files are small).

Besides that, I added test cases in `livecheck_spec.rb` for the `cookies` and `header` options, as I forgot to check the values that are set when I added those options in the past.