### PR TITLE
Prepare cask taps before bundle jobs

### DIFF
--- a/Library/Homebrew/bundle/parallel_installer.rb
+++ b/Library/Homebrew/bundle/parallel_installer.rb
@@ -48,6 +48,23 @@ module Homebrew
         end
         ::Tap.clear_cache if tap_entries.present?
 
+        require "tap"
+        installed_taps = Homebrew::Bundle::Tap.installed_taps
+        pending_entries.each do |entry|
+          tap_with_name = if entry.cls == Homebrew::Bundle::Brew
+            ::Tap.with_formula_name(entry.full_name)
+          elsif entry.cls == Homebrew::Bundle::Cask
+            ::Tap.with_cask_token(entry.full_name)
+          end
+          next unless tap_with_name
+
+          tap = tap_with_name.first
+          next if installed_taps.include?(tap.name) || tap_entries.any? { |tap_entry| tap_entry.name == tap.name }
+
+          tap.ensure_installed!
+          installed_taps << tap.name
+        end
+
         prepare_attestation_verification!(pending_entries)
         dependency_map = build_dependency_map(pending_entries)
         completed = T.let(Set.new, T::Set[String])

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -329,6 +329,7 @@ RSpec.describe Homebrew::Bundle::Installer do
       allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("alpha").and_return(Set.new)
       allow(Homebrew::Bundle::Cask).to receive(:formula_dependencies).with(["tmuxpack/tpack/tpack"])
                                                                      .and_return([])
+      allow(Tap).to receive(:with_cask_token).with("tmuxpack/tpack/tpack").and_return(nil)
       allow(Homebrew::Bundle::Brew).to receive(:install!) do |name, **_options|
         install_order << name
         true
@@ -423,6 +424,7 @@ RSpec.describe Homebrew::Bundle::Installer do
       allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("alpha").and_return(Set.new)
       allow(Homebrew::Bundle::Cask).to receive(:formula_dependencies).with(["tmuxpack/tpack/tpack"])
                                                                      .and_return(["alpha"])
+      allow(Tap).to receive(:with_cask_token).with("tmuxpack/tpack/tpack").and_return(nil)
       allow(Homebrew::Bundle::Brew).to receive(:install!) do |name, **_options|
         install_order << name
         true
@@ -440,6 +442,48 @@ RSpec.describe Homebrew::Bundle::Installer do
       expect(success).to eq(2)
       expect(failure).to eq(0)
       expect(install_order).to eq(["alpha", "tpack"])
+    end
+
+    it "taps fully qualified casks before resolving dependencies" do
+      tpack_entry = Homebrew::Bundle::Installer::InstallableEntry.new(
+        name:    "tpack",
+        options: { args: {}, full_name: "tmuxpack/tpack/tpack" },
+        verb:    "Installing",
+        cls:     Homebrew::Bundle::Cask,
+      )
+      install_order = []
+      event_order = []
+      tap = instance_double(Tap, name: "tmuxpack/tpack", ensure_installed!: nil)
+
+      allow(Homebrew::Bundle::Tap).to receive(:installed_taps).and_return([])
+      allow(Tap).to receive(:with_formula_name).with("alpha").and_return(nil)
+      allow(Tap).to receive(:with_cask_token).with("tmuxpack/tpack/tpack").and_return([tap, "tpack"])
+      allow(tap).to receive(:ensure_installed!) { event_order << :tap_install }
+      allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(false)
+      allow(Homebrew::Bundle::Brew).to receive(:formula_dep_names).with("alpha").and_return([])
+      allow(Homebrew::Bundle::Brew).to receive(:recursive_dep_names).with("alpha").and_return(Set.new)
+      allow(Homebrew::Bundle::Cask).to receive(:formula_dependencies).with(["tmuxpack/tpack/tpack"]) do
+        event_order << :cask_deps
+        ["alpha"]
+      end
+      allow(Homebrew::Bundle::Brew).to receive(:install!) do |name, **_options|
+        install_order << name
+        true
+      end
+      allow(Homebrew::Bundle::Cask).to receive(:install!) do |name, **_options|
+        install_order << name
+        true
+      end
+
+      success, failure = Homebrew::Bundle::ParallelInstaller.new(
+        [alpha_entry, tpack_entry],
+        jobs: 2, no_upgrade: false, verbose: false, force: false, quiet: true,
+      ).run!
+
+      expect(success).to eq(2)
+      expect(failure).to eq(0)
+      expect(install_order).to eq(["alpha", "tpack"])
+      expect(event_order).to eq([:tap_install, :cask_deps])
     end
 
     it "installs unqualified formulae after Brewfile taps" do


### PR DESCRIPTION
- Fully qualified casks can need their tap before dependency discovery.
- Loading those deps before scheduling avoids parallel lock races.

Fixes #22899 

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
