### PR TITLE
Reject inline cask definitions passed to the MCP server

### DIFF
--- a/Library/Homebrew/mcp_server.rb
+++ b/Library/Homebrew/mcp_server.rb
@@ -19,6 +19,9 @@ module Homebrew
     MCP_PROTOCOL_VERSION = "2025-03-26"
     ERROR_CODE = -32601
 
+    # Reject inline `cask ... do`/`cask(...) {}` blocks the cask loader would eval as Ruby.
+    INLINE_CASK_DSL_REGEX = /\A\s*cask\s*['"(]/
+
     SERVER_INFO = T.let({
       name:    "brew-mcp-server",
       version: HOMEBREW_VERSION,
@@ -302,6 +305,11 @@ module Homebrew
       end
 
       require "open3"
+
+      formula_or_cask = request.dig("params", "arguments", "formula_or_cask")
+      if formula_or_cask.is_a?(String) && INLINE_CASK_DSL_REGEX.match?(formula_or_cask)
+        return respond_error(id, "Invalid formula or cask argument")
+      end
 
       command_args = tool_command_arguments(tool_name, request["params"]["arguments"])
       progress_token = request["params"]["_meta"]&.fetch("progressToken", nil)

--- a/Library/Homebrew/test/mcp_server_spec.rb
+++ b/Library/Homebrew/test/mcp_server_spec.rb
@@ -169,6 +169,20 @@ RSpec.describe Homebrew::McpServer do
       server.handle_request(request)
     end
 
+    it "rejects an inline cask definition argument without spawning brew" do
+      expect(Open3).not_to receive(:popen2e)
+      request = {
+        "id"     => id,
+        "method" => "tools/call",
+        "params" => {
+          "name"      => "info",
+          "arguments" => { "formula_or_cask" => %Q(cask "evil" do\n  url "https://example.com"\nend) },
+        },
+      }
+      result = server.handle_request(request)
+      expect(result).to eq({ jsonrpc:, id:, error: { message: "Invalid formula or cask argument", code: } })
+    end
+
     it "responds to tools/call for unknown tool" do
       request = { "id" => id, "method" => "tools/call", "params" => { "name" => "not_a_tool", "arguments" => {} } }
       result = server.handle_request(request)


### PR DESCRIPTION
The Homebrew MCP server forwards the `formula_or_cask` tool argument to `brew` verbatim, and `brew`'s cask loader recognises a full inline `cask "token" do … end` / `cask(…) { … }` string and `instance_eval`s it as Ruby (`Cask::CaskLoader::FromContentLoader`). So an MCP `tools/call` whose `formula_or_cask` is an inline cask block runs arbitrary Ruby in the server's process — including through read-oriented tools like `info` and `list` that advertise themselves as read-only. An argument described as a "name" shouldn't be interpretable as code.

This rejects `formula_or_cask` arguments that look like an inline cask definition at the MCP boundary, before `brew` is spawned, returning a JSON-RPC error. Formula/cask names, tap references, paths and URLs are unaffected, as none begin with `cask` followed by a quote or parenthesis.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

A Codex security scan flagged the inline-eval path; Claude Code (Opus 4.8) validated it against the source, made the change and wrote the tests. I verified with `brew lgtm`.

-----
