### PR TITLE
Restore test-bot tap trust

### DIFF
--- a/Library/Homebrew/test/test_bot/test_cleanup_spec.rb
+++ b/Library/Homebrew/test/test_bot/test_cleanup_spec.rb
@@ -41,6 +41,39 @@ RSpec.describe Homebrew::TestBot do
   end
 
   describe Homebrew::TestBot::CleanupBefore do
+    describe "#run!" do
+      it "restores trust for the tap being tested after cleanup" do
+        tap = Tap.fetch("thirdparty", "foo")
+        tap.path.mkpath
+        cleanup = described_class.new(
+          tap:       tap,
+          git:       "git",
+          dry_run:   true,
+          fail_fast: false,
+          verbose:   false,
+        )
+        args = double
+
+        allow(cleanup).to receive(:test_header)
+        allow(cleanup).to receive(:cleanup_shared) { FileUtils.rm_f Homebrew::Trust.trust_file }
+
+        mktmpdir do |workdir|
+          workdir.cd do
+            with_env(HOMEBREW_USER_CONFIG_HOME: "#{workdir}/.homebrew") do
+              Homebrew::Trust.trust!(:tap, tap)
+              cleanup.run!(args:)
+
+              expect(Homebrew::Trust.trust_file).to exist
+              expect(Homebrew::Trust.trusted_tap?(tap)).to be(true)
+            end
+          end
+        end
+      ensure
+        Homebrew::Trust.clear!(:tap)
+        FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+      end
+    end
+
     describe "#untap_untrusted_taps" do
       it "does not untap the tap being tested" do
         current_tap = instance_double(Tap, name: "current/tap", path: HOMEBREW_TAP_DIRECTORY/"current/homebrew-tap")

--- a/Library/Homebrew/test_bot.rb
+++ b/Library/Homebrew/test_bot.rb
@@ -39,6 +39,14 @@ module Homebrew
       args.local? || GitHub::Actions.env_set?
     end
 
+    sig { params(tap: T.nilable(Tap)).void }
+    def trust_test_tap!(tap)
+      return if tap.nil? || tap.official?
+
+      action = Homebrew::Trust.trust!(:tap, tap) ? "Trusted" : "Already trusted"
+      Homebrew::TestBot.ohai "#{action} tap: #{tap.name}"
+    end
+
     sig { void }
     def setup_github_actions_sandbox!
       return unless GitHub::Actions.env_set?
@@ -142,10 +150,7 @@ module Homebrew
           raise unless quiet_system GIT, "-C", tap.path, "fetch", "--unshallow"
         end
 
-        unless tap.official?
-          action = Homebrew::Trust.trust!(:tap, tap) ? "Trusted" : "Already trusted"
-          Homebrew::TestBot.ohai "#{action} tap: #{tap.name}"
-        end
+        trust_test_tap!(tap)
       end
 
       brew_version = Utils.safe_popen_read(

--- a/Library/Homebrew/test_bot/cleanup_before.rb
+++ b/Library/Homebrew/test_bot/cleanup_before.rb
@@ -26,6 +26,7 @@ module Homebrew
         # Keep all "brew" invocations after cleanup_shared
         # (which cleans up Homebrew/brew)
         cleanup_shared
+        Homebrew::TestBot.trust_test_tap!(tap)
       end
 
       sig { void }


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22775

- `CleanupBefore` can remove the local trust store when it cleans a tap checkout that is also the GitHub Actions workspace
- re-trust the current test tap after cleanup so later `brew doctor` and formula-loading steps see the same trust state
- share the test tap trust helper with initial `test-bot` setup so custom-remote taps keep using their canonical trust reference

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex GPT 5.5 high with local review and a lot of tweaking.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
