### PR TITLE
Fix caveats replacing order (HOMEBREW_PREFIX) in API formula reconstruction

### DIFF
--- a/Library/Homebrew/api_hashable.rb
+++ b/Library/Homebrew/api_hashable.rb
@@ -49,9 +49,9 @@ module APIHashable
     when Array
       value.map { |v| deep_remove_placeholders(v) }
     when String
-      value.gsub(HOMEBREW_HOME_PLACEHOLDER, Dir.home)
-           .gsub(HOMEBREW_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
+      value.gsub(HOMEBREW_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
            .gsub(HOMEBREW_CELLAR_PLACEHOLDER, HOMEBREW_CELLAR)
+           .gsub(HOMEBREW_HOME_PLACEHOLDER, Dir.home)
     else
       value
     end

--- a/Library/Homebrew/test/api/formula_struct_spec.rb
+++ b/Library/Homebrew/test/api/formula_struct_spec.rb
@@ -302,4 +302,21 @@ RSpec.describe Homebrew::API::FormulaStruct do
       expect(restored.post_install_steps).to eq(original.post_install_steps)
     end
   end
+
+  describe "::from_hash" do
+    it "does not replace home placeholders inside prefix placeholders" do
+      original = described_class.from_hash(
+        "desc"                 => "caveats replace test",
+        "homepage"             => "https://example.com",
+        "license"              => "MIT",
+        "ruby_source_checksum" => "abc123",
+        "stable_version"       => "1.0.0",
+        "caveats"              => "unix://$HOMEBREW_PREFIX",
+      )
+
+      expect(original.caveats).to eq(
+        "unix://#{HOMEBREW_PREFIX}",
+      )
+    end
+  end
 end


### PR DESCRIPTION
$HOMEBREW_PREFIX prefiexed with / (e.g. unix://$HOMEBREW_PREFIX) results in broken path.
This is because `/$HOME` is replaced before `$HOMEBREW_PREFIX` in API.
This PR fixes the order of replacing HOMEBREW_PREFIX, HOMEBREW_CELLAR, HOME.

## Actual behavior

```bash
% brew info socktainer
==> socktainer ✔: stable 1.0.0 (bottled), HEAD
Docker-compatible REST API on top of Apple container
https://socktainer.github.io
Installed (on request)
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/s/socktainer.rb
License: Apache-2.0
==> Installed Kegs and Versions
socktainer ✔ HEAD-21af0b5 (7 files, 68.6MB) [Linked]
==> Dependencies
Required (1): container ✔
Recursive Runtime (1): all installed ✔
==> Options
--HEAD
	Install HEAD version
==> Caveats
Socktainer exposes a Docker-compatible REST API. You can connect any tools you installed for Docker daemon.

To connect it to your tools, add the following to ~/.bash_profile or ~/.zshrc:
  export DOCKER_HOST=unix://Users/umireonBREW_PREFIX/var/run/socktainer/.socktainer/container.sock

To restart socktainer after an upgrade:
  brew services restart socktainer
Or, if you don't want/need a background service you can just run:
  HOME="/opt/homebrew/var/run/socktainer" /opt/homebrew/opt/socktainer/bin/socktainer
==> Analytics
install: 14 (30 days), 29 (90 days), 29 (365 days)
install-on-request: 14 (30 days), 29 (90 days), 29 (365 days)
build-error: 0 (30 days)
```

## Expected behavior

```
To connect it to your tools, add the following to ~/.bash_profile or ~/.zshrc:
  export DOCKER_HOST=unix:///opt/homebrew/var/run/socktainer/.socktainer/container.sock
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

I used OpenAI Codex to investigate the root cause of this bug. I wrote all the code by my hands and carefully examined thoroughly. I have run test and actual command repeatedly to confirm this change works as expected.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
