### PR TITLE
Stabilise formula auditor merge-base specs

### DIFF
--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -1437,9 +1437,8 @@ RSpec.describe Homebrew::FormulaAuditor do
       foo_path.write(test_formula_source(name: "foo"))
       allow(tap).to receive(:formula_files_by_name)
         .and_return({ "foo" => foo_path, "bar" => tap_path/"Formula/bar.rb" })
-      allow(Utils::Git).to receive(:git).and_return("git")
       allow(Utils).to receive(:popen_read).and_call_original
-      allow(Utils).to receive(:popen_read).with("git", "-C", tap.path, "merge-base", "origin/HEAD", "HEAD")
+      allow(Utils).to receive(:popen_read).with(Utils::Git.git, "-C", tap.path, "merge-base", "origin/HEAD", "HEAD")
                                           .and_return("merge-base-sha\n")
       allow(Utils).to receive(:safe_popen_read).and_return("Formula/f/foo.rb\n")
 
@@ -1452,11 +1451,11 @@ RSpec.describe Homebrew::FormulaAuditor do
       foo_path.dirname.mkpath
       foo_path.write(test_formula_source(name: "foo"))
       allow(tap).to receive(:formula_files_by_name).and_return({ "foo" => foo_path })
-      allow(Utils::Git).to receive(:git).and_return("git")
       allow(Utils).to receive(:popen_read).and_call_original
-      allow(Utils).to receive(:popen_read).with("git", "-C", tap.path, "merge-base", "origin/HEAD", "HEAD")
+      allow(Utils).to receive(:popen_read).with(Utils::Git.git, "-C", tap.path, "merge-base", "origin/HEAD", "HEAD")
                                           .and_return("merge-base-sha\n")
-      expect(Utils).to receive(:safe_popen_read).with("git", "-C", tap.path, "diff", "--name-only", "merge-base-sha")
+      expect(Utils).to receive(:safe_popen_read).with(Utils::Git.git, "-C", tap.path, "diff", "--name-only",
+                                                      "merge-base-sha")
                                                 .and_return("Formula/f/foo.rb\n")
 
       expect(auditor.send(:changed_formulae_paths, tap, only_names: ["foo"])).to eq([foo_path])
@@ -1486,9 +1485,8 @@ RSpec.describe Homebrew::FormulaAuditor do
     let(:formula_versions) { instance_double(FormulaVersions) }
 
     it "walks history from the merge-base with origin/HEAD" do
-      allow(Utils::Git).to receive(:git).and_return("git")
       allow(Utils).to receive(:popen_read).and_call_original
-      allow(Utils).to receive(:popen_read).with("git", "-C", tap.path, "merge-base", "origin/HEAD", "HEAD")
+      allow(Utils).to receive(:popen_read).with(Utils::Git.git, "-C", tap.path, "merge-base", "origin/HEAD", "HEAD")
                                           .and_return("merge-base-sha\n")
       allow(FormulaVersions).to receive(:new).with(target_formula).and_return(formula_versions)
       expect(formula_versions).to receive(:rev_list).with("merge-base-sha")


### PR DESCRIPTION
- match the real `Utils::Git.git` in the `merge-base` and `diff` stubs instead of stubbing it to a literal, so the expectations track the argument the auditor actually passes
- this avoids a cross-file flake where the stub did not apply, the real `git merge-base` ran in a fixture tap and `git_audit_base_ref` fell back to `origin/HEAD`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 high with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
