### PR TITLE
Expand deferred env in curl URLs

### DIFF
--- a/Library/Homebrew/context.rb
+++ b/Library/Homebrew/context.rb
@@ -9,11 +9,19 @@ module Context
 
   # Struct describing the current execution context.
   class ContextStruct
-    sig { params(debug: T.nilable(T::Boolean), quiet: T.nilable(T::Boolean), verbose: T.nilable(T::Boolean)).void }
-    def initialize(debug: nil, quiet: nil, verbose: nil)
+    sig {
+      params(
+        debug:                          T.nilable(T::Boolean),
+        quiet:                          T.nilable(T::Boolean),
+        verbose:                        T.nilable(T::Boolean),
+        deferred_environment_expansion: T.nilable(T::Boolean),
+      ).void
+    }
+    def initialize(debug: nil, quiet: nil, verbose: nil, deferred_environment_expansion: nil)
       @debug = debug
       @quiet = quiet
       @verbose = verbose
+      @deferred_environment_expansion = deferred_environment_expansion
     end
 
     sig { returns(T::Boolean) }
@@ -29,6 +37,11 @@ module Context
     sig { returns(T::Boolean) }
     def verbose?
       @verbose == true
+    end
+
+    sig { returns(T::Boolean) }
+    def deferred_environment_expansion?
+      @deferred_environment_expansion == true
     end
   end
 
@@ -69,13 +82,24 @@ module Context
     Context.current.verbose?
   end
 
+  sig { returns(T::Boolean) }
+  def deferred_environment_expansion?
+    Context.current.deferred_environment_expansion?
+  end
+
   sig {
-    params(debug: T.nilable(T::Boolean), quiet: T.nilable(T::Boolean), verbose: T.nilable(T::Boolean),
-           _block: T.proc.void).returns(T.untyped)
+    params(
+      debug:                          T.nilable(T::Boolean),
+      quiet:                          T.nilable(T::Boolean),
+      verbose:                        T.nilable(T::Boolean),
+      deferred_environment_expansion: T.nilable(T::Boolean),
+      _block:                         T.proc.void,
+    ).returns(T.untyped)
   }
-  def with_context(debug: debug?, quiet: quiet?, verbose: verbose?, &_block)
+  def with_context(debug: debug?, quiet: quiet?, verbose: verbose?,
+                   deferred_environment_expansion: deferred_environment_expansion?, &_block)
     old_context = Context.current
-    Thread.current[:context] = ContextStruct.new(debug:, quiet:, verbose:)
+    Thread.current[:context] = ContextStruct.new(debug:, quiet:, verbose:, deferred_environment_expansion:)
 
     begin
       yield

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -40,3 +40,14 @@ require "download_strategy/mercurial_download_strategy"
 require "download_strategy/bazaar_download_strategy"
 require "download_strategy/fossil_download_strategy"
 require "download_strategy/download_strategy_detector"
+
+AbstractDownloadStrategy::HOMEBREW_CONTROLLED_STRATEGIES = T.let([
+  CurlApacheMirrorDownloadStrategy,
+  CurlDownloadStrategy,
+  CurlGitHubPackagesDownloadStrategy,
+  CurlPostDownloadStrategy,
+  HomebrewCurlDownloadStrategy,
+  NoUnzipCurlDownloadStrategy,
+  PyPIDownloadStrategy,
+].freeze, T::Array[T::Class[AbstractDownloadStrategy]])
+AbstractDownloadStrategy.private_constant :HOMEBREW_CONTROLLED_STRATEGIES

--- a/Library/Homebrew/download_strategy/abstract_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/abstract_download_strategy.rb
@@ -77,6 +77,11 @@ class AbstractDownloadStrategy
     Context.current.quiet? || @quiet || false
   end
 
+  sig { params(downloader: AbstractDownloadStrategy).returns(T::Boolean) }
+  def self.expand_deferred_environment_for?(downloader)
+    HOMEBREW_CONTROLLED_STRATEGIES.include?(downloader.class)
+  end
+
   # Unpack {#cached_location} into the current working directory.
   #
   # Additionally, if a block is given, the working directory was previously empty

--- a/Library/Homebrew/download_strategy/curl_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/curl_download_strategy.rb
@@ -16,6 +16,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
   sig { params(url: String, name: String, version: T.nilable(T.any(String, Version)), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     @try_partial = T.let(true, T::Boolean)
+    @expand_deferred_environment = T.let(false, T::Boolean)
     @mirrors = T.let(meta.fetch(:mirrors, []), T::Array[String])
     @file_size = T.let(nil, T.nilable(Integer))
     @last_modified = T.let(nil, T.nilable(Time))
@@ -261,6 +262,20 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
     curl_download resolved_url, to:, try_partial: @try_partial, timeout:
   end
 
+  sig { void }
+  def allow_deferred_environment_expansion!
+    @expand_deferred_environment = true
+  end
+
+  sig { params(args: T::Array[String]).returns(T::Array[String]) }
+  def expand_deferred_environment_args(args)
+    return args unless @expand_deferred_environment
+
+    with_context(deferred_environment_expansion: true) do
+      args.map { |arg| ENV.expand_deferred_environment(arg) }
+    end
+  end
+
   # Curl options to be always passed to curl,
   # with raw head calls (`curl --head`) or with actual `fetch`.
   sig { returns(T::Array[String]) }
@@ -273,7 +288,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     args += ["--user", meta.fetch(:user)] if meta.key?(:user)
 
-    args += meta.fetch(:headers, []).flat_map { |h| ["--header", ENV.expand_deferred_environment(h).strip] }
+    args += expand_deferred_environment_args(meta.fetch(:headers, [])).flat_map { |h| ["--header", h.strip] }
 
     args
   end
@@ -285,7 +300,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
   sig { override.params(args: String, options: T.untyped).returns(SystemCommand::Result) }
   def curl_output(*args, **options)
-    super(*_curl_args, *args, **_curl_opts, **options)
+    super(*_curl_args, *expand_deferred_environment_args(args), **_curl_opts, **options)
   end
 
   sig {
@@ -294,6 +309,6 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
   }
   def curl(*args, print_stdout: true, **options)
     options[:connect_timeout] = 15 unless mirrors.empty?
-    super(*_curl_args, *args, **_curl_opts, **command_output_options, **options)
+    super(*_curl_args, *expand_deferred_environment_args(args), **_curl_opts, **command_output_options, **options)
   end
 end

--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -134,7 +134,11 @@ module Downloadable
       raise ArgumentError, "attempted to use a `Downloadable` without a URL!" if primary_url.blank?
 
       download_strategy.new(primary_url, download_name, version,
-                            mirrors:, cache:, **T.must(@url).specs)
+                            mirrors:, cache:, **T.must(@url).specs).tap do |downloader|
+        if AbstractDownloadStrategy.expand_deferred_environment_for?(downloader)
+          downloader.send(:allow_deferred_environment_expansion!)
+        end
+      end
     end
   end
 

--- a/Library/Homebrew/extend/ENV/sensitive.rb
+++ b/Library/Homebrew/extend/ENV/sensitive.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "env_config"
+require "context"
 
 module EnvSensitive
   extend T::Helpers
@@ -68,6 +69,7 @@ module EnvSensitive
   sig { params(value: String).returns(String) }
   def expand_deferred_environment(value)
     return value unless value.include?(DEFERRED_PLACEHOLDER_PREFIX)
+    return value unless Context.current.deferred_environment_expansion?
 
     prefix = Regexp.escape(DEFERRED_PLACEHOLDER_PREFIX)
     suffix = Regexp.escape(DEFERRED_PLACEHOLDER_SUFFIX)

--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "ENV" do
   subject(:env) { {}.extend(EnvActivation).extend(described_class) }
 
   shared_examples EnvActivation do
+    include Context
+
     it "supports switching compilers" do
       subject.clang
       expect(subject["LD"]).to be_nil
@@ -188,20 +190,23 @@ RSpec.describe "ENV" do
     end
 
     describe "#clear_sensitive_environment_for_eval!" do
-      it "defers HOMEBREW_ secrets to a placeholder that expands to the real value" do
+      it "defers HOMEBREW_ secrets to a placeholder" do
         subject["HOMEBREW_PRIVATE_TOKEN"] = "glpat-secret"
 
         deferred = subject.clear_sensitive_environment_for_eval! { subject["HOMEBREW_PRIVATE_TOKEN"] }
 
         expect(deferred).not_to eq("glpat-secret")
         expect(deferred).not_to be_empty
-        expect(subject.expand_deferred_environment("PRIVATE-TOKEN: #{deferred}")).to eq("PRIVATE-TOKEN: glpat-secret")
+        expect(subject.expand_deferred_environment("PRIVATE-TOKEN: #{deferred}")).to eq("PRIVATE-TOKEN: #{deferred}")
       end
 
       it "never expands a non-HOMEBREW_ secret back to its real value" do
         subject["SECRET_TOKEN"] = "password"
         deferred = subject.clear_sensitive_environment_for_eval! { subject["SECRET_TOKEN"] }
-        expect(subject.expand_deferred_environment("X: #{deferred}")).not_to include("password")
+
+        with_context(deferred_environment_expansion: true) do
+          expect(subject.expand_deferred_environment("X: #{deferred}")).not_to include("password")
+        end
       end
 
       it "keeps HOMEBREW_GITHUB_API_TOKEN readable during eval" do
@@ -221,6 +226,16 @@ RSpec.describe "ENV" do
     describe "#expand_deferred_environment" do
       it "leaves values without a deferred placeholder unchanged" do
         expect(subject.expand_deferred_environment("PRIVATE-TOKEN: plain")).to eq("PRIVATE-TOKEN: plain")
+      end
+
+      it "expands placeholders only during download strategy fetches" do
+        subject["HOMEBREW_PRIVATE_TOKEN"] = "glpat-secret"
+        deferred = subject.clear_sensitive_environment_for_eval! { subject["HOMEBREW_PRIVATE_TOKEN"] }
+
+        with_context(deferred_environment_expansion: true) do
+          expect(subject.expand_deferred_environment("PRIVATE-TOKEN: #{deferred}"))
+            .to eq("PRIVATE-TOKEN: glpat-secret")
+        end
       end
     end
   end

--- a/Library/Homebrew/test/download_strategies/curl_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_spec.rb
@@ -36,8 +36,35 @@ RSpec.describe CurlDownloadStrategy do
 
     after { ENV.delete("HOMEBREW_PRIVATE_TOKEN") }
 
-    it "expands the placeholder to the real value at download time" do
-      expect(strategy.send(:_curl_args)).to include("PRIVATE-TOKEN: glpat-secret")
+    it "does not expand the placeholder outside Downloadable#fetch" do
+      expect(header).to include(EnvSensitive::DEFERRED_PLACEHOLDER_PREFIX)
+      expect(strategy.send(:_curl_args)).to include(header)
+    end
+  end
+
+  context "with a deferred HOMEBREW_ secret in the URL" do
+    let(:url) do
+      ENV["HOMEBREW_PRIVATE_TOKEN"] = "glpat-secret"
+      ENV.clear_sensitive_environment_for_eval! do
+        "https://example.com/foo.tar.gz?private_token=#{ENV.fetch("HOMEBREW_PRIVATE_TOKEN", nil)}"
+      end
+    end
+
+    after { ENV.delete("HOMEBREW_PRIVATE_TOKEN") }
+
+    it "does not expand the placeholder outside Downloadable#fetch" do
+      expect(url).to include(EnvSensitive::DEFERRED_PLACEHOLDER_PREFIX)
+      expect(strategy).to receive(:system_command)
+        .with(
+          /curl/,
+          hash_including(args: array_including(url)),
+        )
+        .at_least(:once)
+        .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "", assert_success!: nil))
+
+      strategy.temporary_path.dirname.mkpath
+      FileUtils.touch strategy.temporary_path
+      strategy.fetch
     end
   end
 

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -149,6 +149,66 @@ RSpec.describe Resource do
     end
   end
 
+  describe "#fetch" do
+    let(:url) do
+      ENV["HOMEBREW_PRIVATE_TOKEN"] = "glpat-secret"
+      ENV.clear_sensitive_environment_for_eval! do
+        "https://example.com/foo.tar.gz?private_token=#{ENV.fetch("HOMEBREW_PRIVATE_TOKEN", nil)}"
+      end
+    end
+    let(:headers) do
+      {
+        "accept-ranges"  => "bytes",
+        "content-length" => "37182",
+      }
+    end
+
+    before do
+      resource.url(url)
+      allow(resource.downloader).to receive(:curl_headers).with(any_args)
+                                                          .and_return({ responses: [{ headers: }] })
+    end
+
+    after do
+      ENV.delete("HOMEBREW_PRIVATE_TOKEN")
+      resource.clear_cache
+    end
+
+    it "expands deferred environment placeholders while downloading" do
+      expect(url).to include(EnvSensitive::DEFERRED_PLACEHOLDER_PREFIX)
+      expect(resource.downloader).to receive(:system_command)
+        .with(
+          /curl/,
+          hash_including(args: array_including("https://example.com/foo.tar.gz?private_token=glpat-secret")),
+        )
+        .at_least(:once)
+        .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "", assert_success!: nil))
+
+      resource.downloader.temporary_path.dirname.mkpath
+      FileUtils.touch resource.downloader.temporary_path
+      resource.fetch(verify_download_integrity: false)
+    end
+
+    it "does not expand placeholders for custom curl download strategies" do
+      expect(url).to include(EnvSensitive::DEFERRED_PLACEHOLDER_PREFIX)
+      resource.url(url, using: Class.new(CurlDownloadStrategy))
+      allow(resource.downloader).to receive(:curl_headers).with(any_args)
+                                                          .and_return({ responses: [{ headers: }] })
+
+      expect(resource.downloader).to receive(:system_command)
+        .with(
+          /curl/,
+          hash_including(args: array_including(url)),
+        )
+        .at_least(:once)
+        .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "", assert_success!: nil))
+
+      resource.downloader.temporary_path.dirname.mkpath
+      FileUtils.touch resource.downloader.temporary_path
+      resource.fetch(verify_download_integrity: false)
+    end
+  end
+
   describe "#stage" do
     let(:last_modified) { Time.utc(2026, 5, 6, 13, 43, 5) }
     let(:tarball) { TEST_FIXTURE_DIR/"tarballs/testball-0.1.tbz" }

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -651,6 +651,22 @@ RSpec.describe "Utils::Curl" do
 
       curl_output("--location", "https://example.com/example.tar.gz")
     end
+
+    it "does not expand deferred environment placeholders" do
+      ENV["HOMEBREW_PRIVATE_TOKEN"] = "glpat-secret"
+      url = ENV.clear_sensitive_environment_for_eval! do
+        "https://example.com/example.tar.gz?private_token=#{ENV.fetch("HOMEBREW_PRIVATE_TOKEN", nil)}"
+      end
+
+      expect(self).to receive(:system_command).with(
+        /curl/,
+        hash_including(args: array_including(url)),
+      ).and_return(
+        instance_double(SystemCommand::Result, success?: true, stdout: ""),
+      )
+
+      curl_output(url)
+    end
   end
 
   describe "::http_status_ok?" do


### PR DESCRIPTION
- Resolve deferred Homebrew secrets at the shared curl boundary so query-string tokens reach HEAD and download requests.
- Keep formula evaluation output masked while still passing real values to curl.

Fixes https://github.com/Homebrew/brew/issues/22879

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
