### PR TITLE
Warn when all bottles are lost

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -14,6 +14,7 @@ require "utils/gzip"
 require "api"
 require "extend/hash/deep_merge"
 require "metafiles"
+require "utils/github"
 
 module Homebrew
   module DevCmd
@@ -739,11 +740,25 @@ module Homebrew
                        tag_hashes.uniq { |tag_hash| "#{tag_hash["cellar"]}-#{tag_hash["sha256"]}" }.one?
 
           old_all_bottle = old_bottle_spec.tag?(Utils::Bottles.tag(:all))
-          if !all_bottle && old_all_bottle && !args.no_all_checks?
-            odie <<~ERROR
-              #{formula} should have an `:all` bottle but one cannot be created:
-              #{JSON.pretty_generate(tag_hashes)}
-            ERROR
+          github_event_path = ENV.fetch("GITHUB_EVENT_PATH", nil)
+          if !all_bottle && old_all_bottle && !args.no_all_checks? && github_event_path.present?
+            begin
+              github_event = JSON.parse(File.read(github_event_path))
+              repository = github_event.dig("repository", "full_name")
+              pull_request_number = github_event.dig("pull_request", "number")
+              if repository.present? && pull_request_number.present?
+                GitHub.create_issue_comment(repository, pull_request_number, <<~MARKDOWN)
+                  Warning: #{formula} should have had an `:all` bottle but one could not be created.
+                  #{Utils::Bottles.missing_all_bottle_publish_note.capitalize}.
+
+                  ```json
+                  #{JSON.pretty_generate(tag_hashes)}
+                  ```
+                MARKDOWN
+              end
+            rescue GitHub::API::Error, JSON::ParserError, Errno::ENOENT => e
+              opoo "Failed to post missing `:all` bottle warning to pull request: #{e.message}"
+            end
           end
 
           bottle_hash["bottle"]["tags"].each do |tag, tag_hash|

--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -128,6 +128,16 @@ module Homebrew
         end
         ENV["HOMEBREW_TEST_BOT"] = "1"
 
+        Homebrew.install_bundler_gems!(groups: ["ast"]) if args.only_formulae? || [
+          args.only_cleanup_before?,
+          args.only_setup?,
+          args.only_tap_syntax?,
+          args.only_formulae_detect?,
+          args.only_formulae_dependents?,
+          args.only_bottles_fetch?,
+          args.only_cleanup_after?,
+        ].none?
+
         TestBot.run!(args)
       end
     end

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -357,6 +357,36 @@ RSpec.describe Homebrew::DevCmd::Bottle do
         expect(Pathname("testball--1.0.all.bottle.tar.gz")).to exist
       end
     end
+
+    it "merges when an all bottle cannot be created" do
+      core_tap.path.cd do
+        system "git", "-c", "init.defaultBranch=master", "init"
+        setup_test_formula "testball", bottle_block: <<~RUBY
+
+          bottle do
+            sha256 cellar: :any_skip_relocation, all: "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97"
+          end
+        RUBY
+        system "git", "add", "--all"
+        system "git", "commit", "-m", "testball 0.1"
+      end
+
+      expect do
+        brew "bottle",
+             "--merge",
+             "--write",
+             "--no-commit",
+             "#{TEST_TMPDIR}/testball-1.0.arm64_big_sur.bottle.json",
+             "#{TEST_TMPDIR}/testball-1.0.big_sur.bottle.json",
+             { "GITHUB_EVENT_PATH" => nil }
+      end.to output(/sha256 cellar: :any_skip_relocation, arm64_big_sur:/).to_stdout
+                                                                          .and not_to_output.to_stderr
+                                                                                            .and be_a_success
+
+      formula_contents = (core_tap.path/"Formula/testball.rb").read
+      expect(formula_contents).to include("big_sur:")
+      expect(formula_contents).not_to include("all:")
+    end
   end
 
   describe "bottle_cmd" do

--- a/Library/Homebrew/test/test_bot/formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_spec.rb
@@ -100,6 +100,70 @@ RSpec.describe Homebrew::TestBot::Formulae do
     end
   end
 
+  describe "#annotate_missing_all_bottle" do
+    it "writes a warning annotation for a platform-specific bottle replacing an all bottle" do
+      Dir.mktmpdir do |tmpdir|
+        tag = Utils::Bottles.tag
+        sha256 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        tap_path = Pathname(tmpdir)
+        formula_path = tap_path/"Formula/foo.rb"
+        formula_path.dirname.mkpath
+        formula_path.write <<~RUBY
+          class Foo < Formula
+            desc "Foo"
+            homepage "https://example.com"
+            url "foo-1.0"
+            sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+            bottle do
+              sha256 cellar: :any_skip_relocation, #{tag.to_sym}: "#{sha256}"
+            end
+          end
+        RUBY
+        (tap_path/"foo--1.0.#{tag}.bottle.json").write JSON.generate(
+          "foo" => {
+            "bottle" => {
+              "tags" => {
+                tag.to_s => {
+                  "cellar" => "any_skip_relocation",
+                  "sha256" => sha256,
+                },
+              },
+            },
+          },
+        )
+
+        old_formula = formula("foo", path: formula_path) do
+          T.bind(self, T.class_of(Formula))
+          url "foo-1.0"
+          bottle do
+            sha256 cellar: :any_skip_relocation,
+                   all:    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+          end
+        end
+        formulae = described_class.new(
+          tap: instance_double(Tap, path: tap_path), git: "git", dry_run: true, fail_fast: false, verbose: false,
+          output_paths: {
+            bottle:                     Pathname.new("#{tmpdir}/bottle.txt"),
+            linkage:                    Pathname.new("#{tmpdir}/linkage.txt"),
+            skipped_or_failed_formulae: Pathname.new("#{tmpdir}/skipped.txt"),
+          }
+        )
+
+        with_env(GITHUB_ACTIONS: "true", GITHUB_WORKSPACE: tap_path.to_s) do
+          expect { formulae.send(:annotate_missing_all_bottle, old_formula, bottle_dir: tap_path) }
+            .to output(
+              "::warning file=Formula/foo.rb,line=8,title=foo: missing :all bottle::" \
+              "This formula had an `:all` bottle but the #{tag} test-bot bottle is platform-specific " \
+              "(cellar `any_skip_relocation`, sha256 `#{sha256}`). " \
+              "If the final bottle merge cannot create a new `:all` bottle, expect publishing without one anyway; " \
+              "this is for information only and should not block merge.\n",
+            ).to_stdout
+        end
+      end
+    end
+  end
+
   describe "#testing_portable_ruby?" do
     it "returns false (not nil) when tap is nil" do
       # Regression test: without `!!`, tap&.core_tap? returns nil when tap is nil,

--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -40,6 +40,20 @@ RSpec.describe GitHub do
     end
   end
 
+  describe "::create_issue_comment" do
+    it "posts a GitHub issue comment" do
+      response = { "html_url" => "https://github.com/Homebrew/homebrew-core/issues/123#issuecomment-1" }
+
+      expect(GitHub::API).to receive(:open_rest).with(
+        "https://api.github.com/repos/Homebrew/homebrew-core/issues/123/comments",
+        data:   { body: "Comment body" },
+        scopes: GitHub::CREATE_ISSUE_FORK_OR_PR_SCOPES,
+      ).and_return(response)
+
+      expect(described_class.create_issue_comment("Homebrew/homebrew-core", 123, "Comment body")).to eq(response)
+    end
+  end
+
   describe "::repository_approved_reviews", :needs_network do
     it "can get reviews for a pull request" do
       reviews = described_class.repository_approved_reviews("Homebrew", "homebrew-core", 1, commit: "deadbeef")

--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -310,6 +310,7 @@ module Homebrew
         bottle_merge_args << "--keep-old" if args.keep_old? && !new_formula
 
         test "brew", "bottle", *bottle_merge_args
+        annotate_missing_all_bottle(formula) if steps.fetch(-1).passed?
         test "brew", "uninstall", "--formula", "--force", "--ignore-dependencies", formula.full_name
 
         @testing_formulae.delete(formula.name)
@@ -452,6 +453,61 @@ module Homebrew
         end
       rescue => e
         opoo "Failed to determine dependency impact for #{formula.full_name}: #{e}"
+      end
+
+      sig { params(formula: Formula, bottle_dir: Pathname).void }
+      def annotate_missing_all_bottle(formula, bottle_dir: Pathname.pwd)
+        return unless formula.bottle_specification.tag?(Utils::Bottles.tag(:all))
+
+        require "utils/ast"
+
+        bottle_tag = Utils::Bottles.tag
+        bottle_sha256_node_tag = lambda do |sha256_node, tag|
+          sha256_node.arguments.grep(RuboCop::AST::HashNode).any? do |hash_node|
+            hash_node.pairs.any? do |pair|
+              Utils::AST.literal_value(pair.key) == tag ||
+                Utils::AST.literal_value(pair.value) == tag
+            end
+          end
+        end
+        bottle_node = Utils::AST::FormulaAST.new(formula.path.read).bottle_block
+        sha256_nodes = Utils::AST.body_children(
+          bottle_node.is_a?(RuboCop::AST::BlockNode) ? bottle_node.body : nil,
+        ).filter_map do |node|
+          next unless node.is_a?(RuboCop::AST::SendNode)
+          next if node.method_name != :sha256
+
+          node
+        end
+        return if sha256_nodes.any? { |sha256_node| bottle_sha256_node_tag.call(sha256_node, :all) }
+
+        tag_hash = local_bottle_hash(formula.name, bottle_dir:)&.dig(formula.name, "bottle", "tags", bottle_tag.to_s)
+        line = sha256_nodes.find do |sha256_node|
+          bottle_sha256_node_tag.call(sha256_node, bottle_tag.to_sym)
+        end&.source_range&.line
+        bottle_details = if tag_hash.present?
+          " (cellar `#{tag_hash["cellar"]}`, sha256 `#{tag_hash["sha256"]}`)"
+        else
+          ""
+        end
+        message = "This formula had an `:all` bottle but the #{bottle_tag} test-bot bottle is " \
+                  "platform-specific#{bottle_details}. If the final bottle merge cannot create a new " \
+                  "`:all` bottle, expect #{Utils::Bottles.missing_all_bottle_publish_note}; this is for " \
+                  "information only and should not block merge."
+
+        if GitHub::Actions.env_set?
+          puts GitHub::Actions::Annotation.new(
+            :warning,
+            message,
+            file:  formula.path.to_s.delete_prefix("#{repository}/"),
+            line:,
+            title: "#{formula}: missing :all bottle",
+          )
+        else
+          opoo message
+        end
+      rescue => e
+        opoo "Failed to determine missing `:all` bottle impact for #{formula.full_name}: #{e}"
       end
 
       sig { params(formula: Formula).void }

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -142,6 +142,11 @@ module Utils
         tab
       end
 
+      sig { returns(String) }
+      def missing_all_bottle_publish_note
+        "publishing without one anyway"
+      end
+
       private
 
       sig { params(bottle_file: Pathname).returns(T::Array[String]) }

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -46,6 +46,12 @@ module GitHub
     API.open_rest(url, data:, scopes: CREATE_ISSUE_FORK_OR_PR_SCOPES)["html_url"]
   end
 
+  sig { params(repo: String, issue: T.any(String, Integer), body: String).returns(T::Hash[String, T.untyped]) }
+  def self.create_issue_comment(repo, issue, body)
+    url = "#{API_URL}/repos/#{repo}/issues/#{issue}/comments"
+    API.open_rest(url, data: { body: }, scopes: CREATE_ISSUE_FORK_OR_PR_SCOPES)
+  end
+
   sig { params(user: String, repo: String).returns(T::Hash[String, T.untyped]) }
   def self.repository(user, repo)
     API.open_rest(url_to("repos", user, repo))


### PR DESCRIPTION
- Avoid blocking bottle merges when an old `:all` bottle cannot be recreated, while still notifying maintainers on the PR.
- Surface the likely loss during `test-bot` with the bottle block AST, so the annotation points at the generated platform bottle line.
- Share the publishing note and GitHub issue-comment helper across the merge and annotation paths.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
