### PR TITLE
Skip self-conflicts during install

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -655,6 +655,8 @@ on_request: installed_on_request?, options:)
     return unless link_keg
 
     conflicts = formula.conflicts.select do |c|
+      next false if c.name == formula.name || c.name == formula.full_name
+
       f = Formulary.factory(c.name)
     rescue TapFormulaUnavailableError
       # If the formula name is a fully-qualified name let's silently

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -299,6 +299,20 @@ RSpec.describe FormulaInstaller do
         expect { installer.check_conflicts }.not_to raise_error
       end
     end
+
+    it "ignores conflicts that name the formula being installed" do
+      f = formula("terraform", tap: Tap.fetch("thirdparty", "selfconflict")) do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+        conflicts_with "terraform"
+      end
+
+      expect(Formulary).not_to receive(:factory)
+
+      described_class.new(f).check_conflicts
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
   end
 
   describe "#install_dependencies" do


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22748

- A tap formula can declare `conflicts_with` using its own unqualified name, as `hashicorp/tap/terraform` does.
- Resolving that name in `FormulaInstaller#check_conflicts` reloads the same formula through normal name lookup and can enter tap trust paths inside the build sandbox.
- Skip conflicts matching `Formula#name` or `Formula#full_name`; other conflicts still resolve as before.
- Add a regression that fails if `check_conflicts` asks `Formulary` to load a self-conflict.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
