### PR TITLE
formula_auditor: propagate OS requirement to dependents

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -425,10 +425,10 @@ module Homebrew
 
           # we can only verify the OS requirement of the currently running platform
           os_req = if Homebrew::SimulateSystem.simulating_or_running_on_linux? &&
-                      !dep_f.supports_linux? && formula.supports_linux?
+                      !dep_f.supports_linux? && !spec.depends_on_macos_set_top_level?
             "macOS"
           elsif Homebrew::SimulateSystem.simulating_or_running_on_macos? &&
-                !dep_f.supports_macos? && formula.supports_macos?
+                !dep_f.supports_macos? && !spec.depends_on_linux_set_top_level?
             "Linux"
           end
           problem <<~EOS if os_req

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -423,6 +423,19 @@ module Homebrew
             EOS
           end
 
+          # we can only verify the OS requirement of the currently running platform
+          os_req = if Homebrew::SimulateSystem.simulating_or_running_on_linux? &&
+                      !dep_f.supports_linux? && formula.supports_linux?
+            "macOS"
+          elsif Homebrew::SimulateSystem.simulating_or_running_on_macos? &&
+                !dep_f.supports_macos? && formula.supports_macos?
+            "Linux"
+          end
+          problem <<~EOS if os_req
+            Dependency '#{dep.name}' has a #{os_req} requirement. Either move the
+            dependency inside an `on_#{os_req.downcase}` block or add `depends_on :#{os_req.downcase}`.
+          EOS
+
           # we want to allow uses_from_macos for aliases but not bare dependencies.
           # we also allow `pkg-config` for backwards compatibility in external taps.
           if self.class.aliases.include?(dep.name) && !dep.uses_from_macos? && (dep.name != "pkg-config" || @core_tap)

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -1331,8 +1331,10 @@ RSpec.describe Homebrew::FormulaAuditor do
           end
         end
 
-        before do
-          allow(Homebrew::SimulateSystem).to receive(:simulating_or_running_on_linux?).and_return(false)
+        around do |example|
+          Homebrew::SimulateSystem.with(os: :macos) do
+            example.run
+          end
         end
 
         it "reports missing requirement" do

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -1278,6 +1278,69 @@ RSpec.describe Homebrew::FormulaAuditor do
         it(:problems) { expect(f_a.problems).to be_empty }
       end
     end
+
+    describe "when formula lacks OS requirement but has OS-specific dependency" do
+      subject(:f_a) { fa }
+
+      let(:fa) do
+        formula_auditor "foo", <<~RUBY, core_tap: true
+          class Foo < Formula
+            url "https://brew.sh/foo-1.0.tgz"
+            homepage "https://brew.sh"
+
+            depends_on "os-only"
+          end
+        RUBY
+      end
+
+      before do
+        allow(fa.formula.deps.first).to receive(:to_formula).and_return(f_os_only)
+      end
+
+      describe "for macOS when running on Linux" do
+        let(:f_os_only) do
+          formula do
+            T.bind(self, T.class_of(Formula))
+            url "https://brew.sh/os-only-1.0.tgz"
+            homepage "https://brew.sh"
+
+            depends_on :macos
+          end
+        end
+
+        around do |example|
+          Homebrew::SimulateSystem.with(os: :linux) do
+            example.run
+          end
+        end
+
+        it "reports missing requirement" do
+          fa.audit_deps
+          expect(f_a.problems).to include(a_hash_including(message: a_string_matching(/has a macOS requirement/)))
+        end
+      end
+
+      describe "for Linux when running on macOS" do
+        let(:f_os_only) do
+          formula do
+            T.bind(self, T.class_of(Formula))
+            url "https://brew.sh/os-only-1.0.tgz"
+            homepage "https://brew.sh"
+
+            depends_on :linux
+          end
+        end
+
+        before do
+          allow(Homebrew::SimulateSystem).to receive(:simulating_or_running_on_linux?).and_return(false)
+        end
+
+        it "reports missing requirement" do
+          fa.audit_deps
+          expect(f_a.problems).to include(a_hash_including(message: a_string_matching(/has a Linux requirement/)))
+        end
+      end
+    end
   end
 
   describe "#audit_stable_version" do


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Previously, CI runs would silently skip running and show pass result when a formula included an incorrect OS-specific dependency. This often requires a subsequent PR to fix. This commit makes it required for Homebrew/core formulae to explicitly propagate OS-specific requirements.

One additional advantage is this will properly display OS requirements at places like formulae.brew.sh.