### PR TITLE
os/mac/mach: avoid delegate for dylib_id

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -30,8 +30,8 @@ module OS
             modified = T.let(false, T::Boolean)
             needs_codesigning = T.let(false, T::Boolean)
 
-            if file.dylib?
-              id = relocated_name_for(file.dylib_id, relocation)
+            if file.dylib? && (dylib_id = file.dylib_id)
+              id = relocated_name_for(dylib_id, relocation)
               modified = change_dylib_id(id, file) if id
               needs_codesigning ||= modified
             end
@@ -150,15 +150,16 @@ module OS
 
       sig { params(file: MachOShim).returns(String) }
       def dylib_id_for(file)
+        dylib_id = T.must(file.dylib_id)
         # Swift dylib IDs should be /usr/lib/swift
-        return file.dylib_id if file.dylib_id.start_with?("/usr/lib/swift/libswift")
+        return dylib_id if dylib_id.start_with?("/usr/lib/swift/libswift")
 
         # Preserve @rpath install names if the formula has specified preserve_rpath
-        return file.dylib_id if file.dylib_id.start_with?("@rpath") && formula_preserve_rpath?
+        return dylib_id if dylib_id.start_with?("@rpath") && formula_preserve_rpath?
 
         # The new dylib ID should have the same basename as the old dylib ID, not
         # the basename of the file itself.
-        basename = File.basename(file.dylib_id)
+        basename = File.basename(dylib_id)
         relative_dirname = file.dirname.relative_path_from(path)
         (opt_record/relative_dirname/basename).to_s
       end

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -5,7 +5,6 @@ require "macho"
 
 # {Pathname} extension for dealing with Mach-O files.
 module MachOShim
-  extend Forwardable
   extend T::Helpers
 
   requires_ancestor { Pathname }

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -10,8 +10,6 @@ module MachOShim
 
   requires_ancestor { Pathname }
 
-  delegate [:dylib_id] => :macho
-
   sig { params(args: T.untyped).void }
   def initialize(*args)
     @macho = T.let(nil, T.nilable(T.any(MachO::MachOFile, MachO::FatFile)))
@@ -19,6 +17,9 @@ module MachOShim
 
     super
   end
+
+  sig { returns(T.nilable(String)) }
+  def dylib_id = macho.dylib_id
 
   sig { returns(T.any(MachO::MachOFile, MachO::FatFile)) }
   def macho

--- a/Library/Homebrew/sorbet/rbi/dsl/mach_o_shim.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/mach_o_shim.rbi
@@ -5,7 +5,4 @@
 # Please instead update this file by running `bin/tapioca dsl MachOShim`.
 
 
-module MachOShim
-  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
-  def dylib_id(*args, &block); end
-end
+module MachOShim; end


### PR DESCRIPTION
Delegate causes issues for portable Ruby testing as running `brew typecheck --update` on Linux will remove the RBI file causing `brew typecheck` failures.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
