### PR TITLE
dev-cmd/tap-new: update actions versions

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -107,7 +107,7 @@ module Homebrew
                     token: ${{ secrets.GITHUB_TOKEN }}
 
                 - name: Cache Homebrew Bundler RubyGems
-                  uses: actions/cache@v4
+                  uses: actions/cache@v5
                   with:
                     path: ${{ steps.set-up-homebrew.outputs.gems-path }}
                     key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -138,7 +138,7 @@ module Homebrew
 
                 - name: Upload bottles as artifact
                   if: always() && github.event_name == 'pull_request'
-                  uses: actions/upload-artifact@v4
+                  uses: actions/upload-artifact@v7
                   with:
                     name: bottles_${{ matrix.os }}
                     path: '*.bottle.*'


### PR DESCRIPTION
Update the tap-new GitHub Actions template to use the current major versions of actions/cache and actions/upload-artifact for new tap CI workflows, for the sake of security.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----