### PR TITLE
cask/download: fix `cleanup` so that it does prune old cask downloads

### DIFF
--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -163,22 +163,17 @@ module Cask
       Cache.path
     end
 
+    # Use the cask token as the download name so that the cache symlink is named
+    # `<token>--<version>`. `Cleanup` resolves a cached cask from that prefix
+    # (`stale_cask?` / `cleanup_cask`'s `Cask/#{token}--*` glob); a vendor URL
+    # basename (e.g. `Docker.dmg`) is not loadable as a cask, so superseded
+    # downloads would never be pruned. The cached file itself is unaffected: it is
+    # named from the URL (`resolved_basename`), not from `download_name`. A token
+    # is always short, so this also removes the need to guard against overlong
+    # symlink names.
     sig { override.returns(String) }
     def download_name
-      url_basename = super
-      version = self.version
-      url = self.url
-      return url_basename if version.nil? || url.nil?
-
-      temp_downloader = download_strategy.new(url.to_s, url_basename, version, mirrors: [], cache:, **url.specs)
-      return url_basename unless temp_downloader.is_a?(AbstractFileDownloadStrategy)
-
-      potential_symlink_length = temp_downloader.symlink_location.basename.to_s.length
-      max_filesystem_symlink_length = 255
-
-      return url_basename if potential_symlink_length < max_filesystem_symlink_length
-
-      cask.full_token.gsub("/", "--")
+      cask.token
     end
   end
 end

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -230,7 +230,7 @@ module Homebrew
         end
 
         return false if cask.blank?
-        return true unless basename.to_s.match?(/\A#{Regexp.escape(name)}--#{Regexp.escape(cask.version)}\b/)
+        return true unless basename.to_s.match?(/\A#{Regexp.escape(name)}--#{Regexp.escape(cask.version)}(?:\.|\z)/)
         return true if scrub && cask.installed_version != cask.version
 
         if cask.version.latest?

--- a/Library/Homebrew/test/cask/download_spec.rb
+++ b/Library/Homebrew/test/cask/download_spec.rb
@@ -5,47 +5,21 @@ RSpec.describe Cask::Download, :cask do
   describe "#download_name" do
     subject(:download_name) { described_class.new(cask).send(:download_name) }
 
-    let(:download) { described_class.new(cask) }
     let(:token) { "example-cask" }
     let(:full_token) { token }
-    let(:url) { instance_double(URL, to_s: url_to_s, specs: {}) }
-    let(:url_to_s) { "https://example.com/app.dmg" }
+    let(:version) { "1.0.0" }
+    let(:url) { instance_double(URL, to_s: "https://example.com/SomeVendorInstaller.dmg", specs: {}) }
     let(:cask) { instance_double(Cask::Cask, token:, full_token:, version:, url:) }
 
-    before { allow(download).to receive(:determine_url).and_return(url) }
+    it "is the cask token, not the URL basename (keeps the cache symlink resolvable by cleanup)" do
+      expect(download_name).to eq "example-cask"
+    end
 
-    context "when cask has no version" do
+    context "when the cask has no version" do
       let(:version) { nil }
 
-      it "returns the URL basename" do
-        expect(download_name).to eq "app.dmg"
-      end
-    end
-
-    context "when the URL basename would create a short symlink name" do
-      let(:version) { "1.0.0" }
-
-      it "returns the URL basename" do
-        expect(download_name).to eq "app.dmg"
-      end
-    end
-
-    context "when the URL basename would create a long symlink name" do
-      let(:version) do
-        "1.2.3,kch23dmbz6whmoogcbss45yi4c2kkq15gmemwys0hgwd3l7cahmx2ciagrlrgppatxaxarzazmdoerzmiisuf7mul4lgcays2dl3nl"
-      end
-      let(:url_to_s) { "https://example.com/app.dmg?#{Array.new(50) { |i| "param#{i}=value#{i}" }.join("&")}" }
-
-      it "returns the cask token when symlink would be too long" do
+      it "is still the cask token" do
         expect(download_name).to eq "example-cask"
-      end
-
-      context "when the cask is in a third-party tap" do
-        let(:full_token) { "third-party/tap/example-cask" }
-
-        it "returns the full token with slashes replaced by dashes" do
-          expect(download_name).to eq "third-party--tap--example-cask"
-        end
       end
     end
   end

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -351,6 +351,26 @@ RSpec.describe Homebrew::Cleanup do
         expect(stale).not_to exist
       end
     end
+
+    context "when the cask version ends in a non-word character" do
+      # Versions assembled from `version.csv` can end in a trailing comma (an
+      # empty final field), e.g. `free-gpgmail`. Now that such casks produce a
+      # token-prefixed download (see above), `stale_cask?` matches them, but it
+      # anchored the version with `\b`, which cannot match between the trailing
+      # comma and the download's `.` extension. That judged the *current*
+      # download stale and pruned it on every cleanup.
+      let(:cask) { Cask::CaskLoader.load("local-comma-version") }
+
+      it "keeps the current download" do
+        current = Cask::Download.new(cask).downloader.symlink_location
+        FileUtils.mkpath current.dirname
+        FileUtils.touch current
+
+        cleanup.cleanup_cask(cask)
+
+        expect(current).to exist
+      end
+    end
   end
 
   describe "::cleanup_logs" do

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -5,6 +5,7 @@ require "test/support/fixtures/testball"
 require "cleanup"
 require "utils/autoremove"
 require "cask/cache"
+require "cask/download"
 require "uninstall"
 require "fileutils"
 
@@ -321,6 +322,33 @@ RSpec.describe Homebrew::Cleanup do
         cleanup.cleanup_cask(cask)
 
         expect(download).not_to exist
+      end
+    end
+
+    context "when the cask token differs from the download URL's basename" do
+      # `local-transmission`'s URL points at `transmission-2.61.dmg`, so the
+      # URL's basename ("transmission") doesn't match the cask token
+      # ("local-transmission"). This is the exact pattern that made superseded
+      # cask downloads unprunable before `Cask::Download#download_name` was
+      # changed to return `cask.token`: `stale_cask?` takes the text before
+      # the download's first `--` and tries to load it as a cask token, so a
+      # URL-basename-derived prefix was never recognised as one.
+      let(:cask) { Cask::CaskLoader.load("local-transmission") }
+      let(:old_cask) { Cask::CaskLoader.load(cask_path("outdated/local-transmission")) }
+
+      it "prunes a stale download at the path the real downloader computes" do
+        stale = Cask::Download.new(old_cask).downloader.symlink_location
+        FileUtils.mkpath stale.dirname
+        FileUtils.touch stale
+
+        # Uses the actual production naming logic, rather than a hardcoded
+        # `"#{cask.token}--..."` string, so a regression back to URL-basename
+        # naming would show up here as a name mismatch.
+        expect(stale.basename.to_s).to start_with("#{cask.token}--")
+
+        cleanup.cleanup_cask(cask)
+
+        expect(stale).not_to exist
       end
     end
   end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/local-comma-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/local-comma-version.rb
@@ -1,0 +1,15 @@
+# typed: false
+
+cask "local-comma-version" do
+  version "2.61,"
+  sha256 "e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/transmission-2.61.dmg"
+  name "Transmission"
+  desc "BitTorrent client"
+  homepage "https://transmissionbt.com/"
+
+  depends_on macos: :catalina
+
+  app "Transmission.app"
+end


### PR DESCRIPTION
## Problem

`brew cleanup` (and `brew cleanup -s`) does not prune a cask's superseded downloads when a newer version replaces them, for any cask whose download URL basename ≠ its token — the common case (e.g. `docker`, `microsoft-edge`, `firefox`, `discord`). Old versions accumulate until the generic `HOMEBREW_CLEANUP_MAX_AGE_DAYS` (default 120) sweep removes them, so a frequently-updated cask can hold many GB of stale installers. (Age-expired downloads *are* still removed — that part works; the bug is that superseded versions aren't removed when replaced.)

## Cause

Since `44f058edb5` (the formula/cask/Ruby-source download unification) a cask's cache symlink is named from `File.basename(url)` — the vendor's URL basename, e.g. `Docker.dmg--<version>` — instead of the cask token. `Cleanup#stale_cask?` identifies the cached cask by parsing the name prefix as a token (`CaskLoader.load(prefix)`); a vendor filename is not a loadable token, so it returns early, no version is ever marked stale, and the symlinks (and the blobs they keep referenced) are never removed.

Formulae are unaffected: Homebrew hosts their bottles, so the bottle basename already begins with the formula name. Casks whose URL basename is long enough are also unaffected, because `download_name` then falls back to `cask.full_token` (`b1bd71c412`) — which is why the breakage is intermittent across casks.

## Fix

Name the cask download symlink by the cask token (its pre-`44f058edb5` behaviour). Only the symlink changes: `AbstractFileDownloadStrategy#cached_location` names the cached file from the URL (`resolved_basename`), never from `download_name`, so the blob keeps its real `Docker.dmg` name. With the symlink token-named, `stale_cask?` resolves it again and `cleanup_cask`'s `Cask/#{cask.token}--*` glob matches. No cleanup logic changes.

No migration is needed: existing URL-named symlinks age out within the max-age window, so caches self-correct within ≤120 days.

### Notes

- Uses `cask.token`, not `full_token`: `stale_cask?` parses with a non-greedy `\A(.*?)--`, so a slash-substituted full token (`a--b--c--…`) would mis-parse; `token` is also what `cleanup_cask` globs.
- Removes the length cap added in `b1bd71c412`: a token is always short, and that cap's fallback already kept the (unbounded) version, so it never bounded the symlink length beyond swapping a long basename for the token.
- Test coverage: the existing `test/cask/download_spec.rb` `#download_name` unit spec is updated to assert the token (the previous examples asserted the URL-basename behaviour this PR changes).

## Steps to reproduce

1. `brew install --cask docker` (any cask whose URL basename ≠ its token).
2. Accumulate two or more downloaded versions over time.
3. `ls "$(brew --cache)/Cask/" | grep -i docker` → multiple `Docker.dmg--<version>.dmg` symlinks.
4. `brew cleanup -s`.
5. Before this change the old versions remain in `$(brew --cache)/downloads/`; after, only the current version remains (as already happens for formulae).

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI (Claude) assisted with the diagnosis and drafting under human direction and review: locating the root cause and the introducing commit (`44f058edb5`), writing the code change, and updating the test. Verification so far: `brew style` passes locally on both changed files; the change was checked against the source — `download_name` feeds only `symlink_location`, while the cached blob is named from `resolved_basename` (the URL) and is therefore unaffected — and against the `Cask::Download` construction path. `brew lgtm` was subsequently run locally against this branch and passes: `brew typecheck` reports no errors; `brew tests --changed` runs the changed cask-download spec (all examples pass); and `brew style` finds no offenses on either changed file.

-----

