### PR TITLE
Share opt-bin PATH helpers

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -7,6 +7,7 @@ require "unpack_strategy"
 require "lock_file"
 require "system_command"
 require "utils/output"
+require "utils/path"
 
 # Need to define this before requiring Mechanize to avoid:
 #   uninitialized constant Mechanize

--- a/Library/Homebrew/download_strategy/bazaar_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/bazaar_download_strategy.rb
@@ -37,10 +37,7 @@ class BazaarDownloadStrategy < VCSDownloadStrategy
 
   sig { override.returns(T::Hash[String, String]) }
   def env
-    {
-      "PATH"     => PATH.new(Formula["breezy"].opt_bin, ENV.fetch("PATH")),
-      "BZR_HOME" => HOMEBREW_TEMP,
-    }
+    Utils::Path.formula_opt_bin_env("breezy").merge("BZR_HOME" => HOMEBREW_TEMP.to_s)
   end
 
   sig { override.returns(String) }

--- a/Library/Homebrew/download_strategy/cvs_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/cvs_download_strategy.rb
@@ -45,7 +45,7 @@ class CVSDownloadStrategy < VCSDownloadStrategy
 
   sig { override.returns(T::Hash[String, String]) }
   def env
-    { "PATH" => PATH.new("/usr/bin", Formula["cvs"].opt_bin, ENV.fetch("PATH")) }
+    { "PATH" => PATH.new("/usr/bin", Utils::Path.formula_opt_bin_path("cvs")).to_s }
   end
 
   sig { override.returns(String) }

--- a/Library/Homebrew/download_strategy/fossil_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/fossil_download_strategy.rb
@@ -41,7 +41,7 @@ class FossilDownloadStrategy < VCSDownloadStrategy
 
   sig { override.returns(T::Hash[String, String]) }
   def env
-    { "PATH" => PATH.new(Formula["fossil"].opt_bin, ENV.fetch("PATH")) }
+    Utils::Path.formula_opt_bin_env("fossil")
   end
 
   sig { override.returns(String) }

--- a/Library/Homebrew/download_strategy/mercurial_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/mercurial_download_strategy.rb
@@ -34,7 +34,7 @@ class MercurialDownloadStrategy < VCSDownloadStrategy
 
   sig { override.returns(T::Hash[String, String]) }
   def env
-    { "PATH" => PATH.new(Formula["mercurial"].opt_bin, ENV.fetch("PATH")) }
+    Utils::Path.formula_opt_bin_env("mercurial")
   end
 
   sig { override.returns(String) }

--- a/Library/Homebrew/test/unpack_strategy/bzip2_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/bzip2_spec.rb
@@ -18,7 +18,25 @@ RSpec.describe UnpackStrategy::Bzip2 do
       expect(strategy).to receive(:system_command!).with(
         "bzip2",
         args:    ["-q", "-d", target],
-        env:     { "PATH" => an_instance_of(PATH) },
+        env:     { "PATH" => an_instance_of(String) },
+        verbose: false,
+      )
+
+      strategy.extract(to: unpack_dir)
+    end
+  end
+
+  it "adds Homebrew bzip2 to PATH without resolving a formula" do
+    strategy = described_class.new(path)
+
+    Dir.mktmpdir do |dir|
+      unpack_dir = Pathname(dir)
+      target = unpack_dir/path.basename
+      expect(Formula).not_to receive(:[])
+      expect(strategy).to receive(:system_command!).with(
+        "bzip2",
+        args:    ["-q", "-d", target],
+        env:     Utils::Path.formula_opt_bin_env("bzip2", ORIGINAL_PATHS),
         verbose: false,
       )
 

--- a/Library/Homebrew/test/utils/path_spec.rb
+++ b/Library/Homebrew/test/utils/path_spec.rb
@@ -32,6 +32,37 @@ RSpec.describe Utils::Path do
     end
   end
 
+  describe "::formula_opt_bin" do
+    it "returns a formula opt bin path without loading a Formula object" do
+      expect(described_class.formula_opt_bin("foo")).to eq(HOMEBREW_PREFIX/"opt/foo/bin")
+    end
+  end
+
+  describe "::formula_opt_bin_path" do
+    it "prepends a formula opt bin path to the current PATH by default" do
+      expect(described_class.formula_opt_bin_path("foo")).to eq(PATH.new(HOMEBREW_PREFIX/"opt/foo/bin",
+                                                                         ENV.fetch("PATH")))
+    end
+
+    it "prepends a formula opt bin path to PATH entries" do
+      expect(described_class.formula_opt_bin_path("foo", "/usr/bin")).to eq(PATH.new(HOMEBREW_PREFIX/"opt/foo/bin",
+                                                                                     "/usr/bin",
+                                                                                     ENV.fetch("PATH")))
+    end
+  end
+
+  describe "::formula_opt_bin_env" do
+    it "returns a PATH environment with a formula opt bin path prepended to the current PATH by default" do
+      expect(described_class.formula_opt_bin_env("foo"))
+        .to eq({ "PATH" => PATH.new(HOMEBREW_PREFIX/"opt/foo/bin", ENV.fetch("PATH")).to_s })
+    end
+
+    it "returns a PATH environment with extra PATH entries" do
+      expect(described_class.formula_opt_bin_env("foo", "/usr/bin"))
+        .to eq({ "PATH" => PATH.new(HOMEBREW_PREFIX/"opt/foo/bin", "/usr/bin", ENV.fetch("PATH")).to_s })
+    end
+  end
+
   describe "::loadable_package_path?" do
     it "accepts formula paths under a symlinked cellar" do
       tmpdir = mktmpdir

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -4,6 +4,7 @@
 require "mktemp"
 require "system_command"
 require "utils/output"
+require "utils/path"
 
 # Module containing all available strategies for unpacking archives.
 module UnpackStrategy

--- a/Library/Homebrew/unpack_strategy/bzip2.rb
+++ b/Library/Homebrew/unpack_strategy/bzip2.rb
@@ -29,7 +29,7 @@ module UnpackStrategy
       quiet_flags = verbose ? [] : ["-q"]
       system_command! "bzip2",
                       args:    [*quiet_flags, "-d", unpack_dir/basename],
-                      env:     { "PATH" => PATH.new(Formula["bzip2"].opt_bin, ORIGINAL_PATHS, ENV.fetch("PATH")) },
+                      env:     Utils::Path.formula_opt_bin_env("bzip2", ORIGINAL_PATHS),
                       verbose:
     end
   end

--- a/Library/Homebrew/unpack_strategy/cab.rb
+++ b/Library/Homebrew/unpack_strategy/cab.rb
@@ -25,7 +25,7 @@ module UnpackStrategy
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "cabextract",
                       args:    ["-d", unpack_dir, "--", path],
-                      env:     { "PATH" => PATH.new(Formula["cabextract"].opt_bin, ENV.fetch("PATH")) },
+                      env:     Utils::Path.formula_opt_bin_env("cabextract"),
                       verbose:
     end
   end

--- a/Library/Homebrew/unpack_strategy/fossil.rb
+++ b/Library/Homebrew/unpack_strategy/fossil.rb
@@ -36,7 +36,7 @@ module UnpackStrategy
       system_command! "fossil",
                       args:    ["open", path, *args],
                       chdir:   unpack_dir,
-                      env:     { "PATH" => PATH.new(Formula["fossil"].opt_bin, ENV.fetch("PATH")) },
+                      env:     Utils::Path.formula_opt_bin_env("fossil"),
                       verbose:
     end
   end

--- a/Library/Homebrew/unpack_strategy/generic_unar.rb
+++ b/Library/Homebrew/unpack_strategy/generic_unar.rb
@@ -30,7 +30,7 @@ module UnpackStrategy
                         "-force-overwrite", "-quiet", "-no-directory",
                         "-output-directory", unpack_dir, "--", path
                       ],
-                      env:     { "PATH" => PATH.new(Formula["unar"].opt_bin, ENV.fetch("PATH")) },
+                      env:     Utils::Path.formula_opt_bin_env("unar"),
                       verbose:
     end
   end

--- a/Library/Homebrew/unpack_strategy/lha.rb
+++ b/Library/Homebrew/unpack_strategy/lha.rb
@@ -27,7 +27,7 @@ module UnpackStrategy
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "lha",
                       args:    ["xq2w=#{unpack_dir}", path],
-                      env:     { "PATH" => PATH.new(Formula["lha"].opt_bin, ENV.fetch("PATH")) },
+                      env:     Utils::Path.formula_opt_bin_env("lha"),
                       verbose:
     end
   end

--- a/Library/Homebrew/unpack_strategy/lzip.rb
+++ b/Library/Homebrew/unpack_strategy/lzip.rb
@@ -29,7 +29,7 @@ module UnpackStrategy
       quiet_flags = verbose ? [] : ["-q"]
       system_command! "lzip",
                       args:    ["-d", *quiet_flags, unpack_dir/basename],
-                      env:     { "PATH" => PATH.new(Formula["lzip"].opt_bin, ENV.fetch("PATH")) },
+                      env:     Utils::Path.formula_opt_bin_env("lzip"),
                       verbose:
     end
   end

--- a/Library/Homebrew/unpack_strategy/lzma.rb
+++ b/Library/Homebrew/unpack_strategy/lzma.rb
@@ -29,7 +29,7 @@ module UnpackStrategy
       quiet_flags = verbose ? [] : ["-q"]
       system_command! "unlzma",
                       args:    [*quiet_flags, "--", unpack_dir/basename],
-                      env:     { "PATH" => PATH.new(Formula["xz"].opt_bin, ENV.fetch("PATH")) },
+                      env:     Utils::Path.formula_opt_bin_env("xz"),
                       verbose:
     end
   end

--- a/Library/Homebrew/unpack_strategy/mercurial.rb
+++ b/Library/Homebrew/unpack_strategy/mercurial.rb
@@ -17,7 +17,7 @@ module UnpackStrategy
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "hg",
                       args:    ["--cwd", path, "archive", "--subrepos", "-y", "-t", "files", unpack_dir],
-                      env:     { "PATH" => PATH.new(Formula["mercurial"].opt_bin, ENV.fetch("PATH")) },
+                      env:     Utils::Path.formula_opt_bin_env("mercurial"),
                       verbose:
     end
   end

--- a/Library/Homebrew/unpack_strategy/p7zip.rb
+++ b/Library/Homebrew/unpack_strategy/p7zip.rb
@@ -27,7 +27,7 @@ module UnpackStrategy
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "7zr",
                       args:    ["x", "-y", "-bd", "-bso0", path, "-o#{unpack_dir}"],
-                      env:     { "PATH" => PATH.new(Formula["p7zip"].opt_bin, ENV.fetch("PATH")) },
+                      env:     Utils::Path.formula_opt_bin_env("p7zip"),
                       verbose:
     end
   end

--- a/Library/Homebrew/unpack_strategy/rar.rb
+++ b/Library/Homebrew/unpack_strategy/rar.rb
@@ -27,7 +27,7 @@ module UnpackStrategy
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "bsdtar",
                       args:    ["x", "-f", path, "-C", unpack_dir],
-                      env:     { "PATH" => PATH.new(Formula["libarchive"].opt_bin, ENV.fetch("PATH")) },
+                      env:     Utils::Path.formula_opt_bin_env("libarchive"),
                       verbose:
     end
   end

--- a/Library/Homebrew/unpack_strategy/xz.rb
+++ b/Library/Homebrew/unpack_strategy/xz.rb
@@ -29,7 +29,7 @@ module UnpackStrategy
       quiet_flags = verbose ? [] : ["-q"]
       system_command! "unxz",
                       args:    [*quiet_flags, "-T0", "--", unpack_dir/basename],
-                      env:     { "PATH" => PATH.new(Formula["xz"].opt_bin, ENV.fetch("PATH")) },
+                      env:     Utils::Path.formula_opt_bin_env("xz"),
                       verbose:
     end
   end

--- a/Library/Homebrew/unpack_strategy/zstd.rb
+++ b/Library/Homebrew/unpack_strategy/zstd.rb
@@ -29,7 +29,7 @@ module UnpackStrategy
       quiet_flags = verbose ? [] : ["-q"]
       system_command! "unzstd",
                       args:    [*quiet_flags, "-T0", "--rm", "--", unpack_dir/basename],
-                      env:     { "PATH" => PATH.new(Formula["zstd"].opt_bin, ENV.fetch("PATH")) },
+                      env:     Utils::Path.formula_opt_bin_env("zstd"),
                       verbose:
     end
   end

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "system_command"
+require "utils/path"
 
 module Utils
   # Helper functions for querying Git information.
@@ -179,7 +180,7 @@ module Utils
 
     sig { void }
     def self.setup_gpg!
-      gnupg_bin = HOMEBREW_PREFIX/"opt/gnupg/bin"
+      gnupg_bin = Utils::Path.formula_opt_bin("gnupg")
       return unless gnupg_bin.directory?
 
       ENV["PATH"] = PATH.new(ENV.fetch("PATH")).prepend(gnupg_bin).to_s

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -3,6 +3,7 @@
 
 require "system_command"
 require "utils/output"
+require "utils/path"
 
 module GitHub
   sig { params(scopes: T::Array[String]).returns(String) }
@@ -169,10 +170,7 @@ module GitHub
     def self.github_cli_token
       require "utils/uid"
       # Avoid `Formula["gh"].opt_bin` so this method works even with `HOMEBREW_DISABLE_LOAD_FORMULA`.
-      env = {
-        "PATH" => PATH.new(HOMEBREW_PREFIX/"opt/gh/bin", ENV.fetch("PATH")),
-        "HOME" => Utils::UID.uid_home,
-      }.compact
+      env = Utils::Path.formula_opt_bin_env("gh").merge("HOME" => Utils::UID.uid_home).compact
       gh_out, _, result = system_command("gh",
                                          args:            ["auth", "token", "--hostname", "github.com"],
                                          env:,

--- a/Library/Homebrew/utils/path.rb
+++ b/Library/Homebrew/utils/path.rb
@@ -12,6 +12,21 @@ module Utils
       false
     end
 
+    sig { params(formula_name: String).returns(Pathname) }
+    def self.formula_opt_bin(formula_name)
+      HOMEBREW_PREFIX/"opt/#{formula_name}/bin"
+    end
+
+    sig { params(formula_name: String, paths: PATH::Elements).returns(PATH) }
+    def self.formula_opt_bin_path(formula_name, *paths)
+      PATH.new(formula_opt_bin(formula_name), *paths, ENV.fetch("PATH"))
+    end
+
+    sig { params(formula_name: String, paths: PATH::Elements).returns(T::Hash[String, String]) }
+    def self.formula_opt_bin_env(formula_name, *paths)
+      { "PATH" => formula_opt_bin_path(formula_name, *paths).to_s }
+    end
+
     sig { params(path: Pathname, package_type: Symbol).returns(T::Boolean) }
     def self.loadable_package_path?(path, package_type)
       return true unless Homebrew::EnvConfig.forbid_packages_from_paths?


### PR DESCRIPTION
- Linux installs may unpack `tbz` test fixtures before a `bzip2` formula exists in the test tap. This fixes the issue where `brew tests` may fail if it's not installed by the system.
- Several download and unpack strategies only need a formula's stable `opt/bin` directory to locate helper tools.
- Add `Utils::Path` helpers for formula `opt/bin` paths and PATH envs so callers can avoid resolving `Formula` objects just to build paths.
- Use the helpers across the unpack strategies for consistency, including `bzip2` extraction where Linux sandboxed tests may not have a formula in the test tap.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was `used` to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
