### PR TITLE
cask/upgrade: update the install receipt after a successful upgrade

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -434,6 +434,16 @@ module Cask
         # If successful, wipe the old cask from staging.
         old_cask_installer.finalize_upgrade
 
+        # Update the install receipt to the new version. The next upgrade
+        # resolves the old cask through it (the installed caskfile carries no
+        # version), so leaving it stale makes that upgrade back up and rename
+        # Caskroom paths that were purged here and abort with `Errno::ENOENT`.
+        # Written only after `finalize_upgrade` so a reverted upgrade never
+        # leaves a new-version receipt over a restored old install.
+        tab = Tab.create(new_cask)
+        tab.installed_on_request = Tab.for_cask(new_cask).installed_on_request
+        tab.write
+
         reopen_apps_after_upgrade(old_cask, new_cask) if quit
       rescue => e
         new_cask_installer.uninstall_artifacts(successor: old_cask, quit:) if new_artifacts_installed

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -642,6 +642,57 @@ RSpec.describe Cask::Upgrade, :cask do
     end
   end
 
+  context "when upgrading the same cask twice" do
+    # These tests perform real installs and upgrades: the bug under test is in
+    # the on-disk bookkeeping (INSTALL_RECEIPT.json), which stubs would bypass.
+    before do
+      Cask::Installer.new(Cask::CaskLoader.load(cask_path("outdated/local-caffeine"))).install
+    end
+
+    it "updates the install receipt on upgrade" do
+      expect(Cask::Tab.for_cask(local_caffeine).source["version"]).to eq "1.2.2"
+
+      described_class.upgrade_casks!(local_caffeine, args:)
+
+      expect(local_caffeine.installed_version).to eq "1.2.3"
+      expect(Cask::Tab.for_cask(local_caffeine).source["version"]).to eq "1.2.3"
+    end
+
+    it "resolves the old cask's version from the installed caskfile after an upgrade" do
+      described_class.upgrade_casks!(local_caffeine, args:)
+      expect(local_caffeine.installed_version).to eq "1.2.3"
+
+      # This is how the next upgrade builds its "old cask": a stale version
+      # here means that upgrade backs up and purges Caskroom paths that no
+      # longer exist and aborts mid-flight.
+      old_cask = Cask::CaskLoader.load_from_installed_caskfile(local_caffeine.installed_caskfile)
+      expect(old_cask.version.to_s).to eq "1.2.3"
+    end
+
+    it "upgrades a second time" do
+      described_class.upgrade_casks!(local_caffeine, args:)
+      expect(local_caffeine.installed_version).to eq "1.2.3"
+
+      newer = Cask::CaskLoader::FromContentLoader.new(<<~RUBY).load(config: nil)
+        cask "local-caffeine" do
+          version "1.2.4"
+          sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+          url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+          homepage "https://brew.sh/"
+
+          app "Caffeine.app"
+        end
+      RUBY
+
+      expect do
+        described_class.upgrade_casks!(newer, args:)
+      end.not_to raise_error
+
+      expect(newer.installed_version).to eq "1.2.4"
+    end
+  end
+
   context "when there were multiple failures" do
     # This test exercises upgrade error handling, so it needs installed Casks.
     before do


### PR DESCRIPTION
-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

-----

## Summary

### What 

I can't upgrade a cask the second time, I am seeing `No such file or directory @ rb_file_s_rename` errors when attempting. 

I tried replicating the whole thing at a dummy repo -> https://github.com/marinsokol5/brew-dummy, it only outputs the version when `brew-dummy` is invoked through the CLI. 
You can fork it and then have smt of a https://github.com/marinsokol5/homebrew-tap on your end for releasing, although I imagine you have a better dev setup anyway. 

I ran commands there in the following order:
```console
$ make publish V=0.0.1 
$ brew install --cask marinsokol5/tap/brew-dummy   # v0.0.1 — INSTALL_RECEIPT.json says 0.0.1
$ make publish V=0.0.2  
$ brew upgrade --cask brew-dummy                   # "0.0.1 -> 0.0.2", succeeds; INSTALL_RECEIPT.json still says 0.0.1
$ make publish V=0.0.3
$ brew upgrade --cask brew-dummy                   # "0.0.1 -> 0.0.3" (!) then:
Error: … No such file or directory @ rb_file_s_rename - (…/Caskroom/brew-dummy/0.0.1, …/Caskroom/brew-dummy/0.0.1.upgrading)
```

Tried to search for version strings in the `/opt/homebrew/Caskroom/brew-dummy` folder which lead me to the `INSTALL_RECEIPT.json` where version is frozen during installation. This might be the reason for `brew` to attempt to still upgrade from an older version instead of from a new one. 

There might be something wrong with the way I am releasing the cask on my end, if so, I do apologize for wasting your time. 
There are 2 commits in this PR, the first one are just the tests replicating the behaviour, you can cherry-pick those if you want to implement the change yourself. I am not familiar with Ruby, the change is fully implemented by the LLM, and it's just an attempt, I can fully close it and move it to an Issue if it's not helpful.

All the best.

## AI Summary, potentially useful for your LLM

The diagnosis, fix and specs were produced with the assistance of Claude Code (Anthropic), driven and reviewed by me. Verification was empirical, not AI-asserted: the three new regression specs fail on current `main` and pass with the fix; the bug itself was additionally reproduced end-to-end on a real public tap cask (transcript below) on macOS/Homebrew 6.0.7; `brew lgtm` passes locally.

### What the bug is

For a plain versioned cask from a tap, the **second `brew upgrade` after any full install always fails**, aborting mid-flight *after* the old artifacts have already been removed:

```
==> Upgrading brew-dummy
  0.0.1 -> 0.0.3        ← the actually installed version was 0.0.2
==> Unlinking Binary '/opt/homebrew/bin/brew-dummy'
==> Purging files for version 0.0.3 of Cask brew-dummy
Error: marinsokol5/tap/brew-dummy: No such file or directory @ rb_file_s_rename - (/opt/homebrew/Caskroom/brew-dummy/0.0.1, /opt/homebrew/Caskroom/brew-dummy/0.0.1.upgrading)
```

The user is left with the app/binary uninstalled, an orphaned `<version>.upgrading` directory, and a Caskroom inconsistent enough that a follow-up `brew install` fails too (`It seems the App source '…' is not there`). Recovery requires `brew uninstall --cask --force` + reinstall.

### Root cause

- `Cask::Upgrade.upgrade_cask` installs the new cask via `stage` + `install_artifacts` and never calls `Installer#install` — which is the only place the cask tab (`INSTALL_RECEIPT.json`) is written (`Tab.create` + `tab.write` in `Installer#install`). So the receipt keeps the version of the last **full install** forever.
- The next upgrade builds its "old cask" via `CaskLoader.load_from_installed_caskfile`. The installed caskfile carries no version of its own (`Cask#to_installed_json_hash` stores at most `url_specs` — it is literally `{}` for a cask with no `*flight` blocks and no `url … only_path`), so the old cask's version falls back to the stale tab.
- `Installer#start_upgrade` → `backup` then renames `Caskroom/<token>/<stale-version>` and its `.metadata/<stale-version>` twin — directories that were purged an upgrade ago → `Errno::ENOENT`.

Net effect: **install → first upgrade works** (the receipt still happens to match the version being replaced) **→ second upgrade always crashes** (the receipt is now one version behind).

### Steps to reproduce

With any versioned tap cask without flight blocks (reproduced with https://github.com/marinsokol5/brew-dummy, a one-script cask created to verify this):

```console
$ brew install --cask marinsokol5/tap/brew-dummy   # v0.0.1 — receipt says 0.0.1
# release 0.0.2 to the tap
$ brew upgrade --cask brew-dummy                   # "0.0.1 -> 0.0.2", succeeds; receipt still says 0.0.1
# release 0.0.3 to the tap
$ brew upgrade --cask brew-dummy                   # "0.0.1 -> 0.0.3" (!) then:
Error: … No such file or directory @ rb_file_s_rename - (…/Caskroom/brew-dummy/0.0.1, …/Caskroom/brew-dummy/0.0.1.upgrading)
```

First hit in production with `marinsokol5/tap/agent-manager`, twice in one day: `0.1.0 → 0.1.2` upgraded fine, `0.1.2 → 0.2.0` crashed claiming the installed version was `0.1.0`; after a clean reinstall, `0.2.0 → 0.2.1` upgraded fine and `0.2.1 → 0.2.2` crashed claiming `0.2.0`.

### The fix

Write a fresh tab (preserving `installed_on_request` from the existing receipt) in `upgrade_cask` once the old cask is wiped — deliberately **after** `finalize_upgrade`, so a reverted upgrade can never leave a new-version receipt on top of a restored old install.

### Commit structure & tests

The PR is two commits on purpose:

1. **Regression specs only** (cherry-pickable on its own if you'd prefer to fix this differently): three specs in `test/cask/upgrade_spec.rb` pinning the bug at increasing depth — the receipt content after one upgrade, the old-cask version resolution the next upgrade relies on, and the user-visible second-upgrade crash (fails with the exact `Errno::ENOENT` above). All three fail on current `main`.
2. **The fix** (10 lines in `cask/upgrade.rb`), which turns them green.

Locally verified: full `cask/upgrade` spec (33 examples), plus `cask/installer`, `cask/reinstall`, `cask/uninstall` and `cask/tab` specs, `brew style`, `brew typecheck`, `brew lgtm`.
