### PR TITLE
Revalidate tap restrictions for git redirects

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -70,13 +70,30 @@ module Homebrew
           redirected_remotes_path = Pathname(redirected_remotes_file)
           if redirected_remotes_path.file?
             begin
+              denied_redirects = []
               redirected_remotes_path.each_line do |line|
                 tap_path, redirected_remote = line.chomp.split("\t", 2)
                 next if tap_path.blank? || redirected_remote.blank?
                 next unless (tap = Tap.from_path(tap_path))
 
                 old_repository_var_suffix = tap.repository_var_suffix
-                tap.apply_redirected_remote!(redirected_remote, quiet: args.quiet?)
+                begin
+                  tap.apply_redirected_remote!(redirected_remote, quiet: args.quiet?)
+                rescue TapRedirectNotAllowedError => e
+                  # update.sh may already have merged redirected content, so roll back every denied tap.
+                  before_revision = ENV.fetch("HOMEBREW_UPDATE_BEFORE#{old_repository_var_suffix}", nil)
+                  if before_revision.present? && tap.installed?
+                    git_args = ["-C", tap.path.to_s]
+                    safe_system "git", *git_args, "reset", "--hard", "-q", before_revision
+                    branch = Utils.popen_read("git", *git_args, "symbolic-ref", "--short", "-q", "HEAD").chomp
+                    branch = branch.presence || tap.git_repository.origin_branch_name
+                    if branch.present?
+                      safe_system "git", *git_args, "update-ref", "refs/remotes/origin/#{branch}", before_revision
+                    end
+                  end
+                  denied_redirects << e.message
+                  next
+                end
                 new_repository_var_suffix = tap.repository_var_suffix
                 next if old_repository_var_suffix == new_repository_var_suffix
 
@@ -88,6 +105,7 @@ module Homebrew
                   ENV["#{prefix}#{new_repository_var_suffix}"] ||= old_value
                 end
               end
+              odie denied_redirects.join("\n\n") if denied_redirects.any?
             ensure
               redirected_remotes_path.unlink if redirected_remotes_path.exist?
             end

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -485,6 +485,9 @@ class TapNoCustomRemoteError < RuntimeError
   end
 end
 
+# Raised when a Git redirect targets a disallowed or forbidden tap remote.
+class TapRedirectNotAllowedError < RuntimeError; end
+
 # Raised when another Homebrew operation is already in progress.
 class OperationInProgressError < RuntimeError
   sig { params(locked_path: Pathname).void }

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -552,26 +552,47 @@ class Tap
     return if old_remote.present? && self.class.same_remote?(old_remote, redirected_remote)
 
     redirected_reference = self.class.remote_to_reference(redirected_remote)
-    if redirected_reference.present? && !self.class.remote_reference?(redirected_reference)
-      redirected_tap = Tap.fetch(redirected_reference)
-      if redirected_tap.name != name && !redirected_tap.installed?
-        old_path = path
-        redirected_tap.path.dirname.mkpath
-        FileUtils.mv(old_path, redirected_tap.path)
-        old_path.parent.rmdir_if_possible
-
-        @user = redirected_tap.user
-        @repository = redirected_tap.repository
-        @name = redirected_tap.name
-        @full_repository = redirected_tap.full_repository
-        @full_name = redirected_tap.full_name
-        @path = redirected_tap.path
-        @git_repository = GitRepository.new(@path)
-        clear_cache
-      end
+    redirected_tap = if redirected_reference.present? && !self.class.remote_reference?(redirected_reference)
+      Tap.fetch(redirected_reference)
     end
 
-    safe_system "git", "-C", path, "remote", "set-url", "origin", redirected_remote
+    # Redirect targets must pass the same allow/forbid checks as requested remotes.
+    redirect_target = redirected_tap || self
+    redirect_allowed = redirect_target.allowed_by_env?(remote: redirected_remote)
+    redirect_forbidden = redirect_target.forbidden_by_env?(remote: redirected_remote)
+    if !redirect_allowed || redirect_forbidden
+      owner = Homebrew::EnvConfig.forbidden_owner
+      owner_contact = if (contact = Homebrew::EnvConfig.forbidden_owner_contact.presence)
+        "\n#{contact}"
+      end
+
+      error_message = "#{old_name} was redirected to #{redirected_remote} but #{owner}\n"
+      error_message << "has not allowed this tap in `$HOMEBREW_ALLOWED_TAPS`" unless redirect_allowed
+      error_message << " and\n" if !redirect_allowed && redirect_forbidden
+      error_message << "has forbidden this tap in `$HOMEBREW_FORBIDDEN_TAPS`" if redirect_forbidden
+      error_message << ".#{owner_contact}"
+
+      raise TapRedirectNotAllowedError, error_message
+    end
+
+    if redirected_tap && redirected_tap.name != name && !redirected_tap.installed?
+      old_path = path
+      redirected_tap.path.dirname.mkpath
+      FileUtils.mv(old_path, redirected_tap.path)
+      old_path.parent.rmdir_if_possible
+
+      @user = redirected_tap.user
+      @repository = redirected_tap.repository
+      @name = redirected_tap.name
+      @full_repository = redirected_tap.full_repository
+      @full_name = redirected_tap.full_name
+      @path = redirected_tap.path
+      @git_repository = GitRepository.new(@path)
+      clear_cache
+    end
+
+    # `--` guards against a redirect value that begins with `-` being treated as a `git` option.
+    safe_system "git", "-C", path, "remote", "set-url", "origin", "--", redirected_remote
     clear_cache
     Tap.clear_cache
 

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -12,6 +12,24 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
 
   it_behaves_like "reinstall_pkgconf_if_needed"
 
+  # Simulate update.sh after a redirected fetch has advanced HEAD and origin/<branch>.
+  def setup_redirected_tap(name)
+    tap = Tap.fetch("allowed", name)
+    tap.path.mkpath
+    system "git", "-C", tap.path.to_s, "init"
+    system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://allowed.example/homebrew-#{name}"
+    (tap.path/"before").write("before")
+    system "git", "-C", tap.path.to_s, "add", "--all"
+    system "git", "-C", tap.path.to_s, "commit", "-q", "-m", "before"
+    before_revision = Utils.popen_read("git", "-C", tap.path.to_s, "rev-parse", "HEAD").chomp
+    (tap.path/"after").write("after")
+    system "git", "-C", tap.path.to_s, "add", "--all"
+    system "git", "-C", tap.path.to_s, "commit", "-q", "-m", "after"
+    branch = Utils.popen_read("git", "-C", tap.path.to_s, "symbolic-ref", "--short", "HEAD").chomp
+    system "git", "-C", tap.path.to_s, "update-ref", "refs/remotes/origin/#{branch}", "HEAD"
+    [tap, before_revision, branch]
+  end
+
   it "copies update revisions for redirected tap names" do
     redirected_remotes_file = mktmpdir/"redirected-remotes"
     redirected_remotes_file.write("/tmp/homebrew-foo\thttps://github.com/new/homebrew-foo.git\n")
@@ -38,6 +56,94 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
       expect(ENV.fetch("HOMEBREW_UPDATE_BEFORE_NEW_HOMEBREW_FOO")).to eq("123")
       expect(ENV.fetch("HOMEBREW_UPDATE_AFTER_NEW_HOMEBREW_FOO")).to eq("456")
     end
+  end
+
+  it "refuses an off-allowlist redirect and rolls the tap back to its pre-update revision" do
+    tap, before_revision, branch = setup_redirected_tap("foo")
+    redirected_remotes_file = mktmpdir/"redirected-remotes"
+    redirected_remotes_file.write("#{tap.path}\thttps://attacker.example/homebrew-foo\n")
+    allow(Homebrew::EnvConfig).to receive_messages(allowed_taps: "https://allowed.example/homebrew-foo",
+                                                   disable_load_formula?: true, no_install_from_api?: true)
+    update_report = described_class.new(["--quiet"])
+
+    with_env(
+      "HOMEBREW_REDIRECTED_REMOTES_FILE"                   => redirected_remotes_file.to_s,
+      "HOMEBREW_UPDATE_BEFORE"                             => "abc",
+      "HOMEBREW_UPDATE_AFTER"                              => "abc",
+      "HOMEBREW_UPDATE_BEFORE#{tap.repository_var_suffix}" => before_revision,
+    ) do
+      expect { update_report.run }.to raise_error(SystemExit)
+    end
+
+    expect(Utils.popen_read("git", "-C", tap.path, "rev-parse", "HEAD").chomp).to eq(before_revision)
+    expect(Utils.popen_read("git", "-C", tap.path, "rev-parse", "refs/remotes/origin/#{branch}").chomp)
+      .to eq(before_revision)
+    expect(Utils.popen_read("git", "-C", tap.path, "config", "remote.origin.url").chomp)
+      .to eq("https://allowed.example/homebrew-foo")
+  ensure
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"allowed"
+  end
+
+  it "rolls back every denied tap when several off-allowlist redirects are in the file" do
+    foo_tap, foo_before, foo_branch = setup_redirected_tap("foo")
+    bar_tap, bar_before, bar_branch = setup_redirected_tap("bar")
+    redirected_remotes_file = mktmpdir/"redirected-remotes"
+    redirected_remotes_file.write(
+      "#{foo_tap.path}\thttps://attacker.example/homebrew-foo\n" \
+      "#{bar_tap.path}\thttps://attacker.example/homebrew-bar\n",
+    )
+    allow(Homebrew::EnvConfig).to receive_messages(
+      allowed_taps:          "https://allowed.example/homebrew-foo https://allowed.example/homebrew-bar",
+      disable_load_formula?: true,
+      no_install_from_api?:  true,
+    )
+    update_report = described_class.new(["--quiet"])
+
+    with_env(
+      "HOMEBREW_REDIRECTED_REMOTES_FILE"                       => redirected_remotes_file.to_s,
+      "HOMEBREW_UPDATE_BEFORE"                                 => "abc",
+      "HOMEBREW_UPDATE_AFTER"                                  => "abc",
+      "HOMEBREW_UPDATE_BEFORE#{foo_tap.repository_var_suffix}" => foo_before,
+      "HOMEBREW_UPDATE_BEFORE#{bar_tap.repository_var_suffix}" => bar_before,
+    ) do
+      expect { update_report.run }.to raise_error(SystemExit)
+    end
+
+    expect(Utils.popen_read("git", "-C", foo_tap.path, "rev-parse", "HEAD").chomp).to eq(foo_before)
+    expect(Utils.popen_read("git", "-C", foo_tap.path, "rev-parse", "refs/remotes/origin/#{foo_branch}").chomp)
+      .to eq(foo_before)
+    expect(Utils.popen_read("git", "-C", bar_tap.path, "rev-parse", "HEAD").chomp).to eq(bar_before)
+    expect(Utils.popen_read("git", "-C", bar_tap.path, "rev-parse", "refs/remotes/origin/#{bar_branch}").chomp)
+      .to eq(bar_before)
+  ensure
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"allowed"
+  end
+
+  it "rolls back the remote-tracking ref for a denied redirect when HEAD is detached" do
+    tap, before_revision, branch = setup_redirected_tap("foo")
+    # Detached HEAD makes `symbolic-ref HEAD` empty, so the rollback must fall back to origin/HEAD.
+    system "git", "-C", tap.path.to_s, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/#{branch}"
+    system "git", "-C", tap.path.to_s, "checkout", "-q", "--detach", "HEAD"
+    redirected_remotes_file = mktmpdir/"redirected-remotes"
+    redirected_remotes_file.write("#{tap.path}\thttps://attacker.example/homebrew-foo\n")
+    allow(Homebrew::EnvConfig).to receive_messages(allowed_taps: "https://allowed.example/homebrew-foo",
+                                                   disable_load_formula?: true, no_install_from_api?: true)
+    update_report = described_class.new(["--quiet"])
+
+    with_env(
+      "HOMEBREW_REDIRECTED_REMOTES_FILE"                   => redirected_remotes_file.to_s,
+      "HOMEBREW_UPDATE_BEFORE"                             => "abc",
+      "HOMEBREW_UPDATE_AFTER"                              => "abc",
+      "HOMEBREW_UPDATE_BEFORE#{tap.repository_var_suffix}" => before_revision,
+    ) do
+      expect { update_report.run }.to raise_error(SystemExit)
+    end
+
+    expect(Utils.popen_read("git", "-C", tap.path, "rev-parse", "HEAD").chomp).to eq(before_revision)
+    expect(Utils.popen_read("git", "-C", tap.path, "rev-parse", "refs/remotes/origin/#{branch}").chomp)
+      .to eq(before_revision)
+  ensure
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"allowed"
   end
 
   describe Reporter do

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -622,6 +622,81 @@ RSpec.describe Tap do
       CoreCaskTap.instance.clear_cache
       FileUtils.rm_rf CoreCaskTap.instance.path
     end
+
+    it "refuses an off-allowlist redirect and preserves the original remote" do
+      allow(Homebrew::EnvConfig).to receive(:allowed_taps).and_return("https://allowed.example/homebrew-foo")
+      tap = described_class.fetch("allowed", "foo")
+      tap.path.mkpath
+      system "git", "-C", tap.path.to_s, "init"
+      system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://allowed.example/homebrew-foo"
+
+      expect do
+        tap.update_remote_from_git_redirect!(
+          "warning: redirecting to https://attacker.example/homebrew-foo\n",
+          quiet: true,
+        )
+      end.to raise_error(TapRedirectNotAllowedError)
+      expect(Utils.popen_read("git", "-C", tap.path, "config", "remote.origin.url").chomp)
+        .to eq("https://allowed.example/homebrew-foo")
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"allowed"
+    end
+
+    it "refuses a redirect to a forbidden tap and preserves the original remote" do
+      allow(Homebrew::EnvConfig).to receive(:forbidden_taps).and_return("attacker/foo")
+      tap = described_class.fetch("oldowner", "foo")
+      tap.path.mkpath
+      system "git", "-C", tap.path.to_s, "init"
+      system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://github.com/oldowner/homebrew-foo"
+
+      expect do
+        tap.update_remote_from_git_redirect!(
+          "warning: redirecting to https://github.com/attacker/homebrew-foo\n",
+          quiet: true,
+        )
+      end.to raise_error(TapRedirectNotAllowedError)
+      expect(Utils.popen_read("git", "-C", tap.path, "config", "remote.origin.url").chomp)
+        .to eq("https://github.com/oldowner/homebrew-foo")
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"oldowner"
+    end
+
+    it "applies a redirect to a tap allowed by name", :trust_store do
+      allow(Homebrew::EnvConfig).to receive(:allowed_taps).and_return("newowner/foo")
+      tap = described_class.fetch("oldowner", "foo")
+      tap.path.mkpath
+      system "git", "-C", tap.path.to_s, "init"
+      system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://github.com/oldowner/homebrew-foo"
+
+      tap.update_remote_from_git_redirect!(
+        "warning: redirecting to https://github.com/newowner/homebrew-foo\n",
+        quiet: true,
+      )
+
+      expect(tap.name).to eq("newowner/foo")
+      expect(Utils.popen_read("git", "-C", tap.path, "config", "remote.origin.url").chomp)
+        .to eq("https://github.com/newowner/homebrew-foo")
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"oldowner"
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"newowner"
+    end
+
+    it "treats a redirect beginning with a dash as a URL, not a git option", :trust_store do
+      tap = described_class.fetch("dashy", "foo")
+      tap.path.mkpath
+      system "git", "-C", tap.path.to_s, "init"
+      system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://github.com/dashy/homebrew-foo"
+
+      tap.update_remote_from_git_redirect!(
+        "warning: redirecting to -u:evil\n",
+        quiet: true,
+      )
+
+      expect(Utils.popen_read("git", "-C", tap.path, "config", "remote.origin.url").chomp)
+        .to eq("-u:evil")
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"dashy"
+    end
   end
 
   specify "Git variant" do


### PR DESCRIPTION
When `git` prints `redirecting to <url>` during a tap fetch, Homebrew may rewrite that tap's `origin` to the redirected remote and move the tap to a new name. That path already invalidates tap trust entries for the old tap name/remote, so trust is not silently carried across the redirect. However, `HOMEBREW_ALLOWED_TAPS` / `HOMEBREW_FORBIDDEN_TAPS` are a separate policy boundary, and until now those checks were not re-evaluated against the redirected remote.

This re-evaluates `allowed_by_env?` / `forbidden_by_env?` against the redirect target in `Tap#apply_redirected_remote!`, before any directory move or `git remote set-url`. Redirects outside `HOMEBREW_ALLOWED_TAPS`, or inside `HOMEBREW_FORBIDDEN_TAPS`, are refused, while legitimate renames to allowed taps still apply. When `update-report` consumes `.git/REDIRECTED_REMOTES`, denied redirects are rolled back to the tap's pre-update revision, including the working tree and remote-tracking ref, and all denied taps in a multi-tap update are rolled back before aborting. The redirected URL is also passed after `--` at the `set-url` call so a value beginning with `-` cannot be treated as a `git` option.

This keeps server-supplied redirects from persistently retargeting an installed tap outside the configured allow/forbid policy boundary.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code (Opus 4.8) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the fix and pass with it, and ran the relevant targeted tests plus style/typecheck.

-----
