### PR TITLE
Improve awkward wording of Backing Up App

### DIFF
--- a/Library/Homebrew/cask/artifact/moved.rb
+++ b/Library/Homebrew/cask/artifact/moved.rb
@@ -210,7 +210,7 @@ module Cask
           raise CaskError, "It seems the #{self.class.english_name} source '#{target}' is not there."
         end
 
-        ohai "Backing #{self.class.english_name} '#{target.basename}' up to '#{source}'"
+        ohai "Backing Up #{self.class.english_name} '#{target.basename}' to '#{source}'"
         source.dirname.mkpath
 
         # We need to preserve extended attributes between copies.

--- a/Library/Homebrew/cask/artifact/moved.rb
+++ b/Library/Homebrew/cask/artifact/moved.rb
@@ -210,7 +210,7 @@ module Cask
           raise CaskError, "It seems the #{self.class.english_name} source '#{target}' is not there."
         end
 
-        ohai "Backing Up #{self.class.english_name} '#{target.basename}' to '#{source}'"
+        ohai "Backing up #{self.class.english_name} '#{target.basename}' to '#{source}'"
         source.dirname.mkpath
 
         # We need to preserve extended attributes between copies.

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Cask::Reinstall, :cask do
     output = Regexp.new <<~EOS
       ==> Fetching downloads for:.*caffeine
       ==> Uninstalling Cask local-caffeine
-      ==> Backing App 'Caffeine.app' up to '.*Caffeine.app'
+      ==> Backing Up App 'Caffeine.app' to '.*Caffeine.app'
       ==> Removing App '.*Caffeine.app'
       ==> Purging files for version 1.2.3 of Cask local-caffeine
       ==> Installing Cask local-caffeine
@@ -33,7 +33,7 @@ RSpec.describe Cask::Reinstall, :cask do
 
     output = Regexp.new <<~EOS
       ==> Fetching downloads for:.*caffeine
-      ==> Backing App 'Caffeine.app' up to '.*Caffeine.app'
+      ==> Backing Up App 'Caffeine.app' to '.*Caffeine.app'
       ==> Removing App '.*Caffeine.app'
       ==> Dispatching zap stanza
       ==> Trashing files:

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Cask::Reinstall, :cask do
     output = Regexp.new <<~EOS
       ==> Fetching downloads for:.*caffeine
       ==> Uninstalling Cask local-caffeine
-      ==> Backing Up App 'Caffeine.app' to '.*Caffeine.app'
+      ==> Backing up App 'Caffeine.app' to '.*Caffeine.app'
       ==> Removing App '.*Caffeine.app'
       ==> Purging files for version 1.2.3 of Cask local-caffeine
       ==> Installing Cask local-caffeine
@@ -33,7 +33,7 @@ RSpec.describe Cask::Reinstall, :cask do
 
     output = Regexp.new <<~EOS
       ==> Fetching downloads for:.*caffeine
-      ==> Backing Up App 'Caffeine.app' to '.*Caffeine.app'
+      ==> Backing up App 'Caffeine.app' to '.*Caffeine.app'
       ==> Removing App '.*Caffeine.app'
       ==> Dispatching zap stanza
       ==> Trashing files:

--- a/Library/Homebrew/test/cask/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/uninstall_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Cask::Uninstall, :cask do
 
       output = Regexp.new <<~EOS
         ==> Uninstalling Cask local-caffeine
-        ==> Backing Up App 'Caffeine.app' to '.*Caffeine.app'
+        ==> Backing up App 'Caffeine.app' to '.*Caffeine.app'
         ==> Removing App '.*Caffeine.app'
         ==> Purging files for version 1.2.3 of Cask local-caffeine
       EOS

--- a/Library/Homebrew/test/cask/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/uninstall_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Cask::Uninstall, :cask do
 
       output = Regexp.new <<~EOS
         ==> Uninstalling Cask local-caffeine
-        ==> Backing App 'Caffeine.app' up to '.*Caffeine.app'
+        ==> Backing Up App 'Caffeine.app' to '.*Caffeine.app'
         ==> Removing App '.*Caffeine.app'
         ==> Purging files for version 1.2.3 of Cask local-caffeine
       EOS


### PR DESCRIPTION
Previously, it would log:
==> Backing App 'GitX.app' up to '/opt/homebrew/Caskroom/gitx/1.4/GitX.app'

Now it logs:
==> Backing Up App 'GitX.app' to '/opt/homebrew/Caskroom/gitx/1.4/GitX.app'

The previous awkward wording has been a pet peeve of mine for several years, so I finally created a PR to improve it.  :)

I considered using the lower-case "Backing up App ...", but I think the upper-case "Backing Up" looks better in the surrounding context, where many other words are already capitalized.

Existing tests are modified with this PR to match the new wording.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
