### PR TITLE
contributions: fix type error

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -213,7 +213,7 @@ module Homebrew
           person:       String,
           from:         String,
           to:           String,
-        ).returns(T::Hash[Symbol, T.untyped])
+        ).returns(T::Hash[String, T.untyped])
       }
       def scan_repositories(organisation, repositories, person, from:, to:)
         data = {}
@@ -266,7 +266,7 @@ module Homebrew
         data
       end
 
-      sig { params(results: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, Integer]) }
+      sig { params(results: T::Hash[String, T.untyped]).returns(T::Hash[Symbol, Integer]) }
       def total(results)
         totals = {}
 

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -213,7 +213,7 @@ module Homebrew
           person:       String,
           from:         String,
           to:           String,
-        ).returns(T::Hash[String, T.untyped])
+        ).returns(T::Hash[String, T::Hash[Symbol, Integer]])
       }
       def scan_repositories(organisation, repositories, person, from:, to:)
         data = {}
@@ -266,7 +266,7 @@ module Homebrew
         data
       end
 
-      sig { params(results: T::Hash[String, T.untyped]).returns(T::Hash[Symbol, Integer]) }
+      sig { params(results: T::Hash[String, T::Hash[Symbol, Integer]]).returns(T::Hash[Symbol, Integer]) }
       def total(results)
         totals = {}
 


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

When `brew contributions` is run with the
`HOMEBREW_SORBET_RECURSIVE=1` environment variable set, Sorbet produces a type error when `scan_repositories` is called (`Return value: Expected type T::Hash[Symbol, T.untyped], got T::Hash[String, T::Hash[Symbol, Integer]]`) and when `total` is called (`Parameter 'results': Expected type T::Hash[Symbol, T.untyped], got T::Hash[String, T::Hash[Symbol, Integer]]`). The issue is that `scan_repositories` returns a hash that uses string keys (i.e., it sets `data[repository]`, where `repository` is a member of the `repositories` array, which is explicitly typed as `T::Array[String]`) but the related signatures advertise the type as a hash with symbol keys.

This addresses the type error by updating the related types to be a hash with string keys.

-----

You can reproduce this type error by running something like `HOMEBREW_SORBET_RECURSIVE=1 brew contributions --user samford --quarter 2`.