### PR TITLE
Restrict livecheck redirects

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -44,14 +44,21 @@ module Homebrew
       # redirections, followed by a final `200 OK` response.
       MAX_PARSE_ITERATIONS = T.let(MAX_REDIRECTIONS + 1, Integer)
 
+      # `curl` arguments used when following redirections in {Strategy}
+      # methods.
+      REDIRECTION_CURL_ARGS = T.let([
+        "--max-redirs", MAX_REDIRECTIONS.to_s,
+        *https_redirect_curl_args
+      ].freeze, T::Array[String])
+
       # Baseline `curl` arguments used in {Strategy} methods.
       DEFAULT_CURL_ARGS = T.let([
         # Follow redirections to handle mirrors, relocations, etc.
         "--location",
-        "--max-redirs", MAX_REDIRECTIONS.to_s,
+        *REDIRECTION_CURL_ARGS,
         # Avoid progress bar text, so we can reliably identify `curl` error
         # messages in output
-        "--silent"
+        "--silent",
       ].freeze, T::Array[String])
 
       # `curl` arguments used in `Strategy#page_content` method.
@@ -236,8 +243,7 @@ module Homebrew
           begin
             parsed_output = curl_headers(
               *curl_post_args,
-              "--max-redirs",
-              MAX_REDIRECTIONS.to_s,
+              *REDIRECTION_CURL_ARGS,
               url,
               wanted_headers:    ["location", "content-disposition"],
               use_homebrew_curl: options.homebrew_curl || false,

--- a/Library/Homebrew/test/livecheck/strategy_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy_spec.rb
@@ -187,6 +187,25 @@ RSpec.describe Homebrew::Livecheck::Strategy do
       expect(strategy.page_headers(url)).to eq([responses.first[:headers]])
     end
 
+    it "only allows HTTPS redirects" do
+      expect(strategy).to receive(:curl_headers).with(
+        "--max-redirs",
+        "5",
+        "--proto-redir",
+        "=https",
+        url,
+        wanted_headers:    ["location", "content-disposition"],
+        use_homebrew_curl: false,
+        cookies:           nil,
+        header:            nil,
+        referer:           nil,
+        user_agent:        :default,
+        **Homebrew::Livecheck::Strategy::DEFAULT_CURL_OPTIONS,
+      ).and_return({ responses:, body: })
+
+      expect(strategy.page_headers(url)).to eq([responses.first[:headers]])
+    end
+
     it "handles `cookies` `url` options" do
       allow(strategy).to receive(:curl_headers).and_return({ responses:, body: })
 
@@ -278,6 +297,31 @@ RSpec.describe Homebrew::Livecheck::Strategy do
     it "returns hash including fetched content" do
       allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
       allow(strategy).to receive(:curl_output).and_return([response_text[:ok], nil, success_status])
+
+      expect(strategy.page_content(url)).to eq({ content: body })
+    end
+
+    it "only allows HTTPS redirects" do
+      allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
+
+      expect(strategy).to receive(:curl_output).with(
+        "--fail-with-body",
+        "--include",
+        "--location",
+        "--max-redirs",
+        "5",
+        "--proto-redir",
+        "=https",
+        "--silent",
+        "--compressed",
+        url,
+        **Homebrew::Livecheck::Strategy::DEFAULT_CURL_OPTIONS,
+        use_homebrew_curl: false,
+        cookies:           nil,
+        header:            nil,
+        referer:           nil,
+        user_agent:        :default,
+      ).and_return([response_text[:ok], nil, success_status])
 
       expect(strategy.page_content(url)).to eq({ content: body })
     end

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -42,11 +42,14 @@ module Utils
     # the status code and any following descriptive text (e.g. `Not Found`).
     HTTP_STATUS_LINE_REGEX = %r{^HTTP/.* (?<code>\d+)(?: (?<text>[^\r\n]+))?}
 
+    HTTPS_REDIRECT_CURL_ARGS = T.let(["--proto-redir", "=https"].freeze, T::Array[String])
+
     private_constant :CURL_WEIRD_SERVER_REPLY_EXIT_CODE,
                      :CURL_HTTP_RETURNED_ERROR_EXIT_CODE,
                      :CURL_RECV_ERROR_EXIT_CODE,
                      :ETAG_VALUE_REGEX, :HTTP_RESPONSE_BODY_SEPARATOR,
-                     :HTTP_STATUS_LINE_REGEX
+                     :HTTP_STATUS_LINE_REGEX,
+                     :HTTPS_REDIRECT_CURL_ARGS
 
     module_function
 
@@ -172,6 +175,11 @@ module Utils
         url.start_with?("https://") && !resolved_url.start_with?("https://")
     end
 
+    sig { returns(T::Array[String]) }
+    def https_redirect_curl_args
+      HTTPS_REDIRECT_CURL_ARGS
+    end
+
     sig { params(args: T::Array[String]).returns(T::Array[String]) }
     def no_insecure_redirect_curl_args(args)
       return args unless Homebrew::EnvConfig.no_insecure_redirect?
@@ -191,7 +199,7 @@ module Utils
       # This blocks an HTTPS request from following a redirect to HTTP at the
       # curl layer, including cases where a preflight request saw a different
       # redirect chain than the real download.
-      ["--proto-redir", "=https", *args]
+      [*https_redirect_curl_args, *args]
     end
 
     sig {


### PR DESCRIPTION
- Prevent `brew livecheck` from following upstream redirects to non-HTTPS targets by default.
- Keep livecheck content and header fetches aligned so redirect handling does not diverge.
- Cover the redirect protocol guard with focused regressions.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
