### PR TITLE
Store cask metadata as JSON more often

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -623,6 +623,14 @@ module Cask
       hash
     end
 
+    sig { returns(T::Hash[String, T.untyped]) }
+    def to_installed_json_hash
+      cask_url = url
+      return {} if cask_url.nil? || cask_url.only_path.blank?
+
+      { "url_specs" => { "only_path" => cask_url.only_path } }
+    end
+
     sig { params(uninstall_only: T::Boolean).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
     def artifacts_list(uninstall_only: false)
       artifacts.filter_map do |artifact|

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -171,8 +171,9 @@ module Cask
         @config = config
 
         if !self.class.invalid_path?(path, valid_extnames: %w[.json]) &&
-           (from_json = JSON.parse(@content).presence) &&
-           from_json.is_a?(Hash)
+           (from_json = JSON.parse(@content)) &&
+           from_json.is_a?(Hash) &&
+           (@from_installed_caskfile || from_json.present?)
           begin
             from_internal_json = path.to_s.end_with?(".internal.json")
             return FromAPILoader.new(
@@ -456,6 +457,14 @@ module Cask
 
       sig { params(config: T.nilable(Config), api_source: T::Hash[String, T.untyped]).returns(Cask) }
       def load_from_json(config:, api_source:)
+        if @from_installed_caskfile
+          api_source = api_source.dup
+          installed_tab = Cask.new(token).tab
+          api_source["version"] = api_source["version"].presence || installed_tab.version.presence ||
+                                  @sourcefile_path.dirname.dirname.dirname.basename.to_s
+          api_source["artifacts"] ||= installed_tab.uninstall_artifacts || []
+        end
+
         tap_git_head = api_source["tap_git_head"]
         cask_struct = Homebrew::API::Cask::CaskStructGenerator.generate_cask_struct_hash(
           api_source, ignore_types: @from_installed_caskfile

--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -11,7 +11,7 @@ module Cask
   module Caskroom
     extend ::Utils::Output::Mixin
 
-    CASKFILE_EXTENSIONS = %w[internal.json json rb].freeze
+    CASKFILE_EXTENSIONS = %w[json internal.json rb].freeze
 
     sig { returns(Pathname) }
     def self.path

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -537,22 +537,12 @@ on_request: true)
 
       return if @cask.source.blank?
 
-      extension = if @cask.loaded_from_internal_api?
-        "internal.json"
-      elsif @cask.loaded_from_api?
-        "json"
+      if @cask.uninstall_flight_blocks?
+        (metadata_subdir/"#{@cask.token}.rb").write @cask.source.to_s
       else
-        "rb"
+        (metadata_subdir/"#{@cask.token}.json").write JSON.pretty_generate(@cask.to_installed_json_hash)
       end
 
-      source = if @cask.loaded_from_internal_api? && (api_source = @cask.api_source)
-        api_source = api_source.merge({ "tap_git_head" => @cask.tap_git_head })
-        JSON.pretty_generate(api_source)
-      else
-        @cask.source
-      end
-
-      (metadata_subdir/"#{@cask.token}.#{extension}").write source
       FileUtils.rm_r(old_savedir) if old_savedir
     end
 

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -189,16 +189,15 @@ module Cask
       end
 
       upgradable_casks = outdated_casks.filter_map do |c|
-        invalid_cask = !c.installed?
-
-        invalid_cask ||= begin
-          loaded_cask = CaskLoader.load(T.must(c.installed_caskfile))
-          false
-        rescue CaskInvalidError, CaskUnavailableError, MethodDeprecatedError
-          true
+        loaded_cask = if c.installed? && (installed_caskfile = c.installed_caskfile)
+          begin
+            CaskLoader.load_from_installed_caskfile(installed_caskfile)
+          rescue CaskInvalidError, CaskUnavailableError, MethodDeprecatedError
+            nil
+          end
         end
 
-        if invalid_cask
+        if loaded_cask.nil?
           opoo <<~EOS
             The cask '#{c.token}' cannot be upgraded as-is. To fix this, run:
             brew reinstall --cask --force #{c.token}

--- a/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
+++ b/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
@@ -130,6 +130,40 @@ blocks need the source because the API stores available language codes, but not
 the selected block return value or stanza effects; language-specific URLs must
 be resolved before the download can be enqueued.
 
+## Installed Cask Metadata Format
+
+Store supported installed cask metadata as regular `<token>.json`, not Ruby
+caskfiles or internal JSON. Casks with `uninstall_preflight` or
+`uninstall_postflight` Ruby blocks should keep using Ruby caskfiles in the
+Caskroom until those blocks are ported to structured JSON data. The installed
+caskfile is a post-install snapshot, so it should only retain data that can be
+useful after installation has finished. This lets future uninstall, reinstall,
+upgrade and zap runs reload supported installed metadata without evaluating the
+original Ruby caskfile.
+
+The installed JSON is deliberately minimal. It relies on
+`INSTALL_RECEIPT.json` for receipt-owned data such as the installed cask
+`version` and uninstallable artifacts, and only keeps data not otherwise
+available after installation, such as `url_specs.only_path` when needed to
+reconstruct staged artifact sources. It omits the full API snapshot so future
+JSON API or DSL changes cannot affect post-install operations through fields
+that are not needed after installation.
+
+The installed JSON omits legacy `preflight` and `postflight` Ruby block
+placeholders because JSON cannot represent their block bodies and they are not
+needed after installation. Casks with `uninstall_preflight` or
+`uninstall_postflight` Ruby blocks must remain backed by Ruby metadata so those
+blocks continue to run on uninstall, zap, reinstall and upgrade. The goal is to
+replace those Ruby blocks with structured uninstall step DSLs so they can be
+migrated to JSON too.
+
+The `brew update` migration should convert existing supported Caskroom `.rb`
+and `.internal.json` caskfiles to regular `.json` caskfiles.
+
+As the cask step DSLs grow, keep migrating post-install behaviour from legacy
+Ruby flight blocks into structured JSON data so less installed cask behaviour
+is stripped during metadata serialisation.
+
 ## Install Step Examples
 
 - `languagetool`: `post_install_steps { mkdir "log/languagetool", base: :var }`.

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -10,6 +10,99 @@ RSpec.describe Cask::Installer, :cask do
     end
   end
 
+  describe "#save_caskfile" do
+    it "stores casks loaded from Ruby source as JSON metadata" do
+      cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+
+      described_class.new(cask).save_caskfile
+
+      expect([
+        cask.installed_caskfile&.basename&.to_s,
+        Cask::CaskLoader.load_from_installed_caskfile(cask.installed_caskfile).token,
+        JSON.parse(cask.installed_caskfile.read).keys.sort,
+      ]).to eq(["local-caffeine.json", "local-caffeine", []])
+    end
+
+    it "stores URL only_path metadata needed to reconstruct artifact sources" do
+      cask = Cask::Cask.new("only-path", source: "{}") do
+        version "1.0"
+        sha256 :no_check
+        url "https://example.com/only-path.git", only_path: "nested"
+        app "Only Path.app"
+      end
+
+      described_class.new(cask).save_caskfile
+      Cask::Tab.create(cask).write
+
+      loaded_cask = Cask::CaskLoader.load_from_installed_caskfile(cask.installed_caskfile)
+      expect([
+        JSON.parse(cask.installed_caskfile.read).keys.sort,
+        loaded_cask.artifacts.grep(Cask::Artifact::App).first.source,
+      ]).to eq([
+        %w[url_specs],
+        Cask::Caskroom.path/"only-path/1.0/nested/Only Path.app",
+      ])
+    end
+
+    it "strips legacy install flight blocks from JSON metadata" do
+      cask = Cask::CaskLoader.load(cask_path("with-preflight"))
+
+      described_class.new(cask).save_caskfile
+
+      expect(JSON.parse(cask.installed_caskfile.read).keys).to be_empty
+    end
+
+    it "stores legacy uninstall flight block casks as Ruby metadata" do
+      expect(%w[with-uninstall-preflight with-uninstall-postflight].map do |token|
+        cask = Cask::CaskLoader.load(cask_path(token))
+
+        described_class.new(cask).save_caskfile
+
+        [
+          cask.installed_caskfile&.basename&.to_s,
+          Cask::CaskLoader.load_from_installed_caskfile(cask.installed_caskfile).uninstall_flight_blocks?,
+        ]
+      end).to eq([
+        ["with-uninstall-preflight.rb", true],
+        ["with-uninstall-postflight.rb", true],
+      ])
+    end
+
+    it "stores casks loaded from the internal API as JSON metadata" do
+      cask = Cask::Cask.new(
+        "api-cask",
+        source:                   "{}",
+        loaded_from_api:          true,
+        loaded_from_internal_api: true,
+        api_source:               {
+          "homepage"      => "https://example.com/api-cask",
+          "names"         => ["API Cask"],
+          "raw_artifacts" => [[":app", ["API Cask.app"]]],
+          "sha256"        => "no_check",
+          "url_args"      => ["https://example.com/api-cask.zip"],
+          "version"       => "1.0",
+        },
+      ) do
+        version "1.0"
+        sha256 :no_check
+        url "https://example.com/api-cask.zip"
+        name "API Cask"
+        homepage "https://example.com/api-cask"
+        app "API Cask.app"
+      end
+
+      described_class.new(cask).save_caskfile
+
+      loaded_cask = Cask::CaskLoader.load_from_installed_caskfile(cask.installed_caskfile)
+      expect([
+        cask.installed_caskfile&.basename&.to_s,
+        loaded_cask.token,
+        loaded_cask.loaded_from_internal_api?,
+        JSON.parse(cask.installed_caskfile.read).keys.sort,
+      ]).to eq(["api-cask.json", "api-cask", false, []])
+    end
+  end
+
   describe "install" do
     it "downloads and installs a nice fresh Cask" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -400,10 +400,11 @@ RSpec.describe Cask::Upgrade, :cask do
     end
 
     it "warns and skips when the installed caskfile raises CaskInvalidError" do
-      allow(Cask::CaskLoader).to receive(:load).and_call_original
-      allow(Cask::CaskLoader).to receive(:load).with(auto_updates.installed_caskfile)
-                                               .and_raise(Cask::CaskInvalidError.new(auto_updates.token,
-                                                                                     "broken DSL"))
+      allow(Cask::CaskLoader).to receive(:load_from_installed_caskfile).and_call_original
+      allow(Cask::CaskLoader)
+        .to receive(:load_from_installed_caskfile)
+        .with(auto_updates.installed_caskfile)
+        .and_raise(Cask::CaskInvalidError.new(auto_updates.token, "broken DSL"))
 
       expect do
         described_class.upgrade_casks!(dry_run: true, args:)
@@ -411,10 +412,11 @@ RSpec.describe Cask::Upgrade, :cask do
     end
 
     it "warns and skips when the installed caskfile raises CaskUnreadableError" do
-      allow(Cask::CaskLoader).to receive(:load).and_call_original
-      allow(Cask::CaskLoader).to receive(:load).with(auto_updates.installed_caskfile)
-                                               .and_raise(Cask::CaskUnreadableError.new(auto_updates.token,
-                                                                                        "syntax error"))
+      allow(Cask::CaskLoader).to receive(:load_from_installed_caskfile).and_call_original
+      allow(Cask::CaskLoader)
+        .to receive(:load_from_installed_caskfile)
+        .with(auto_updates.installed_caskfile)
+        .and_raise(Cask::CaskUnreadableError.new(auto_updates.token, "syntax error"))
 
       expect do
         described_class.upgrade_casks!(dry_run: true, args:)
@@ -422,9 +424,11 @@ RSpec.describe Cask::Upgrade, :cask do
     end
 
     it "warns and skips when the installed caskfile raises MethodDeprecatedError" do
-      allow(Cask::CaskLoader).to receive(:load).and_call_original
-      allow(Cask::CaskLoader).to receive(:load).with(auto_updates.installed_caskfile)
-                                               .and_raise(MethodDeprecatedError.new)
+      allow(Cask::CaskLoader).to receive(:load_from_installed_caskfile).and_call_original
+      allow(Cask::CaskLoader)
+        .to receive(:load_from_installed_caskfile)
+        .with(auto_updates.installed_caskfile)
+        .and_raise(MethodDeprecatedError.new)
 
       expect do
         described_class.upgrade_casks!(dry_run: true, args:)

--- a/Library/Homebrew/test/cmd/doctor_spec.rb
+++ b/Library/Homebrew/test/cmd/doctor_spec.rb
@@ -50,11 +50,11 @@ RSpec.describe Homebrew::Cmd::Doctor do
   specify "does not print removed caveats method errors for installed casks", :cask do
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
     installer = InstallHelper.install_with_caskfile(cask)
-    installed_caskfile = installer.metadata_subdir/"#{cask.token}.rb"
+    installed_caskfile = installer.metadata_subdir/"#{cask.token}.json"
     expect(installed_caskfile).to exist
 
-    installed_caskfile.write(
-      installed_caskfile.read.sub(
+    (installer.metadata_subdir/"#{cask.token}.rb").write(
+      cask_path("local-caffeine").read.sub(
         /\nend\n\z/,
         <<~RUBY,
             caveats do
@@ -64,6 +64,7 @@ RSpec.describe Homebrew::Cmd::Doctor do
         RUBY
       ),
     )
+    installed_caskfile.unlink
 
     (CoreCaskTap.instance.cask_dir/"local-caffeine.rb").unlink
     CoreCaskTap.instance.clear_cache

--- a/Library/Homebrew/test/cmd/uninstall_spec.rb
+++ b/Library/Homebrew/test/cmd/uninstall_spec.rb
@@ -66,9 +66,11 @@ RSpec.describe Homebrew::Cmd::UninstallCmd do
     cask_file.write <<~RUBY
       raise "untrusted tap cask evaluated"
     RUBY
-    cask.installed_caskfile&.write <<~RUBY
+    installed_caskfile = cask.installed_caskfile
+    (installed_caskfile.dirname/"local-caffeine.rb").write <<~RUBY
       raise "untrusted installed cask evaluated"
     RUBY
+    installed_caskfile.unlink
     allow(Homebrew::Cleanup).to receive(:autoremove)
 
     original_argv = ARGV.dup
@@ -103,14 +105,7 @@ RSpec.describe Homebrew::Cmd::UninstallCmd do
     cask_file.write <<~RUBY
       raise "untrusted tap cask evaluated"
     RUBY
-    installed_caskfile = cask.installed_caskfile
-    json_caskfile = installed_caskfile.dirname/"local-caffeine.json"
-    json = JSON.parse((TEST_FIXTURE_DIR/"cask/caffeine.json").read)
-    json["token"] = "local-caffeine"
-    json["full_token"] = full_name
-    json["tap"] = tap.name
-    json_caskfile.write JSON.pretty_generate(json)
-    installed_caskfile.write <<~RUBY
+    (cask.installed_caskfile.dirname/"local-caffeine.rb").write <<~RUBY
       raise "untrusted installed cask evaluated"
     RUBY
     allow(Homebrew::Cleanup).to receive(:autoremove)

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -906,11 +906,11 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   it "does not print removed caveats method errors for installed casks", :cask do
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
     installer = InstallHelper.install_with_caskfile(cask)
-    installed_caskfile = installer.metadata_subdir/"#{cask.token}.rb"
+    installed_caskfile = installer.metadata_subdir/"#{cask.token}.json"
     expect(installed_caskfile).to exist
 
-    installed_caskfile.write(
-      installed_caskfile.read.sub(
+    (installer.metadata_subdir/"#{cask.token}.rb").write(
+      cask_path("local-caffeine").read.sub(
         /\nend\n\z/,
         <<~RUBY,
             caveats do
@@ -920,6 +920,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
         RUBY
       ),
     )
+    installed_caskfile.unlink
 
     (CoreCaskTap.instance.cask_dir/"local-caffeine.rb").unlink
     CoreCaskTap.instance.clear_cache


### PR DESCRIPTION
- Use a minimal post-install snapshot for supported casks.
- Read receipt-owned version and artifacts from `INSTALL_RECEIPT.json`.
- Leave uninstall flight block caskfiles as Ruby until ported.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
