### PR TITLE
services: check `--sudo-service-user` exists

### DIFF
--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -376,9 +376,14 @@ module Homebrew
       sig { params(service: Services::FormulaWrapper, file: T.nilable(Pathname), enable: T::Boolean).void }
       def self.service_load(service, file, enable:)
         if System.root? && !service.service_startup? && !sudo_service_user
-          opoo "#{service.name} must be run as non-root to start at user login!"
+          opoo "`#{service.name}` must be run as non-root to start at user login!"
         elsif !System.root? && service.service_startup?
-          opoo "#{service.name} must be run as root to start at system startup!"
+          opoo "`#{service.name}` must be run as root to start at system startup!"
+        end
+
+        if (service_user = sudo_service_user) && !System.user_exists?(service_user)
+          function = enable ? "start" : "run"
+          odie "Cannot #{function} `#{service.name}` as `#{service_user}` is not a user!"
         end
 
         if System.launchctl?

--- a/Library/Homebrew/services/system.rb
+++ b/Library/Homebrew/services/system.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "etc"
 require_relative "system/systemctl"
 require "utils/output"
 
@@ -54,6 +55,18 @@ module Homebrew
         else
           Utils.safe_popen_read("ps", "-o", "user", "-p", pid.to_s).lines.second&.chomp
         end
+      end
+
+      sig { params(username: String).returns(T::Boolean) }
+      def self.user_exists?(username)
+        # Current user must be present
+        return true if username == user
+
+        # Check other users
+        Etc.getpwnam(username)
+        true
+      rescue ArgumentError
+        false
       end
 
       # Run at boot.

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -544,7 +544,7 @@ RSpec.describe Homebrew::Services::Cli do
           nil,
           enable: true,
         )
-      end.to output(/name must be run as non-root to start at user login!/).to_stderr
+      end.to output(/`name` must be run as non-root to start at user login!/).to_stderr
     end
 
     it "does not warn root for login when given `--sudo-service-user`" do
@@ -552,6 +552,7 @@ RSpec.describe Homebrew::Services::Cli do
       expect(Homebrew::Services::System).to receive(:systemctl?).once.and_return(false)
       expect(Homebrew::Services::System).to receive(:root?).twice.and_return(true)
       allow(services_cli).to receive(:sudo_service_user).and_return("_serviced")
+      allow(Homebrew::Services::System).to receive(:user_exists?).with("_serviced").and_return(true)
       expect do
         services_cli.service_load(
           instance_double(
@@ -564,6 +565,46 @@ RSpec.describe Homebrew::Services::Cli do
           enable: true,
         )
       end.not_to output(/must be run as non-root to start at user login!/).to_stderr
+    end
+
+    it "errors then exits when given a `--sudo-service-user` which does not exist" do
+      allow(services_cli).to receive(:sudo_service_user).and_return("not_a_real_user")
+      expect(Homebrew::Services::System).to receive(:user_exists?).with("not_a_real_user").and_return(false)
+      expect do
+        services_cli.service_load(
+          instance_double(
+            Homebrew::Services::FormulaWrapper,
+            name:             "name",
+            service_name:     "service.name",
+            service_startup?: false,
+          ),
+          nil,
+          enable: true,
+        )
+      end.to output(/Error: Cannot start `name` as `not_a_real_user` is not a user!/).to_stderr
+                                                                                     .and raise_error(SystemExit)
+    end
+
+    it "continues loading when given a `--sudo-service-user` which exists" do
+      expect(Homebrew::Services::System).to receive(:launchctl?).once.and_return(false)
+      expect(Homebrew::Services::System).to receive(:systemctl?).once.and_return(false)
+      expect(Homebrew::Services::System).to receive(:root?).twice.and_return(true)
+      allow(services_cli).to receive(:sudo_service_user).and_return("_serviced")
+      expect(Homebrew::Services::System).to receive(:user_exists?).with("_serviced").and_return(true)
+      expect do
+        services_cli.service_load(
+          instance_double(
+            Homebrew::Services::FormulaWrapper,
+            name:             "name",
+            service_name:     "service.name",
+            service_startup?: false,
+            service_file:     instance_double(Pathname, exist?: false),
+            path_dirs:        [],
+          ),
+          nil,
+          enable: true,
+        )
+      end.to output("==> Successfully started `name` (label: service.name)\n").to_stdout
     end
 
     it "triggers launchctl" do

--- a/Library/Homebrew/test/services/system_spec.rb
+++ b/Library/Homebrew/test/services/system_spec.rb
@@ -110,6 +110,16 @@ RSpec.describe Homebrew::Services::System do
     end
   end
 
+  describe "#user_exists?" do
+    it "returns true when a specified user exists" do
+      expect(described_class.user_exists?(ENV.fetch("USER"))).to be(true)
+    end
+
+    it "returns false when a specified user does not exist" do
+      expect(described_class.user_exists?("not_a_real_user_#{SecureRandom.hex(4)}")).to be(false)
+    end
+  end
+
   describe "#domain_target" do
     it "returns the current domain target" do
       allow(described_class).to receive(:root?).and_return(false)


### PR DESCRIPTION
### Motivation
The `--sudo-service-user` flag for `brew services [start/restart]` (fixed in #22500) can be used on macOS to run services as a specified user. The launch daemon is bootstrapped irrespective of the user's existence, resulting in an incorrect message and broken daemon if the specified user is not present. E.g.,
```
$ sudo brew services start nginx --sudo-service-user not_a_real_user
==> Setting username in homebrew.mxcl.nginx to: not_a_real_user
==> Successfully started `nginx` (label: homebrew.mxcl.nginx)

$ launchctl print system/homebrew.mxcl.nginx | grep -E 'last exit'
	last exit code = 78: EX_CONFIG
```

This could be misleading for some users.

### Feature
A new method in `services/system.rb` to check whether a given user is present on the system. This is used to display an error and avoid bootstrapping the daemon when provided a `--sudo-service-user` which does not exist. This provides a clearer indication of the service's state; e.g.,

```
$ sudo brew services start nginx --sudo-service-user not_a_real_user
==> Setting username in homebrew.mxcl.nginx to: not_a_real_user
Error: Cannot start `nginx` as `not_a_real_user` is not a user!

$ launchctl print system/homebrew.mxcl.nginx
Bad request.
Could not find service "homebrew.mxcl.nginx" in domain for system
```

Note that a daemon with the specified user will still be set, as to not break the workflow where a `brew services`-prepared daemon is manually bootstrapped following user creation.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

    Claude Opus 4.8 was used solely to review this PR prior to creation, although no suggestions were incorporated.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
