### PR TITLE
Isolate the upgrade summary alignment spec from the formula API

### DIFF
--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       .to output(/minimum-version-formula 1\.2\.2 -> 1\.2\.3/).to_stdout
   end
 
-  it "aligns formula-only no-ask upgrade summaries" do
+  it "aligns formula-only no-ask upgrade summaries", :no_api do
     write_formula "gh", <<~RUBY
       url "https://brew.sh/gh-2.95.0"
     RUBY


### PR DESCRIPTION
The `aligns formula-only no-ask upgrade summaries` spec writes a `gh` fixture to the core tap, but `gh` is a real `homebrew/core` formula. With install-from-API enabled (the default for untagged examples), the bare `gh` argument resolves through the `Formulary` API loader to the real core formula rather than the written fixture, so the expected summary broke whenever core `gh` moved. The merge queue saw `2.96.0` against the fixture version.

Tagging the example `:no_api` sets `HOMEBREW_NO_INSTALL_FROM_API`, so `gh` resolves to the written tap fixture. This is how every other fixture in the file already resolves: synthetic names are absent from the API index and fall through to the tap loader, so only the real-named `gh` case was affected.

The spec is now deterministic and independent of the live core `gh` version, with no change to what it asserts about summary alignment.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 4.8) diagnosed the failing spec; I reviewed the diff and verified with `brew lgtm` and the targeted `cmd/upgrade` spec.

-----
