### PR TITLE
Rescue `MethodDeprecatedError` when attempting to load installed caskfiles

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -193,7 +193,7 @@ module Cask
         invalid_cask ||= begin
           loaded_cask = CaskLoader.load(T.must(c.installed_caskfile))
           false
-        rescue CaskInvalidError, CaskUnavailableError
+        rescue CaskInvalidError, CaskUnavailableError, MethodDeprecatedError
           true
         end
 

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -421,6 +421,16 @@ RSpec.describe Cask::Upgrade, :cask do
       end.to output(/The cask 'auto-updates' cannot be upgraded as-is/).to_stderr
     end
 
+    it "warns and skips when the installed caskfile raises MethodDeprecatedError" do
+      allow(Cask::CaskLoader).to receive(:load).and_call_original
+      allow(Cask::CaskLoader).to receive(:load).with(auto_updates.installed_caskfile)
+                                               .and_raise(MethodDeprecatedError.new)
+
+      expect do
+        described_class.upgrade_casks!(dry_run: true, args:)
+      end.to output(/The cask 'auto-updates' cannot be upgraded as-is/).to_stderr
+    end
+
     it "warns and skips when the cask is not fully installed" do
       # Stub installed? to return false after outdated detection
       # to simulate a cask with a broken metadata directory


### PR DESCRIPTION
When attempting to load old installed casks during `brew upgrade`, we already fail fast if we're unable to load the cask due to `CaskInvalidError` or `CaskUnavailableError`, but we don't currently catch `MethodDeprecatedError`s meaning `odeprecated` calls within cask definitions will be raised with a not-super-helpful error message.

Instead, let's handle the deprecation as if it's a `CaskInvalidError`, and prompt the user to reinstall with `--force`. This makes it clear what needs to happen.

Before:

```console
$ brew upgrade
Error: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :catalina` instead.
```

After

```console
❯ brew upgrade
Warning: The cask '1password-cli' cannot be upgraded as-is. To fix this, run:
brew reinstall --cask --force 1password-cli
Warning: The cask 'raspberry-pi-imager' cannot be upgraded as-is. To fix this, run:
brew reinstall --cask --force raspberry-pi-imager
Warning: The cask 'slack' cannot be upgraded as-is. To fix this, run:
brew reinstall --cask --force slack
==> Would upgrade 4 outdated packages
docker-desktop 4.76.0,228118 -> 4.79.0,230596
gitbutler 0.20.0,3069 -> 0.20.3,3103
google-chrome 149.0.7827.54 -> 149.0.7827.156
visual-studio-code 1.123.0 -> 1.125.1
==> Do you want to proceed with the upgrade? [y/n]
...
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
