### PR TITLE
style: fix infinite loop in array alphabetisation

### DIFF
--- a/Library/Homebrew/rubocops/cask/array_alphabetization.rb
+++ b/Library/Homebrew/rubocops/cask/array_alphabetization.rb
@@ -53,7 +53,8 @@ module RuboCop
           to_sort.sort! do |a, b|
             a_non_comment = a.split("\n").reject { |line| line.strip.start_with?("#") }.fetch(0)
             b_non_comment = b.split("\n").reject { |line| line.strip.start_with?("#") }.fetch(0)
-            a_non_comment.downcase <=> b_non_comment.downcase || raise("Expected non-comment lines to be present")
+            a_non_comment.strip.downcase <=> b_non_comment.strip.downcase ||
+              raise("Expected non-comment lines to be present")
           end
 
           # Merge the sorted lines and the unsorted lines, preserving the original positions of the unsorted lines

--- a/Library/Homebrew/test/rubocops/cask/array_alphabetization_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/array_alphabetization_spec.rb
@@ -63,6 +63,33 @@ RSpec.describe RuboCop::Cop::Cask::ArrayAlphabetization, :config do
     CASK
   end
 
+  it "sorts by element content regardless of inconsistent indentation" do
+    expect_offense(<<~CASK)
+      cask "foo" do
+        url "https://example.com/foo.zip"
+
+        zap trash: [
+                   ^ The array elements should be ordered alphabetically
+             "~/Library/Caches/Foo",
+             "~/Library/HTTPStorages/Foo",
+          "~/Library/Application Support/Foo",
+        ]
+      end
+    CASK
+
+    expect_correction(<<~CASK)
+      cask "foo" do
+        url "https://example.com/foo.zip"
+
+        zap trash: [
+          "~/Library/Application Support/Foo",
+             "~/Library/Caches/Foo",
+             "~/Library/HTTPStorages/Foo",
+        ]
+      end
+    CASK
+  end
+
   it "autocorrects alphabetization in zap trash paths with interpolation" do
     expect_offense(<<~CASK)
       cask "foo" do


### PR DESCRIPTION
Fix an infinite loop in `brew style --fix` on casks with inconsistently-indented arrays.

The array alphabetization cop could run into an infinite loop error when there was inconsistent indentation in the array. The order now compares stripped element content only, so it's stable regardless of how the layout cops re-indent and the two converge in a single pass.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

I used `claude-code` with `opus-4.8` to fix the issue.