### PR TITLE
Don't bold upgradable dependencies in install plans

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -825,7 +825,8 @@ on_request: installed_on_request?, options:)
         names = deps_with_formulae.map do |dep, dep_formula|
           installed = dep_formula.any_version_installed?
           pretty_install_status(Formatter.identifier(dep), installed:,
-                                outdated: installed && dep_formula.outdated?, mark_uninstalled: false)
+                                outdated: installed && dep_formula.outdated?, mark_uninstalled: false,
+                                bold: false)
         end
         oh1 "Installing dependencies for #{formula.full_name}: #{names.to_sentence}", truncate: false
       end

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -512,7 +512,7 @@ module Homebrew
           name = yield dependency
           installed = dependency.any_version_installed?
           pretty_install_status(name, installed:, outdated: installed && dependency.outdated?,
-                                mark_uninstalled: false)
+                                mark_uninstalled: false, bold: false)
         end
         return if formula_names.empty?
 

--- a/Library/Homebrew/test/utils/output_spec.rb
+++ b/Library/Homebrew/test/utils/output_spec.rb
@@ -41,6 +41,28 @@ RSpec.describe Utils::Output do
     end
   end
 
+  describe "#pretty_upgradable" do
+    context "when $stdout is a TTY" do
+      before { allow($stdout).to receive(:tty?).and_return(true) }
+
+      it "returns a bold string with a colored up arrow by default" do
+        expect(described_class.pretty_upgradable("foo")).to match(/#{esc 1}foo #{esc 32}↑#{esc 0}/)
+      end
+
+      it "omits the bold escape when bold is false" do
+        expect(described_class.pretty_upgradable("foo", bold: false)).to match(/\Afoo #{esc 32}↑#{esc 0}/)
+      end
+    end
+
+    context "when $stdout is not a TTY" do
+      before { allow($stdout).to receive(:tty?).and_return(false) }
+
+      it "returns plain text" do
+        expect(described_class.pretty_upgradable("foo", bold: false)).to eq("foo")
+      end
+    end
+  end
+
   describe "#pretty_uninstalled" do
     subject(:pretty_uninstalled_output) { described_class.pretty_uninstalled("foo") }
 

--- a/Library/Homebrew/utils/output.rb
+++ b/Library/Homebrew/utils/output.rb
@@ -262,14 +262,15 @@ module Utils
         end
       end
 
-      sig { params(string: String).returns(String) }
-      def pretty_upgradable(string)
+      sig { params(string: String, bold: T::Boolean).returns(String) }
+      def pretty_upgradable(string, bold: true)
+        weight = bold ? Tty.bold : ""
         if !$stdout.tty?
           string
         elsif Homebrew::EnvConfig.no_emoji?
-          "#{Tty.bold}#{string} (upgradable)#{Tty.reset}"
+          "#{weight}#{string} (upgradable)#{Tty.reset}"
         else
-          "#{Tty.bold}#{string} #{Formatter.success("↑")}#{Tty.reset}"
+          "#{weight}#{string} #{Formatter.success("↑")}#{Tty.reset}"
         end
       end
 
@@ -306,12 +307,12 @@ module Utils
 
       sig {
         params(string: String, installed: T::Boolean, outdated: T::Boolean, deprecated: T::Boolean,
-               disabled: T::Boolean, mark_uninstalled: T::Boolean).returns(String)
+               disabled: T::Boolean, mark_uninstalled: T::Boolean, bold: T::Boolean).returns(String)
       }
       def pretty_install_status(string, installed:, outdated: false, deprecated: false, disabled: false,
-                                mark_uninstalled: true)
+                                mark_uninstalled: true, bold: true)
         status = if installed && outdated
-          pretty_upgradable(string)
+          pretty_upgradable(string, bold:)
         elsif installed
           pretty_installed(string)
         elsif mark_uninstalled


### PR DESCRIPTION
In my previous PR (https://github.com/Homebrew/brew/pull/22761), I forgot to check the output manually, and when running it now it looks weird that only the upgradable ones are bolded and not the uninstalled ones:


```
❯ brew install asciidoc
✔︎ JSON API packages.arm64_tahoe.jws.json                                                                                             Downloaded   15.2MB/ 15.2MB
==> Would install 1 formula:
asciidoc
==> Downloading https://ghcr.io/v2/homebrew/core/asciidoc/manifests/10.2.1_1
Already downloaded: /Users/Harald/Library/Caches/Homebrew/downloads/d3d2ae70eea0fe1224314928dd05150d27f30d1619b71ae1bab1de2689ba6531--asciidoc-10.2.1_1.bottle_manifest.json
==> Would install 6 dependencies for asciidoc:
docbook
ca-certificates ↑
sqlite ↑
python@3.14 ↑
boost
source-highlight
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claud Code, Extra High

-----
