### PR TITLE
Redact GitHub token in bump dry-run output

### DIFF
--- a/Library/Homebrew/bump.rb
+++ b/Library/Homebrew/bump.rb
@@ -3,6 +3,7 @@
 
 require "system_command"
 require "tap"
+require "utils/formatter"
 require "utils/git"
 require "utils/github"
 require "utils/output"
@@ -103,7 +104,7 @@ module Homebrew
             ohai "git add #{changed_files.join(" ")}"
             ohai "git commit --no-edit --verbose --message='#{commit_message}' " \
                  "-- #{changed_files.join(" ")}"
-            ohai "git push --set-upstream #{remote_url} #{branch}:#{branch}"
+            ohai "git push --set-upstream #{redacted_url(remote_url)} #{branch}:#{branch}"
             ohai "git checkout --quiet -"
             ohai "create pull request with GitHub API (base branch: #{remote_branch})"
           else
@@ -142,6 +143,12 @@ module Homebrew
         url.sub!(%r{^https://github\.com/}, "https://x-access-token:#{GitHub::API.credentials}@github.com/")
       end
       url
+    end
+
+    # Redact any token `add_auth_token_to_url!` embedded, so dry-run output doesn't leak it.
+    sig { params(url: T.nilable(String)).returns(String) }
+    private_class_method def self.redacted_url(url)
+      Formatter.redact_secrets(url.to_s, [GitHub::API.credentials].compact)
     end
 
     sig { params(tap_remote_repo: String, org: T.nilable(String)).returns([String, String]) }

--- a/Library/Homebrew/test/bump_spec.rb
+++ b/Library/Homebrew/test/bump_spec.rb
@@ -1,0 +1,21 @@
+# typed: true
+# frozen_string_literal: true
+
+require "bump"
+
+RSpec.describe Homebrew::Bump do
+  describe "::redacted_url" do
+    it "masks env-token credentials embedded in a push URL" do
+      allow(GitHub::API).to receive(:credentials).and_return("ghp_secrettoken")
+      expect(described_class.send(:redacted_url,
+                                  "https://x-access-token:ghp_secrettoken@github.com/Homebrew/homebrew-core"))
+        .to eq("https://x-access-token:******@github.com/Homebrew/homebrew-core")
+    end
+
+    it "leaves a credential-free URL unchanged" do
+      allow(GitHub::API).to receive(:credentials).and_return(nil)
+      expect(described_class.send(:redacted_url, "https://github.com/Homebrew/homebrew-core"))
+        .to eq("https://github.com/Homebrew/homebrew-core")
+    end
+  end
+end


### PR DESCRIPTION
When `brew bump-formula-pr` or `bump-cask-pr` run with `--dry-run`, the would-be `git push` command is printed via `ohai`. If `HOMEBREW_GITHUB_API_TOKEN` is set, `add_auth_token_to_url!` has already rewritten the remote to embed `https://x-access-token:<token>@github.com/…`, so the dry-run transcript prints the token in cleartext — into the terminal, and into CI logs if the dry run is scripted. The real push goes through `system_command!`, which redacts secrets, but the dry-run `ohai` path did not.

This redacts the credentials with `Formatter.redact_secrets` before printing, so the dry-run shows `https://x-access-token:******@github.com/…`, matching how the executed push is already logged. Both the `--no-fork` and default fork paths embed the token (`add_auth_token_to_url!` is called in each), so redacting at the print site covers both.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

A Codex security scan flagged the leak; Claude Code (Opus 4.8) validated it against the source, made the change and wrote the tests. I verified with `brew lgtm`.

-----
