### PR TITLE
Flag scoped service path helpers

### DIFF
--- a/Library/Homebrew/rubocops/formula_path_methods.rb
+++ b/Library/Homebrew/rubocops/formula_path_methods.rb
@@ -8,18 +8,6 @@ module RuboCop
       class FormulaPathMethods < Base
         extend AutoCorrector
 
-        MSG = "Use `%<preferred>s` instead of `%<current>s`."
-        RESTRICT_ON_SEND = [
-          :any_version_installed?,
-          :installed?,
-          :installed_version,
-          :opt_bin,
-          :opt_lib,
-          :opt_libexec,
-          :opt_include,
-          :opt_prefix,
-        ].freeze
-
         FORMULA_OPT_HELPERS = T.let({
           opt_bin:     "formula_opt_bin",
           opt_lib:     "formula_opt_lib",
@@ -27,6 +15,27 @@ module RuboCop
           opt_include: "formula_opt_include",
           opt_prefix:  "formula_opt_prefix",
         }.freeze, T::Hash[Symbol, String])
+        SCOPED_FORMULA_HELPERS = T.let([
+          :formula_any_version_installed?,
+          :formula_opt_bin,
+          :formula_opt_include,
+          :formula_opt_lib,
+          :formula_opt_libexec,
+          :formula_opt_prefix,
+        ].freeze, T::Array[Symbol])
+
+        MSG = "Use `%<preferred>s` instead of `%<current>s`."
+        RESTRICT_ON_SEND = T.let([
+          :any_version_installed?,
+          :installed?,
+          :installed_version,
+          :opt_bin,
+          :opt_include,
+          :opt_lib,
+          :opt_libexec,
+          :opt_prefix,
+          *SCOPED_FORMULA_HELPERS,
+        ].freeze, T::Array[Symbol])
 
         def_node_matcher :formula_lookup_name_node, <<~PATTERN
           (send (const {nil? cbase} :Formula) :[] $_)
@@ -47,8 +56,16 @@ module RuboCop
           (class _ (const {nil? cbase} :Formula) ...)
         PATTERN
 
+        def_node_matcher :utils_path?, <<~PATTERN
+          (const (const {nil? cbase} :Utils) :Path)
+        PATTERN
+
         def_node_matcher :cask_block?, <<~PATTERN
           (block (send nil? :cask ...) ...)
+        PATTERN
+
+        def_node_matcher :service_block?, <<~PATTERN
+          (block (send nil? :service) ...)
         PATTERN
 
         sig { params(node: RuboCop::AST::SendNode).void }
@@ -85,6 +102,13 @@ module RuboCop
             cask_new_token_node(node.receiver) do |cask_token|
               return "Cask::Caskroom.cask_installed_version(#{cask_token.source})"
             end
+          when *SCOPED_FORMULA_HELPERS
+            receiver = node.receiver
+            return unless receiver
+            return unless utils_path?(receiver)
+            return unless node.each_ancestor.any? { |ancestor| service_block?(ancestor) }
+
+            return "#{node.method_name}(#{node.arguments.map(&:source).join(", ")})"
           else
             return if node.each_ancestor.any?(&:rescue_type?)
 

--- a/Library/Homebrew/sorbet/rbi/dsl/rubo_cop/cop/homebrew/formula_path_methods.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/rubo_cop/cop/homebrew/formula_path_methods.rbi
@@ -20,4 +20,10 @@ class RuboCop::Cop::Homebrew::FormulaPathMethods
 
   sig { params(node: RuboCop::AST::Node, kwargs: T.untyped, block: T.untyped).returns(T.untyped) }
   def formula_path_name_node(node, **kwargs, &block); end
+
+  sig { params(node: T.nilable(RuboCop::AST::Node), kwargs: T.anything, block: T.nilable(Proc)).returns(T.anything) }
+  def service_block?(node, **kwargs, &block); end
+
+  sig { params(node: T.nilable(RuboCop::AST::Node), kwargs: T.anything, block: T.nilable(Proc)).returns(T.anything) }
+  def utils_path?(node, **kwargs, &block); end
 end

--- a/Library/Homebrew/test/rubocops/formula_path_methods_spec.rb
+++ b/Library/Homebrew/test/rubocops/formula_path_methods_spec.rb
@@ -53,6 +53,25 @@ RSpec.describe RuboCop::Cop::Homebrew::FormulaPathMethods, :config do
     RUBY
   end
 
+  it "registers an offense and corrects scoped formula helpers in service blocks" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        service do
+          Utils::Path.formula_opt_bin("foo")/"foo"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `formula_opt_bin("foo")` instead of `Utils::Path.formula_opt_bin("foo")`.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo < Formula
+        service do
+          formula_opt_bin("foo")/"foo"
+        end
+      end
+    RUBY
+  end
+
   it "registers an offense and corrects `Formulary.factory` opt path calls" do
     expect_offense(<<~RUBY)
       Formulary.factory("foo").opt_prefix/"bin/foo"
@@ -162,6 +181,16 @@ RSpec.describe RuboCop::Cop::Homebrew::FormulaPathMethods, :config do
         Formula[dependency].any_version_installed?
       rescue FormulaUnavailableError
         false
+      end
+    RUBY
+  end
+
+  it "does not register an offense for scoped formula helpers outside service blocks" do
+    expect_no_offenses(<<~RUBY)
+      class Foo < Formula
+        on_linux do
+          Utils::Path.formula_any_version_installed?("glibc")
+        end
       end
     RUBY
   end


### PR DESCRIPTION
- Keep service DSL helper use consistent after `Service` includes `Utils::Path`.
- Leave class-level formula DSL blocks using the scoped form because the bare helper is not available there.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
