### PR TITLE
github_runner_matrix: exclude disabled dependents from testing

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -326,7 +326,8 @@ class GitHubRunnerMatrix
             next false if macos_version && !simulated_dependent_f.compatible_with?(macos_version)
 
             simulated_dependent_f.public_send(:"#{platform}_compatible?") &&
-              simulated_dependent_f.public_send(:"#{arch}_compatible?")
+              simulated_dependent_f.public_send(:"#{arch}_compatible?") &&
+              !simulated_dependent_f.formula.disabled?
           end
         end
 

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -234,6 +234,24 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
             expect(get_runner_names(runner_matrix)).to eq(get_runner_names(runner_matrix, :arm64?))
           end
         end
+
+        context "when dependents are disabled" do
+          it "activates no runners" do
+            testball_depender_disabled = setup_test_runner_formula("testball-depender-disabled", ["testball"])
+
+            allow(Formulary).to receive(:factory).and_call_original
+            allow(Formulary).to receive(:factory).with("testball-depender-disabled") do
+              formula = testball_depender_disabled.formula
+              allow(formula).to receive(:disabled?).and_return(true)
+              formula
+            end
+
+            allow(Formula).to receive(:all).and_return([testball, testball_depender_disabled].map(&:formula))
+
+            runner_matrix = described_class.new([testball], [], all_supported: false, dependent_matrix: true)
+            expect(runner_matrix.runners.any?(&:active)).to be(false)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->
AI was used to write the test

-----
Motivated by https://github.com/Homebrew/homebrew-core/actions/runs/27780871045/job/82205457469 , where dependent testing was triggered for `ruff`, even though its only dependent, `ruff-lsp`, is disabled. One of the unnecessarily-triggered tests (macOS 14-x86_64 (deps)) took 15 minutes to complete, during which it got set up, realized no tests were needed, and got cleaned up.