### PR TITLE
Reject patch targets that escape the staged source tree

### DIFF
--- a/Library/Homebrew/embedded_patch.rb
+++ b/Library/Homebrew/embedded_patch.rb
@@ -43,6 +43,7 @@ class EmbeddedPatch
     if (subdirectory = directory.presence)
       dir /= subdirectory
     end
+    Patch.ensure_targets_within!(data, strip:, base: dir)
     dir.cd do
       Utils.safe_popen_write("patch", *args) { |p| p.write(data) }
     end

--- a/Library/Homebrew/external_patch.rb
+++ b/Library/Homebrew/external_patch.rb
@@ -71,6 +71,9 @@ class ExternalPatch
         patch_files.each do |patch_file|
           ohai "Applying #{patch_file}"
           patch_file = patch_dir/patch_file
+          Patch.ensure_targets_within!(
+            patch_file.read.gsub("@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX), strip:, base: dir
+          )
           Utils.safe_popen_write("patch", "-g", "0", "-f", "-#{strip}") do |p|
             File.foreach(patch_file) do |line|
               data = line.gsub("@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX)

--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -6,6 +6,7 @@ require "data_patch"
 require "external_patch"
 require "string_patch"
 require "local_patch"
+require "utils/path"
 
 # Helper module for creating patches.
 module Patch
@@ -36,6 +37,22 @@ module Patch
     return "security" if id.match?(/\ACVE-\d{4}-\d{4,}\z/) || id.match?(GHSA_PATTERN)
 
     "defect"
+  end
+
+  # Reject patch target paths (absolute or `..`-traversing) that escape the staged source tree.
+  sig { params(text: String, strip: T.any(Symbol, String), base: Pathname).void }
+  def self.ensure_targets_within!(text, strip:, base:)
+    strip_count = strip.to_s[/\d+/].to_i
+    text.each_line do |line|
+      # Headers are whitespace-delimited; take the first token, ignoring any timestamp.
+      next unless (path = line[/\A(?:---|\+\+\+|\*\*\*)\s+(\S+)/, 1])
+      next if path == File::NULL
+
+      relative = path.split("/").drop(strip_count).join("/")
+      next if Utils::Path.child_of?(base, base/relative)
+
+      raise "Patch target path escapes the staged source tree: #{path}"
+    end
   end
 
   sig {

--- a/Library/Homebrew/test/patch_spec.rb
+++ b/Library/Homebrew/test/patch_spec.rb
@@ -154,6 +154,42 @@ RSpec.describe Patch do
     end
   end
 
+  describe ".ensure_targets_within!" do
+    let(:base) { Pathname("/tmp/brew-build") }
+
+    it "allows targets that stay within the source tree" do
+      expect { described_class.ensure_targets_within!("--- a/src/foo.c\n+++ b/src/foo.c\n", strip: :p1, base:) }
+        .not_to raise_error
+    end
+
+    it "allows /dev/null headers for added or deleted files" do
+      expect { described_class.ensure_targets_within!("--- /dev/null\n+++ b/new.c\n", strip: :p1, base:) }
+        .not_to raise_error
+    end
+
+    it "rejects a target that escapes via `..`" do
+      expect { described_class.ensure_targets_within!("--- a/../evil\n+++ a/../evil\n", strip: :p1, base:) }
+        .to raise_error(/escapes the staged source tree/)
+    end
+
+    it "rejects an absolute target that survives the strip level" do
+      expect { described_class.ensure_targets_within!("--- /etc/passwd\n+++ /etc/passwd\n", strip: :p0, base:) }
+        .to raise_error(/escapes the staged source tree/)
+    end
+
+    it "allows /dev/null with a space-separated timestamp" do
+      expect do
+        described_class.ensure_targets_within!("--- /dev/null 2024-01-01 10:00:00\n+++ b/new.c\n", strip: :p0, base:)
+      end
+        .not_to raise_error
+    end
+
+    it "rejects a tab-delimited header that escapes via `..`" do
+      expect { described_class.ensure_targets_within!("---\ta/../evil\n+++\ta/../evil\n", strip: :p1, base:) }
+        .to raise_error(/escapes the staged source tree/)
+    end
+  end
+
   describe "#resolves" do
     it "merges explicit resolves with CVEs inferred from url and apply paths" do
       patch = T.cast(described_class.create(:p1, nil) do
@@ -244,6 +280,17 @@ RSpec.describe Patch do
       end
 
       it(:cached_download) { expect(patch.cached_download).to eq("/tmp/foo.tar.gz") }
+    end
+  end
+
+  describe StringPatch do
+    it "refuses to apply a patch whose target escapes the source tree" do
+      patch = described_class.new(:p1, "--- a/../evil\n+++ a/../evil\n@@ -1 +1 @@\n-x\n+y\n")
+      mktmpdir do |dir|
+        Dir.chdir(dir) do
+          expect { patch.apply }.to raise_error(/escapes the staged source tree/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
External `patch do url ... end` and inline (`:DATA`/string) patches are streamed straight into `patch -g 0 -f -p<strip>` with no inspection of their target paths. Apple's `/usr/bin/patch` (unlike GNU patch 2.6+) honors `..` and absolute targets, so a patch whose `---`/`+++` headers point at `../outside` or `/abs/path` can write outside the staged source tree. External-patch checksums are only warned, not enforced, so an unchecksummed patch served by a compromised mirror is a realistic vector.

This adds `Patch.ensure_targets_within!`, called before `patch` runs from both `ExternalPatch#apply` and `EmbeddedPatch#apply`. It parses the diff's target-path headers, applies the strip level, and rejects any target whose normalized destination escapes the build directory, reusing the existing `Utils::Path.child_of?` containment check (`/dev/null` and in-tree paths pass through unchanged).

Most out-of-tree writes are already contained by the default macOS build sandbox, so this is primarily defense-in-depth, but it also covers Linux builds and runs where the sandbox is unavailable, and is cheap.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

A Codex security scan flagged the missing patch-target containment; Claude Code (Opus 4.8) validated it against the source, made the change and wrote the tests. I verified with `brew lgtm`.

-----
