### PR TITLE
Locate installed racks from untrusted taps

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -1138,8 +1138,15 @@ module Formulary
 
   sig { params(ref: String).returns(Pathname) }
   def self.to_rack(ref)
-    # If using a fully-scoped reference, check if the formula can be resolved.
-    factory(ref) if ref.include? "/"
+    # If using a fully-scoped reference, check the formula can be resolved to
+    # reject a bogus reference like `fake/tap/hello`. An untrusted tap is no
+    # barrier to uninstalling an installed formula: this error only fires once
+    # the formula file exists and is raised before the file is evaluated.
+    begin
+      factory(ref) if ref.include? "/"
+    rescue Homebrew::UntrustedTapError
+      nil
+    end
 
     # Check whether the rack with the given name exists.
     if (rack = HOMEBREW_CELLAR/File.basename(ref, ".rb")).directory?

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -837,6 +837,27 @@ RSpec.describe Formulary do
         described_class.to_rack("a/b/#{formula_name}")
       end.to raise_error(TapFormulaUnavailableError)
     end
+
+    it "locates an installed Rack from an untrusted tap without evaluating its formula" do
+      tap = Tap.fetch("untrustedrack", "foo")
+      formula_path = tap.formula_dir/"#{formula_name}.rb"
+      formula_path.dirname.mkpath
+      eval_marker = mktmpdir/"evaluated"
+      formula_path.write <<~RUBY
+        class #{described_class.class_s(formula_name)} < Formula
+          url "https://brew.sh/#{formula_name}-1.0.tar.gz"
+          File.write("#{eval_marker}", "evaluated")
+        end
+      RUBY
+      rack_path.mkpath
+
+      with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1", HOMEBREW_USER_CONFIG_HOME: mktmpdir) do
+        expect(described_class.to_rack("#{tap.name}/#{formula_name}")).to eq(rack_path)
+        expect(eval_marker).not_to exist
+      end
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"untrustedrack"
+    end
   end
 
   describe "::core_path" do


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22770

- `brew uninstall` of a package from an untrusted tap aborted because `Formulary.to_rack` ran a `factory` validity check that hit the tap trust gate before the cellar was consulted
- rescue `UntrustedTapError` there so resolution falls through to the installed rack; uninstalling needs only the on-disk keg, not the tap
- this reads the cellar without evaluating untrusted formula code, so installing or loading such formulae still requires trust

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
