### PR TITLE
info: bold dependencies of uninstalled packages

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -664,6 +664,7 @@ module Homebrew
           outdated:,
           deprecated: formula.deprecated?,
           disabled:   formula.disabled?,
+          bold:       true,
         )
 
         puts "#{oh1_title(name_with_status)}: #{specs * ", "}#{" [#{attrs * ", "}]" unless attrs.empty?}"
@@ -903,7 +904,7 @@ module Homebrew
           installed ||= formula.any_version_installed? if !installed && formula
           outdated = T.let(installed && formula&.outdated? == true, T::Boolean)
           warning = missing_library_deps.include?(Utils.name_from_full_name(dep.name))
-          pretty_install_status(display, warning:, installed:, outdated:, mark_uninstalled:)
+          pretty_install_status(display, warning:, installed:, outdated:, mark_uninstalled:, bold: true)
         end.join(", ")
       end
 
@@ -911,7 +912,7 @@ module Homebrew
       def decorate_requirements(requirements, mark_uninstalled: true)
         req_status = requirements.map do |req|
           req_s = req.display_s
-          pretty_install_status(req_s, installed: req.satisfied?, mark_uninstalled:)
+          pretty_install_status(req_s, installed: req.satisfied?, mark_uninstalled:, bold: true)
         end
         req_status.join(", ")
       end

--- a/Library/Homebrew/test/utils/output_spec.rb
+++ b/Library/Homebrew/test/utils/output_spec.rb
@@ -95,6 +95,47 @@ RSpec.describe Utils::Output do
     end
   end
 
+  describe "#pretty_unmarked" do
+    context "when $stdout is a TTY" do
+      before { allow($stdout).to receive(:tty?).and_return(true) }
+
+      it "returns a bold string" do
+        expect(described_class.pretty_unmarked("foo")).to match(/\A#{esc 1}foo#{esc 0}\z/)
+      end
+    end
+
+    context "when $stdout is not a TTY" do
+      before { allow($stdout).to receive(:tty?).and_return(false) }
+
+      it "returns plain text" do
+        expect(described_class.pretty_unmarked("foo")).to eq("foo")
+      end
+    end
+  end
+
+  describe "#pretty_install_status" do
+    before { allow($stdout).to receive(:tty?).and_return(true) }
+
+    it "bolds an uninstalled string when bold is true" do
+      expect(described_class.pretty_install_status("foo", installed: false, mark_uninstalled: false, bold: true))
+        .to match(/\A#{esc 1}foo#{esc 0}\z/)
+    end
+
+    it "leaves an uninstalled string plain when bold is unset" do
+      expect(described_class.pretty_install_status("foo", installed: false, mark_uninstalled: false)).to eq("foo")
+    end
+
+    it "bolds an installed entry when bold is unset" do
+      expect(described_class.pretty_install_status("foo", installed: true, outdated: true))
+        .to match(/\A#{esc 1}foo #{esc 32}↑#{esc 0}/)
+    end
+
+    it "omits the bold escape on every entry when bold is false" do
+      expect(described_class.pretty_install_status("foo", installed: true, outdated: true, bold: false))
+        .to match(/\Afoo #{esc 32}↑#{esc 0}/)
+    end
+  end
+
   describe "#pretty_deprecated" do
     subject(:pretty_deprecated_output) { described_class.pretty_deprecated("foo") }
 

--- a/Library/Homebrew/utils/output.rb
+++ b/Library/Homebrew/utils/output.rb
@@ -307,6 +307,15 @@ module Utils
       end
 
       sig { params(string: String, bold: T::Boolean).returns(String) }
+      def pretty_unmarked(string, bold: true)
+        if bold && $stdout.tty?
+          "#{Tty.bold}#{string}#{Tty.reset}"
+        else
+          string
+        end
+      end
+
+      sig { params(string: String, bold: T::Boolean).returns(String) }
       def pretty_warning(string, bold: true)
         weight = bold ? Tty.bold.to_s : ""
         if !$stdout.tty?
@@ -321,10 +330,11 @@ module Utils
       sig {
         params(string: String, installed: T::Boolean, warning: T::Boolean, outdated: T::Boolean,
                deprecated: T::Boolean, disabled: T::Boolean, mark_uninstalled: T::Boolean,
-               bold: T::Boolean).returns(String)
+               bold: T.nilable(T::Boolean)).returns(String)
       }
       def pretty_install_status(string, installed:, warning: false, outdated: false, deprecated: false,
-                                disabled: false, mark_uninstalled: true, bold: true)
+                                disabled: false, mark_uninstalled: true, bold: nil)
+        bold = installed if bold.nil?
         status = if warning
           pretty_warning(string, bold:)
         elsif installed && outdated
@@ -334,7 +344,7 @@ module Utils
         elsif mark_uninstalled
           pretty_uninstalled(string, bold:)
         else
-          string
+          pretty_unmarked(string, bold:)
         end
         if disabled
           pretty_disabled(status)


### PR DESCRIPTION
I ran 'brew info' on an uninstalled package and thought it looked weird that the uninstalled deps of that were not bolded.

The goal here (https://github.com/Homebrew/brew/pull/22342) was to remove the red X, not to unbold them necessarily.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code

-----
