### PR TITLE
Info: hide unlinkable kegs

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -855,6 +855,7 @@ module Homebrew
           ]
           ordered_kegs.each_with_index.map { |keg, index| [other, keg, index.zero?] }
         end
+        with_kegs = with_kegs.select { |_other, keg, newest| newest || keg.linked? } unless verbose
         rows = with_kegs.map do |other, keg, newest|
           name_status = pretty_install_status(other.full_name, installed: true, outdated: other.outdated?)
           version = keg.version.to_s

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -735,7 +735,7 @@ module Homebrew
 
         installed_lines = installed_section_lines(shadowing_formula || formula, verbose: args.verbose?)
         unless installed_lines.empty?
-          ohai "Installed Kegs and Versions"
+          ohai(args.verbose? ? "Installed Kegs and Versions" : "Installed Versions")
           installed_lines.each { |line| puts line }
         end
 

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -1316,7 +1316,7 @@ RSpec.describe Homebrew::Cmd::Info do
 
       expect { info.send(:info_formula, main_formula) }
         .to output(Regexp.new(
-                     "==> Installed Kegs and Versions\n" \
+                     "==> Installed Versions\n" \
                      ".*testball\\b.*\\s+1\\.0\\s+\\(.*\\)\n" \
                      ".*testball@0\\.9\\b.*\\s+0\\.9\\s+\\(",
                    )).to_stdout
@@ -1343,7 +1343,7 @@ RSpec.describe Homebrew::Cmd::Info do
       allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
 
       expect { info.send(:info_formula, main_formula) }
-        .to output(/==> Installed Kegs and Versions\n.*testball\b.*\s+1\.0 → 2\.0\s+\(/).to_stdout
+        .to output(/==> Installed Versions\n.*testball\b.*\s+1\.0 → 2\.0\s+\(/).to_stdout
         .and not_to_output(/0\.9 →/).to_stdout
         .and not_to_output.to_stderr
     end
@@ -1367,7 +1367,7 @@ RSpec.describe Homebrew::Cmd::Info do
       allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
 
       expect { info.send(:info_formula, main_formula) }
-        .to output(/==> Installed Kegs and Versions\n.*testball\b.*\s+1\.0\s+\(/).to_stdout
+        .to output(/==> Installed Versions\n.*testball\b.*\s+1\.0\s+\(/).to_stdout
         .and not_to_output(/\s+0\.9\s+\(/).to_stdout
         .and not_to_output.to_stderr
     end
@@ -1437,7 +1437,7 @@ RSpec.describe Homebrew::Cmd::Info do
 
       expect { info.send(:info_formula, versioned) }
         .to output(Regexp.new(
-                     "==> Installed Kegs and Versions\n" \
+                     "==> Installed Versions\n" \
                      ".*testball\\b.*\\s+1\\.0\\s+\\(.*\\)\n" \
                      ".*testball@0\\.9\\b.*\\s+0\\.9\\s+\\(",
                    )).to_stdout
@@ -1461,7 +1461,7 @@ RSpec.describe Homebrew::Cmd::Info do
       allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
 
       expect { info.send(:info_formula, main_formula) }
-        .to output(/==> Installed Kegs and Versions\n.*testball\b.*\s+1\.0\s+\(/).to_stdout
+        .to output(/==> Installed Versions\n.*testball\b.*\s+1\.0\s+\(/).to_stdout
         .and not_to_output.to_stderr
     end
 
@@ -1488,7 +1488,7 @@ RSpec.describe Homebrew::Cmd::Info do
       allow(info).to receive(:github_info).with(versioned).and_return("https://example.com/testball.rb")
 
       expect { info.send(:info_formula, versioned) }
-        .to output(/==> Installed Kegs and Versions\n.*testball\b.*\s+1\.0\s+\(/).to_stdout
+        .to output(/==> Installed Versions\n.*testball\b.*\s+1\.0\s+\(/).to_stdout
         .and not_to_output(/testball@0\.9 \(0\.9\)/).to_stdout
         .and not_to_output.to_stderr
     end
@@ -1533,7 +1533,7 @@ RSpec.describe Homebrew::Cmd::Info do
       allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
 
       expect { info.send(:info_formula, main_formula) }
-        .to not_to_output(/==> Installed Kegs and Versions\b/).to_stdout
+        .to not_to_output(/==> Installed Versions\b/).to_stdout
         .and not_to_output.to_stderr
     end
   end

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -1343,12 +1343,32 @@ RSpec.describe Homebrew::Cmd::Info do
       allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
 
       expect { info.send(:info_formula, main_formula) }
-        .to output(Regexp.new(
-                     "==> Installed Kegs and Versions\n" \
-                     ".*testball\\b.*\\s+1\\.0 → 2\\.0\\s+\\(.*\\)\n" \
-                     ".*testball\\b.*\\s+0\\.9\\s+\\(",
-                   )).to_stdout
+        .to output(/==> Installed Kegs and Versions\n.*testball\b.*\s+1\.0 → 2\.0\s+\(/).to_stdout
         .and not_to_output(/0\.9 →/).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "hides older non-linked kegs by default" do
+      info = described_class.new([])
+      main_formula = formula("testball") do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/testball-1.0.tar.gz"
+      end
+
+      ["1.0", "0.9"].each do |version|
+        keg_path = HOMEBREW_CELLAR/"testball/#{version}"
+        keg_path.mkpath
+        tab = Tab.empty
+        tab.tabfile = keg_path/AbstractTab::FILENAME
+        tab.write
+      end
+
+      allow(main_formula).to receive(:versioned_formulae).and_return([])
+      allow(info).to receive(:github_info).with(main_formula).and_return("https://example.com/testball.rb")
+
+      expect { info.send(:info_formula, main_formula) }
+        .to output(/==> Installed Kegs and Versions\n.*testball\b.*\s+1\.0\s+\(/).to_stdout
+        .and not_to_output(/\s+0\.9\s+\(/).to_stdout
         .and not_to_output.to_stderr
     end
 
@@ -1473,8 +1493,8 @@ RSpec.describe Homebrew::Cmd::Info do
         .and not_to_output.to_stderr
     end
 
-    it "lists every installed keg of a formula, newest first" do
-      info = described_class.new([])
+    it "lists every installed keg of a formula, newest first, with --verbose" do
+      info = described_class.new(["--verbose"])
       main_formula = formula("testball") do
         T.bind(self, T.class_of(Formula))
         url "https://brew.sh/testball-1.0.tar.gz"
@@ -1495,7 +1515,9 @@ RSpec.describe Homebrew::Cmd::Info do
         .to output(Regexp.new(
                      "==> Installed Kegs and Versions\n" \
                      ".*testball\\b.*\\s+1\\.0\\b.*\\(.*\\)\n" \
+                     "(?: .*\n)*" \
                      ".*testball\\b.*\\s+0\\.10\\s+\\(.*\\)\n" \
+                     "(?: .*\n)*" \
                      ".*testball\\b.*\\s+0\\.9\\s+\\(",
                    )).to_stdout
         .and not_to_output.to_stderr

--- a/Library/Homebrew/test/utils/path_spec.rb
+++ b/Library/Homebrew/test/utils/path_spec.rb
@@ -86,6 +86,16 @@ RSpec.describe Utils::Path do
       expect(described_class.formula_installed_prefixes(["foo", "old-foo"]))
         .to eq([tmpdir/"old-foo/1.0", tmpdir/"foo/2.0"])
     end
+
+    it "does not list kegs twice when a name is a symlink to another rack" do
+      tmpdir = mktmpdir
+      stub_const("HOMEBREW_CELLAR", tmpdir)
+      (tmpdir/"foo/1.0").mkpath
+      FileUtils.ln_s(tmpdir/"foo", tmpdir/"foo-alias")
+
+      expect(described_class.formula_installed_prefixes(["foo", "foo-alias"]))
+        .to eq([tmpdir/"foo/1.0"])
+    end
   end
 
   describe "::formula_any_version_installed?" do

--- a/Library/Homebrew/utils/path.rb
+++ b/Library/Homebrew/utils/path.rb
@@ -108,6 +108,7 @@ module Utils
     def self.formula_installed_prefixes(formula_names)
       Array(formula_names).map { |formula_name| HOMEBREW_CELLAR/Utils.name_from_full_name(formula_name) }
                           .select(&:directory?)
+                          .uniq(&:realpath)
                           .flat_map(&:subdirs)
                           .sort_by(&:basename)
     end


### PR DESCRIPTION
I temporarily switched to my old laptop with outdated packages, and was confused about the output now, so thought I would improve it.

Only show the newest keg of each formula plus any linked keg in the "Installed Kegs and Versions" section by default. Older, non-linked kegs are listed only with --verbose.

```
$ brew info python
==> python@3.14 ↑: 3.7.1 → stable 3.14.6
...
==> Installed Versions
python@3.9 ↑  3.9.4 → 3.9.25 (7,828 files, 121.3MB) [Linked]
python@3.14 ↑ 3.7.1 → 3.14.6 (3,904 files, 63.3MB)


$ brew info python -v
==> python@3.14 ↑: 3.7.1 → stable 3.14.6
...
==> Installed Kegs and Versions
python@3.9 ↑  3.9.4 → 3.9.25 (7,828 files, 121.3MB) [Linked]
  Built from source on 2021-04-11 at 22:10:27
python@3.14 ↑ 3.7.1 → 3.14.6 (3,904 files, 63.3MB)
  Poured from bottle on 2018-11-18 at 00:53:51
python@3.14 ↑ 3.6.4_4        (4,831 files, 105MB)
  Poured from bottle on 2018-03-10 at 12:12:56
python@3.14 ↑ 3.6.1          (3,807 files, 61MB)
  Poured from bottle on 2017-06-25 at 03:09:08
python@3.14 ↑ 2.7.14_2       (3,576 files, 51.8MB)
  Poured from bottle on 2018-02-04 at 12:50:32
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code wrote the code as it iterated toward the solution.

Manually tested changes.

-----
