### PR TITLE
service: raise clear error for unsupported cron syntax

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -347,7 +347,11 @@ module Homebrew
         raise TypeError, "Service#parse_cron expects a valid cron syntax" if cron_parts.length != 5
 
         [:Minute, :Hour, :Day, :Month, :Weekday].each_with_index do |selector, index|
-          parsed[selector] = Integer(cron_parts.fetch(index)) if cron_parts.fetch(index) != "*"
+          part = cron_parts.fetch(index)
+          next if part == "*"
+          raise TypeError, "Service#parse_cron does not support cron syntax: #{part}" unless part.match?(/\A\d+\z/)
+
+          parsed[selector] = Integer(part)
         end
       end
 

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -1138,6 +1138,20 @@ RSpec.describe Homebrew::Service do
       end.to raise_error TypeError, "Service#parse_cron expects a valid cron syntax"
     end
 
+    it "throws on unsupported cron syntax" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          run_type :cron
+          cron "*/5 * * * *"
+        end
+      end
+
+      expect do
+        f.service.to_systemd_timer
+      end.to raise_error TypeError, "Service#parse_cron does not support cron syntax: */5"
+    end
+
     it "returns valid cron timers" do
       styles = {
         "@hourly":   "*-*-* *:00:00",


### PR DESCRIPTION
`Service#parse_cron` accepts a five-field cron statement and converts each
field with `Integer(...)`. Any field that is not a bare integer or `*` —
i.e. standard cron step/range/list syntax such as `*/5`, `9-17` or `1,15` —
reaches `Integer("*/5")` and raises a cryptic, internal-looking error:

```
ArgumentError: invalid value for Integer(): "*/5"
```

The length check just above already raises a clean `TypeError` for malformed
input, so this is the only field-level path that leaks a raw Ruby conversion
error to formula authors.

**Why:** the cryptic `ArgumentError` gives a formula author no hint about what
is wrong or which field caused it. This change keeps the existing supported
scope (bare integers and `*`) but raises a clear, consistent `TypeError`
naming the offending field. Supporting full step/range/list syntax would be a
larger, separate feature.

### Steps to reproduce

```bash
cat > /tmp/cron-repro.rb <<'RUBY'
require "formula"
require "service"
f = Formula["hello"]   # any installed formula
svc = Homebrew::Service.new(f)
svc.run_type :cron
svc.cron "*/5 * * * *"
svc.to_systemd_timer
RUBY
brew ruby /tmp/cron-repro.rb
```

Before: `ArgumentError: invalid value for Integer(): "*/5"`
After: `TypeError: Service#parse_cron does not support cron syntax: */5`

The same path runs whenever a formula's `service` block uses cron syntax such
as `cron "*/5 * * * *"`. Run the added regression test with
`brew tests --only=service`. No other open PRs touch `parse_cron` (checked
open and closed PRs).

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Developed with Claude Code (Claude Opus 4.8). I reviewed every line, confirmed
the red/green behaviour of the new test (it fails against the old
`ArgumentError` and passes with the fix), and ran `brew lgtm` locally
(typecheck, style, tests) — all green. This is my only AI-assisted PR open.

-----
