### PR TITLE
Forward the `--quiet` flag to all `brew bundle` subcommands

### DIFF
--- a/Library/Homebrew/bundle/subcommand.rb
+++ b/Library/Homebrew/bundle/subcommand.rb
@@ -48,7 +48,7 @@ module Homebrew
           end
           raise UsageError, "Unknown subcommand: #{context.subcommand}" unless subcommand_class
 
-          subcommand_class.new(args, context:).run
+          subcommand_class.new(args, context:, quiet: args.quiet?).run
         end
 
         sig {

--- a/Library/Homebrew/test/cmd/bundle_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Homebrew::Cmd::Bundle do
   it "disables ask mode for subcommands" do
     with_env(HOMEBREW_ASK: nil, HOMEBREW_NO_ASK: nil) do
       args = described_class.new(%w[cleanup]).args
-      expect(Homebrew::Cmd::Bundle::CleanupSubcommand).to receive(:new) do |_, context:|
+      expect(Homebrew::Cmd::Bundle::CleanupSubcommand).to receive(:new) do |_, context:, **|
         expect(context.ask).to be(true)
         expect(ENV.fetch("HOMEBREW_ASK", nil)).to be_nil
         expect(ENV.fetch("HOMEBREW_NO_ASK", nil)).to eq("1")


### PR DESCRIPTION
While writing some scripts that utilize a `brew bundle check --quiet || brew bundle install` style pattern for installing dependencies, I noticed that `brew bundle check --quiet` was always emitting output, even when the `--quiet` flag was provided, that the implementation suggested it should silence.

Upon further investigation, it became clear that the `--quiet` flag, but wasn't being forwarded when the subcommand was invoked.

This changes fixes that forwarding bug<del>, and adds an integration test to validate that the `--quiet` flag is handled by the `brew bundle check` subcommand</del>.

## Reproducing

Requires a satisfied Brewfile.

Before:

```
> brew bundle check --quiet
The Brewfile's dependencies are satisfied.
```

After:

```
> brew bundle check --quiet
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

The only thing raised by `brew lgtm` is a pre-existing violation unrelated to my specific change (missing documentation for `Library/Homebrew/bundle/subcommand.rb` class).

-----

- [x] AI was used to generate or assist with generating this PR.

AI was used to research the existing code base to determine the source of the underlying bug once I had observed the behavior in some scripts I was writing locally. It came up with the recommendation on how to fix the problem. It did not author the code changes, the commit message, or the prose in the pull request.

-----
