### PR TITLE
Add install step config writes

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -168,6 +168,22 @@ module Homebrew
         symlink(source, target, source_base:, target_base:, source_formula:, target_formula:, force: true, uninstall:)
       end
 
+      sig {
+        params(
+          path:      ::T.any(::String, ::Pathname),
+          content:   ::String,
+          base:      ::T.nilable(::T.any(::String, ::Symbol)),
+          overwrite: ::T::Boolean,
+        ).void
+      }
+      def write(path, content, base: nil, overwrite: false)
+        content = "#{content}\n" unless content.end_with?("\n")
+        add_step("write",
+                 "path"      => path_spec(path, base:, default_base: @default_base),
+                 "content"   => content,
+                 "overwrite" => overwrite)
+      end
+
       sig { void }
       def compile_gsettings_schemas
         add_rebuild_action("compile_gsettings_schemas", "share/glib-2.0/schemas")
@@ -243,6 +259,14 @@ module Homebrew
     end
 
     class Runner
+      # Path tokens reuse the step base resolution; `HOMEBREW_PREFIX`, `version`
+      # and `version.major_minor` are resolved separately. Anything else is left
+      # verbatim so literal braces in templates are never rewritten.
+      CONTENT_PATH_TOKENS = T.let(
+        %w[prefix opt_prefix bin var etc pkgetc staged_path appdir].freeze,
+        T::Array[String],
+      )
+
       sig { params(context: T.untyped).void }
       def initialize(context:)
         @context = context
@@ -290,6 +314,15 @@ module Homebrew
           target.dirname.mkpath
           FileUtils.rm_f target if step["force"] == true
           File.symlink link_source(step.fetch("source")), target
+        when "write"
+          content = step["content"]
+          raise ArgumentError, "install step write requires non-empty content" if content.blank?
+
+          path = resolve_path(step.fetch("path"))
+          if step["overwrite"] == true || !path.exist?
+            path.dirname.mkpath
+            path.write(expand_content_tokens(content))
+          end
         when "compile_gsettings_schemas"
           run_formula_tool("glib", "glib-compile-schemas", resolve_path(step.fetch("path")))
         when "gio_querymodules"
@@ -314,6 +347,33 @@ module Homebrew
 
         target = resolve_path(step.fetch("target"))
         FileUtils.rm_f target if target.symlink?
+      end
+
+      sig { params(content: String).returns(String) }
+      def expand_content_tokens(content)
+        content.gsub(/\{\{([A-Za-z_][\w.]*)\}\}/) do |match|
+          value = content_token_value(T.must(Regexp.last_match(1)))
+          value.nil? ? match : value.to_s
+        end
+      end
+
+      sig { params(token: String).returns(T.untyped) }
+      def content_token_value(token)
+        case token
+        when "HOMEBREW_PREFIX"
+          HOMEBREW_PREFIX
+        when "version"
+          context_version
+        when "version.major_minor"
+          context_version&.major_minor
+        else
+          root_path(token, nil) if CONTENT_PATH_TOKENS.include?(token)
+        end
+      end
+
+      sig { returns(T.untyped) }
+      def context_version
+        @context.version if @context.respond_to?(:version)
       end
 
       sig { params(spec: T.untyped).returns(Pathname) }

--- a/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
+++ b/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
@@ -46,6 +46,26 @@ Before opening follow-up PRs, run `bundle exec rake lint` from `docs/` to catch
 markdown lint issues and run `brew style homebrew/core homebrew/cask` to catch
 tap-wide formula or cask opportunities exposed by the new DSLs.
 
+## Per-DSL Pull Request Workflow
+
+From PR 5 onwards each new DSL step type ships as four separate
+commits/branches/PRs rather than one combined change:
+
+1. Add the new DSL in `Homebrew/brew`: the step method(s), runner execution,
+   shared step block allow-list entries so tap syntax checks accept the method,
+   JSON API round-tripping, tests and docs. No legacy-to-steps autocorrection.
+2. Add the new RuboCops in `Homebrew/brew` that enforce and audit the DSL:
+   conflict checks against legacy blocks and conservative autocorrection from
+   the matching legacy Ruby pattern.
+3. Tap `homebrew/core`: convert formulae to the new DSL.
+4. Tap `homebrew/cask`: convert casks to the new DSL.
+
+Merge order is `1`, `3`, `4`, `2`. PR `1` ships the DSL and its allow-list so
+taps can adopt it; PR `2` (the enforcing/autocorrecting cops) merges last so it
+does not flag formulae or casks before the DSL is widely available. After PR `1`
+is merged and before PRs `3` and `4` are merged, cut a new `Homebrew/brew`
+stable release so `homebrew/core` and `homebrew/cask` CI have the new DSL.
+
 ## Formula Patterns
 
 Local scan source: `homebrew/core` at `fb0ca6682b4`.
@@ -185,7 +205,7 @@ be resolved before the download can be enqueued.
   non-Homebrew code and should be ready for future sandboxing. Land RuboCop
   autocorrection and tap-wide conversions in a separate follow-up after the
   new DSL methods are available in a stable Homebrew release.
-- [ ] PR 5, default config and template writes.
+- PR 5, default config and template writes (four-PR workflow above).
   Estimated existing formulae/casks affected: about `71` formulae write or
   patch default configuration/data files, and a subset of the `78` file-prep
   cask flight blocks write small files.
@@ -193,6 +213,36 @@ be resolved before the download can be enqueued.
   Ruby interpolation; require literal templates or API-safe template data;
   define overwrite, `unless_exists` and upgrade semantics before adding
   autocorrection.
+  - [x] PR 5.1, add the `write` DSL in `Homebrew/brew`.
+    Commit: `Add install step config writes`.
+    Scope: shared `write` step method with `base:` and `overwrite:`, runner
+    execution that skips existing files unless `overwrite` is set, formula and
+    cask step block allow-list entries, non-interpolated heredoc (`dstr`)
+    support so `write` content can use heredocs, runner tests and cookbook
+    docs. Default behaviour preserves existing files so user edits survive
+    upgrades. Content stays a literal template in the JSON API but supports a
+    fixed `{{...}}` token allow-list (`HOMEBREW_PREFIX`, `prefix`, `opt_prefix`,
+    `bin`, `var`, `etc`, `pkgetc`, `version`, `version.major_minor`; casks add
+    `staged_path` and `appdir`) expanded at install time; any other `{{...}}`
+    is left verbatim. Dynamic interpolation (random cookies, `popen`-derived
+    paths, `File.read` rewrites) is intentionally out of scope and stays as
+    legacy Ruby.
+  - [ ] PR 5.2, add the `write` enforcing RuboCops in `Homebrew/brew`.
+  - [x] PR 5.3, convert `homebrew/core` formulae to `write`.
+    Branch `install-steps-config-write`, commits
+    `tronbyt-server: use post_install_steps` and `node@18: use
+    post_install_steps`. `tronbyt-server` mapped with literal content;
+    `node@18` became convertible once `{{HOMEBREW_PREFIX}}` token expansion
+    landed (its whole `post_install` was one `atomic_write`). All other
+    `.write` formulae interpolate paths, interpolate unsupported values, or
+    run unsupported Ruby (`cp_r`, `inreplace`, `safe_popen_read`, loops).
+  - [x] PR 5.4, convert `homebrew/cask` casks to `write`.
+    Branch `install-steps-config-write`, commit
+    `dnsmonitor: use postflight_steps`. Only `dnsmonitor` had a flight block
+    with literal content. Token expansion does not unblock more casks: the
+    `{{appdir}}`-content flight writes all target a `shimscript` local that is
+    also wired to a `binary` stanza, and the literal-path LibreOffice packs
+    interpolate an unsupported language `token` and run `system_command`.
 - [ ] PR 6, database and service data directory initialisation.
   Estimated existing formulae/casks affected: about `27` formulae initialise
   service data directories.

--- a/Library/Homebrew/rubocops/cask/install_steps.rb
+++ b/Library/Homebrew/rubocops/cask/install_steps.rb
@@ -43,10 +43,10 @@ module RuboCop
             next unless stanza.method_node.block_type?
             next unless (offense_node = install_step_block_offense_node(
               T.cast(stanza.method_node, RuboCop::AST::BlockNode),
-              allowed_methods: FILE_PREPARATION_STEP_METHODS,
+              allowed_methods: CASK_ALLOWED_STEP_METHODS,
             ))
 
-            add_offense(offense_node, message: step_block_msg(FILE_PREPARATION_STEP_METHODS))
+            add_offense(offense_node, message: step_block_msg(CASK_ALLOWED_STEP_METHODS))
           end
         end
 

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -8,18 +8,28 @@ module RuboCop
         [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :symlink, :ln_s, :ln_sf].freeze,
         T::Array[Symbol],
       )
+      CONFIG_WRITE_STEP_METHODS = T.let(
+        [:write].freeze,
+        T::Array[Symbol],
+      )
       REBUILD_ACTION_STEP_METHODS = T.let(
         [:compile_gsettings_schemas, :gio_querymodules, :gdk_pixbuf_query_loaders, :gtk_update_icon_cache,
          :update_mime_database, :update_desktop_database].freeze,
         T::Array[Symbol],
       )
       ALLOWED_STEP_METHODS = T.let(
-        [*FILE_PREPARATION_STEP_METHODS, *REBUILD_ACTION_STEP_METHODS].freeze,
+        [*FILE_PREPARATION_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *REBUILD_ACTION_STEP_METHODS].freeze,
+        T::Array[Symbol],
+      )
+      CASK_ALLOWED_STEP_METHODS = T.let(
+        [*FILE_PREPARATION_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS].freeze,
         T::Array[Symbol],
       )
 
+      # `dstr` covers non-interpolated heredocs such as `write` content; any
+      # interpolation adds `begin`/`send` descendants that remain disallowed.
       ALLOWED_STEP_ARGUMENT_NODE_TYPES = T.let(
-        [:array, :hash, :nil, :pair, :str, :sym].freeze,
+        [:array, :dstr, :hash, :nil, :pair, :str, :sym].freeze,
         T::Array[Symbol],
       )
 

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -96,6 +96,67 @@ RSpec.describe Homebrew::InstallSteps do
     )
   end
 
+  specify "expands a scoped set of content tokens and leaves others verbatim", :aggregate_failures do
+    root_path = root
+    versioned_context = Class.new do
+      define_method(:prefix) { root_path/"prefix" }
+      define_method(:version) { Version.new("1.2.3") }
+    end.new
+
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :prefix) do
+      write "config.ini", <<~EOS
+        prefix = {{prefix}}
+        cellar = {{HOMEBREW_PREFIX}}
+        series = {{version.major_minor}} ({{version}})
+        literal = {{unknown}} {single}
+      EOS
+    end
+
+    Homebrew::InstallSteps::Runner.new(context: versioned_context).run(steps)
+
+    written = (root/"prefix/config.ini").read
+    expect(written).to include("prefix = #{root}/prefix")
+    expect(written).to include("cellar = #{HOMEBREW_PREFIX}")
+    expect(written).to include("series = 1.2 (1.2.3)")
+    expect(written).to include("literal = {{unknown}} {single}")
+  end
+
+  specify "writes a default config file and preserves existing ones", :aggregate_failures do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      write "config/new.conf", "fresh"
+      write "config/kept.conf", "default"
+      write "config/replaced.conf", "default", overwrite: true
+    end
+
+    (root/"var/config").mkpath
+    (root/"var/config/kept.conf").write "user edit"
+    (root/"var/config/replaced.conf").write "user edit"
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect((root/"var/config/new.conf").read).to eq("fresh\n")
+    expect((root/"var/config/kept.conf").read).to eq("user edit")
+    expect((root/"var/config/replaced.conf").read).to eq("default\n")
+  end
+
+  specify "appends a trailing newline unless already present", :aggregate_failures do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      write "missing-newline", "value"
+      write "has-newline", "value\n"
+    end
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect((root/"var/missing-newline").read).to eq("value\n")
+    expect((root/"var/has-newline").read).to eq("value\n")
+  end
+
+  specify "raises when a write step has missing or blank content" do
+    expect do
+      Homebrew::InstallSteps::Runner.new(context:).run([{ "type" => "write", "path" => "config/new.conf" }])
+    end.to raise_error(ArgumentError, /non-empty content/)
+  end
+
   specify "runs named desktop and cache rebuild actions" do
     steps = Homebrew::InstallSteps::DSL.build do
       compile_gsettings_schemas

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           system "true"
-          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`.
+          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`.
         end
       end
     CASK
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           update_desktop_database
-          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`.
+          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`.
         end
       end
     CASK

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
         end
       end
     RUBY
@@ -45,12 +45,29 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           mv "source", "target"
           move_children "source", "target"
           ln_sf "source", "target", source_base: :relative, uninstall: true
+          write "foo.conf", "key = value\n", base: :etc
+          write "foo/banner", <<~TEXT
+            literal banner
+          TEXT
           compile_gsettings_schemas
           gio_querymodules
           gdk_pixbuf_query_loaders
           gtk_update_icon_cache
           update_mime_database
           update_desktop_database
+        end
+      end
+    RUBY
+  end
+
+  it "reports an offense when write content is interpolated" do
+    expect_offense(<<~'RUBY')
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        post_install_steps do
+          write "foo.conf", "prefix = #{prefix}"
+                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
         end
       end
     RUBY

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -592,6 +592,7 @@ Relative paths default to `staged_path` for `base:`, `source_base:` and `target_
 * `symlink`: create a symlink; example: `symlink "Shared/payload", "Payload", source_base: :relative`.
 * `ln_s`: alias for `symlink`; example: `ln_s "Shared/payload", "Payload", source_base: :relative`.
 * `ln_sf`: create or replace a symlink; example: `ln_sf "Shared/payload", "Payload", source_base: :relative, uninstall: true`.
+* `write`: write literal content to a file unless it already exists; example: `write "Shared/foo.conf", "key = value"`. Pass `overwrite: true` to always replace the file. A trailing newline is appended unless the content already ends with one. Content may use the `{{staged_path}}`, `{{appdir}}` and `{{version}}` tokens, which are expanded at install time; any other `{{...}}` is left verbatim.
 
 Flight blocks are not currently run in the cask sandbox. They should be written as though they may be sandboxed in the future: prefer the mini-DSL helpers below and keep filesystem writes limited to paths owned by the cask.
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1133,6 +1133,17 @@ A formula may define either `post_install_steps` or `post_install`, not both.
 * `ln_s`: alias for `symlink`; example: `ln_s "cert.pem", "foo/cert.pem", source_base: :relative`.
 * `ln_sf`: create or replace a symlink; example: `ln_sf "cert.pem", "foo/cert.pem", source_base: :relative`.
 
+#### Default config and template steps
+
+`write` creates a default configuration or data file from literal content. It defaults to the same base as the other file preparation steps; pass `base:` (such as `base: :etc`) to target another formula path. By default `write` does not overwrite an existing file, so user edits are preserved across upgrades; pass `overwrite: true` to always replace the file.
+
+* `write`: write literal content to a file unless it already exists; example: `write "foo.conf", "key = value", base: :etc`.
+* `write` with `overwrite: true`: always replace the file; example: `write "foo/version", "1.0", overwrite: true`.
+
+A trailing newline is appended unless the content already ends with one, so written files end in a newline as POSIX expects.
+
+Content may use a fixed set of `{{...}}` tokens that are expanded at install time so paths are not hardcoded into the JSON API: `{{HOMEBREW_PREFIX}}`, `{{prefix}}`, `{{opt_prefix}}`, `{{bin}}`, `{{var}}`, `{{etc}}`, `{{pkgetc}}`, `{{version}}` and `{{version.major_minor}}`. Any other `{{...}}` is left verbatim, so literal braces are never rewritten. Use tokens instead of Ruby interpolation, for example `write "foo.conf", "prefix = {{HOMEBREW_PREFIX}}", base: :etc`.
+
 #### Desktop and cache rebuild steps
 
 These steps rebuild shared desktop and cache state using Homebrew-owned tools.


### PR DESCRIPTION
- add a shared `write` install step so formulae and casks can ship default configuration or data files through structured JSON API data
- skip existing files unless `overwrite: true` so user edits survive upgrades; restrict content to literal strings for now
- allow `write` in formula and cask step blocks so taps can adopt it ahead of the enforcing RuboCops, per the per-DSL PR workflow

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 high with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
