### PR TITLE
trust: replace T.untyped

### DIFF
--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -200,7 +200,7 @@ module Homebrew
 
     # Whether the tap appears in the trust list, ignoring any implicit official-tap trust. The
     # entries may be `user/repository` names or remote URLs, so match via {Tap#matches_reference?}.
-    sig { params(tap: T.untyped).returns(T::Boolean) }
+    sig { params(tap: Tap).returns(T::Boolean) }
     def self.explicitly_trusted_tap?(tap)
       trusted_entries(:tap).any? { |reference| tap.matches_reference?(reference) }
     end
@@ -496,7 +496,7 @@ module Homebrew
     end
     private_class_method :with_trust_store_lock
 
-    sig { params(path: Pathname).returns(T.untyped) }
+    sig { params(path: Pathname).returns(T.nilable(Tap)) }
     def self.tap_from_path(path)
       Tap.from_path(path)
     end
@@ -518,7 +518,7 @@ module Homebrew
     end
     private_class_method :trusted_file?
 
-    sig { params(type: Symbol, full_name: String, tap: T.untyped).returns(T::Boolean) }
+    sig { params(type: Symbol, full_name: String, tap: Tap).returns(T::Boolean) }
     def self.explicitly_allowed?(type, full_name, tap)
       return false if type == :command
 
@@ -558,7 +558,7 @@ module Homebrew
     end
     private_class_method :trusted_entry_prefix?
 
-    sig { params(type: Symbol, name: String, tap: T.untyped).void }
+    sig { params(type: Symbol, name: String, tap: Tap).void }
     def self.raise_untrusted!(type, name, tap)
       raise UntrustedTapError, "Refusing to load #{type} #{name} from untrusted tap #{tap.name}.\n" \
                                "Run `brew trust --#{type} #{name}` or `brew trust #{tap.name}` to trust it."


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Narrowing some T.untyped to actual types to reduce Sorbet escape hatches