### PR TITLE
Clarify Linux build tools installation instructions

### DIFF
--- a/Library/Homebrew/extend/os/linux/development_tools.rb
+++ b/Library/Homebrew/extend/os/linux/development_tools.rb
@@ -30,6 +30,23 @@ module OS
         sig { returns(Symbol) }
         def default_compiler = :gcc
 
+        sig { returns(String) }
+        def installation_instructions
+          <<~EOS
+            Install a system C compiler and the standard development tools for
+            your Linux distribution. See:
+              https://docs.brew.sh/Homebrew-on-Linux#requirements
+          EOS
+        end
+
+        sig { returns(String) }
+        def custom_installation_instructions
+          <<~EOS
+            Install GNU's GCC:
+              brew install gcc
+          EOS
+        end
+
         sig { returns(T::Boolean) }
         def needs_libc_formula?
           return @needs_libc_formula unless @needs_libc_formula.nil?

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -11,6 +11,15 @@ RSpec.describe Homebrew::Diagnostic::Checks do
     expect(checks.inject_file_list(%w[/a /b], "foo:\n")).to eq("foo:\n  /a\n  /b\n")
   end
 
+  specify "#check_for_installed_developer_tools uses installation instructions" do
+    allow(DevelopmentTools).to receive_messages(installed?: false, installation_instructions: "Install build tools.")
+
+    expect(checks.check_for_installed_developer_tools).to eq <<~EOS
+      No developer tools installed.
+      Install build tools.
+    EOS
+  end
+
   specify "#check_access_directories" do
     skip "User is root so everything is writable." if Process.euid.zero?
     begin

--- a/Library/Homebrew/test/os/linux/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/linux/diagnostic_spec.rb
@@ -41,6 +41,23 @@ RSpec.describe Homebrew::Diagnostic::Checks do
       .to match(/Your Linux kernel .+ is too old/)
   end
 
+  specify "#check_for_installed_developer_tools explains system build tools" do
+    allow(DevelopmentTools).to receive(:installed?).and_return(false)
+
+    expect(checks.check_for_installed_developer_tools)
+      .to include(
+        "No developer tools installed.",
+        "Install a system C compiler and the standard development tools",
+        "https://docs.brew.sh/Homebrew-on-Linux#requirements",
+      )
+  end
+
+  describe ".custom_installation_instructions" do
+    it "points at brew install gcc" do
+      expect(DevelopmentTools.custom_installation_instructions).to include("brew install gcc")
+    end
+  end
+
   specify "#fatal_build_from_source_checks" do
     expect(checks.fatal_build_from_source_checks).not_to include("check_linux_sandbox")
   end

--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -5,7 +5,7 @@ redirect_from:
   - /linux
   - /Linux
   - /Linuxbrew
-last_review_date: "2026-04-03"
+last_review_date: "2026-07-02"
 ---
 
 # Homebrew on Linux
@@ -47,6 +47,8 @@ If you're using an older distribution of Linux, installing your first package wi
 ## Requirements
 
 See [Support Tiers](Support-Tiers.md#linux) for the full list of Linux requirements.
+
+Homebrew expects a working system C compiler and the standard Linux development tools. Homebrew can install its own current version of *gcc* when needed, but this does not replace the system compiler required for bootstrap and post-install steps.
 
 To install build tools, paste at a terminal prompt:
 


### PR DESCRIPTION
On Linux, `brew doctor` and the missing-build-tools errors previously advised users to "Install Clang or run `brew install gcc`". That guidance is misleading here: a Homebrew-installed `gcc` does not provide the system `/usr/bin/cc` toolchain that bootstrap and post-install steps rely on (for example, `brew postinstall gcc` shells out to `/usr/bin/cc -print-file-name=crti.o` when building against the system glibc, which fails until a system compiler is installed). This overrides the Linux `DevelopmentTools.installation_instructions` to point at the system C compiler and the standard development tools, with a link to the requirements docs.

`CompilerSelectionError` still recommends `brew install gcc` via a Linux `custom_installation_instructions` override, mirroring the existing macOS split: the system toolchain for "no developer tools installed", and `brew install gcc` when a formula fails with every available compiler.

The Requirements section of the Linux docs now notes that Homebrew expects a working system C compiler and that its own `gcc` does not replace it for bootstrap and post-install steps.

This follows https://github.com/orgs/Homebrew/discussions/6940 and supersedes #22921.

Note: `check_for_installed_developer_tools` only fires when no compiler is detected at all, so it does not trigger for the specific case in the discussion where a Homebrew `gcc` is present but `/usr/bin/cc` is absent. This PR improves the guidance and documentation rather than adding a new detector for that case.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code drafted the code, tests and docs from my design and iterated on my review; I reviewed every change and verified locally with `brew typecheck`, `brew style` and `brew lgtm` (the Linux-only specs run in CI).

-----
