### PR TITLE
Raise ArgumentError when get_make_var variable is missing

### DIFF
--- a/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
+++ b/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
@@ -244,6 +244,15 @@ RSpec.describe StringInreplaceExtension do
         expect(string_extension.get_make_var("CFLAGS")).to match(/^-Wall -O2 \\\n +-DSOME_VAR=1$/)
       end
     end
+
+    context "when the variable is missing" do
+      let(:string) { "CFLAGS = -Wall -O2\n" }
+
+      it "raises an error" do
+        expect { string_extension.get_make_var("LDFLAGS") }
+          .to raise_error(ArgumentError, 'expected to find make variable "LDFLAGS"')
+      end
+    end
   end
 
   describe "#sub!" do

--- a/Library/Homebrew/utils/string_inreplace_extension.rb
+++ b/Library/Homebrew/utils/string_inreplace_extension.rb
@@ -74,11 +74,12 @@ class StringInreplaceExtension
     end
   end
 
-  # Finds the specified variable.
+  # Finds the specified variable, or raises an `ArgumentError` if it is not present.
   #
   # @api public
   sig { params(flag: String).returns(String) }
   def get_make_var(flag)
-    T.must(inreplace_string[/^#{Regexp.escape(flag)}[ \t]*[\\?+:!]?=[ \t]*((?:.*\\\n)*.*)$/, 1])
+    inreplace_string[/^#{Regexp.escape(flag)}[ \t]*[\\?+:!]?=[ \t]*((?:.*\\\n)*.*)$/, 1] ||
+      raise(ArgumentError, "expected to find make variable #{flag.inspect}")
   end
 end


### PR DESCRIPTION
`StringInreplaceExtension#get_make_var` behaves differently depending on whether
the Sorbet runtime is enabled. Its body is `inreplace_string[regex, 1]`, and
`String#[]` returns `nil` when the requested make variable is absent. A 2023
strict-typing change (c7369b7ea9) wrapped that in `T.must`, but `T.must` only
raises under `HOMEBREW_SORBET_RUNTIME` (set for `brew test`/`tests`/`test-bot`).
So the same missing variable raises `TypeError: Passed nil into T.must` under
test-bot and CI, but silently returns `nil` in a user's `brew install`, where it
surfaces later as a confusing `NoMethodError` if the formula uses the result.

As discussed in the review comments, a missing variable should fail loudly and
identically everywhere: this is a public formula DSL method, its callers in
Homebrew/core all expect a `String`, and a formula author bumping a version
wants to know when a variable disappears from the Makefile. `get_make_var` now
raises a descriptive `ArgumentError` instead of relying on `T.must`, keeping
`returns(String)` honest in both runtime modes.

Reproduce with a formula whose `install` calls `get_make_var("CFLAGS")` against
a Makefile that doesn't define `CFLAGS`:

| command | before this PR | after this PR |
| --- | --- | --- |
| `brew install --build-from-source <formula>` | succeeds; `get_make_var("CFLAGS")` returns `nil` | fails: `ArgumentError: expected to find make variable "CFLAGS"` |
| `HOMEBREW_SORBET_RUNTIME=1 brew install --build-from-source <formula>` | fails: `TypeError: Passed 'nil' into T.must` | fails with the same `ArgumentError` |

A new test covers the missing-variable case.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

This PR was written with assistance from Claude Code (Claude Opus 4.8 and
Claude Fable 5). I reviewed all generated changes, verified the fix with a
red/green test (against the old code the new test raises `TypeError: Passed
nil into T.must`; with the fix it raises the descriptive `ArgumentError`), and
ran `brew lgtm` locally (all green). See
https://docs.brew.sh/Responsible-AI-Usage.

-----
