### PR TITLE
Allow running bubblewrap in container

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -325,7 +325,9 @@ jobs:
     needs: syntax
     if: github.repository_owner == 'Homebrew' && github.event_name != 'push'
     runs-on: ${{ matrix.runs-on }}
-    container: ${{ matrix.container }}
+    container:
+      image: ${{ matrix.container }}
+      options: ${{ matrix.container != '' && '--privileged' }}
     strategy:
       fail-fast: false
       matrix:

--- a/Library/Homebrew/extend/os/linux/dev-cmd/tests.rb
+++ b/Library/Homebrew/extend/os/linux/dev-cmd/tests.rb
@@ -35,11 +35,7 @@ module OS
           else
             ::Sandbox.ensure_sandbox_installed!(install_from_tests: true)
           end
-          return if ::Sandbox.available?
-
-          reason = ::Sandbox.failure_reason ||
-                   "`HOMEBREW_SANDBOX_LINUX` requires a working rootless Bubblewrap sandbox."
-          raise UsageError, reason
+          ::Sandbox.ensure_sandbox_available!
         end
       end
     end

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -107,12 +107,15 @@ class GitHubRunnerMatrix
     else raise "Unknown Linux architecture: #{arch}"
     end
 
+    options = %w[--user linuxbrew --env GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED]
+    options << "--privileged" if Homebrew::EnvConfig.sandbox_linux?
+
     LinuxRunnerSpec.new(
       name:      "Linux #{arch}",
       runner:    linux_runner,
       container: {
         image:   "ghcr.io/homebrew/brew:main",
-        options: "--user=linuxbrew -e GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED",
+        options: options.join(" "),
       },
       workdir:   "/github/home",
       timeout:   GITHUB_ACTIONS_LONG_TIMEOUT,

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -120,6 +120,13 @@ class Sandbox
   sig { params(install_from_tests: T::Boolean).void }
   def self.ensure_sandbox_installed!(install_from_tests: false); end
 
+  sig { void }
+  def self.ensure_sandbox_available!
+    return if available?
+
+    raise failure_reason || "The sandbox is not available."
+  end
+
   sig { returns(Symbol) }
   def self.state
     available? ? :available : :unavailable
@@ -153,7 +160,7 @@ class Sandbox
   sig { params(command: T.any(String, Pathname), writable_path: T.any(String, Pathname), deny_network: T::Boolean).void }
   def self.run_command(*command, writable_path:, deny_network: false)
     ensure_sandbox_installed!
-    raise failure_reason || "The sandbox is not available." unless available?
+    ensure_sandbox_available!
 
     writable_path = Pathname(writable_path).expand_path
     if !writable_path.directory? || !writable_path.writable?

--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Homebrew::DevCmd::Tests do
       expect(Sandbox).to receive(:ensure_sandbox_installed!).with(install_from_tests: true)
 
       expect { tests.send(:check_test_environment!) }
-        .to raise_error(UsageError, "Invalid usage: Bubblewrap is not working.")
+        .to raise_error(RuntimeError, "Bubblewrap is not working.")
     end
 
     it "installs and probes sandbox availability when Linux sandboxing is enabled" do

--- a/Library/Homebrew/test/test_bot_spec.rb
+++ b/Library/Homebrew/test/test_bot_spec.rb
@@ -209,8 +209,17 @@ RSpec.describe Homebrew::TestBot do
       described_class.setup_github_actions_sandbox!
     end
 
-    it "disables the Linux sandbox if GitHub Actions cannot configure it" do
+    it "raises when GitHub Actions cannot configure the Linux sandbox for Homebrew repositories" do
       allow(described_class).to receive(:configure_sandbox!).and_return(false)
+      allow(ENV).to receive(:[]).with("GITHUB_REPOSITORY_OWNER").and_return("Homebrew")
+      allow(Sandbox).to receive(:available?).and_return(false)
+
+      expect { described_class.setup_github_actions_sandbox! }.to raise_error(RuntimeError)
+    end
+
+    it "disables the Linux sandbox if GitHub Actions cannot configure it for external repositories" do
+      allow(described_class).to receive(:configure_sandbox!).and_return(false)
+      allow(ENV).to receive(:[]).with("GITHUB_REPOSITORY_OWNER").and_return("foo")
 
       described_class.setup_github_actions_sandbox!
 

--- a/Library/Homebrew/test_bot.rb
+++ b/Library/Homebrew/test_bot.rb
@@ -56,8 +56,10 @@ module Homebrew
 
       return if configure_sandbox!
 
-      ENV["HOMEBREW_NO_SANDBOX_LINUX"] = "1"
       require "sandbox"
+      Sandbox.ensure_sandbox_available! if ENV["GITHUB_REPOSITORY_OWNER"] == "Homebrew"
+
+      ENV["HOMEBREW_NO_SANDBOX_LINUX"] = "1"
       Sandbox.reset_state!
     end
 


### PR DESCRIPTION
Experimenting to see if it is possible to run bubblewrap inside container.

Currently, Homebrew/core always disables sandbox on Linux as container lacks necessary privileges to run bubblewrap. This means sandbox feature, `deny_network_access!`, etc don't actually work yet.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
