### PR TITLE
Avoid generated rmdir for shared file lists

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-zap.rb
+++ b/Library/Homebrew/dev-cmd/generate-zap.rb
@@ -79,6 +79,8 @@ module Homebrew
 
       RMDIR_EXCLUSIONS = T.let([
         "Library/Application Support/CrashReporter",
+        "Library/Application Support/com.apple.sharedfilelist/" \
+        "com.apple.LSSharedFileList.ApplicationRecentDocuments",
         "/Library/Application Support",
         "/Library/Caches",
         "/Library/Preferences",

--- a/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
@@ -321,6 +321,15 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
       expect(result).to be_empty
     end
 
+    it "does not suggest rmdir for application recent documents" do
+      paths = [
+        "~/Library/Application Support/com.apple.sharedfilelist/" \
+        "com.apple.LSSharedFileList.ApplicationRecentDocuments/org.example.foo.sfl2",
+      ]
+      result = generate_zap.send(:derive_rmdir_candidates, paths)
+      expect(result).to be_empty
+    end
+
     it "does not suggest rmdir for system-level shared directories" do
       paths = ["/Library/Application Support/Foo"]
       result = generate_zap.send(:derive_rmdir_candidates, paths)

--- a/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
@@ -321,13 +321,15 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
       expect(result).to be_empty
     end
 
-    it "does not suggest rmdir for application recent documents" do
-      paths = [
+    it "does not suggest rmdir for application recent documents directory" do
+      application_recent_documents =
         "~/Library/Application Support/com.apple.sharedfilelist/" \
-        "com.apple.LSSharedFileList.ApplicationRecentDocuments/org.example.foo.sfl2",
+        "com.apple.LSSharedFileList.ApplicationRecentDocuments"
+      paths = [
+        "#{application_recent_documents}/org.example.foo.sfl2",
       ]
       result = generate_zap.send(:derive_rmdir_candidates, paths)
-      expect(result).to be_empty
+      expect(result).not_to include(application_recent_documents)
     end
 
     it "does not suggest rmdir for system-level shared directories" do


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

GitHub Copilot CLI helped make this small change. I verified it with the new regression test, `./bin/brew lgtm --online`, and `./bin/brew generate-zap transmission`.

-----

This prevents `brew generate-zap` from suggesting `rmdir` for Apple's shared recent documents directory when it finds an app-specific `.sfl*` file under that directory.

For example, before this change, running:

```sh
brew generate-zap transmission
```

could suggest removing:

```ruby
rmdir: "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments"
```

`zap rmdir` only removes directories if they are empty, so this would not remove
other applications' shared file list entries.
However, this parent directory is macOS-owned and not app-specific, so including
it in generated cask-specific zap stanzas is misleading noise.
The matching app-specific shared file list file is already included under
`trash`.

This adds that directory to the generated `rmdir` exclusions and adds a regression test for the derived `rmdir` candidates.

`./bin/brew lgtm --online` passes locally.
