### PR TITLE
test/test_bot_spec: use :trust_store context when testing trust

### DIFF
--- a/Library/Homebrew/test/test_bot_spec.rb
+++ b/Library/Homebrew/test/test_bot_spec.rb
@@ -5,7 +5,7 @@ require "dev-cmd/test-bot"
 
 RSpec.describe Homebrew::TestBot do
   describe "::run!" do
-    it "trusts a third-party tap before running test-bot" do
+    it "trusts a third-party tap before running test-bot", :trust_store do
       tap = Tap.fetch("thirdparty", "foo")
       tap.path.mkpath
       args = double(
@@ -38,7 +38,7 @@ RSpec.describe Homebrew::TestBot do
       FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
     end
 
-    it "trusts a custom-remote third-party tap by its remote URL" do
+    it "trusts a custom-remote third-party tap by its remote URL", :trust_store do
       tap = Tap.fetch("thirdparty", "custom")
       tap.path.mkpath
       system "git", "-C", tap.path.to_s, "init"
@@ -73,7 +73,7 @@ RSpec.describe Homebrew::TestBot do
       FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
     end
 
-    it "trusts a third-party tap in the local test-bot config home" do
+    it "trusts a third-party tap in the local test-bot config home", :trust_store do
       old_umask = T.let(nil, T.nilable(Integer))
       tap = Tap.fetch("thirdparty", "foo")
       tap.path.mkpath


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Trying to fix a failing test seen in portable Ruby runs:
- https://github.com/Homebrew/homebrew-core/pull/287049#issuecomment-4887503584

```
Homebrew::TestBot::run! trusts a third-party tap before running test-bot
Failure/Error: expect { described_class.run!(args) }.to output(%r{==> Trusted tap: thirdparty/foo}).to_stdout

  expected block to output /==> Trusted tap: thirdparty\/foo/ to stdout, but output "==> Already trusted tap: thirdparty/foo\n==> Using Homebrew/brew revision (revision)\n==> Using Homebrew/homebrew-core revision\n==> Testing thirdparty/homebrew-foo (Homebrew/homebrew-core) revision:\n"
  Diff:
  @@ -1 +1,4 @@
  -/==> Trusted tap: thirdparty\/foo/
  +==> Already trusted tap: thirdparty/foo
  +==> Using Homebrew/brew revision (revision)
  +==> Using Homebrew/homebrew-core revision
  +==> Testing thirdparty/homebrew-foo (Homebrew/homebrew-core) revision:
```