### PR TITLE
build.rb: guard against broken error pipe

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -308,7 +308,15 @@ rescue Exception => e # rubocop:disable Lint/RescueException
     error_hash["output"] = e.output
   end
 
-  error_pipe&.puts error_hash.to_json
-  error_pipe&.close
+  begin
+    error_pipe&.puts error_hash.to_json
+  rescue Errno::EPIPE, Errno::EBADF
+    # Parent process closed the error pipe — exit below.
+  end
+  begin
+    error_pipe&.close
+  rescue Errno::EPIPE, Errno::EBADF
+    # Already closed or broken — ignore.
+  end
   exit! 1
 end


### PR DESCRIPTION
-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

AI/LLM: DeepSeek V4 Flash. Used for analysis and code generation. All changes reviewed by author.

-----

### Summary

Wrap `error_pipe.puts` and `error_pipe.close` in `rescue Errno::EPIPE, Errno::EBADF` blocks in `build.rb`.

### Motivation

During a child process error in `build.rb` (inside the `rescue Exception` block at line 285), the error hash is written to the SCM_RIGHTS error pipe via `error_pipe.puts`. This pipe connects the child process (build.rb) back to the parent (safe_fork in fork.rb).

The parent creates the pipe and reads from it in this sequence (fork.rb:95-103):
1. `socket.send_io(write)` — sends write end to child
2. `write.close`
3. `read.read` — blocks waiting for child data

If the parent crashes or terminates between step 1 and step 3, the pipe closes on the parent side. When the child subsequently tries `error_pipe.puts`, it gets `Errno::EPIPE` (or `Errno::EBADF`). This occurs **inside** the existing `rescue Exception` block, so it is not caught — the child exits with an unhandled exception instead of cleanly calling `exit! 1`.

This change adds targeted rescue blocks around the two pipe operations so that a broken pipe never masks the original error or leaves the child in an undefined state.

### Why it matters (defense in depth)

- **Zero runtime cost**: the rescue blocks only activate when the pipe is broken (extremely rare)
- **Consistency**: `error_pipe&.puts` already guards against `nil`; adding EPIPE/EBADF guards makes the crash reporting path fully robust
- **Post-mortem clarity**: an unhandled EPIPE inside the error handler is harder to diagnose than a clean `exit! 1`

### Testing

- `brew style --fix Library/Homebrew/build.rb` — no offenses
- `brew typecheck` — no errors