### PR TITLE
Enable Sorbet/ConstantsFromStrings and override cops

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -292,15 +292,6 @@ RSpec/Output:
   Exclude:
     - "**/fixtures/**/*.rb"
 
-# These are legacy violations that we should try to fix.
-Sorbet/AllowIncompatibleOverride:
-  Exclude:
-    - "Homebrew/livecheck/strategy/*.rb"
-
-# Try getting rid of these.
-Sorbet/ConstantsFromStrings:
-  Enabled: false
-
 # This is already the default
 Sorbet/FalseSigil:
   Enabled: false

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -139,9 +139,8 @@ begin
     Homebrew.require?(external_ruby_cmd_path)
     exit Homebrew.failed? ? 1 : 0
   elsif external_cmd_path
-    %w[CACHE LIBRARY_PATH].each do |env|
-      ENV["HOMEBREW_#{env}"] = Object.const_get(:"HOMEBREW_#{env}").to_s
-    end
+    ENV["HOMEBREW_CACHE"] = HOMEBREW_CACHE.to_s
+    ENV["HOMEBREW_LIBRARY_PATH"] = HOMEBREW_LIBRARY_PATH.to_s
     exec external_cmd_path.to_s, *ARGV
   else
     raise UsageError, "Unknown command: brew #{cmd}"

--- a/Library/Homebrew/bundle/brew.rb
+++ b/Library/Homebrew/bundle/brew.rb
@@ -13,10 +13,13 @@ module Homebrew
     class Brew < Homebrew::Bundle::PackageType
       extend Utils::Output::Mixin
 
-      PACKAGE_TYPE = :brew
-      PACKAGE_TYPE_NAME = "Formula"
-
       class << self
+        sig { override.returns(Symbol) }
+        def type = :brew
+
+        sig { override.returns(String) }
+        def check_label = "Formula"
+
         sig { override.params(subclass: T.class_of(Homebrew::Bundle::PackageType)).void }
         def inherited(subclass)
           return if subclass.name == "Homebrew::Bundle::Brew::Services"

--- a/Library/Homebrew/bundle/cask.rb
+++ b/Library/Homebrew/bundle/cask.rb
@@ -11,10 +11,13 @@ module Homebrew
     class Cask < Homebrew::Bundle::PackageType
       extend ::Utils::Output::Mixin
 
-      PACKAGE_TYPE = :cask
-      PACKAGE_TYPE_NAME = "Cask"
-
       class << self
+        sig { override.returns(Symbol) }
+        def type = :cask
+
+        sig { override.returns(String) }
+        def check_label = "Cask"
+
         sig { override.void }
         def reset!
           @casks = T.let(nil, T.nilable(T::Array[::Cask::Cask]))

--- a/Library/Homebrew/bundle/extensions/cargo.rb
+++ b/Library/Homebrew/bundle/extensions/cargo.rb
@@ -6,11 +6,16 @@ require "bundle/extensions/extension"
 module Homebrew
   module Bundle
     class Cargo < Extension
-      PACKAGE_TYPE = :cargo
-      PACKAGE_TYPE_NAME = "Cargo Package"
-      BANNER_NAME = "Cargo packages"
-
       class << self
+        sig { override.returns(Symbol) }
+        def type = :cargo
+
+        sig { override.returns(String) }
+        def check_label = "Cargo Package"
+
+        sig { override.returns(String) }
+        def banner_name = "Cargo packages"
+
         sig { override.void }
         def reset!
           @packages = T.let(nil, T.nilable(T::Array[String]))

--- a/Library/Homebrew/bundle/extensions/extension.rb
+++ b/Library/Homebrew/bundle/extensions/extension.rb
@@ -18,20 +18,8 @@ module Homebrew
         Homebrew::Bundle.register_extension(T.cast(subclass, T.class_of(Homebrew::Bundle::Extension)))
       end
 
-      sig { returns(Symbol) }
-      def self.type
-        T.cast(const_get(:PACKAGE_TYPE), Symbol)
-      end
-
-      sig { returns(String) }
-      def self.check_label
-        T.cast(const_get(:PACKAGE_TYPE_NAME), String)
-      end
-
-      sig { returns(String) }
-      def self.banner_name
-        T.cast(const_get(:BANNER_NAME), String)
-      end
+      sig { abstract.returns(String) }
+      def self.banner_name; end
 
       sig { params(description: String).returns(String) }
       def self.switch_description(description)

--- a/Library/Homebrew/bundle/extensions/flatpak.rb
+++ b/Library/Homebrew/bundle/extensions/flatpak.rb
@@ -8,11 +8,16 @@ module Homebrew
     class Flatpak < Extension
       Package = T.type_alias { { name: String, remote: String, remote_url: T.nilable(String) } }
 
-      PACKAGE_TYPE = :flatpak
-      PACKAGE_TYPE_NAME = "Flatpak"
-      BANNER_NAME = "Flatpak packages"
-
       class << self
+        sig { override.returns(Symbol) }
+        def type = :flatpak
+
+        sig { override.returns(String) }
+        def check_label = "Flatpak"
+
+        sig { override.returns(String) }
+        def banner_name = "Flatpak packages"
+
         sig { override.params(description: String).returns(String) }
         def switch_description(description)
           "#{super} Note: Linux only."

--- a/Library/Homebrew/bundle/extensions/go.rb
+++ b/Library/Homebrew/bundle/extensions/go.rb
@@ -6,11 +6,16 @@ require "bundle/extensions/extension"
 module Homebrew
   module Bundle
     class Go < Extension
-      PACKAGE_TYPE = :go
-      PACKAGE_TYPE_NAME = "Go Package"
-      BANNER_NAME = "Go packages"
-
       class << self
+        sig { override.returns(Symbol) }
+        def type = :go
+
+        sig { override.returns(String) }
+        def check_label = "Go Package"
+
+        sig { override.returns(String) }
+        def banner_name = "Go packages"
+
         sig { override.void }
         def reset!
           @packages = T.let(nil, T.nilable(T::Array[String]))

--- a/Library/Homebrew/bundle/extensions/krew.rb
+++ b/Library/Homebrew/bundle/extensions/krew.rb
@@ -6,11 +6,16 @@ require "bundle/extensions/extension"
 module Homebrew
   module Bundle
     class Krew < Extension
-      PACKAGE_TYPE = :krew
-      PACKAGE_TYPE_NAME = "Krew Plugin"
-      BANNER_NAME = "Krew plugins"
-
       class << self
+        sig { override.returns(Symbol) }
+        def type = :krew
+
+        sig { override.returns(String) }
+        def check_label = "Krew Plugin"
+
+        sig { override.returns(String) }
+        def banner_name = "Krew plugins"
+
         sig { override.void }
         def reset!
           @packages = T.let(nil, T.nilable(T::Array[String]))

--- a/Library/Homebrew/bundle/extensions/mac_app_store.rb
+++ b/Library/Homebrew/bundle/extensions/mac_app_store.rb
@@ -13,11 +13,16 @@ module Homebrew
       end
       CheckablePackages = T.type_alias { T.any(T::Array[Object], T::Hash[Integer, String]) }
 
-      PACKAGE_TYPE = :mas
-      PACKAGE_TYPE_NAME = "App"
-      BANNER_NAME = "Mac App Store dependencies"
-
       class << self
+        sig { override.returns(Symbol) }
+        def type = :mas
+
+        sig { override.returns(String) }
+        def check_label = "App"
+
+        sig { override.returns(String) }
+        def banner_name = "Mac App Store dependencies"
+
         sig { override.returns(Symbol) }
         def legacy_check_step
           :apps_to_install

--- a/Library/Homebrew/bundle/extensions/npm.rb
+++ b/Library/Homebrew/bundle/extensions/npm.rb
@@ -7,11 +7,16 @@ require "language/node"
 module Homebrew
   module Bundle
     class Npm < Extension
-      PACKAGE_TYPE = :npm
-      PACKAGE_TYPE_NAME = "npm Package"
-      BANNER_NAME = "npm packages"
-
       class << self
+        sig { override.returns(Symbol) }
+        def type = :npm
+
+        sig { override.returns(String) }
+        def check_label = "npm Package"
+
+        sig { override.returns(String) }
+        def banner_name = "npm packages"
+
         sig { override.void }
         def reset!
           @packages = T.let(nil, T.nilable(T::Array[String]))

--- a/Library/Homebrew/bundle/extensions/uv.rb
+++ b/Library/Homebrew/bundle/extensions/uv.rb
@@ -11,11 +11,16 @@ module Homebrew
       Checkable = T.type_alias { { name: String, options: WithOptions } }
       ToolEntry = T.type_alias { T.any(Tool, Checkable) }
 
-      PACKAGE_TYPE = :uv
-      PACKAGE_TYPE_NAME = "uv Tool"
-      BANNER_NAME = "uv tools"
-
       class << self
+        sig { override.returns(Symbol) }
+        def type = :uv
+
+        sig { override.returns(String) }
+        def check_label = "uv Tool"
+
+        sig { override.returns(String) }
+        def banner_name = "uv tools"
+
         sig { override.params(name: String, options: Homebrew::Bundle::EntryInputOptions).returns(Dsl::Entry) }
         def entry(name, options = {})
           unknown_options = options.keys - [:with]

--- a/Library/Homebrew/bundle/extensions/vscode_extension.rb
+++ b/Library/Homebrew/bundle/extensions/vscode_extension.rb
@@ -6,12 +6,18 @@ require "bundle/extensions/extension"
 module Homebrew
   module Bundle
     class VscodeExtension < Extension
-      PACKAGE_TYPE = :vscode
-      PACKAGE_TYPE_NAME = "VSCode Extension"
-      BANNER_NAME = "VSCode (and forks/variants) extensions"
       EXTENSION_ID_REGEX = /\A[a-z0-9][a-z0-9-]*\.[a-z0-9][a-z0-9._-]*\z/i
 
       class << self
+        sig { override.returns(Symbol) }
+        def type = :vscode
+
+        sig { override.returns(String) }
+        def check_label = "VSCode Extension"
+
+        sig { override.returns(String) }
+        def banner_name = "VSCode (and forks/variants) extensions"
+
         sig { override.void }
         def reset!
           @extensions = T.let(nil, T.nilable(T::Array[String]))

--- a/Library/Homebrew/bundle/extensions/winget.rb
+++ b/Library/Homebrew/bundle/extensions/winget.rb
@@ -44,11 +44,16 @@ module Homebrew
         /\ANvidia\.PhysX\z/i,
       ].freeze, T::Array[Regexp])
 
-      PACKAGE_TYPE = :winget
-      PACKAGE_TYPE_NAME = "WinGet Package"
-      BANNER_NAME = "WinGet packages"
-
       class << self
+        sig { override.returns(Symbol) }
+        def type = :winget
+
+        sig { override.returns(String) }
+        def check_label = "WinGet Package"
+
+        sig { override.returns(String) }
+        def banner_name = "WinGet packages"
+
         sig { override.params(description: String).returns(String) }
         def switch_description(description)
           "#{super} Note: WSL only."

--- a/Library/Homebrew/bundle/package_type.rb
+++ b/Library/Homebrew/bundle/package_type.rb
@@ -23,10 +23,11 @@ module Homebrew
         Homebrew::Bundle.register_package_type(subclass)
       end
 
-      sig { returns(Symbol) }
-      def self.type
-        T.cast(const_get(:PACKAGE_TYPE), Symbol)
-      end
+      sig { abstract.returns(Symbol) }
+      def self.type; end
+
+      sig { abstract.returns(String) }
+      def self.check_label; end
 
       sig { returns(T::Boolean) }
       def self.dump_supported?
@@ -122,7 +123,7 @@ module Homebrew
         else
           "needs to be installed or updated."
         end
-        "#{self.class.const_get(:PACKAGE_TYPE_NAME)} #{name} #{reason}"
+        "#{self.class.check_label} #{name} #{reason}"
       end
 
       sig { params(packages: T::Array[Object], no_upgrade: T::Boolean).returns(T::Array[String]) }
@@ -136,7 +137,7 @@ module Homebrew
         require "bundle/skipper"
         all_entries.filter_map do |entry|
           entry = T.cast(entry, Dsl::Entry)
-          next if entry.type != self.class.const_get(:PACKAGE_TYPE)
+          next if entry.type != self.class.type
           next if Bundle::Skipper.skip?(entry)
 
           entry

--- a/Library/Homebrew/bundle/tap.rb
+++ b/Library/Homebrew/bundle/tap.rb
@@ -8,10 +8,13 @@ require "trust"
 module Homebrew
   module Bundle
     class Tap < Homebrew::Bundle::PackageType
-      PACKAGE_TYPE = :tap
-      PACKAGE_TYPE_NAME = "Tap"
-
       class << self
+        sig { override.returns(Symbol) }
+        def type = :tap
+
+        sig { override.returns(String) }
+        def check_label = "Tap"
+
         sig { override.void }
         def reset!
           @taps = T.let(nil, T.nilable(T::Array[::Tap]))

--- a/Library/Homebrew/cask/artifact/abstract_flight_block.rb
+++ b/Library/Homebrew/cask/artifact/abstract_flight_block.rb
@@ -46,7 +46,10 @@ module Cask
       sig { params(dsl_key: Symbol).returns(T::Class[::Cask::DSL::Base]) }
       def class_for_dsl_key(dsl_key)
         namespace = self.class.name.to_s.sub(/::.*::.*$/, "")
+        # The DSL class name is derived dynamically from the flight block's key.
+        # rubocop:disable Sorbet/ConstantsFromStrings
         self.class.const_get("#{namespace}::DSL::#{dsl_key.to_s.split("_").map(&:capitalize).join}")
+        # rubocop:enable Sorbet/ConstantsFromStrings
       end
 
       sig { params(dsl_key: Symbol).void }

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4287,8 +4287,11 @@ class Formula
       namespace = T.must(to_s.split("::")[0..-2]).join("::")
       return [] if namespace.empty?
 
+      # The namespace is derived dynamically from the formula's own name.
+      # rubocop:disable Sorbet/ConstantsFromStrings
       mod = const_get(namespace)
       mod.const_get(:BUILD_FLAGS)
+      # rubocop:enable Sorbet/ConstantsFromStrings
     end
 
     # Allows adding {.depends_on} and {Patch}es just to the {.stable} {SoftwareSpec}.

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -165,6 +165,8 @@ module Formulary
 
     class_name = class_s(name)
 
+    # The formula's class name and module constants are only known at runtime.
+    # rubocop:disable Sorbet/ConstantsFromStrings
     begin
       mod.const_get(class_name)
     rescue NameError => e
@@ -175,6 +177,7 @@ module Formulary
       remove_const(namespace)
       raise new_exception, "", e.backtrace
     end
+    # rubocop:enable Sorbet/ConstantsFromStrings
   ensure
     # TODO: Make printing to stdout an error so that we can print a tap name.
     #       See discussion at https://github.com/Homebrew/brew/pull/20226#discussion_r2195886888

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -98,6 +98,8 @@ module Homebrew
       # @return [Hash]
       sig { returns(T::Hash[Symbol, T.untyped]) }
       def self.strategies
+        # Strategies (including tap-provided ones) are discovered dynamically.
+        # rubocop:disable Sorbet/ConstantsFromStrings
         @strategies ||= T.let(Strategy.constants.sort.each_with_object({}) do |const_symbol, hash|
           constant = Strategy.const_get(const_symbol)
           next unless constant.is_a?(Class)
@@ -105,6 +107,7 @@ module Homebrew
           key = Utils.underscore(const_symbol).to_sym
           hash[key] = constant
         end, T.nilable(T::Hash[Symbol, T.untyped]))
+        # rubocop:enable Sorbet/ConstantsFromStrings
       end
       private_class_method :strategies
 
@@ -147,9 +150,12 @@ module Homebrew
             # Only treat the strategy as usable if the `livecheck` block
             # specifies the strategy and contains a `strategy` block
             next if (livecheck_strategy != strategy_symbol) || !block_provided
+          # The strategy's optional `PRIORITY` constant is read dynamically.
+          # rubocop:disable Sorbet/ConstantsFromStrings
           elsif strategy.const_defined?(:PRIORITY) &&
                 !strategy.const_get(:PRIORITY).positive? &&
                 livecheck_strategy != strategy_symbol
+            # rubocop:enable Sorbet/ConstantsFromStrings
             # Ignore strategies with a priority of 0 or lower, unless the
             # strategy is specified in the `livecheck` block
             next
@@ -161,7 +167,10 @@ module Homebrew
         # Sort usable strategies in descending order by priority, using the
         # DEFAULT_PRIORITY when a strategy doesn't contain a PRIORITY constant
         usable_strategies.sort_by do |strategy|
+          # The strategy's optional `PRIORITY` constant is read dynamically.
+          # rubocop:disable Sorbet/ConstantsFromStrings
           strategy.const_defined?(:PRIORITY) ? -strategy.const_get(:PRIORITY) : -DEFAULT_PRIORITY
+          # rubocop:enable Sorbet/ConstantsFromStrings
         end
       end
 

--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -151,6 +151,9 @@ module Homebrew
         # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
+          # `find_versions` requires a `cask`, unlike the `Strategic` interface,
+          # so `Livecheck` passes it via reflection on the strategy's parameters.
+          # rubocop:disable Sorbet/AllowIncompatibleOverride
           override(allow_incompatible: true).params(
             cask:    Cask::Cask,
             url:     T.nilable(String),
@@ -159,6 +162,7 @@ module Homebrew
             options: Options,
             block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.anything])
+          # rubocop:enable Sorbet/AllowIncompatibleOverride
         }
         def self.find_versions(cask:, url: nil, regex: nil, content: nil, options: Options.new, &block)
           if regex.present? && !block_given?

--- a/Library/Homebrew/prof/vernier_fork_guard.rb
+++ b/Library/Homebrew/prof/vernier_fork_guard.rb
@@ -19,7 +19,9 @@ module Homebrew
 
       # `Vernier::Autorun` is created by `-r vernier/autorun`; Sorbet's RBI for
       # the gem does not expose it, so keep this lookup dynamic.
+      # rubocop:disable Sorbet/ConstantsFromStrings
       autorun = T.let(Object.const_get(:Vernier).const_get(:Autorun), T.untyped)
+      # rubocop:enable Sorbet/ConstantsFromStrings
       return yield unless autorun.running?
 
       # Vernier registers internal thread hooks and owns native mutexes while the
@@ -46,7 +48,10 @@ module Homebrew
     def self.stop_running_collector
       return unless Object.const_defined?(:Vernier)
 
+      # `Vernier::Autorun` is absent from the gem's RBI, so look it up dynamically.
+      # rubocop:disable Sorbet/ConstantsFromStrings
       autorun = T.let(Object.const_get(:Vernier).const_get(:Autorun), T.untyped)
+      # rubocop:enable Sorbet/ConstantsFromStrings
       return unless autorun.running?
 
       autorun.stop

--- a/Library/Homebrew/sorbet/tapioca/compilers/api_structs.rb
+++ b/Library/Homebrew/sorbet/tapioca/compilers/api_structs.rb
@@ -16,9 +16,12 @@ module Tapioca
       sig { override.void }
       def decorate
         root.create_class(T.must(constant.name)) do |klass|
+          # `constant` is one of the gathered structs, resolved at runtime.
+          # rubocop:disable Sorbet/ConstantsFromStrings
           constant.const_get(:PREDICATES).each do |predicate_name|
             klass.create_method("#{predicate_name}?", return_type: "T::Boolean")
           end
+          # rubocop:enable Sorbet/ConstantsFromStrings
         end
       end
     end

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -158,13 +158,10 @@ module SystemConfig
     sig { params(out: T.any(File, StringIO, IO)).void }
     def homebrew_env_config(out = $stdout)
       out.puts "HOMEBREW_PREFIX: #{HOMEBREW_PREFIX}"
-      {
-        HOMEBREW_REPOSITORY: Homebrew::DEFAULT_REPOSITORY,
-        HOMEBREW_CELLAR:     Homebrew::DEFAULT_CELLAR,
-      }.freeze.each do |key, default|
-        value = Object.const_get(key)
-        out.puts "#{key}: #{value}" if value.to_s != default.to_s
-      end
+      repository = HOMEBREW_REPOSITORY
+      cellar = HOMEBREW_CELLAR
+      out.puts "HOMEBREW_REPOSITORY: #{repository}" if repository.to_s != Homebrew::DEFAULT_REPOSITORY.to_s
+      out.puts "HOMEBREW_CELLAR: #{cellar}" if cellar.to_s != Homebrew::DEFAULT_CELLAR.to_s
 
       Homebrew::EnvConfig::ENVS.each do |env, hash|
         next if Homebrew::EnvConfig.hidden?(hash) && !ENV.key?(env.to_s)

--- a/Library/Homebrew/test/cmd/bundle/check_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/check_subcommand_spec.rb
@@ -367,8 +367,8 @@ RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
   context "when a new checker fails to implement installed_and_up_to_date" do
     it "raises an exception" do
       stub_const("TestChecker", Class.new(Homebrew::Bundle::PackageType) do
-        class_eval("PACKAGE_TYPE = :test", __FILE__, __LINE__)
-        class_eval("PACKAGE_TYPE_NAME = 'Test'", __FILE__, __LINE__)
+        def self.type = :test
+        def self.check_label = "Test"
 
         def self.reset!; end
 

--- a/Library/Homebrew/test/cmd/shared_examples/args_parse.rb
+++ b/Library/Homebrew/test/cmd/shared_examples/args_parse.rb
@@ -12,7 +12,10 @@ RSpec.shared_examples "parseable arguments" do |command_name: nil|
     else
       # for tests of remote taps, we need to load the command class
       require(Commands.external_ruby_v2_cmd_path(command_name))
+      # The command class name is only known at runtime.
+      # rubocop:disable Sorbet/ConstantsFromStrings
       klass = Object.const_get(command)
+      # rubocop:enable Sorbet/ConstantsFromStrings
     end
     argv = klass.parser.instance_variable_get(:@min_named_args)&.times&.map { "argument" } || []
     cmd = klass.new(argv)

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -117,7 +117,10 @@ RSpec.describe "Exception" do
     end
 
     context "when the class is not derived from Formula" do
+      # The constant lives on the dynamically built test module.
+      # rubocop:disable Sorbet/ConstantsFromStrings
       let(:list) { [mod.const_get(:Bar)] }
+      # rubocop:enable Sorbet/ConstantsFromStrings
 
       it(:to_s) do
         expect(error.to_s).to match(/Expected to find class Foo, but only found: Bar \(not derived from Formula!\)\./)
@@ -125,7 +128,10 @@ RSpec.describe "Exception" do
     end
 
     context "when the class is derived from Formula" do
+      # The constant lives on the dynamically built test module.
+      # rubocop:disable Sorbet/ConstantsFromStrings
       let(:list) { [mod.const_get(:Baz)] }
+      # rubocop:enable Sorbet/ConstantsFromStrings
 
       it(:to_s) { expect(error.to_s).to match(/Expected to find class Foo, but only found: Baz\./) }
     end

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -220,7 +220,10 @@ RSpec.describe Requirement do
 
   describe "#name and #option_names" do
     let(:const) { :FooRequirement }
+    # The stubbed requirement class is resolved by name at runtime.
+    # rubocop:disable Sorbet/ConstantsFromStrings
     let(:klass) { self.class.const_get(const) }
+    # rubocop:enable Sorbet/ConstantsFromStrings
 
     before do
       stub_const const.to_s, Class.new(described_class)

--- a/Library/Homebrew/test/sandbox_shared_spec.rb
+++ b/Library/Homebrew/test/sandbox_shared_spec.rb
@@ -257,7 +257,10 @@ RSpec.describe Sandbox do
     ].each do |constant, directory|
       it "skips the deny when #{constant} is inside the real home" do
         stub_const(constant.to_s, home/directory)
+        # The constant under test is chosen dynamically per example.
+        # rubocop:disable Sorbet/ConstantsFromStrings
         Object.const_get(constant).mkpath
+        # rubocop:enable Sorbet/ConstantsFromStrings
 
         sandbox.deny_read_home
 

--- a/Library/Homebrew/test/support/helper/cmd/brew-verify-undefined.rb
+++ b/Library/Homebrew/test/support/helper/cmd/brew-verify-undefined.rb
@@ -76,7 +76,10 @@ end
 parser.parse
 
 UNDEFINED_CONSTANTS.each do |constant_name|
+  # The constant name is iterated from the list above.
+  # rubocop:disable Sorbet/ConstantsFromStrings
   Object.const_get(constant_name)
+  # rubocop:enable Sorbet/ConstantsFromStrings
   Utils::Output.ofail "#{constant_name} should not be defined at startup"
 rescue NameError
   # We expect this to error as it should not be defined.

--- a/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe UnpackStrategy::Dmg, :needs_macos do
     specify "#extract" do
       Dir.mktmpdir do |dir|
         unpack_dir = Pathname(dir)
+        # `Mount` is a private constant on the strategy under test.
+        # rubocop:disable Sorbet/ConstantsFromStrings
         mount = instance_double(described_class.const_get(:Mount, false))
+        # rubocop:enable Sorbet/ConstantsFromStrings
         unpack_strategy = described_class.new(path)
 
         allow(unpack_strategy).to receive(:mount).with(verbose: false).and_yield([mount])

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -80,7 +80,10 @@ module UnpackStrategy
     }.fetch(type, type)
 
     begin
+      # The strategy class name is derived dynamically from the type.
+      # rubocop:disable Sorbet/ConstantsFromStrings
       const_get(type.to_s.split("_").map(&:capitalize).join.gsub(/\d+[a-z]/, &:upcase))
+      # rubocop:enable Sorbet/ConstantsFromStrings
     rescue NameError
       nil
     end

--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -7,7 +7,10 @@ require "utils/socket"
 module Utils
   sig { params(child_error: T::Hash[String, T.untyped]).returns(Exception) }
   def self.rewrite_child_error(child_error)
+    # The error class name comes from the forked child's serialised JSON.
+    # rubocop:disable Sorbet/ConstantsFromStrings
     inner_class = Object.const_get(child_error["json_class"])
+    # rubocop:enable Sorbet/ConstantsFromStrings
     error = if child_error["cmd"] && inner_class == ErrorDuringExecution
       ErrorDuringExecution.new(child_error["cmd"],
                                status: child_error["status"],


### PR DESCRIPTION
- drop the blanket `Sorbet/ConstantsFromStrings` disable and the directory-wide `Sorbet/AllowIncompatibleOverride` exclude so both cops run across the codebase again
- convert the `brew bundle` `PACKAGE_TYPE`, `PACKAGE_TYPE_NAME` and `BANNER_NAME` constants into abstract `type`, `check_label` and `banner_name` methods so the base classes no longer reach into subclass constants via `const_get`
- replace the `brew.rb` and `system_config.rb` `const_get` lookups with direct constant references
- annotate the remaining genuinely dynamic `const_get` lookups with scoped `rubocop:disable` blocks explaining why they must stay

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Opus 4.8 high with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
