### PR TITLE
Uninstall untrusted casks safely

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -9,10 +9,12 @@ require "utils/output"
 
 require "api/cask_download"
 require "cask/config"
+require "cask/dsl"
 require "cask/download"
 require "cask/migrator"
 require "cask/quarantine"
 require "cask/tab"
+require "trust"
 
 module Cask
   # Installer for a {Cask}.
@@ -56,6 +58,7 @@ module Cask
       @download_queue = download_queue
       @defer_fetch = defer_fetch
       @source_download = T.let(nil, T.nilable(Homebrew::API::SourceDownload))
+      @default_uninstall_artifacts = T.let(nil, T.nilable(ArtifactSet))
       @ran_prelude_fetch = T.let(false, T::Boolean)
       @ran_prelude = T.let(false, T::Boolean)
       @cask_and_formula_dependencies = T.let(nil, T.nilable(T::Array[T.any(Formula, ::Cask::Cask)]))
@@ -272,7 +275,7 @@ on_request: true)
 
     sig { returns(ArtifactSet) }
     def artifacts
-      @cask.artifacts
+      @default_uninstall_artifacts || @cask.artifacts
     end
 
     sig { params(to: Pathname).void }
@@ -1000,6 +1003,44 @@ on_request: true)
       installed_caskfile = @cask.installed_caskfile
 
       if installed_caskfile&.exist?
+        tab = @cask.tab
+        tap = tab.tap
+        if installed_caskfile.extname == ".rb" &&
+           Homebrew::EnvConfig.require_tap_trust? &&
+           tap &&
+           !Homebrew::Trust.trusted?(:cask, "#{tap.name}/#{@cask.token}")
+          opoo "Skipping loading untrusted Cask #{tap.name}/#{@cask.token}; uninstalling recorded artifacts only."
+
+          dsl = DSL.new(@cask)
+          default_uninstall_artifact_keys = DSL::ACTIVATABLE_ARTIFACT_CLASSES.filter_map do |klass|
+            next if [Artifact::Uninstall, Artifact::Zap].include?(klass)
+            next if !klass.method_defined?(:uninstall_phase) && !klass.method_defined?(:post_uninstall_phase)
+
+            klass.dsl_key
+          end.to_set
+          Array(tab.uninstall_artifacts).each do |artifact_entry|
+            next unless artifact_entry.is_a?(Hash)
+
+            artifact_entry.each do |raw_key, raw_args|
+              dsl_key = raw_key.to_sym
+              next unless default_uninstall_artifact_keys.include?(dsl_key)
+
+              args = Array(raw_args)
+              if args.last.is_a?(Hash)
+                dsl.public_send(
+                  dsl_key,
+                  *args[...-1],
+                  **T.cast(args.last, T::Hash[T.any(Symbol, String), T.anything]).transform_keys(&:to_sym),
+                )
+              else
+                dsl.public_send(dsl_key, *args)
+              end
+            end
+          end
+          @default_uninstall_artifacts = dsl.artifacts
+          return
+        end
+
         begin
           @cask = CaskLoader.load_from_installed_caskfile(installed_caskfile)
           return

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -381,7 +381,13 @@ module Homebrew
             cask = begin
               config = Cask::Config.from_args(@parent) if @cask_options
               options = { warn: }.compact
-              candidate_cask = Cask::CaskLoader.load(name, config:, **options)
+              untrusted_installed_cask = (load_untrusted_installed_cask(name, config:) if want_keg_like_cask)
+              candidate_cask = untrusted_installed_cask || Cask::CaskLoader.load(name, config:, **options)
+              skip_installed_caskfile_load = if untrusted_installed_cask
+                !untrusted_installed_cask.loaded_from_api?
+              else
+                false
+              end
 
               if unreadable_error
                 onoe <<~EOS
@@ -393,7 +399,7 @@ module Homebrew
 
               # If we're trying to get a keg-like Cask, do our best to use the same cask
               # file that was used for installation, if possible.
-              if want_keg_like_cask &&
+              if want_keg_like_cask && !skip_installed_caskfile_load &&
                  (installed_caskfile = candidate_cask.installed_caskfile) &&
                  installed_caskfile.exist?
                 cask = Cask::CaskLoader.load_from_installed_caskfile(installed_caskfile)
@@ -411,6 +417,12 @@ module Homebrew
               else
                 candidate_cask
               end
+            rescue Homebrew::UntrustedTapError
+              raise unless want_keg_like_cask
+
+              raise unless (untrusted_installed_cask = load_untrusted_installed_cask(name, config:))
+
+              untrusted_installed_cask
             rescue Cask::CaskUnreadableError, Cask::CaskInvalidError => e
               # If we're trying to get a keg-like Cask, do our best to handle it
               # not being readable and return something that can be used.
@@ -458,6 +470,38 @@ module Homebrew
           end
 
           raise NoSuchKegError, name if resolve_formula(name)
+        end
+      end
+
+      sig {
+        params(name: String, config: T.nilable(Cask::Config))
+          .returns(T.nilable(Cask::Cask))
+      }
+      def load_untrusted_installed_cask(name, config: nil)
+        return unless Homebrew::EnvConfig.require_tap_trust?
+
+        require "trust"
+
+        requested_tap, token = Tap.with_cask_token(name) || [nil, name]
+        token = ::Utils.name_from_full_name(token)
+        installed_cask = Cask::Cask.new(token, config:)
+        installed_caskfile = installed_cask.installed_caskfile
+        return unless installed_caskfile&.exist?
+
+        installed_tap = installed_cask.tab.tap
+        return unless installed_tap
+        return if requested_tap && requested_tap != installed_tap
+        return if Homebrew::Trust.trusted?(:cask, "#{installed_tap.name}/#{token}")
+
+        if installed_caskfile.extname == ".json"
+          return Cask::CaskLoader.load_from_installed_caskfile(installed_caskfile,
+                                                               config:)
+        end
+
+        return unless (cask_version = Cask::Caskroom.cask_installed_version(token))
+
+        Cask::Cask.new(token, tap: installed_tap, config:) do
+          version cask_version
         end
       end
 

--- a/Library/Homebrew/test/cmd/uninstall_spec.rb
+++ b/Library/Homebrew/test/cmd/uninstall_spec.rb
@@ -51,4 +51,85 @@ RSpec.describe Homebrew::Cmd::UninstallCmd do
 
     cmd.run
   end
+
+  it "does not read an untrusted installed cask when uninstalling", :cask, :trust_store do
+    tap = Tap.fetch("untrusted", "tap")
+    full_name = "untrusted/tap/local-caffeine"
+    cask_file = tap.cask_dir/"local-caffeine.rb"
+    cask_file.dirname.mkpath
+    FileUtils.cp cask_path("local-caffeine"), cask_file
+    tap.clear_cache
+
+    cask = with_env(HOMEBREW_NO_REQUIRE_TAP_TRUST: "1") do
+      Cask::CaskLoader.load(full_name).tap { |cask| Cask::Installer.new(cask).install }
+    end
+    cask_file.write <<~RUBY
+      raise "untrusted tap cask evaluated"
+    RUBY
+    cask.installed_caskfile&.write <<~RUBY
+      raise "untrusted installed cask evaluated"
+    RUBY
+    allow(Homebrew::Cleanup).to receive(:autoremove)
+
+    original_argv = ARGV.dup
+    begin
+      ARGV.replace(["--cask", "--force", full_name])
+      with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1", HOMEBREW_NO_REQUIRE_TAP_TRUST: nil) do
+        expect { described_class.new(["--cask", "--force", full_name]).run }
+          .to output(/Uninstalling Cask local-caffeine/).to_stdout
+          .and output(/Skipping loading untrusted Cask #{full_name}; uninstalling recorded artifacts only/).to_stderr
+          .and not_to_output(/untrusted .* cask evaluated/).to_stderr
+      end
+    ensure
+      ARGV.replace(original_argv)
+      FileUtils.rm_rf tap.path.parent
+    end
+
+    expect(Pathname(cask.config.appdir).join("Caffeine.app")).not_to exist
+    expect(cask).not_to be_installed
+  end
+
+  it "reads installed JSON cask metadata when uninstalling from an untrusted tap", :cask, :trust_store do
+    tap = Tap.fetch("untrusted", "json")
+    full_name = "untrusted/json/local-caffeine"
+    cask_file = tap.cask_dir/"local-caffeine.rb"
+    cask_file.dirname.mkpath
+    FileUtils.cp cask_path("local-caffeine"), cask_file
+    tap.clear_cache
+
+    cask = with_env(HOMEBREW_NO_REQUIRE_TAP_TRUST: "1") do
+      Cask::CaskLoader.load(full_name).tap { |cask| Cask::Installer.new(cask).install }
+    end
+    cask_file.write <<~RUBY
+      raise "untrusted tap cask evaluated"
+    RUBY
+    installed_caskfile = cask.installed_caskfile
+    json_caskfile = installed_caskfile.dirname/"local-caffeine.json"
+    json = JSON.parse((TEST_FIXTURE_DIR/"cask/caffeine.json").read)
+    json["token"] = "local-caffeine"
+    json["full_token"] = full_name
+    json["tap"] = tap.name
+    json_caskfile.write JSON.pretty_generate(json)
+    installed_caskfile.write <<~RUBY
+      raise "untrusted installed cask evaluated"
+    RUBY
+    allow(Homebrew::Cleanup).to receive(:autoremove)
+
+    original_argv = ARGV.dup
+    begin
+      ARGV.replace(["--cask", "--force", full_name])
+      with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1", HOMEBREW_NO_REQUIRE_TAP_TRUST: nil) do
+        expect { described_class.new(["--cask", "--force", full_name]).run }
+          .to output(/Uninstalling Cask local-caffeine/).to_stdout
+          .and not_to_output(/Skipping loading untrusted Cask/).to_stderr
+          .and not_to_output(/untrusted .* cask evaluated/).to_stderr
+      end
+    ensure
+      ARGV.replace(original_argv)
+      FileUtils.rm_rf tap.path.parent
+    end
+
+    expect(Pathname(cask.config.appdir).join("Caffeine.app")).not_to exist
+    expect(cask).not_to be_installed
+  end
 end


### PR DESCRIPTION
- Avoid evaluating untrusted Ruby cask files during `uninstall`
- Keep installed JSON cask metadata usable for default removal
- Warn when falling back to recorded uninstall artifacts

Fixes https://github.com/Homebrew/brew/issues/22892
Closes https://github.com/Homebrew/brew/pull/22894

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
