### PR TITLE
Handle API source patch symlinks

### DIFF
--- a/Library/Homebrew/local_patch.rb
+++ b/Library/Homebrew/local_patch.rb
@@ -35,7 +35,9 @@ class LocalPatch < EmbeddedPatch
     formula = T.cast(owner, SoftwareSpec).owner
     raise ArgumentError, "LocalPatch#contents requires a formula owner!" unless formula.is_a?(::Formula)
 
-    repository_path = repository_path(formula)
+    formula_path = formula.specified_path || formula.path
+    api_repository_path = api_source_repository_path(formula_path)
+    repository_path = api_repository_path || formula.tap&.path || formula_path.dirname
     file_path = repository_path/Pathname(file)
     repository_realpath = repository_path.realpath
     file_realpath = begin
@@ -43,7 +45,14 @@ class LocalPatch < EmbeddedPatch
     rescue Errno::ENOENT
       raise ArgumentError, "Patch file does not exist: #{file}"
     end
-    if file_realpath.ascend.none?(repository_realpath)
+    if file_realpath.ascend.none?(repository_realpath) &&
+       !(api_repository_path &&
+         begin
+           file_path.expand_path.ascend.any?(api_repository_path.expand_path) &&
+             file_realpath.ascend.any?((HOMEBREW_CACHE/"downloads").realpath)
+         rescue Errno::ENOENT
+           false
+         end)
       raise ArgumentError, "Patch file must be within the formula repository."
     end
     raise ArgumentError, "Patch file must be a file: #{file}" unless file_realpath.file?
@@ -57,12 +66,6 @@ class LocalPatch < EmbeddedPatch
   end
 
   private
-
-  sig { params(formula: ::Formula).returns(Pathname) }
-  def repository_path(formula)
-    formula_path = formula.specified_path || formula.path
-    api_source_repository_path(formula_path) || formula.tap&.path || formula_path.dirname
-  end
 
   sig { params(path: Pathname).returns(T.nilable(Pathname)) }
   def api_source_repository_path(path)

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Homebrew::API::Formula do
   let(:source_cache_dir) { mktmpdir }
 
   before do
+    stub_const("HOMEBREW_CACHE", cache_dir)
     stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
     stub_const("Homebrew::API::HOMEBREW_CACHE_API_SOURCE", source_cache_dir)
     described_class.clear_cache
@@ -198,7 +199,9 @@ RSpec.describe Homebrew::API::Formula do
     it "loads local patch files from API source cache" do
       source_path = source_cache_dir/"Homebrew/homebrew-core/abc123/Formula/testball.rb"
       source_path.dirname.mkpath
-      source_path.write <<~RUBY
+      cached_source_path = cache_dir/"downloads/testball.rb"
+      cached_source_path.dirname.mkpath
+      cached_source_path.write <<~RUBY
         class Testball < Formula
           url "https://brew.sh/testball-0.1.tar.gz"
 
@@ -207,12 +210,15 @@ RSpec.describe Homebrew::API::Formula do
           end
         end
       RUBY
+      FileUtils.ln_s cached_source_path.relative_path_from(source_path.dirname), source_path
 
       allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:fetch) do |download|
         next if download.symlink_location.basename.to_s != "noop-a.diff"
 
-        download.symlink_location.dirname.mkpath
-        download.symlink_location.write("patch contents")
+        cached_patch_path = download.downloader.cached_location
+        cached_patch_path.dirname.mkpath
+        cached_patch_path.write("patch contents")
+        download.downloader.create_symlink_to_cached_download(cached_patch_path)
       end
 
       result = described_class.source_download_formula(f)


### PR DESCRIPTION
- API source formulae store local patch files as symlinks into the downloads cache.
- Allow that cache layout while preserving repository escape checks.
- Cover the `gcc`-style local patch path loaded from API source.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex high with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
