### PR TITLE
Clarify install output for durations and single deps

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -851,7 +851,7 @@ on_request: installed_on_request?, options:)
       deps_with_formulae.each { |dep, dep_formula| install_dependency(dep, dep_formula) }
     end
 
-    @show_header = true if deps.length > 1
+    @show_header = true unless deps.empty?
   end
 
   sig { params(dep: Dependency).void }

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -405,6 +405,20 @@ RSpec.describe FormulaInstaller do
       expect { installer.install_dependencies(deps) }
         .to output(/:\e\[0m /).to_stdout
     end
+
+    it "shows the formula header after installing a single dependency" do
+      dep = formula("single-dep") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      deps = [instance_double(Dependency, to_formula: dep, name: dep.name, to_s: dep.name)]
+      installer = described_class.new(Testball.new)
+      allow(installer).to receive(:install_dependency)
+
+      installer.install_dependencies(deps)
+
+      expect(installer.show_header?).to be(true)
+    end
   end
 
   describe "#expand_dependencies_for_formula" do

--- a/Library/Homebrew/test/utils/output_spec.rb
+++ b/Library/Homebrew/test/utils/output_spec.rb
@@ -185,6 +185,11 @@ RSpec.describe Utils::Output do
       expect(described_class.pretty_duration(42)).to eq("42 seconds")
       expect(described_class.pretty_duration(240)).to eq("4 minutes")
       expect(described_class.pretty_duration(252.45)).to eq("4 minutes 12 seconds")
+      expect(described_class.pretty_duration(300)).to eq("5 minutes")
+      expect(described_class.pretty_duration(365)).to eq("6 minutes")
+      expect(described_class.pretty_duration(3600)).to eq("1 hour")
+      expect(described_class.pretty_duration(3660)).to eq("1 hour 1 minute")
+      expect(described_class.pretty_duration(73_085)).to eq("20 hours 18 minutes")
     end
   end
 

--- a/Library/Homebrew/utils/output.rb
+++ b/Library/Homebrew/utils/output.rb
@@ -358,13 +358,24 @@ module Utils
       sig { params(seconds: T.nilable(T.any(Integer, Float))).returns(String) }
       def pretty_duration(seconds)
         seconds = seconds.to_i
+        hide_seconds = seconds > 300
+
+        minutes, seconds = seconds.divmod(60)
+        hours, minutes = minutes.divmod(60)
+
         res = +""
 
-        if seconds > 59
-          minutes = seconds / 60
-          seconds %= 60
-          res = +Utils.pluralize("minute", minutes, include_count: true)
-          return res.freeze if seconds.zero?
+        if hours.positive?
+          res << Utils.pluralize("hour", hours, include_count: true)
+          return res.freeze if minutes.zero?
+
+          res << " " << Utils.pluralize("minute", minutes, include_count: true)
+          return res.freeze
+        end
+
+        if minutes.positive?
+          res << Utils.pluralize("minute", minutes, include_count: true)
+          return res.freeze if hide_seconds || seconds.zero?
 
           res << " "
         end


### PR DESCRIPTION
Make sure that time is formatted in a more friendly way for long-running installs (likely from source). And clarify in the the UI when dep installation is finished and real package installation starts.

Old output:

```
▶ brew install rust
Warning: You are using macOS 12.
We (and Apple) do not provide support for this old version.
You may have better luck with MacPorts which supports older versions of macOS:
  https://www.macports.org

This is a Tier 3 configuration:
  https://docs.brew.sh/Support-Tiers#tier-3
You can report issues with Tier 3 configurations to Homebrew/* repositories!
Read the above document before opening any issues or PRs.

==> Would install 1 formula:
rust
==> Would install 1 dependency for rust:
llvm
==> Do you want to proceed with the installation? [y/n]
==> Fetching downloads for: rust
✔︎ API Source rust.rb                                                                                                                            Verified      9.1KB/  9.1KB
✔︎ API Source llvm.rb                                                                                                                            Verified     34.8KB/ 34.8KB
✔︎ Patch 1381ad497b9a6d3da630cbef53cbfa9ddf117bb6...40a8c7c0ff3f688b690e4c74db734de67f0f89e9.diff                                                Verified      4.5KB/  4.5KB
✔︎ Resource rust--cargo-bootstrap                                                                                                                Verified      9.4MB/  9.4MB
✔︎ Resource rust--rust-std-bootstrap                                                                                                             Verified     28.7MB/ 28.7MB
✔︎ Resource rust--rustc-bootstrap                                                                                                                Verified     79.8MB/ 79.8MB
✔︎ Formula llvm (22.1.8)                                                                                                                         Verified    167.1MB/167.1MB
✔︎ Formula rust (1.96.1)                                                                                                                         Verified    528.7MB/528.7MB
==> Installing rust dependency: llvm
==> Patching
==> Applying 1381ad497b9a6d3da630cbef53cbfa9ddf117bb6...40a8c7c0ff3f688b690e4c74db734de67f0f89e9.diff
==> cmake -G Ninja .. -DLLVM_ENABLE_PROJECTS=clang;clang-tools-extra;mlir;polly;lldb -DLLVM_ENABLE_RUNTIMES=compiler-rt;libcxx;libcxxabi;libunwind;openmp -DLLVM_POLLY_LINK
==> cmake --build .

==> cmake --build . --target install
==> /usr/libexec/PlistBuddy -c Add:CFBundleIdentifier string org.llvm.22.1.8 Info.plist
==> /usr/libexec/PlistBuddy -c Add:CompatibilityVersion integer 2 Info.plist
Warning: The post-install step did not complete successfully
You can try again using:
  brew postinstall llvm
==> Summary
🍺  /usr/local/Cellar/llvm/22.1.8: 9,637 files, 1.6GB, built in 1218 minutes 5 seconds
==> ./configure --sysconfdir=/usr/local/etc --tools=analysis,cargo,clippy,rustdoc,rustfmt,rust-analyzer-proc-macro-srv,rust-demangler,src --llvm-root=/usr/local/opt/llvm -
==> make
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code

-----
As