### PR TITLE
Add user-facing warning guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,29 @@ Do not use conventional commit prefixes such as `feat:`, `fix:`, `chore:`, `refa
 - Put a comment immediately above each `shellcheck disable` explaining why it is needed.
 - Aim to wrap human-written user-facing terminal output at around 80 characters; this does not apply to generated output or code.
 
+### User-Facing Errors And Warnings
+
+When changing `odie`, `ofail`, `opoo`, caveats, diagnostics, or other terminal
+output, make the message actionable at the boundary where it appears.
+
+- Say what happened and name the relevant operation, package, tap, file, or
+  setting.
+- Include the specific problematic items when the message recommends acting on
+  specific items.
+- Put the recommended next step before broader or less-preferred alternatives.
+- Provide copy-pasteable commands when possible, and ensure they are valid for
+  the state being reported.
+- Make clear whether the current command is blocked, continuing with degraded
+  behavior, skipping specific items, or only reporting a broader diagnostic.
+- Avoid dead-end messages: if the user cannot fix it directly, link to the
+  relevant documentation or give the escalation/debugging path.
+- Link to deeper docs when the "why" is too long for command output, but keep
+  the immediate reason and next step in the output.
+- Preserve useful diagnostic context in structured errors, logs, or tests rather
+  than replacing it with friendlier but less specific prose.
+- Test important warning/error text when the behavior depends on ordering,
+  copy-paste commands, or user-visible decision paths.
+
 ## Repository Structure
 
 - `bin/brew`: Homebrew's `brew` command main Bash entry point script


### PR DESCRIPTION
Add repo-local agent guidance for user-facing errors, warnings, diagnostics, caveats and other terminal output.

This is prompted by #22776 and #22777, where the tap trust warning was technically accurate but hard to act on in context. It recommended trusting specific formulae, casks or commands, but led with tap names and did not make clear whether the current `brew upgrade` was blocked, continuing, or only reporting a broader diagnostic.

The added guidance is intended to codify patterns Homebrew already uses well, and make future edits more consistent.

Good existing examples:

- `Library/Homebrew/install.rb` explains that a formula is HEAD-only and gives the exact command to install it with `--HEAD`.
- `Library/Homebrew/install.rb` explains when the same formula name is installed from a different tap, names both taps, and gives the uninstall/install sequence.
- `Library/Homebrew/diagnostic.rb` reports missing or suspicious git origins with the current state and exact `git remote` repair command.
- `Library/Homebrew/diagnostic.rb` reports corrupt cask metadata with the affected Caskroom paths and exact `brew reinstall --cask --force ...` commands.

A few high-visibility places show why the guidance is useful:

1. `Library/Homebrew/cmd/install.rb`

Current:

```text
No formula or cask found for foo.
```

A more actionable shape would be:

```text
No formula or cask found for foo.

Search for similarly named formulae and casks with:
  brew search foo

If this is from a third-party tap, tap it first:
  brew tap user/repo
```

2. `Library/Homebrew/cleanup.rb`

Current:

```text
Skipping surreal: tap formula is not trusted
```

A more actionable shape would be:

```text
Skipping surreal because surrealdb/tap is not trusted.

To let Homebrew load this installed formula during cleanup, run:
  brew trust --formula surrealdb/tap/surreal

For more information, see:
  https://docs.brew.sh/Tap-Trust
```

3. `Library/Homebrew/items.sh`

Current:

```text
Skipping user/repo because it is not trusted. Run `brew trust user/repo` to trust it.
```

A more actionable shape would avoid making whole-tap trust the only obvious path:

```text
Skipping items from user/repo because the tap is not trusted.

Trust only the item you need, for example:
  brew trust --formula user/repo/name

If you intentionally trust the whole tap, run:
  brew trust user/repo
```

4. `Library/Homebrew/cmd/update-reset.sh`

Current:

```text
Can't find a working Git!
```

A more actionable shape would be:

```text
Homebrew could not find a working Git executable.

Install or repair Git, then retry:
  brew install git

If `git` is installed elsewhere, make sure it appears in PATH before running `brew update-reset`.
```

These examples are not part of this PR. They show the kind of future edits the `AGENTS.md` guidance is intended to steer: name the failed thing, say whether Homebrew is blocked or skipping, show the specific command where possible, and link deeper docs when the explanation is too long for command output.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? Documentation-only change to agent guidance; no tests added.
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex was used to inspect existing Homebrew warning/error output, compare it against prior local guidance on actionable error messages, and draft this `AGENTS.md` guidance. I reviewed the examples and final text.

Validation:

```sh
./bin/brew lgtm
```


-----

