### PR TITLE
Add shared Utils::Path.ensure_child_of! containment helper

### DIFF
--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -49,9 +49,10 @@ module Patch
       next if path == File::NULL
 
       relative = path.split("/").drop(strip_count).join("/")
-      next if Utils::Path.child_of?(base, base/relative)
-
-      raise "Patch target path escapes the staged source tree: #{path}"
+      Utils::Path.ensure_child_of!(
+        base, base/relative,
+        message: "Patch target path escapes the staged source tree: #{path}"
+      )
     end
   end
 

--- a/Library/Homebrew/test/utils/path_spec.rb
+++ b/Library/Homebrew/test/utils/path_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe Utils::Path do
     end
   end
 
+  describe "::ensure_child_of!" do
+    it "allows a path that is a child of the parent" do
+      expect { described_class.ensure_child_of!("/foo", "/foo/bar", message: "outside") }.not_to raise_error
+    end
+
+    it "raises the provided message for a path that is not a child" do
+      expect { described_class.ensure_child_of!("/foo", "/bar/baz", message: "outside") }.to raise_error("outside")
+    end
+  end
+
   describe "::formula_opt_prefix" do
     it "returns a formula opt prefix without loading a Formula object" do
       expect(described_class.formula_opt_prefix("foo")).to eq(HOMEBREW_PREFIX/"opt/foo")

--- a/Library/Homebrew/utils/path.rb
+++ b/Library/Homebrew/utils/path.rb
@@ -14,6 +14,13 @@ module Utils
       false
     end
 
+    sig { params(parent: T.any(Pathname, String), child: T.any(Pathname, String), message: String).void }
+    def self.ensure_child_of!(parent, child, message:)
+      return if child_of?(parent, child)
+
+      raise message
+    end
+
     # The stable install path for a given formula name.
     #
     # @api public


### PR DESCRIPTION
Follow-up to #22881, which added `Patch.ensure_targets_within!` to reject patch targets that escape the staged source tree using `Utils::Path.child_of?`. In review, @MikeMcQuaid asked whether the containment enforcement should be broader than just patches.

This extracts the "enforce containment or raise" step into a shared `Utils::Path.ensure_child_of!(parent, child, message:)` helper, alongside the existing `child_of?` predicate, and routes the patch check through it. The diff-header parsing and `-p<strip>` handling stay in `Patch`, where they're genuinely patch-specific.

It has a single caller today, but as a security primitive a named, discoverable raiser is worth sharing: it nudges future containment checks toward it instead of re-rolling the kind of ad-hoc string-prefix logic that caused the `HOMEBREW_FORBID_PACKAGES_FROM_PATHS` bypass fixed in #22872.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code (Opus 4.8) extracted the shared helper and wrote the spec. I verified the refactor is behaviour-preserving with `brew lgtm`.

-----
