### PR TITLE
Clarify tap trust warning next steps

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -706,40 +706,40 @@ module Homebrew
         return if untrusted_taps.empty?
 
         untrusted_tap_names = untrusted_taps.map(&:name)
-        installed_formulae_by_tap = T.let({}, T::Hash[String, T::Array[String]])
-        installed_casks_by_tap = T.let({}, T::Hash[String, T::Array[String]])
+        untrusted_tap_name_set = untrusted_tap_names.to_set
+        installed_formulae_by_tap = {}
+        installed_casks_by_tap = {}
         Formula.racks.each do |rack|
           next unless (keg = Keg.from_rack(rack))
           next unless (tap = keg.tab.tap)
-          next unless untrusted_tap_names.include?(tap.name)
+          next unless untrusted_tap_name_set.include?(tap.name)
 
-          installed_formulae_by_tap[tap.name] ||= []
-          installed_formulae_by_tap.fetch(tap.name) << "#{tap.name}/#{rack.basename}"
+          installed_formulae = installed_formulae_by_tap[tap.name] ||= []
+          installed_formulae << "#{tap.name}/#{rack.basename}"
         rescue
           nil
         end
-        installed_formula_message = installed_formulae_by_tap.filter_map do |_tap_name, formulae|
+        installed_formula_message = installed_formulae_by_tap.sort_by(&:first).filter_map do |_tap_name, formulae|
           next if formulae.empty?
 
           "  brew trust --formula #{formulae.sort.join(" ")}"
         end.join("\n")
         Cask::Caskroom.casks.each do |cask|
           next unless (tap = cask.tab.tap)
-          next unless untrusted_tap_names.include?(tap.name)
+          next unless untrusted_tap_name_set.include?(tap.name)
 
-          installed_casks_by_tap[tap.name] ||= []
-          installed_casks_by_tap.fetch(tap.name) << "#{tap.name}/#{cask.token}"
+          installed_casks = installed_casks_by_tap[tap.name] ||= []
+          installed_casks << "#{tap.name}/#{cask.token}"
         end
-        sorted_installed_casks_by_tap = installed_casks_by_tap.sort_by do |tap_name, _casks|
-          tap_name
-        end
-        installed_cask_message = sorted_installed_casks_by_tap.filter_map do |_tap_name, casks|
+        installed_cask_message = installed_casks_by_tap.sort_by(&:first).filter_map do |_tap_name, casks|
           next if casks.empty?
 
           "  brew trust --cask #{casks.sort.join(" ")}"
         end.join("\n")
-        generic_trust_types = T.let([], T::Array[String])
-        generic_trust_commands = T.let([], T::Array[String])
+        installed_items_from_untrusted_taps = installed_formula_message.present? || installed_cask_message.present?
+        untap_message = "Untap them with:\n  brew untap #{untrusted_tap_names.join(" ")}"
+        generic_trust_types = []
+        generic_trust_commands = []
         if installed_formula_message.blank?
           generic_trust_types << "formulae"
           generic_trust_commands << "  brew trust --formula <user>/<tap>/<formula>"
@@ -750,38 +750,49 @@ module Homebrew
         end
         generic_trust_types << "commands"
         generic_trust_commands << "  brew trust --command <user>/<tap>/<command>"
-        generic_trust_prefix = if installed_formula_message.present? || installed_cask_message.present?
+        generic_trust_prefix = if installed_items_from_untrusted_taps
           "Trust other specific"
         else
           "Trust specific"
         end
-        trust_messages = T.let(
-          ["Prefer trusting only the specific formulae, casks or commands you need."],
-          T::Array[String],
-        )
+        generic_trust_message = "#{generic_trust_prefix} #{generic_trust_types.to_sentence} with:\n" \
+                                "#{generic_trust_commands.join("\n")}"
+        trust_messages = if installed_items_from_untrusted_taps
+          ["Prefer trusting only the specific formulae, casks or commands you need."]
+        else
+          [untap_message]
+        end
         if installed_formula_message.present?
           trust_messages << "Trust installed formulae from these taps with:\n#{installed_formula_message}"
         end
         if installed_cask_message.present?
           trust_messages << "Trust installed casks from these taps with:\n#{installed_cask_message}"
         end
-        trust_messages << "#{generic_trust_prefix} #{generic_trust_types.to_sentence} with:\n" \
-                          "#{generic_trust_commands.join("\n")}"
+        trust_messages << generic_trust_message
+        trust_messages << <<~EOS.chomp
+          Whole-tap trust is broader and includes all current and future formulae,
+          casks and commands from the listed taps. Trust whole taps with:
+            brew trust #{untrusted_tap_names.join(" ")}
+        EOS
+        trust_messages << untap_message if installed_items_from_untrusted_taps
+        unless Homebrew::EnvConfig.no_env_hints?
+          trust_messages << <<~EOS.chomp
+            To disable trust checks:
+              export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
+            This is not recommended and will be removed in a later release.
+          EOS
+        end
+        trust_messages << <<~EOS.chomp
+          For more information, see:
+            #{Formatter.url("https://docs.brew.sh/Tap-Trust")}
+        EOS
+
         <<~EOS
           The following taps are not trusted:
             #{untrusted_tap_names.join("\n  ")}
 
           Homebrew is currently ignoring formulae, casks and commands from these taps because tap trust is required.
           #{trust_messages.join("\n")}
-          If you intentionally trust an entire tap, trust all formulae, casks and commands from these taps with:
-            brew trust #{untrusted_tap_names.join(" ")}
-          Untap them with:
-            brew untap #{untrusted_tap_names.join(" ")}
-          To disable trust checks:
-            export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
-          This is not recommended and will be removed in a later release.
-          For more information, see:
-            #{Formatter.url("https://docs.brew.sh/Tap-Trust")}
         EOS
       end
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -707,6 +707,7 @@ module Homebrew
 
         untrusted_tap_names = untrusted_taps.map(&:name)
         installed_formulae_by_tap = T.let({}, T::Hash[String, T::Array[String]])
+        installed_casks_by_tap = T.let({}, T::Hash[String, T::Array[String]])
         Formula.racks.each do |rack|
           next unless (keg = Keg.from_rack(rack))
           next unless (tap = keg.tab.tap)
@@ -722,24 +723,65 @@ module Homebrew
 
           "  brew trust --formula #{formulae.sort.join(" ")}"
         end.join("\n")
+        Cask::Caskroom.casks.each do |cask|
+          next unless (tap = cask.tab.tap)
+          next unless untrusted_tap_names.include?(tap.name)
+
+          installed_casks_by_tap[tap.name] ||= []
+          installed_casks_by_tap.fetch(tap.name) << "#{tap.name}/#{cask.token}"
+        end
+        sorted_installed_casks_by_tap = installed_casks_by_tap.sort_by do |tap_name, _casks|
+          tap_name
+        end
+        installed_cask_message = sorted_installed_casks_by_tap.filter_map do |_tap_name, casks|
+          next if casks.empty?
+
+          "  brew trust --cask #{casks.sort.join(" ")}"
+        end.join("\n")
+        generic_trust_types = T.let([], T::Array[String])
+        generic_trust_commands = T.let([], T::Array[String])
+        if installed_formula_message.blank?
+          generic_trust_types << "formulae"
+          generic_trust_commands << "  brew trust --formula <user>/<tap>/<formula>"
+        end
+        if installed_cask_message.blank?
+          generic_trust_types << "casks"
+          generic_trust_commands << "  brew trust --cask <user>/<tap>/<cask>"
+        end
+        generic_trust_types << "commands"
+        generic_trust_commands << "  brew trust --command <user>/<tap>/<command>"
+        generic_trust_prefix = if installed_formula_message.present? || installed_cask_message.present?
+          "Trust other specific"
+        else
+          "Trust specific"
+        end
+        trust_messages = T.let(
+          ["Prefer trusting only the specific formulae, casks or commands you need."],
+          T::Array[String],
+        )
+        if installed_formula_message.present?
+          trust_messages << "Trust installed formulae from these taps with:\n#{installed_formula_message}"
+        end
+        if installed_cask_message.present?
+          trust_messages << "Trust installed casks from these taps with:\n#{installed_cask_message}"
+        end
+        trust_messages << "#{generic_trust_prefix} #{generic_trust_types.to_sentence} with:\n" \
+                          "#{generic_trust_commands.join("\n")}"
         <<~EOS
           The following taps are not trusted:
             #{untrusted_tap_names.join("\n  ")}
 
           Homebrew is currently ignoring formulae, casks and commands from these taps because tap trust is required.
-          Trust specific formulae, casks or commands with:
-            brew trust --formula <user>/<tap>/<formula>
-            brew trust --cask <user>/<tap>/<cask>
-            brew trust --command <user>/<tap>/<command>
-          #{"or trust installed formulae from these taps with:\n#{installed_formula_message}" if installed_formula_message.present?}
-          You can trust all formulae, casks and commands from these taps with:
+          #{trust_messages.join("\n")}
+          If you intentionally trust an entire tap, trust all formulae, casks and commands from these taps with:
             brew trust #{untrusted_tap_names.join(" ")}
-          Prefer trusting only the specific formulae, casks or commands you need.
           Untap them with:
             brew untap #{untrusted_tap_names.join(" ")}
           To disable trust checks:
             export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
           This is not recommended and will be removed in a later release.
+          For more information, see:
+            #{Formatter.url("https://docs.brew.sh/Tap-Trust")}
         EOS
       end
 

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -124,33 +124,49 @@ RSpec.describe Homebrew::Diagnostic::Checks do
   end
 
   specify "#check_untrusted_taps" do
-    tap = instance_double(Tap, name: "thirdparty/foo")
-    rack = HOMEBREW_CELLAR/"bar"
-    keg = instance_double(Keg, tab: instance_double(Tab, tap:))
-    cask = instance_double(Cask::Cask, token: "baz", tab: instance_double(Cask::Tab, tap:))
-    allow(Homebrew::Trust).to receive(:wholly_untrusted_taps).and_return([tap])
-    allow(Formula).to receive(:racks).and_return([rack])
-    allow(Keg).to receive(:from_rack).with(rack).and_return(keg)
-    allow(Cask::Caskroom).to receive(:casks).and_return([cask])
+    foo_tap = instance_double(Tap, name: "thirdparty/foo")
+    bar_tap = instance_double(Tap, name: "thirdparty/bar")
+    foo_rack = HOMEBREW_CELLAR/"foo-formula"
+    bar_rack = HOMEBREW_CELLAR/"bar-formula"
+    foo_keg = instance_double(Keg, tab: instance_double(Tab, tap: foo_tap))
+    bar_keg = instance_double(Keg, tab: instance_double(Tab, tap: bar_tap))
+    foo_cask = instance_double(Cask::Cask, token: "foo-cask", tab: instance_double(Cask::Tab, tap: foo_tap))
+    bar_cask = instance_double(Cask::Cask, token: "bar-cask", tab: instance_double(Cask::Tab, tap: bar_tap))
+    allow(Homebrew::Trust).to receive(:wholly_untrusted_taps).and_return([foo_tap, bar_tap])
+    allow(Formula).to receive(:racks).and_return([foo_rack, bar_rack])
+    allow(Keg).to receive(:from_rack).with(foo_rack).and_return(foo_keg)
+    allow(Keg).to receive(:from_rack).with(bar_rack).and_return(bar_keg)
+    allow(Cask::Caskroom).to receive(:casks).and_return([foo_cask, bar_cask])
 
     with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
       check_untrusted_taps = checks.check_untrusted_taps
-      expect(check_untrusted_taps).to include <<~EOS
+      expect(check_untrusted_taps).to eq <<~EOS
+        The following taps are not trusted:
+          thirdparty/foo
+          thirdparty/bar
+
         Homebrew is currently ignoring formulae, casks and commands from these taps because tap trust is required.
         Prefer trusting only the specific formulae, casks or commands you need.
         Trust installed formulae from these taps with:
-          brew trust --formula thirdparty/foo/bar
+          brew trust --formula thirdparty/bar/bar-formula
+          brew trust --formula thirdparty/foo/foo-formula
         Trust installed casks from these taps with:
-          brew trust --cask thirdparty/foo/baz
+          brew trust --cask thirdparty/bar/bar-cask
+          brew trust --cask thirdparty/foo/foo-cask
         Trust other specific commands with:
           brew trust --command <user>/<tap>/<command>
+        Whole-tap trust is broader and includes all current and future formulae,
+        casks and commands from the listed taps. Trust whole taps with:
+          brew trust thirdparty/foo thirdparty/bar
+        Untap them with:
+          brew untap thirdparty/foo thirdparty/bar
+        To disable trust checks:
+          export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
+        This is not recommended and will be removed in a later release.
+        For more information, see:
+          #{Formatter.url("https://docs.brew.sh/Tap-Trust")}
       EOS
 
-      expect(check_untrusted_taps).to include(
-        "brew untap thirdparty/foo",
-        "brew trust thirdparty/foo",
-        Formatter.url("https://docs.brew.sh/Tap-Trust"),
-      )
       expect(check_untrusted_taps)
         .not_to include(
           "brew trust --formula <user>/<tap>/<formula>",
@@ -166,18 +182,40 @@ RSpec.describe Homebrew::Diagnostic::Checks do
     allow(Cask::Caskroom).to receive(:casks).and_return([])
 
     with_env(HOMEBREW_REQUIRE_TAP_TRUST: nil, HOMEBREW_NO_REQUIRE_TAP_TRUST: nil) do
-      expect(checks.check_untrusted_taps)
-        .to include(
-          "Homebrew is currently ignoring formulae, casks and commands from these taps " \
-          "because tap trust is required.",
-          Formatter.url("https://docs.brew.sh/Tap-Trust"),
-          "brew untap thirdparty/foo",
-          "brew trust thirdparty/foo",
-          "If you intentionally trust an entire tap",
-          "export HOMEBREW_NO_REQUIRE_TAP_TRUST=1",
-          "This is not recommended and will be removed in a later release.",
-          "Prefer trusting only the specific formulae, casks or commands you need.",
-        )
+      check_untrusted_taps = checks.check_untrusted_taps
+      expect(check_untrusted_taps).to eq <<~EOS
+        The following taps are not trusted:
+          thirdparty/foo
+
+        Homebrew is currently ignoring formulae, casks and commands from these taps because tap trust is required.
+        Untap them with:
+          brew untap thirdparty/foo
+        Trust specific formulae, casks and commands with:
+          brew trust --formula <user>/<tap>/<formula>
+          brew trust --cask <user>/<tap>/<cask>
+          brew trust --command <user>/<tap>/<command>
+        Whole-tap trust is broader and includes all current and future formulae,
+        casks and commands from the listed taps. Trust whole taps with:
+          brew trust thirdparty/foo
+        To disable trust checks:
+          export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
+        This is not recommended and will be removed in a later release.
+        For more information, see:
+          #{Formatter.url("https://docs.brew.sh/Tap-Trust")}
+      EOS
+    end
+  end
+
+  specify "#check_untrusted_taps hides trust checks opt-out with HOMEBREW_NO_ENV_HINTS" do
+    tap = instance_double(Tap, name: "thirdparty/foo")
+    allow(Homebrew::Trust).to receive(:wholly_untrusted_taps).and_return([tap])
+    allow(Formula).to receive(:racks).and_return([])
+    allow(Cask::Caskroom).to receive(:casks).and_return([])
+
+    with_env(HOMEBREW_NO_ENV_HINTS: "1") do
+      check_untrusted_taps = checks.check_untrusted_taps
+      expect(check_untrusted_taps).to include(Formatter.url("https://docs.brew.sh/Tap-Trust"))
+      expect(check_untrusted_taps).not_to include("export HOMEBREW_NO_REQUIRE_TAP_TRUST=1")
     end
   end
 

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -127,19 +127,34 @@ RSpec.describe Homebrew::Diagnostic::Checks do
     tap = instance_double(Tap, name: "thirdparty/foo")
     rack = HOMEBREW_CELLAR/"bar"
     keg = instance_double(Keg, tab: instance_double(Tab, tap:))
+    cask = instance_double(Cask::Cask, token: "baz", tab: instance_double(Cask::Tab, tap:))
     allow(Homebrew::Trust).to receive(:wholly_untrusted_taps).and_return([tap])
     allow(Formula).to receive(:racks).and_return([rack])
     allow(Keg).to receive(:from_rack).with(rack).and_return(keg)
+    allow(Cask::Caskroom).to receive(:casks).and_return([cask])
 
     with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
-      expect(checks.check_untrusted_taps)
-        .to include(
-          "Homebrew is currently ignoring formulae, casks and commands from these taps " \
-          "because tap trust is required.",
-          "brew untap thirdparty/foo",
-          "brew trust thirdparty/foo",
-          "brew trust --formula thirdparty/foo/bar",
-          "Prefer trusting only the specific formulae, casks or commands you need.",
+      check_untrusted_taps = checks.check_untrusted_taps
+      expect(check_untrusted_taps).to include <<~EOS
+        Homebrew is currently ignoring formulae, casks and commands from these taps because tap trust is required.
+        Prefer trusting only the specific formulae, casks or commands you need.
+        Trust installed formulae from these taps with:
+          brew trust --formula thirdparty/foo/bar
+        Trust installed casks from these taps with:
+          brew trust --cask thirdparty/foo/baz
+        Trust other specific commands with:
+          brew trust --command <user>/<tap>/<command>
+      EOS
+
+      expect(check_untrusted_taps).to include(
+        "brew untap thirdparty/foo",
+        "brew trust thirdparty/foo",
+        Formatter.url("https://docs.brew.sh/Tap-Trust"),
+      )
+      expect(check_untrusted_taps)
+        .not_to include(
+          "brew trust --formula <user>/<tap>/<formula>",
+          "brew trust --cask <user>/<tap>/<cask>",
         )
     end
   end
@@ -148,14 +163,17 @@ RSpec.describe Homebrew::Diagnostic::Checks do
     tap = instance_double(Tap, name: "thirdparty/foo")
     allow(Homebrew::Trust).to receive(:wholly_untrusted_taps).and_return([tap])
     allow(Formula).to receive(:racks).and_return([])
+    allow(Cask::Caskroom).to receive(:casks).and_return([])
 
     with_env(HOMEBREW_REQUIRE_TAP_TRUST: nil, HOMEBREW_NO_REQUIRE_TAP_TRUST: nil) do
       expect(checks.check_untrusted_taps)
         .to include(
           "Homebrew is currently ignoring formulae, casks and commands from these taps " \
           "because tap trust is required.",
+          Formatter.url("https://docs.brew.sh/Tap-Trust"),
           "brew untap thirdparty/foo",
           "brew trust thirdparty/foo",
+          "If you intentionally trust an entire tap",
           "export HOMEBREW_NO_REQUIRE_TAP_TRUST=1",
           "This is not recommended and will be removed in a later release.",
           "Prefer trusting only the specific formulae, casks or commands you need.",


### PR DESCRIPTION
Improve the untrusted tap warning so the recommended specific-item trust path is easier to act on.

This changes the warning to:

- link to the Tap Trust documentation;
- move the “prefer trusting only specific formulae, casks or commands” guidance before broader options;
- list installed formula trust commands before the generic placeholders;
- phrase whole-tap trust as intentional, because it can still be appropriate for a user's own tap or a known trust boundary.

This is a small wording change rather than a full behavioral change. The related issue discusses the broader confusion I hit: `brew upgrade` can print this warning while entering the formula preinstall path, then stop printing it after the relevant formula upgrades are complete, which can make the warning feel like an urgent action item for the current command even when the upgrade can proceed.

Related context I checked before opening this:

- #22776 is the issue for the broader warning-context confusion.
- #22739 reported confusing untrusted tap warning output in update-style flows.
- #22503 refined the tap trust warning wording and added the Tap Trust documentation.
- #22551 discussed usability improvements around trusting formulae instead of whole taps.
- I did not find an open PR duplicating this wording-only change.

Refs #22776

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex was used to investigate the `brew upgrade`/preinstall diagnostic path, draft the warning text, update the focused specs, and run local validation. I reviewed the code, reproduced the warning against my installed Homebrew state with the local diagnostic loaded, and verified the change with:

```sh
./bin/brew tests --only=diagnostic_checks
./bin/brew lgtm
```

-----
