### PR TITLE
cask/installer: prepend cask name to macOS requirement error

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -393,11 +393,10 @@ on_request: true)
 
     sig { void }
     def check_macos_requirements
-      macos_requirements = [@cask.depends_on.macos, @cask.depends_on.maximum_macos].compact
-      return if macos_requirements.empty?
-      return if macos_requirements.all?(&:satisfied?)
+      macos_requirement = [@cask.depends_on.macos, @cask.depends_on.maximum_macos].compact.find { !it.satisfied? }
+      return unless macos_requirement
 
-      raise CaskError, macos_requirements.find { |requirement| !requirement.satisfied? }&.message(type: :cask)
+      raise CaskError, "#{@cask}: #{macos_requirement.message(type: :cask)}"
     end
 
     sig { void }

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe Cask::Installer, :cask do
 
         expect do
           described_class.new(cask, download_queue:).enqueue_downloads
-        end.to raise_error(Cask::CaskError, "macOS is required")
+        end.to raise_error(Cask::CaskError, "with-preflight: macOS is required")
       end
 
       it "checks requirements before loading the source cask during fetch" do
@@ -295,7 +295,7 @@ RSpec.describe Cask::Installer, :cask do
 
         expect do
           described_class.new(cask).fetch
-        end.to raise_error(Cask::CaskError, "macOS is required")
+        end.to raise_error(Cask::CaskError, "with-preflight: macOS is required")
       end
     end
 


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Related to https://github.com/orgs/Homebrew/discussions/6913

This also aligns with style of formula message at:

https://github.com/Homebrew/brew/blob/2642c278b458e689a0ac0265f0b1d8f4ba82c68d/Library/Homebrew/formula_installer.rb#L718
