### PR TITLE
bump-formula-pr: do not repeat release notes multiple times

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -168,6 +168,8 @@ module Homebrew
 
         return if all_formulae.empty?
 
+        added_release_info = Set.new
+
         commits = all_formulae.filter_map do |formula_name|
           commit_formula = Formula[formula_name]
           raise FormulaUnspecifiedError if commit_formula.blank?
@@ -390,6 +392,7 @@ module Homebrew
             owner = Regexp.last_match(1)
             repo = Regexp.last_match(2)
             tag = Regexp.last_match(3)
+            release_id = "#{owner}/#{repo}/#{tag}"
             github_release_data = begin
               GitHub::API.open_rest("#{GitHub::API_URL}/repos/#{owner}/#{repo}/releases/tags/#{tag}")
             rescue GitHub::API::HTTPNotFoundError
@@ -397,7 +400,8 @@ module Homebrew
               nil
             end
 
-            if github_release_data.present? && github_release_data["body"].present?
+            if github_release_data.present? && github_release_data["body"].present? &&
+               added_release_info.exclude?(release_id)
               pre = "pre" if github_release_data["prerelease"].present?
               # maximum length of PR body is 65,536 characters so let's truncate release notes to half of that.
               body = Formatter.truncate(github_release_data["body"], max: 32_768)
@@ -412,6 +416,8 @@ module Homebrew
                   <p>View the full release notes at <a href="#{html_url}">#{html_url}</a>.</p>
                 </details>
               XML
+
+              added_release_info << release_id
             end
           end
 


### PR DESCRIPTION
I noticed that autobump workflow failed to autobump synced `loki`/`logcli` because the resulting PR message body exceeds 2^16 bytes (https://github.com/Homebrew/homebrew-core/actions/runs/28116918257/job/83258667631#step:6:17552) Turns out `bump-formula-pr` repeats the same release notes for synced formulae. Let's make sure we don't repeat the same release notes twice (maybe it makes sense to limit one release notes per PR but I guess there are might be synced formulae which have different source URLs)

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
