### PR TITLE
Allow sometimes skipping the sandbox inside nested sandboxes

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -103,6 +103,14 @@ module Homebrew
         default_text: "`86400` (24 hours), `3600` (1 hour) if a developer command has been run " \
                       "or `300` (5 minutes) if `$HOMEBREW_NO_INSTALL_FROM_API` is set.",
       },
+      HOMEBREW_AVOID_NESTED_SANDBOXING:          {
+        description: "If set, skip Homebrew's sandbox when it is itself running inside another " \
+                     "sandbox, for an unprivileged user outside the default prefix. This trades " \
+                     "Homebrew's build-time network and filesystem denial for trust in the outer " \
+                     "sandbox. Homebrew errors out if the prefix or group makes skipping " \
+                     "unsupported.",
+        boolean:     :set,
+      },
       HOMEBREW_BAT:                              {
         description: "If set, use `bat` for the `brew cat` command.",
         boolean:     true,

--- a/Library/Homebrew/extend/os/linux/sandbox.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox.rb
@@ -3,6 +3,7 @@
 
 require "fileutils"
 require "env_config"
+require "utils/popen"
 require "utils/github/actions"
 
 module OS
@@ -31,6 +32,8 @@ module OS
       HOMEBREW_BUBBLEWRAP_PATHS = T.let([
         "#{HOMEBREW_PREFIX}/bin",
       ].freeze, T::Array[String])
+      NESTED_BUBBLEWRAP_ERROR = "Creating new namespace failed: nesting depth or /proc/sys/user/max_*_namespaces " \
+                                "exceeded"
       class SysctlSetting < T::Struct
         const :assignment, String
         const :description, T::Array[String]
@@ -76,7 +79,8 @@ module OS
         "apk"     => "sudo apk add bubblewrap",
       }.freeze, T::Hash[String, String])
       private_constant :BUBBLEWRAP, :BUBBLEWRAP_TEST_ARGS, :SYSTEM_BUBBLEWRAP_PATHS, :HOMEBREW_BUBBLEWRAP_PATHS,
-                       :SysctlSetting, :SANDBOX_SYSCTL_SETTINGS, :TIOCSCTTY, :BUBBLEWRAP_INSTALL_COMMANDS
+                       :NESTED_BUBBLEWRAP_ERROR, :SysctlSetting, :SANDBOX_SYSCTL_SETTINGS, :TIOCSCTTY,
+                       :BUBBLEWRAP_INSTALL_COMMANDS
 
       sig { returns(::PATH) }
       def self.bubblewrap_candidate_paths
@@ -189,6 +193,20 @@ module OS
         sig { returns(T::Boolean) }
         def available?
           state == :available
+        end
+
+        # Bubblewrap reports this specific namespace error when an outer
+        # Bubblewrap sandbox prevents Homebrew from creating another rootless
+        # sandbox. The shared `avoid_nested_sandboxing?` only calls this once the
+        # `$HOMEBREW_AVOID_NESTED_SANDBOXING` opt-in is set.
+        sig { returns(T::Boolean) }
+        def nested_sandbox?
+          return false unless Homebrew::EnvConfig.sandbox_linux?
+
+          bubblewrap = bubblewrap_executable
+          return false unless bubblewrap
+
+          Utils.popen_read(bubblewrap.to_s, *BUBBLEWRAP_TEST_ARGS, err: :out).include?(NESTED_BUBBLEWRAP_ERROR)
         end
 
         sig { returns(Symbol) }

--- a/Library/Homebrew/extend/os/mac/sandbox.rb
+++ b/Library/Homebrew/extend/os/mac/sandbox.rb
@@ -3,6 +3,7 @@
 
 require "erb"
 require "fcntl"
+require "fiddle"
 
 module OS
   module Mac
@@ -64,6 +65,22 @@ module OS
         sig { returns(T::Boolean) }
         def available?
           File.executable?(SANDBOX_EXEC)
+        end
+
+        # Nested `sandbox-exec` invocations hang inside an existing macOS sandbox
+        # (e.g. an agent's), so detect that via the libSystem `sandbox_check`
+        # syscall. The shared `avoid_nested_sandboxing?` only calls this once the
+        # `$HOMEBREW_AVOID_NESTED_SANDBOXING` opt-in is set.
+        sig { returns(T::Boolean) }
+        def nested_sandbox?
+          sandbox_check = Fiddle::Function.new(
+            Fiddle.dlopen(nil)["sandbox_check"],
+            [Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT],
+            Fiddle::TYPE_INT,
+          )
+          sandbox_check.call(Process.pid, nil, 0) == 1
+        rescue Fiddle::DLError
+          false
         end
 
         sig { returns(Integer) }

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1138,7 +1138,7 @@ on_request: installed_on_request?, options:)
       formula_path,
     ].concat(build_argv)
 
-    if Sandbox.available?
+    if use_sandbox?("building")
       sandbox = Sandbox.new
       sandbox.allow_read_if_exists path: formula_path
       if Homebrew::EnvConfig.require_tap_trust?
@@ -1161,7 +1161,6 @@ on_request: installed_on_request?, options:)
       sandbox.deny_all_network unless formula.network_access_allowed?(:build)
       sandbox.run(*args)
     else
-      opoo "Sandbox unavailable: building without sandboxing!"
       Utils.safe_fork do
         exec(*args)
       end
@@ -1394,7 +1393,7 @@ on_request: installed_on_request?, options:)
 
     args << post_install_formula_path
 
-    if Sandbox.available?
+    if use_sandbox?("running post-install")
       sandbox = Sandbox.new
       formula.logs.mkpath
       sandbox.record_log(formula.logs/"postinstall.sandbox.log")
@@ -1410,7 +1409,6 @@ on_request: installed_on_request?, options:)
       end
       sandbox.run(*args)
     else
-      opoo "Sandbox unavailable: running post-install without sandboxing!"
       Utils.safe_fork do
         exec(*args)
       end
@@ -1791,6 +1789,25 @@ on_request: installed_on_request?, options:)
   end
 
   private
+
+  # Whether to run the given install `step` (e.g. `"building"`) inside
+  # Homebrew's sandbox. Warns when it will not: noting reliance on the outer
+  # sandbox when `$HOMEBREW_AVOID_NESTED_SANDBOXING` skips a nested sandbox,
+  # otherwise that no sandbox is available.
+  sig { params(step: String).returns(T::Boolean) }
+  def use_sandbox?(step)
+    unless Sandbox.available?
+      opoo "Sandbox unavailable: #{step} without sandboxing!"
+      return false
+    end
+
+    if Sandbox.avoid_nested_sandboxing?
+      opoo "#{step.capitalize} without Homebrew's sandbox; relying on the outer sandbox."
+      return false
+    end
+
+    true
+  end
 
   sig { returns(T::Boolean) }
   def auto_link_versioned_keg_only?

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "etc"
 require "io/console"
 require "pty"
 require "tempfile"
@@ -11,6 +12,10 @@ require "utils/output"
 # Helper class for running a sub-process inside of a sandboxed environment.
 class Sandbox
   include Utils::Output::Mixin
+  extend Utils::Output::Mixin
+
+  # Privileged groups that are expected to be able to use a working sandbox.
+  PRIVILEGED_GROUPS = T.let(%w[admin staff root wheel].freeze, T::Array[String])
 
   class SandboxPathFilter
     sig { returns(String) }
@@ -73,6 +78,43 @@ class Sandbox
   sig { returns(T::Boolean) }
   def self.available?
     false
+  end
+
+  # Whether Homebrew is itself running inside another sandbox, which would make
+  # its own nested sandbox hang (macOS) or fail to start (Linux). Overridden
+  # per-OS.
+  sig { returns(T::Boolean) }
+  def self.nested_sandbox? = false
+
+  # Skip Homebrew's own sandbox when it is opted into via
+  # `$HOMEBREW_AVOID_NESTED_SANDBOXING` and already running inside another
+  # sandbox. The skip is only supported for an unprivileged user in a custom
+  # prefix; error out explaining why rather than silently sandboxing (and
+  # hanging) when either is not the case.
+  sig { returns(T::Boolean) }
+  def self.avoid_nested_sandboxing?
+    return false unless Homebrew::EnvConfig.avoid_nested_sandboxing?
+    return false unless nested_sandbox?
+
+    if Homebrew.default_prefix?
+      odie "Refusing to skip the sandbox: `$HOMEBREW_AVOID_NESTED_SANDBOXING` is set " \
+           "inside another sandbox but Homebrew is using its default prefix " \
+           "(#{HOMEBREW_PREFIX}); this is only supported in a custom prefix."
+    end
+
+    privileged_group = PRIVILEGED_GROUPS.find do |name|
+      group = Etc.getgrnam(name)
+      group && Process.groups.include?(group.gid)
+    rescue ArgumentError
+      false
+    end
+    if privileged_group
+      odie "Refusing to skip the sandbox: `$HOMEBREW_AVOID_NESTED_SANDBOXING` is set " \
+           "inside another sandbox but you are in the privileged `#{privileged_group}` " \
+           "group; this is only supported for an unprivileged user."
+    end
+
+    true
   end
 
   sig { params(install_from_tests: T::Boolean).void }

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -35,6 +35,9 @@ module Homebrew::EnvConfig
     def auto_update_secs; end
 
     sig { returns(T::Boolean) }
+    def avoid_nested_sandboxing?; end
+
+    sig { returns(T::Boolean) }
     def bat?; end
 
     sig { returns(T.nilable(::String)) }

--- a/Library/Homebrew/test/sandbox_linux_spec.rb
+++ b/Library/Homebrew/test/sandbox_linux_spec.rb
@@ -60,17 +60,33 @@ RSpec.describe Sandbox, :needs_linux do
     let(:bubblewrap) { bubblewrap_dir/"bwrap" }
     let(:fallback_bubblewrap_dir) { mktmpdir }
     let(:fallback_bubblewrap) { fallback_bubblewrap_dir/"bwrap" }
+    let(:bubblewrap_test_args) do
+      [
+        bubblewrap.to_s,
+        "--unshare-user",
+        "--unshare-ipc",
+        "--unshare-pid",
+        "--unshare-uts",
+        "--unshare-cgroup-try",
+        "--ro-bind", "/", "/",
+        "--proc", "/proc",
+        "--dev", "/dev",
+        "true",
+        { err: :out }
+      ]
+    end
 
     before do
+      allow(Homebrew::EnvConfig).to receive(:sandbox_linux?).and_return(true)
       FileUtils.touch bubblewrap
       FileUtils.chmod "+x", bubblewrap
       sandbox_class.test_executable_candidate_paths = PATH.new(bubblewrap_dir)
     end
 
     it "returns false when Linux sandboxing is disabled" do
-      with_env(HOMEBREW_NO_SANDBOX_LINUX: "1") do
-        expect(sandbox_class.available?).to be(false)
-      end
+      allow(Homebrew::EnvConfig).to receive(:sandbox_linux?).and_return(false)
+
+      expect(sandbox_class.available?).to be(false)
     end
 
     it "returns false when bubblewrap is unavailable" do
@@ -153,6 +169,27 @@ RSpec.describe Sandbox, :needs_linux do
       expect(sandbox_class.available?).to be(false)
       expect(sandbox_class.state).to eq(:unavailable)
       expect(sandbox_class.failure_reason).to include("cannot create a rootless sandbox")
+    end
+
+    it "does not treat generic bubblewrap sandbox probe failures as nested" do
+      FileUtils.touch fallback_bubblewrap
+      FileUtils.chmod "+x", fallback_bubblewrap
+      sandbox_class.test_executable_candidate_paths = PATH.new(bubblewrap_dir, fallback_bubblewrap_dir)
+
+      expect(Utils).to receive(:popen_read)
+        .with(*bubblewrap_test_args)
+        .and_return("bwrap: No permissions to create a new namespace\n")
+
+      expect(sandbox_class.nested_sandbox?).to be(false)
+    end
+
+    it "treats a bubblewrap namespace nesting failure as nested" do
+      expect(Utils).to receive(:popen_read)
+        .with(*bubblewrap_test_args)
+        .and_return("bwrap: Creating new namespace failed: " \
+                    "nesting depth or /proc/sys/user/max_*_namespaces exceeded (ENOSPC)\n")
+
+      expect(sandbox_class.nested_sandbox?).to be(true)
     end
   end
 

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -15,6 +15,39 @@ RSpec.describe Sandbox, :needs_macos do
     skip "Sandbox not implemented." unless described_class.available?
   end
 
+  describe ".avoid_nested_sandboxing?" do
+    before do
+      allow(Homebrew::EnvConfig).to receive(:avoid_nested_sandboxing?).and_return(true)
+      allow(described_class).to receive(:nested_sandbox?).and_return(true)
+      allow(Homebrew).to receive(:default_prefix?).and_return(false)
+      allow(Process).to receive(:groups).and_return([])
+    end
+
+    it "skips the sandbox for an unprivileged user in a custom prefix" do
+      expect(described_class.avoid_nested_sandboxing?).to be(true)
+    end
+
+    it "is false when not opted in via the environment" do
+      allow(Homebrew::EnvConfig).to receive(:avoid_nested_sandboxing?).and_return(false)
+      expect(described_class.avoid_nested_sandboxing?).to be(false)
+    end
+
+    it "is false when not running inside another sandbox" do
+      allow(described_class).to receive(:nested_sandbox?).and_return(false)
+      expect(described_class.avoid_nested_sandboxing?).to be(false)
+    end
+
+    it "errors out in the default prefix" do
+      allow(Homebrew).to receive(:default_prefix?).and_return(true)
+      expect { described_class.avoid_nested_sandboxing? }.to raise_error(SystemExit)
+    end
+
+    it "errors out for a user in a privileged group" do
+      allow(Process).to receive(:groups).and_return([Etc.getgrnam("staff")&.gid].compact)
+      expect { described_class.avoid_nested_sandboxing? }.to raise_error(SystemExit)
+    end
+  end
+
   specify "#allow_write" do
     sandbox.allow_write path: file
     sandbox.run "touch", file

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -4249,6 +4249,14 @@ command execution (e.g. `$(cat file)`).
   *Default:* `86400` (24 hours), `3600` (1 hour) if a developer command has been
   run or `300` (5 minutes) if `$HOMEBREW_NO_INSTALL_FROM_API` is set.
 
+`HOMEBREW_AVOID_NESTED_SANDBOXING`
+
+: If set, skip Homebrew's sandbox when it is itself running inside another
+  sandbox, for an unprivileged user outside the default prefix. This trades
+  Homebrew's build-time network and filesystem denial for trust in the outer
+  sandbox. Homebrew errors out if the prefix or group makes skipping
+  unsupported.
+
 `HOMEBREW_BAT`
 
 : If set, use `bat` for the `brew cat` command.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2715,6 +2715,9 @@ Run \fBbrew update\fP once every \fB$HOMEBREW_AUTO_UPDATE_SECS\fP seconds before
 \fIDefault:\fP \fB86400\fP (24 hours), \fB3600\fP (1 hour) if a developer command has been run or \fB300\fP (5 minutes) if \fB$HOMEBREW_NO_INSTALL_FROM_API\fP is set\.
 .RE
 .TP
+\fBHOMEBREW_AVOID_NESTED_SANDBOXING\fP
+If set, skip Homebrew\[u2019]s sandbox when it is itself running inside another sandbox, for an unprivileged user outside the default prefix\. This trades Homebrew\[u2019]s build\-time network and filesystem denial for trust in the outer sandbox\. Homebrew errors out if the prefix or group makes skipping unsupported\.
+.TP
 \fBHOMEBREW_BAT\fP
 If set, use \fBbat\fP for the \fBbrew cat\fP command\.
 .TP


### PR DESCRIPTION
AI agents increasingly test sandboxed parts of Homebrew (builds, post-install, cask artifacts, tests) from within their own sandbox or an additional one e.g. `sandvault`.

Nesting Homebrew's sandbox there hangs `sandbox-exec` on macOS and fails to start `bwrap` on Linux, so those code paths cannot be tested.

Add `$HOMEBREW_AVOID_NESTED_SANDBOXING` to opt into skipping Homebrew's own sandbox only when it is itself running inside another sandbox.

This detects nesting per-OS: the libSystem `sandbox_check` syscall on macOS and defers to the `:unavailable` Bubblewrap state (only reachable with `LINUX_SANDBOX` enabled) on Linux.
If desired, I can do some more development on my WSL machine to improve the detecting on Linux rather than just assuming "unavailable" means "sandbox within a sandbox".

We restrict the skip to an unprivileged user (not in `admin`, `staff`, `root` or `wheel` groups) running outside the default prefix, since that is the agent scenario and one that requires e.g. building from source.

An `odie` explains why instead of silently sandboxing and warning or hanging when the prefix or group is unsupported

----

Opening this as much for discussion as review. Maybe this is fundamentally a bad/insecure idea 🤷🏻 

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code Opus 4.8 with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
