### PR TITLE
Skip auto-update outdated list before upgrade/outdated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ Do not use conventional commit prefixes such as `feat:`, `fix:`, `chore:`, `refa
   Write fast tests by preferring a single `expect` per unit test and combine expectations in a single test when it is an integration test or has non-trivial `before` for test setup.
 - When adding or tightening tests, verify them with a red/green cycle using the exact `--only=file:line` target for the example you changed.
 - Formula classes created in specs may be frozen; avoid stubbing class methods on them with RSpec mocks and prefer instance-level stubs or test setup that does not require class-method stubbing.
+- RSpec snapshots and restores `ENV` around every example via the global `config.around` hook in `Library/Homebrew/test/spec_helper.rb` (it saves `ENV.to_hash` before `example.run` and calls `ENV.replace` in the `ensure`), so specs can set environment variables directly without a `with_env` wrapper or manual cleanup.
 - Keep comments minimal; prefer self-documenting code through strings, variable names, etc. over more comments.
 - Put a comment immediately above each `shellcheck disable` explaining why it is needed.
 - Aim to wrap human-written user-facing terminal output at around 80 characters; this does not apply to generated output or code.

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -371,6 +371,21 @@ auto-update() {
       done
     fi
 
+    # When auto-updating before a zero-argument `brew upgrade` or `brew outdated`,
+    # that command lists the outdated packages itself so skip doing so here too.
+    # Two-way sync: `dump` in `Library/Homebrew/cmd/update_report/reporter_hub.rb`.
+    if [[ "${HOMEBREW_COMMAND}" == "upgrade" || "${HOMEBREW_COMMAND}" == "outdated" ]]
+    then
+      HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED="1"
+      for arg in "${@:2}"
+      do
+        [[ "${arg}" == -* ]] && continue
+        HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED=""
+        break
+      done
+      [[ -n "${HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED}" ]] && export HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED
+    fi
+
     if [[ -z "${HOMEBREW_AUTO_UPDATE_SECS}" ]]
     then
       if [[ -n "${HOMEBREW_NO_INSTALL_FROM_API}" || -n "${HOMEBREW_AUTO_UPDATE_TAP}" ]]
@@ -413,6 +428,7 @@ auto-update() {
     done
     if [[ -z "${needs_auto_update}" ]]
     then
+      unset HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED
       return
     fi
 
@@ -420,6 +436,7 @@ auto-update() {
 
     unset HOMEBREW_AUTO_UPDATING
     unset HOMEBREW_AUTO_UPDATE_TAP
+    unset HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED
 
     if [[ $# -gt 0 ]]
     then

--- a/Library/Homebrew/cmd/update_report/reporter_hub.rb
+++ b/Library/Homebrew/cmd/update_report/reporter_hub.rb
@@ -73,6 +73,11 @@ class ReporterHub
 
     return if msg.blank?
 
+    # When auto-updating before a zero-argument `brew upgrade` or `brew outdated`,
+    # that command lists the outdated packages itself so don't duplicate it here.
+    # Two-way sync: `auto-update` in `Library/Homebrew/brew.sh`.
+    return if auto_update && ENV["HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED"].present?
+
     puts
     puts "You have #{msg} installed."
     # If we're auto-updating, don't need to suggest commands that we're perhaps

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -326,6 +326,15 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
       EOS
     end
 
+    it "skips the outdated count when auto-updating before a zero-argument upgrade or outdated" do
+      ENV["HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED"] = "1"
+      allow(Formula).to receive(:installed).and_return([
+        instance_double(Formula, name: "foo", outdated?: true),
+      ])
+      allow(Cask::Caskroom).to receive(:casks).and_return([])
+      expect { hub.dump(auto_update: true) }.not_to output.to_stdout
+    end
+
     it "prints nothing if there are no changes" do
       allow(Formula).to receive(:installed).and_return([])
       allow(Cask::Caskroom).to receive(:casks).and_return([])


### PR DESCRIPTION
- a zero-argument `brew upgrade` or `brew outdated` lists the outdated packages itself right after auto-updating
- suppress the duplicate `You have N outdated ...` count that the auto-update report would otherwise print first (and may be inconsistent)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
