### PR TITLE
doc: Clarify version explanation of `--json` info

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -57,9 +57,9 @@ module Homebrew
                description: "Fetch GitHub Packages manifest for extra information when <formula> is not installed.",
                odeprecated: true
         flag   "--json",
-               description: "Print a JSON representation. Currently the default value for <version> is `v1` for " \
-                            "<formula>. For <formula> and <cask> use `v2`. See the docs for examples of using the " \
-                            "JSON output: <https://docs.brew.sh/Querying-Brew>"
+               description: "Print a JSON representation. Currently the default value for <version> is `v1`." \
+                            "`v1` is valid for <formula> only. `v2` is valid for both <formula> and <cask>." \
+                            "See the docs for examples of using the JSON output: <https://docs.brew.sh/Querying-Brew>"
         switch "--installed",
                description: "Output a human-readable inventory of installed formulae and casks. If `--json` is " \
                             "passed, print JSON for installed formulae and, with `--json=v2`, installed casks."


### PR DESCRIPTION
For formula, we don't have to specify `v2`.
This change makes it clear that we need to specify `v2` only for cask. It now also explains how to specify version.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

`brew lgtm` failed, but it's not related to this change.

```
==> brew style --changed --fix
Library/Homebrew/cmd/info.rb:20:5: C: Style/Documentation: Missing top-level documentation comment for class Homebrew::Cmd::Info.
    class Info < AbstractCommand
    ^^^^^^^^^^
Library/Homebrew/cmd/info.rb:21:7: C: Style/Documentation: Missing top-level documentation comment for class Homebrew::Cmd::Info::NameSize.
      class NameSize < T::Struct
      ^^^^^^^^^^^^^^

1 file inspected, 2 offenses detected
Error: Failure while executing; `/opt/homebrew/bin/brew style --changed --fix` exited with 1.
```

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
