### PR TITLE
Enable more cask metadata migration to JSON for all users

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -355,7 +355,6 @@ module Homebrew
 
       sig { void }
       def migrate_caskroom_caskfiles_to_json
-        return unless Homebrew::EnvConfig.developer?
         return unless Cask::Caskroom.path.directory?
 
         Cask::Caskroom.path.glob("*/.metadata/*/*/Casks/*.{internal.json,rb}").each do |caskfile|

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
     FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"allowed"
   end
 
-  it "migrates supported Caskroom Ruby and internal JSON metadata to JSON for developers" do
+  it "migrates supported Caskroom Ruby and internal JSON metadata to JSON for all users" do
     caskroom = mktmpdir/"Caskroom"
     rb_caskfile = caskroom/"local-caffeine/.metadata/1.0/20250101000000.000/Casks/local-caffeine.rb"
     json_caskfile = rb_caskfile.sub_ext(".json")
@@ -199,7 +199,7 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
     })
 
     allow(Cask::Caskroom).to receive(:path).and_return(caskroom)
-    allow(Homebrew::EnvConfig).to receive_messages(developer?: true, disable_load_formula?: true,
+    allow(Homebrew::EnvConfig).to receive_messages(developer?: false, disable_load_formula?: true,
                                                    no_install_from_api?: true)
 
     with_env(


### PR DESCRIPTION
- Remove the developer gate after proving the update-time path.
- Keep the regression pinned to a non-developer update run.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
