### PR TITLE
formula_auditor: fix grammar in Wayback Machine audit message

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -694,7 +694,7 @@ module Homebrew
       return if formula.deprecated? || formula.disabled?
 
       regex = %r{^https?://web\.archive\.org}
-      problem_prefix = "Formula with a Internet Archive Wayback Machine"
+      problem_prefix = "Formula with an Internet Archive Wayback Machine"
 
       if formula.stable && regex.match?(T.must(formula.stable).url)
         problem "#{problem_prefix} `url` should be deprecated with `:repo_removed`"

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -757,6 +757,21 @@ RSpec.describe Homebrew::FormulaAuditor do
     end
   end
 
+  describe "#audit_wayback_url" do
+    specify "#audit_wayback_url for an Internet Archive Wayback Machine homepage" do
+      fa = formula_auditor "foo", <<~RUBY, core_tap: true
+        class Foo < Formula
+          homepage "https://web.archive.org/web/https://example.com"
+          url "https://brew.sh/foo-1.0.tgz"
+        end
+      RUBY
+
+      fa.audit_wayback_url
+      expect(fa.problems.first[:message])
+        .to start_with("Formula with an Internet Archive Wayback Machine")
+    end
+  end
+
   describe "#audit_specs" do
     let(:livecheck_throttle) { "livecheck do\n    throttle 10\n  end" }
     let(:livecheck_throttle_days) { "livecheck do\n    throttle days: 1\n  end" }


### PR DESCRIPTION
`audit_wayback_url` builds its user-facing audit messages from
`problem_prefix = "Formula with a Internet Archive Wayback Machine"`. "Internet"
takes "an", so the emitted `brew audit` output is grammatically incorrect:
`Formula with a Internet Archive Wayback Machine \`url\` should be deprecated...`.

**Why:** it's user-facing `brew audit` output; the fix makes it read correctly
("an Internet Archive Wayback Machine"). One-word change plus a regression test.

### Steps to reproduce

Audit a formula whose `homepage` (or stable `url`) points at the Wayback
Machine, e.g. `homepage "https://web.archive.org/web/https://example.com"`:

```bash
brew audit --new <formula>   # or: brew audit <formula-in-a-tap>
```

Before: `Formula with a Internet Archive Wayback Machine homepage ...`
After: `Formula with an Internet Archive Wayback Machine homepage ...`

A regression test in `formula_auditor_spec.rb` asserts the corrected prefix.
Run with `brew tests --only=formula_auditor`.

No other open PRs touch this message (checked open and closed PRs).

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Developed with Claude Code (Claude Opus 4.8). I reviewed the change, confirmed
the regression test fails on the old string and passes with the fix, and ran
`brew lgtm` (style, typecheck, tests) locally — all green.

-----
