### PR TITLE
livecheck: prevent unnecessary boolean args

### DIFF
--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -207,6 +207,8 @@ class Livecheck
     referer: nil,
     user_agent: nil
   )
+    raise ArgumentError, "`compressed` option should only be `false` or omitted" if compressed == true
+    raise ArgumentError, "`homebrew_curl` option should only be `true` or omitted" if homebrew_curl == false
     raise ArgumentError, "Only use `post_form` or `post_json`, not both" if post_form && post_json
 
     @options.compressed = compressed unless compressed.nil?

--- a/Library/Homebrew/livecheck/options.rb
+++ b/Library/Homebrew/livecheck/options.rb
@@ -10,7 +10,7 @@ module Homebrew
     # set.
     class Options < T::Struct
       # Whether to request a compressed response.
-      prop :compressed, T.nilable(T::Boolean)
+      prop :compressed, T.nilable(FalseClass)
 
       # Cookies for curl to use when making a request.
       prop :cookies, T.nilable(T::Hash[String, String])
@@ -19,7 +19,7 @@ module Homebrew
       prop :header, T.nilable(T.any(String, T::Array[String]))
 
       # Whether to use brewed curl.
-      prop :homebrew_curl, T.nilable(T::Boolean)
+      prop :homebrew_curl, T.nilable(TrueClass)
 
       # Form data to use when making a `POST` request.
       prop :post_form, T.nilable(T::Hash[Symbol, String])

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -209,6 +209,18 @@ RSpec.describe Livecheck do
       end.to raise_error ArgumentError
     end
 
+    it "raises an ArgumentError if `compressed: true` argument is provided" do
+      expect do
+        livecheck_f.url(:stable, compressed: true)
+      end.to raise_error ArgumentError
+    end
+
+    it "raises an ArgumentError if `homebrew_curl: false` argument is provided" do
+      expect do
+        livecheck_f.url(:stable, homebrew_curl: false)
+      end.to raise_error ArgumentError
+    end
+
     it "raises an ArgumentError if both `post_form` and `post_json` arguments are provided" do
       expect do
         livecheck_f.url(:stable, post_form: post_hash, post_json: post_hash)


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

I recently added a boolean `compressed` option to the `Livecheck.url` method but it should only be used with a `false` value, as livecheck uses compression for `page_content` fetches by default. Similarly, `homebrew_curl` is another boolean option but it should only be `true` or omitted, as brewed curl isn't used by default.

This adds additional guards to `Livecheck.url` to prevent unnecessary values from being set as `url` options. This also modifies the related property types in `Livecheck::Options` to only allow the correct types. Under normal circumstances, users should only see the errors from `Livecheck.url` (not Sorbet type errors) as they prevent the method from setting `Options` values that would trigger a type error.

The stricter `Options` property types are a safeguard to ensure that we don't use incorrect values when setting these options in livecheck itself. For example, we have some code in livecheck that infers whether a check should use brewed curl and this sets the `homebrew_curl` option value. That logic should only be exercised if `use_homebrew_curl?` returns `true` but the stricter type would catch a `false` value if we were less careful.