### PR TITLE
generate-zap: load casks via named args and skip unreadable dirs

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-zap.rb
+++ b/Library/Homebrew/dev-cmd/generate-zap.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "abstract_command"
-require "cask/cask_loader"
+require "cask"
 require "system_command"
 
 module Homebrew
@@ -88,12 +88,10 @@ module Homebrew
 
       sig { override.void }
       def run
-        input = args.named.fetch(0)
-
         patterns = if args.name?
-          [input]
+          [args.named.fetch(0)]
         else
-          resolve_patterns_from_cask(input)
+          resolve_patterns_from_cask(args.named.to_casks.fetch(0))
         end
 
         ohai "Scanning for files matching #{format_patterns(patterns)}..."
@@ -117,18 +115,16 @@ module Homebrew
 
       private
 
-      sig { params(token: String).returns(T::Array[String]) }
-      def resolve_patterns_from_cask(token)
-        cask = Cask::CaskLoader.load(token)
-
+      sig { params(cask: Cask::Cask).returns(T::Array[String]) }
+      def resolve_patterns_from_cask(cask)
         app_artifact = cask.artifacts.find { |a| a.is_a?(Cask::Artifact::App) }
         if app_artifact
           patterns = [app_artifact.target.basename(".app").to_s]
           patterns.concat(bundle_identifiers(app_artifact))
           patterns.uniq
         else
-          ohai "No app artifact found in cask \"#{token}\"; using token as app name."
-          [token.tr("-", " ").split.map(&:capitalize).join(" ")]
+          ohai "No app artifact found in cask \"#{cask.token}\"; using token as app name."
+          [cask.token.tr("-", " ").split.map(&:capitalize).join(" ")]
         end
       end
 
@@ -165,7 +161,7 @@ module Homebrew
           full_dir = home_relative ? File.join(home, dir) : dir
           next unless File.directory?(full_dir)
 
-          Dir.each_child(full_dir) do |entry|
+          each_readable_child(full_dir) do |entry|
             downcased_entry = entry.downcase
             next unless downcased_patterns.any? { |pattern| downcased_entry.include?(pattern) }
 
@@ -183,7 +179,7 @@ module Homebrew
         downcased_patterns = patterns.map(&:downcase)
         matches = []
 
-        Dir.each_child(home) do |entry|
+        each_readable_child(home) do |entry|
           next unless entry.start_with?(".")
 
           downcased_entry = entry.downcase
@@ -193,6 +189,14 @@ module Homebrew
         end
 
         matches.sort
+      end
+
+      sig { params(dir: String, block: T.proc.params(entry: String).void).void }
+      def each_readable_child(dir, &block)
+        Dir.each_child(dir, &block)
+      rescue Errno::EPERM, Errno::EACCES
+        # Skip directories we lack permission to read, e.g. macOS-protected paths.
+        nil
       end
 
       sig { params(paths: T::Array[String]).returns(T::Array[String]) }

--- a/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
@@ -14,9 +14,8 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
       app = instance_double(Cask::Artifact::App, target: Pathname.new("TestCask.app"))
       allow(app).to receive(:is_a?).with(Cask::Artifact::App).and_return(true)
       cask = instance_double(Cask::Cask, artifacts: [app])
-      allow(Cask::CaskLoader).to receive(:load).with("test-cask").and_return(cask)
 
-      expect(generate_zap.send(:resolve_patterns_from_cask, "test-cask")).to eq(["TestCask"])
+      expect(generate_zap.send(:resolve_patterns_from_cask, cask)).to eq(["TestCask"])
     end
 
     it "resolves bundle identifier from an installed app artifact" do
@@ -31,12 +30,11 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
         cask = instance_double(Cask::Cask, artifacts: [app])
 
         allow(app).to receive(:is_a?).with(Cask::Artifact::App).and_return(true)
-        allow(Cask::CaskLoader).to receive(:load).with("test-cask").and_return(cask)
         allow(generate_zap).to receive(:system_command!)
           .with("plutil", args: ["-convert", "xml1", "-o", "-", info_plist])
           .and_return(result)
 
-        expect(generate_zap.send(:resolve_patterns_from_cask, "test-cask"))
+        expect(generate_zap.send(:resolve_patterns_from_cask, cask))
           .to eq(["TestCask", "com.example.testcask"])
       end
     end
@@ -44,9 +42,7 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
     it "falls back to title-cased token when no app artifact exists" do
       cask = Cask::Cask.new("test-cask")
 
-      allow(Cask::CaskLoader).to receive(:load).with("test-cask").and_return(cask)
-
-      expect(generate_zap.send(:resolve_patterns_from_cask, "test-cask")).to eq(["Test Cask"])
+      expect(generate_zap.send(:resolve_patterns_from_cask, cask)).to eq(["Test Cask"])
     end
   end
 
@@ -103,6 +99,26 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
         expect(results.size).to eq(1)
         expect(results.first).to include(".foo")
       end
+    end
+  end
+
+  describe "#each_readable_child" do
+    it "yields each child entry of a readable directory" do
+      Dir.mktmpdir do |tmpdir|
+        FileUtils.touch("#{tmpdir}/a")
+        FileUtils.touch("#{tmpdir}/b")
+
+        entries = []
+        generate_zap.send(:each_readable_child, tmpdir) { |entry| entries << entry }
+
+        expect(entries).to contain_exactly("a", "b")
+      end
+    end
+
+    it "skips directories that raise a permission error" do
+      allow(Dir).to receive(:each_child).and_raise(Errno::EPERM)
+
+      expect { generate_zap.send(:each_readable_child, "/protected") { |_entry| nil } }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
Resolve the cask through `args.named.to_casks` instead of calling `Cask::CaskLoader.load` directly. The shared named-args loader path defaults to `warn: false`, so `generate-zap` no longer reprints a tap migration/rename warning on every run the way the direct call did (it inherited the loader's `warn: true` default), and it picks up the standard cask resolution and error handling for free.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code (Opus 4.8) investigated the issue, made the change, and wrote the
tests; I verified with `brew lgtm` and by re-running `brew generate-zap` before
and after.

-----
