### PR TITLE
Add `CCACHE_FOUND=OFF` to default CMake flags

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2125,6 +2125,7 @@ class Formula
       -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=#{HOMEBREW_LIBRARY_PATH}/cmake/trap_fetchcontent_provider.cmake
       -Wno-dev
       -DBUILD_TESTING=OFF
+      -DCCACHE_FOUND=OFF
     ]
   end
 


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

As discussed with @SMillerDev in https://github.com/orgs/Homebrew/discussions/6920, some formulae fail to build if `ccache` is installed. Simple example:
```bash
docker run --rm -it ghcr.io/homebrew/ubuntu24.04:main \
bash -lc 'brew install --yes ccache && brew install --yes --build-from-source ada-url'
```

This is due to the fact that `ccache` integration in several formulae is typically handled as e.g.:
```cmake
find_program(CCACHE_FOUND ccache)
if(CCACHE_FOUND)
  message(STATUS "Ccache found: using it as compiler launcher.")
  set(CMAKE_C_COMPILER_LAUNCHER ccache)
  set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
endif()
```
instead of e.g.:
```cmake
find_program(CCACHE_FOUND ccache)
if(CCACHE_FOUND)
  message(STATUS "Using ccache: ${CCACHE_FOUND}")
  set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_FOUND})
  set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_FOUND})
endif()
```
So, if `ccache` is not on `$PATH`, the build will fail.

This is certainly an upstream problem. However, as a matter of fact, it currently affects at least 20 Homebrew formulae (minimum, these are just the ones I could find): [ada-url](https://github.com/ada-url/ada/blob/791fb5c0a570b69b598d71b98827ff9f18a6a6c3/cmake/ada-flags.cmake#L61), [apache-arrow](https://github.com/apache/arrow/blob/ad31a1c62cafc3094171cc975e32457de9488150/cpp/CMakeLists.txt#L266), [cppinsights](https://github.com/andreasfertig/cppinsights/blob/37b1b1f2da9eb8af30809de81beb424dd2c1e89e/CMakeLists.txt#L513), [exiv2](https://github.com/Exiv2/exiv2/blob/57684e1489af041fc54be6fdaa0110c2b9861639/cmake/findDependencies.cmake#L88), [kingfisher](https://github.com/mongodb/kingfisher/blob/61a2ab66a0b99521f4eb3073af7638e44a055978/vendor/vectorscan-rs/vectorscan-rs-sys/vectorscan/CMakeLists.txt#L31), [libff](https://github.com/scipr-lab/libff/blob/674e437446216ade040194105b4fc9ff3d8db6f1/CMakeLists.txt#L199), [librealsense](https://github.com/IntelRealSense/librealsense/blob/b9d9454b8b00f5dd7b700a25b21731dd34696985/CMake/global_config.cmake#L13), [libwbxml](https://github.com/libwbxml/libwbxml/blob/ebeb80d6f3ded9a951f1d28229368db8edf05df7/CMakeLists.txt#L273), [lief](https://github.com/lief-project/LIEF/blob/00341b040edda834dd5c001b0d2e4e019bae288f/CMakeLists.txt#L56), [merve](https://github.com/nodejs/merve/blob/12945b6c3c082878288b5e5804eb7bd68a3398a9/cmake/lexer-flags.cmake#L32), [musikcube](https://github.com/clangen/musikcube/blob/9bc1234c8c36e40e255bc3878c0eba2c82b9cdeb/CMakeLists.txt#L33), [osrm-backend](https://github.com/Project-OSRM/osrm-backend/blob/1486e7fd45073f41a20159f139e0a2f91bd8b7fb/CMakeLists.txt#L471), [ppsspp](https://github.com/hrydgard/ppsspp/blob/dee3cbac84f5a905661e2204d04ef47cc1fba32a/cmake/Modules/ccache.cmake#L3), [rapidjson](https://github.com/Tencent/rapidjson/blob/24b5e7a8b27f42fa16b96fc70aade9106cf7102f/CMakeLists.txt#L49), [rocksdb](https://github.com/facebook/rocksdb/blob/43d60bfe9ee44c07832f3cea260e2335b1bbd6dd/CMakeLists.txt#L90), [rtags](https://github.com/Andersbakken/rtags/blob/9a452df19b7bf9ec71765a602bfb77bc73cf2fac/CMakeLists.txt#L10), [taglib](https://github.com/taglib/taglib/blob/e589efd0dac005c45ff739a959463f3ecba2aa12/CMakeLists.txt#L26), [tdlib](https://github.com/tdlib/td/blob/a17f87c4cff7b90b278d12b91ba0614383aaee82/CMakeLists.txt#L61), [vectorscan](https://github.com/VectorCamp/vectorscan/blob/77c9011a293c403215605ebf1af4bd11840a62d5/CMakeLists.txt#L38), [yalantinglibs](https://github.com/alibaba/yalantinglibs/blob/01ea3aacc2e65c44b2ba14cb5d1a5fcc9b7c0ff0/cmake/build.cmake#L79).

As the CMake snippets above seem to be a fairly standard approach even for formulae not currently packaged by Homebrew, as it can be quickly verified by a code search, this PR proposes to add `-DCCACHE_FOUND=OFF` to the standard CMake flags. For the same formula as before, this will now work if using the proposed additional flag:
```bash
docker run --rm -it ghcr.io/homebrew/ubuntu24.04:main \
bash -lc 'set -euo pipefail; export HOMEBREW_NO_AUTO_UPDATE=1; curl -fsSL https://raw.githubusercontent.com/matteosecli/brew/344b6d838de7caf9457c4c58db879b8481d929b8/Library/Homebrew/formula.rb > "$(brew --repository)/Library/Homebrew/formula.rb"; brew install --yes ccache && brew install --yes --build-from-source ada-url'
```

Adding this flag will also be beneficial if other formulae, in the future, decide to include the same CMake snippet or to enable ccache discovery by default in their CMake files, or if newer CI build images will happen to ship with ccache preinstalled.