### PR TITLE
Enable formula path helper cop

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -71,12 +71,6 @@ Homebrew/CompactBlank:
     # `blank?` is not necessarily available here:
     - "Homebrew/extend/enumerable.rb"
 
-Homebrew/FormulaPathMethods:
-  Exclude:
-    # TODO: Remove this after Homebrew/core has applied formula autocorrections.
-    - "/**/Formula/**/*.rb"
-    - "**/Formula/**/*.rb"
-
 Homebrew/NoFileutilsRmrf:
   Include:
     - "/**/{Formula,Casks}/**/*.rb"

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -3,6 +3,7 @@
 
 require "ipaddr"
 require "on_system"
+require "utils/path"
 require "utils/service"
 
 module Homebrew
@@ -12,6 +13,7 @@ module Homebrew
   class Service
     extend Forwardable
     include OnSystem::MacOSAndLinux
+    include Utils::Path
 
     RUN_TYPE_IMMEDIATE = :immediate
     RUN_TYPE_INTERVAL = :interval

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe Homebrew::Service do
     end
   end
 
+  describe "#formula_opt_bin" do
+    it "is available in service blocks" do
+      f = stub_formula do
+        service do
+          run formula_opt_bin("foo")/"foo"
+        end
+      end
+
+      expect(f.service.run).to eq([(HOMEBREW_PREFIX/"opt/foo/bin/foo").to_s])
+    end
+  end
+
   describe "#process_type" do
     it "throws for unexpected type" do
       f = stub_formula do


### PR DESCRIPTION
Re-enable formula autocorrection after homebrew/core has been updated.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
