### PR TITLE
bump-cask-pr: error when update fails

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -168,7 +168,10 @@ module Homebrew
               commit_message += " (intel only)"
             end
           end
+
+          before_contents = new_contents
           new_contents = replace_version_and_checksum(cask, new_hash, new_version, new_contents)
+          raise "Unable to update cask" if new_contents == before_contents
         end
 
         commit_message ||= "#{cask.token}: update checksum" if new_hash


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

With the new approach to version/checksum modification that was introduced recently (https://github.com/Homebrew/brew/pull/22462), `bump-cask-pr` doesn't attempt to modify values in an on_arch block that's nested within another block (e.g., on_os). In this scenario, `replace_version_and_checksum` won't modify the provided contents but `bump-cask-pr` won't fail unless/until a subsequent audit fails (e.g., livecheck version mismatch).

`bump-cask-pr` shouldn't proceed to the audit or style check steps if the cask hasn't been modified, so this adds a guard to raise an error instead.

-----

For context, I encountered this issue while looking through homebrew-cask autobump logs. For example, the `r-app` cask is unable to be autobumped to the latest version because it uses arch-specific versions nested in an `on_big_sur :or_newer` block, which `bump-cask-pr` doesn't attempt to modify (i.e., `unsupported_nested_arch_stanza?(contents, :version, arch)` is true for both archs in `replace_version_and_checksum`). The update attempt only fails during the audit step, as the cask's versions differ from the livecheck versions (due to being unchanged).