### PR TITLE
Store bottle SBOM data in manifests

### DIFF
--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -236,6 +236,14 @@ class Bottle
     resource.path_exec_files
   end
 
+  sig { returns(T.nilable(T::Hash[String, Object])) }
+  def sbom_supplement
+    resource = github_packages_manifest_resource
+    return unless resource&.downloaded_and_valid?
+
+    resource.sbom_supplement
+  end
+
   sig { returns(Filename) }
   def filename = Filename.new(@name, @pkg_version, @tag, @spec.rebuild)
 

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -516,7 +516,7 @@ module Homebrew
             end
 
             sbom = SBOM.create(formula, tab)
-            sbom.write
+            sbom.write(bottling: true)
 
             keg.consistent_reproducible_symlink_permissions!
 
@@ -659,6 +659,9 @@ module Homebrew
           installed_size = keg.disk_usage
         end
 
+        bottle_tab = tab
+        odie "Cannot generate bottle JSON without an installation receipt." if bottle_tab.nil?
+
         json = {
           formula.full_name => {
             "formula" => {
@@ -688,7 +691,8 @@ module Homebrew
                   "filename"        => filename.url_encode,
                   "local_filename"  => filename.to_s,
                   "sha256"          => sha256,
-                  "tab"             => T.must(tab).to_bottle_hash,
+                  "tab"             => bottle_tab.to_bottle_hash,
+                  "sbom"            => SBOM.create(formula, bottle_tab).to_spdx_supplement,
                   "path_exec_files" => path_exec_files,
                   "all_files"       => all_files,
                   "installed_size"  => installed_size,
@@ -804,6 +808,10 @@ module Homebrew
               all_bottle_tag_hash["filename"] = all_filename.url_encode
               all_bottle_tag_hash["local_filename"] = all_filename.to_s
               cellar = all_bottle_tag_hash.delete("cellar")
+              sbom_tags = bottle_hash["bottle"]["tags"].filter_map do |tag, tag_hash|
+                [tag, tag_hash["sbom"]] if tag_hash["sbom"].present?
+              end.to_h
+              all_bottle_tag_hash["sbom"] = { "tags" => sbom_tags } if sbom_tags.present?
 
               all_bottle_formula_hash = bottle_hash.dup
               all_bottle_formula_hash["bottle"]["cellar"] = cellar

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1042,7 +1042,12 @@ on_request: installed_on_request?, options:)
     if @poured_bottle
       if (install_time = tab.time)
         require "sbom"
-        SBOM.update_pour_metadata(SBOM.spdxfile(formula), homebrew_version: HOMEBREW_VERSION, time: install_time)
+        SBOM.update_pour_metadata(
+          SBOM.spdxfile(formula),
+          homebrew_version: HOMEBREW_VERSION,
+          time:             install_time,
+          supplement:       (api_bottle || formula.bottle)&.sbom_supplement,
+        )
       end
     elsif Homebrew::EnvConfig.sbom? && !build_bottle?
       require "sbom"

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -366,6 +366,8 @@ class GitHubPackages
       processed_image_refs << manifest["annotations"]["org.opencontainers.image.ref.name"]
     end
 
+    require "sbom"
+
     manifests += bottle_hash["bottle"]["tags"].map do |bottle_tag, tag_hash|
       bottle_tag = Utils::Bottles::Tag.from_symbol(bottle_tag.to_sym)
       all_bottle = bottle_tag.to_sym == :all
@@ -431,6 +433,16 @@ class GitHubPackages
       path_exec_files_string = if (path_exec_files = tag_hash["path_exec_files"].presence)
         path_exec_files.join(",")
       end
+      sbom_supplement_annotation = SBOM.github_packages_sbom_supplement_annotation(
+        tag_hash["sbom"],
+        formula_full_name:,
+        formula_name:,
+        version:,
+        tar_gz_sha256:,
+        root_url:          bottle_hash["bottle"]["root_url"],
+        license:,
+        created_date:,
+      )
 
       descriptor_annotations_hash = {
         "org.opencontainers.image.ref.name" => tag,
@@ -441,6 +453,7 @@ class GitHubPackages
         "sh.brew.bottle.installed_size"     => tag_hash["installed_size"].to_s,
         "sh.brew.license"                   => license,
         "sh.brew.tab"                       => (all_bottle ? tab.except("arch", "built_on") : tab).to_json,
+        "sh.brew.sbom.supplement"           => sbom_supplement_annotation,
         "sh.brew.path_exec_files"           => path_exec_files_string,
       }.compact_blank
 

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -361,7 +361,7 @@ class Resource
     def initialize(bottle)
       super("#{bottle.name}_bottle_manifest")
       @bottle = bottle
-      @manifest_annotations = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
+      @manifest_annotations = T.let(nil, T.nilable(T::Hash[String, String]))
     end
 
     sig { override.void }
@@ -414,6 +414,26 @@ class Resource
       manifest_annotations["sh.brew.path_exec_files"]&.split(",")
     end
 
+    sig { returns(T.nilable(T::Hash[String, Object])) }
+    def sbom_supplement
+      supplement = manifest_annotations["sh.brew.sbom.supplement"]
+      return if supplement.blank?
+
+      parsed_supplement = JSON.parse(supplement)
+      return unless parsed_supplement.is_a?(Hash)
+
+      if (tags = parsed_supplement["tags"]).is_a?(Hash)
+        tag_supplement = tags[Utils::Bottles.tag.to_s]
+        return tag_supplement if tag_supplement.is_a?(Hash)
+
+        return
+      end
+
+      parsed_supplement
+    rescue JSON::ParserError
+      nil
+    end
+
     sig { override.returns(String) }
     def download_queue_type = "Bottle Manifest"
 
@@ -422,7 +442,7 @@ class Resource
 
     private
 
-    sig { returns(T::Hash[String, T.untyped]) }
+    sig { returns(T::Hash[String, String]) }
     def manifest_annotations
       cached = @manifest_annotations
       return cached unless cached.nil?
@@ -455,7 +475,7 @@ class Resource
       end
       raise Error, "Couldn't find manifest matching bottle checksum." if manifests_annotation.blank?
 
-      @manifest_annotations = manifests_annotation
+      @manifest_annotations = manifests_annotation.to_h { |key, value| [key.to_s, value.to_s] }
     end
   end
 

--- a/Library/Homebrew/sbom.rb
+++ b/Library/Homebrew/sbom.rb
@@ -12,6 +12,8 @@ class SBOM
 
   FILENAME = "sbom.spdx.json"
   SCHEMA_FILE = T.let((HOMEBREW_LIBRARY_PATH/"data/schemas/sbom.json").freeze, Pathname)
+  SPDXHash = T.type_alias { T::Hash[String, Object] }
+  SPDXSymbolHash = T.type_alias { T::Hash[Symbol, Object] }
 
   class Source < T::Struct
     const :path, String
@@ -19,7 +21,7 @@ class SBOM
     const :tap_git_head, T.nilable(String)
     const :spec, Symbol
     const :patches, T::Array[T.any(EmbeddedPatch, ExternalPatch)]
-    const :bottle, T::Hash[String, T.untyped]
+    const :bottle, T::Hash[String, Object]
     const :version, T.nilable(Version)
     const :url, T.nilable(String)
     const :checksum, T.nilable(Checksum)
@@ -42,7 +44,7 @@ class SBOM
       compiler:             tab.compiler,
       stdlib:               tab.stdlib,
       runtime_dependencies: SBOM.runtime_deps_hash(T.cast(Array(tab.runtime_dependencies),
-                                                          T::Array[T::Hash[String, T.untyped]])),
+                                                          T::Array[T::Hash[String, Object]])),
       license:              SPDX.license_expression_to_string(formula.license),
       built_on:             DevelopmentTools.build_system_info,
       source:               Source.new(
@@ -65,10 +67,10 @@ class SBOM
     formula.prefix/FILENAME
   end
 
-  sig { params(deps: T::Array[T::Hash[String, T.untyped]]).returns(T::Array[T::Hash[String, T.anything]]) }
+  sig { params(deps: T::Array[T::Hash[String, Object]]).returns(T::Array[T::Hash[String, Object]]) }
   def self.runtime_deps_hash(deps)
     deps.map do |dep|
-      full_name = dep.fetch("full_name")
+      full_name = dep.fetch("full_name").to_s
       dep_formula = Formula[full_name]
       {
         "full_name"           => full_name,
@@ -86,8 +88,85 @@ class SBOM
     spdxfile(formula).exist?
   end
 
-  sig { params(spdxfile: Pathname, homebrew_version: String, time: Integer).void }
-  def self.update_pour_metadata(spdxfile, homebrew_version:, time:)
+  sig {
+    params(
+      supplement:        T.nilable(SPDXHash),
+      formula_full_name: String,
+      formula_name:      String,
+      version:           Version,
+      tar_gz_sha256:     String,
+      root_url:          String,
+      license:           String,
+      created_date:      String,
+    ).returns(T.nilable(String))
+  }
+  def self.github_packages_sbom_supplement_annotation(supplement, formula_full_name:, formula_name:, version:,
+                                                      tar_gz_sha256:, root_url:, license:, created_date:)
+    require "github_packages"
+
+    add_bottle_package_to_supplement(
+      supplement,
+      bottle_package(
+        formula_full_name,
+        formula_name,
+        version,
+        tar_gz_sha256,
+        root_url:,
+        license:,
+        created_date:,
+      ),
+    )&.to_json
+  end
+
+  sig {
+    params(
+      formula_full_name: String,
+      formula_name:      String,
+      version:           Version,
+      tar_gz_sha256:     String,
+      root_url:          String,
+      license:           String,
+      created_date:      String,
+    ).returns(SPDXHash)
+  }
+  def self.bottle_package(formula_full_name, formula_name, version, tar_gz_sha256, root_url:, license:, created_date:)
+    {
+      "SPDXID"           => "SPDXRef-Bottle-#{formula_name}",
+      "name"             => formula_name,
+      "versionInfo"      => version.to_s,
+      "filesAnalyzed"    => false,
+      "licenseDeclared"  => "NOASSERTION",
+      "builtDate"        => created_date,
+      "licenseConcluded" => license.presence || "NOASSERTION",
+      "downloadLocation" => "#{root_url}/#{GitHubPackages.image_formula_name(formula_name)}/" \
+                            "blobs/sha256:#{tar_gz_sha256}",
+      "copyrightText"    => "NOASSERTION",
+      "externalRefs"     => [
+        {
+          "referenceCategory" => "PACKAGE-MANAGER",
+          "referenceLocator"  => "pkg:brew/#{formula_full_name}@#{version}",
+          "referenceType"     => "purl",
+        },
+      ],
+      "checksums"        => [
+        {
+          "algorithm"     => "SHA256",
+          "checksumValue" => tar_gz_sha256,
+        },
+      ],
+    }
+  end
+  private_class_method :bottle_package
+
+  sig {
+    params(
+      spdxfile:         Pathname,
+      homebrew_version: String,
+      time:             Integer,
+      supplement:       T.nilable(SPDXHash),
+    ).void
+  }
+  def self.update_pour_metadata(spdxfile, homebrew_version:, time:, supplement: nil)
     return unless spdxfile.exist?
 
     spdx = JSON.parse(spdxfile.read)
@@ -98,6 +177,7 @@ class SBOM
 
     creation_info["created"] = Time.at(time).utc.iso8601
     creation_info["creators"] = ["Tool: https://github.com/Homebrew/brew@#{homebrew_version}"]
+    merge_spdx_supplement(spdx, supplement) if supplement
     spdxfile.atomic_write(JSON.pretty_generate(spdx))
   rescue JSON::ParserError
     nil
@@ -105,11 +185,11 @@ class SBOM
 
   sig { returns(T::Hash[String, T.anything]) }
   def self.schema
-    @schema ||= T.let(JSON.parse(SCHEMA_FILE.read, freeze: true), T.nilable(T::Hash[String, T.untyped]))
+    @schema ||= T.let(JSON.parse(SCHEMA_FILE.read, freeze: true), T.nilable(T::Hash[String, Object]))
   end
 
-  sig { params(data: T::Hash[Symbol, T.anything]).returns(T::Array[String]) }
-  def schema_validation_errors(data = to_spdx_sbom)
+  sig { params(data: T.nilable(T::Hash[Symbol, T.anything]), bottling: T::Boolean).returns(T::Array[String]) }
+  def schema_validation_errors(data = nil, bottling: false)
     unless Homebrew.require? "json_schemer"
       error_message = "Need json_schemer to validate SBOM, run `brew install-bundler-gems --add-groups=bottle`!"
       odie error_message if ENV["HOMEBREW_ENFORCE_SBOM"]
@@ -118,12 +198,12 @@ class SBOM
 
     schemer = JSONSchemer.schema(SBOM.schema)
 
-    schemer.validate(data).map { |error| error["error"] }
+    schemer.validate(data || to_spdx_sbom(bottling:)).map { |error| error["error"] }
   end
 
-  sig { params(data: T::Hash[Symbol, T.anything]).returns(T::Boolean) }
-  def valid?(data = to_spdx_sbom)
-    validation_errors = schema_validation_errors(data)
+  sig { params(data: T.nilable(T::Hash[Symbol, T.anything]), bottling: T::Boolean).returns(T::Boolean) }
+  def valid?(data = nil, bottling: false)
+    validation_errors = schema_validation_errors(data, bottling:)
     return true if validation_errors.empty?
 
     opoo "SBOM validation errors:"
@@ -134,15 +214,15 @@ class SBOM
     false
   end
 
-  sig { params(validate: T::Boolean).void }
-  def write(validate: true)
+  sig { params(validate: T::Boolean, bottling: T::Boolean).void }
+  def write(validate: true, bottling: false)
     # If this is a new installation, the cache of installed formulae
     # will no longer be valid.
     Formula.clear_cache unless spdxfile.exist?
 
-    spdx_sbom = to_spdx_sbom
+    spdx_sbom = to_spdx_sbom(bottling:)
 
-    if validate && !valid?(spdx_sbom)
+    if validate && !valid?(spdx_sbom, bottling:)
       opoo "SBOM is not valid, not writing to disk!"
       return
     end
@@ -150,41 +230,13 @@ class SBOM
     spdxfile.atomic_write(JSON.pretty_generate(spdx_sbom))
   end
 
-  sig { returns(T::Hash[Symbol, T.anything]) }
-  def to_spdx_sbom
-    runtime_full = full_spdx_runtime_dependencies
+  sig { params(bottling: T::Boolean).returns(T::Hash[Symbol, T.anything]) }
+  def to_spdx_sbom(bottling: false)
+    runtime_full = full_spdx_runtime_dependencies(bottling:)
+    compiler_info = compiler_packages
+    compiler_info = {} if bottling
 
-    compiler_info = {
-      "SPDXRef-Compiler" => {
-        SPDXID:           "SPDXRef-Compiler",
-        name:             compiler.to_s,
-        versionInfo:      assert_value(built_on["xcode"]),
-        filesAnalyzed:    false,
-        licenseDeclared:  assert_value(nil),
-        licenseConcluded: assert_value(nil),
-        copyrightText:    assert_value(nil),
-        downloadLocation: assert_value(nil),
-        checksums:        [],
-        externalRefs:     [],
-      },
-    }
-
-    if stdlib.present?
-      compiler_info["SPDXRef-Stdlib"] = {
-        SPDXID:           "SPDXRef-Stdlib",
-        name:             stdlib.to_s,
-        versionInfo:      stdlib.to_s,
-        filesAnalyzed:    false,
-        licenseDeclared:  assert_value(nil),
-        licenseConcluded: assert_value(nil),
-        copyrightText:    assert_value(nil),
-        downloadLocation: assert_value(nil),
-        checksums:        [],
-        externalRefs:     [],
-      }
-    end
-
-    packages = generate_packages_json(runtime_full, compiler_info)
+    packages = generate_packages_json(runtime_full, compiler_info, bottling:)
     files = generate_files_json
     {
       SPDXID:            "SPDXRef-DOCUMENT",
@@ -199,11 +251,92 @@ class SBOM
       documentDescribes: packages.map { |dependency| dependency[:SPDXID] },
       files:,
       packages:,
-      relationships:     generate_relations_json(runtime_full, compiler_info),
+      relationships:     generate_relations_json(runtime_full, compiler_info, bottling:),
+    }
+  end
+
+  sig { returns(SPDXHash) }
+  def to_spdx_supplement
+    runtime_full = full_spdx_runtime_dependencies(bottling: false)
+    compiler_info = compiler_packages
+    packages = runtime_full + compiler_info.values
+    relationships = T.let([], T::Array[SPDXSymbolHash])
+    runtime_full.each do |dependency|
+      relationships << {
+        spdxElementId:      dependency[:SPDXID],
+        relationshipType:   "RUNTIME_DEPENDENCY_OF",
+        relatedSpdxElement: bottle_spdx_id,
+      }
+    end
+
+    if compiler_info["SPDXRef-Compiler"].present?
+      relationships << {
+        spdxElementId:      "SPDXRef-Compiler",
+        relationshipType:   "BUILD_TOOL_OF",
+        relatedSpdxElement: "SPDXRef-Archive-#{name}-src",
+      }
+    end
+
+    if compiler_info["SPDXRef-Stdlib"].present?
+      relationships << {
+        spdxElementId:      "SPDXRef-Stdlib",
+        relationshipType:   "DEPENDENCY_OF",
+        relatedSpdxElement: bottle_spdx_id,
+      }
+    end
+
+    {
+      "documentDescribes" => packages.map { |package| package[:SPDXID] },
+      "packages"          => packages,
+      "relationships"     => relationships,
     }
   end
 
   private
+
+  sig { params(spdx: SPDXHash, supplement: SPDXHash).void }
+  def self.merge_spdx_supplement(spdx, supplement)
+    ["documentDescribes", "packages", "relationships"].each do |key|
+      spdx_value = spdx[key]
+      supplement_value = supplement[key]
+      next if !spdx_value.is_a?(Array) || !supplement_value.is_a?(Array)
+
+      spdx_value.concat(supplement_value)
+    end
+  end
+  private_class_method :merge_spdx_supplement
+
+  sig {
+    params(
+      supplement:     T.nilable(SPDXHash),
+      bottle_package: SPDXHash,
+    ).returns(T.nilable(SPDXHash))
+  }
+  def self.add_bottle_package_to_supplement(supplement, bottle_package)
+    return if supplement.nil?
+
+    if (tags = supplement["tags"]).is_a?(Hash)
+      tag_supplements = tags.filter_map do |tag, tag_supplement|
+        next if !tag.is_a?(String) || !tag_supplement.is_a?(Hash)
+
+        [tag, add_bottle_package_to_supplement(tag_supplement, bottle_package)]
+      end.to_h.compact
+      return { "tags" => tag_supplements } if tag_supplements.present?
+    end
+
+    packages = supplement["packages"]
+    return unless packages.is_a?(Array)
+
+    document_describes = supplement["documentDescribes"]
+    relationships = supplement["relationships"]
+    document_describes += [bottle_package.fetch("SPDXID")] if document_describes.is_a?(Array)
+    {
+      "documentDescribes" => document_describes.is_a?(Array) ? document_describes : [],
+      "packages"          => packages + [bottle_package],
+      "relationships"     => relationships.is_a?(Array) ? relationships : [],
+    }
+  end
+  private_class_method :add_bottle_package_to_supplement
 
   sig { returns(String) }
   attr_reader :name
@@ -230,7 +363,7 @@ class SBOM
       source_modified_time: Integer,
       compiler:             T.any(String, Symbol),
       stdlib:               T.nilable(T.any(String, Symbol)),
-      runtime_dependencies: T::Array[T::Hash[String, T.untyped]],
+      runtime_dependencies: T::Array[T::Hash[String, Object]],
       license:              T.nilable(String),
       built_on:             T::Hash[String, T.nilable(String)],
       source:               Source,
@@ -249,18 +382,54 @@ class SBOM
     @source = source
   end
 
+  sig { returns(T::Hash[String, SPDXSymbolHash]) }
+  def compiler_packages
+    packages = {
+      "SPDXRef-Compiler" => {
+        SPDXID:           "SPDXRef-Compiler",
+        name:             compiler.to_s,
+        versionInfo:      assert_value(built_on["xcode"]),
+        filesAnalyzed:    false,
+        licenseDeclared:  assert_value(nil),
+        licenseConcluded: assert_value(nil),
+        copyrightText:    assert_value(nil),
+        downloadLocation: assert_value(nil),
+        checksums:        [],
+        externalRefs:     [],
+      },
+    }
+
+    if stdlib.present?
+      packages["SPDXRef-Stdlib"] = {
+        SPDXID:           "SPDXRef-Stdlib",
+        name:             stdlib.to_s,
+        versionInfo:      stdlib.to_s,
+        filesAnalyzed:    false,
+        licenseDeclared:  assert_value(nil),
+        licenseConcluded: assert_value(nil),
+        copyrightText:    assert_value(nil),
+        downloadLocation: assert_value(nil),
+        checksums:        [],
+        externalRefs:     [],
+      }
+    end
+
+    packages
+  end
+
   sig {
     params(
-      runtime_dependency_declaration: T::Array[T::Hash[Symbol, T.untyped]],
-      compiler_declaration:           T::Hash[String, T.untyped],
-    ).returns(T::Array[T::Hash[Symbol, T.untyped]])
+      runtime_dependency_declaration: T::Array[SPDXSymbolHash],
+      compiler_declaration:           T::Hash[String, Object],
+      bottling:                       T::Boolean,
+    ).returns(T::Array[SPDXSymbolHash])
   }
-  def generate_relations_json(runtime_dependency_declaration, compiler_declaration)
+  def generate_relations_json(runtime_dependency_declaration, compiler_declaration, bottling:)
     runtime = runtime_dependency_declaration.map do |dependency|
       {
         spdxElementId:      dependency[:SPDXID],
         relationshipType:   "RUNTIME_DEPENDENCY_OF",
-        relatedSpdxElement: described_package_spdx_id,
+        relatedSpdxElement: described_package_spdx_id(bottling:),
       }
     end
 
@@ -274,7 +443,7 @@ class SBOM
       }
     end
 
-    base = T.let([], T::Array[T::Hash[Symbol, T.untyped]])
+    base = T.let([], T::Array[SPDXSymbolHash])
 
     if source.checksum.present?
       base << {
@@ -284,18 +453,20 @@ class SBOM
       }
     end
 
-    base << {
-      spdxElementId:      "SPDXRef-Compiler",
-      relationshipType:   "BUILD_TOOL_OF",
-      relatedSpdxElement: "SPDXRef-Archive-#{name}-src",
-    }
-
-    if compiler_declaration["SPDXRef-Stdlib"].present?
+    unless bottling
       base << {
-        spdxElementId:      "SPDXRef-Stdlib",
-        relationshipType:   "DEPENDENCY_OF",
-        relatedSpdxElement: described_package_spdx_id,
+        spdxElementId:      "SPDXRef-Compiler",
+        relationshipType:   "BUILD_TOOL_OF",
+        relatedSpdxElement: "SPDXRef-Archive-#{name}-src",
       }
+
+      if compiler_declaration["SPDXRef-Stdlib"].present?
+        base << {
+          spdxElementId:      "SPDXRef-Stdlib",
+          relationshipType:   "DEPENDENCY_OF",
+          relatedSpdxElement: described_package_spdx_id(bottling:),
+        }
+      end
     end
 
     runtime + patches + base
@@ -303,13 +474,14 @@ class SBOM
 
   sig {
     params(
-      runtime_dependency_declaration: T::Array[T::Hash[Symbol, T.anything]],
-      compiler_declaration:           T::Hash[String, T::Hash[Symbol, T.anything]],
-    ).returns(T::Array[T::Hash[Symbol, T.untyped]])
+      runtime_dependency_declaration: T::Array[SPDXSymbolHash],
+      compiler_declaration:           T::Hash[String, SPDXSymbolHash],
+      bottling:                       T::Boolean,
+    ).returns(T::Array[SPDXSymbolHash])
   }
-  def generate_packages_json(runtime_dependency_declaration, compiler_declaration)
+  def generate_packages_json(runtime_dependency_declaration, compiler_declaration, bottling:)
     bottle = []
-    if bottle_package? &&
+    if bottle_package?(bottling:) &&
        (bottle_info = get_bottle_info(source.bottle)) &&
        (stable_version = source.version)
       bottle << {
@@ -385,7 +557,7 @@ class SBOM
     ] + patches + runtime_dependency_declaration + compiler_declaration.values + bottle
   end
 
-  sig { returns(T::Array[T::Hash[Symbol, T.anything]]) }
+  sig { returns(T::Array[SPDXSymbolHash]) }
   def generate_files_json
     checksum = source.checksum
     return [] unless checksum
@@ -404,23 +576,32 @@ class SBOM
     ]
   end
 
-  sig { returns(T::Array[T::Hash[Symbol, T.any(T::Boolean, String, T::Array[T::Hash[Symbol, String]])]]) }
-  def full_spdx_runtime_dependencies
-    return [] if @runtime_dependencies.blank?
+  sig {
+    params(bottling: T::Boolean).returns(T::Array[SPDXSymbolHash])
+  }
+  def full_spdx_runtime_dependencies(bottling:)
+    return [] if bottling || @runtime_dependencies.blank?
 
     @runtime_dependencies.compact.filter_map do |dependency|
       next unless dependency.present?
 
-      bottle_info = get_bottle_info(dependency["bottle"])
+      dependency_bottle = dependency["bottle"]
+      next unless dependency_bottle.is_a?(Hash)
+
+      bottle_info = get_bottle_info(dependency_bottle)
       next unless bottle_info.present?
 
+      dependency_name = dependency.fetch("name").to_s
+      dependency_pkg_version = dependency.fetch("pkg_version").to_s
+      dependency_formula_pkg_version = dependency.fetch("formula_pkg_version").to_s
+
       # Only set bottle URL if the dependency is the same version as the formula/bottle.
-      bottle_url = bottle_info["url"] if dependency["pkg_version"] == dependency["formula_pkg_version"]
+      bottle_url = bottle_info["url"] if dependency_pkg_version == dependency_formula_pkg_version
 
       dependency_json = {
-        SPDXID:           "SPDXRef-Package-SPDXRef-#{dependency["name"].tr("/", "-")}-#{dependency["pkg_version"]}",
-        name:             dependency["name"],
-        versionInfo:      dependency["pkg_version"],
+        SPDXID:           "SPDXRef-Package-SPDXRef-#{dependency_name.tr("/", "-")}-#{dependency_pkg_version}",
+        name:             dependency_name,
+        versionInfo:      dependency_pkg_version,
         filesAnalyzed:    false,
         licenseDeclared:  assert_value(nil),
         licenseConcluded: assert_value(dependency["license"]),
@@ -435,7 +616,7 @@ class SBOM
         externalRefs:     [
           {
             referenceCategory: "PACKAGE-MANAGER",
-            referenceLocator:  "pkg:brew/#{dependency["full_name"]}@#{dependency["pkg_version"]}",
+            referenceLocator:  "pkg:brew/#{dependency["full_name"]}@#{dependency_pkg_version}",
             referenceType:     "purl",
           },
         ],
@@ -444,28 +625,36 @@ class SBOM
     end
   end
 
-  sig { params(base: T.nilable(T::Hash[String, T.untyped])).returns(T.nilable(T::Hash[String, String])) }
+  sig { params(base: T.nilable(T::Hash[String, Object])).returns(T.nilable(T::Hash[String, String])) }
   def get_bottle_info(base)
     return unless base.present?
 
-    files = base["files"].presence
-    return unless files
+    files = base["files"]
+    return unless files.is_a?(Hash)
 
-    files[Utils::Bottles.tag.to_sym] || files[:all]
+    bottle_info = files[Utils::Bottles.tag.to_sym] || files[:all]
+    return unless bottle_info.is_a?(Hash)
+
+    bottle_info.to_h { |key, value| [key.to_s, value.to_s] }
   end
 
-  sig { returns(T::Boolean) }
-  def bottle_package?
-    get_bottle_info(source.bottle).present? && spec_symbol == :stable && source.version.present?
+  sig { params(bottling: T::Boolean).returns(T::Boolean) }
+  def bottle_package?(bottling:)
+    !bottling && get_bottle_info(source.bottle).present? && spec_symbol == :stable && source.version.present?
   end
 
-  sig { returns(String) }
-  def described_package_spdx_id
-    if bottle_package?
-      "SPDXRef-Bottle-#{name}"
+  sig { params(bottling: T::Boolean).returns(String) }
+  def described_package_spdx_id(bottling:)
+    if bottle_package?(bottling:)
+      bottle_spdx_id
     else
       "SPDXRef-Archive-#{name}-src"
     end
+  end
+
+  sig { returns(String) }
+  def bottle_spdx_id
+    "SPDXRef-Bottle-#{name}"
   end
 
   sig { returns(Symbol) }
@@ -494,10 +683,10 @@ class SBOM
     Time.at(@source_modified_time).utc
   end
 
-  sig { params(val: T.untyped).returns(T.any(String, Symbol)) }
+  sig { params(val: Object).returns(String) }
   def assert_value(val)
     return :NOASSERTION.to_s unless val.present?
 
-    val
+    val.to_s
   end
 end

--- a/Library/Homebrew/test/bottle_spec.rb
+++ b/Library/Homebrew/test/bottle_spec.rb
@@ -36,4 +36,23 @@ RSpec.describe Bottle do
       expect(bottle.downloaded_and_valid?).to be true
     end
   end
+
+  describe "#sbom_supplement" do
+    it "reads the supplement from a valid bottle manifest" do
+      bottle_spec = BottleSpecification.new
+      bottle_spec.sha256(arm64_big_sur: "deadbeef" * 8)
+      bottle = described_class.new(nil, bottle_spec, Utils::Bottles::Tag.from_symbol(:arm64_big_sur),
+                                   name: "foo", pkg_version: PkgVersion.new(Version.new("1.2.3"), 0))
+      supplement = { "packages" => [{ "SPDXID" => "SPDXRef-Compiler" }] }
+      manifest_resource = instance_double(
+        Resource::BottleManifest,
+        downloaded_and_valid?: true,
+        sbom_supplement:       supplement,
+      )
+
+      allow(bottle).to receive(:github_packages_manifest_resource).and_return(manifest_resource)
+
+      expect(bottle.sbom_supplement).to eq(supplement)
+    end
+  end
 end

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Homebrew::DevCmd::Bottle do
                     "filename":"#{parameters[:filename]}",
                     "local_filename":"#{parameters[:local_filename]}",
                     "sha256":"#{parameters[:sha256]}"
+                    #{",\"sbom\":#{parameters[:sbom].to_json}" if parameters[:sbom]}
                  }
               }
            }
@@ -330,6 +331,7 @@ RSpec.describe Homebrew::DevCmd::Bottle do
               filename:       "testball-1.0.#{tag}.bottle.tar.gz",
               local_filename: "testball--1.0.#{tag}.bottle.tar.gz",
               sha256:,
+              sbom:           { "packages" => [{ "SPDXID" => "SPDXRef-#{tag}" }] },
             )
           end
         end
@@ -353,6 +355,7 @@ RSpec.describe Homebrew::DevCmd::Bottle do
           "local_filename" => "testball--1.0.all.bottle.tar.gz",
           "sha256"         => sha256,
         )
+        expect(all_bottle_tag_hash.dig("sbom", "tags").keys).to contain_exactly("arm64_big_sur", "big_sur")
         expect(all_bottle_tag_hash).not_to have_key("cellar")
         expect(Pathname("testball--1.0.all.bottle.tar.gz")).to exist
       end

--- a/Library/Homebrew/test/github_packages_spec.rb
+++ b/Library/Homebrew/test/github_packages_spec.rb
@@ -42,6 +42,11 @@ RSpec.describe GitHubPackages do
                                            "os_version" => "macOS 15",
                                          },
                                        },
+                                       "sbom"           => {
+                                         "documentDescribes" => ["SPDXRef-Compiler"],
+                                         "packages"          => [{ "SPDXID" => "SPDXRef-Compiler" }],
+                                         "relationships"     => [],
+                                       },
                                        "installed_size" => 100,
                                      },
                                      "arm64_sonoma" => {
@@ -71,6 +76,19 @@ RSpec.describe GitHubPackages do
         expect(manifests_by_tag.fetch("1.0.all")).not_to have_key("platform")
         expect(JSON.parse(manifests_by_tag.fetch("1.0.all").fetch("annotations").fetch("sh.brew.tab")))
           .not_to include("arch", "built_on")
+        all_annotations = manifests_by_tag.fetch("1.0.all").fetch("annotations")
+        all_supplement = JSON.parse(all_annotations.fetch("sh.brew.sbom.supplement"))
+        all_package_ids = all_supplement.fetch("packages").map { |package| package.fetch("SPDXID") }
+        expect(all_package_ids).to include("SPDXRef-Compiler", "SPDXRef-Bottle-testball")
+        expect(all_supplement.fetch("documentDescribes")).to include("SPDXRef-Bottle-testball")
+        expect(all_supplement.fetch("packages").find do |package|
+          package.fetch("SPDXID") == "SPDXRef-Bottle-testball"
+        end.fetch("checksums")).to eq([
+          {
+            "algorithm"     => "SHA256",
+            "checksumValue" => all_annotations.fetch("sh.brew.bottle.digest"),
+          },
+        ])
         expect(manifests_by_tag.fetch("1.0.arm64_sonoma"))
           .to include("platform" => include("architecture" => "arm64", "os" => "darwin"))
         expect(JSON.parse(manifests_by_tag.fetch("1.0.arm64_sonoma").fetch("annotations").fetch("sh.brew.tab")))

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 require "resource"
+require "bottle"
+require "github_packages"
 require "livecheck"
 
 RSpec.describe Resource do
@@ -260,6 +262,48 @@ RSpec.describe Resource do
       resource.patch(:p1, :DATA)
       expect(resource.patches.count).to eq(1)
       expect(resource.patches.first.strip).to eq(:p1)
+    end
+  end
+
+  describe Resource::BottleManifest do
+    describe "#sbom_supplement" do
+      it "returns the current platform supplement from an all bottle manifest" do
+        bottle_resource = Resource.new("testball")
+        bottle_resource.version("1.0")
+        bottle_resource.sha256(TEST_SHA256)
+
+        bottle = instance_double(
+          Bottle,
+          name:     "testball",
+          rebuild:  0,
+          resource: bottle_resource,
+          tag:      Utils::Bottles.tag(:all),
+        )
+        manifest = described_class.new(bottle)
+
+        current_tag_supplement = { "packages" => [{ "SPDXID" => "SPDXRef-current" }] }
+        manifest_json = {
+          "manifests" => [
+            {
+              "annotations" => {
+                "org.opencontainers.image.ref.name" => "1.0.all",
+                "sh.brew.bottle.digest"             => TEST_SHA256,
+                "sh.brew.sbom.supplement"           => {
+                  "tags" => {
+                    Utils::Bottles.tag.to_s => current_tag_supplement,
+                    "other"                 => { "packages" => [{ "SPDXID" => "SPDXRef-other" }] },
+                  },
+                }.to_json,
+              },
+            },
+          ],
+        }
+        cached_download = mktmpdir/"manifest.json"
+        cached_download.write(JSON.generate(manifest_json))
+        allow(manifest).to receive(:cached_download).and_return(cached_download)
+
+        expect(manifest.sbom_supplement).to eq(current_tag_supplement)
+      end
     end
   end
 

--- a/Library/Homebrew/test/sbom_spec.rb
+++ b/Library/Homebrew/test/sbom_spec.rb
@@ -132,6 +132,66 @@ RSpec.describe SBOM do
         )
       end
 
+      it "omits host-specific packages when bottling" do
+        spdx = sbom.to_spdx_sbom(bottling: true)
+        package_ids = spdx[:packages].map { |package| package[:SPDXID] }
+
+        expect(package_ids).to contain_exactly(
+          "SPDXRef-Archive-formula_name-src",
+          "SPDXRef-Patch-formula_name-0",
+        )
+        expect(spdx[:relationships].flat_map do |relation|
+          [relation[:spdxElementId], relation[:relatedSpdxElement]]
+        end).to all(
+          satisfy do |spdx_id|
+            package_ids.include?(spdx_id) || spdx_id == "SPDXRef-File-formula_name"
+          end,
+        )
+      end
+
+      it "emits host-specific packages in a pour supplement" do
+        package_ids = sbom.to_spdx_supplement.fetch("packages").map { |package| package.fetch(:SPDXID) }
+
+        expect(package_ids).to include(
+          "SPDXRef-Compiler",
+          "SPDXRef-Stdlib",
+          "SPDXRef-Package-SPDXRef-beanstalkd-1.1",
+          "SPDXRef-Package-SPDXRef-zlib-1.1",
+        )
+        expect(package_ids).not_to include(
+          "SPDXRef-Archive-formula_name-src",
+          "SPDXRef-Patch-formula_name-0",
+        )
+      end
+
+      it "builds a GitHub Packages manifest annotation supplement" do
+        annotation = described_class.github_packages_sbom_supplement_annotation(
+          {
+            "documentDescribes" => ["SPDXRef-Compiler"],
+            "packages"          => [{ "SPDXID" => "SPDXRef-Compiler" }],
+            "relationships"     => [],
+          },
+          formula_full_name: "formula_name",
+          formula_name:      "formula_name",
+          version:           Version.new("0.1"),
+          tar_gz_sha256:     TEST_SHA256,
+          root_url:          "https://ghcr.io/v2/homebrew/core",
+          license:           "MIT",
+          created_date:      "2026-05-10T00:00:00Z",
+        )
+        raise "missing annotation" if annotation.nil?
+
+        supplement = JSON.parse(annotation)
+        bottle_package = supplement.fetch("packages").find do |package|
+          package.fetch("SPDXID") == "SPDXRef-Bottle-formula_name"
+        end
+
+        expect(bottle_package).to include(
+          "checksums"        => [{ "algorithm" => "SHA256", "checksumValue" => TEST_SHA256 }],
+          "downloadLocation" => "https://ghcr.io/v2/homebrew/core/formula_name/blobs/sha256:#{TEST_SHA256}",
+        )
+      end
+
       it "updates only pour-time creation metadata" do
         spdxfile = mktmpdir/SBOM::FILENAME
         spdxfile.write(JSON.pretty_generate(sbom.to_spdx_sbom))
@@ -145,6 +205,29 @@ RSpec.describe SBOM do
           "creators" => ["Tool: https://github.com/Homebrew/brew@1.2.3"],
         )
         expect(updated_spdx.except("creationInfo")).to eq(original_spdx.except("creationInfo"))
+      end
+
+      it "merges pour supplements without validating full SBOMs" do
+        spdxfile = mktmpdir/SBOM::FILENAME
+        spdxfile.write(JSON.pretty_generate(
+                         "creationInfo"      => {},
+                         "documentDescribes" => [],
+                         "packages"          => [],
+                         "relationships"     => [],
+                       ))
+        supplement = {
+          "documentDescribes" => ["SPDXRef-Compiler"],
+          "packages"          => [{ "SPDXID" => "SPDXRef-Compiler" }],
+          "relationships"     => [{ "spdxElementId" => "SPDXRef-Compiler" }],
+        }
+
+        described_class.update_pour_metadata(spdxfile, homebrew_version: "1.2.3", time: 1_720_189_863,
+                                                       supplement:)
+
+        updated_spdx = JSON.parse(spdxfile.read)
+        expect(updated_spdx.fetch("documentDescribes")).to eq(supplement.fetch("documentDescribes"))
+        expect(updated_spdx.fetch("packages")).to eq(supplement.fetch("packages"))
+        expect(updated_spdx.fetch("relationships")).to eq(supplement.fetch("relationships"))
       end
 
       it "skips malformed pour metadata SBOMs" do


### PR DESCRIPTION
- Keep bottled SBOMs reproducible by moving pour-specific runtime, compiler and bottle package data into package manifests.
- Preserve per-platform supplements for `:all` bottles so installs merge only the current platform data.
- Avoid validating full SBOMs during pour by appending manifest supplement arrays.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
