### PR TITLE
Resolve patch targets via `patch --dry-run` for containment

### DIFF
--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -7,6 +7,7 @@ require "external_patch"
 require "string_patch"
 require "local_patch"
 require "utils/path"
+require "utils/popen"
 
 # Helper module for creating patches.
 module Patch
@@ -42,16 +43,21 @@ module Patch
   # Reject patch target paths (absolute or `..`-traversing) that escape the staged source tree.
   sig { params(text: String, strip: T.any(Symbol, String), base: Pathname).void }
   def self.ensure_targets_within!(text, strip:, base:)
-    strip_count = strip.to_s[/\d+/].to_i
-    text.each_line do |line|
-      # Headers are whitespace-delimited; take the first token, ignoring any timestamp.
-      next unless (path = line[/\A(?:---|\+\+\+|\*\*\*)\s+(\S+)/, 1])
-      next if path == File::NULL
+    # Resolve targets with `patch --dry-run` so containment matches what `patch`
+    # actually writes, covering `Index:`/`====` and non-selected context headers.
+    output = with_env(LC_ALL: "C", LANG: "C") do
+      base.cd do
+        Utils.popen_write("patch", "-g", "0", "-f", "-#{strip}", "--dry-run", err: :out) { |p| p.write(text) }
+      end
+    end
 
-      relative = path.split("/").drop(strip_count).join("/")
+    output.each_line do |line|
+      next unless (target = line.chomp[/\A(?:patching|checking) file (.+)\z/, 1])
+
+      target = target.delete_prefix("'").delete_suffix("'") if target.start_with?("'") && target.end_with?("'")
       Utils::Path.ensure_child_of!(
-        base, base/relative,
-        message: "Patch target path escapes the staged source tree: #{path}"
+        base, base/target,
+        message: "Patch target path escapes the staged source tree: #{target}"
       )
     end
   end

--- a/Library/Homebrew/test/patch_spec.rb
+++ b/Library/Homebrew/test/patch_spec.rb
@@ -155,38 +155,65 @@ RSpec.describe Patch do
   end
 
   describe ".ensure_targets_within!" do
-    let(:base) { Pathname("/tmp/brew-build") }
-
     it "allows targets that stay within the source tree" do
-      expect { described_class.ensure_targets_within!("--- a/src/foo.c\n+++ b/src/foo.c\n", strip: :p1, base:) }
-        .not_to raise_error
+      mktmpdir do |base|
+        (base/"src").mkpath
+        (base/"src/foo.c").write("old\n")
+        patch = <<~EOS
+          --- a/src/foo.c
+          +++ b/src/foo.c
+          @@ -1 +1 @@
+          -old
+          +new
+        EOS
+
+        expect { described_class.ensure_targets_within!(patch, strip: :p1, base:) }.not_to raise_error
+      end
     end
 
     it "allows /dev/null headers for added or deleted files" do
-      expect { described_class.ensure_targets_within!("--- /dev/null\n+++ b/new.c\n", strip: :p1, base:) }
-        .not_to raise_error
-    end
+      mktmpdir do |base|
+        patch = <<~EOS
+          --- /dev/null
+          +++ b/new.c
+          @@ -0,0 +1 @@
+          +new
+        EOS
 
-    it "rejects a target that escapes via `..`" do
-      expect { described_class.ensure_targets_within!("--- a/../evil\n+++ a/../evil\n", strip: :p1, base:) }
-        .to raise_error(/escapes the staged source tree/)
-    end
-
-    it "rejects an absolute target that survives the strip level" do
-      expect { described_class.ensure_targets_within!("--- /etc/passwd\n+++ /etc/passwd\n", strip: :p0, base:) }
-        .to raise_error(/escapes the staged source tree/)
-    end
-
-    it "allows /dev/null with a space-separated timestamp" do
-      expect do
-        described_class.ensure_targets_within!("--- /dev/null 2024-01-01 10:00:00\n+++ b/new.c\n", strip: :p0, base:)
+        expect { described_class.ensure_targets_within!(patch, strip: :p1, base:) }.not_to raise_error
       end
-        .not_to raise_error
     end
 
-    it "rejects a tab-delimited header that escapes via `..`" do
-      expect { described_class.ensure_targets_within!("---\ta/../evil\n+++\ta/../evil\n", strip: :p1, base:) }
-        .to raise_error(/escapes the staged source tree/)
+    it "allows a context diff whose selected target stays within the source tree" do
+      mktmpdir do |base|
+        (base/"lib/sh").mkpath
+        (base/"lib/sh/foo.c").write("old\n")
+        patch = <<~EOS
+          *** ../pkg-1.0-patched/lib/sh/foo.c	2024-01-01
+          --- lib/sh/foo.c	2024-01-01
+          ***************
+          *** 1 ****
+          ! old
+          --- 1 ----
+          ! new
+        EOS
+
+        expect { described_class.ensure_targets_within!(patch, strip: :p0, base:) }.not_to raise_error
+      end
+    end
+
+    it "rejects an Index header that escapes via `..`", :needs_macos do
+      mktmpdir do |base|
+        patch = <<~EOS
+          Index: a/../escape.txt
+          ===================================================================
+          @@ -0,0 +1 @@
+          +owned
+        EOS
+
+        expect { described_class.ensure_targets_within!(patch, strip: :p1, base:) }
+          .to raise_error(/escapes the staged source tree/)
+      end
     end
   end
 
@@ -284,12 +311,107 @@ RSpec.describe Patch do
   end
 
   describe StringPatch do
-    it "refuses to apply a patch whose target escapes the source tree" do
-      patch = described_class.new(:p1, "--- a/../evil\n+++ a/../evil\n@@ -1 +1 @@\n-x\n+y\n")
+    it "applies a patch whose target stays within the source tree" do
+      patch = described_class.new(:p1, <<~EOS)
+        --- a/foo
+        +++ b/foo
+        @@ -1 +1 @@
+        -old
+        +new
+      EOS
       mktmpdir do |dir|
-        Dir.chdir(dir) do
-          expect { patch.apply }.to raise_error(/escapes the staged source tree/)
+        (dir/"source").mkpath
+        (dir/"source/foo").write("old\n")
+        Dir.chdir(dir/"source") { patch.apply }
+
+        expect((dir/"source/foo").read).to eq("new\n")
+      end
+    end
+
+    it "refuses to apply a patch whose target escapes the source tree" do
+      patch = described_class.new(:p1, <<~EOS)
+        Index: a/../evil
+        ===================================================================
+        @@ -0,0 +1 @@
+        +owned
+      EOS
+      mktmpdir do |dir|
+        (dir/"source").mkpath
+        Dir.chdir(dir/"source") do
+          expect { patch.apply }.to raise_error(StandardError)
         end
+        expect(dir/"evil").not_to exist
+      end
+    end
+
+    it "does not let a Perforce target escape the source tree" do
+      patch = described_class.new(:p1, <<~EOS)
+        ==== a/../evil ====
+        @@ -0,0 +1 @@
+        +owned
+      EOS
+      mktmpdir do |dir|
+        (dir/"source").mkpath
+        Dir.chdir(dir/"source") do
+          expect { patch.apply }.to raise_error(StandardError)
+        end
+        expect(dir/"evil").not_to exist
+      end
+    end
+
+    it "does not let a standard target escape the source tree" do
+      patch = described_class.new(:p1, <<~EOS)
+        --- a/../evil
+        +++ b/../evil
+        @@ -0,0 +1 @@
+        +owned
+      EOS
+      mktmpdir do |dir|
+        (dir/"source").mkpath
+        Dir.chdir(dir/"source") do
+          expect { patch.apply }.to raise_error(StandardError)
+        end
+        expect(dir/"evil").not_to exist
+      end
+    end
+
+    it "does not let an absolute target escape the source tree" do
+      mktmpdir do |dir|
+        (dir/"source").mkpath
+        escape = dir/"evil"
+        patch = described_class.new(:p0, <<~EOS)
+          Index: #{escape}
+          ===================================================================
+          @@ -0,0 +1 @@
+          +owned
+        EOS
+
+        Dir.chdir(dir/"source") do
+          expect { patch.apply }.to raise_error(StandardError)
+        end
+        expect(escape).not_to exist
+      end
+    end
+
+    it "does not let one escaping target in a multi-file patch escape the source tree" do
+      patch = described_class.new(:p1, <<~EOS)
+        --- a/decoy.c
+        +++ b/decoy.c
+        @@ -1 +1 @@
+        -old
+        +new
+        Index: a/../evil
+        ===================================================================
+        @@ -0,0 +1 @@
+        +owned
+      EOS
+      mktmpdir do |dir|
+        (dir/"source").mkpath
+        (dir/"source/decoy.c").write("old\n")
+        Dir.chdir(dir/"source") do
+          expect { patch.apply }.to raise_error(StandardError)
+        end
+        expect(dir/"evil").not_to exist
       end
     end
   end


### PR DESCRIPTION
`Patch.ensure_targets_within!` (#22881) scanned `---`/`+++`/`***` headers and rejected absolute or `..`-traversing targets — effectively re-implementing `patch`'s `best_name` selection, which is wrong both ways. It misses sources `patch` honors, so an `Index:`- or Perforce `==== … ====`-only patch escapes on Apple `patch`; and it rejects legitimate patches whose non-selected "from" header is a sibling dir (e.g. bash/readline's `*** ../bash-5.3/jobs.c`, though `patch` writes the in-tree `jobs.c`), which breaks build-from-source (Homebrew/discussions#6934).

This resolves targets with `patch --dry-run` and validates the `patching file`/`checking file` names it reports. Since `patch` announces every file it writes, this matches its own selection on Apple and GNU `patch`: in-tree targets apply; `Index:`/`====`/`..`/absolute escapes are rejected. Escape closure stays defense-in-depth (delivery is still gated by `sha256` and the sandbox), consistent with #22881. Tests cover both directions and pass against Apple and GNU `patch`.

Reproduce with `brew install --build-from-source bash`: before this change it aborts applying the `bash53-*` patches with `Patch target path escapes the staged source tree: ../bash-5.3/jobs.c`; with it, the patch applies.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 4.8) drafted the change. I verified: reproduced the `Index:` and `====` escapes against Apple `patch` (out-of-tree writes before the fix); reproduced the bash regression on the real `bash53-001` patch (pre-fix rejected `../bash-5.3/jobs.c`, with this PR allowed and resolved to the in-tree `jobs.c`); ran `brew lgtm` and targeted checks against Apple `patch 2.0-12u11` and GNU `patch 2.8`.

-----