### PR TITLE
audit: require curl dependencies to have a working HTTP mirror

### DIFF
--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -183,7 +183,7 @@ module Homebrew
     def audit_urls
       urls = [url.to_s] + mirrors
 
-      curl_dep = self.class.curl_deps.include?(owner!.name)
+      curl_dep = curl_dep?
       # Ideally `ca-certificates` would not be excluded here, but sourcing a HTTP mirror was tricky.
       # Instead, we have logic elsewhere to pass `--insecure` to curl when downloading the certs.
       # TODO: try remove the OS/env conditional
@@ -232,6 +232,44 @@ module Homebrew
       end
     end
 
+    # `curl` dependencies must be fetchable before `ca-certificates`, so at least
+    # one mirror must serve the expected file over plain HTTP.
+    sig { void }
+    def audit_curl_dep_http_mirror
+      return unless @online
+      return if spec_name != :stable
+      # Only audit the formula's own source, not its `resource` blocks.
+      return if name != owner!.name
+      return unless curl_dep?
+
+      checksum = self.checksum
+      return if checksum.nil?
+
+      http_mirrors = mirrors.select { |mirror| mirror.start_with?("http://") }
+      return if http_mirrors.empty?
+
+      working_mirror = http_mirrors.find do |mirror|
+        details = curl_http_content_headers_and_checksum(
+          mirror,
+          hash_needed:       true,
+          use_homebrew_curl: @use_homebrew_curl,
+          # Fail rather than follow an HTTPS redirect, so a successful request
+          # with a matching checksum proves the bytes came over plain HTTP.
+          specs:             { proto_redir: "=http" },
+        )
+
+        # Reject an explicit HTTPS `final_url` as defence-in-depth; a relative or
+        # HTTP `Location` from an HTTP-to-HTTP redirect is fine.
+        http_status_ok?(details[:status_code]) &&
+          !details[:final_url].to_s.start_with?("https://") &&
+          details[:file_hash] == checksum.hexdigest
+      end
+      return if working_mirror
+
+      problem "`curl` dependencies must have a working HTTP mirror that serves " \
+              "the expected checksum over plain HTTP."
+    end
+
     sig { void }
     def audit_head_branch
       return unless @online
@@ -263,6 +301,11 @@ module Homebrew
     end
 
     private
+
+    sig { returns(T::Boolean) }
+    def curl_dep?
+      self.class.curl_deps.include?(owner!.name)
+    end
 
     sig { returns(Resource::Owner) }
     def owner!

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -798,6 +798,98 @@ RSpec.describe Homebrew::FormulaAuditor do
       expect(fa.problems).to be_empty
     end
 
+    it "accepts a curl dependency with a working HTTP mirror" do
+      sha256 = "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
+      mirror_url = "http://brew.sh/mirror/foo-1.0.tgz"
+      allow(Homebrew::ResourceAuditor).to receive(:curl_deps).and_return(["foo"])
+      fa = formula_auditor "foo", <<~RUBY, online: true
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          mirror "#{mirror_url}"
+          sha256 "#{sha256}"
+        end
+      RUBY
+      allow_any_instance_of(Homebrew::ResourceAuditor).to receive(:curl_http_content_headers_and_checksum)
+        .and_return(status_code: "200", final_url: nil, file_hash: sha256)
+
+      fa.audit_specs
+      expect(fa.problems).to be_empty
+    end
+
+    it "accepts a curl dependency whose HTTP mirror redirects to a relative path" do
+      sha256 = "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
+      allow(Homebrew::ResourceAuditor).to receive(:curl_deps).and_return(["foo"])
+      fa = formula_auditor "foo", <<~RUBY, online: true
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          mirror "http://brew.sh/mirror/foo-1.0.tgz"
+          sha256 "#{sha256}"
+        end
+      RUBY
+      allow_any_instance_of(Homebrew::ResourceAuditor).to receive(:curl_http_content_headers_and_checksum)
+        .and_return(status_code: "200", final_url: "/mirror/foo-1.0.tgz", file_hash: sha256)
+
+      fa.audit_specs
+      expect(fa.problems).to be_empty
+    end
+
+    it "reports a curl dependency whose HTTP mirror serves the wrong checksum" do
+      mirror_url = "http://brew.sh/mirror/foo-1.0.tgz"
+      allow(Homebrew::ResourceAuditor).to receive(:curl_deps).and_return(["foo"])
+      fa = formula_auditor "foo", <<~RUBY, online: true
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          mirror "#{mirror_url}"
+          sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
+        end
+      RUBY
+      allow_any_instance_of(Homebrew::ResourceAuditor).to receive(:curl_http_content_headers_and_checksum)
+        .and_return(status_code: "200", final_url: mirror_url, file_hash: "deadbeef")
+
+      fa.audit_specs
+      expect(fa.problems).to include(
+        a_hash_including(message: a_string_including("must have a working HTTP mirror")),
+      )
+    end
+
+    it "reports a curl dependency whose HTTP mirror is unreachable" do
+      mirror_url = "http://brew.sh/mirror/foo-1.0.tgz"
+      allow(Homebrew::ResourceAuditor).to receive(:curl_deps).and_return(["foo"])
+      fa = formula_auditor "foo", <<~RUBY, online: true
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          mirror "#{mirror_url}"
+          sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
+        end
+      RUBY
+      allow_any_instance_of(Homebrew::ResourceAuditor).to receive(:curl_http_content_headers_and_checksum)
+        .and_return(status_code: nil, final_url: nil, file_hash: nil)
+
+      fa.audit_specs
+      expect(fa.problems).to include(
+        a_hash_including(message: a_string_including("must have a working HTTP mirror")),
+      )
+    end
+
+    it "reports a curl dependency whose HTTP mirror redirects to HTTPS" do
+      sha256 = "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
+      allow(Homebrew::ResourceAuditor).to receive(:curl_deps).and_return(["foo"])
+      fa = formula_auditor "foo", <<~RUBY, online: true
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          mirror "http://brew.sh/mirror/foo-1.0.tgz"
+          sha256 "#{sha256}"
+        end
+      RUBY
+      allow_any_instance_of(Homebrew::ResourceAuditor).to receive(:curl_http_content_headers_and_checksum)
+        .and_return(status_code: "200", final_url: "https://brew.sh/mirror/foo-1.0.tgz", file_hash: sha256)
+
+      fa.audit_specs
+      expect(fa.problems).to include(
+        a_hash_including(message: a_string_including("must have a working HTTP mirror")),
+      )
+    end
+
     it "requires `branch:` to be specified for Git head URLs" do
       fa = formula_auditor "foo", <<~RUBY, online: true
         class Foo < Formula


### PR DESCRIPTION
`brew audit` already checks that `curl` dependencies *list* an HTTP mirror, since they can be fetched before `ca-certificates` is available and so need a source archive reachable over plain HTTP. It never checks that the mirror actually *works*, though, so a silently broken HTTP mirror still passes. Spotted by @cho-m after a recent `libpsl` update whose HTTP mirror (MacPorts) started 404ing while the audit stayed green.

This adds an online `ResourceAuditor#audit_curl_dep_http_mirror`, run only for stable specs of `curl` dependencies. It fetches each `http://` mirror with `--proto-redir =http` so that an HTTPS redirect fails rather than masking a non-functional plain-HTTP path, then confirms the bytes match the resource checksum, reporting a problem only when no HTTP mirror works. It generalises the manual checksum check the `xz` formula currently performs in its `test` block.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Drafted with Claude Code (Opus 4.8). I verified with `brew lgtm` and by confirming the new specs fail against the disabled check and pass with it.

-----
