### PR TITLE
Filter info JSON package types

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -524,12 +524,17 @@ module Homebrew
         when :v2
           formulae, casks = T.let(
             if eval_all
-              [
-                Formula.all(eval_all:).sort,
-                Cask::Cask.all(eval_all:).sort_by(&:full_name),
-              ]
+              formulae = [] if args.cask?
+              formulae ||= Formula.all(eval_all:).sort
+              casks = [] if args.formula?
+              casks ||= Cask::Cask.all(eval_all:).sort_by(&:full_name)
+              [formulae, casks]
             elsif args.installed?
-              [Formula.installed.sort, Cask::Caskroom.casks.sort_by(&:full_name)]
+              formulae = [] if args.cask?
+              formulae ||= Formula.installed.sort
+              casks = [] if args.formula?
+              casks ||= Cask::Caskroom.casks.sort_by(&:full_name)
+              [formulae, casks]
             else
               named_formulae, named_casks = T.cast(
                 args.named.to_formulae_to_casks, [T::Array[Formula], T::Array[Cask::Cask]]

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -60,6 +60,45 @@ RSpec.describe Homebrew::Cmd::Info do
       .and be_a_success
   end
 
+  it "does not include installed casks in formula JSON" do
+    formula = installed_info_formula
+
+    allow(Formula).to receive(:installed).and_return([formula])
+    expect(Cask::Caskroom).not_to receive(:casks)
+
+    output = +""
+    expect { described_class.new(["--json=v2", "--installed", "--formula"]).run }
+      .to output(satisfy { |s|
+        output << s
+        true
+      }).to_stdout
+        .and not_to_output.to_stderr
+
+    json = JSON.parse(output)
+    expect(json["formulae"].length).to eq(1)
+    expect(json["casks"]).to be_empty
+  end
+
+  it "does not include eval-all casks in formula JSON" do
+    formula = installed_info_formula
+
+    allow(Formula).to receive(:all).and_return([formula])
+    allow(Homebrew::EnvConfig).to receive(:tap_trust_configured?).and_return(true)
+    expect(Cask::Cask).not_to receive(:all)
+
+    output = +""
+    expect { described_class.new(["--json=v2", "--formula"]).run }
+      .to output(satisfy { |s|
+        output << s
+        true
+      }).to_stdout
+        .and not_to_output.to_stderr
+
+    json = JSON.parse(output)
+    expect(json["formulae"].length).to eq(1)
+    expect(json["casks"]).to be_empty
+  end
+
   it "prints installed formulae in a human-readable inventory" do
     mktmpdir do |dir|
       tabfile = dir/AbstractTab::FILENAME


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22850

- Respect package-type filters for `brew info --json=v2` output.
- Avoid loading casks for formula-only JSON inventory paths.
- Cover installed and eval-all formula-only JSON regressions.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review, testing and tweaking.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
