### PR TITLE
Remove T.let from frozen constants Sorbet can now infer

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -30,7 +30,7 @@ module Homebrew
     # malicious backfilled signatures.
     #
     # @api private
-    BACKFILL_CUTOFF = T.let(DateTime.new(2024, 3, 14).freeze, DateTime)
+    BACKFILL_CUTOFF = DateTime.new(2024, 3, 14).freeze
 
     # Raised when the attestation was not found.
     #

--- a/Library/Homebrew/cask/artifact/generated_completion.rb
+++ b/Library/Homebrew/cask/artifact/generated_completion.rb
@@ -13,7 +13,7 @@ module Cask
   module Artifact
     # Artifact corresponding to the `generate_completions_from_executable` stanza.
     class GeneratedCompletion < AbstractArtifact
-      SUPPORTED_SHELLS = T.let([:bash, :zsh, :fish, :pwsh].freeze, T::Array[Symbol])
+      SUPPORTED_SHELLS = [:bash, :zsh, :fish, :pwsh].freeze
 
       sig { override.returns(Symbol) }
       def self.dsl_key

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -574,7 +574,7 @@ module Cask
       }
     end
 
-    HASH_KEYS_TO_SKIP = T.let(%w[outdated installed pinned pinned_version versions].freeze, T::Array[String])
+    HASH_KEYS_TO_SKIP = %w[outdated installed pinned pinned_version versions].freeze
     private_constant :HASH_KEYS_TO_SKIP
 
     AUTO_UPDATES_BAD_BUNDLE_VERSIONS = %w[0 0.0].freeze

--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -17,7 +17,7 @@ module Cask
     class Caveats < Base
       # Built-in caveats that have runtime conditions (arch, prefix, etc.)
       # and should not be pre-serialized into the API JSON string.
-      CONDITIONAL_CAVEATS = T.let([:requires_rosetta, :files_in_usr_local].freeze, T::Array[Symbol])
+      CONDITIONAL_CAVEATS = [:requires_rosetta, :files_in_usr_local].freeze
 
       sig { params(args: T.anything).void }
       def initialize(*args)

--- a/Library/Homebrew/dependable.rb
+++ b/Library/Homebrew/dependable.rb
@@ -19,10 +19,7 @@ module Dependable
 
   # `:run` and `:linked` are no longer used but keep them here to avoid their
   # misuse in future.
-  RESERVED_TAGS = T.let(
-    [:build, :optional, :recommended, :run, :test, :linked, :implicit, :no_linkage].freeze,
-    T::Array[Symbol],
-  )
+  RESERVED_TAGS = [:build, :optional, :recommended, :run, :test, :linked, :implicit, :no_linkage].freeze
 
   abstract!
 

--- a/Library/Homebrew/dev-cmd/formula-analytics.rb
+++ b/Library/Homebrew/dev-cmd/formula-analytics.rb
@@ -58,7 +58,7 @@ module Homebrew
         hide_from_man_page!
       end
 
-      FIRST_INFLUXDB_ANALYTICS_DATE = T.let(Date.new(2023, 03, 27).freeze, Date)
+      FIRST_INFLUXDB_ANALYTICS_DATE = Date.new(2023, 03, 27).freeze
 
       sig { override.void }
       def run

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -799,7 +799,7 @@ module Homebrew
     # `false`. Use `boolean: :set` for toggles used by Bash or with inverse
     # `_NO_` variants, where any non-empty value must mean enabled. Use
     # `disabled_by:` when one boolean env var should override another.
-    FALSY_VALUES = T.let(%w[false no off nil 0].freeze, T::Array[String])
+    FALSY_VALUES = %w[false no off nil 0].freeze
 
     ENVS.each do |env, hash|
       # Needs a custom implementation.

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -143,7 +143,7 @@ module Kernel
     end
   end
 
-  IGNORE_INTERRUPTS_MUTEX = T.let(Thread::Mutex.new.freeze, Thread::Mutex)
+  IGNORE_INTERRUPTS_MUTEX = Thread::Mutex.new.freeze
 
   sig { type_parameters(:U).params(_block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
   def ignore_interrupts(&_block)

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -123,8 +123,8 @@ class GitHubRunnerMatrix
     )
   end
 
-  VALID_PLATFORMS = T.let([:macos, :linux].freeze, T::Array[Symbol])
-  VALID_ARCHES = T.let([:arm64, :x86_64].freeze, T::Array[Symbol])
+  VALID_PLATFORMS = [:macos, :linux].freeze
+  VALID_ARCHES = [:arm64, :x86_64].freeze
   private_constant :VALID_PLATFORMS, :VALID_ARCHES
 
   sig {

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -26,7 +26,7 @@ HOMEBREW_SYSTEM = T.let(ENV.fetch("HOMEBREW_SYSTEM").freeze, String)
 HOMEBREW_PROCESSOR = T.let(ENV.fetch("HOMEBREW_PROCESSOR").freeze, String)
 HOMEBREW_PHYSICAL_PROCESSOR = T.let(ENV.fetch("HOMEBREW_PHYSICAL_PROCESSOR").freeze, String)
 
-HOMEBREW_BREWED_CURL_PATH = T.let(Pathname(ENV.fetch("HOMEBREW_BREWED_CURL_PATH")).freeze, Pathname)
+HOMEBREW_BREWED_CURL_PATH = Pathname.new(ENV.fetch("HOMEBREW_BREWED_CURL_PATH")).freeze
 HOMEBREW_USER_AGENT_CURL = T.let(ENV.fetch("HOMEBREW_USER_AGENT_CURL").freeze, String)
 HOMEBREW_USER_AGENT_FAKE_SAFARI =
   # Don't update this beyond 10.15.7 until Safari actually updates their

--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -262,10 +262,7 @@ module Homebrew
       # Path tokens reuse the step base resolution; `HOMEBREW_PREFIX`, `version`
       # and `version.major_minor` are resolved separately. Anything else is left
       # verbatim so literal braces in templates are never rewritten.
-      CONTENT_PATH_TOKENS = T.let(
-        %w[prefix opt_prefix bin var etc pkgetc staged_path appdir].freeze,
-        T::Array[String],
-      )
+      CONTENT_PATH_TOKENS = %w[prefix opt_prefix bin var etc pkgetc staged_path appdir].freeze
 
       sig { params(context: T.untyped).void }
       def initialize(context:)

--- a/Library/Homebrew/livecheck/strategy/header_match.rb
+++ b/Library/Homebrew/livecheck/strategy/header_match.rb
@@ -22,7 +22,7 @@ module Homebrew
         URL_MATCH_REGEX = %r{^https?://}i
 
         # The header fields to check when a `strategy` block isn't provided.
-        DEFAULT_HEADERS_TO_CHECK = T.let(["content-disposition", "location"].freeze, T::Array[String])
+        DEFAULT_HEADERS_TO_CHECK = ["content-disposition", "location"].freeze
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -23,7 +23,7 @@ module Homebrew
         URL_MATCH_REGEX = %r{^https?://}i
 
         # Common `os` values used in appcasts to refer to macOS.
-        APPCAST_MACOS_STRINGS = T.let(["macos", "osx"].freeze, T::Array[String])
+        APPCAST_MACOS_STRINGS = ["macos", "osx"].freeze
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -5,7 +5,7 @@ module OS
   module Mac
     # Helper module for querying Xcode information.
     module Xcode
-      DEFAULT_BUNDLE_PATH = T.let(Pathname("/Applications/Xcode.app").freeze, ::Pathname)
+      DEFAULT_BUNDLE_PATH = ::Pathname.new("/Applications/Xcode.app").freeze
       BUNDLE_ID = "com.apple.dt.Xcode"
       OLD_BUNDLE_ID = "com.apple.Xcode"
       APPLE_DEVELOPER_DOWNLOAD_URL = "https://developer.apple.com/download/all/"

--- a/Library/Homebrew/rubocops/cask/uninstall_methods_order.rb
+++ b/Library/Homebrew/rubocops/cask/uninstall_methods_order.rb
@@ -16,10 +16,7 @@ module RuboCop
 
         # These keys are ignored when checking method order.
         # Mirrors AbstractUninstall::METADATA_KEYS.
-        METADATA_KEYS = T.let(
-          [:on_upgrade].freeze,
-          T::Array[Symbol],
-        )
+        METADATA_KEYS = [:on_upgrade].freeze
 
         USELESS_METADATA_MSG =
           "`on_upgrade` has no effect without matching `uninstall signal:` directive"

--- a/Library/Homebrew/rubocops/os_depends_on.rb
+++ b/Library/Homebrew/rubocops/os_depends_on.rb
@@ -30,7 +30,7 @@ module RuboCop
         ].freeze, T::Array[Symbol])
 
         CASK_STANZA_ORDER = T.let(RuboCop::Cask::Constants::STANZA_ORDER, T::Array[Symbol])
-        MACOS_DEPENDENCY_STANZAS = T.let([:macos, :maximum_macos].freeze, T::Array[Symbol])
+        MACOS_DEPENDENCY_STANZAS = [:macos, :maximum_macos].freeze
 
         RESTRICT_ON_SEND = [:depends_on].freeze
 

--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -11,7 +11,7 @@ module RuboCop
         extend AutoCorrector
 
         # Keep in sync with `Patch::TYPES` in `Library/Homebrew/patch.rb`.
-        PATCH_TYPES = T.let([:unofficial, :backport, :cherry_pick].freeze, T::Array[Symbol])
+        PATCH_TYPES = [:unofficial, :backport, :cherry_pick].freeze
 
         sig { override.params(formula_nodes: FormulaNodes).void }
         def audit_formula(formula_nodes)

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -4,19 +4,12 @@
 module RuboCop
   module Cop
     module InstallStepsHelper
-      FILE_PREPARATION_STEP_METHODS = T.let(
-        [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :symlink, :ln_s, :ln_sf].freeze,
-        T::Array[Symbol],
-      )
-      CONFIG_WRITE_STEP_METHODS = T.let(
-        [:write].freeze,
-        T::Array[Symbol],
-      )
-      REBUILD_ACTION_STEP_METHODS = T.let(
+      FILE_PREPARATION_STEP_METHODS =
+        [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :symlink, :ln_s, :ln_sf].freeze
+      CONFIG_WRITE_STEP_METHODS = [:write].freeze
+      REBUILD_ACTION_STEP_METHODS =
         [:compile_gsettings_schemas, :gio_querymodules, :gdk_pixbuf_query_loaders, :gtk_update_icon_cache,
-         :update_mime_database, :update_desktop_database].freeze,
-        T::Array[Symbol],
-      )
+         :update_mime_database, :update_desktop_database].freeze
       ALLOWED_STEP_METHODS = T.let(
         [*FILE_PREPARATION_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *REBUILD_ACTION_STEP_METHODS].freeze,
         T::Array[Symbol],
@@ -28,10 +21,7 @@ module RuboCop
 
       # `dstr` covers non-interpolated heredocs such as `write` content; any
       # interpolation adds `begin`/`send` descendants that remain disallowed.
-      ALLOWED_STEP_ARGUMENT_NODE_TYPES = T.let(
-        [:array, :dstr, :hash, :nil, :pair, :str, :sym].freeze,
-        T::Array[Symbol],
-      )
+      ALLOWED_STEP_ARGUMENT_NODE_TYPES = [:array, :dstr, :hash, :nil, :pair, :str, :sym].freeze
 
       STEP_BLOCK_MSG = T.let(
         "Steps blocks may only contain install step DSL calls: " \

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -15,7 +15,7 @@ class Sandbox
   extend Utils::Output::Mixin
 
   # Privileged groups that are expected to be able to use a working sandbox.
-  PRIVILEGED_GROUPS = T.let(%w[admin staff root wheel].freeze, T::Array[String])
+  PRIVILEGED_GROUPS = %w[admin staff root wheel].freeze
 
   class SandboxPathFilter
     sig { returns(String) }

--- a/Library/Homebrew/services/subcommand/list.rb
+++ b/Library/Homebrew/services/subcommand/list.rb
@@ -39,9 +39,9 @@ module Homebrew
 
         extend Utils::Output::Mixin
 
-        TRIGGERS = T.let([nil, "list", "ls"].freeze, T::Array[T.nilable(String)])
+        TRIGGERS = [nil, "list", "ls"].freeze
 
-        JSON_FIELDS = T.let([:name, :status, :user, :file, :exit_code].freeze, T::Array[Symbol])
+        JSON_FIELDS = [:name, :status, :user, :file, :exit_code].freeze
 
         # Print the JSON representation in the CLI
         # @private

--- a/Library/Homebrew/sorbet/tapioca/compilers/cask/config.rb
+++ b/Library/Homebrew/sorbet/tapioca/compilers/cask/config.rb
@@ -12,7 +12,7 @@ module Tapioca
       # Dirs defined in `OS::Linux::Cask::Config::ClassMethods::DEFAULT_DIRS`
       # that aren't visible to `Cask::Config.defaults` when this compiler is
       # run on macOS, but still need accessor methods generated in the RBI.
-      LINUX_ONLY_DIRS = T.let([:appimagedir].freeze, T::Array[Symbol])
+      LINUX_ONLY_DIRS = [:appimagedir].freeze
 
       sig { override.returns(T::Enumerable[T::Module[T.anything]]) }
       def self.gather_constants = [Cask::Config]

--- a/Library/Homebrew/sorbet/tapioca/compilers/forwardables.rb
+++ b/Library/Homebrew/sorbet/tapioca/compilers/forwardables.rb
@@ -9,9 +9,9 @@ module Tapioca
   module Compilers
     class Forwardables < Tapioca::Dsl::Compiler
       FORWARDABLE_FILENAME = "forwardable.rb"
-      ARRAY_METHODS = T.let(["to_a", "to_ary"].freeze, T::Array[String])
-      HASH_METHODS = T.let(["to_h", "to_hash"].freeze, T::Array[String])
-      STRING_METHODS = T.let(["to_s", "to_str", "to_json"].freeze, T::Array[String])
+      ARRAY_METHODS = ["to_a", "to_ary"].freeze
+      HASH_METHODS = ["to_h", "to_hash"].freeze
+      STRING_METHODS = ["to_s", "to_str", "to_json"].freeze
       # Use this to override the default return type of a forwarded method:
       RETURN_TYPE_OVERRIDES = T.let({
         "::Cask::Cask" => {

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -26,7 +26,7 @@ HOMEBREW_DEFAULT_TAP_CASK_REGEX =
 HOMEBREW_TAP_DIR_REGEX =
   %r{#{Regexp.escape(HOMEBREW_LIBRARY.to_s)}/Taps/(?<user>[^/]+)/(?<repository>[^/]+)}
 # Match taps' formula paths, e.g. `HOMEBREW_LIBRARY/Taps/someuser/sometap/someformula`.
-HOMEBREW_TAP_PATH_REGEX = T.let(Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + %r{(?:/.*)?\Z}.source).freeze, Regexp)
+HOMEBREW_TAP_PATH_REGEX = Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + %r{(?:/.*)?\Z}.source).freeze
 # Match official cask taps, e.g `homebrew/cask`.
 HOMEBREW_CASK_TAP_REGEX =
   %r{(?:([Cc]askroom)/(cask)|([Hh]omebrew)/(?:homebrew-)?(cask|cask-[\w-]+))}

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -27,9 +27,9 @@ module GitHub
   PAGINATE_RETRY_COUNT = 3
   private_constant :PAGINATE_RETRY_COUNT
 
-  CREATE_GIST_SCOPES = T.let(["gist"].freeze, T::Array[String])
-  CREATE_ISSUE_FORK_OR_PR_SCOPES = T.let(["repo"].freeze, T::Array[String])
-  CREATE_WORKFLOW_SCOPES = T.let(["workflow"].freeze, T::Array[String])
+  CREATE_GIST_SCOPES = ["gist"].freeze
+  CREATE_ISSUE_FORK_OR_PR_SCOPES = ["repo"].freeze
+  CREATE_WORKFLOW_SCOPES = ["workflow"].freeze
   ALL_SCOPES = T.let((CREATE_GIST_SCOPES + CREATE_ISSUE_FORK_OR_PR_SCOPES + CREATE_WORKFLOW_SCOPES).freeze,
                      T::Array[String])
   private_constant :ALL_SCOPES
@@ -93,14 +93,11 @@ module GitHub
       end
     end
 
-    GITHUB_IP_ALLOWLIST_ERROR = T.let(
-      Regexp.new(
-        "Although you appear to have the correct authorization credentials, " \
-        "the `(.+)` organization has an IP allow list enabled, " \
-        "and your IP address is not permitted to access this resource",
-      ).freeze,
-      Regexp,
-    )
+    GITHUB_IP_ALLOWLIST_ERROR = Regexp.new(
+      "Although you appear to have the correct authorization credentials, " \
+      "the `(.+)` organization has an IP allow list enabled, " \
+      "and your IP address is not permitted to access this resource",
+    ).freeze
 
     NO_CREDENTIALS_MESSAGE = T.let(<<~MESSAGE.freeze, String)
       No GitHub credentials found in macOS Keychain, GitHub CLI or the environment.

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -141,7 +141,7 @@ class Version
   private_constant :NullToken
 
   # Represents the absence of a token.
-  NULL_TOKEN = T.let(NullToken.new.freeze, NullToken)
+  NULL_TOKEN = NullToken.new.freeze
 
   # A token string.
   class StringToken < Token


### PR DESCRIPTION
Removes `T.let` type annotations from frozen constants that Sorbet can now infer, following up on Homebrew/brew#22883 (comment: https://github.com/Homebrew/brew/pull/22883#issuecomment-4821728195): since 0.6.13304, Sorbet infers `X = A.new.freeze` the same as `X = A.new`. This trims boilerplate and lets the annotations that remain carry more signal.

Two groups of constants qualify:

- Direct `.new(...).freeze` calls on non-generic classes, which infer the exact class previously declared. `Pathname(...)` kernel-method calls are not inferred, so those are converted to `Pathname.new(...)` instead.
- Pure-literal arrays (symbol/string/nil literals, including nested literal arrays), which infer as fixed-size tuple types. Tuples are subtypes of the previously declared `T::Array` types, and there is existing precedent for tuple-typed constants (e.g. `MACOS_MODULE_NAMES` in `rubocops/shared/on_system_conditionals_helper.rb`).

Shapes that are still not inferred through `.freeze` (verified against Sorbet 0.6.13316 with `T.reveal_type` probes) keep their `T.let`: plain method calls (e.g. `ENV.fetch(...)`), interpolated strings, hash literals, generic `.new` (e.g. `Set.new(...)` infers `T::Set[T.untyped]`), empty arrays, and arrays containing splats, constant references or method-call elements.

No new tests: this is a type-annotation-only change with no runtime behaviour difference (beyond equivalent `Pathname` construction), covered by existing typechecking and tests.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code found the candidate constants, probed which expression shapes Sorbet infers through `.freeze` (using temporary `typed: strict` files with `T.reveal_type`) and applied the edits. Verified locally with `brew typecheck`, `brew style --fix --changed` and `brew tests --online --changed`, plus manual review of the full diff.

-----
