### PR TITLE
Avoid duplicate upgrade warnings

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -369,6 +369,7 @@ module Homebrew
           end
         end
 
+        quiet = args.quiet? || (dry_run && !args.dry_run?)
         not_outdated = T.let([], T::Array[Formula])
         if formulae.blank?
           outdated = Formula.installed.select do |f|
@@ -383,7 +384,7 @@ module Homebrew
           end
 
           minimum_version_skipped.each do |f|
-            next if args.quiet?
+            next if quiet
 
             opoo "Not upgrading #{f.full_specified_name}, the installed version is not below " \
                  "the minimum version #{minimum_version}"
@@ -400,7 +401,7 @@ module Homebrew
             if latest_keg.nil?
               ofail "#{f.full_specified_name} not installed"
             else
-              opoo "#{f.full_specified_name} #{latest_keg.version} already installed" unless args.quiet?
+              opoo "#{f.full_specified_name} #{latest_keg.version} already installed" unless quiet
             end
           end
         end
@@ -821,7 +822,8 @@ module Homebrew
                                   download_queue: nil)
         return false if args.formula?
 
-        casks = minimum_version_casks(casks)
+        quiet = args.quiet? || (dry_run && !args.dry_run?)
+        casks = minimum_version_casks(casks, quiet:)
         return false if minimum_version.present? && casks.empty?
 
         Cask::Upgrade.upgrade_casks!(
@@ -836,7 +838,7 @@ module Homebrew
           skip_cask_deps:       args.skip_cask_deps?,
           quit:                 !args.no_quit?,
           verbose:              args.verbose?,
-          quiet:                args.quiet?,
+          quiet:,
           skip_prefetch:,
           show_upgrade_summary:,
           download_queue:,

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -162,6 +162,25 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       ).to_stderr
   end
 
+  it "warns once for a named formula that is already up-to-date" do
+    write_formula "up-to-date-formula", <<~RUBY
+      url "https://brew.sh/up-to-date-formula-1.2.3"
+    RUBY
+    install_formula_version "up-to-date-formula", "1.2.3", optlinked: true
+
+    warning = "Warning: up-to-date-formula 1.2.3 already installed\n"
+    expect { described_class.new(["up-to-date-formula"]).run }
+      .to output(satisfy { |stderr| stderr.scan(warning).one? }).to_stderr
+  end
+
+  it "warns once for a named cask that is already up-to-date", :cask do
+    InstallHelper.stub_cask_installation(Cask::CaskLoader.load(cask_path("local-caffeine")))
+
+    warning = "Warning: Not upgrading local-caffeine, the latest version is already installed\n"
+    expect { described_class.new(["--cask", "local-caffeine"]).run }
+      .to output(satisfy { |stderr| stderr.scan(warning).one? }).to_stderr
+  end
+
   it "does not summarize dry-run formula upgrades blocked by pinned dependencies" do
     setup_pinned_dependency_upgrade
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22801

- Suppress ask-mode preview warnings for named packages that are checked again during the actual upgrade pass.
- Add coverage so up-to-date formula upgrades only warn once.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 high with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
