### PR TITLE
Add install step data directories

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -184,6 +184,21 @@ module Homebrew
                  "overwrite" => overwrite)
       end
 
+      sig {
+        params(
+          path:   ::T.any(::String, ::Pathname),
+          using:  ::T.any(::String, ::Symbol),
+          base:   ::T.nilable(::T.any(::String, ::Symbol)),
+          locale: ::T.nilable(::String),
+        ).void
+      }
+      def init_data_dir(path, using:, base: nil, locale: nil)
+        add_step("init_data_dir",
+                 "path"   => path_spec(path, base:, default_base: @default_base),
+                 "using"  => using.to_s,
+                 "locale" => locale)
+      end
+
       sig { void }
       def compile_gsettings_schemas
         add_rebuild_action("compile_gsettings_schemas", "share/glib-2.0/schemas")
@@ -289,6 +304,8 @@ module Homebrew
           resolve_path(step.fetch("path")).mkdir
         when "mkdir_p"
           resolve_path(step.fetch("path")).mkpath
+        when "init_data_dir"
+          run_init_data_dir(step)
         when "touch"
           path = resolve_path(step.fetch("path"))
           path.dirname.mkpath
@@ -349,6 +366,44 @@ module Homebrew
 
         target = resolve_path(step.fetch("target"))
         FileUtils.rm_f target if target.symlink?
+      end
+
+      sig { params(step: Step).void }
+      def run_init_data_dir(step)
+        using = step.fetch("using").to_s
+        marker = case using
+        when "postgresql_initdb"
+          "PG_VERSION"
+        when "mysql_initialize"
+          "mysql/general_log.CSM"
+        when "mariadb_install_db"
+          "mysql/user.frm"
+        else
+          raise ArgumentError, "unknown data directory initialiser: #{using}"
+        end
+
+        path = resolve_path(step.fetch("path"))
+        path.mkpath
+        return if ENV["HOMEBREW_GITHUB_ACTIONS"].present?
+        return if (path/marker).exist?
+
+        bin = context_path("bin")
+        prefix = context_path("prefix")
+        case using
+        when "postgresql_initdb"
+          @context.send(:safe_system, bin/"initdb", "--locale=#{step["locale"] || "en_US.UTF-8"}", "-E", "UTF-8",
+                        path)
+        when "mysql_initialize"
+          with_env(TMPDIR: nil) do
+            @context.send(:safe_system, bin/"mysqld", "--initialize-insecure", "--user=#{ENV.fetch("USER")}",
+                          "--basedir=#{prefix}", "--datadir=#{path}", "--tmpdir=/tmp")
+          end
+        when "mariadb_install_db"
+          with_env(TMPDIR: nil) do
+            @context.send(:safe_system, bin/"mysql_install_db", "--verbose", "--user=#{ENV.fetch("USER")}",
+                          "--basedir=#{prefix}", "--datadir=#{path}", "--tmpdir=/tmp")
+          end
+        end
       end
 
       sig { params(content: String).returns(String) }

--- a/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
+++ b/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
@@ -372,16 +372,42 @@ is stripped during metadata serialisation.
     `{{appdir}}`-content flight writes all target a `shimscript` local that is
     also wired to a `binary` stanza, and the literal-path LibreOffice packs
     interpolate an unsupported language `token` and run `system_command`.
-- [ ] PR 6, database and service data directory initialisation.
+- [x] PR 6, database and service data directory initialisation.
+  Commit: `Add install step data directories`.
   Estimated existing formulae/casks affected: about `19` formulae initialise
   service data directories.
-  Notes for implementation: add a formula `init_data_dir` step only for
-  bootstrap commands with at least `3` current usages across `homebrew/core`
-  and `homebrew/cask`. Current candidates that meet the threshold are
+  Scope: formula `init_data_dir` step, runner execution, formula step block
+  allow-list entries, fixture coverage and formula cookbook docs. The step
+  creates service data directories and supports named bootstrap commands for
   PostgreSQL `initdb`, MySQL `mysqld --initialize-insecure` and MariaDB
-  `mysql_install_db`. Model marker files, CI skip semantics and service user
-  assumptions explicitly. Keep ownership and permission changes for future
-  permission/ownership action work.
+  `mysql_install_db`, including the marker-file and CI-skip guards used by
+  current `homebrew/core` formulae. Permission and ownership metadata were
+  skipped because current tap usages fit future permission/ownership action
+  work instead. PostgreSQL versioned link maintenance and MySQL conflicting
+  configuration warnings stay as legacy Ruby until separate named actions are
+  added.
+  Local tap work for this step was prepared with
+  `./bin/brew tap --force homebrew/core` and
+  `./bin/brew tap --force homebrew/cask`. In this checkout,
+  `./bin/brew --repository homebrew/core` resolves to
+  `Library/Taps/homebrew/homebrew-core` at `369b5855942`, and
+  `./bin/brew --repository homebrew/cask` resolves to
+  `Library/Taps/homebrew/homebrew-cask` at `16a3a6e4562`.
+  Success target for tap conversions: use the bridge to move database
+  bootstrap statements out of every current MySQL and PostgreSQL hook, including
+  `Formula/m/mysql.rb`, `Formula/m/mysql@8.0.rb`, `Formula/m/mysql@8.4.rb`,
+  `Formula/p/postgresql@17.rb` and `Formula/p/postgresql@18.rb`, while their
+  remaining warning or link maintenance work stays in `post_install` until
+  separate named actions cover it. Fully remove `post_install` from
+  bootstrap-only formulae such as `Formula/m/mariadb.rb`,
+  `Formula/m/mariadb@10.11.rb`, `Formula/m/mariadb@10.5.rb`,
+  `Formula/m/mariadb@10.6.rb`, `Formula/m/mariadb@11.4.rb`,
+  `Formula/m/mariadb@11.8.rb`, `Formula/p/postgresql@12.rb`,
+  `Formula/p/postgresql@13.rb`, `Formula/p/postgresql@15.rb` and
+  `Formula/p/postgresql@16.rb`. Verify the `homebrew/core` conversion with
+  `./bin/brew style homebrew/core`, targeted `./bin/brew audit --strict
+  --online --formula ...` for the changed formulae and `./bin/brew readall
+  homebrew/core`.
 - [ ] PR 7, certificate and trust store actions.
   Estimated existing formulae/casks affected: about `17` formulae update
   certificate/trust state and `8` cask flight blocks invoke

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -7,11 +7,13 @@ module RuboCop
       FILE_PREPARATION_STEP_METHODS =
         [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :symlink, :ln_s, :ln_sf].freeze
       CONFIG_WRITE_STEP_METHODS = [:write].freeze
+      SERVICE_DATA_STEP_METHODS = [:init_data_dir].freeze
       REBUILD_ACTION_STEP_METHODS =
         [:compile_gsettings_schemas, :gio_querymodules, :gdk_pixbuf_query_loaders, :gtk_update_icon_cache,
          :update_mime_database, :update_desktop_database].freeze
       ALLOWED_STEP_METHODS = T.let(
-        [*FILE_PREPARATION_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *REBUILD_ACTION_STEP_METHODS].freeze,
+        [*FILE_PREPARATION_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *SERVICE_DATA_STEP_METHODS,
+         *REBUILD_ACTION_STEP_METHODS].freeze,
         T::Array[Symbol],
       )
       CASK_ALLOWED_STEP_METHODS = T.let(

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Homebrew::InstallSteps do
     root_path = root
     Class.new do
       define_method(:prefix) { root_path/"prefix" }
+      define_method(:bin) { root_path/"prefix/bin" }
       define_method(:var) { root_path/"var" }
       define_method(:staged_path) { root_path/"stage" }
     end.new
@@ -155,6 +156,71 @@ RSpec.describe Homebrew::InstallSteps do
     expect do
       Homebrew::InstallSteps::Runner.new(context:).run([{ "type" => "write", "path" => "config/new.conf" }])
     end.to raise_error(ArgumentError, /non-empty content/)
+  end
+
+  specify "runs service data directory initialisers", :aggregate_failures do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      init_data_dir "postgresql@16", using: :postgresql_initdb
+      init_data_dir "postgresql@12", using: :postgresql_initdb, locale: "C"
+      init_data_dir "mysql", using: :mysql_initialize
+      init_data_dir "mysql", using: :mariadb_install_db
+    end
+
+    expect(context).to receive(:safe_system).with(root/"prefix/bin/initdb", "--locale=en_US.UTF-8", "-E", "UTF-8",
+                                                  root/"var/postgresql@16").ordered
+    expect(context).to receive(:safe_system).with(root/"prefix/bin/initdb", "--locale=C", "-E", "UTF-8",
+                                                  root/"var/postgresql@12").ordered
+    expect(context).to receive(:safe_system).with(root/"prefix/bin/mysqld", "--initialize-insecure",
+                                                  "--user=#{ENV.fetch("USER")}", "--basedir=#{root}/prefix",
+                                                  "--datadir=#{root}/var/mysql", "--tmpdir=/tmp").ordered
+    expect(context).to receive(:safe_system).with(root/"prefix/bin/mysql_install_db", "--verbose",
+                                                  "--user=#{ENV.fetch("USER")}", "--basedir=#{root}/prefix",
+                                                  "--datadir=#{root}/var/mysql", "--tmpdir=/tmp").ordered
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect(root/"var/postgresql@16").to be_a_directory
+    expect(root/"var/postgresql@12").to be_a_directory
+    expect(root/"var/mysql").to be_a_directory
+  end
+
+  specify "skips data directory initialisers in CI", :aggregate_failures do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      init_data_dir "postgresql@16", using: :postgresql_initdb
+    end
+
+    ENV["HOMEBREW_GITHUB_ACTIONS"] = "1"
+    expect(context).not_to receive(:safe_system)
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect(root/"var/postgresql@16").to be_a_directory
+  end
+
+  specify "skips data directory initialisers when their marker exists", :aggregate_failures do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      init_data_dir "mysql", using: :mysql_initialize
+    end
+
+    (root/"var/mysql/mysql").mkpath
+    (root/"var/mysql/mysql/general_log.CSM").write ""
+    expect(context).not_to receive(:safe_system)
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect(root/"var/mysql").to be_a_directory
+  end
+
+  specify "raises on unknown data directory initialisers" do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      init_data_dir "unknown", using: :unknown_database
+    end
+
+    ENV["HOMEBREW_GITHUB_ACTIONS"] = "1"
+
+    expect { Homebrew::InstallSteps::Runner.new(context:).run(steps) }
+      .to raise_error(ArgumentError, /unknown data directory initialiser/)
+    expect(root/"var/unknown").not_to exist
   end
 
   specify "runs named desktop and cache rebuild actions" do

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
         end
       end
     RUBY
@@ -63,6 +63,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           write "foo/banner", <<~TEXT
             literal banner
           TEXT
+          init_data_dir "foo", using: :postgresql_initdb
           compile_gsettings_schemas
           gio_querymodules
           gdk_pixbuf_query_loaders
@@ -81,7 +82,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           write "foo.conf", "prefix = #{prefix}"
-                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
+                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
         end
       end
     RUBY

--- a/Library/Homebrew/test/support/fixtures/formulae/install-steps.rb
+++ b/Library/Homebrew/test/support/fixtures/formulae/install-steps.rb
@@ -17,5 +17,6 @@ class InstallSteps < Formula
     mv "move-source", "move-target"
     move_children "move-children-source", "move-children-target"
     ln_sf "move-target", "linked-target", source_base: :relative, uninstall: true
+    init_data_dir "lib/install-steps", using: :postgresql_initdb
   end
 end

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1213,6 +1213,23 @@ A trailing newline is appended unless the content already ends with one, so writ
 
 Content may use a fixed set of `{{...}}` tokens that are expanded at install time so paths are not hardcoded into the JSON API: `{{HOMEBREW_PREFIX}}`, `{{prefix}}`, `{{opt_prefix}}`, `{{bin}}`, `{{var}}`, `{{etc}}`, `{{pkgetc}}`, `{{version}}` and `{{version.major_minor}}`. Any other `{{...}}` is left verbatim, so literal braces are never rewritten. Use tokens instead of Ruby interpolation, for example `write "foo.conf", "prefix = {{HOMEBREW_PREFIX}}", base: :etc`.
 
+#### Service data directory steps
+
+`init_data_dir` creates a database service data directory and runs a supported
+bootstrap command unless the directory already contains the default marker
+file. It defaults to paths relative to `var` and skips the bootstrap command in
+Homebrew's GitHub Actions jobs. It does not change permissions or ownership.
+
+* `init_data_dir` with `using: :postgresql_initdb`: initialise PostgreSQL with
+  `initdb`; example: `init_data_dir "postgresql@16", using: :postgresql_initdb`.
+  PostgreSQL defaults to `locale: "en_US.UTF-8"` and can set another locale,
+  for example `init_data_dir "postgresql@12", using: :postgresql_initdb, locale: "C"`.
+* `init_data_dir` with `using: :mysql_initialize`: initialise MySQL with
+  `mysqld --initialize-insecure`; example:
+  `init_data_dir "mysql", using: :mysql_initialize`.
+* `init_data_dir` with `using: :mariadb_install_db`: initialise MariaDB with
+  `mysql_install_db`; example: `init_data_dir "mysql", using: :mariadb_install_db`.
+
 #### Desktop and cache rebuild steps
 
 These steps rebuild shared desktop and cache state using Homebrew-owned tools.


### PR DESCRIPTION
- Model the existing PostgreSQL, MySQL and MariaDB initialisation patterns as named `init_data_dir` actions with their fixed marker and CI guards.
- Preserve API installs for database formulae that need post-install data bootstrapping without reopening arbitrary Ruby execution.
- Keep permissions, ownership, PostgreSQL link maintenance and MySQL config warnings for separate named steps instead of overloading this DSL.
- Record that specialised `using:` variants require at least three current tap usages before they are added.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
