### PR TITLE
formula_installer: create opt link even when skip_link

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -978,17 +978,9 @@ on_request: installed_on_request?, options:)
     ohai "Finishing up" if verbose?
 
     keg = Keg.new(formula.prefix)
-    if skip_link?
-      unless quiet?
-        ohai "Skipping 'link' on request"
-        puts "You can run it manually using:"
-        puts "  brew link #{formula.full_name}"
-      end
-    else
-      link(keg)
-      warning = link_manual_command_warning
-      opoo warning if !quiet? && warning.present?
-    end
+    link(keg)
+    warning = link_manual_command_warning
+    opoo warning if !quiet? && warning.present?
 
     install_service
 
@@ -1206,9 +1198,13 @@ on_request: installed_on_request?, options:)
     if cask_installed_with_formula_name
       ohai "#{formula.name} cask is installed, skipping link."
       @link_keg = false
+    elsif skip_link? && !quiet?
+      ohai "Skipping 'link' on request"
+      puts "You can run it manually using:"
+      puts "  brew link #{formula.full_name}"
     end
 
-    unless link_keg
+    if !link_keg || skip_link?
       begin
         keg.optlink(verbose: verbose?, overwrite: overwrite?)
       rescue Keg::LinkError => e


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Previously, this skipped both prefix link and opt link. The resulting installation is somewhat broken as opt path is essential to normal operation as it is used for install_name, linkage paths, etc.

Lack of opt link also meant that running
```
brew install <formula>
brew unlink <formula>
brew bundle dump
brew uninstall <formula>
brew bundle install
```
would not produce the same installation.

---

For a specific example of above before this PR running on fresh `brew:main` container
```console
$ brew install libcap
==> Would install 1 formula:
libcap
...

$ brew unlink libcap
Unlinking /home/linuxbrew/.linuxbrew/Cellar/libcap/2.78... 96 symlinks removed.

$ brew bundle dump

$ cat Brewfile
tap "homebrew/core"
# User-space interfaces to POSIX 1003.1e capabilities
brew "libcap", link: false

$ ls $(brew --prefix libcap)
CHANGELOG             License  include  sbin            share
INSTALL_RECEIPT.json  README   lib      sbom.spdx.json

$ brew uninstall libcap
Uninstalling /home/linuxbrew/.linuxbrew/Cellar/libcap/2.78... (103 files, 1MB)

$ brew bundle install
Fetching libcap
Using homebrew/core
Installing libcap
`brew bundle` complete! 2 Brewfile dependencies now installed.

$ ls $(brew --prefix libcap)
ls: cannot access '/home/linuxbrew/.linuxbrew/opt/libcap': No such file or directory
```