### PR TITLE
download_queue: prevent flickering

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -161,6 +161,8 @@ module Homebrew
                 finished_states.include?(future.state)
               end
 
+              stdout_print_and_flush_if_tty Tty.begin_synchronized_output
+
               finished_downloads.each do |downloadable, future|
                 previous_pending_line_count -= 1
                 output_message.call(downloadable, future, false)
@@ -185,11 +187,15 @@ module Homebrew
                 end
               end
 
+              stdout_print_and_flush_if_tty Tty.end_synchronized_output
+
               sleep 0.05
             # We want to catch all exceptions to ensure we can cancel any
             # running downloads and flush the TTY.
             rescue Exception # rubocop:disable Lint/RescueException
               cancel
+
+              stdout_print_and_flush_if_tty Tty.end_synchronized_output
 
               if previous_pending_line_count.positive?
                 stdout_print_and_flush_if_tty Tty.move_cursor_down(previous_pending_line_count - 1)

--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -8,6 +8,18 @@ RSpec.describe Tty do
     end
   end
 
+  describe "::begin_synchronized_output" do
+    it "returns the synchronized output begin escape sequence" do
+      expect(described_class.begin_synchronized_output).to eq("\033[?2026h")
+    end
+  end
+
+  describe "::end_synchronized_output" do
+    it "returns the synchronized output end escape sequence" do
+      expect(described_class.end_synchronized_output).to eq("\033[?2026l")
+    end
+  end
+
   describe "::width" do
     specify do
       expect(described_class.width).to be_a(Integer)

--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -90,6 +90,16 @@ module Tty
       "\033[?25h"
     end
 
+    sig { returns(String) }
+    def begin_synchronized_output
+      "\033[?2026h"
+    end
+
+    sig { returns(String) }
+    def end_synchronized_output
+      "\033[?2026l"
+    end
+
     sig { returns(T.nilable([Integer, Integer])) }
     def size
       return @size if defined?(@size)


### PR DESCRIPTION
Use [Synchronized Output](https://github.com/contour-terminal/vt-extensions/blob/master/synchronized-output.md) to prevent flickering when the download queue renders updates (which is particularly noticeable in Ghostty).

This builds on the work in: https://github.com/Homebrew/brew/pull/21535

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I used Opus 4.8 in Claude to help write this change (and to generate the download queue demo below).

To test it I used the following script in Terminal.app and Ghostty.app to run with and without this pull request's changes. In Ghostty, without the changes, the flicker is noticeable every time and these changes eliminate it.
```rb
# typed: false
# frozen_string_literal: true

# Visual test harness for `Homebrew::DownloadQueue`'s progress bar.
#
# It fakes out everything network/disk related: each "download" is a plain
# in-memory object that simply grows its `fetched_size` over time while flipping
# through the real download phases (preparing -> downloading -> downloaded ->
# verifying -> verified). We then hand hand-built futures straight to the queue's
# private `@downloads` hash and call the real `#fetch`, so the exact rendering
# code path used in production drives the terminal.
#
# Run it (from the brew repo root) with:
#
#   ./bin/brew ruby -- /private/tmp/claude-501/-Users-chris-src-brew/13633e28-3185-4e9d-89cd-822c6cbcb3a2/scratchpad/download_queue_demo.rb
#
# Optionally override concurrency:
#
#   HOMEBREW_DOWNLOAD_CONCURRENCY=8 ./bin/brew ruby -- .../download_queue_demo.rb

require "download_queue"

module Homebrew
  # A stand-in for a real `Downloadable` whose "download" is just a timer that
  # bumps `fetched_size` toward `total_size`. All the queue's progress renderer
  # ever reads is `fetched_size`, `total_size`, `phase` and the message helpers,
  # so this is enough to exercise the bar realistically.
  class FakeDownload
    include Downloadable

    sig { override.returns(String) }
    attr_reader :download_queue_type

    sig { override.returns(String) }
    attr_reader :download_queue_name

    # Avoid the real downloader (which demands a URL); this is used as a hash key
    # via `Downloadable#hash`/`#eql?` and is otherwise inert in this demo.
    sig { override.returns(Pathname) }
    def cached_download = Pathname.new("/tmp/brew-download-queue-demo/#{@download_queue_name}")

    def initialize(name:, type: "Bottle", total_size:, mb_per_sec: 8.0,
                   prepare_delay: 0.4, verify_delay: 0.6, unknown_total: false,
                   fail_at: nil)
      super()
      @download_queue_name = name
      @download_queue_type = type
      @real_total_size = total_size
      @total_size = unknown_total ? nil : total_size
      @unknown_total = unknown_total
      @fetched_size = nil
      @bytes_per_tick = (mb_per_sec * 1024 * 1024 * 0.05).to_i
      @prepare_delay = prepare_delay
      @verify_delay = verify_delay
      @fail_at = fail_at
      @phase = :preparing
    end

    # The queue renderer reads these two while the simulation thread writes them.
    # Ruby's GVL makes this plenty safe for a visual demo.
    sig { override.returns(T.nilable(Integer)) }
    attr_reader :fetched_size

    sig { override.returns(T.nilable(Integer)) }
    attr_reader :total_size

    # Simulate the whole lifecycle. Runs on the queue's thread pool.
    def simulate!
      sleep @prepare_delay # sit in :preparing so the spinner + name show alone

      @total_size = @real_total_size if @unknown_total
      @fetched_size = 0
      downloading!

      until @fetched_size >= @real_total_size
        sleep 0.05
        @fetched_size = [@fetched_size + @bytes_per_tick, @real_total_size].min
        if @fail_at && @fetched_size >= (@real_total_size * @fail_at)
          raise "simulated network failure after #{@fetched_size} bytes"
        end
      end

      downloaded!
      sleep 0.15
      verifying!
      sleep @verify_delay
      verified!
      "done"
    end
  end
end

mb = 1024 * 1024

downloads = [
  Homebrew::FakeDownload.new(name: "wget-1.24.5.arm64_sequoia.bottle.tar.gz", total_size: 3 * mb, mb_per_sec: 6.0),
  Homebrew::FakeDownload.new(name: "openssl@3-3.4.0.arm64_sequoia.bottle.tar.gz", total_size: 12 * mb, mb_per_sec: 14.0),
  Homebrew::FakeDownload.new(name: "curl-8.11.0.arm64_sequoia.bottle.tar.gz", total_size: 2 * mb, mb_per_sec: 4.0),
  Homebrew::FakeDownload.new(name: "python@3.13-3.13.1.arm64_sequoia.bottle.tar.gz", total_size: 32 * mb, mb_per_sec: 20.0),
  Homebrew::FakeDownload.new(name: "cmake-3.31.2.arm64_sequoia.bottle.tar.gz", total_size: 18 * mb, mb_per_sec: 10.0, prepare_delay: 0.9),
  Homebrew::FakeDownload.new(name: "node-23.4.0.arm64_sequoia.bottle.tar.gz", total_size: 24 * mb, mb_per_sec: 16.0, unknown_total: true),
  Homebrew::FakeDownload.new(name: "sqlite-3.47.2.arm64_sequoia.bottle.tar.gz", total_size: 5 * mb, mb_per_sec: 8.0),
  Homebrew::FakeDownload.new(name: "ffmpeg-7.1.arm64_sequoia.bottle.tar.gz", total_size: 40 * mb, mb_per_sec: 12.0, fail_at: 0.5),
  Homebrew::FakeDownload.new(name: "git-2.47.1.arm64_sequoia.bottle.tar.gz", total_size: 9 * mb, mb_per_sec: 9.0),
  Homebrew::FakeDownload.new(name: "ruby-3.4.1.arm64_sequoia.bottle.tar.gz", total_size: 22 * mb, mb_per_sec: 18.0),
]

queue = Homebrew::DownloadQueue.new
pool = queue.instance_variable_get(:@pool)

futures = downloads.to_h do |download|
  [download, Concurrent::Promises.future_on(pool) { download.simulate! }]
end
queue.instance_variable_set(:@downloads, futures)

puts "Simulating #{downloads.count} downloads " \
     "(concurrency: #{queue.instance_variable_get(:@concurrency)})...\n\n"

queue.fetch
queue.shutdown

puts "\nfetch_failed? => #{queue.fetch_failed}"
```
-----
