### PR TITLE
perf/sorbet: skip sorbet-runtime dispatch when runtime disabled (~6-8% faster)

### DIFF
--- a/Library/Homebrew/standalone/sorbet.rb
+++ b/Library/Homebrew/standalone/sorbet.rb
@@ -60,23 +60,26 @@ if ENV["HOMEBREW_SORBET_RUNTIME"]
     end
   end
 else
-  # Redefine `T.let`, etc. to make the `checked` parameter default to `false` rather than `true`.
+  # Redefine `T.let`, etc. to return the value without dispatching to
+  # sorbet-runtime at all: these methods are called often enough (e.g. for
+  # every `Pathname` allocation) that even the disabled-check dispatch is
+  # measurable.
   # @private
   module TNoChecks
-    def cast(value, type, checked: false)
-      super
+    def cast(value, _type, checked: false)
+      value
     end
 
-    def let(value, type, checked: false)
-      super
+    def let(value, _type, checked: false)
+      value
     end
 
-    def bind(value, type, checked: false)
-      super
+    def bind(value, _type, checked: false)
+      value
     end
 
-    def assert_type!(value, type, checked: false)
-      super
+    def assert_type!(value, _type, checked: false)
+      value
     end
   end
 


### PR DESCRIPTION
## Summary

When `$HOMEBREW_SORBET_RUNTIME` is unset (every user except CI and developers running `brew tests`/`test-bot`), `standalone/sorbet.rb` prepends `TNoChecks` so that `T.let`/`T.cast`/`T.bind`/`T.assert_type!` default to `checked: false`. Each call still pays two keyword-argument dispatches, though: `TNoChecks#let` and then `super` into sorbet-runtime, which immediately returns via `return value unless checked`.

These methods are called often enough for that dispatch to be measurable: for example, `EagerInitializeExtension#initialize` runs six `T.let`s on every `Pathname` allocation. In a stackprof profile of `brew upgrade --dry-run` taken with `$HOMEBREW_SORBET_RUNTIME` unset, `TNoChecks#let` alone accounted for ~4% of samples.

## Changes

Make the `TNoChecks` overrides return the value directly instead of calling `super`, eliminating the second dispatch and sorbet-runtime's disabled-check branch entirely.

Behavior is unchanged:

- The runtime-enabled branch (`$HOMEBREW_SORBET_RUNTIME` set, as used by `brew tests` and `brew test-bot`) is untouched.
- No Homebrew code passes `checked: true` explicitly, so nothing relied on opting back into validation while the runtime is disabled.
- The `checked:` keyword remains accepted so any explicit `checked:` call sites keep working.

**Benchmarks** (Hyperfine, 10 runs each, warmup 2, `HOMEBREW_SORBET_RUNTIME` unset, clean trees, on the top 3 commands from the [last 365 days of analytics](https://formulae.brew.sh/analytics/brew-command-run-options/365d/)):

| Command | Before | After | Change |
|---|---|---|---|
| `brew upgrade --dry-run` (3rd most-run, ~30 outdated) | 4.792 s ± 0.153 s | 4.399 s ± 0.088 s | **~8% decrease** |
| `brew install <installed formula>` (2nd most-run) | 611.0 ms ± 30.4 ms | 566.4 ms ± 11.6 ms | **~7% decrease** |
| `brew config` (4th most-run) | 755.9 ms ± 29.9 ms | 709.6 ms ± 17.2 ms | **~6% decrease** |

No new unit tests: the changed branch only loads when `$HOMEBREW_SORBET_RUNTIME` is unset, and `brew tests` always sets it, so the no-op path cannot be exercised from the test suite.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code was used to profile representative commands with stackprof, identify the double dispatch, implement the change and run the benchmarks. Verified by smoke-testing commands with `$HOMEBREW_SORBET_RUNTIME` both set and unset, checking there are no explicit `checked: true` call sites in the codebase, clean-tree before/after Hyperfine benchmarks and running `brew lgtm` locally.

-----
