### PR TITLE
Add install step write cops

### DIFF
--- a/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
+++ b/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
@@ -227,7 +227,12 @@ be resolved before the download can be enqueued.
     is left verbatim. Dynamic interpolation (random cookies, `popen`-derived
     paths, `File.read` rewrites) is intentionally out of scope and stays as
     legacy Ruby.
-  - [ ] PR 5.2, add the `write` enforcing RuboCops in `Homebrew/brew`.
+  - [x] PR 5.2, add the `write` enforcing RuboCops in `Homebrew/brew`.
+    Commit: `Add install step write cops`.
+    Scope: formula and cask RuboCops conservatively autocorrect literal,
+    newline-terminated `.write`, `.atomic_write` and `File.write` legacy
+    blocks to `*_steps` `write` calls with `overwrite: true`. Writes without
+    trailing newlines stay as legacy Ruby because the step DSL appends one.
   - [x] PR 5.3, convert `homebrew/core` formulae to `write`.
     Branch `install-steps-config-write`, commits
     `tronbyt-server: use post_install_steps` and `node@18: use

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -171,6 +171,22 @@ module RuboCop
           return mkdir_step_line(:mkdir_p, path, default_base)
         end
 
+        if [:write, :atomic_write].include?(send_node.method_name)
+          if send_node.receiver&.const_type? && send_node.receiver&.const_name == "File"
+            return if send_node.method_name != :write || send_node.arguments.length != 2
+
+            return write_step_line(
+              install_step_path(send_node.arguments.fetch(0)),
+              send_node.arguments.fetch(1),
+              default_base,
+            )
+          end
+
+          return if send_node.receiver.nil? || send_node.arguments.length != 1
+
+          return write_step_line(install_step_path(send_node.receiver), send_node.arguments.fetch(0), default_base)
+        end
+
         return unless fileutils_or_no_receiver?(send_node)
 
         case send_node.method_name
@@ -268,6 +284,42 @@ module RuboCop
         ].compact
         "#{method_name} #{install_step_path_source(source)}, #{install_step_path_source(target)}" \
           "#{install_step_kwargs(kwargs)}"
+      end
+
+      sig {
+        params(
+          path:         T.nilable(InstallStepPath),
+          content_node: RuboCop::AST::Node,
+          default_base: Symbol,
+        ).returns(T.nilable(String))
+      }
+      def write_step_line(path, content_node, default_base)
+        return if path.nil? || relative_install_step_path?(path)
+
+        kwargs = [
+          install_step_path_keyword(path, base: default_base, keyword: :base),
+          "overwrite: true",
+        ].compact
+        return unless (content_source = write_content_source(content_node, kwargs))
+
+        "write #{install_step_path_source(path)}, #{content_source}"
+      end
+
+      sig { params(content_node: RuboCop::AST::Node, kwargs: T::Array[String]).returns(T.nilable(String)) }
+      def write_content_source(content_node, kwargs)
+        return unless content_node.str_type?
+        return unless T.cast(content_node, RuboCop::AST::StrNode).str_content.end_with?("\n")
+
+        unless content_node.loc.respond_to?(:heredoc_end)
+          return "#{content_node.source}#{install_step_kwargs(kwargs)}"
+        end
+
+        heredoc_end = content_node.loc.heredoc_end
+        return "#{content_node.source}#{install_step_kwargs(kwargs)}" if heredoc_end.nil?
+
+        "#{content_node.loc.expression.source}#{install_step_kwargs(kwargs)}" \
+          "#{::Parser::Source::Range.new(content_node.loc.expression.source_buffer,
+                                         content_node.loc.expression.end_pos, heredoc_end.end_pos).source}"
       end
 
       sig { params(send_node: RuboCop::AST::SendNode).returns(T::Boolean) }

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
           mv "source", "target"
           move_children "source", "target"
           ln_sf "source", "target", source_base: :relative, uninstall: true
+          write "foo.conf", "key = value\n"
         end
       end
     CASK
@@ -93,6 +94,44 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
           touch "Prepared/touched"
           mv "source", "target"
           ln_s "target", "Linked", source_base: :relative
+        end
+      end
+    CASK
+  end
+
+  it "autocorrects simple flight block config writes" do
+    expect_offense <<~'CASK'
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        postflight do
+        ^^^^^^^^^^^^^ Use `postflight_steps` for simple file preparation.
+          File.write staged_path/"Prepared/foo.conf", "key = value\n"
+        end
+      end
+    CASK
+
+    expect_correction <<~'CASK'
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        postflight_steps do
+          write "Prepared/foo.conf", "key = value\n", overwrite: true
+        end
+      end
+    CASK
+  end
+
+  it "does not autocorrect config writes without trailing newlines" do
+    expect_no_offenses <<~CASK
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        postflight do
+          File.write staged_path/"Prepared/foo.conf", "key = value"
         end
       end
     CASK

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -102,6 +102,47 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
     RUBY
   end
 
+  it "autocorrects simple `post_install` config writes" do
+    expect_offense(<<~'RUBY')
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        def post_install
+        ^^^^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Use `post_install_steps` for simple file preparation.
+          (etc/"foo/foo.conf").write "key = value\n"
+          (var/"foo/banner").atomic_write <<~TEXT
+            literal banner
+          TEXT
+        end
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        post_install_steps do
+          write "foo/foo.conf", "key = value\n", base: :etc, overwrite: true
+          write "foo/banner", <<~TEXT, overwrite: true
+            literal banner
+          TEXT
+        end
+      end
+    RUBY
+  end
+
+  it "does not autocorrect config writes without trailing newlines" do
+    expect_no_offenses(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        def post_install
+          (var/"foo.conf").write "key = value"
+        end
+      end
+    RUBY
+  end
+
   it "autocorrects known `post_install` rebuild actions" do
     expect_offense(<<~RUBY)
       class Foo < Formula


### PR DESCRIPTION
- Make the install-step RuboCops convert simple literal writes now that the `write` DSL can preserve overwrite semantics explicitly.
- Leave newline-less writes as legacy Ruby because the step DSL appends a trailing newline and autocorrection must not alter file contents.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
