### PR TITLE
patch: add directory for local patch

### DIFF
--- a/Library/Homebrew/embedded_patch.rb
+++ b/Library/Homebrew/embedded_patch.rb
@@ -40,7 +40,9 @@ class EmbeddedPatch
     data = contents.gsub("@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX)
     args = %W[-g 0 -f -#{strip}]
     dir = Pathname.pwd
-    dir /= T.must(directory) if directory.present?
+    if (subdirectory = directory.presence)
+      dir /= subdirectory
+    end
     dir.cd do
       Utils.safe_popen_write("patch", *args) { |p| p.write(data) }
     end

--- a/Library/Homebrew/embedded_patch.rb
+++ b/Library/Homebrew/embedded_patch.rb
@@ -17,10 +17,14 @@ class EmbeddedPatch
   sig { returns(T.any(String, Symbol)) }
   attr_reader :strip
 
+  sig { returns(T.nilable(T.any(String, Pathname))) }
+  attr_accessor :directory
+
   sig { params(strip: T.any(String, Symbol)).void }
   def initialize(strip)
     @strip = strip
     @owner = T.let(nil, T.nilable(Resource::Owner))
+    @directory = T.let(nil, T.nilable(T.any(String, Pathname)))
   end
 
   sig { returns(T::Boolean) }
@@ -35,7 +39,11 @@ class EmbeddedPatch
   def apply
     data = contents.gsub("@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX)
     args = %W[-g 0 -f -#{strip}]
-    Utils.safe_popen_write("patch", *args) { |p| p.write(data) }
+    dir = Pathname.pwd
+    dir /= T.must(directory) if directory.present?
+    dir.cd do
+      Utils.safe_popen_write("patch", *args) { |p| p.write(data) }
+    end
   end
 
   sig { returns(String) }

--- a/Library/Homebrew/local_patch.rb
+++ b/Library/Homebrew/local_patch.rb
@@ -21,10 +21,17 @@ class LocalPatch < EmbeddedPatch
       !path.to_s.start_with?("../")
   end
 
-  sig { params(strip: T.any(String, Symbol), file: T.any(String, Pathname)).void }
-  def initialize(strip, file)
+  sig {
+    params(
+      strip:     T.any(String, Symbol),
+      file:      T.any(String, Pathname),
+      directory: T.nilable(T.any(String, Pathname)),
+    ).void
+  }
+  def initialize(strip, file, directory = nil)
     super(strip)
     @file = file
+    self.directory = directory
   end
 
   sig { override.returns(String) }

--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -34,10 +34,9 @@ module Patch
         if (file = resource.file)
           raise ArgumentError, "Patch cannot have both `file` and `url`." if resource.url.present?
           raise ArgumentError, "Patch cannot use `sha256` with `file`." if resource.checksum
-          raise ArgumentError, "Patch cannot use `directory` with `file`." if resource.directory.present?
           raise ArgumentError, "Patch cannot use `apply` with `file`." if resource.patch_files.present?
 
-          LocalPatch.new(strip, file)
+          LocalPatch.new(strip, file, resource.directory)
         else
           external_patch
         end

--- a/Library/Homebrew/test/patch_spec.rb
+++ b/Library/Homebrew/test/patch_spec.rb
@@ -110,13 +110,14 @@ RSpec.describe Patch do
       end.to raise_error(ArgumentError, "Patch cannot use `sha256` with `file`.")
     end
 
-    it "rejects local file patches with directory" do
-      expect do
-        described_class.create(:p1, nil) do
-          file "Patches/foo.diff"
-          directory "subdir"
-        end
-      end.to raise_error(ArgumentError, "Patch cannot use `directory` with `file`.")
+    it "accepts local file patches with directory" do
+      patch = described_class.create(:p1, nil) do
+        file "Patches/foo.diff"
+        directory "subdir"
+      end
+
+      expect(patch).to be_a LocalPatch
+      expect(T.cast(patch, LocalPatch).directory).to eq("subdir")
     end
 
     it "rejects local file patches with apply" do

--- a/Library/Homebrew/test/patching_spec.rb
+++ b/Library/Homebrew/test/patching_spec.rb
@@ -120,6 +120,17 @@ RSpec.describe "patching", type: :system do
     ).to be_patched
   end
 
+  specify "local_patch_dsl_with_directory" do
+    expect(
+      formula(path: fixture("testball.rb")) do
+        patch do
+          file "patches/noop-b.diff"
+          directory "libexec"
+        end
+      end,
+    ).to be_patched
+  end
+
   specify "local_patch_dsl_with_strip" do
     expect(
       formula(path: fixture("testball.rb")) do


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Opus 4.8 is used to investigate and generate codes but have reviewed all the changes by myself. 

-----

Local patch isn't support directory but there are 7 cases with homebrew own patch with directory stanza. So this will replace the exact commit hash usage, e.g.

```
  # Fix -flat_namespace being used on Big Sur and later.
  patch do
    url "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a0/Patches/libtool/configure-pre-0.4.2.418-big_sur.diff"
    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
    directory "dist"
  end
```

from `berkeley-db@4` and so we don't need to rely on the commit hash for all. 

As a result of this changes, local patch is quite similar to the extarnal patch and I think we might refactor them to use same structure but just abstracted to get the patch resources from local or external. Just an idea. 