### PR TITLE
shell: add tests for Utils::Shell.export_value

### DIFF
--- a/Library/Homebrew/test/utils/shell_spec.rb
+++ b/Library/Homebrew/test/utils/shell_spec.rb
@@ -84,6 +84,52 @@ RSpec.describe Utils::Shell do
     expect(described_class.send(:csh_quote, "word")).to eq("word")
   end
 
+  describe "::export_value" do
+    it "supports Bash" do
+      expect(described_class.export_value("FOO", "bar", :bash)).to eq('export FOO="bar"')
+    end
+
+    it "supports Zsh with the same form as Bash" do
+      expect(described_class.export_value("FOO", "bar", :zsh)).to eq('export FOO="bar"')
+    end
+
+    it "supports Ksh with the same form as Bash" do
+      expect(described_class.export_value("FOO", "bar", :ksh)).to eq('export FOO="bar"')
+    end
+
+    it "supports sh with the same form as Bash" do
+      expect(described_class.export_value("FOO", "bar", :sh)).to eq('export FOO="bar"')
+    end
+
+    it "supports fish" do
+      expect(described_class.export_value("FOO", "bar", :fish)).to eq('set -gx FOO "bar"')
+    end
+
+    it "supports rc" do
+      expect(described_class.export_value("FOO", "bar", :rc)).to eq("FOO=(bar)")
+    end
+
+    it "supports tcsh" do
+      expect(described_class.export_value("FOO", "bar", :tcsh)).to eq("setenv FOO bar;")
+    end
+
+    it "supports csh" do
+      expect(described_class.export_value("FOO", "bar", :csh)).to eq("setenv FOO bar;")
+    end
+
+    it "quotes unsafe characters via sh_quote for Bourne-compatible shells" do
+      expect(described_class.export_value("FOO", "hello world", :bash)).to eq('export FOO="hello\\ world"')
+    end
+
+    it "quotes unsafe characters via csh_quote for csh" do
+      expect(described_class.export_value("FOO", "hello world", :csh)).to eq("setenv FOO hello\\ world;")
+    end
+
+    it "returns nil for an unsupported shell" do
+      expect(described_class.export_value("FOO", "bar", :pwsh)).to be_nil
+    end
+  end
+
   describe "::prepend_path_in_profile" do
     let(:path) { "/my/path" }
 


### PR DESCRIPTION
`Utils::Shell.export_value` builds a shell-specific environment export string
for Bourne-compatible shells (bash/zsh/ksh/sh), fish, rc, and csh/tcsh, and
returns `nil` for unsupported shells. It had no direct unit coverage —
`shell_spec.rb` exercised `from_path`, `profile`, `sh_quote`, `csh_quote`,
`prepend_path_in_profile`, `set_variable_in_profile`, and `shell_with_prompt`,
but not `export_value`.

**Why:** the method has several per-shell branches plus value quoting via
`sh_quote`/`csh_quote`. Characterization tests lock in the exact output per
shell so refactors can't silently change it (mirrors the sibling coverage
recently added for `set_variable_in_profile` in #22727). No production code is
changed.

This adds an `::export_value` describe block covering each shell branch, the
quoting path for unsafe characters, and the unsupported-shell `nil` case. Run
with `brew tests --only=utils/shell`.

No other open PRs touch `export_value` (checked open and closed PRs).

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Developed with Claude Code (Claude Opus 4.8). I reviewed every assertion and
verified each expected string against the source in `utils/shell.rb`, and ran
`brew lgtm` (style, typecheck, tests) locally — all green.

-----
