### PR TITLE
test: add :needs_daemon_manager to some tests

### DIFF
--- a/Library/Homebrew/test/bundle/brew_services_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_services_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
       described_class.reset!
     end
 
-    it "returns started services" do
+    it "returns started services", :needs_daemon_manager do
       allow(Utils).to receive(:safe_popen_read).and_return <<~JSON
         [
           {
@@ -30,7 +30,7 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
       expect(described_class.started_services).to contain_exactly("nginx", "mysql")
     end
 
-    it "returns empty array when no services exist" do
+    it "returns empty array when no services exist", :needs_daemon_manager do
       allow(Utils).to receive(:safe_popen_read).and_return("[]\n")
       expect(described_class.started_services).to eq([])
     end

--- a/Library/Homebrew/test/services/formula_wrapper_spec.rb
+++ b/Library/Homebrew/test/services/formula_wrapper_spec.rb
@@ -5,7 +5,7 @@ require "services/system"
 require "services/formula_wrapper"
 require "tempfile"
 
-RSpec.describe Homebrew::Services::FormulaWrapper do
+RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
   subject(:service) { described_class.new(formula) }
 
   let(:formula) do


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Fixes some failures seen in Homebrew/core portable ruby tests as systemd doesn't exist in container - https://github.com/Homebrew/homebrew-core/actions/runs/28347279631/job/83973717708?pr=287049#step:4:233