### PR TITLE
Follow symlinked trust stores

### DIFF
--- a/Library/Homebrew/test/test_bot_spec.rb
+++ b/Library/Homebrew/test/test_bot_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Homebrew::TestBot do
     end
 
     it "trusts a third-party tap in the local test-bot config home" do
+      old_umask = T.let(nil, T.nilable(Integer))
       tap = Tap.fetch("thirdparty", "foo")
       tap.path.mkpath
       args = double(
@@ -67,15 +68,19 @@ RSpec.describe Homebrew::TestBot do
             HOME:                      "#{workdir}/original",
             XDG_CONFIG_HOME:           "#{workdir}/xdg",
           ) do
+            old_umask = File.umask(0002)
+
             expect { described_class.run!(args) }.to output(%r{==> Trusted tap: thirdparty/foo}).to_stdout
 
             trust_file = workdir/"home/.homebrew/trust.json"
             expect(trust_file).to exist
+            expect(trust_file.dirname.stat.mode & 0777).to eq(0700)
             expect(JSON.parse(trust_file.read).fetch("trustedtaps")).to include("thirdparty/foo")
           end
         end
       end
     ensure
+      File.umask(old_umask) if old_umask
       Homebrew::Trust.clear!(:tap)
       FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
     end

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -246,6 +246,94 @@ RSpec.describe Homebrew::Trust, :trust_store do
     described_class.clear!(:tap)
   end
 
+  it "creates the trust store directory with user-only permissions" do
+    trust_file = described_class.trust_file
+    FileUtils.rm_rf trust_file.dirname
+    old_umask = T.let(nil, T.nilable(Integer))
+    old_umask = File.umask(0002)
+
+    described_class.trust!(:tap, "thirdparty/foo")
+
+    expect(trust_file.dirname.stat.mode & 0777).to eq(0700)
+  ensure
+    File.umask(old_umask) if old_umask
+    described_class.clear!(:tap)
+  end
+
+  it "rejects a trust store in a group-writable directory" do
+    trust_file = T.let(nil, T.nilable(Pathname))
+    trust_file = described_class.trust_file
+    trust_file.dirname.chmod(0770)
+
+    expect { described_class.trust!(:tap, "thirdparty/foo") }
+      .to raise_error(Homebrew::InsecureTrustStoreError, /Refusing to write insecure trust store/)
+  ensure
+    if trust_file
+      trust_file.dirname.chmod(0700) if trust_file.dirname.exist?
+      FileUtils.rm_f trust_file
+    end
+  end
+
+  it "rejects a group-writable trust store" do
+    trust_file = T.let(nil, T.nilable(Pathname))
+    trust_file = described_class.trust_file
+    trust_file.write(JSON.generate({ trustedtaps: ["thirdparty/foo"] }))
+    trust_file.chmod(0660)
+
+    expect { described_class.trust!(:tap, "thirdparty/bar") }
+      .to raise_error(Homebrew::InsecureTrustStoreError, /Refusing to write insecure trust store/)
+  ensure
+    trust_file.chmod(0600) if trust_file&.exist?
+    FileUtils.rm_f trust_file if trust_file
+  end
+
+  it "writes a symlinked trust store through to its target" do
+    trust_file = described_class.trust_file
+    target_dir = T.let(nil, T.nilable(Pathname))
+    target_dir = Pathname(TEST_TMPDIR)/"trust-target"
+    target_dir.mkpath
+    target_file = target_dir/"trust.json"
+    target_file.write(JSON.generate({ trustedtaps: ["thirdparty/foo"] }))
+    FileUtils.ln_s target_file, trust_file
+
+    described_class.trust!(:tap, "thirdparty/bar")
+
+    expect(trust_file).to be_a_symlink
+    expect(JSON.parse(target_file.read).fetch("trustedtaps")).to eq(["thirdparty/bar", "thirdparty/foo"])
+  ensure
+    described_class.clear!(:tap)
+    FileUtils.rm_rf target_dir if target_dir
+  end
+
+  it "rejects a symlinked trust store in a group-writable directory" do
+    trust_file = described_class.trust_file
+    target_dir = T.let(nil, T.nilable(Pathname))
+    target_dir = Pathname(TEST_TMPDIR)/"trust-target"
+    target_dir.mkpath
+    target_dir.chmod(0770)
+    FileUtils.ln_s target_dir/"trust.json", trust_file
+
+    expect { described_class.trust!(:tap, "thirdparty/foo") }
+      .to raise_error(Homebrew::InsecureTrustStoreError, /Refusing to write insecure trust store/)
+  ensure
+    target_dir.chmod(0700) if target_dir&.exist?
+    FileUtils.rm_rf target_dir if target_dir
+  end
+
+  it "rejects a symlinked trust store pointing to another symlink" do
+    trust_file = described_class.trust_file
+    target_dir = T.let(nil, T.nilable(Pathname))
+    target_dir = Pathname(TEST_TMPDIR)/"trust-target"
+    target_dir.mkpath
+    FileUtils.ln_s target_dir/"real-trust.json", target_dir/"trust.json"
+    FileUtils.ln_s target_dir/"trust.json", trust_file
+
+    expect { described_class.trust!(:tap, "thirdparty/foo") }
+      .to raise_error(Homebrew::InsecureTrustStoreError, /Refusing to write insecure trust store/)
+  ensure
+    FileUtils.rm_rf target_dir if target_dir
+  end
+
   it "requires third-party taps by default" do
     described_class.clear!(:tap)
     tap = Tap.fetch("thirdparty", "foo")

--- a/Library/Homebrew/test_bot.rb
+++ b/Library/Homebrew/test_bot.rb
@@ -110,6 +110,7 @@ module Homebrew
         ENV["HOMEBREW_LOGS"] = logs
         FileUtils.mkdir_p home
         FileUtils.mkdir_p ENV.fetch("HOMEBREW_USER_CONFIG_HOME")
+        FileUtils.chmod 0700, ENV.fetch("HOMEBREW_USER_CONFIG_HOME")
         FileUtils.mkdir_p logs
         FileUtils.cp gitconfig, home if File.exist?(gitconfig)
         FileUtils.cp trust_file, ENV.fetch("HOMEBREW_USER_CONFIG_HOME") if trust_file.exist?

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -8,6 +8,7 @@ require "utils"
 require "utils/output"
 
 module Homebrew
+  class InsecureTrustStoreError < RuntimeError; end
   class UntrustedTapError < RuntimeError; end
 
   module Trust
@@ -388,17 +389,74 @@ module Homebrew
 
     sig { params(store: T::Hash[String, T::Array[String]]).void }
     def self.write_trust_store(store)
-      trust_path = trust_file
+      write_path = trust_file
+      if write_path.symlink?
+        link_parent = write_path.dirname.realpath
+        assert_secure_trust_store_path!(link_parent, link_parent.stat, "symlink directory")
+        if write_path.lstat.uid != Process.euid
+          raise InsecureTrustStoreError,
+                "Refusing to write insecure trust store: symlink #{write_path} is not owned by the current user."
+        end
+        target_path = write_path.readlink
+        target_path = write_path.dirname/target_path unless target_path.absolute?
+        target_parent = target_path.dirname.realpath
+        assert_secure_trust_store_path!(target_parent, target_parent.stat, "target directory")
+        write_path = target_parent/target_path.basename
+        if write_path.symlink?
+          raise InsecureTrustStoreError,
+                "Refusing to write insecure trust store: target is a symlink."
+        end
+        if write_path.exist?
+          assert_secure_trust_store_path!(write_path, write_path.stat, "target")
+          unless write_path.file?
+            raise InsecureTrustStoreError,
+                  "Refusing to write insecure trust store: target is not a regular file."
+          end
+        end
+      else
+        ensure_secure_trust_store_directory!(write_path.dirname, "trust store directory")
+        if write_path.exist?
+          assert_secure_trust_store_path!(write_path, write_path.stat, "trust store")
+          unless write_path.file?
+            raise InsecureTrustStoreError,
+                  "Refusing to write insecure trust store: trust store is not a regular file."
+          end
+        end
+      end
       if store.empty?
-        trust_path.unlink if trust_path.exist?
+        write_path.unlink if write_path.exist?
         return
       end
 
-      trust_path.dirname.mkpath
-      trust_path.atomic_write("#{JSON.pretty_generate(store)}\n")
-      trust_path.chmod(0600)
+      write_path.atomic_write("#{JSON.pretty_generate(store)}\n")
+      write_path.chmod(0600)
+    rescue Errno::ENOENT
+      raise InsecureTrustStoreError, "Refusing to write insecure trust store: target directory does not exist."
     end
     private_class_method :write_trust_store
+
+    sig { params(path: Pathname, description: String).void }
+    def self.ensure_secure_trust_store_directory!(path, description)
+      existed = path.exist?
+      path.mkpath
+      path.chmod(0700) unless existed
+      assert_secure_trust_store_path!(path, path.stat, description)
+    end
+    private_class_method :ensure_secure_trust_store_directory!
+
+    sig { params(path: Pathname, stat: File::Stat, description: String).void }
+    def self.assert_secure_trust_store_path!(path, stat, description)
+      if stat.uid != Process.euid
+        raise InsecureTrustStoreError,
+              "Refusing to write insecure trust store: #{description} #{path} is not owned by the current user."
+      end
+
+      return if stat.mode.nobits?(022)
+
+      raise InsecureTrustStoreError,
+            "Refusing to write insecure trust store: #{description} #{path} is group or world writable."
+    end
+    private_class_method :assert_secure_trust_store_path!
 
     # Serialises trust store mutations so concurrent processes or threads
     # (e.g. parallel `brew bundle` installs) cannot lose entries in the
@@ -408,7 +466,7 @@ module Homebrew
     }
     def self.with_trust_store_lock(&_block)
       lock_path = Pathname.new("#{trust_file}.lock")
-      lock_path.dirname.mkpath
+      ensure_secure_trust_store_directory!(lock_path.dirname, "trust store directory")
       File.open(lock_path, File::RDWR | File::CREAT, 0600) do |lock_file|
         lock_file.flock(File::LOCK_EX)
         yield


### PR DESCRIPTION
- Preserve user-managed `trust.json` symlinks during trust updates.
- Reject unsafe trust-store paths before writing user trust data.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
