### PR TITLE
install_steps: allow gtk_update_icon_cache to run gtk4-update-icon-cache

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -327,7 +327,12 @@ module Homebrew
         when "gdk_pixbuf_query_loaders"
           run_formula_tool("gdk-pixbuf", "gdk-pixbuf-query-loaders", "--update-cache")
         when "gtk_update_icon_cache"
-          run_formula_tool("gtk+3", "gtk3-update-icon-cache", "-q", "-t", "-f", resolve_path(step.fetch("path")))
+          require "utils/path"
+          if Utils::Path.formula_any_version_installed?("gtk4")
+            run_formula_tool("gtk4", "gtk4-update-icon-cache", "-q", "-t", "-f", resolve_path(step.fetch("path")))
+          else
+            run_formula_tool("gtk+3", "gtk3-update-icon-cache", "-q", "-t", "-f", resolve_path(step.fetch("path")))
+          end
         when "update_mime_database"
           run_formula_tool("shared-mime-info", "update-mime-database", resolve_path(step.fetch("path")))
         when "update_desktop_database"

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -162,7 +162,6 @@ RSpec.describe Homebrew::InstallSteps do
       compile_gsettings_schemas
       gio_querymodules
       gdk_pixbuf_query_loaders
-      gtk_update_icon_cache
       update_mime_database
       update_desktop_database
     end
@@ -170,7 +169,6 @@ RSpec.describe Homebrew::InstallSteps do
     formula = instance_double(Formula, opt_bin: root/"opt/bin")
     allow(Formula).to receive(:[]).with("glib").and_return(formula)
     allow(Formula).to receive(:[]).with("gdk-pixbuf").and_return(formula)
-    allow(Formula).to receive(:[]).with("gtk+3").and_return(formula)
     allow(Formula).to receive(:[]).with("shared-mime-info").and_return(formula)
     allow(Formula).to receive(:[]).with("desktop-file-utils").and_return(formula)
     expect(context).to receive(:safe_system).with(root/"opt/bin/glib-compile-schemas",
@@ -178,14 +176,37 @@ RSpec.describe Homebrew::InstallSteps do
     expect(context).to receive(:safe_system).with(root/"opt/bin/gio-querymodules",
                                                   HOMEBREW_PREFIX/"lib/gio/modules").ordered
     expect(context).to receive(:safe_system).with(root/"opt/bin/gdk-pixbuf-query-loaders", "--update-cache").ordered
-    expect(context).to receive(:safe_system).with(root/"opt/bin/gtk3-update-icon-cache", "-q", "-t", "-f",
-                                                  HOMEBREW_PREFIX/"share/icons/hicolor").ordered
     expect(context).to receive(:safe_system).with(root/"opt/bin/update-mime-database",
                                                   HOMEBREW_PREFIX/"share/mime").ordered
     expect(context).to receive(:safe_system).with(root/"opt/bin/update-desktop-database",
                                                   HOMEBREW_PREFIX/"share/applications").ordered
 
     Homebrew::InstallSteps::Runner.new(context:).run(steps)
+  end
+
+  describe "runs gtk_update_icon_cache rebuild action" do
+    let(:formula) { instance_double(Formula, opt_bin: root/"opt/bin") }
+    let(:steps) do
+      Homebrew::InstallSteps::DSL.build do
+        gtk_update_icon_cache
+      end
+    end
+
+    it "with gtk4" do
+      allow(Formula).to receive(:[]).with("gtk4").and_return(formula)
+      allow(Utils::Path).to receive(:formula_any_version_installed?).with("gtk4").and_return(true)
+      expect(context).to receive(:safe_system).with(root/"opt/bin/gtk4-update-icon-cache", "-q", "-t", "-f",
+                                                    HOMEBREW_PREFIX/"share/icons/hicolor").ordered
+      Homebrew::InstallSteps::Runner.new(context:).run(steps)
+    end
+
+    it "with gtk+3" do
+      allow(Formula).to receive(:[]).with("gtk+3").and_return(formula)
+      allow(Utils::Path).to receive(:formula_any_version_installed?).with("gtk4").and_return(false)
+      expect(context).to receive(:safe_system).with(root/"opt/bin/gtk3-update-icon-cache", "-q", "-t", "-f",
+                                                    HOMEBREW_PREFIX/"share/icons/hicolor").ordered
+      Homebrew::InstallSteps::Runner.new(context:).run(steps)
+    end
   end
 
   specify "does not add the default base to home paths" do


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Not sure on best way to handle different copies of update-icon-cache but this PR is one option.

There are a couple different alternatives, e.g.
* Use separate `gtk3_update_icon_cache` and `gtk4_update_icon_cache` DSL
* Add a parameter to `gtk_update_icon_cache`
* Splitting out `gtk-update-icon-cache` as separate formula similar to Linux distros (bit complicated to do in Homebrew).

Currently went with running any installed variant prioritizing newer copies. The cache command overwrites the same file so `gtk3-update-icon-cache` and `gtk4-update-icon-cache` should produce same results. 

This avoids having to update formula when dependency changes.

Also may make it possible to collect multiple instances of `gtk_update_icon_cache` and try to run once. Would need to check if any scenario where another postinstall will need the icon cache prior to running though I'm guessing not likely given icon cache is for GUI usage.