### PR TITLE
system_command: use Process.spawn to avoid fork-unsafe exec3 child

### DIFF
--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -404,19 +404,29 @@ class SystemCommand
     err_r, err_w = IO.pipe
     options[:err] = err_w
 
-    pid = fork do
+    exec_env = env.merge({ "COLUMNS" => Tty.width.to_s })
+
+    # `Process.spawn` avoids running `malloc` in a `fork`ed child, which is not
+    # fork-safe on macOS and can abort it. `fork` is kept for privilege changes
+    # and as a fallback.
+    pid = if (run_as_real_uid? || reset_uid?) && Process.euid != Process.uid
+      nil
+    else
+      begin
+        Process.spawn(exec_env, [executable, executable], *args, **options)
+      rescue SystemCallError
+        nil
+      end
+    end
+
+    pid ||= fork do
       if run_as_real_uid? && Process.euid != Process.uid
         Process::UID.change_privilege(Process.uid)
       elsif reset_uid? && Process.euid != Process.uid
         Process::UID.change_privilege(Process.euid)
       end
 
-      exec(
-        env.merge({ "COLUMNS" => Tty.width.to_s }),
-        [executable, executable],
-        *args,
-        **options,
-      )
+      exec(exec_env, [executable, executable], *args, **options)
     rescue SystemCallError => e
       $stderr.puts(e.message)
       exit!(127)

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -287,6 +287,13 @@ RSpec.describe SystemCommand do
       end.not_to raise_error
     end
 
+    it "uses `Process.spawn` rather than `fork` when no privilege change is required" do
+      command = described_class.new("true")
+      expect(command).not_to receive(:fork)
+      expect(Process).to receive(:spawn).and_call_original
+      command.run!
+    end
+
     it 'does not format `stderr` when it starts with \r' do
       expect do
         Class.new.extend(SystemCommand::Mixin).system_command \


### PR DESCRIPTION
`SystemCommand#exec3` forked and then called `exec(env, ...)` in the child. Ruby builds the `execve` argv/envp buffers (calling `malloc`) in that child, which is not fork-safe on macOS while other threads are running (here, the `Timeout.timeout` watcher thread wrapping the cask quit loop). The child can abort before `exec` completes, as reported in https://github.com/orgs/Homebrew/discussions/6922: an intermittent `ruby ... malloc: tiny_free_list_remove_ptr: Internal invariant broken` / `SIGABRT` "crashed on child side of fork pre-exec" during a `brew upgrade` of a cask. The upgrade itself recovered via the quit retry loop.

This `fork`+`exec` path was introduced in 19617cb161, which replaced `Open3.popen3` (spawning via `posix_spawn`) with a hand-rolled `fork` so a UID change could happen in the child.

Use `Process.spawn` (which builds those buffers in the parent via `posix_spawn`) whenever no privilege change is required. `fork`+`exec` is kept only when one actually is (`reset_uid`/`run_as_real_uid` with a differing euid/uid), and as a fallback when `Process.spawn` raises `SystemCallError`, preserving the existing exit-127 behaviour for a missing executable. Adds a spec asserting the non-privileged path uses `Process.spawn`.

-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code (Opus 4.8) wrote the `exec3` change and the spec; I confirmed the root cause against the discussion's crash report, ran `brew lgtm` (typecheck, style, tests) locally, and checked runtime behaviour (a normal command goes via `Process.spawn`; a missing executable still exits 127 with the message on stderr).

-----
