### PR TITLE
bundle: narrow types

### DIFF
--- a/Library/Homebrew/bundle/brew.rb
+++ b/Library/Homebrew/bundle/brew.rb
@@ -490,11 +490,11 @@ module Homebrew
 
       sig {
         override.params(
-          entries:             T::Array[Object],
+          entries:             T::Array[Dsl::Entry],
           exit_on_first_error: T::Boolean,
           no_upgrade:          T::Boolean,
           verbose:             T::Boolean,
-        ).returns(T::Array[Object])
+        ).returns(T::Array[String])
       }
       def find_actionable(entries, exit_on_first_error: false, no_upgrade: false, verbose: false)
         requested = instance_of?(Homebrew::Bundle::Brew) ? checkable_entries(entries) : format_checkable(entries)

--- a/Library/Homebrew/bundle/brew_services.rb
+++ b/Library/Homebrew/bundle/brew_services.rb
@@ -155,7 +155,7 @@ module Homebrew
           old_name
         end
 
-        sig { params(entries: T::Array[Object]).returns(T::Array[Object]) }
+        sig { params(entries: T::Array[Dsl::Entry]).returns(T::Array[Object]) }
         def format_checkable(entries)
           checkable_entries(entries)
         end

--- a/Library/Homebrew/bundle/checker.rb
+++ b/Library/Homebrew/bundle/checker.rb
@@ -8,7 +8,11 @@ require "bundle/brew_services"
 module Homebrew
   module Bundle
     module Checker
-      CheckResult = Struct.new :work_to_be_done, :errors
+      class CheckResult < T::Struct
+        const :work_to_be_done, T::Boolean
+        const :errors, T::Array[String]
+      end
+
       CheckStep = T.type_alias { Symbol }
 
       CORE_CHECKS = T.let([
@@ -34,7 +38,7 @@ module Homebrew
         @dsl = T.let(@dsl, T.nilable(Homebrew::Bundle::Dsl))
         @dsl ||= Brewfile.read(global:, file:)
 
-        errors = T.let([], T::Array[Object])
+        errors = T.let([], T::Array[String])
         enumerator = exit_on_first_error ? :find : :map
 
         work_to_be_done = CORE_CHECKS.public_send(enumerator) do |check_step|
@@ -46,7 +50,7 @@ module Homebrew
 
         work_to_be_done = Array(work_to_be_done).flatten.any?
 
-        CheckResult.new work_to_be_done, errors
+        CheckResult.new(work_to_be_done:, errors:)
       end
 
       sig {
@@ -54,7 +58,7 @@ module Homebrew
           exit_on_first_error: T::Boolean,
           no_upgrade:          T::Boolean,
           verbose:             T::Boolean,
-        ).returns(T::Array[Object])
+        ).returns(T::Array[String])
       }
       def self.apps_to_install(exit_on_first_error: false, no_upgrade: false, verbose: false)
         extension_errors(:apps_to_install, exit_on_first_error:, no_upgrade:, verbose:)
@@ -65,7 +69,7 @@ module Homebrew
           exit_on_first_error: T::Boolean,
           no_upgrade:          T::Boolean,
           verbose:             T::Boolean,
-        ).returns(T::Array[Object])
+        ).returns(T::Array[String])
       }
       def self.formulae_to_start(exit_on_first_error: false, no_upgrade: false, verbose: false)
         raise ArgumentError, "dsl is unset!" unless @dsl
@@ -81,7 +85,7 @@ module Homebrew
           exit_on_first_error: T::Boolean,
           no_upgrade:          T::Boolean,
           verbose:             T::Boolean,
-        ).returns(T::Array[Object])
+        ).returns(T::Array[String])
       }
       def self.taps_to_tap(exit_on_first_error: false, no_upgrade: false, verbose: false)
         package_type_errors(:tap, exit_on_first_error:, no_upgrade:, verbose:)
@@ -92,7 +96,7 @@ module Homebrew
           exit_on_first_error: T::Boolean,
           no_upgrade:          T::Boolean,
           verbose:             T::Boolean,
-        ).returns(T::Array[Object])
+        ).returns(T::Array[String])
       }
       def self.casks_to_install(exit_on_first_error: false, no_upgrade: false, verbose: false)
         package_type_errors(:cask, exit_on_first_error:, no_upgrade:, verbose:)
@@ -103,7 +107,7 @@ module Homebrew
           exit_on_first_error: T::Boolean,
           no_upgrade:          T::Boolean,
           verbose:             T::Boolean,
-        ).returns(T::Array[Object])
+        ).returns(T::Array[String])
       }
       def self.formulae_to_install(exit_on_first_error: false, no_upgrade: false, verbose: false)
         package_type_errors(:brew, exit_on_first_error:, no_upgrade:, verbose:)
@@ -114,7 +118,7 @@ module Homebrew
           exit_on_first_error: T::Boolean,
           no_upgrade:          T::Boolean,
           verbose:             T::Boolean,
-        ).returns(T::Array[Object])
+        ).returns(T::Array[String])
       }
       def self.registered_extensions_to_install(exit_on_first_error: false, no_upgrade: false, verbose: false)
         extension_errors(:registered_extensions_to_install, exit_on_first_error:, no_upgrade:, verbose:)
@@ -126,13 +130,13 @@ module Homebrew
           exit_on_first_error: T::Boolean,
           no_upgrade:          T::Boolean,
           verbose:             T::Boolean,
-        ).returns(T::Array[Object])
+        ).returns(T::Array[String])
       }
       def self.extension_errors(step, exit_on_first_error:, no_upgrade:, verbose:)
         raise ArgumentError, "dsl is unset!" unless @dsl
 
         matching_extensions = Homebrew::Bundle.extensions.select { |extension| extension.legacy_check_step == step }
-        errors = T.let([], T::Array[Object])
+        errors = T.let([], T::Array[String])
 
         matching_extensions.each do |extension|
           check_errors = extension.check(
@@ -162,7 +166,7 @@ module Homebrew
           exit_on_first_error: T::Boolean,
           no_upgrade:          T::Boolean,
           verbose:             T::Boolean,
-        ).returns(T::Array[Object])
+        ).returns(T::Array[String])
       }
       def self.package_type_errors(type, exit_on_first_error:, no_upgrade:, verbose:)
         raise ArgumentError, "dsl is unset!" unless @dsl

--- a/Library/Homebrew/bundle/checker.rb
+++ b/Library/Homebrew/bundle/checker.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "bundle/dsl"
+require "bundle/extensions"
 require "bundle/package_types"
 require "bundle/brew_services"
 

--- a/Library/Homebrew/bundle/dsl.rb
+++ b/Library/Homebrew/bundle/dsl.rb
@@ -1,11 +1,15 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "bundle/package_type"
-require "utils"
-
 module Homebrew
   module Bundle
+    EntryOptionScalar = T.type_alias { T.nilable(T.any(String, Integer, Symbol, TrueClass, FalseClass)) }
+    NestedEntryOptionValue = T.type_alias { T.any(EntryOptionScalar, T::Array[String]) }
+    NestedEntryOptions = T.type_alias { T::Hash[Symbol, NestedEntryOptionValue] }
+    EntryOption = T.type_alias { T.any(EntryOptionScalar, T::Array[String], NestedEntryOptions) }
+    EntryOptions = T.type_alias { T::Hash[Symbol, EntryOption] }
+    EntryInputOptions = T.type_alias { T::Hash[Symbol, Object] }
+
     class Dsl
       class Entry
         sig { returns(Symbol) }
@@ -134,6 +138,7 @@ module Homebrew
 
       sig { params(name: String).returns(String) }
       def self.sanitize_cask_name(name)
+        require "utils"
         Utils.name_from_full_name(name).downcase
       end
 

--- a/Library/Homebrew/bundle/dsl.rb
+++ b/Library/Homebrew/bundle/dsl.rb
@@ -147,6 +147,7 @@ module Homebrew
                         block: T.nilable(T.proc.void)).returns(T.untyped)
       }
       def method_missing(method_name, *args, **options, &block)
+        require "bundle/extensions"
         extension = Homebrew::Bundle.extension(method_name)
         return super if extension.nil?
         raise ArgumentError, "blocks are not supported for #{method_name}" if block
@@ -173,12 +174,9 @@ module Homebrew
 
       sig { override.params(method_name: T.any(String, Symbol), include_private: T::Boolean).returns(T::Boolean) }
       def respond_to_missing?(method_name, include_private = false)
-        Homebrew::Bundle.extension(method_name).present? || super
+        require "bundle/extensions"
+        !Homebrew::Bundle.extension(method_name).nil? || super
       end
     end
   end
 end
-
-# Load extensions after `Dsl` is defined because their `entry` methods build
-# `Dsl::Entry` instances.
-require "bundle/extensions"

--- a/Library/Homebrew/bundle/dumper.rb
+++ b/Library/Homebrew/bundle/dumper.rb
@@ -3,6 +3,7 @@
 
 require "fileutils"
 require "bundle/dsl"
+require "bundle/extensions"
 require "bundle/package_types"
 
 module Homebrew

--- a/Library/Homebrew/bundle/extensions/extension.rb
+++ b/Library/Homebrew/bundle/extensions/extension.rb
@@ -217,11 +217,11 @@ module Homebrew
 
       sig {
         params(
-          entries:             T::Array[Object],
+          entries:             T::Array[Dsl::Entry],
           exit_on_first_error: T::Boolean,
           no_upgrade:          T::Boolean,
           verbose:             T::Boolean,
-        ).returns(T::Array[Object])
+        ).returns(T::Array[String])
       }
       def self.check(entries, exit_on_first_error: false, no_upgrade: false, verbose: false)
         new.find_actionable(entries, exit_on_first_error:, no_upgrade:, verbose:)

--- a/Library/Homebrew/bundle/extensions/flatpak.rb
+++ b/Library/Homebrew/bundle/extensions/flatpak.rb
@@ -356,12 +356,11 @@ module Homebrew
           end
         end
 
-        sig { params(entries: T::Array[Object]).returns(T::Array[String]) }
+        sig { params(entries: T::Array[Dsl::Entry]).returns(T::Array[String]) }
         def cleanup_items(entries)
           return [].freeze unless package_manager_installed?
 
           kept_flatpaks = entries.filter_map do |entry|
-            entry = T.cast(entry, Dsl::Entry)
             entry.name if entry.type == type
           end
 
@@ -379,10 +378,9 @@ module Homebrew
         end
       end
 
-      sig { override.params(entries: T::Array[Object]).returns(T::Array[Object]) }
+      sig { override.params(entries: T::Array[Dsl::Entry]).returns(T::Array[Object]) }
       def format_checkable(entries)
         checkable_entries(entries).map do |entry|
-          entry = T.cast(entry, Dsl::Entry)
           { name: entry.name, options: entry.options }
         end
       end

--- a/Library/Homebrew/bundle/extensions/mac_app_store.rb
+++ b/Library/Homebrew/bundle/extensions/mac_app_store.rb
@@ -264,21 +264,21 @@ module Homebrew
         end
       end
 
-      sig { override.params(entries: T::Array[Object]).returns(T::Array[Object]) }
+      sig { override.params(entries: T::Array[Dsl::Entry]).returns(T::Array[Object]) }
       def format_checkable(entries)
         checkable_entries(entries).map do |entry|
-          entry = T.cast(entry, Dsl::Entry)
           [T.cast(entry.options.fetch(:id), Integer), entry.name]
         end
       end
 
-      sig { override.params(packages: CheckablePackages, no_upgrade: T::Boolean).returns(T::Array[Object]) }
+      sig { override.params(packages: CheckablePackages, no_upgrade: T::Boolean).returns(T::Array[String]) }
       def exit_early_check(packages, no_upgrade:)
-        work_to_be_done = (packages.is_a?(Hash) ? packages.to_a : packages).find do |id, _name|
-          !installed_and_up_to_date?(id, no_upgrade:)
-        end
+        (packages.is_a?(Hash) ? packages.to_a : packages).each do |id, name|
+          next if installed_and_up_to_date?(id, no_upgrade:)
 
-        Array(work_to_be_done)
+          return [failure_reason(name, no_upgrade:)]
+        end
+        []
       end
 
       sig { override.params(packages: CheckablePackages, no_upgrade: T::Boolean).returns(T::Array[String]) }

--- a/Library/Homebrew/bundle/extensions/uv.rb
+++ b/Library/Homebrew/bundle/extensions/uv.rb
@@ -229,10 +229,9 @@ module Homebrew
         end
       end
 
-      sig { override.params(entries: T::Array[Object]).returns(T::Array[Object]) }
+      sig { override.params(entries: T::Array[Dsl::Entry]).returns(T::Array[Object]) }
       def format_checkable(entries)
         checkable_entries(entries).map do |entry|
-          entry = T.cast(entry, Dsl::Entry)
           with = if entry.options.is_a?(Hash)
             value = entry.options[:with]
             value.is_a?(Array) ? value : []

--- a/Library/Homebrew/bundle/extensions/winget.rb
+++ b/Library/Homebrew/bundle/extensions/winget.rb
@@ -516,10 +516,9 @@ module Homebrew
         end
       end
 
-      sig { override.params(entries: T::Array[Object]).returns(T::Array[Object]) }
+      sig { override.params(entries: T::Array[Dsl::Entry]).returns(T::Array[Object]) }
       def format_checkable(entries)
         checkable_entries(entries).map do |entry|
-          entry = T.cast(entry, Dsl::Entry)
           App.new(id: T.cast(entry.options.fetch(:id), String), name: entry.name,
                   source: T.cast(entry.options.fetch(:source), String))
         end

--- a/Library/Homebrew/bundle/package_type.rb
+++ b/Library/Homebrew/bundle/package_type.rb
@@ -1,15 +1,10 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "bundle/dsl"
+
 module Homebrew
   module Bundle
-    EntryOptionScalar = T.type_alias { T.nilable(T.any(String, Integer, Symbol, TrueClass, FalseClass)) }
-    NestedEntryOptionValue = T.type_alias { T.any(EntryOptionScalar, T::Array[String]) }
-    NestedEntryOptions = T.type_alias { T::Hash[Symbol, NestedEntryOptionValue] }
-    EntryOption = T.type_alias { T.any(EntryOptionScalar, T::Array[String], NestedEntryOptions) }
-    EntryOptions = T.type_alias { T::Hash[Symbol, EntryOption] }
-    EntryInputOptions = T.type_alias { T::Hash[Symbol, Object] }
-
     class PackageType
       extend T::Helpers
 
@@ -86,11 +81,11 @@ module Homebrew
 
       sig {
         params(
-          entries:             T::Array[Object],
+          entries:             T::Array[Dsl::Entry],
           exit_on_first_error: T::Boolean,
           no_upgrade:          T::Boolean,
           verbose:             T::Boolean,
-        ).returns(T::Array[Object])
+        ).returns(T::Array[String])
       }
       def self.check(entries, exit_on_first_error: false, no_upgrade: false, verbose: false)
         new.find_actionable(entries, exit_on_first_error:, no_upgrade:, verbose:)
@@ -107,13 +102,14 @@ module Homebrew
         dump
       end
 
-      sig { params(packages: T::Array[Object], no_upgrade: T::Boolean).returns(T::Array[Object]) }
+      sig { params(packages: T::Array[Object], no_upgrade: T::Boolean).returns(T::Array[String]) }
       def exit_early_check(packages, no_upgrade:)
-        work_to_be_done = packages.find do |pkg|
-          !installed_and_up_to_date?(pkg, no_upgrade:)
-        end
+        packages.each do |pkg|
+          next if installed_and_up_to_date?(pkg, no_upgrade:)
 
-        Array(work_to_be_done)
+          return [failure_reason(pkg, no_upgrade:)]
+        end
+        []
       end
 
       sig { overridable.params(name: Object, no_upgrade: T::Boolean).returns(String) }
@@ -132,11 +128,10 @@ module Homebrew
                 .map { |pkg| failure_reason(pkg, no_upgrade:) }
       end
 
-      sig { params(all_entries: T::Array[Object]).returns(T::Array[Object]) }
+      sig { params(all_entries: T::Array[Dsl::Entry]).returns(T::Array[Dsl::Entry]) }
       def checkable_entries(all_entries)
         require "bundle/skipper"
         all_entries.filter_map do |entry|
-          entry = T.cast(entry, Dsl::Entry)
           next if entry.type != self.class.type
           next if Bundle::Skipper.skip?(entry)
 
@@ -144,12 +139,9 @@ module Homebrew
         end
       end
 
-      sig { params(entries: T::Array[Object]).returns(T::Array[Object]) }
+      sig { params(entries: T::Array[Dsl::Entry]).returns(T::Array[Object]) }
       def format_checkable(entries)
-        checkable_entries(entries).map do |entry|
-          entry = T.cast(entry, Dsl::Entry)
-          entry.name
-        end
+        checkable_entries(entries).map(&:name)
       end
 
       sig { params(_pkg: Object, no_upgrade: T::Boolean).returns(T::Boolean) }
@@ -159,11 +151,11 @@ module Homebrew
 
       sig {
         params(
-          entries:             T::Array[Object],
+          entries:             T::Array[Dsl::Entry],
           exit_on_first_error: T::Boolean,
           no_upgrade:          T::Boolean,
           verbose:             T::Boolean,
-        ).returns(T::Array[Object])
+        ).returns(T::Array[String])
       }
       def find_actionable(entries, exit_on_first_error: false, no_upgrade: false, verbose: false)
         requested = format_checkable(entries)

--- a/Library/Homebrew/bundle/tap.rb
+++ b/Library/Homebrew/bundle/tap.rb
@@ -161,7 +161,7 @@ module Homebrew
       end
 
       sig {
-        override.params(entries: T::Array[Object], exit_on_first_error: T::Boolean,
+        override.params(entries: T::Array[Dsl::Entry], exit_on_first_error: T::Boolean,
                         no_upgrade: T::Boolean, verbose: T::Boolean).returns(T::Array[String])
       }
       def find_actionable(entries, exit_on_first_error: false, no_upgrade: false, verbose: false)


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Updates some Object usage to more specific types. Some changes include:

- Change `exit_early_check` to return String errors so that it has the same return signature as `full_check`
- Make `CheckResult` into a `T::Struct` for better type checking
- `entries` consist of `Dsl::Entry` which avoids having to `T.cast`

---

This allows Sorbet to follow types better.

Some usage of Object needs to remain due to odd inheritance hacks we have for different "packages". Will require a refactor to get rid of these.