### PR TITLE
Disable tap Git credential prompts

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -594,7 +594,7 @@ class Tap
   def git_command!(args, chdir: nil)
     require "system_command"
 
-    SystemCommand.run!("git", args:, chdir:, print_stderr: true)
+    SystemCommand.run!("git", args:, chdir:, env: { "GIT_TERMINAL_PROMPT" => "0" }, print_stderr: true)
   end
   private :git_command!
 

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -619,6 +619,15 @@ RSpec.describe Tap do
   end
 
   describe "#install" do
+    it "disables terminal prompts for git commands" do
+      require "system_command"
+
+      expect(SystemCommand).to receive(:run!)
+        .with("git", args: %w[fetch], chdir: path, env: { "GIT_TERMINAL_PROMPT" => "0" }, print_stderr: true)
+
+      homebrew_foo_tap.send(:git_command!, %w[fetch], chdir: path)
+    end
+
     it "raises an error when the Tap is already tapped" do
       setup_git_repo
       already_tapped_tap = described_class.fetch("Homebrew", "foo")


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22866

- Avoid stopped `git` children when private HTTPS taps prompt via `/dev/tty`.
- Let configured credential helpers satisfy authentication non-interactively.
- Cover `Tap#git_command!` so clone and fetch paths keep the guard.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
