### PR TITLE
Fix bundle jobs cask deps

### DIFF
--- a/Library/Homebrew/bundle/cask.rb
+++ b/Library/Homebrew/bundle/cask.rb
@@ -227,11 +227,21 @@ module Homebrew
 
         sig { params(cask_list: T::Array[String]).returns(T::Array[String]) }
         def formula_dependencies(cask_list)
-          return [] unless Bundle.cask_installed?
           return [] if cask_list.blank?
 
-          casks.flat_map do |cask|
-            next unless cask_list.include?(cask.to_s)
+          require "cask/cask_loader"
+
+          installed_cask_objects = casks
+          cask_list.flat_map do |cask_name|
+            cask = installed_cask_objects.find do |installed_cask|
+              cask_name == installed_cask.to_s || cask_name == installed_cask.full_name
+            end
+            cask ||= begin
+              ::Cask::CaskLoader.load(cask_name)
+            rescue ::Cask::CaskUnavailableError
+              nil
+            end
+            next unless cask
 
             cask.depends_on[:formula]
           end.compact

--- a/Library/Homebrew/bundle/parallel_installer.rb
+++ b/Library/Homebrew/bundle/parallel_installer.rb
@@ -48,6 +48,7 @@ module Homebrew
         end
         ::Tap.clear_cache if tap_entries.present?
 
+        prepare_attestation_verification!(pending_entries)
         dependency_map = build_dependency_map(pending_entries)
         completed = T.let(Set.new, T::Set[String])
         until pending_entries.empty?
@@ -88,6 +89,9 @@ module Homebrew
       sig { params(entries: T::Array[Installer::InstallableEntry]).returns(T::Hash[String, T::Set[String]]) }
       def build_dependency_map(entries)
         installed_taps = Homebrew::Bundle::Tap.installed_taps
+        attestation_formula = if Homebrew::EnvConfig.verify_attestations?
+          entries.find { |entry| entry.cls == Homebrew::Bundle::Brew && entry.name == "gh" }
+        end
 
         # Phase 1: Map both full and short names so dep lookups work either way.
         entry_name_map = entries.each_with_object({}) do |entry, map|
@@ -103,13 +107,17 @@ module Homebrew
           when "Homebrew::Bundle::Brew"
             Homebrew::Bundle::Brew.formula_dep_names(entry.name)
           when "Homebrew::Bundle::Cask"
-            Homebrew::Bundle::Cask.formula_dependencies([entry.name])
+            Homebrew::Bundle::Cask.formula_dependencies([entry.full_name])
           else
             []
           end
 
           # Entries from non-default taps depend on the tap being installed first.
           deps += Homebrew::Bundle::Installer.tap_dependencies(entry, entries:, installed_taps:)
+          if attestation_formula && [Homebrew::Bundle::Brew, Homebrew::Bundle::Cask].include?(entry.cls) &&
+             entry.name != attestation_formula.name
+            deps << attestation_formula.name
+          end
 
           brewfile_deps[entry.name] = deps
         end
@@ -156,6 +164,17 @@ module Homebrew
         Utils.name_from_full_name(name)
       end
 
+      sig { params(entries: T::Array[Installer::InstallableEntry]).void }
+      def prepare_attestation_verification!(entries)
+        return unless Homebrew::EnvConfig.verify_attestations?
+        return unless entries.any? { |entry| [Homebrew::Bundle::Brew, Homebrew::Bundle::Cask].include?(entry.cls) }
+        return if entries.any? { |entry| entry.cls == Homebrew::Bundle::Brew && entry.name == "gh" }
+
+        require "attestation"
+
+        Homebrew::Attestation.gh_executable
+      end
+
       # Walk cask-on-cask dependencies transitively, returning the set of
       # cask names (from the Brewfile) that this cask depends on.
       sig { params(name: String, cask_names: T::Set[String]).returns(T::Set[String]) }
@@ -183,7 +202,7 @@ module Homebrew
         failure = 0
         entries.each do |entry|
           installed = begin
-            !futures.fetch(entry).value!.nil?
+            futures.fetch(entry).value! == true
           rescue => e
             write_output(Formatter.error("Installing #{entry.name} has failed!"), stream: $stderr)
             write_output("[#{entry.name}] #{e.message}", stream: $stderr) if @verbose

--- a/Library/Homebrew/test/bundle/cask_spec.rb
+++ b/Library/Homebrew/test/bundle/cask_spec.rb
@@ -4,6 +4,7 @@
 require "bundle"
 require "bundle/cask"
 require "cask"
+require "cask/cask_loader"
 
 RSpec.describe Homebrew::Bundle::Cask do
   describe "dumping" do
@@ -136,14 +137,34 @@ RSpec.describe Homebrew::Bundle::Cask do
       context "when multiple casks have the same dependency" do
         before do
           described_class.reset!
-          foo = instance_double(Cask::Cask, to_s: "foo", depends_on: { formula: ["baz", "qux"] })
-          bar = instance_double(Cask::Cask, to_s: "bar", depends_on: {})
+          foo = instance_double(Cask::Cask, to_s: "foo", full_name: "foo", depends_on: { formula: ["baz", "qux"] })
+          bar = instance_double(Cask::Cask, to_s: "bar", full_name: "bar", depends_on: {})
           allow(Cask::Caskroom).to receive(:casks).and_return([foo, bar])
           allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(true)
         end
 
         it "returns an array of unique formula dependencies" do
           expect(dumper.formula_dependencies(["foo", "bar"])).to eql(["baz", "qux"])
+        end
+      end
+
+      context "when the cask is not installed" do
+        before do
+          described_class.reset!
+          allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(false)
+        end
+
+        it "loads formula dependencies from the cask definition" do
+          cask = instance_double(
+            Cask::Cask,
+            to_s:       "tpack",
+            full_name:  "tmuxpack/tpack/tpack",
+            depends_on: { formula: ["tmux"] },
+          )
+
+          expect(Cask::CaskLoader).to receive(:load).with("tmuxpack/tpack/tpack").and_return(cask)
+
+          expect(dumper.formula_dependencies(["tmuxpack/tpack/tpack"])).to eql(["tmux"])
         end
       end
     end

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "bundle"
+require "attestation"
 require "bundle/dsl"
 require "bundle/installer"
 require "bundle/parallel_installer"
@@ -290,6 +291,65 @@ RSpec.describe Homebrew::Bundle::Installer do
       expect(failure).to eq(0)
     end
 
+    it "counts false parallel install results as failures" do
+      allow(Homebrew::Bundle::Brew).to receive(:formulae_by_full_name).with("alpha").and_return({ dependencies: [] })
+      allow(Homebrew::Bundle::Brew).to receive(:formulae_by_full_name).with("beta").and_return({ dependencies: [] })
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("alpha").and_return(Set.new)
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("beta").and_return(Set.new)
+      allow(Homebrew::Bundle::Brew).to receive(:install!)
+        .with("alpha", preinstall: true, no_upgrade: false, verbose: false, force: false)
+        .and_return(true)
+      allow(Homebrew::Bundle::Brew).to receive(:install!)
+        .with("beta", preinstall: true, no_upgrade: false, verbose: false, force: false)
+        .and_return(false)
+
+      success, failure = Homebrew::Bundle::ParallelInstaller.new(
+        [alpha_entry, beta_entry],
+        jobs: 2, no_upgrade: false, verbose: false, force: false, quiet: true,
+      ).run!
+
+      expect(success).to eq(1)
+      expect(failure).to eq(1)
+    end
+
+    it "prepares attestation verification before parallel installs" do
+      tpack_entry = Homebrew::Bundle::Installer::InstallableEntry.new(
+        name:    "tpack",
+        options: { args: {}, full_name: "tmuxpack/tpack/tpack" },
+        verb:    "Installing",
+        cls:     Homebrew::Bundle::Cask,
+      )
+      install_order = []
+
+      allow(Homebrew::EnvConfig).to receive(:verify_attestations?).and_return(true)
+      allow(Homebrew::Attestation).to receive(:gh_executable) do
+        install_order << "gh"
+        Pathname("/fake/gh")
+      end
+      allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(false)
+      allow(Homebrew::Bundle::Brew).to receive(:formula_dep_names).with("alpha").and_return([])
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("alpha").and_return(Set.new)
+      allow(Homebrew::Bundle::Cask).to receive(:formula_dependencies).with(["tmuxpack/tpack/tpack"])
+                                                                     .and_return([])
+      allow(Homebrew::Bundle::Brew).to receive(:install!) do |name, **_options|
+        install_order << name
+        true
+      end
+      allow(Homebrew::Bundle::Cask).to receive(:install!) do |name, **_options|
+        install_order << name
+        true
+      end
+
+      success, failure = Homebrew::Bundle::ParallelInstaller.new(
+        [alpha_entry, tpack_entry],
+        jobs: 2, no_upgrade: false, verbose: false, force: false, quiet: true,
+      ).run!
+
+      expect(success).to eq(2)
+      expect(failure).to eq(0)
+      expect(install_order.first).to eq("gh")
+    end
+
     it "serializes dependent formulae" do
       install_order = []
       allow(Homebrew::Bundle::Brew).to receive(:install!) do |name, **_options|
@@ -326,6 +386,62 @@ RSpec.describe Homebrew::Bundle::Installer do
       ).send(:build_dependency_map, entries)
 
       expect(dependency_map.fetch("beta")).to eq(Set["alpha"])
+    end
+
+    it "installs a Brewfile `gh` before other entries when verifying attestations" do
+      gh_entry = Homebrew::Bundle::Installer::InstallableEntry.new(
+        name:    "gh",
+        options: {},
+        verb:    "Installing",
+        cls:     Homebrew::Bundle::Brew,
+      )
+
+      allow(Homebrew::EnvConfig).to receive(:verify_attestations?).and_return(true)
+      allow(Homebrew::Bundle::Brew).to receive(:formula_dep_names).with("gh").and_return([])
+      allow(Homebrew::Bundle::Brew).to receive(:formula_dep_names).with("alpha").and_return([])
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("gh").and_return(Set.new)
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("alpha").and_return(Set.new)
+
+      entries = [alpha_entry, gh_entry]
+      dependency_map = Homebrew::Bundle::ParallelInstaller.new(
+        entries,
+        jobs: 2, no_upgrade: false, verbose: false, force: false, quiet: true,
+      ).send(:build_dependency_map, entries)
+
+      expect(dependency_map.fetch("alpha")).to eq(Set["gh"])
+    end
+
+    it "uses cask full names when resolving formula dependencies" do
+      tpack_entry = Homebrew::Bundle::Installer::InstallableEntry.new(
+        name:    "tpack",
+        options: { args: {}, full_name: "tmuxpack/tpack/tpack" },
+        verb:    "Installing",
+        cls:     Homebrew::Bundle::Cask,
+      )
+      install_order = []
+
+      allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(false)
+      allow(Homebrew::Bundle::Brew).to receive(:formula_dep_names).with("alpha").and_return([])
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("alpha").and_return(Set.new)
+      allow(Homebrew::Bundle::Cask).to receive(:formula_dependencies).with(["tmuxpack/tpack/tpack"])
+                                                                     .and_return(["alpha"])
+      allow(Homebrew::Bundle::Brew).to receive(:install!) do |name, **_options|
+        install_order << name
+        true
+      end
+      allow(Homebrew::Bundle::Cask).to receive(:install!) do |name, **_options|
+        install_order << name
+        true
+      end
+
+      success, failure = Homebrew::Bundle::ParallelInstaller.new(
+        [alpha_entry, tpack_entry],
+        jobs: 2, no_upgrade: false, verbose: false, force: false, quiet: true,
+      ).run!
+
+      expect(success).to eq(2)
+      expect(failure).to eq(0)
+      expect(install_order).to eq(["alpha", "tpack"])
     end
 
     it "installs unqualified formulae after Brewfile taps" do


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22837

- `brew bundle --jobs=auto` skipped formula deps for casks that were not installed yet, so tapped casks could race formula installs.
- Use each cask entry's `full_name` and load the cask definition when no installed cask matches, preserving the installed cask path first.
- Count only `true` worker results as parallel install success so lock failures return a failed bundle status.
- Add regressions for tapped cask deps and false parallel results.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
