### PR TITLE
extend/ENV/super: set CC/CXX to real names for llvm_clang

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -147,6 +147,13 @@ module Superenv
     # a - apply fix for apr-1-config path
   end
 
+  sig { void }
+  def llvm_clang
+    super
+    self["CC"] = self["OBJC"] = "clang"
+    self["CXX"] = self["OBJCXX"] = "clang++"
+  end
+
   private
 
   sig { params(val: T.any(String, Pathname)).returns(String) }

--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -91,10 +91,10 @@ class Cmd
     when "ld" then "ld"
     when "gold", "ld.gold" then "ld.gold"
     when "cpp" then "cpp"
-    when /llvm_(clang(\+\+)?)/
-      "#{ENV["HOMEBREW_PREFIX"]}/opt/llvm/bin/#{Regexp.last_match(1)}"
     when /\w\+\+(-\d+(\.\d)?)?$/
       case ENV["HOMEBREW_CC"]
+      when "llvm_clang"
+        "#{ENV["HOMEBREW_PREFIX"]}/opt/llvm/bin/clang++"
       when "swift_clang"
         "#{ENV["HOMEBREW_PREFIX"]}/opt/swift/libexec/bin/clang++"
       when /clang/

--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -275,6 +275,21 @@ RSpec.describe "ENV" do
       end
     end
 
+    describe "#llvm_clang" do
+      before { env.llvm_clang }
+
+      it "sets HOMEBREW_CC to shim name" do
+        expect(env["HOMEBREW_CC"]).to eq "llvm_clang"
+      end
+
+      it "sets CC/CXX to real names" do
+        expect(env["CC"]).to eq "clang"
+        expect(env["CXX"]).to eq "clang++"
+        expect(env["OBJC"]).to eq "clang"
+        expect(env["OBJCXX"]).to eq "clang++"
+      end
+    end
+
     describe "when using versioned GCC" do
       let(:gcc) { "gcc-#{CompilerConstants::GNU_GCC_VERSIONS.last}" }
 


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`CC=llvm_clang`/`CXX=llvm_clang++` can cause issues in formulae if the value of CC/CXX is saved into binaries/scripts to be used at runtime. This PR follows similar pattern in my versioned GCC PR (https://github.com/Homebrew/brew/pull/22889) so that the build scripts will see the actual name of the command, i.e. `CC=clang`/`CXX=clang++`.

This is also similar to how we handle `swift` shim:
https://github.com/Homebrew/brew/blob/8d94d5c7cffe2c104a27c92605f6f8df3767338c/Library/Homebrew/shims/super/swift#L5-L10

To make this work, need to adjust `cc` shim too so that it handles LLVM Clang the same as all other compilers. Previously, it would only apply LLVM's clang++ when named `llvm_clang++`. Now, even if compiler is invoked as clang++, g++, etc., brew should use HOMEBREW_CC=llvm_clang forward to LLVM's clang++.

---

This should avoid workarounds like 
- https://github.com/Homebrew/homebrew-core/blob/58a1d9aff4768c36851ad2fb49f09c4ceeababef/Formula/e/ecl.rb#L44-L45

I tried removing above and running `brew install --cc llvm_clang ecl`. Snippets of output:
```
checking for gcc... clang
...
libtool: compile:  clang -fPIC -fno-common -DHAVE_CONFIG_H -I../src -I/private/tmp/ecl-20260702-80027-mytn21/ecl-26.5.5/src/bdwgc/libatomic_ops/src -I/opt/homebrew/opt/gmp/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/include -I/opt/homebrew/opt/bdw-gc/include -fPIC -Wall -Wextra -Wpedantic -Wno-long-long -g -O0 -fPIC -fno-common -D_THREAD_SAFE -MT atomic_ops.lo -MD -MP -MF .deps/atomic_ops.Tpo -c /private/tmp/ecl-20260702-80027-mytn21/ecl-26.5.5/src/bdwgc/libatomic_ops/src/atomic_ops.c  -fno-common -DPIC -o atomic_ops.o
```
And underlying 02.make.cc.log:
```
clang called with: -fPIC -fno-common -DHAVE_CONFIG_H -I../src -I/private/tmp/ecl-20260702-80027-mytn21/ecl-26.5.5/src/bdwgc/libatomic_ops/src -I/opt/homebrew/opt/gmp/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/include -I/opt/homebrew/opt/bdw-gc/include -fPIC -Wall -Wextra -Wpedantic -Wno-long-long -g -O0 -fPIC -fno-common -D_THREAD_SAFE -MT atomic_ops.lo -MD -MP -MF .deps/atomic_ops.Tpo -c /private/tmp/ecl-20260702-80027-mytn21/ecl-26.5.5/src/bdwgc/libatomic_ops/src/atomic_ops.c -fno-common -DPIC -o atomic_ops.o
superenv removed:  -Wall -Wextra -Wpedantic -g -O0
superenv added:    -w -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk --sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk -isystem/opt/homebrew/include -isystem/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers -fdebug-prefix-map=/private/tmp/ecl-20260702-80027-mytn21/ecl-26.5.5=.
superenv executed: /opt/homebrew/opt/llvm/bin/clang -w -Os -fPIC -fno-common -DHAVE_CONFIG_H -I../src -I/private/tmp/ecl-20260702-80027-mytn21/ecl-26.5.5/src/bdwgc/libatomic_ops/src -I/opt/homebrew/opt/gmp/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/include -I/opt/homebrew/opt/bdw-gc/include -fPIC -Wno-long-long -fPIC -fno-common -D_THREAD_SAFE -MT atomic_ops.lo -MD -MP -MF .deps/atomic_ops.Tpo -c /private/tmp/ecl-20260702-80027-mytn21/ecl-26.5.5/src/bdwgc/libatomic_ops/src/atomic_ops.c -fno-common -DPIC -o atomic_ops.o -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk --sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk -isystem/opt/homebrew/include -isystem/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers -fdebug-prefix-map=/private/tmp/ecl-20260702-80027-mytn21/ecl-26.5.5=.
```