### PR TITLE
formula_installer: skip conflicts if not linking

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -651,6 +651,7 @@ on_request: installed_on_request?, options:)
   sig { void }
   def check_conflicts
     return if force?
+    return unless link_keg
 
     conflicts = formula.conflicts.select do |c|
       f = Formulary.factory(c.name)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -651,6 +651,7 @@ on_request: installed_on_request?, options:)
   sig { void }
   def check_conflicts
     return if force?
+    return if skip_link?
     return unless link_keg
 
     conflicts = formula.conflicts.select do |c|

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -240,6 +240,67 @@ RSpec.describe FormulaInstaller do
     end
   end
 
+  describe "#check_conflicts" do
+    let(:test_formula) do
+      formula "testball" do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/testball-0.1.tar.gz"
+        conflicts_with "other"
+      end
+    end
+
+    let(:conflicting_formula) do
+      formula "other" do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/other-0.1.tar.gz"
+        conflicts_with "testball"
+      end
+    end
+
+    before { allow(Formulary).to receive(:factory).with("other").and_return(conflicting_formula) }
+
+    context "when conflicting formula is installed but not linked" do
+      before do
+        linked_keg = instance_double(Pathname, exist?: false)
+        opt_prefix = instance_double(Pathname, exist?: true)
+        allow(conflicting_formula).to receive_messages(linked_keg:, opt_prefix:)
+      end
+
+      it "does not raise an error" do
+        installer = described_class.new(test_formula, link_keg: true)
+        expect { installer.check_conflicts }.not_to raise_error
+      end
+    end
+
+    context "when conflicting formula is installed" do
+      before do
+        linked_keg = opt_prefix = instance_double(Pathname, exist?: true)
+        allow(conflicting_formula).to receive_messages(linked_keg:, opt_prefix:)
+      end
+
+      it "raises an error if linking keg" do
+        installer = described_class.new(test_formula, link_keg: true)
+        expect { installer.check_conflicts }.to raise_error(FormulaConflictError)
+      end
+
+      it "does not raise an error with force set" do
+        installer = described_class.new(test_formula, link_keg: true, force: true)
+        expect { installer.check_conflicts }.not_to raise_error
+      end
+
+      it "does not raise an error with skip_link set" do
+        installer = described_class.new(test_formula, link_keg: true, skip_link: true)
+        expect { installer.check_conflicts }.not_to raise_error
+      end
+
+      it "does not raise an error if not linking keg" do
+        allow(test_formula).to receive(:keg_only?).and_return(true)
+        installer = described_class.new(test_formula, link_keg: false, installed_on_request: false)
+        expect { installer.check_conflicts }.not_to raise_error
+      end
+    end
+  end
+
   describe "#install_dependencies" do
     it "marks only outdated dependencies as upgradable in the header" do
       outdated = formula "outdated-dependency" do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Will allow continuing to install `qt@5` as dependency after 
- https://github.com/Homebrew/homebrew-core/pull/288365

Right now, test bot is not aware of conflict due to split out of Qt6 and the new auto link behavior causes issues in CI runs.

Explicitly declaring conflict will allow test bot to automatically unlink/link formulae. However, the conflict handler will fail even if formula is not getting linked, e.g. `brew install --as-dependency qt@5`.

---

One scenario this could break is if 2 formulae conflict even when unlinked. I don't think this happens in Homebrew/core but may be possible in 3rd party tap.

If needed, we could add another argument to `conflicts_with` that scopes the conflict.