### PR TITLE
formula: `std_meson_args` prefix param and relative libdir

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2164,9 +2164,9 @@ class Formula
   # Standard parameters for Meson builds.
   #
   # @api public
-  sig { returns(T::Array[String]) }
-  def std_meson_args
-    ["--prefix=#{prefix}", "--libdir=#{lib}", "--buildtype=release", "--wrap-mode=nofallback"]
+  sig { params(prefix: T.any(String, Pathname), libdir: T.any(String, Pathname)).returns(T::Array[String]) }
+  def std_meson_args(prefix: self.prefix, libdir: "lib")
+    ["--prefix=#{prefix}", "--libdir=#{libdir}", "--buildtype=release", "--wrap-mode=nofallback"]
   end
 
   # Standard parameters for npm builds.

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -546,7 +546,7 @@ It also provides a convenient way to set `-ldflags`, `-gcflags`, and `-tags`, se
 
 ```ruby
 "--prefix=#{prefix}"
-"--libdir=#{lib}"
+"--libdir=lib"
 "--buildtype=release"
 "--wrap-mode=nofallback"
 ```


### PR DESCRIPTION
The prefix parameter allows similar to handling to `std_cmake_args` and `std_configure_args` as some formulae need to modify this to point to another path like for `glib`.

Meson's default `libdir` is a relative path that gets resolved w.r.t. the `prefix`. So we can use "lib" and let meson compute the path.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
