### PR TITLE
Fix core cask tap redirects

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -553,7 +553,7 @@ class Tap
 
     redirected_reference = self.class.remote_to_reference(redirected_remote)
     if redirected_reference.present? && !self.class.remote_reference?(redirected_reference)
-      redirected_tap = self.class.fetch(redirected_reference)
+      redirected_tap = Tap.fetch(redirected_reference)
       if redirected_tap.name != name && !redirected_tap.installed?
         old_path = path
         redirected_tap.path.dirname.mkpath

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -604,6 +604,24 @@ RSpec.describe Tap do
       FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"oldoutput"
       FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"newoutput"
     end
+
+    it "updates the core cask tap remote from a redirect", :trust_store do
+      tap = CoreCaskTap.instance
+      tap.path.mkpath
+      system "git", "-C", tap.path.to_s, "init"
+      system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://github.com/caskroom/homebrew-cask"
+
+      tap.update_remote_from_git_redirect!(
+        "warning: redirecting to https://github.com/Homebrew/homebrew-cask\n",
+        quiet: true,
+      )
+
+      expect(Utils.popen_read("git", "-C", tap.path, "config", "remote.origin.url").chomp)
+        .to eq("https://github.com/Homebrew/homebrew-cask")
+    ensure
+      CoreCaskTap.instance.clear_cache
+      FileUtils.rm_rf CoreCaskTap.instance.path
+    end
   end
 
   specify "Git variant" do


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22873

- Avoid dispatching `fetch` through `CoreCaskTap`.
- The inherited method is private on core tap singletons.
- Keep `brew update` working when caskroom redirects to Homebrew.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
