### PR TITLE
Name the formula or cask in requirement error messages

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -388,7 +388,7 @@ on_request: true)
     def check_stanza_os_requirements
       return if @cask.supports_macos?
 
-      raise CaskError, "Linux is required for this software."
+      raise CaskError, "#{@cask}: This cask requires Linux."
     end
 
     sig { void }
@@ -411,7 +411,7 @@ on_request: true)
       end
 
       raise CaskError,
-            "Cask #{@cask} depends on hardware architecture being one of " \
+            "#{@cask}: This cask depends on hardware architecture being one of " \
             "[#{@cask.depends_on.arch.join(", ")}], " \
             "but you are running #{@current_arch}."
     end

--- a/Library/Homebrew/extend/os/linux/cask/installer.rb
+++ b/Library/Homebrew/extend/os/linux/cask/installer.rb
@@ -13,7 +13,7 @@ module OS
         def check_stanza_os_requirements
           return if !cask.depends_on.requires_macos? && artifacts.all? { |artifact| supported_artifact?(artifact) }
 
-          raise ::Cask::CaskError, "macOS is required for this software."
+          raise ::Cask::CaskError, "#{cask}: This cask requires macOS."
         end
 
         private

--- a/Library/Homebrew/extend/os/mac/cask/installer.rb
+++ b/Library/Homebrew/extend/os/mac/cask/installer.rb
@@ -13,7 +13,7 @@ module OS
         def check_stanza_os_requirements
           return if !cask.depends_on.requires_linux? && artifacts.all? { |artifact| supported_artifact?(artifact) }
 
-          raise ::Cask::CaskError, "Linux is required for this software."
+          raise ::Cask::CaskError, "#{cask}: This cask requires Linux."
         end
 
         private

--- a/Library/Homebrew/requirements/macos_requirement.rb
+++ b/Library/Homebrew/requirements/macos_requirement.rb
@@ -139,31 +139,33 @@ class MacOSRequirement < Requirement
 
   sig { override.params(type: Symbol).returns(String) }
   def message(type: :formula)
-    return "macOS is required for this software." unless version_specified?
+    subject = (type == :cask) ? "This cask" : "This formula"
+
+    return "#{subject} requires macOS." unless version_specified?
 
     version = @version
     case @comparator
     when ">="
-      "This software does not run on macOS versions older than #{T.cast(version, MacOSVersion).pretty_name}."
+      "#{subject} does not run on macOS versions older than #{T.cast(version, MacOSVersion).pretty_name}."
     when "<="
       case type
       when :formula
         <<~EOS
-          This formula either does not compile or function as expected on macOS
+          #{subject} either does not compile or function as expected on macOS
           versions newer than #{T.cast(version, MacOSVersion).pretty_name} due to an upstream incompatibility.
         EOS
       when :cask
-        "This cask does not run on macOS versions newer than #{T.cast(version, MacOSVersion).pretty_name}."
+        "#{subject} does not run on macOS versions newer than #{T.cast(version, MacOSVersion).pretty_name}."
       else
         ""
       end
     else
       if version.respond_to?(:to_ary) || version.is_a?(Array)
         *versions, last = T.unsafe(version).map(&:pretty_name)
-        return "This software does not run on macOS versions other than #{versions.join(", ")} and #{last}."
+        return "#{subject} does not run on macOS versions other than #{versions.join(", ")} and #{last}."
       end
 
-      "This software does not run on macOS versions other than #{T.cast(version, MacOSVersion).pretty_name}."
+      "#{subject} does not run on macOS versions other than #{T.cast(version, MacOSVersion).pretty_name}."
     end
   end
 

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -102,11 +102,30 @@ RSpec.describe Cask::Installer, :cask do
       end.to raise_error(/--require-sha/)
     end
 
-    it "fails to install if Linux is required" do
+    it "names the cask when Linux is required" do
       linux_cask = Cask::CaskLoader.load("with-depends-on-linux-bare")
       expect do
         described_class.new(linux_cask).check_stanza_os_requirements
-      end.to raise_error(Cask::CaskError, "Linux is required for this software.")
+      end.to raise_error(Cask::CaskError, "with-depends-on-linux-bare: This cask requires Linux.")
+    end
+
+    it "names the cask when the macOS requirement is not satisfied" do
+      macos_cask = Cask::CaskLoader.load("with-depends-on-macos-failure")
+      allow(macos_cask.depends_on.maximum_macos).to receive(:satisfied?).and_return(false)
+      expect do
+        described_class.new(macos_cask).check_macos_requirements
+      end.to raise_error(
+        Cask::CaskError,
+        "with-depends-on-macos-failure: This cask does not run on macOS versions newer than Monterey.",
+      )
+    end
+
+    it "names the cask when the architecture is not supported" do
+      arch_cask = Cask::CaskLoader.load("with-depends-on-arch")
+      allow(Hardware::CPU).to receive(:type).and_return(:ppc)
+      expect do
+        described_class.new(arch_cask).check_arch_requirements
+      end.to raise_error(Cask::CaskError, /\Awith-depends-on-arch: This cask depends on hardware architecture/)
     end
 
     it "installs fine if sha256 :no_check is used with --require-sha and --force" do

--- a/Library/Homebrew/test/requirements/macos_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/macos_requirement_spec.rb
@@ -64,4 +64,18 @@ RSpec.describe MacOSRequirement do
     expect(exact_requirement.allows?(tahoe_major)).to be true
     expect(range_requirement.allows?(tahoe_major)).to be true
   end
+
+  specify "#message reflects the dependent type" do
+    min_requirement = described_class.new([:tahoe], comparator: ">=")
+    max_requirement = described_class.new([:monterey], comparator: "<=")
+    no_requirement = described_class.new
+    expect(min_requirement.message)
+      .to eq "This formula does not run on macOS versions older than Tahoe."
+    expect(min_requirement.message(type: :cask))
+      .to eq "This cask does not run on macOS versions older than Tahoe."
+    expect(max_requirement.message(type: :cask))
+      .to eq "This cask does not run on macOS versions newer than Monterey."
+    expect(no_requirement.message).to eq "This formula requires macOS."
+    expect(no_requirement.message(type: :cask)).to eq "This cask requires macOS."
+  end
 end


### PR DESCRIPTION
#22816 named the offending cask in the macOS-version error, but the message still reads `This software does not run…` for both formulae and casks, and the cask OS-stanza and architecture checks don't name the cask at all. This makes `MacOSRequirement#message` type-aware (`This formula`/`This cask`) and gives those cask checks the same `<token>:` prefix, so every requirement error names the dependent and its type.

https://github.com/orgs/Homebrew/discussions/6913

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code (Opus 4.8) made the change and wrote the tests; I verified with `brew lgtm` and by reproducing the before/after error via `brew install --cask`.

-----
