### PR TITLE
Allow uninstalling installed casks from untrusted taps

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -411,6 +411,14 @@ module Homebrew
               else
                 candidate_cask
               end
+            rescue Homebrew::UntrustedTapError
+              # The tap is untrusted, but an already-installed cask can still be
+              # removed by loading its installed cask file, which lives outside
+              # the tap and is therefore not subject to tap trust.
+              raise unless want_keg_like_cask
+
+              Cask::CaskLoader::FromInstalledPathLoader.try_new(name, warn:)&.load(config:) ||
+                Cask::Cask.new(name, config:)
             rescue Cask::CaskUnreadableError, Cask::CaskInvalidError => e
               # If we're trying to get a keg-like Cask, do our best to handle it
               # not being readable and return something that can be used.

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -177,6 +177,18 @@ RSpec.describe Homebrew::CLI::NamedArgs do
     end
   end
 
+  describe "#to_formulae_and_casks_and_unavailable" do
+    it "falls back to the installed cask file when a keg-like cask's tap is untrusted", :needs_macos do
+      allow(Cask::CaskLoader).to receive(:load).with("foo", any_args)
+                                               .and_raise(Homebrew::UntrustedTapError.new("untrusted"))
+      installed_loader = instance_double(Cask::CaskLoader::FromInstalledPathLoader, load: foo_cask)
+      allow(Cask::CaskLoader::FromInstalledPathLoader).to receive(:try_new)
+        .with("foo", any_args).and_return(installed_loader)
+
+      expect(described_class.new("foo").to_formulae_and_casks_and_unavailable(method: :kegs)).to eq [foo_cask]
+    end
+  end
+
   describe "#to_resolved_formulae" do
     it "returns resolved formulae" do
       allow(Formulary).to receive(:resolve).and_return(foo, bar)


### PR DESCRIPTION
When `HOMEBREW_REQUIRE_TAP_TRUST` is set and a cask's tap is untrusted, `brew uninstall` (and `brew bundle cleanup`, which shells out to it) could not remove an already-installed cask. Cask removal must load the cask to know its artifacts, and `NamedArgs#load_formula_or_cask` loaded it from the tap, raising `UntrustedTapError` unless the exact fully-qualified name happened to be in `ARGV`. Passing a bare token or mistyping the name left the cask, and its app, stuck on the system.

Mirror the fallback already used by `Cask::Caskroom.casks`: when a keg-like (uninstall/cleanup) cask load hits `UntrustedTapError`, load the installed cask file instead. That file lives in the Caskroom rather than the tap, so it carries the artifacts needed to remove the app and is not subject to tap trust. Installs still enforce trust.

Closes #22892.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

I used Claude Opus 4.8 in Claude Code to write code and GPT 5.5 to double check results before manually verifying.

-----
