### PR TITLE
Rename Homebrew security docs page

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -136,7 +136,7 @@ Homebrew refuses to work using sudo.
 You should only ever sudo a tool you trust. Of course, you can trust Homebrew 😉 — but do you trust the multi-megabyte Makefile that Homebrew runs? Developers often understand C++ far better than they understand `make` syntax. It’s too high a risk to sudo such stuff. It could modify (or upload) any files on your system. And indeed, we’ve seen some build scripts try to modify `/usr` even when the prefix was specified as something else entirely.
 
 We use the macOS sandbox to stop this but this doesn't work when run as the `root` user (which also has read and write access to almost everything on the system).
-The sandbox is part of Homebrew's wider [Software Supply Chain Security](Supply-Chain-Security.md) measures.
+The sandbox is part of Homebrew's wider [Software Supply Chain Security](Homebrew-Security-and-Supply-Chain.md) measures.
 
 Did you `chown root /Applications/TextMate.app`? Probably not. So is it that important to `chown root wget`?
 

--- a/docs/Homebrew-Security-and-Supply-Chain.md
+++ b/docs/Homebrew-Security-and-Supply-Chain.md
@@ -1,12 +1,16 @@
 ---
+title: Homebrew Security and Supply Chain
+description: Homebrew security and supply chain defences, including package review, checksums, signed metadata, bottles, sandboxing and tap trust.
+redirect_from:
+  - /Supply-Chain-Security
 last_review_date: "2026-06-15"
 ---
 
-# Software Supply Chain Security
+# Homebrew Security and Supply Chain
 
 Homebrew installs software from across the open source ecosystem.
 That makes the security of the software supply chain, the humans involved, repositories, build systems and download servers that turn source code into something you run, a core concern for us.
-This document explains the recent supply-side security incidents affecting other package managers, how Homebrew's trust model differs and the steps we have taken to protect our users.
+This Homebrew security guide explains the recent supply-side security incidents affecting other package managers, how Homebrew's trust model differs and the steps we have taken to protect our users.
 
 * Table of Contents
 {:toc}

--- a/docs/Interesting-Taps-and-Forks.md
+++ b/docs/Interesting-Taps-and-Forks.md
@@ -12,7 +12,7 @@ Your taps are Git repositories located at `$(brew --repository)/Library/Taps`. A
 
 The taps and forks below are third-party repositories that are not maintained, reviewed or trusted by Homebrew.
 Tapping or installing from them runs their code with your user's privileges, so only add ones you trust.
-See [Tap Trust](Tap-Trust.md) for how to trust only the specific formula, cask or command you need and [Software Supply Chain Security](Supply-Chain-Security.md) for why this matters.
+See [Tap Trust](Tap-Trust.md) for how to trust only the specific formula, cask or command you need and [Software Supply Chain Security](Homebrew-Security-and-Supply-Chain.md) for why this matters.
 
 ## Unsupported interesting taps
 

--- a/docs/Tap-Trust.md
+++ b/docs/Tap-Trust.md
@@ -29,7 +29,7 @@ commands that are loaded just because their tap is present. It also makes
 automation clearer: scripts can trust exactly the tap, formula, cask or command
 they intend to use instead of relying on every tapped repository being loaded.
 
-Tap trust is one part of Homebrew's wider approach to [Software Supply Chain Security](Supply-Chain-Security.md).
+Tap trust is one part of Homebrew's wider approach to [Software Supply Chain Security](Homebrew-Security-and-Supply-Chain.md).
 
 Prefer trusting the specific formula, cask or command you need. Trust a whole
 tap only when you are comfortable with all current and future formulae, casks

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ Documentation is grouped below by audience: users, contributors, maintainers and
 - [Bottles (binary packages)](Bottles.md)
 - [Taps (third-party repositories)](Taps.md)
 - [Trusting Taps](Tap-Trust.md)
-- [Software Supply Chain Security](Supply-Chain-Security.md)
+- [Homebrew Security and Supply Chain](Homebrew-Security-and-Supply-Chain.md)
 - [Interesting Taps and Forks](Interesting-Taps-and-Forks.md)
 - [Tips and Tricks](Tips-and-Tricks.md)
 - [Anonymous Analytics](Analytics.md)


### PR DESCRIPTION
- Gives the security guide a URL that targets `homebrew security` searches.
- Keeps the old supply chain URL working through `redirect_from`.
- Updates internal links while limiting visible text changes.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
