### PR TITLE
test_bot/formulae: exclude indirect build dependencies

### DIFF
--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -150,14 +150,16 @@ module Homebrew
         end
 
         info_header "Determining dependencies..."
-        installed = Utils.safe_popen_read("brew", "list", "--formula", "--full-name").split("\n")
-        dependencies =
-          Utils.safe_popen_read("brew", "deps", "--formula",
-                                "--include-build",
-                                "--include-test",
-                                "--full-name",
-                                formula_name)
-               .split("\n")
+        installed = Formula.installed.map(&:full_name).sort!
+        cache_key = "test-bot-#{formula_name}-dependencies"
+        dependencies = Dependency.expand(formula, cache_key:) do |dependent, dep|
+          if dep.required? || dep.recommended? || ((dep.build? || dep.test?) && dependent == formula)
+            # Avoid an exception if tap isn't installed yet and defer handling to a later step
+            Dependable::KEEP_BUT_PRUNE_RECURSIVE_DEPS if (tap = dep.tap) && !tap.installed?
+          else
+            Dependable::PRUNE
+          end
+        end.map(&:name).sort!
         installed_dependencies = installed & dependencies
         installed_dependencies.each do |name|
           link_formula = Formulary.factory(name)


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Test bot currently fetches unused indirect build dependencies as `brew deps --include-build` is recursive. This resulted in unnecessary downloads in CI.

Previously I was looking at rewriting `brew deps` to handle this:
- https://github.com/Homebrew/brew/pull/22863

But seems lower impact to adjust the test-bot handling which also avoids unnecessary brew-calling-brew

---

From glibc CI runner, it is possible to see impact as we previously included the build-dependencies of GCC

- Last main CI run: https://github.com/Homebrew/brew/actions/runs/28064006513/job/83084599890#step:9:39
  ```
  ==> Determining dependencies...
  ==> brew fetch --formulae --retry acl attr autoconf automake bison ca-certificates cmake flex gdbm gettext help2man libtool libunistring libxcrypt libxml2 m4 ncurses openssl@3 perl pkgconf readline texinfo
  ```

- This CI run: https://github.com/Homebrew/brew/actions/runs/28071518927/job/83107109663?pr=22864#step:9:43
  ```
  ==> Determining dependencies...
  ==> brew fetch --formulae --retry ca-certificates cmake ncurses openssl@3
  ```