### PR TITLE
Migrate more cask metadata to JSON for developers

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -5,6 +5,7 @@ require "abstract_command"
 require "migrator"
 require "formulary"
 require "cask/cask_loader"
+require "cask/caskroom"
 require "cask/migrator"
 require "descriptions"
 require "cleanup"
@@ -149,6 +150,7 @@ module Homebrew
         Homebrew::API.write_names_and_aliases unless Homebrew::EnvConfig.no_install_from_api?
 
         Homebrew.failed = true if ENV["HOMEBREW_UPDATE_FAILED"]
+        migrate_caskroom_caskfiles_to_json
         return if Homebrew::EnvConfig.disable_load_formula?
 
         migrate_gcc_dependents_if_needed
@@ -349,6 +351,22 @@ module Homebrew
       sig { void }
       def migrate_gcc_dependents_if_needed
         # do nothing
+      end
+
+      sig { void }
+      def migrate_caskroom_caskfiles_to_json
+        return unless Homebrew::EnvConfig.developer?
+        return unless Cask::Caskroom.path.directory?
+
+        Cask::Caskroom.path.glob("*/.metadata/*/*/Casks/*.{internal.json,rb}").each do |caskfile|
+          cask = Cask::CaskLoader.load(caskfile, warn: false)
+          next if cask.uninstall_flight_blocks?
+
+          (caskfile.dirname/"#{cask.token}.json").atomic_write(JSON.pretty_generate(cask.to_installed_json_hash))
+          caskfile.unlink
+        rescue => e
+          opoo "Failed to migrate #{caskfile} to JSON metadata: #{e}"
+        end
       end
 
       sig { void }

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -146,6 +146,85 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
     FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"allowed"
   end
 
+  it "migrates supported Caskroom Ruby and internal JSON metadata to JSON for developers" do
+    caskroom = mktmpdir/"Caskroom"
+    rb_caskfile = caskroom/"local-caffeine/.metadata/1.0/20250101000000.000/Casks/local-caffeine.rb"
+    json_caskfile = rb_caskfile.sub_ext(".json")
+    uninstall_flight_caskfile =
+      caskroom/"with-uninstall-preflight/.metadata/1.0/20250101000000.000/Casks/with-uninstall-preflight.rb"
+    internal_json_caskfile = caskroom/"api-cask/.metadata/1.0/20250101000000.000/Casks/api-cask.internal.json"
+    api_caskfile = internal_json_caskfile.dirname/"api-cask.json"
+    rb_caskfile.dirname.mkpath
+    rb_caskfile.write <<~RUBY
+      cask "local-caffeine" do
+        version "1.0"
+        sha256 :no_check
+        url "https://example.com/local-caffeine.zip"
+        name "Local Caffeine"
+        homepage "https://example.com/local-caffeine"
+        app "Caffeine.app"
+      end
+    RUBY
+    uninstall_flight_caskfile.dirname.mkpath
+    uninstall_flight_caskfile.write <<~RUBY
+      cask "with-uninstall-preflight" do
+        version "1.0"
+        sha256 :no_check
+        url "https://example.com/with-uninstall-preflight.zip"
+        name "With Uninstall Preflight"
+        homepage "https://example.com/with-uninstall-preflight"
+        app "With Uninstall Preflight.app"
+
+        uninstall_preflight do
+          # do nothing
+        end
+      end
+    RUBY
+    (caskroom/"local-caffeine/.metadata/INSTALL_RECEIPT.json").write JSON.pretty_generate({
+      "source"              => { "version" => "1.0" },
+      "uninstall_artifacts" => [{ "app" => ["Caffeine.app"] }],
+    })
+    internal_json_caskfile.dirname.mkpath
+    internal_json_caskfile.write JSON.pretty_generate({
+      "homepage"      => "https://example.com/api-cask",
+      "names"         => ["API Cask"],
+      "raw_artifacts" => [[":app", ["API Cask.app"]]],
+      "sha256"        => "no_check",
+      "url_args"      => ["https://example.com/api-cask.zip"],
+      "version"       => "1.0",
+    })
+    (caskroom/"api-cask/.metadata/INSTALL_RECEIPT.json").write JSON.pretty_generate({
+      "source"              => { "version" => "1.0" },
+      "uninstall_artifacts" => [{ "app" => ["API Cask.app"] }],
+    })
+
+    allow(Cask::Caskroom).to receive(:path).and_return(caskroom)
+    allow(Homebrew::EnvConfig).to receive_messages(developer?: true, disable_load_formula?: true,
+                                                   no_install_from_api?: true)
+
+    with_env(
+      HOMEBREW_UPDATE_BEFORE: "abc",
+      HOMEBREW_UPDATE_AFTER:  "abc",
+      HOMEBREW_UPDATE_TEST:   "1",
+    ) { described_class.new(["--quiet"]).run }
+
+    loaded_cask = Cask::CaskLoader.load_from_installed_caskfile(json_caskfile)
+    loaded_api_cask = Cask::CaskLoader.load_from_installed_caskfile(api_caskfile)
+    expect([
+      rb_caskfile.exist?,
+      JSON.parse(json_caskfile.read).keys,
+      loaded_cask.version.to_s,
+      loaded_cask.artifacts.grep(Cask::Artifact::App).count,
+      uninstall_flight_caskfile.exist?,
+      uninstall_flight_caskfile.sub_ext(".json").exist?,
+      Cask::CaskLoader.load_from_installed_caskfile(uninstall_flight_caskfile).uninstall_flight_blocks?,
+      internal_json_caskfile.exist?,
+      JSON.parse(api_caskfile.read).keys,
+      loaded_api_cask.loaded_from_internal_api?,
+      loaded_api_cask.artifacts.grep(Cask::Artifact::App).count,
+    ]).to eq([false, [], "1.0", 1, true, false, true, false, [], false, 1])
+  end
+
   describe Reporter do
     let(:tap) { CoreTap.instance }
     let(:reporter_class) do


### PR DESCRIPTION
- Exercise the update-report path under `HOMEBREW_DEVELOPER` first.
- Convert supported Caskroom `.rb` and `.internal.json` metadata.
- Keep uninstall flight block caskfiles as Ruby until ported.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
