### PR TITLE
bump: fix with invalid arch

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -374,6 +374,16 @@ module Homebrew
         # simulate the arm architecture.
         arch_options = is_cask_with_blocks ? OnSystem::ARCH_OPTIONS : [:arm]
 
+        # If the cask restricts to specific architectures via
+        # `depends_on arch:`, only simulate those architectures.
+        if is_cask_with_blocks && formula_or_cask.is_a?(Cask::Cask)
+          arch_deps = formula_or_cask.depends_on.arch
+          if arch_deps.present?
+            supported_archs = arch_deps.filter_map { |dep| dep[:type] } & arch_options
+            arch_options = supported_archs if supported_archs.present?
+          end
+        end
+
         arch_options.each do |arch|
           SimulateSystem.with(arch:) do
             version_key = is_cask_with_blocks ? arch : :general
@@ -425,14 +435,21 @@ module Homebrew
           end
         end
 
-        # If arm and intel versions are identical, as it happens with casks
-        # where only the checksums differ, we consolidate them into a single
-        # version.
-        if current_versions[:arm].present? && current_versions[:arm] == current_versions[:intel]
-          current_versions = { general: current_versions[:arm] }
-        end
-        if new_versions[:arm].present? && new_versions[:arm] == new_versions[:intel]
-          new_versions = { general: new_versions[:arm] }
+        # Consolidate into a single general version when only one architecture
+        # was simulated (e.g. `depends_on arch:` restricts to a single arch) or
+        # when the arm and intel versions are identical, as happens with casks
+        # where only the checksums differ.
+        if is_cask_with_blocks && arch_options.length == 1
+          single_arch = arch_options[0]
+          current_versions = { general: current_versions[single_arch] }
+          new_versions = { general: new_versions[single_arch] }
+        else
+          if current_versions[:arm].present? && current_versions[:arm] == current_versions[:intel]
+            current_versions = { general: current_versions[:arm] }
+          end
+          if new_versions[:arm].present? && new_versions[:arm] == new_versions[:intel]
+            new_versions = { general: new_versions[:arm] }
+          end
         end
 
         current_version = BumpVersionParser.new(general: current_versions[:general],

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -224,6 +224,69 @@ RSpec.describe Homebrew::DevCmd::Bump do
     end
   end
 
+  describe "::retrieve_versions_by_arch" do
+    before do
+      allow(bump).to receive(:retrieve_pull_requests)
+    end
+
+    let(:c_arm_only) do
+      Cask::CaskLoader.load(+<<-RUBY)
+        cask "arm_only_cask" do
+          arch arm: "arm64", intel: "x64"
+
+          version "1.2.3"
+          sha256 :no_check
+
+          url "https://brew.sh/test-\#{arch}.dmg"
+          name "Arm Only Cask"
+          desc "Arm only cask"
+          homepage "https://brew.sh"
+
+          depends_on arch: :arm64
+        end
+      RUBY
+    end
+    let(:c_intel_only) do
+      Cask::CaskLoader.load(+<<-RUBY)
+        cask "intel_only_cask" do
+          arch arm: "arm64", intel: "x64"
+
+          version "1.2.3"
+          sha256 :no_check
+
+          url "https://brew.sh/test-\#{arch}.dmg"
+          name "Intel Only Cask"
+          desc "Intel only cask"
+          homepage "https://brew.sh"
+
+          depends_on arch: :x86_64
+        end
+      RUBY
+    end
+
+    it "simulates only arm and consolidates to a general version when `depends_on arch:` restricts to arm-only" do
+      allow(c_arm_only).to receive(:sourcefile_path).and_return(Pathname("arm_only_cask.rb"))
+      allow(Cask::CaskLoader).to receive(:load).and_return(c_arm_only)
+      expect(bump).to receive(:livecheck_result).once.and_return(Version.new("1.2.4"))
+
+      version_info = bump.send(
+        :retrieve_versions_by_arch, formula_or_cask: c_arm_only, repositories: [], name: "arm-only-cask"
+      )
+      expect(version_info.new_version).to eq(Homebrew::BumpVersionParser.new(general: Version.new("1.2.4")))
+    end
+
+    it "simulates only intel and consolidates to a general version when `depends_on arch:` restricts to intel-only" do
+      allow(c_intel_only).to receive(:sourcefile_path).and_return(Pathname("intel_only_cask.rb"))
+      allow(Cask::CaskLoader).to receive(:load).and_return(c_intel_only)
+      expect(bump).to receive(:livecheck_result).once.and_return(Version.new("1.2.4"))
+
+      version_info = bump.send(
+        :retrieve_versions_by_arch, formula_or_cask: c_intel_only, repositories: [], name: "intel-only-cask"
+      )
+      expect(version_info.new_version).to eq(Homebrew::BumpVersionParser.new(general: Version.new("1.2.4")))
+    end
+  end
+
   describe "::message?" do
     let(:version) { Version.new("1.2.3") }
     let(:cask_version) { Cask::DSL::Version.new("1.2.3,4") }


### PR DESCRIPTION
`brew bump` was failing to return a valid `livecheck` result when an `arch` stanza was used but either `depends_on :arm64` or `depends_on :intel` was within either the `on_macos` or `on_linux` block.

The change causes the "unsupported" architecture pairs to be skipped during the `SimulateSystem` loop, so that `brew bump` doesn't expect a `livecheck` result in an unsupported architecture.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

I used `claude-code` with `opus-4.8`.

<details><summary>Here is the summary of events from Claude:</summary>

When a cask uses arch arm:intel: or os macos:linux: DSL stanzas, bump simulates both :arm and :intel architectures to check livecheck. However, some casks only support arm64 on macOS (e.g. via depends_on arch: :arm64 inside on_macos do) — their intel livecheck URLs don't exist and return errors, causing bump to show intel: unable to get versions despite the arm livecheck succeeding (and standalone brew livecheck working fine).

Two fixes:
1. Before the arch simulation loop, intersect arch_options with the arches declared in depends_on.arch. A cask with depends_on arch: :arm64 on macOS will only simulate :arm, skipping the broken intel URL entirely.
2. Update the version consolidation to also collapse arm-only results (where intel is nil due to being skipped) into a single general version, matching the behaviour for casks where arm == intel.

</details>