### PR TITLE
Cache formula lookups during dependency expansion

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -177,11 +177,14 @@ class Dependency
         deps:            T::Array[Dependency],
         cache_key:       T.nilable(String),
         cache_timestamp: T.nilable(Time),
+        formula_cache:   T.nilable(T::Hash[Dependency, Formula]),
         block:           T.nilable(T.proc.params(arg0: T.any(Formula, CaskDependent),
                                                  arg1: Dependency).returns(T.nilable(Symbol))),
       ).returns(T::Array[Dependency])
     }
-    def expand(dependent, deps = dependent.deps, cache_key: nil, cache_timestamp: nil, &block)
+    def expand(dependent, deps = dependent.deps, cache_key: nil, cache_timestamp: nil, formula_cache: nil, &block)
+      raise ArgumentError, "formula_cache requires cache_key" if formula_cache && cache_key.blank?
+
       # Keep track dependencies to avoid infinite cyclic dependency recursion.
       @expand_stack ||= T.let([], T.nilable(T::Array[T.any(String, Symbol)]))
       @expand_stack.push dependent.name
@@ -206,14 +209,15 @@ class Dependency
           when Dependable::SKIP
             next if @expand_stack.include? dep.name
 
-            expanded_deps.concat(expand(dep.to_formula, cache_key:, &block))
+            expanded_deps.concat(expand(formula_for_dependency(dep, formula_cache), cache_key:, formula_cache:,
+                                        &block))
           when Dependable::KEEP_BUT_PRUNE_RECURSIVE_DEPS
             expanded_deps << dep
           else
             next if @expand_stack.include? dep.name
 
-            dep_formula = dep.to_formula
-            expanded_deps.concat(expand(dep_formula, cache_key:, &block))
+            dep_formula = formula_for_dependency(dep, formula_cache)
+            expanded_deps.concat(expand(dep_formula, cache_key:, formula_cache:, &block))
 
             # Fixes names for renamed/aliased formulae.
             dep = dep.dup_with_formula_name(dep_formula)
@@ -299,6 +303,13 @@ class Dependency
     T::Sig::WithoutRuntime.sig { params(dependent: T.any(Formula, CaskDependent)).returns(String) }
     def cache_id(dependent)
       "#{dependent.full_name}_#{dependent.class}"
+    end
+
+    sig { params(dep: Dependency, formula_cache: T.nilable(T::Hash[Dependency, Formula])).returns(Formula) }
+    def formula_for_dependency(dep, formula_cache)
+      return dep.to_formula unless formula_cache
+
+      formula_cache[dep] ||= dep.to_formula
     end
 
     sig { params(deps: T::Array[Dependency]).returns(T::Array[T.any(String, Symbol)]) }

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -774,7 +774,12 @@ on_request: installed_on_request?, options:)
   def expand_dependencies_for_formula(formula)
     # Cache for this expansion only. FormulaInstaller has a lot of inputs which can alter expansion.
     cache_key = "FormulaInstaller-#{formula.full_name}-#{Time.now.to_f}"
-    Dependency.expand(formula, cache_key:) do |dependent, dep|
+    formula_cache = T.let({}, T::Hash[Dependency, Formula])
+    satisfied_cache = T.let(
+      {},
+      T::Hash[T::Array[T.nilable(T.any(Dependency, String, Integer))], T::Boolean],
+    )
+    Dependency.expand(formula, cache_key:, formula_cache:) do |dependent, dep|
       dependent = T.cast(dependent, Formula)
       build = effective_build_options_for(dependent)
 
@@ -788,11 +793,19 @@ on_request: installed_on_request?, options:)
       minimum_revision = @bottle_tab_runtime_dependencies.dig(dep.name, "revision")&.to_i
       bottle_os_version = @bottle_built_os_version
 
-      if dep.prune_from_option?(build) || ((dep.build? || dep.test?) && !keep_build_test)
-        next Dependable::PRUNE
-      elsif dep.satisfied?(minimum_version:, minimum_revision:, bottle_os_version:)
-        next Dependable::SKIP
+      next Dependable::PRUNE if dep.prune_from_option?(build) || ((dep.build? || dep.test?) && !keep_build_test)
+
+      satisfied_cache_key = T.let([
+        dep,
+        minimum_version&.to_s,
+        minimum_revision,
+        bottle_os_version,
+      ], T::Array[T.nilable(T.any(Dependency, String, Integer))])
+      satisfied = satisfied_cache.fetch(satisfied_cache_key) do
+        satisfied_cache[satisfied_cache_key] = dep.satisfied?(minimum_version:, minimum_revision:, bottle_os_version:)
       end
+
+      next Dependable::SKIP if satisfied
     end
   end
 

--- a/Library/Homebrew/test/dependency_expansion_spec.rb
+++ b/Library/Homebrew/test/dependency_expansion_spec.rb
@@ -112,6 +112,49 @@ RSpec.describe Dependency do
     expect(deps).to eq([foo, baz])
   end
 
+  it "reuses formulae from the provided formula cache" do
+    shared_formula = instance_double(Formula, deps: [], name: "shared", full_name: "shared")
+    shared_dep = described_class.new("shared")
+    repeated_shared_dep = described_class.new("shared")
+    expect(shared_dep).to receive(:to_formula).once.and_return(shared_formula)
+    expect(repeated_shared_dep).not_to receive(:to_formula)
+    f = instance_double(
+      Formula,
+      name:      "f",
+      full_name: "f",
+      deps:      [
+        build_dep(:foo, [], [shared_dep]),
+        build_dep(:bar, [], [repeated_shared_dep]),
+      ],
+    )
+
+    deps = described_class.expand(f, cache_key: "formula-cache-spec", formula_cache: {})
+
+    expect(deps.map(&:name)).to eq(%w[shared foo bar])
+  end
+
+  it "does not reuse formulae for uses_from_macos dependencies with different bounds" do
+    first_formula = instance_double(Formula, deps: [], name: "shared", full_name: "shared")
+    second_formula = instance_double(Formula, deps: [], name: "shared", full_name: "shared")
+    first_dep = UsesFromMacOSDependency.new("shared", [], bounds: { since: :ventura })
+    second_dep = UsesFromMacOSDependency.new("shared", [], bounds: { since: :sonoma })
+    expect(first_dep).to receive(:to_formula).once.and_return(first_formula)
+    expect(second_dep).to receive(:to_formula).once.and_return(second_formula)
+    f = instance_double(
+      Formula,
+      name:      "f",
+      full_name: "f",
+      deps:      [
+        build_dep(:foo, [], [first_dep]),
+        build_dep(:bar, [], [second_dep]),
+      ],
+    )
+
+    deps = described_class.expand(f, cache_key: "uses-from-macos-formula-cache-spec", formula_cache: {})
+
+    expect(deps.map(&:name)).to eq(%w[shared foo bar])
+  end
+
   it "returns only the dependencies given as a collection as second argument" do
     expect(formula.deps).to eq([foo, bar, baz, qux])
     expect(described_class.expand(formula, [bar, baz])).to eq([bar, baz])

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -341,6 +341,76 @@ RSpec.describe FormulaInstaller do
     end
   end
 
+  describe "#expand_dependencies_for_formula" do
+    it "checks equal dependency satisfaction once per expansion" do
+      shared_formula = instance_double(Formula, deps: [], name: "shared", full_name: "shared")
+      shared_dep = Dependency.new("shared")
+      repeated_shared_dep = Dependency.new("shared")
+      expect(shared_dep).to receive(:satisfied?).once.and_return(false)
+      expect(repeated_shared_dep).not_to receive(:satisfied?)
+      allow(shared_dep).to receive(:to_formula).and_return(shared_formula)
+      allow(repeated_shared_dep).to receive(:to_formula).and_return(shared_formula)
+
+      first_parent = Dependency.new("first-parent")
+      first_parent_formula = instance_double(Formula, deps: [shared_dep], name: "first-parent",
+                                                     full_name: "first-parent")
+      allow(first_parent).to receive_messages(satisfied?: false, to_formula: first_parent_formula)
+
+      second_parent = Dependency.new("second-parent")
+      second_parent_formula = instance_double(Formula, deps: [repeated_shared_dep], name: "second-parent",
+                                                      full_name: "second-parent")
+      allow(second_parent).to receive_messages(satisfied?: false, to_formula: second_parent_formula)
+
+      f = formula "homebrew-expand-dependencies-cache" do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      allow(f).to receive(:deps).and_return([first_parent, second_parent])
+
+      installer = described_class.new(f)
+      build_options = BuildOptions.new(Options.new, Options.new)
+      allow(installer).to receive_messages(effective_build_options_for: build_options, install_bottle_for?: false)
+
+      deps = installer.expand_dependencies_for_formula(f)
+
+      expect(deps.map(&:name)).to eq(%w[shared first-parent second-parent])
+    end
+
+    it "checks uses_from_macos dependencies with different bounds separately" do
+      shared_formula = instance_double(Formula, deps: [], name: "shared", full_name: "shared")
+      first_dep = UsesFromMacOSDependency.new("shared", [], bounds: { since: :ventura })
+      second_dep = UsesFromMacOSDependency.new("shared", [], bounds: { since: :sonoma })
+      expect(first_dep).to receive(:satisfied?).once.and_return(false)
+      expect(second_dep).to receive(:satisfied?).once.and_return(false)
+      allow(first_dep).to receive(:to_formula).and_return(shared_formula)
+      allow(second_dep).to receive(:to_formula).and_return(shared_formula)
+
+      first_parent = Dependency.new("first-parent")
+      first_parent_formula = instance_double(Formula, deps: [first_dep], name: "first-parent",
+                                                     full_name: "first-parent")
+      allow(first_parent).to receive_messages(satisfied?: false, to_formula: first_parent_formula)
+
+      second_parent = Dependency.new("second-parent")
+      second_parent_formula = instance_double(Formula, deps: [second_dep], name: "second-parent",
+                                                      full_name: "second-parent")
+      allow(second_parent).to receive_messages(satisfied?: false, to_formula: second_parent_formula)
+
+      f = formula "homebrew-expand-uses-from-macos-dependencies-cache" do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      allow(f).to receive(:deps).and_return([first_parent, second_parent])
+
+      installer = described_class.new(f)
+      build_options = BuildOptions.new(Options.new, Options.new)
+      allow(installer).to receive_messages(effective_build_options_for: build_options, install_bottle_for?: false)
+
+      deps = installer.expand_dependencies_for_formula(f)
+
+      expect(deps.map(&:name)).to eq(%w[shared first-parent second-parent])
+    end
+  end
+
   describe "versioned keg-only linking defaults" do
     let(:base_name) { "homebrew-versioned-formula" }
     let(:formula_name) { "#{base_name}@1.0" }


### PR DESCRIPTION
During a single dependency expansion pass, `Dependency.expand` resolved every dependency edge with a fresh `dep.to_formula`, and `FormulaInstaller#expand_dependencies_for_formula` re-ran `dep.satisfied?` for equal edges. Homebrew's factory cache is disabled on the `install`/`upgrade` path, so each `to_formula` reloads the formula, and a shared low-level dependency reached through many edges is loaded once per edge. That is the repeated `Formulary::FromAPILoader: loading` work reported in #22896, worst on Linux when the implicit `bubblewrap` dependency is unsatisfied and pulled into many subtrees.

This adds two caches scoped to one `expand_dependencies_for_formula` call and discarded afterwards: a formula cache so equal edges reuse one resolved `Formula`, and a satisfied cache so equal edges check `dep.satisfied?` once. Both key on the full dependency identity via `hash`/`eql?` (including `UsesFromMacOSDependency` bounds), so subclass state is never collapsed. Behaviour is unchanged: the caches only remove repeated work, and `formula_cache` raises unless a `cache_key` is also given, so it is only usable where expansion results are already memoized.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 4.8) implemented the per-expansion caching and its tests and reviewed the change for correctness. I reviewed the diff, confirmed the new specs fail without the caches and pass with them, and ran `brew lgtm` plus targeted `brew tests --only=dependency_expansion` / `--only=formula_installer`.

-----
