### PR TITLE
Annotate upgradable dependencies in install plans

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -820,12 +820,16 @@ on_request: installed_on_request?, options:)
     if deps.empty? && only_deps?
       puts "All dependencies for #{formula.full_name} are satisfied."
     elsif !deps.empty?
+      deps_with_formulae = deps.map { |dep| [dep, dep.to_formula] }
       if deps.length > 1
-        oh1 "Installing dependencies for #{formula.full_name}: " \
-            "#{deps.map { Formatter.identifier(it) }.to_sentence}",
-            truncate: false
+        names = deps_with_formulae.map do |dep, dep_formula|
+          installed = dep_formula.any_version_installed?
+          pretty_install_status(Formatter.identifier(dep), installed:,
+                                outdated: installed && dep_formula.outdated?, mark_uninstalled: false)
+        end
+        oh1 "Installing dependencies for #{formula.full_name}: #{names.to_sentence}", truncate: false
       end
-      deps.each { install_dependency(it) }
+      deps_with_formulae.each { |dep, dep_formula| install_dependency(dep, dep_formula) }
     end
 
     @show_header = true if deps.length > 1
@@ -856,12 +860,10 @@ on_request: installed_on_request?, options:)
     fi.enqueue_fetch
   end
 
-  sig { params(dep: Dependency).void }
-  def install_dependency(dep)
-    df = dep.to_formula
-
-    if df.linked_keg.directory?
-      linked_keg = Keg.new(df.linked_keg.resolved_path)
+  sig { params(dep: Dependency, dep_formula: Formula).void }
+  def install_dependency(dep, dep_formula = dep.to_formula)
+    if dep_formula.linked_keg.directory?
+      linked_keg = Keg.new(dep_formula.linked_keg.resolved_path)
       tab = linked_keg.tab
       keg_had_linked_keg = true
       keg_was_linked = linked_keg.linked?
@@ -870,31 +872,31 @@ on_request: installed_on_request?, options:)
       keg_had_linked_keg = false
     end
 
-    if df.latest_version_installed?
-      installed_keg = Keg.new(df.prefix)
+    if dep_formula.latest_version_installed?
+      installed_keg = Keg.new(dep_formula.prefix)
       tab ||= installed_keg.tab
       tmp_keg = Pathname.new("#{installed_keg}.tmp")
       installed_keg.rename(tmp_keg) unless tmp_keg.directory?
     end
 
-    if df.tap.present? && tab.present? && (tab_tap = tab.source["tap"].presence) &&
-       df.tap.to_s != tab_tap.to_s
+    if dep_formula.tap.present? && tab.present? && (tab_tap = tab.source["tap"].presence) &&
+       dep_formula.tap.to_s != tab_tap.to_s
       odie <<~EOS
-        #{df} is already installed from #{tab_tap}!
-        Please `brew uninstall #{df}` first."
+        #{dep_formula} is already installed from #{tab_tap}!
+        Please `brew uninstall #{dep_formula}` first."
       EOS
     end
 
     options = Options.new
     options |= tab.used_options if tab.present?
-    options |= Tab.remap_deprecated_options(df.deprecated_options, dep.options)
-    options &= df.options
+    options |= Tab.remap_deprecated_options(dep_formula.deprecated_options, dep.options)
+    options &= dep_formula.options
 
-    installed_on_request = df.any_version_installed? && tab.present? && tab.installed_on_request
+    installed_on_request = dep_formula.any_version_installed? && tab.present? && tab.installed_on_request
     installed_on_request ||= false
 
     fi = FormulaInstaller.new(
-      df,
+      dep_formula,
       options:,
       link_keg:                   keg_had_linked_keg && keg_was_linked,
       installed_on_request:,

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -509,7 +509,10 @@ module Homebrew
           dependency = dep.to_formula
           next if skip_formula_names.include?(dependency.full_name)
 
-          yield dependency
+          name = yield dependency
+          installed = dependency.any_version_installed?
+          pretty_install_status(name, installed:, outdated: installed && dependency.outdated?,
+                                mark_uninstalled: false)
         end
         return if formula_names.empty?
 

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -89,6 +89,30 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     EOS
   end
 
+  it "marks an outdated dependency as upgradable in the dry-run plan" do
+    formula = formula("changed") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/changed-2.0.tar.gz"
+    end
+    dependency = formula("dependency") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/dependency-1.0.tar.gz"
+    end
+    allow(dependency).to receive_messages(any_version_installed?: true, outdated?: true)
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+    allow(Homebrew::EnvConfig).to receive(:no_emoji?).and_return(true)
+    formula_installer = FormulaInstaller.new(formula)
+    dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
+
+    allow(formula_installer).to receive(:compute_dependencies)
+      .and_return([instance_double(Dependency, to_formula: dependency)])
+    allow(Homebrew::Install).to receive(:ask_input)
+
+    expect do
+      Homebrew::Install.ask_formulae([formula_installer], dependants)
+    end.to output(/dependency \(upgradable\)/).to_stdout
+  end
+
   it "prompts again for return ask input" do
     ["\r", "\n"].each do |input|
       allow($stdin).to receive(:tty?).and_return(true)

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -240,6 +240,32 @@ RSpec.describe FormulaInstaller do
     end
   end
 
+  describe "#install_dependencies" do
+    it "marks only outdated dependencies as upgradable in the header" do
+      outdated = formula "outdated-dependency" do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      uninstalled = formula "uninstalled-dependency" do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      allow(outdated).to receive_messages(any_version_installed?: true, outdated?: true)
+      allow(uninstalled).to receive_messages(any_version_installed?: false, outdated?: false)
+      deps = [
+        instance_double(Dependency, to_formula: outdated, name: outdated.name, to_s: outdated.name),
+        instance_double(Dependency, to_formula: uninstalled, name: uninstalled.name, to_s: uninstalled.name),
+      ]
+      installer = described_class.new(Testball.new)
+      allow(installer).to receive(:install_dependency)
+      allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+      allow(Homebrew::EnvConfig).to receive(:no_emoji?).and_return(true)
+
+      expect { installer.install_dependencies(deps) }
+        .to output(/outdated-dependency.*\(upgradable\).*and.*uninstalled-dependency[^(]*$/m).to_stdout
+    end
+  end
+
   describe "versioned keg-only linking defaults" do
     let(:base_name) { "homebrew-versioned-formula" }
     let(:formula_name) { "#{base_name}@1.0" }


### PR DESCRIPTION
Show upgradable status on deps when running `brew install`, to make the output less jarring, currently it tells me I need to install python 3.14 but I already have it (which `brew info asciidoc` did tell me):


```
$ brew info asciidoc
==> asciidoc ✘: stable 10.2.1 (bottled), HEAD
...
==> Dependencies
Required (3): docbook, python@3.14 ↑, source-highlight
```

```
$ brew install asciidoc
...
==> Would install 6 dependencies for asciidoc:
docbook
ca-certificates
sqlite
python@3.14
boost
source-highlight
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claud Code, Extra High

-----
