### PR TITLE
dependencies_helpers: prune indirect build deps if bottled

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -44,7 +44,8 @@ module Homebrew
         switch "--include-implicit",
                description: "Include implicit dependencies used to download and unpack source files."
         switch "--include-build",
-               description: "Include `:build` dependencies for <formula>."
+               description: "Include `:build` dependencies for <formula> (non-recursive for dependencies with " \
+                            "compatible bottles unless `--graph` or `--tree`)"
         switch "--include-optional",
                description: "Include `:optional` dependencies for <formula>."
         switch "--include-test",

--- a/Library/Homebrew/dependencies_helpers.rb
+++ b/Library/Homebrew/dependencies_helpers.rb
@@ -49,8 +49,12 @@ module DependenciesHelpers
     klass.expand(root_dependent, cache_key:) do |dependent, dep|
       next Dependable::PRUNE if ignores.any? { |ignore| dep.public_send(ignore) }
       next Dependable::PRUNE if includes.none? do |include|
-        # Ignore indirect test dependencies
-        next if include == :test? && dependent != root_dependent
+        if dependent != root_dependent
+          # Ignore indirect test dependencies
+          next if include == :test?
+          # Ignore indirect build dependencies of formulae with compatible bottles
+          next if include == :build? && !dependent.is_a?(CaskDependent) && dependent.bottled?
+        end
 
         dep.public_send(include)
       end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

This should reduce the total dependencies fetched by test-bot where we use `brew deps --formula --include-build --include-test` to fetch all dependencies needed to build and test formulae.

Indirect build dependencies are only needed when a bottle doesn't exist and needs to be built from source. This shouldn't happen in Homebrew/core, but may still be needed in some Tier 2/3 setups.

---

Some optional changes that can be done if preferred:
- Keep existing behavior for `--include-build` and instead add a new flag for this.
- Default to excluding all recursive build dependencies similar to recursive test dependencies, i.e. 
   ```ruby
   next if [:build, :test].include?(include) && dependent != root_dependent
   ```

---

To give an example, Meson's dependency tree has indirect pkgconf and cmake:
```console
❯ brew deps --tree --annotate --include-build meson
meson
├── ninja
└── python@3.14
    ├── pkgconf  [build]
    ├── mpdecimal
    ├── openssl@3
    │   └── ca-certificates
    ├── sqlite
    │   └── readline
    ├── xz
    └── zstd
        ├── cmake  [build]
        ├── lz4
        └── xz

❯ old_deps=$(git checkout -q main && brew deps --annotate --include-build meson)

❯ new_deps=$(git checkout -q deps-prune-some-recursive-build && brew deps --annotate --include-build meson)

❯ diff <(echo $old_deps) <(echo $new_deps)
2d1
< cmake [build]
7d5
< pkgconf [build]
```

And if `zstd` bottle is removed from local formula, it adds `cmake`
```console
❯ new_deps=$(brew deps --annotate --include-build meson)

❯ diff <(echo $old_deps) <(echo $new_deps)
7d6
< pkgconf [build]
```