### PR TITLE
Trust custom-remote tap by reference in test-bot

### DIFF
--- a/Library/Homebrew/test/test_bot_spec.rb
+++ b/Library/Homebrew/test/test_bot_spec.rb
@@ -38,6 +38,41 @@ RSpec.describe Homebrew::TestBot do
       FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
     end
 
+    it "trusts a custom-remote third-party tap by its remote URL" do
+      tap = Tap.fetch("thirdparty", "custom")
+      tap.path.mkpath
+      system "git", "-C", tap.path.to_s, "init"
+      system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://gitlab.com/other/repo"
+      args = double(
+        cleanup?:       false,
+        local?:         false,
+        tap:            tap.name,
+        only_formulae?: false,
+        git_name:       nil,
+        git_email:      nil,
+      )
+
+      allow(args).to receive_messages(only_cleanup_before?:  false,
+                                      only_setup?:           false,
+                                      only_tap_syntax?:      false,
+                                      only_formulae_detect?: false,
+                                      only_bottles_fetch?:   false,
+                                      only_cleanup_after?:   false)
+      allow(described_class).to receive(:setup_github_actions_sandbox!)
+      allow(Utils).to receive(:safe_popen_read).and_return("revision")
+      allow(Homebrew::TestBot::TestRunner).to receive(:run!).and_return(true)
+
+      mktmpdir do |workdir|
+        with_env(HOMEBREW_USER_CONFIG_HOME: "#{workdir}/.homebrew") do
+          described_class.run!(args)
+          expect(Homebrew::Trust.trusted_tap?(tap)).to be(true)
+        end
+      end
+    ensure
+      Homebrew::Trust.clear!(:tap)
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+
     it "trusts a third-party tap in the local test-bot config home" do
       old_umask = T.let(nil, T.nilable(Integer))
       tap = Tap.fetch("thirdparty", "foo")

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -40,6 +40,24 @@ RSpec.describe Homebrew::Trust, :trust_store do
     FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
   end
 
+  it "trusts a custom-remote tap passed as a Tap object" do
+    tap = Tap.fetch("thirdparty", "custom")
+    tap.path.mkpath
+    system "git", "-C", tap.path.to_s, "init"
+    system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://gitlab.com/other/repo"
+
+    described_class.trust!(:tap, tap)
+    expect(described_class.trusted_tap?(tap)).to be(true)
+  ensure
+    described_class.clear!(:tap)
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
+  it "rejects a Tap object for a non-tap trust type" do
+    tap = Tap.fetch("thirdparty", "custom")
+    expect { described_class.trust!(:formula, tap) }.to raise_error(ArgumentError)
+  end
+
   it "canonicalises a GitHub default-remote URL to the tap name" do
     result = described_class.target("https://github.com/thirdparty/homebrew-foo", type: :tap)
     expect(result).to eq([:tap, "thirdparty/foo"])

--- a/Library/Homebrew/test_bot.rb
+++ b/Library/Homebrew/test_bot.rb
@@ -143,7 +143,7 @@ module Homebrew
         end
 
         unless tap.official?
-          action = Homebrew::Trust.trust!(:tap, tap.name) ? "Trusted" : "Already trusted"
+          action = Homebrew::Trust.trust!(:tap, tap) ? "Trusted" : "Already trusted"
           Homebrew::TestBot.ohai "#{action} tap: #{tap.name}"
         end
       end

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -27,8 +27,13 @@ module Homebrew
       Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME"))/"trust.json"
     end
 
-    sig { params(type: Symbol, name: String).returns(T::Boolean) }
+    sig { params(type: Symbol, name: T.any(String, Tap)).returns(T::Boolean) }
     def self.trust!(type, name)
+      if name.is_a?(Tap)
+        raise ArgumentError, "a #{type} trust name must be a String, not a Tap" if type != :tap
+
+        name = name.reference
+      end
       key = setting_key(type)
       name = normalise_name(name)
       with_trust_store_lock do


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22775

- test-bot stored the bare tap name in the trust store, but a custom-remote tap is only matched by its remote URL reference
- this trusted the tap at startup yet refused to load its formulae later, breaking CI for custom-remote third-party taps
- let `Trust.trust!` accept a `Tap` for its `name` argument and use the tap's reference, so callers cannot pass the wrong identifier
- test-bot now passes the `Tap` object directly

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Opus 4.8 high with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
