### PR TITLE
Null Git global config for local repository inspections

### DIFF
--- a/Library/Homebrew/download_strategy/git_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/git_download_strategy.rb
@@ -29,12 +29,8 @@ class GitDownloadStrategy < VCSDownloadStrategy
   # @api public
   sig { override.returns(Time) }
   def source_modified_time
-    # This runs while staging inside the sandbox, where reading the user Git
-    # config is denied and makes Git exit; null the global config here, unlike
-    # the download-time commands that read it for credential helpers.
-    require "utils/git"
     result = system_command("git", args: ["--git-dir", git_dir, "show", "-s", "--format=%cD"],
-                                   env:  env.merge(Utils::Git.no_global_config_env), print_stderr: false)
+                                   env:  local_git_env, print_stderr: false)
     raise "Failed to read the Git commit time:\n#{result.stderr}" unless result.success?
 
     Time.parse(result.stdout)
@@ -49,7 +45,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
   sig { override.returns(String) }
   def last_commit
     args = ["--git-dir", git_dir, "rev-parse", "--short=#{MINIMUM_COMMIT_HASH_LENGTH}", "HEAD"]
-    @last_commit ||= silent_command("git", args:).stdout.chomp.presence
+    @last_commit ||= system_command("git", args:, env: local_git_env, print_stderr: false).stdout.chomp.presence
     @last_commit || ""
   end
 
@@ -60,6 +56,16 @@ class GitDownloadStrategy < VCSDownloadStrategy
   sig { override.returns(T::Hash[String, String]) }
   def env
     { "GIT_TERMINAL_PROMPT" => "0" }
+  end
+
+  # Local, read-only repository inspections (`git --git-dir … rev-parse`/`show`)
+  # can run while staging inside the sandbox, where reading the user's global Git
+  # config is denied and makes Git exit. Null it here, unlike the download-time
+  # commands that read it for credential helpers.
+  sig { returns(T::Hash[String, String]) }
+  def local_git_env
+    require "utils/git"
+    env.merge(Utils::Git.no_global_config_env)
   end
 
   sig { override.returns(String) }
@@ -104,7 +110,8 @@ class GitDownloadStrategy < VCSDownloadStrategy
 
   sig { override.returns(String) }
   def current_revision
-    silent_command("git", args: ["--git-dir", git_dir, "rev-parse", "-q", "--verify", "HEAD"]).stdout.strip
+    system_command("git", args: ["--git-dir", git_dir, "rev-parse", "-q", "--verify", "HEAD"],
+                          env: local_git_env, print_stderr: false).stdout.strip
   end
 
   sig { override.returns(T::Boolean) }

--- a/Library/Homebrew/test/download_strategies/git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/git_spec.rb
@@ -63,13 +63,28 @@ RSpec.describe GitDownloadStrategy do
     end
   end
 
-  specify "#last_commit" do
-    cached_location.cd do
-      setup_git_repo
-      FileUtils.touch "LICENSE"
-      git_commit_all
+  describe "#last_commit" do
+    specify "returns the short hash of the last commit" do
+      cached_location.cd do
+        setup_git_repo
+        FileUtils.touch "LICENSE"
+        git_commit_all
+      end
+      expect(strategy.last_commit).to eq("f68266e")
     end
-    expect(strategy.last_commit).to eq("f68266e")
+
+    it "nulls the global Git config so sandboxed staging reads do not fail" do
+      expect(strategy).to receive(:system_command)
+        .with(
+          "git",
+          args:         ["--git-dir", cached_location/".git", "rev-parse", "--short=7", "HEAD"],
+          env:          { "GIT_TERMINAL_PROMPT" => "0", "GIT_CONFIG_GLOBAL" => File::NULL },
+          print_stderr: false,
+        )
+        .and_return(instance_double(SystemCommand::Result, stdout: "f68266e\n"))
+
+      expect(strategy.last_commit).to eq("f68266e")
+    end
   end
 
   describe "#fetch_last_commit" do


### PR DESCRIPTION
- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

I used Claude to diagnose the bug and write the fix. I reviewed the resulting code and manually ran `brew lgtm` and also manually checked that the bug has been fixed.

-----

`last_commit` and `current_revision` run `git rev-parse` against the
cached clone while staging inside the build sandbox, before the stage
environment nulls the global Git config. There, reading the user's
global Git config is denied and makes Git exit, so `last_commit` returns
an empty string. For HEAD builds this makes `update_commit("")` produce a
bare `HEAD-` version, the build installs to `Cellar/<name>/HEAD-`, and
the install then fails with `Error: Empty installation` once the real
short commit is computed outside the sandbox.

These are local, read-only inspections of an already-cloned repository
that never need credential helpers, so null the global config for them
via a shared `local_git_env` helper, matching the existing
`source_modified_time` fix. The download-time commands keep reading the
user config for private-repository credentials.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

-----

To reproduce, run:
```
brew install --HEAD neovim
```
