### PR TITLE
cask/artifact/pkg: fix type error

### DIFF
--- a/Library/Homebrew/cask/artifact/pkg.rb
+++ b/Library/Homebrew/cask/artifact/pkg.rb
@@ -72,11 +72,14 @@ module Cask
         args << "-allowUntrusted" if stanza_options.fetch(:allow_untrusted, false)
         with_choices_file do |choices_path|
           args << "-applyChoiceChangesXML" << choices_path if choices_path
+
+          current_user_str = User.current&.to_s
           env = {
-            "LOGNAME"  => User.current,
-            "USER"     => User.current,
-            "USERNAME" => User.current,
+            "LOGNAME"  => current_user_str,
+            "USER"     => current_user_str,
+            "USERNAME" => current_user_str,
           }
+
           command.run!(
             "/usr/sbin/installer",
             sudo:         true,

--- a/Library/Homebrew/test/cask/artifact/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/pkg_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Cask::Artifact::Pkg, :cask do
     it "runs the system installer on the specified pkgs" do
       pkg = cask.artifacts.find { |a| a.is_a?(described_class) }
 
+      current_user = User.current&.to_s
       expect(fake_system_command).to receive(:run!).with(
         "/usr/sbin/installer",
         args:         ["-pkg", cask.staged_path.join("MyFancyPkg", "Fancy.pkg"), "-target", "/"],
@@ -20,9 +21,9 @@ RSpec.describe Cask::Artifact::Pkg, :cask do
         sudo_as_root: true,
         print_stdout: true,
         env:          {
-          "LOGNAME"  => ENV.fetch("USER"),
-          "USER"     => ENV.fetch("USER"),
-          "USERNAME" => ENV.fetch("USER"),
+          "LOGNAME"  => an_instance_of(String).and(eq(current_user)),
+          "USER"     => an_instance_of(String).and(eq(current_user)),
+          "USERNAME" => an_instance_of(String).and(eq(current_user)),
         },
       )
 
@@ -59,6 +60,7 @@ RSpec.describe Cask::Artifact::Pkg, :cask do
       expect(file).to receive(:unlink)
       expect(Tempfile).to receive(:open).and_yield(file)
 
+      current_user = User.current&.to_s
       expect(fake_system_command).to receive(:run!).with(
         "/usr/sbin/installer",
         args:         [
@@ -70,9 +72,9 @@ RSpec.describe Cask::Artifact::Pkg, :cask do
         sudo_as_root: true,
         print_stdout: true,
         env:          {
-          "LOGNAME"  => ENV.fetch("USER"),
-          "USER"     => ENV.fetch("USER"),
-          "USERNAME" => ENV.fetch("USER"),
+          "LOGNAME"  => an_instance_of(String).and(eq(current_user)),
+          "USER"     => an_instance_of(String).and(eq(current_user)),
+          "USERNAME" => an_instance_of(String).and(eq(current_user)),
         },
       )
 


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

When the `HOMEBREW_SORBET_RECURSIVE=1` environment variable is set and a cask using the `pkg` stanza is installed/upgraded, Sorbet will give a type error (`Parameter 'env': Expected type T::Hash[String, T.nilable(T.any(PATH, String, T::Boolean))], got T::Hash[String, User]`) related to `SystemCommand.run!`. I looked for usage of `User` in cask and saw that `Cask::Artifact::Pkg.run_installer` uses `User` objects in the `env` arg to `SystemCommand.run!`. This resolves the issue by calling `#to_s` on `User.current`, to ensure it's a string.

You can replicate this by setting the `HOMEBREW_SORBET_RECURSIVE=1` environment variable and installing/upgrading a cask that uses the `pkg` stanza (e.g., `HOMEBREW_SORBET_RECURSIVE=1 brew install cloudflare-warp`).