### PR TITLE
formula_auditor: audit new formulae for duplicates

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -648,6 +648,27 @@ module Homebrew
     end
 
     sig { void }
+    def audit_duplicate_formula
+      return unless @core_tap
+      return unless @new_formula
+
+      # Using internal API here as using `Formulary.factory` is too slow
+      return if !@online && Homebrew::API::Internal.cached_packages_json_file_path.blank?
+
+      formula_url = formula.stable&.url
+      return unless formula_url
+
+      formula_hashes = Homebrew::API::Internal.formula_hashes
+      duplicate_formula_name = formula_hashes.find do |name, formula_hash|
+        formula_hash["stable_url_args"].any?(formula_url) && name != formula.name
+      end&.first
+
+      return unless duplicate_formula_name
+
+      new_formula_problem "Possible duplicate, this formula has the same stable URL as `#{duplicate_formula_name}`"
+    end
+
+    sig { void }
     def audit_bottle_spec
       # special case: new versioned formulae should be audited
       return unless @new_formula_inclusive

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -1831,6 +1831,40 @@ RSpec.describe Homebrew::FormulaAuditor do
     end
   end
 
+  describe "#audit_duplicate_formula" do
+    before do
+      allow(Homebrew::API::Internal).to receive(:formula_hashes).and_return(
+        { "foo" => { "stable_url_args" => ["https://brew.sh/foo-1.0.tgz"] },
+          "bar" => { "stable_url_args" => ["https://foo.com/bar-1.0.tgz"] } },
+      )
+    end
+
+    specify "it warns if new formula uses the same URL as already existing package" do
+      fa = formula_auditor "duplicate-foo", <<~RUBY, new_formula: true, core_tap: true
+        class DuplicateFoo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+        end
+      RUBY
+
+      fa.audit_duplicate_formula
+
+      expect(fa.new_formula_problems.first[:message])
+        .to match("Possible duplicate, this formula has the same stable URL as `foo`")
+    end
+
+    specify "it does not warn about duplicates if formula is not new" do
+      fa = formula_auditor "duplicate-foo", <<~RUBY, new_formula: false, core_tap: true
+        class DuplicateFoo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+        end
+      RUBY
+
+      fa.audit_duplicate_formula
+
+      expect(fa.new_formula_problems).to be_empty
+    end
+  end
+
   describe "#audit_conflicts" do
     before do
       # We don't really test the formula text retrieval here


### PR DESCRIPTION
Simple check that warns if new formula has the same stable URL as already existing package. This should prevent PRs like https://github.com/Homebrew/homebrew-core/pull/289451 in the future

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
