### PR TITLE
Skip invalid casks in Cask::Cask.all

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -65,7 +65,8 @@ module Cask
                              .then { |files| Homebrew::Trust.trusted_cask_files(files) }
       tokens_and_files.filter_map do |token_or_file|
         CaskLoader.load(token_or_file)
-      rescue CaskUnreadableError => e
+      rescue CaskUnreadableError, CaskInvalidError => e
+        # Don't let one broken cask break commands. But do complain.
         opoo e.message
 
         nil

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -85,6 +85,31 @@ RSpec.describe Cask::Cask, :cask do
         expect(described_class.all).to eq([])
       end
     end
+
+    it "skips invalid casks instead of aborting" do
+      tap = Tap.fetch("thirdparty", "foo")
+      cask_path = tap.cask_dir/"mismatch.rb"
+      cask_path.dirname.mkpath
+      cask_path.write <<~RUBY
+        cask "not-mismatch" do
+          version "1.0"
+          sha256 :no_check
+          url "https://example.com/foo.zip"
+          name "Foo"
+          app "Foo.app"
+        end
+      RUBY
+
+      allow(CoreCaskTap.instance).to receive(:cask_tokens).and_return([])
+      allow(Tap).to receive(:reject).and_return([tap])
+
+      with_env(HOMEBREW_NO_REQUIRE_TAP_TRUST: "1") do
+        expect { expect(described_class.all).to eq([]) }
+          .to output(/Cask 'mismatch' definition is invalid/).to_stderr
+      end
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
   end
 
   describe "#any_version_installed?" do


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22773

- `Cask::Cask.all` aborted on a single invalid cask, unlike `Formula.all` which already skips broken formulae.
- A broken cask in any tap broke the description-cache populate run during an auto-tap, so a fully-qualified `brew install` needed a second run to trust and install.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Opus 4.8 high with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
