### PR TITLE
Sort the upgrade summary package list alphabetically

### DIFF
--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -601,8 +601,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
     expect { cmd.send(:show_final_upgrade_summary) }.to output(<<~EOS).to_stdout
       ==> Would upgrade 2 outdated packages
-      testball  0.1 -> 0.2 (500B)
       codex     1.0 -> 2.0
+      testball  0.1 -> 0.2 (500B)
     EOS
   end
 
@@ -662,8 +662,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
     expect { cmd.run }.to output(<<~EOS).to_stdout
       ==> Upgrading 2 outdated packages:
-      deno   2.7.10  -> 2.7.11
       codex  0.117.0 -> 0.118.0
+      deno   2.7.10  -> 2.7.11
       ==> Fetching downloads for: deno and codex
     EOS
   end
@@ -761,8 +761,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     expect { cmd.run }.to output(<<~EOS).to_stdout
       ==> Downloading Cask files
       ==> Upgrading 2 outdated packages:
-      deno   2.7.10  -> 2.7.11
       codex  0.117.0 -> 0.118.0
+      deno   2.7.10  -> 2.7.11
       ==> Fetching downloads for: deno and codex
     EOS
   end
@@ -807,8 +807,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
     expect { cmd.run }.to output(<<~EOS).to_stdout
       ==> Upgrading 2 outdated packages:
-      deno   2.7.10  -> 2.7.11
       codex  0.117.0 -> 0.118.0
+      deno   2.7.10  -> 2.7.11
       ==> Fetching downloads for: deno and codex
     EOS
   end

--- a/Library/Homebrew/test/upgrade_spec.rb
+++ b/Library/Homebrew/test/upgrade_spec.rb
@@ -5,7 +5,7 @@ require "upgrade"
 
 RSpec.describe Homebrew::Upgrade do
   describe "::format_upgrade_summary" do
-    it "aligns a large mixed list of package names and versions" do
+    it "sorts alphabetically and aligns a large mixed list of package names and versions" do
       upgrades = [
         "sqlite 3.53.1 -> 3.53.2 (2.4MB)",
         "docker 29.5.2 -> 29.6.0 (9.3MB)",
@@ -26,21 +26,21 @@ RSpec.describe Homebrew::Upgrade do
       ]
 
       expect(described_class.format_upgrade_summary(upgrades)).to eq([
-        "sqlite              3.53.1     -> 3.53.2 (2.4MB)",
+        "certifi             2026.5.20  -> 2026.6.17 (5.7KB)",
         "docker              29.5.2     -> 29.6.0 (9.3MB)",
         "gh                  2.93.0     -> 2.95.0 (13.4MB)",
-        "python@3.14         3.14.5     -> 3.14.6 (19.2MB)",
-        "pnpm                11.5.1     -> 11.8.0 (4MB)",
-        "usage               3.4.0      -> 3.5.2 (2.9MB)",
-        "certifi             2026.5.20  -> 2026.6.17 (5.7KB)",
-        "libvmaf             3.1.0      -> 3.2.0 (1.2MB)",
-        "kubernetes-cli      1.36.1     -> 1.36.2 (18.2MB)",
         "jq                  1.8.1      -> 1.8.2 (441KB)",
+        "kubernetes-cli      1.36.1     -> 1.36.2 (18.2MB)",
+        "libvmaf             3.1.0      -> 3.2.0 (1.2MB)",
         "mise                2026.6.0   -> 2026.6.11 (34.8MB)",
-        "sdl2                2.32.70 (636.8KB)",
         "opencode-desktop    1.14.48    -> 1.17.9",
+        "pnpm                11.5.1     -> 11.8.0 (4MB)",
+        "python@3.14         3.14.5     -> 3.14.6 (19.2MB)",
+        "sdl2                2.32.70 (636.8KB)",
         "slack               4.48.102   -> 4.50.140",
         "spotify             1.2.84.476 -> 1.2.92.148",
+        "sqlite              3.53.1     -> 3.53.2 (2.4MB)",
+        "usage               3.4.0      -> 3.5.2 (2.9MB)",
         "visual-studio-code  1.111.0    -> 1.125.1",
       ])
     end

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -24,6 +24,7 @@ module Homebrew
     class << self
       sig { params(upgrades: T::Array[String]).returns(T::Array[String]) }
       def format_upgrade_summary(upgrades)
+        upgrades = upgrades.sort_by { |upgrade| upgrade.split(" ", 2).fetch(0) }
         return upgrades if upgrades.size < 2
 
         name_width = upgrades.map { |upgrade| upgrade.split(" ", 2).fetch(0).length }.max

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -24,8 +24,9 @@ module Homebrew
     class << self
       sig { params(upgrades: T::Array[String]).returns(T::Array[String]) }
       def format_upgrade_summary(upgrades)
-        upgrades = upgrades.sort_by { |upgrade| upgrade.split(" ", 2).fetch(0) }
         return upgrades if upgrades.size < 2
+
+        upgrades = upgrades.sort_by { |upgrade| upgrade.split(" ", 2).fetch(0) }
 
         name_width = upgrades.map { |upgrade| upgrade.split(" ", 2).fetch(0).length }.max
         name_width ||= 0

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -26,12 +26,12 @@ module Homebrew
       def format_upgrade_summary(upgrades)
         return upgrades if upgrades.size < 2
 
-        upgrades = upgrades.sort_by { |upgrade| upgrade.split(" ", 2).fetch(0) }
+        upgrades = upgrades.map { |upgrade| upgrade.split(" ", 2) }.sort_by { |upgrade| upgrade.fetch(0) }
 
-        name_width = upgrades.map { |upgrade| upgrade.split(" ", 2).fetch(0).length }.max
+        name_width = upgrades.map { |upgrade| upgrade.fetch(0).length }.max
         name_width ||= 0
         old_version_width = upgrades.filter_map do |upgrade|
-          versions = upgrade.split(" ", 2).fetch(1, "")
+          versions = upgrade.fetch(1, "")
           next unless versions.include?(" -> ")
 
           versions.split(" -> ", 2).fetch(0).length
@@ -39,9 +39,8 @@ module Homebrew
         old_version_width ||= 0
 
         upgrades.map do |upgrade|
-          parts = upgrade.split(" ", 2)
-          name = parts.fetch(0)
-          versions = parts.fetch(1, "")
+          name = upgrade.fetch(0)
+          versions = upgrade.fetch(1, "")
           next name if versions.blank?
 
           if versions.include?(" -> ")


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

This PR was prepared with the assistance of Claude Code (model: Claude Opus 4.8). I reviewed all of the generated content, ran `brew lgtm` locally, and am able to address review comments independently.

-----

## What this does

`brew upgrade` lists packages in the upgrade summary in resolution order, which is effectively arbitrary. This sorts them alphabetically by package name in `Homebrew::Upgrade.format_upgrade_summary` — the shared helper used by the formula upgrade preview, the final "Upgraded N outdated packages" summary, and the cask upgrade summary — so all three become consistently alphabetical.

Column widths in the formatted output depend only on the set of items, not their order, so this change only reorders the printed lines. The existing `::format_upgrade_summary` spec was updated to expect alphabetical order.

## Why

An alphabetically sorted list is easier to scan and makes the output deterministic, so the same set of upgrades always prints in the same order.

This is not a bug fix, so there are no reproduction steps.