### PR TITLE
upgrade: Split deps and find older version better

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -845,7 +845,8 @@ on_request: installed_on_request?, options:)
                                 outdated: installed && dep_formula.outdated?, mark_uninstalled: false,
                                 bold: false)
         end
-        oh1 "Installing dependencies for #{formula.full_name}: #{names.to_sentence}", truncate: false
+        oh1 "Installing dependencies for #{formula.full_name}:#{Tty.reset} #{names.to_sentence}",
+            truncate: false
       end
       deps_with_formulae.each { |dep, dep_formula| install_dependency(dep, dep_formula) }
     end

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -505,20 +505,21 @@ module Homebrew
       def print_dry_run_dependencies(formula, dependencies, skip_formula_names: [], &_block)
         return if dependencies.empty?
 
-        formula_names = dependencies.filter_map do |dep|
+        entries = dependencies.filter_map do |dep|
           dependency = dep.to_formula
           next if skip_formula_names.include?(dependency.full_name)
 
-          name = yield dependency
-          installed = dependency.any_version_installed?
-          pretty_install_status(name, installed:, outdated: installed && dependency.outdated?,
-                                mark_uninstalled: false, bold: false)
+          [dependency.any_version_installed?, yield(dependency)]
         end
-        return if formula_names.empty?
 
-        ohai "Would install #{Utils.pluralize("dependency", formula_names.count, include_count: true)} " \
-             "for #{formula.name}:"
-        puts formula_names.join("\n")
+        upgrade, install = entries.partition(&:first)
+        { install:, upgrade: }.each do |verb, group|
+          next if group.empty?
+
+          ohai "Would #{verb} #{Utils.pluralize("dependency", group.count, include_count: true)} " \
+               "for #{formula.name}:"
+          puts Upgrade.format_upgrade_summary(group.map(&:last))
+        end
       end
 
       # If asking the user is enabled, show dry-run information.

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     EOS
   end
 
-  it "marks an outdated dependency as upgradable in the dry-run plan" do
+  it "groups an installed dependency under the upgrade header in the dry-run plan" do
     formula = formula("changed") do
       T.bind(self, T.class_of(Formula))
       url "https://brew.sh/changed-2.0.tar.gz"
@@ -98,9 +98,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
       T.bind(self, T.class_of(Formula))
       url "https://brew.sh/dependency-1.0.tar.gz"
     end
-    allow(dependency).to receive_messages(any_version_installed?: true, outdated?: true)
-    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
-    allow(Homebrew::EnvConfig).to receive(:no_emoji?).and_return(true)
+    allow(dependency).to receive(:any_version_installed?).and_return(true)
     formula_installer = FormulaInstaller.new(formula)
     dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
 
@@ -110,7 +108,12 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
 
     expect do
       Homebrew::Install.ask_formulae([formula_installer], dependants)
-    end.to output(/dependency \(upgradable\)/).to_stdout
+    end.to output(<<~EOS).to_stdout
+      ==> Would install 1 formula:
+      changed
+      ==> Would upgrade 1 dependency for changed:
+      dependency
+    EOS
   end
 
   it "prompts again for return ask input" do

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -339,6 +339,29 @@ RSpec.describe FormulaInstaller do
       expect { installer.install_dependencies(deps) }
         .to output(/outdated-dependency.*\(upgradable\).*and.*uninstalled-dependency[^(]*$/m).to_stdout
     end
+
+    it "does not render the first dependency name bolder than the rest" do
+      ENV["HOMEBREW_COLOR"] = "1"
+      dep_a = formula("dep-a") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      dep_b = formula("dep-b") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      [dep_a, dep_b].each { |f| allow(f).to receive_messages(any_version_installed?: true, outdated?: true) }
+      deps = [
+        instance_double(Dependency, to_formula: dep_a, name: dep_a.name, to_s: dep_a.name),
+        instance_double(Dependency, to_formula: dep_b, name: dep_b.name, to_s: dep_b.name),
+      ]
+      installer = described_class.new(Testball.new)
+      allow(installer).to receive(:install_dependency)
+      allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+      expect { installer.install_dependencies(deps) }
+        .to output(/:\e\[0m /).to_stdout
+    end
   end
 
   describe "#expand_dependencies_for_formula" do

--- a/Library/Homebrew/test/install_spec.rb
+++ b/Library/Homebrew/test/install_spec.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 require "install"
+require "dependency"
+require "test/support/fixtures/testball"
 
 RSpec.describe Homebrew::Install do
   specify "::perform_preinstall_checks runs non-fatal preinstall diagnostics" do
@@ -20,5 +22,27 @@ RSpec.describe Homebrew::Install do
       .ordered
 
     described_class.send(:perform_preinstall_checks)
+  end
+
+  describe "::print_dry_run_dependencies" do
+    it "splits fresh installs and upgrades under separate headers" do
+      fresh = formula("fresh-dep") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      installed = formula("installed-dep") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      allow(fresh).to receive(:any_version_installed?).and_return(false)
+      allow(installed).to receive(:any_version_installed?).and_return(true)
+      deps = [
+        instance_double(Dependency, to_formula: fresh),
+        instance_double(Dependency, to_formula: installed),
+      ]
+
+      expect { described_class.print_dry_run_dependencies(Testball.new, deps, &:name) }
+        .to output(/Would install 1 dependency.*fresh-dep.*Would upgrade 1 dependency.*installed-dep/m).to_stdout
+    end
   end
 end

--- a/Library/Homebrew/test/upgrade_spec.rb
+++ b/Library/Homebrew/test/upgrade_spec.rb
@@ -2,6 +2,11 @@
 # frozen_string_literal: true
 
 require "upgrade"
+require "formula_installer"
+require "dependency"
+require "keg"
+require "pkg_version"
+require "test/support/fixtures/testball"
 
 RSpec.describe Homebrew::Upgrade do
   describe "::format_upgrade_summary" do
@@ -43,6 +48,26 @@ RSpec.describe Homebrew::Upgrade do
         "spotify             1.2.84.476 -> 1.2.92.148",
         "visual-studio-code  1.111.0    -> 1.125.1",
       ])
+    end
+  end
+
+  describe "::upgrade_formula" do
+    it "shows the version transition for an unlinked dependency installed at an older version" do
+      python = formula("python@3.14") do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/python-3.14.6.tgz"
+      end
+      kegs = ["2.7.14_2", "3.6.1", "3.6.4_4", "3.7.1"].map do |v|
+        instance_double(Keg, version: PkgVersion.parse(v))
+      end
+      allow(python).to receive_messages(any_version_installed?: true, optlinked?: false, installed_kegs: kegs)
+      dependency = instance_double(Dependency, to_formula: python)
+      formula_installer = instance_double(
+        FormulaInstaller, formula: Testball.new, compute_dependencies: [dependency]
+      )
+
+      expect { described_class.send(:upgrade_formula, formula_installer, dry_run: true) }
+        .to output(/Would upgrade.*python@3.14 3.7.1 -> 3.14.6/m).to_stdout
     end
   end
 end

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -459,8 +459,13 @@ module Homebrew
           Install.print_dry_run_dependencies(formula, formula_installer.compute_dependencies,
                                              skip_formula_names:) do |f|
             name = f.full_specified_name
-            if f.optlinked?
-              "#{name} #{Keg.new(f.opt_prefix).version} -> #{f.pkg_version}"
+            current_version = if f.optlinked?
+              Keg.new(f.opt_prefix).version
+            else
+              f.installed_kegs.map(&:version).max
+            end
+            if current_version && current_version != f.pkg_version
+              "#{name} #{current_version} -> #{f.pkg_version}"
             else
               "#{name} #{f.pkg_version}"
             end


### PR DESCRIPTION
Group `brew upgrade --dry-run` dependencies into separate "Would install" and "Would upgrade" sections aligned with format_upgrade_summary, and read the installed version from the kegs so unlinked upgrades still show "old -> new".

Also stop the first dependency in the "Installing dependencies for" line from rendering bolder than the rest.

```
▶ brew upgrade --dry-run ffmpeg
...

==> Would install 11 dependencies for ffmpeg:
expat        2.8.2
meson        1.11.1
nasm         3.02
dav1d        1.5.3
libvmaf      3.2.0
libvpx       1.16.0
opus         1.6.1
sdl3         3.4.12
sdl2-compat  2.32.70
svt-av1      4.1.0
x265         4.2
==> Would upgrade 9 dependencies for ffmpeg:
ninja        1.10.2_1 -> 1.13.2
openssl@3    3.6.2    -> 3.6.3
readline     8.1.2    -> 8.3.3
sqlite       3.38.0   -> 3.53.3
xz           5.4.1    -> 5.8.3
lz4          1.9.4    -> 1.10.0
zstd         1.5.2    -> 1.5.7_1
python@3.14  3.7.1    -> 3.14.6
x264         r2854    -> r3222
```
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Written by Claude Code and I iterated on in many times to get what I wanted.

-----
