### PR TITLE
dev-cmd/test-bot: make `--skip-recursive-dependents` default

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -65,8 +65,10 @@ module Homebrew
                description: "Don't test any dependents."
         switch "--skip-livecheck",
                description: "Don't test livecheck."
-        switch "--skip-recursive-dependents",
-               description: "Only test the direct dependents."
+        switch "--[no-]skip-recursive-dependents",
+               description: "Only test the direct dependents (default: enabled).",
+               replacement: "the default behaviour",
+               odeprecated: true
         switch "--skip-checksum-only-audit",
                description: "Don't audit checksum-only changes."
         switch "--skip-stable-version-audit",

--- a/Library/Homebrew/test_bot/formulae_dependents.rb
+++ b/Library/Homebrew/test_bot/formulae_dependents.rb
@@ -503,7 +503,7 @@ module Homebrew
 
       sig { params(_formula: Formula, args: Homebrew::Cmd::TestBotCmd::Args).returns(T::Boolean) }
       def skip_recursive_dependents?(_formula, args:)
-        args.skip_recursive_dependents?
+        args.skip_recursive_dependents? != false
       end
 
       sig { params(_dependent: Formula).returns(T::Boolean) }


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

This PR makes `--skip-recursive-dependents` default as we have made indirect linkage into explicit dependencies. Something we've discussed before to reduce time to finish tests.

Added a deprecation period with `--no` flag in case there are any specific issues that are found either in Homebrew/core or external taps. If everything looks good, we can rip out the recursive dependents logic from test-bot

Partner PR to:
- https://github.com/Homebrew/homebrew-core/pull/291338

---

Looking at `args.skip_recursive_dependents?.inspect`, `[no-]` switch defaults to nil (though `brew typecheck --update` doesn't change test_bot_cmd.rbi) so adding nil handling logic.