### PR TITLE
linkage_checker: always report incorrect `:no_linkage`

### DIFF
--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -98,10 +98,10 @@ class LinkageChecker
     display_items("Unwanted system libraries", @unwanted_system_dylibs, puts_output:)
     display_items("Conflicting libraries", @version_conflict_deps, puts_output:)
     display_items("Indirect dependencies with linkage", @indirect_deps, puts_output:)
+    display_items("Unexpected linkage for no_linkage dependencies", @unexpected_linkage_deps, puts_output:)
     return unless strict
 
     display_items("Undeclared dependencies with linkage", @undeclared_deps, puts_output:)
-    display_items("Unexpected linkage for no_linkage dependencies", @unexpected_linkage_deps, puts_output:)
     display_items("Files with missing rpath", @files_missing_rpaths, puts_output:)
     display_items "@executable_path references in libraries", @executable_path_dylibs, puts_output:
   end
@@ -112,11 +112,8 @@ class LinkageChecker
 
     issues = [@broken_deps, @broken_dylibs]
     if test
-      issues += [@unwanted_system_dylibs, @version_conflict_deps, @indirect_deps]
-      if strict
-        issues += [@undeclared_deps, @unexpected_linkage_deps,
-                   @files_missing_rpaths, @executable_path_dylibs]
-      end
+      issues += [@unwanted_system_dylibs, @version_conflict_deps, @indirect_deps, @unexpected_linkage_deps]
+      issues += [@undeclared_deps, @files_missing_rpaths, @executable_path_dylibs] if strict
     end
     issues.any?(&:present?)
   end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`:no_linkage` only makes sense if there is actually no linkage. There shouldn't be any false positives here (though the linkage may differ on macOS/Linux which is possible to handle via on_system blocks).

Just helps improve the metadata. Won't have a functional impact even if incorrect `:no_linkage` as we don't use this data outside of `brew linkage` output. But helps keep a canonical representation of a formula.

---

Among remaining that are strict-only:
* Missing RPATH has a lot of false positives as shared modules/bundle (macOS .so files) usually don't use dyld but we still report those.
* `@executable_path` are usually app bundles. This could be a potential issue when an app bundle includes copies of libraries, but we sometimes fix these up via symlinks so can be a false positive. Not sure if we can guarantee no usage of this.

For declared deps, I think that will fail the test if a dependency is linked into library but not installed during test. Though I can't tell if there are any false positives here so will leave this strict-only.