### PR TITLE
Fix brew bundle topological sort crash on missing dependency node

### DIFF
--- a/Library/Homebrew/bundle/brew.rb
+++ b/Library/Homebrew/bundle/brew.rb
@@ -791,7 +791,7 @@ module Homebrew
 
         sig { override.params(node: String, block: T.proc.params(arg0: String).void).void }
         def tsort_each_child(node, &block)
-          fetch(node.downcase).sort.each(&block)
+          fetch(node, []).sort.each(&block)
         end
       end
     end

--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -906,4 +906,14 @@ RSpec.describe Homebrew::Bundle::Brew do
       end
     end
   end
+
+  describe Homebrew::Bundle::Brew::Topo do
+    it "treats an edge to a missing node as a leaf" do
+      topo = described_class.new
+      topo["a"] = ["b"]
+      topo["b"] = ["libice"]
+
+      expect(topo.tsort).to eq(["libice", "b", "a"])
+    end
+  end
 end


### PR DESCRIPTION
Fixes a `brew bundle` crash on Linux where the dependency topological sort dies with `key not found: "libice"` (or another library name).

`Topo#tsort_each_child` fetched a node's children with an unguarded `fetch(node.downcase)`. That raises `KeyError` whenever a dependency *edge* points at a formula that is not in the *node* set. Nodes come from installed formulae, where kegs that fail to load are silently dropped. Edges come from `formulae_by_name` loaded from the tap or API. The two sources can disagree, so an edge target can have no matching key and the sort blows up instead of completing.

The fix defaults a missing node to a leaf (no children), matching the existing defensive pattern at `formula_dep_names` (`find_formula(name)&.fetch(:dependencies, []) || []`). I also dropped the `.downcase`: the `Topo` keys are stored verbatim from each formula's `name`/`full_name`, and the node passed in is always one of those exact strings, so `.downcase` could only ever break a lookup, never enable one. It was incidental dead code.

## Tests

Added a unit spec for `Homebrew::Bundle::Brew::Topo`: build a graph whose edge references a node with no key of its own, then assert `.tsort` returns the present nodes in dependency order without raising. Verified red/green with `--only=bundle/brew` (the example raises `KeyError` before the change, passes after).

## Reproduction

This triggers when an installed keg fails to load and is dropped from the node set while still appearing as a dependency edge of another formula. On an affected Linux machine:

```
brew bundle dump
```

crashes in the sort with `key not found: "<library>"`. After this change the sort completes.

I reproduced this in GitHub Actions CI and am hitting it deterministically:

https://github.com/bendrucker/dotfiles/actions/runs/27803390575/job/82279728443

---

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do?
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)?
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

---

- [x] AI was used to generate or assist with generating this PR.

AI was used to aid in diagnosing the crash and drafting the fix and test. I reviewed all of the code in detail before opening this PR. Tool: Claude Code (Opus 4.8).
