### PR TITLE
utils/path: add `formula_opt_include` helper

### DIFF
--- a/Library/Homebrew/test/utils/path_spec.rb
+++ b/Library/Homebrew/test/utils/path_spec.rb
@@ -60,6 +60,12 @@ RSpec.describe Utils::Path do
     end
   end
 
+  describe "::formula_opt_include" do
+    it "returns a formula opt include path without loading a Formula object" do
+      expect(described_class.formula_opt_include("foo")).to eq(HOMEBREW_PREFIX/"opt/foo/include")
+    end
+  end
+
   describe "::formula_installed_prefixes" do
     it "returns installed prefixes for formula names" do
       tmpdir = mktmpdir

--- a/Library/Homebrew/utils/path.rb
+++ b/Library/Homebrew/utils/path.rb
@@ -78,6 +78,22 @@ module Utils
       Utils::Path.formula_opt_libexec(formula_name)
     end
 
+    # The `include` directory under the stable install path for a given formula name.
+    #
+    # @api public
+    sig { params(formula_name: String).returns(Pathname) }
+    def self.formula_opt_include(formula_name)
+      formula_opt_prefix(formula_name)/"include"
+    end
+
+    # The `include` directory under the stable install path for a given formula name.
+    #
+    # @api public
+    sig { params(formula_name: String).returns(Pathname) }
+    def formula_opt_include(formula_name)
+      Utils::Path.formula_opt_include(formula_name)
+    end
+
     # The installed prefix directories for one or more formula names.
     #
     # @api public


### PR DESCRIPTION
Add one more path helper similar to `formula_opt_(bin|lib|libexec|prefix)`. Adding it for consistency with other path methods

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
