### PR TITLE
test_bot/formulae: handle runtime deps similar to Formula

### DIFF
--- a/Library/Homebrew/test/test_bot/formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_spec.rb
@@ -42,16 +42,33 @@ RSpec.describe Homebrew::TestBot::Formulae do
       bar = formula("bar") do
         T.bind(self, T.class_of(Formula))
         url "bar-1.0"
+        depends_on "not-runtime" => :build
         depends_on "existing"
         depends_on "baz"
       end
       baz = formula("baz") do
         T.bind(self, T.class_of(Formula))
         url "baz-1.0"
+        depends_on "not-runtime" => :test
+        depends_on "recommended" => :recommended
+      end
+      recommended = formula("recommended") do
+        T.bind(self, T.class_of(Formula))
+        url "recommended-1.0"
+        depends_on "not-runtime" => :optional
+      end
+      not_runtime = formula("not-runtime") do
+        T.bind(self, T.class_of(Formula))
+        url "not-runtime-1.0"
+        depends_on "other"
+      end
+      other = formula("other") do
+        T.bind(self, T.class_of(Formula))
+        url "other-1.0"
       end
 
-      [existing, bar, baz].each { |f| stub_formula_loader f }
-      [[bar, 1_000_000], [baz, 500_000]].each do |f, size|
+      [existing, bar, baz, recommended, not_runtime, other].each { |f| stub_formula_loader f }
+      [[bar, 1_000_000], [baz, 500_000], [recommended, 400_000]].each do |f, size|
         allow(f).to receive(:bottle_for_tag)
           .and_return(instance_double(Bottle, fetch_tab: nil, installed_size: size))
       end
@@ -75,8 +92,8 @@ RSpec.describe Homebrew::TestBot::Formulae do
           expect { formulae.send(:annotate_added_dependencies, formula) }
             .to output(
               "::warning file=#{formula.path.relative_path_from(CoreTap.instance.path)},line=7," \
-              "title=foo: new dependency impact::Adding `bar` adds 2 new recursive dependencies " \
-              "on #{Utils::Bottles.tag} (1.5MB).\n",
+              "title=foo: new dependency impact::Adding `bar` adds 3 new recursive dependencies " \
+              "on #{Utils::Bottles.tag} (1.9MB).\n",
             ).to_stdout
         end
       end

--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -357,9 +357,13 @@ module Homebrew
         Utils.name_from_full_name(dependency.name) == Utils.name_from_full_name(dependency_name)
       end
 
-      sig { params(formula: Formula, dependencies: T::Array[Dependency]).returns(T::Array[String]) }
-      def recursive_runtime_dependency_names(formula, dependencies)
-        Dependency.expand(formula, dependencies).map { |dependency| dependency.to_formula.full_name }.uniq
+      sig { params(_formula: Formula, dependencies: T::Array[Dependency]).returns(T::Array[String]) }
+      def recursive_runtime_dependency_names(_formula, dependencies)
+        dependencies.each_with_object(Set.new) do |dep, set|
+          dep_f = dep.to_formula
+          set.add(dep_f.full_name)
+          set.merge(dep_f.runtime_dependencies(read_from_tab: false, undeclared: false).map(&:name))
+        end.to_a
       end
 
       sig { params(formula: Formula).void }


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Previous calculation of dependencies would use default handler, which omits optional and recommends but keeps build and test. This is different from how `Formula#declared_runtime_dependencies` behaves which omits build/test/optional but keeps recommends.

`Formula#runtime_dependencies` is able to cache entries so can avoid issues with large dependency trees. For example, previous code could take hours to calculate Qt dependents' dependency trees, e.g.
- https://github.com/Homebrew/homebrew-core/pull/291387
