### PR TITLE
Respect auto-update cask opt-out

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -439,6 +439,8 @@ module Cask
       return if installed_version == version
 
       if auto_updates && !greedy && !greedy_auto_updates
+        return unless Homebrew::EnvConfig.upgrade_auto_updates_casks?
+
         return installed_version if auto_updates_bundle_outdated?
 
         return
@@ -733,7 +735,6 @@ module Cask
 
     sig { returns(T::Boolean) }
     def auto_updates_bundle_outdated?
-      return false unless Homebrew::EnvConfig.upgrade_auto_updates_casks?
       return false if !auto_updates || version.latest?
       return false unless installed_app_info_plist
 

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -304,6 +304,16 @@ RSpec.describe Cask::Cask, :cask do
         expect(cask.outdated_version).to eq("2.57")
       end
 
+      it "is not outdated when auto-update upgrades are disabled" do
+        allow(Homebrew::EnvConfig).to receive(:upgrade_auto_updates_casks?).and_return(false)
+        tap_version = "2.61"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.57")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.57", bundle_version: "2057")
+
+        expect(cask.outdated_version).to be_nil
+      end
+
       it "is not outdated when the short version matches and the bundle version is lower than a CSV candidate" do
         tap_version = "2.61,3000"
         cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Cask::Upgrade, :cask do
       end
 
       it 'excludes "auto_updates true" casks when HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS is set' do
-        allow(Homebrew::EnvConfig).to receive(:upgrade_auto_updates_casks?).and_return(false)
+        allow(Homebrew::EnvConfig).to receive(:upgrade_auto_updates_casks?).and_call_original
 
         expect(described_class).not_to receive(:upgrade_cask)
         expect(described_class).to receive(:show_upgrade_summary) do |cask_upgrades, dry_run:|
@@ -122,7 +122,9 @@ RSpec.describe Cask::Upgrade, :cask do
           expect(cask_upgrades.grep(/auto-updates/)).to be_empty
         end
 
-        described_class.upgrade_casks!(dry_run: true, args:)
+        with_env(HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS: "1") do
+          described_class.upgrade_casks!(dry_run: true, args:)
+        end
       end
 
       it "lets HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS override HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS" do

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -61,6 +61,31 @@ RSpec.describe Homebrew::Cmd::Outdated do
     expect(cmd.send(:select_outdated, [cask])).to eq([cask])
   end
 
+  it "excludes auto-updating casks when auto-update upgrades are disabled", :cask do
+    InstallHelper.stub_cask_installation(Cask::CaskLoader.load(cask_path("outdated/auto-updates")))
+
+    info_plist = Pathname(Cask::CaskLoader.load(cask_path("auto-updates")).config.appdir)
+                 .join("MyFancyApp.app/Contents/Info.plist")
+    info_plist.dirname.mkpath
+    info_plist.write <<~PLIST
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>CFBundleShortVersionString</key>
+        <string>2.57</string>
+        <key>CFBundleVersion</key>
+        <string>2057</string>
+      </dict>
+      </plist>
+    PLIST
+
+    with_env(HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS: "1") do
+      expect { described_class.new(["--cask"]).run }
+        .not_to output.to_stdout
+    end
+  end
+
   it "outputs JSON for outdated formulae and casks", :cask, :integration_test do
     setup_test_formula "testball"
     (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22820

- Keep `HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS` outside the bundle metadata helper so the opt-out applies before `Info.plist` versions are compared.
- Cover `brew outdated` and `brew upgrade -n` with regressions that use the real env parser.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 high with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
