### PR TITLE
Null Git global config for source_modified_time

### DIFF
--- a/Library/Homebrew/download_strategy/git_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/git_download_strategy.rb
@@ -29,7 +29,15 @@ class GitDownloadStrategy < VCSDownloadStrategy
   # @api public
   sig { override.returns(Time) }
   def source_modified_time
-    Time.parse(silent_command("git", args: ["--git-dir", git_dir, "show", "-s", "--format=%cD"]).stdout)
+    # This runs while staging inside the sandbox, where reading the user Git
+    # config is denied and makes Git exit; null the global config here, unlike
+    # the download-time commands that read it for credential helpers.
+    require "utils/git"
+    result = system_command("git", args: ["--git-dir", git_dir, "show", "-s", "--format=%cD"],
+                                   env:  env.merge(Utils::Git.no_global_config_env), print_stderr: false)
+    raise "Failed to read the Git commit time:\n#{result.stderr}" unless result.success?
+
+    Time.parse(result.stdout)
   end
 
   sig { override.returns(T.nilable(String)) }

--- a/Library/Homebrew/test/download_strategies/git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/git_spec.rb
@@ -40,17 +40,26 @@ RSpec.describe GitDownloadStrategy do
       expect(strategy.source_modified_time.to_i).to eq(1_485_115_153)
     end
 
-    it "reads user Git configuration without prompting for credentials" do
+    it "nulls the global Git config so sandboxed staging reads do not fail" do
       expect(strategy).to receive(:system_command)
         .with(
           "git",
           args:         ["--git-dir", cached_location/".git", "show", "-s", "--format=%cD"],
-          env:          { "GIT_TERMINAL_PROMPT" => "0" },
+          env:          { "GIT_TERMINAL_PROMPT" => "0", "GIT_CONFIG_GLOBAL" => File::NULL },
           print_stderr: false,
         )
-        .and_return(instance_double(SystemCommand::Result, stdout: "Fri, 12 Jun 2026 06:12:11 -0700"))
+        .and_return(instance_double(SystemCommand::Result, success?: true,
+                                                           stdout:   "Fri, 12 Jun 2026 06:12:11 -0700"))
 
       expect(strategy.source_modified_time).to eq(Time.parse("Fri, 12 Jun 2026 06:12:11 -0700"))
+    end
+
+    it "raises the underlying Git error instead of a Time parsing error on failure" do
+      allow(strategy).to receive(:system_command)
+        .and_return(instance_double(SystemCommand::Result, success?: false,
+                                                           stdout: "", stderr: "fatal: unable to access"))
+
+      expect { strategy.source_modified_time }.to raise_error(/fatal: unable to access/)
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22784
Fixes https://github.com/Homebrew/brew/issues/22785

- Reading the user Git config for private downloads (#22779) made the staging-time `git show` read `~/.gitconfig`, which the build sandbox denies, so Git exits and `Time.parse("")` raised `ArgumentError`.
- This broke every `--HEAD` and stable build-from-source install or upgrade of a Git-sourced formula.
- Null the global config for this staging read only; download commands still read it so credential helpers keep working.
- Raise the underlying Git error instead of a Time parsing error when the command fails, so future failures are diagnosable.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- Do not delete these checkboxes or this pull request will be closed automatically. -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you written new tests (excluding integration tests) for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 high with local review and full build-from-source testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted/generated PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
