### PR TITLE
Read user Git config for private downloads

### DIFF
--- a/Library/Homebrew/download_strategy/git_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/git_download_strategy.rb
@@ -47,10 +47,11 @@ class GitDownloadStrategy < VCSDownloadStrategy
 
   private
 
-  # Avoid user Git config reads; sandbox-denied config files make Git exit.
+  # Read user Git config so credential helpers work for private downloads,
+  # but never block on an interactive credential prompt.
   sig { override.returns(T::Hash[String, String]) }
   def env
-    Utils::Git.no_global_config_env
+    { "GIT_TERMINAL_PROMPT" => "0" }
   end
 
   sig { override.returns(String) }

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3757,6 +3757,7 @@ class Formula
       _JAVA_OPTIONS:           "-Duser.home=#{HOMEBREW_CACHE}/java_cache",
       GOCACHE:                 "#{HOMEBREW_CACHE}/go_cache",
       GIT_CONFIG_GLOBAL:       Utils::Git.no_global_config_file,
+      GIT_TERMINAL_PROMPT:     "0",
       GOENV:                   "off",
       GOPATH:                  "#{HOMEBREW_CACHE}/go_mod_cache",
       CARGO_HOME:              "#{HOMEBREW_CACHE}/cargo_cache",

--- a/Library/Homebrew/test/download_strategies/git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/git_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe GitDownloadStrategy do
       expect(strategy.source_modified_time.to_i).to eq(1_485_115_153)
     end
 
-    it "does not read user Git configuration" do
+    it "reads user Git configuration without prompting for credentials" do
       expect(strategy).to receive(:system_command)
         .with(
           "git",
           args:         ["--git-dir", cached_location/".git", "show", "-s", "--format=%cD"],
-          env:          Utils::Git.no_global_config_env,
+          env:          { "GIT_TERMINAL_PROMPT" => "0" },
           print_stderr: false,
         )
         .and_return(instance_double(SystemCommand::Result, stdout: "Fri, 12 Jun 2026 06:12:11 -0700"))

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1154,6 +1154,7 @@ RSpec.describe Formula do
 
     expect(env).to include(
       "GIT_CONFIG_GLOBAL"     => Utils::Git.no_global_config_file,
+      "GIT_TERMINAL_PROMPT"   => "0",
       "GOENV"                 => "off",
       "NPM_CONFIG_USERCONFIG" => File::NULL,
       "PIP_CONFIG_FILE"       => File::NULL,
@@ -3151,6 +3152,7 @@ RSpec.describe Formula do
 
       expect(f.send(:common_sandbox_env, home)).to include(
         GIT_CONFIG_GLOBAL:     Utils::Git.no_global_config_file,
+        GIT_TERMINAL_PROMPT:   "0",
         GOENV:                 "off",
         NPM_CONFIG_USERCONFIG: File::NULL,
         PIP_CONFIG_FILE:       File::NULL,


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22774

- Nulling `GIT_CONFIG_GLOBAL` stripped `credential.helper` so private git downloads fell back to an interactive prompt and hung.
- Downloads run before staging, outside the sandbox, so they can read the user config; set `GIT_TERMINAL_PROMPT=0` to fail fast instead.
- Build, test and postinstall phases still null the global config, so credentials stay scoped to download time.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
