### PR TITLE
audit: fix except_cops array

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -198,7 +198,7 @@ module Homebrew
         elsif except_cops
           style_options[:except_cops] = except_cops
         elsif !strict
-          style_options[:except_cops] = [:FormulaAuditStrict]
+          style_options[:except_cops] = %w[FormulaAuditStrict]
         end
 
         # Run tap audits first


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

The `brew audit` command calls `Style.check_style_json`, which calls `Style.check_style_impl` internally. `DevCmd::Audit.run` passes an `except_cops` array as part of the options and it defaults to an array with a `:FormulaAuditStrict` symbol in it but the expected type is an array of strings, causing a Sorbet type error (`Parameter 'except_cops': Expected type T.nilable(T::Array[String]), got type Array with value [:FormulaAuditStrict]`). This addresses the issue by switching this to a string array, borrowing similar code from `brew style`.

I encountered this issue while testing `brew bump`, as it runs `brew audit` as part of updating a package. I usually run `brew audit --strict --online`, so I normally wouldn't exercise this code path otherwise (i.e., this only comes into play when `--strict` isn't used).