### PR TITLE
test/bundle/brew_spec: allow running test on generic OS

### DIFF
--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -221,6 +221,9 @@ RSpec.describe Homebrew::Bundle::Brew do
 
     describe "#dump" do
       it "returns a dump string with installed formulae" do
+        allow(Homebrew::Bundle::Brew::Services).to receive(:started_services).and_return([])
+        allow(Homebrew::Trust).to receive(:trusted_entries).with(:formula).and_return(["bazzles/bizzles/baz"])
+
         expect(Formula).to receive(:installed).and_return([foo, bar, baz])
         expect(bar.linked_keg).to receive(:realpath).and_return(instance_double(Pathname, basename: "1.0"))
         expect(Tab).to receive(:for_keg).with(bar.linked_keg).and_return(
@@ -230,7 +233,6 @@ RSpec.describe Homebrew::Bundle::Brew do
                           runtime_dependencies: [],
                           used_options:         []),
         )
-        allow(Utils).to receive(:safe_popen_read).and_return("[]")
         expected = <<~RUBY
           # barfoo
           brew "bar"
@@ -238,7 +240,6 @@ RSpec.describe Homebrew::Bundle::Brew do
           # foobar
           brew "qux/quuz/foo"
         RUBY
-        allow(Homebrew::Trust).to receive(:trusted_entries).with(:formula).and_return(["bazzles/bizzles/baz"])
         expect(dumper.dump(describe: true)).to eql(expected.chomp)
       end
     end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Fixing a test failure with `--generic` on Linux seen in portable Ruby run - https://github.com/Homebrew/homebrew-core/pull/287049#issuecomment-4887503584
```
Homebrew::Bundle::Brew dumping #dump returns a dump string with installed formulae
Failure/Error: expect(dumper.dump(describe: true)).to eql(expected.chomp)

SystemExit:
  exit
# ./utils/output.rb:153:in 'Kernel#exit'
# ./utils/output.rb:153:in 'Utils::Output::Mixin#odie'
# ./bundle/brew_services.rb:73:in 'Homebrew::Bundle::Brew::Services.started_services_without_daemon_manager'
# ./bundle/brew_services.rb:80:in 'Homebrew::Bundle::Brew::Services.started_services'
# ./bundle/brew_services.rb:68:in 'Homebrew::Bundle::Brew::Services.started?'
# ./bundle/brew.rb:267:in 'block in Homebrew::Bundle::Brew.dump'
```

Issue is there is OS-specific code hit for systemd but Linux extends are not loaded. 