### PR TITLE
Key Brewfile trust entries by custom tap remotes

### DIFF
--- a/Library/Homebrew/bundle/trust.rb
+++ b/Library/Homebrew/bundle/trust.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "bundle/dsl"
+require "trust"
 require "utils"
 
 module Homebrew
@@ -17,52 +18,62 @@ module Homebrew
 
       sig { params(entries: T::Array[Homebrew::Bundle::Dsl::Entry]).returns(T::Array[[Symbol, String]]) }
       def self.entries(entries)
+        # Resolve every item through `Homebrew::Trust.target`, the same canonicalizer `brew trust`
+        # uses, so bundle does not write a second, divergent entry for a custom-remote tap. A
+        # `brew`/`cask` entry takes its remote from the matching `tap` entry, which can appear later
+        # in the Brewfile, so map each tap name to its declared remote first.
+        tap_remotes = entries.filter_map do |entry|
+          next if entry.type != :tap
+
+          clone_target = entry.options[:clone_target].presence
+          [entry.name.downcase, clone_target.to_s] if clone_target
+        end.to_h
+
         entries.flat_map do |entry|
           trusted = entry.options[:trusted]
-          full_name = T.cast(entry.options.fetch(:full_name, entry.name), String)
+          next [] if trusted.blank?
 
-          entry_type = entry.type
-
-          case entry_type
+          targets = T.let([], T::Array[[Symbol, String, T.nilable(String)]])
+          case entry.type
           when :tap
-            next [] if trusted.blank?
+            tap_remote = entry.options[:clone_target].presence&.to_s
+            if trusted == true
+              targets << [:tap, entry.name, tap_remote]
+            elsif trusted.is_a?(Hash)
+              unsupported_keys = trusted.keys - TRUSTED_ITEM_KEYS.values.flatten
+              if unsupported_keys.present?
+                raise UsageError,
+                      "Unsupported trusted keys: #{unsupported_keys.join(", ")}"
+              end
 
-            clone_target = entry.options[:clone_target].presence
-            tap_reference = if clone_target
-              require "tap"
-              ::Tap.remote_to_reference(clone_target.to_s) || clone_target.to_s
-            else
-              entry.name
-            end
-            next [[:tap, tap_reference]] if trusted == true
-            next [] unless trusted.is_a?(Hash)
+              TRUSTED_ITEM_KEYS.each do |type, keys|
+                keys.each do |key|
+                  Array(trusted[key]).each do |item|
+                    item_name = case item
+                    when String, Symbol, Integer
+                      Utils.name_from_full_name(item.to_s)
+                    end
+                    next if item_name.blank?
 
-            unsupported_keys = trusted.keys - TRUSTED_ITEM_KEYS.values.flatten
-            raise UsageError, "Unsupported trusted keys: #{unsupported_keys.join(", ")}" if unsupported_keys.present?
-
-            TRUSTED_ITEM_KEYS.flat_map do |type, keys|
-              keys.flat_map do |key|
-                Array(trusted[key]).filter_map do |item|
-                  item_name = case item
-                  when String, Symbol, Integer
-                    Utils.name_from_full_name(item.to_s)
+                    targets << [type, "#{entry.name}/#{item_name}", tap_remote]
                   end
-                  next if item_name.blank?
-
-                  [type, "#{tap_reference}/#{item_name}"]
                 end
               end
             end
           when :brew, :cask
-            # Only fully-qualified names map to a tap, so unqualified names
-            # cannot be meaningfully trusted.
-            next [] if trusted != true || !Utils.full_name?(full_name)
+            full_name = T.cast(entry.options.fetch(:full_name, entry.name), String)
+            next [] if trusted != true
+            # Only fully-qualified names map to a tap, so unqualified names cannot be trusted.
+            next [] unless Utils.full_name?(full_name)
 
-            type = (entry_type == :brew) ? :formula : :cask
-            [[type, full_name]]
-          else
-            []
+            type = (entry.type == :brew) ? :formula : :cask
+            tap_name = Utils.tap_from_full_name(full_name)
+            canonical_tap_name = Dsl.sanitize_tap_name(tap_name) if tap_name
+            tap_remote = tap_remotes[canonical_tap_name] if canonical_tap_name
+            targets << [type, full_name, tap_remote]
           end
+
+          targets.map { |type, name, tap_remote| Homebrew::Trust.target(name, type:, tap_remote:) }
         end.uniq
       end
     end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -886,11 +886,12 @@ class Tap
     remote.present? && custom_remote?
   end
 
-  # The canonical allow/forbid/trust list reference for this {Tap}.
-  sig { returns(String) }
-  def reference
-    remote = self.remote
-    return name if remote.nil? || !custom_remote?
+  # The canonical allow/forbid/trust list reference for this {Tap}. Pass `remote` to resolve against
+  # a not-yet-cloned remote (e.g. a Brewfile `clone_target`) instead of the installed one.
+  sig { params(remote: T.nilable(String)).returns(String) }
+  def reference(remote: nil)
+    remote = remote.presence || self.remote
+    return name if remote.nil? || self.class.same_remote?(remote, default_remote)
 
     remote
   end

--- a/Library/Homebrew/test/bundle/trust_spec.rb
+++ b/Library/Homebrew/test/bundle/trust_spec.rb
@@ -1,0 +1,161 @@
+# typed: true
+# frozen_string_literal: true
+
+require "bundle"
+require "bundle/trust"
+require "bundle/dsl"
+require "tap"
+require "trust"
+
+RSpec.describe Homebrew::Bundle::Trust do
+  describe ".entries" do
+    def brew_entry(full_name)
+      Homebrew::Bundle::Dsl::Entry.new(:brew, full_name, { trusted: true })
+    end
+
+    def cask_entry(full_name)
+      Homebrew::Bundle::Dsl::Entry.new(:cask, full_name, { trusted: true })
+    end
+
+    def tap_entry(name, clone_target = nil, **options)
+      options[:clone_target] = clone_target if clone_target
+      Homebrew::Bundle::Dsl::Entry.new(:tap, name, options)
+    end
+
+    def install_tap(name, remote)
+      tap = Tap.fetch(name)
+      tap.path.mkpath
+      system "git", "-C", tap.path.to_s, "init"
+      system "git", "-C", tap.path.to_s, "remote", "add", "origin", remote
+      tap
+    end
+
+    it "keeps a default-remote tap formula as its tap-qualified name" do
+      expect(described_class.entries([brew_entry("defaultremote/foo/bar")]))
+        .to eq([[:formula, "defaultremote/foo/bar"]])
+    end
+
+    it "ignores an unqualified brew name that maps to no tap" do
+      expect(described_class.entries([brew_entry("wget")])).to be_empty
+    end
+
+    it "normalises a brew entry to the remote declared by its tap, before the tap is cloned" do
+      result = described_class.entries([
+        tap_entry("thirdparty/custom", "https://gitlab.com/other/repo"),
+        brew_entry("thirdparty/custom/bar"),
+      ])
+
+      expect(result).to eq([[:formula, "https://gitlab.com/other/repo/bar"]])
+    end
+
+    it "normalises a cask entry to the remote declared by its tap" do
+      result = described_class.entries([
+        tap_entry("thirdparty/custom", "https://gitlab.com/other/repo"),
+        cask_entry("thirdparty/custom/baz"),
+      ])
+
+      expect(result).to eq([[:cask, "https://gitlab.com/other/repo/baz"]])
+    end
+
+    it "normalises a cask entry written with the homebrew- tap prefix to its declared remote" do
+      brewfile = <<~BREWFILE
+        tap "thirdparty/homebrew-custom", "https://gitlab.com/other/repo"
+        cask "thirdparty/homebrew-custom/baz", trusted: true
+      BREWFILE
+      entries = Homebrew::Bundle::Dsl.new(StringIO.new(brewfile)).entries
+
+      expect(described_class.entries(entries)).to eq([[:cask, "https://gitlab.com/other/repo/baz"]])
+    end
+
+    it "resolves a brew entry independently of the Brewfile order of its tap entry" do
+      brew = brew_entry("thirdparty/custom/bar")
+      tap = tap_entry("thirdparty/custom", "https://gitlab.com/other/repo")
+
+      expect(described_class.entries([brew, tap])).to eq(described_class.entries([tap, brew]))
+    end
+
+    it "collapses a tap trusted-hash item and a brew entry for the same custom-remote item" do
+      result = described_class.entries([
+        tap_entry("thirdparty/custom", "https://gitlab.com/other/repo", trusted: { formula: "bar" }),
+        brew_entry("thirdparty/custom/bar"),
+      ])
+
+      expect(result).to eq([[:formula, "https://gitlab.com/other/repo/bar"]])
+    end
+
+    it "keeps whole-tap trust keyed to a declared custom remote, not the aliased default it resembles" do
+      result = described_class.entries([
+        tap_entry("thirdparty/custom", "https://github.com/other/homebrew-project", trusted: true),
+      ])
+
+      expect(result).to eq([[:tap, "https://github.com/other/homebrew-project"]])
+    end
+
+    it "treats default-remote clone targets in any URL form as the plain tap name" do
+      [
+        "https://github.com/defaultremote/homebrew-foo",
+        "git@github.com:defaultremote/homebrew-foo.git",
+        "https://github.com/defaultremote/homebrew-foo.git",
+        "https://github.com/defaultremote/homebrew-foo/",
+      ].each do |remote|
+        result = described_class.entries([
+          tap_entry("defaultremote/foo", remote),
+          brew_entry("defaultremote/foo/bar"),
+        ])
+
+        expect(result).to eq([[:formula, "defaultremote/foo/bar"]])
+      end
+    end
+
+    it "produces the same entry whether or not the declared custom-remote tap is installed" do
+      entries = [
+        tap_entry("thirdparty/custom", "https://gitlab.com/other/repo"),
+        brew_entry("thirdparty/custom/bar"),
+      ]
+
+      untapped = described_class.entries(entries)
+      install_tap("thirdparty/custom", "https://gitlab.com/other/repo")
+      installed = described_class.entries(entries)
+
+      expect(untapped).to eq([[:formula, "https://gitlab.com/other/repo/bar"]])
+      expect(installed).to eq(untapped)
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+
+    # Keyed verbatim (here including `.git`) so bundle, installed-name `brew trust`, and the items.sh
+    # shell filter all match the same raw origin; normalising only the declared remote would diverge.
+    it "keys a custom-remote brew entry identically whether its remote is declared or installed" do
+      remote = "https://gitlab.com/other/repo.git"
+
+      declared = described_class.entries([
+        tap_entry("thirdparty/custom", remote),
+        brew_entry("thirdparty/custom/bar"),
+      ])
+      install_tap("thirdparty/custom", remote)
+      installed = described_class.entries([brew_entry("thirdparty/custom/bar")])
+
+      expect(declared).to eq([[:formula, "https://gitlab.com/other/repo.git/bar"]])
+      expect(installed).to eq(declared)
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+
+    it "uses the installed remote for an installed custom tap with no declared clone target" do
+      install_tap("thirdparty/custom", "https://gitlab.com/other/repo")
+
+      expect(described_class.entries([tap_entry("thirdparty/custom", trusted: true)]))
+        .to eq([[:tap, "https://gitlab.com/other/repo"]])
+      expect(described_class.entries([tap_entry("thirdparty/custom", trusted: { formula: "bar" })]))
+        .to eq([[:formula, "https://gitlab.com/other/repo/bar"]])
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+
+    it "raises on unsupported trusted keys" do
+      expect do
+        described_class.entries([tap_entry("thirdparty/custom", trusted: { bogus: "bar" })])
+      end.to raise_error(UsageError, /Unsupported trusted keys/)
+    end
+  end
+end

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -147,6 +147,29 @@ RSpec.describe Homebrew::Trust, :trust_store do
     FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
   end
 
+  it "keys an item by a declared custom remote before the tap is installed" do
+    result = described_class.target("thirdparty/custom/bar", type:       :formula,
+                                                             tap_remote: "https://gitlab.com/other/repo")
+    expect(result).to eq([:formula, "https://gitlab.com/other/repo/bar"])
+  end
+
+  it "keys an item by its tap name when the declared remote is its default remote" do
+    result = described_class.target("thirdparty/custom/bar", type:       :formula,
+                                                             tap_remote: "https://github.com/thirdparty/homebrew-custom")
+    expect(result).to eq([:formula, "thirdparty/custom/bar"])
+  end
+
+  it "keeps a declared remote custom relative to its tap name even when it resembles another default" do
+    result = described_class.target("thirdparty/custom/bar", type:       :formula,
+                                                             tap_remote: "https://github.com/other/homebrew-project")
+    expect(result).to eq([:formula, "https://github.com/other/homebrew-project/bar"])
+  end
+
+  it "keys a whole tap by a declared custom remote before the tap is installed" do
+    result = described_class.target("thirdparty/custom", type: :tap, tap_remote: "https://gitlab.com/other/repo")
+    expect(result).to eq([:tap, "https://gitlab.com/other/repo"])
+  end
+
   it "trusts formulae from trusted taps" do
     Tap.fetch("trustedformulae", "foo")
 

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -304,9 +304,13 @@ module Homebrew
       name.downcase
     end
 
-    sig { params(name: String, type: T.nilable(Symbol), include_existing: T::Boolean).returns([Symbol, String]) }
-    def self.target(name, type: nil, include_existing: false)
-      return [type, trust_name(type, name, include_existing:)] if type
+    sig {
+      params(
+        name: String, type: T.nilable(Symbol), include_existing: T::Boolean, tap_remote: T.nilable(String),
+      ).returns([Symbol, String])
+    }
+    def self.target(name, type: nil, include_existing: false, tap_remote: nil)
+      return [type, trust_name(type, name, include_existing:, tap_remote:)] if type
 
       infer_target(name, include_existing:)
     end
@@ -346,8 +350,12 @@ module Homebrew
     end
     private_class_method :infer_target
 
-    sig { params(type: Symbol, name: String, include_existing: T::Boolean).returns(String) }
-    def self.trust_name(type, name, include_existing: false)
+    sig {
+      params(
+        type: Symbol, name: String, include_existing: T::Boolean, tap_remote: T.nilable(String),
+      ).returns(String)
+    }
+    def self.trust_name(type, name, include_existing: false, tap_remote: nil)
       case type
       when :tap
         if Tap.remote_reference?(name)
@@ -356,17 +364,17 @@ module Homebrew
 
           reference
         else
-          Tap.fetch(name).reference
+          Tap.fetch(name).reference(remote: tap_remote)
         end
       when :formula
         tap, formula_name = fully_qualified_package_name(name, "Formulae")
-        item_trust_name(type, tap, formula_name, include_existing:)
+        item_trust_name(type, tap, formula_name, include_existing:, tap_remote:)
       when :cask
         tap, token = fully_qualified_package_name(name, "Casks")
-        item_trust_name(type, tap, token, include_existing:)
+        item_trust_name(type, tap, token, include_existing:, tap_remote:)
       when :command
         tap, command_name = fully_qualified_package_name(name, "Commands")
-        item_trust_name(type, tap, command_name, include_existing:)
+        item_trust_name(type, tap, command_name, include_existing:, tap_remote:)
       else
         raise UsageError, "Unsupported trust target type: #{type}"
       end
@@ -375,14 +383,20 @@ module Homebrew
     end
     private_class_method :trust_name
 
-    sig { params(type: Symbol, tap: Tap, item_name: String, include_existing: T::Boolean).returns(String) }
-    def self.item_trust_name(type, tap, item_name, include_existing: false)
+    sig {
+      params(
+        type: Symbol, tap: Tap, item_name: String, include_existing: T::Boolean, tap_remote: T.nilable(String),
+      ).returns(String)
+    }
+    def self.item_trust_name(type, tap, item_name, include_existing: false, tap_remote: nil)
       item_name = normalise_name(item_name)
       full_name = "#{tap.name}/#{item_name}"
       return full_name if include_existing && trusted_entries(type).include?(normalise_name(full_name))
-      return full_name unless tap.uses_custom_remote?
 
-      "#{normalise_name(tap.reference)}/#{item_name}"
+      reference = tap.reference(remote: tap_remote)
+      return full_name if reference == tap.name
+
+      "#{normalise_name(reference)}/#{item_name}"
     end
     private_class_method :item_trust_name
 


### PR DESCRIPTION
For taps with custom Git remotes, `brew bundle` could write trust entries under the tap name while `brew trust` writes the same items under the tap remote. That produced duplicate or mismatched `trust.json` entries for one formula or cask.

Route Brewfile trust entries through `Homebrew::Trust.target`, passing the remote declared by the matching `tap` entry when available. Bundle now builds the trust target first and canonicalizes it in one place, so whole-tap trust, tap-level item hashes, and `brew`/`cask` entries use the same key. Default remotes still use the tap name; custom remotes use the effective remote spelling.

Tests cover declared custom remotes, `brew` and `cask` entries, Brewfile order, default-remote URL variants, installed versus declared remotes, `.git` remote spelling, `homebrew-` tap prefixes, and convergence between tap item hashes and item entries.

## Steps to reproduce

For a tap whose Git remote is not the default `github.com/<user>/homebrew-<repo>`:

```bash
brew tap example/foo https://gitlab.com/example/foo
brew trust --formula example/foo/bar   # stored remote-keyed: https://gitlab.com/example/foo/bar

printf 'brew "example/foo/bar", trusted: true\n' > Brewfile
brew bundle                            # before: writes a second, name-keyed entry "example/foo/bar"

brew trust --json=v1                   # before: two entries for one formula; after: one
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code assisted with the implementation. I reviewed the code and text, and verified the change locally with `brew lgtm --online` plus focused red/green checks for the new specs.

-----
