### PR TITLE
Fix HOMEBREW_FORBID_PACKAGES_FROM_PATHS bypasses

### DIFF
--- a/Library/Homebrew/test/utils/path_spec.rb
+++ b/Library/Homebrew/test/utils/path_spec.rb
@@ -158,5 +158,52 @@ RSpec.describe Utils::Path do
 
       expect(described_class.loadable_package_path?(formula_path, :formula)).to be(true)
     end
+
+    it "accepts formula paths under a symlinked tap" do
+      tmpdir = mktmpdir.realpath
+      library = tmpdir/"Library"
+      (library/"Taps/homebrew").mkpath
+      stub_const("HOMEBREW_LIBRARY", library)
+      allow(Homebrew::EnvConfig).to receive(:forbid_packages_from_paths?).and_return(true)
+
+      external_tap = tmpdir/"external/homebrew-foo"
+      (external_tap/"Formula").mkpath
+      FileUtils.ln_s(external_tap, library/"Taps/homebrew/homebrew-foo")
+
+      formula_path = library/"Taps/homebrew/homebrew-foo/Formula/foo.rb"
+      formula_path.write "class Foo < Formula; end\n"
+
+      expect(described_class.loadable_package_path?(formula_path, :formula)).to be(true)
+    end
+
+    it "rejects formula paths that escape a trusted root via `..` segments" do
+      tmpdir = mktmpdir.realpath
+      library = tmpdir/"Library"
+      (library/"Taps").mkpath
+      stub_const("HOMEBREW_LIBRARY", library)
+      allow(Homebrew::EnvConfig).to receive(:forbid_packages_from_paths?).and_return(true)
+
+      escaped = tmpdir/"evil.rb"
+      escaped.write "class Evil < Formula; end\n"
+
+      # Textually starts under `Taps/` but resolves to `tmpdir/evil.rb` outside it.
+      traversal_path = library/"Taps/../../evil.rb"
+
+      expect { described_class.loadable_package_path?(traversal_path, :formula) }
+        .to raise_error(/to be in a tap/)
+    end
+
+    it "rejects local JSON cask paths" do
+      tmpdir = mktmpdir.realpath
+      (tmpdir/"Library/Taps").mkpath
+      stub_const("HOMEBREW_LIBRARY", tmpdir/"Library")
+      allow(Homebrew::EnvConfig).to receive(:forbid_packages_from_paths?).and_return(true)
+
+      cask_path = tmpdir/"evil.json"
+      cask_path.write "{}\n"
+
+      expect { described_class.loadable_package_path?(cask_path, :cask) }
+        .to raise_error(/to be in a tap/)
+    end
   end
 end

--- a/Library/Homebrew/utils/path.rb
+++ b/Library/Homebrew/utils/path.rb
@@ -151,9 +151,13 @@ module Utils
         trusted_package_root(Cask::Caskroom.path)
       end
 
-      return true if !path_realpath.end_with?(".rb") && !path_string.end_with?(".rb")
-      return true if allowed_paths.any? { |path| path_realpath.start_with?(path) }
-      return true if allowed_paths.any? { |path| path_string.start_with?(path) }
+      # Casks can also be loaded from local JSON files, not just Ruby.
+      package_extnames = (package_type == :cask) ? %w[.rb .json] : %w[.rb]
+      return true if package_extnames.none? { |ext| path_realpath.end_with?(ext) || path_string.end_with?(ext) }
+
+      # Compare path ancestry, not string prefixes, so `..` can't escape a trusted root.
+      return true if allowed_paths.any? { |root| child_of?(root, path_realpath) }
+      return true if allowed_paths.any? { |root| child_of?(root, path) }
 
       # Looks like a local path, Ruby file and not a tap.
       if path_string.include?("./") || path_string.end_with?(".rb") || path_string.count("/") != 2


### PR DESCRIPTION
`HOMEBREW_FORBID_PACKAGES_FROM_PATHS` refuses to load formulae or casks from local file paths (e.g. `brew install ./pkg.rb`) and is enabled by default for non-developers. `loadable_package_path?` enforced it with raw string-prefix checks, so a path like `<repository>/Library/Taps/../../../../tmp/evil.rb` passed: it textually starts under `Taps/` even though it resolves outside any tap. A crafted argument could therefore load — and `instance_eval` — a Ruby formula from anywhere on disk, despite the restriction.

This compares path ancestry with the existing `child_of?` helper instead of string prefixes, so `..` segments can't spell an in-tap path. Symlinked taps still load, because `child_of?` collapses `..` without resolving symlinks.

While here, the same check only looked at `.rb`, so a local `.json` cask definition skipped the policy entirely; casks can also be loaded from JSON, so this adds `.json` to the cask package extensions. (JSON casks are parsed rather than evaluated, so this is a smaller gap than the traversal above.)

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

A Codex security scan flagged the bypasses; Claude Code (Opus 4.8) validated them against the source, made the change and wrote the tests. I verified with `brew lgtm` and by confirming the new specs fail against the unpatched check and pass with it.

-----
