### PR TITLE
generate_completions: add style for default shells and auto corrections

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -3,6 +3,7 @@
 
 require "rubocops/extend/formula_cop"
 require "rubocops/shared/on_system_conditionals_helper"
+require "utils/shell_completion"
 
 module RuboCop
   module Cop
@@ -827,6 +828,51 @@ module RuboCop
 
           problem "Use `#{replacement}` instead of `#{@offensive_node.source}`." do |corrector|
             corrector.replace(@offensive_node.source_range, replacement)
+          end
+        end
+      end
+
+      # This cop makes sure that the default shells are not passed to
+      # `generate_completions_from_executable`, as they are the default.
+      class RedundantGenerateCompletionsShells < FormulaCop
+        extend AutoCorrector
+        include RangeHelp
+
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          install = find_method_def(formula_nodes.body_node, :install)
+          return if install.blank?
+
+          find_every_method_call_by_name(install, :generate_completions_from_executable).each do |method|
+            kwargs = method.arguments.last
+            next unless kwargs&.hash_type?
+
+            pairs = T.cast(kwargs, RuboCop::AST::HashNode).pairs
+            shells_pair = pairs.find { |pair| pair.key.sym_type? && pair.key.value == :shells }
+            next if shells_pair.nil?
+
+            shells_node = shells_pair.value
+            next unless shells_node.array_type?
+            next unless shells_node.values.all?(&:sym_type?)
+
+            # The default shells depend on `shell_parameter_format`, so skip non-literal values.
+            format_node = pairs.find { |pair| pair.key.sym_type? && pair.key.value == :shell_parameter_format }&.value
+            next if format_node && !format_node.sym_type? && !format_node.str_type?
+
+            shells = shells_node.values.map(&:value)
+            default_shells = ::Utils::ShellCompletion.default_completion_shells(format_node&.value)
+            # Flag only when the passed shells are exactly the defaults for this format.
+            next if (default_shells - shells).any? || (shells - default_shells).any?
+
+            offending_node(shells_pair)
+            problem "Passing the default shells to `generate_completions_from_executable` is redundant" do |corrector|
+              corrector.remove(
+                range_with_surrounding_comma(
+                  range_with_surrounding_space(range: shells_pair.source_range, side: :left),
+                  :left,
+                ),
+              )
+            end
           end
         end
       end

--- a/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
@@ -162,4 +162,149 @@ RSpec.describe RuboCop::Cop::FormulaAudit do
       RUBY
     end
   end
+
+  describe RuboCop::Cop::FormulaAudit::RedundantGenerateCompletionsShells do
+    subject(:cop) { described_class.new }
+
+    it "reports an offense and removes `shells:` when all default shells are passed" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", "completions", shells: [:bash, :zsh, :fish])
+                                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/RedundantGenerateCompletionsShells: Passing the default shells to `generate_completions_from_executable` is redundant
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", "completions")
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense regardless of the order of the default shells" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", "completions", shells: [:fish, :bash, :zsh])
+                                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/RedundantGenerateCompletionsShells: Passing the default shells to `generate_completions_from_executable` is redundant
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", "completions")
+          end
+        end
+      RUBY
+    end
+
+    it "removes only `shells:` and keeps other keyword arguments" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", "completions", shells: [:bash, :zsh, :fish], base_name: "bar")
+                                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/RedundantGenerateCompletionsShells: Passing the default shells to `generate_completions_from_executable` is redundant
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", "completions", base_name: "bar")
+          end
+        end
+      RUBY
+    end
+
+    it "does not report an offense when only some default shells are passed" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", "completions", shells: [:bash, :zsh])
+          end
+        end
+      RUBY
+    end
+
+    it "does not report an offense when a non-default shell is included" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", "completions", shells: [:bash, :zsh, :fish, :pwsh])
+          end
+        end
+      RUBY
+    end
+
+    it "treats `:pwsh` as a default when `shell_parameter_format` is `:cobra`" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", shells: [:bash, :zsh, :fish, :pwsh], shell_parameter_format: :cobra)
+                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/RedundantGenerateCompletionsShells: Passing the default shells to `generate_completions_from_executable` is redundant
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", shell_parameter_format: :cobra)
+          end
+        end
+      RUBY
+    end
+
+    it "does not report an offense when `:cobra` is used without its `:pwsh` default" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", shells: [:bash, :zsh, :fish], shell_parameter_format: :cobra)
+          end
+        end
+      RUBY
+    end
+
+    it "does not report an offense when `shell_parameter_format` is not a literal" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            format = :cobra
+            generate_completions_from_executable(bin/"foo", shells: [:bash, :zsh, :fish], shell_parameter_format: format)
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude opus 4.8 is used to create this code

-----

Some formulae used shells with default values, which is not required. Here I add a style check and auto corrections for those cases.
- https://github.com/Homebrew/homebrew-core/pull/288621

