### PR TITLE
github_runner_matrix: exclude deprecated dependents from testing

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -327,7 +327,8 @@ class GitHubRunnerMatrix
 
             simulated_dependent_f.public_send(:"#{platform}_compatible?") &&
               simulated_dependent_f.public_send(:"#{arch}_compatible?") &&
-              !simulated_dependent_f.formula.disabled?
+              !simulated_dependent_f.formula.disabled? &&
+              !simulated_dependent_f.formula.deprecated?
           end
         end
 

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -252,6 +252,24 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
             expect(runner_matrix.runners.any?(&:active)).to be(false)
           end
         end
+
+        context "when dependents are deprecated" do
+          it "activates no runners" do
+            testball_depender_deprecated = setup_test_runner_formula("testball-depender-deprecated", ["testball"])
+
+            allow(Formulary).to receive(:factory).and_call_original
+            allow(Formulary).to receive(:factory).with("testball-depender-deprecated") do
+              formula = testball_depender_deprecated.formula
+              allow(formula).to receive(:deprecated?).and_return(true)
+              formula
+            end
+
+            allow(Formula).to receive(:all).and_return([testball, testball_depender_deprecated].map(&:formula))
+
+            runner_matrix = described_class.new([testball], [], all_supported: false, dependent_matrix: true)
+            expect(runner_matrix.runners.any?(&:active)).to be(false)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
Follow-up to https://github.com/Homebrew/brew/pull/22834, since deprecated dependents, not just disabled, are also skipped: https://github.com/Homebrew/brew/blob/827fe7d6423e1967f852f4b596965b93f28e21e1/Library/Homebrew/test_bot/formulae_dependents.rb#L366-L370