### PR TITLE
Preserve bottled SBOMs on pour

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -516,7 +516,7 @@ module Homebrew
             end
 
             sbom = SBOM.create(formula, tab)
-            sbom.write(bottling: true)
+            sbom.write
 
             keg.consistent_reproducible_symlink_permissions!
 

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -651,8 +651,10 @@ module Homebrew
         odeprecated: true,
       },
       HOMEBREW_SBOM:                             {
-        description: "If set, Homebrew will write SBOM files and run SBOM-related installation logic.",
-        boolean:     true,
+        description: "Write SBOM files for source installs.",
+        boolean:     :set,
+        default:     true,
+        hidden:      true,
       },
       HOMEBREW_SIMULATE_MACOS_ON_LINUX:          {
         description: "If set, running Homebrew on Linux will simulate certain macOS code paths. This is useful " \

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1042,8 +1042,13 @@ on_request: installed_on_request?, options:)
     tab.runtime_dependencies = Tab.runtime_deps_hash(formula, f_runtime_deps)
     tab.write
 
-    # write/update a SBOM file (if requested and we aren't bottling)
-    if Homebrew::EnvConfig.sbom? && !build_bottle?
+    # Update packaged SBOM metadata or write a source-install SBOM.
+    if @poured_bottle
+      if (install_time = tab.time)
+        require "sbom"
+        SBOM.update_pour_metadata(SBOM.spdxfile(formula), homebrew_version: HOMEBREW_VERSION, time: install_time)
+      end
+    elsif Homebrew::EnvConfig.sbom? && !build_bottle?
       require "sbom"
       sbom = SBOM.create(formula, tab)
       sbom.write(validate: Homebrew::EnvConfig.developer?)

--- a/Library/Homebrew/sbom.rb
+++ b/Library/Homebrew/sbom.rb
@@ -37,9 +37,7 @@ class SBOM
 
     new(
       name:                 formula.name,
-      homebrew_version:     HOMEBREW_VERSION,
       spdxfile:             SBOM.spdxfile(formula),
-      time:                 tab.time || Time.now,
       source_modified_time: tab.source_modified_time.to_i,
       compiler:             tab.compiler,
       stdlib:               tab.stdlib,
@@ -88,13 +86,30 @@ class SBOM
     spdxfile(formula).exist?
   end
 
+  sig { params(spdxfile: Pathname, homebrew_version: String, time: Integer).void }
+  def self.update_pour_metadata(spdxfile, homebrew_version:, time:)
+    return unless spdxfile.exist?
+
+    spdx = JSON.parse(spdxfile.read)
+    return unless spdx.is_a?(Hash)
+
+    creation_info = spdx["creationInfo"]
+    return unless creation_info.is_a?(Hash)
+
+    creation_info["created"] = Time.at(time).utc.iso8601
+    creation_info["creators"] = ["Tool: https://github.com/Homebrew/brew@#{homebrew_version}"]
+    spdxfile.atomic_write(JSON.pretty_generate(spdx))
+  rescue JSON::ParserError
+    nil
+  end
+
   sig { returns(T::Hash[String, T.anything]) }
   def self.schema
     @schema ||= T.let(JSON.parse(SCHEMA_FILE.read, freeze: true), T.nilable(T::Hash[String, T.untyped]))
   end
 
-  sig { params(bottling: T::Boolean).returns(T::Array[String]) }
-  def schema_validation_errors(bottling: false)
+  sig { params(data: T::Hash[Symbol, T.anything]).returns(T::Array[String]) }
+  def schema_validation_errors(data = to_spdx_sbom)
     unless Homebrew.require? "json_schemer"
       error_message = "Need json_schemer to validate SBOM, run `brew install-bundler-gems --add-groups=bottle`!"
       odie error_message if ENV["HOMEBREW_ENFORCE_SBOM"]
@@ -102,14 +117,13 @@ class SBOM
     end
 
     schemer = JSONSchemer.schema(SBOM.schema)
-    data = to_spdx_sbom(bottling:)
 
     schemer.validate(data).map { |error| error["error"] }
   end
 
-  sig { params(bottling: T::Boolean).returns(T::Boolean) }
-  def valid?(bottling: false)
-    validation_errors = schema_validation_errors(bottling:)
+  sig { params(data: T::Hash[Symbol, T.anything]).returns(T::Boolean) }
+  def valid?(data = to_spdx_sbom)
+    validation_errors = schema_validation_errors(data)
     return true if validation_errors.empty?
 
     opoo "SBOM validation errors:"
@@ -120,27 +134,79 @@ class SBOM
     false
   end
 
-  sig { params(validate: T::Boolean, bottling: T::Boolean).void }
-  def write(validate: true, bottling: false)
+  sig { params(validate: T::Boolean).void }
+  def write(validate: true)
     # If this is a new installation, the cache of installed formulae
     # will no longer be valid.
     Formula.clear_cache unless spdxfile.exist?
 
-    if validate && !valid?(bottling:)
+    spdx_sbom = to_spdx_sbom
+
+    if validate && !valid?(spdx_sbom)
       opoo "SBOM is not valid, not writing to disk!"
       return
     end
 
-    spdxfile.atomic_write(JSON.pretty_generate(to_spdx_sbom(bottling:)))
+    spdxfile.atomic_write(JSON.pretty_generate(spdx_sbom))
+  end
+
+  sig { returns(T::Hash[Symbol, T.anything]) }
+  def to_spdx_sbom
+    runtime_full = full_spdx_runtime_dependencies
+
+    compiler_info = {
+      "SPDXRef-Compiler" => {
+        SPDXID:           "SPDXRef-Compiler",
+        name:             compiler.to_s,
+        versionInfo:      assert_value(built_on["xcode"]),
+        filesAnalyzed:    false,
+        licenseDeclared:  assert_value(nil),
+        licenseConcluded: assert_value(nil),
+        copyrightText:    assert_value(nil),
+        downloadLocation: assert_value(nil),
+        checksums:        [],
+        externalRefs:     [],
+      },
+    }
+
+    if stdlib.present?
+      compiler_info["SPDXRef-Stdlib"] = {
+        SPDXID:           "SPDXRef-Stdlib",
+        name:             stdlib.to_s,
+        versionInfo:      stdlib.to_s,
+        filesAnalyzed:    false,
+        licenseDeclared:  assert_value(nil),
+        licenseConcluded: assert_value(nil),
+        copyrightText:    assert_value(nil),
+        downloadLocation: assert_value(nil),
+        checksums:        [],
+        externalRefs:     [],
+      }
+    end
+
+    packages = generate_packages_json(runtime_full, compiler_info)
+    files = generate_files_json
+    {
+      SPDXID:            "SPDXRef-DOCUMENT",
+      spdxVersion:       "SPDX-2.3",
+      name:              "SBOM-SPDX-#{name}-#{spec_version}",
+      creationInfo:      {
+        created:  source_modified_time.iso8601,
+        creators: ["Tool: https://github.com/Homebrew/brew"],
+      },
+      dataLicense:       "CC0-1.0",
+      documentNamespace: "https://formulae.brew.sh/spdx/#{name}-#{spec_version}.json",
+      documentDescribes: packages.map { |dependency| dependency[:SPDXID] },
+      files:,
+      packages:,
+      relationships:     generate_relations_json(runtime_full, compiler_info),
+    }
   end
 
   private
 
   sig { returns(String) }
-  attr_reader :name, :homebrew_version
-
-  sig { returns(T.any(Integer, Time)) }
-  attr_reader :time
+  attr_reader :name
 
   sig { returns(T.nilable(T.any(String, Symbol))) }
   attr_reader :stdlib
@@ -160,9 +226,7 @@ class SBOM
   sig {
     params(
       name:                 String,
-      homebrew_version:     String,
       spdxfile:             Pathname,
-      time:                 T.any(Integer, Time),
       source_modified_time: Integer,
       compiler:             T.any(String, Symbol),
       stdlib:               T.nilable(T.any(String, Symbol)),
@@ -172,12 +236,10 @@ class SBOM
       source:               Source,
     ).void
   }
-  def initialize(name:, homebrew_version:, spdxfile:, time:, source_modified_time:,
-                 compiler:, stdlib:, runtime_dependencies:, license:, built_on:, source:)
+  def initialize(name:, spdxfile:, source_modified_time:, compiler:, stdlib:, runtime_dependencies:,
+                 license:, built_on:, source:)
     @name = name
-    @homebrew_version = homebrew_version
     @spdxfile = spdxfile
-    @time = time
     @source_modified_time = source_modified_time
     @compiler = compiler
     @stdlib = stdlib
@@ -191,15 +253,14 @@ class SBOM
     params(
       runtime_dependency_declaration: T::Array[T::Hash[Symbol, T.untyped]],
       compiler_declaration:           T::Hash[String, T.untyped],
-      bottling:                       T::Boolean,
     ).returns(T::Array[T::Hash[Symbol, T.untyped]])
   }
-  def generate_relations_json(runtime_dependency_declaration, compiler_declaration, bottling:)
+  def generate_relations_json(runtime_dependency_declaration, compiler_declaration)
     runtime = runtime_dependency_declaration.map do |dependency|
       {
         spdxElementId:      dependency[:SPDXID],
         relationshipType:   "RUNTIME_DEPENDENCY_OF",
-        relatedSpdxElement: described_package_spdx_id(bottling:),
+        relatedSpdxElement: described_package_spdx_id,
       }
     end
 
@@ -223,20 +284,18 @@ class SBOM
       }
     end
 
-    unless bottling
-      base << {
-        spdxElementId:      "SPDXRef-Compiler",
-        relationshipType:   "BUILD_TOOL_OF",
-        relatedSpdxElement: "SPDXRef-Archive-#{name}-src",
-      }
+    base << {
+      spdxElementId:      "SPDXRef-Compiler",
+      relationshipType:   "BUILD_TOOL_OF",
+      relatedSpdxElement: "SPDXRef-Archive-#{name}-src",
+    }
 
-      if compiler_declaration["SPDXRef-Stdlib"].present?
-        base << {
-          spdxElementId:      "SPDXRef-Stdlib",
-          relationshipType:   "DEPENDENCY_OF",
-          relatedSpdxElement: described_package_spdx_id(bottling:),
-        }
-      end
+    if compiler_declaration["SPDXRef-Stdlib"].present?
+      base << {
+        spdxElementId:      "SPDXRef-Stdlib",
+        relationshipType:   "DEPENDENCY_OF",
+        relatedSpdxElement: described_package_spdx_id,
+      }
     end
 
     runtime + patches + base
@@ -246,12 +305,11 @@ class SBOM
     params(
       runtime_dependency_declaration: T::Array[T::Hash[Symbol, T.anything]],
       compiler_declaration:           T::Hash[String, T::Hash[Symbol, T.anything]],
-      bottling:                       T::Boolean,
     ).returns(T::Array[T::Hash[Symbol, T.untyped]])
   }
-  def generate_packages_json(runtime_dependency_declaration, compiler_declaration, bottling:)
+  def generate_packages_json(runtime_dependency_declaration, compiler_declaration)
     bottle = []
-    if bottle_package?(bottling:) &&
+    if bottle_package? &&
        (bottle_info = get_bottle_info(source.bottle)) &&
        (stable_version = source.version)
       bottle << {
@@ -305,12 +363,6 @@ class SBOM
       package
     end
 
-    compiler_declarations = if bottling
-      []
-    else
-      compiler_declaration.values
-    end
-
     [
       {
         SPDXID:           "SPDXRef-Archive-#{name}-src",
@@ -330,7 +382,7 @@ class SBOM
           },
         ],
       },
-    ] + patches + runtime_dependency_declaration + compiler_declarations + bottle
+    ] + patches + runtime_dependency_declaration + compiler_declaration.values + bottle
   end
 
   sig { returns(T::Array[T::Hash[Symbol, T.anything]]) }
@@ -352,12 +404,9 @@ class SBOM
     ]
   end
 
-  sig {
-    params(bottling: T::Boolean)
-      .returns(T::Array[T::Hash[Symbol, T.any(T::Boolean, String, T::Array[T::Hash[Symbol, String]])]])
-  }
-  def full_spdx_runtime_dependencies(bottling:)
-    return [] if bottling || @runtime_dependencies.blank?
+  sig { returns(T::Array[T::Hash[Symbol, T.any(T::Boolean, String, T::Array[T::Hash[Symbol, String]])]]) }
+  def full_spdx_runtime_dependencies
+    return [] if @runtime_dependencies.blank?
 
     @runtime_dependencies.compact.filter_map do |dependency|
       next unless dependency.present?
@@ -395,65 +444,6 @@ class SBOM
     end
   end
 
-  sig { params(bottling: T::Boolean).returns(T::Hash[Symbol, T.anything]) }
-  def to_spdx_sbom(bottling:)
-    runtime_full = full_spdx_runtime_dependencies(bottling:)
-
-    compiler_info = {
-      "SPDXRef-Compiler" => {
-        SPDXID:           "SPDXRef-Compiler",
-        name:             compiler.to_s,
-        versionInfo:      assert_value(built_on["xcode"]),
-        filesAnalyzed:    false,
-        licenseDeclared:  assert_value(nil),
-        licenseConcluded: assert_value(nil),
-        copyrightText:    assert_value(nil),
-        downloadLocation: assert_value(nil),
-        checksums:        [],
-        externalRefs:     [],
-      },
-    }
-
-    if stdlib.present?
-      compiler_info["SPDXRef-Stdlib"] = {
-        SPDXID:           "SPDXRef-Stdlib",
-        name:             stdlib.to_s,
-        versionInfo:      stdlib.to_s,
-        filesAnalyzed:    false,
-        licenseDeclared:  assert_value(nil),
-        licenseConcluded: assert_value(nil),
-        copyrightText:    assert_value(nil),
-        downloadLocation: assert_value(nil),
-        checksums:        [],
-        externalRefs:     [],
-      }
-    end
-
-    # Improve reproducibility when bottling.
-    if bottling
-      created = source_modified_time.iso8601
-      creators = ["Tool: https://github.com/Homebrew/brew"]
-    else
-      created = Time.at(time).utc.iso8601
-      creators = ["Tool: https://github.com/Homebrew/brew@#{homebrew_version}"]
-    end
-
-    packages = generate_packages_json(runtime_full, compiler_info, bottling:)
-    files = generate_files_json
-    {
-      SPDXID:            "SPDXRef-DOCUMENT",
-      spdxVersion:       "SPDX-2.3",
-      name:              "SBOM-SPDX-#{name}-#{spec_version}",
-      creationInfo:      { created:, creators: },
-      dataLicense:       "CC0-1.0",
-      documentNamespace: "https://formulae.brew.sh/spdx/#{name}-#{spec_version}.json",
-      documentDescribes: packages.map { |dependency| dependency[:SPDXID] },
-      files:,
-      packages:,
-      relationships:     generate_relations_json(runtime_full, compiler_info, bottling:),
-    }
-  end
-
   sig { params(base: T.nilable(T::Hash[String, T.untyped])).returns(T.nilable(T::Hash[String, String])) }
   def get_bottle_info(base)
     return unless base.present?
@@ -464,14 +454,14 @@ class SBOM
     files[Utils::Bottles.tag.to_sym] || files[:all]
   end
 
-  sig { params(bottling: T::Boolean).returns(T::Boolean) }
-  def bottle_package?(bottling:)
-    !bottling && get_bottle_info(source.bottle).present? && spec_symbol == :stable && source.version.present?
+  sig { returns(T::Boolean) }
+  def bottle_package?
+    get_bottle_info(source.bottle).present? && spec_symbol == :stable && source.version.present?
   end
 
-  sig { params(bottling: T::Boolean).returns(String) }
-  def described_package_spdx_id(bottling:)
-    if bottle_package?(bottling:)
+  sig { returns(String) }
+  def described_package_spdx_id
+    if bottle_package?
       "SPDXRef-Bottle-#{name}"
     else
       "SPDXRef-Archive-#{name}-src"

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -313,6 +313,25 @@ RSpec.describe Homebrew::EnvConfig do
     end
   end
 
+  describe ".sbom?" do
+    around do |example|
+      with_env(HOMEBREW_SBOM: nil) { example.run }
+    end
+
+    it "returns true by default" do
+      expect(env_config.sbom?).to be(true)
+    end
+
+    it "returns true if set to a falsey value" do
+      ENV["HOMEBREW_SBOM"] = "0"
+      expect(env_config.sbom?).to be(true)
+    end
+
+    it "is hidden" do
+      expect(env_config.hidden?(Homebrew::EnvConfig::ENVS.fetch(:HOMEBREW_SBOM))).to be(true)
+    end
+  end
+
   describe ".no_sandbox_cask?" do
     it "deprecates HOMEBREW_NO_SANDBOX_CASK" do
       ENV["HOMEBREW_NO_SANDBOX_CASK"] = "1"

--- a/Library/Homebrew/test/sbom_spec.rb
+++ b/Library/Homebrew/test/sbom_spec.rb
@@ -21,10 +21,6 @@ RSpec.describe SBOM do
       expect(sbom.schema_validation_errors).to be_empty
     end
 
-    it "returns true if valid when bottling" do
-      expect(sbom.schema_validation_errors(bottling: true)).to be_empty
-    end
-
     context "with a maximal SBOM" do
       let(:f) do
         formula do
@@ -40,6 +36,7 @@ RSpec.describe SBOM do
           end
 
           bottle do
+            root_url "https://brew.sh/bottles"
             sha256 all: "9befdad158e59763fb0622083974a6252878019702d8c961e1bec3a5f5305339"
           end
 
@@ -93,12 +90,8 @@ RSpec.describe SBOM do
         expect(sbom.schema_validation_errors).to be_empty
       end
 
-      it "returns true if valid when bottling" do
-        expect(sbom.schema_validation_errors(bottling: true)).to be_empty
-      end
-
       it "only emits relationships with defined SPDX IDs" do
-        spdx = sbom.send(:to_spdx_sbom, bottling: false)
+        spdx = sbom.to_spdx_sbom
         spdx_ids = Set.new(["SPDXRef-DOCUMENT"] + spdx[:packages].map { |package| package[:SPDXID] } +
                            spdx[:files].map { |file| file[:SPDXID] })
 
@@ -108,7 +101,7 @@ RSpec.describe SBOM do
       end
 
       it "emits external patches as packages" do
-        spdx = sbom.send(:to_spdx_sbom, bottling: false)
+        spdx = sbom.to_spdx_sbom
 
         expect(spdx[:packages]).to include(
           hash_including(
@@ -117,6 +110,62 @@ RSpec.describe SBOM do
             checksums:        [{ algorithm: "SHA256", checksumValue: TEST_SHA256 }],
           ),
         )
+      end
+
+      it "emits reproducible creation info" do
+        expect(sbom.to_spdx_sbom[:creationInfo]).to eq(
+          created:  Time.at(tab.source_modified_time.to_i).utc.iso8601,
+          creators: ["Tool: https://github.com/Homebrew/brew"],
+        )
+      end
+
+      it "emits bottle metadata when bottle filenames are available" do
+        expect(sbom.to_spdx_sbom[:packages]).to include(
+          hash_including(
+            SPDXID:           "SPDXRef-Bottle-formula_name",
+            downloadLocation: "https://brew.sh/bottles/formula_name-0.1.all.bottle.tar.gz",
+            checksums:        [{
+              algorithm:     "SHA256",
+              checksumValue: "9befdad158e59763fb0622083974a6252878019702d8c961e1bec3a5f5305339",
+            }],
+          ),
+        )
+      end
+
+      it "updates only pour-time creation metadata" do
+        spdxfile = mktmpdir/SBOM::FILENAME
+        spdxfile.write(JSON.pretty_generate(sbom.to_spdx_sbom))
+        original_spdx = JSON.parse(spdxfile.read)
+
+        described_class.update_pour_metadata(spdxfile, homebrew_version: "1.2.3", time: 1_720_189_863)
+
+        updated_spdx = JSON.parse(spdxfile.read)
+        expect(updated_spdx.fetch("creationInfo")).to eq(
+          "created"  => "2024-07-05T14:31:03Z",
+          "creators" => ["Tool: https://github.com/Homebrew/brew@1.2.3"],
+        )
+        expect(updated_spdx.except("creationInfo")).to eq(original_spdx.except("creationInfo"))
+      end
+
+      it "skips malformed pour metadata SBOMs" do
+        spdxfile = mktmpdir/SBOM::FILENAME
+        spdxfile.write("{")
+
+        expect do
+          described_class.update_pour_metadata(spdxfile, homebrew_version: "1.2.3", time: 1_720_189_863)
+        end.not_to raise_error
+        expect(spdxfile.read).to eq("{")
+      end
+
+      it "skips pour metadata SBOMs without creation info objects" do
+        spdxfile = mktmpdir/SBOM::FILENAME
+        spdxfile.write(JSON.pretty_generate("creationInfo" => []))
+        original_spdx = spdxfile.read
+
+        expect do
+          described_class.update_pour_metadata(spdxfile, homebrew_version: "1.2.3", time: 1_720_189_863)
+        end.not_to raise_error
+        expect(spdxfile.read).to eq(original_spdx)
       end
     end
 
@@ -127,10 +176,6 @@ RSpec.describe SBOM do
 
       it "returns false" do
         expect(sbom.schema_validation_errors).not_to be_empty
-      end
-
-      it "returns false when bottling" do
-        expect(sbom.schema_validation_errors(bottling: true)).not_to be_empty
       end
     end
   end

--- a/Library/Homebrew/test_bot.rb
+++ b/Library/Homebrew/test_bot.rb
@@ -106,7 +106,6 @@ module Homebrew
       ENV["HOMEBREW_GIT"] = ENV["HOMEBREW_GIT_PATH"] = GIT
       ENV["HOMEBREW_DISALLOW_LIBNSL1"] = "1"
       ENV["HOMEBREW_NO_ENV_HINTS"] = "1"
-      ENV["HOMEBREW_SBOM"] = "1"
       ENV["HOMEBREW_PATH"] = ENV["PATH"] =
         "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV.fetch("PATH")}"
 


### PR DESCRIPTION
- Write bottle SBOMs during `brew bottle` after relocation and final bottle tab updates, not during `--build-bottle` install.
- Keep source-install SBOM generation always enabled and hide `HOMEBREW_SBOM`, since source builds are already the slow path.
- Patch only SPDX creation metadata during bottle pours, even when `HOMEBREW_SBOM` is unset, without regenerating SBOM contents.
- Reuse the generated SPDX payload for validated SBOM writes to avoid duplicate SBOM generation.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
