### PR TITLE
install_steps: handle EUID/UID like postinstall does

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "system_command"
+
 module Homebrew
   # Declarative install steps that can be serialised through the JSON APIs.
   module InstallSteps
@@ -348,6 +350,8 @@ module Homebrew
     end
 
     class Runner
+      include SystemCommand::Mixin
+
       # Path tokens reuse the step base resolution; formula metadata tokens are
       # resolved separately. Anything else is left verbatim so literal braces in
       # templates are never rewritten.
@@ -490,16 +494,16 @@ module Homebrew
         prefix = context_path("prefix")
         case using
         when "postgresql_initdb"
-          run_safe_system bin/"initdb", "--locale=#{step["locale"] || "en_US.UTF-8"}", "-E", "UTF-8", path
+          run_command bin/"initdb", "--locale=#{step["locale"] || "en_US.UTF-8"}", "-E", "UTF-8", path
         when "mysql_initialize"
           with_env(TMPDIR: nil) do
-            run_safe_system bin/"mysqld", "--initialize-insecure", "--user=#{ENV.fetch("USER")}",
-                            "--basedir=#{prefix}", "--datadir=#{path}", "--tmpdir=/tmp"
+            run_command bin/"mysqld", "--initialize-insecure", "--user=#{ENV.fetch("USER")}",
+                        "--basedir=#{prefix}", "--datadir=#{path}", "--tmpdir=/tmp"
           end
         when "mariadb_install_db"
           with_env(TMPDIR: nil) do
-            run_safe_system bin/"mysql_install_db", "--verbose", "--user=#{ENV.fetch("USER")}",
-                            "--basedir=#{prefix}", "--datadir=#{path}", "--tmpdir=/tmp"
+            run_command bin/"mysql_install_db", "--verbose", "--user=#{ENV.fetch("USER")}",
+                        "--basedir=#{prefix}", "--datadir=#{path}", "--tmpdir=/tmp"
           end
         end
       end
@@ -589,7 +593,7 @@ module Homebrew
       def run_formula_tool(formula, executable, *args)
         # Load the formula so missing helper formulae fail before running a guessed path.
         # rubocop:disable Homebrew/FormulaPathMethods
-        run_safe_system Formula[formula].opt_bin/executable, *args
+        run_command Formula[formula].opt_bin/executable, *args
         # rubocop:enable Homebrew/FormulaPathMethods
       end
 
@@ -644,9 +648,8 @@ module Homebrew
       end
 
       sig { params(command: SystemCommandArg, args: SystemCommandArg).void }
-      def run_safe_system(command, *args)
-        # `safe_system` is private on Formula contexts, so `public_send` cannot be used.
-        @context.send(:safe_system, command, *args)
+      def run_command(command, *args)
+        system_command!(command, args: args, print_stdout: true, print_stderr: true, reset_uid: true)
       end
     end
   end

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -166,18 +166,20 @@ RSpec.describe Homebrew::InstallSteps do
       init_data_dir "mysql", using: :mariadb_install_db
     end
 
-    expect(context).to receive(:safe_system).with(root/"prefix/bin/initdb", "--locale=en_US.UTF-8", "-E", "UTF-8",
-                                                  root/"var/postgresql@16").ordered
-    expect(context).to receive(:safe_system).with(root/"prefix/bin/initdb", "--locale=C", "-E", "UTF-8",
-                                                  root/"var/postgresql@12").ordered
-    expect(context).to receive(:safe_system).with(root/"prefix/bin/mysqld", "--initialize-insecure",
-                                                  "--user=#{ENV.fetch("USER")}", "--basedir=#{root}/prefix",
-                                                  "--datadir=#{root}/var/mysql", "--tmpdir=/tmp").ordered
-    expect(context).to receive(:safe_system).with(root/"prefix/bin/mysql_install_db", "--verbose",
-                                                  "--user=#{ENV.fetch("USER")}", "--basedir=#{root}/prefix",
-                                                  "--datadir=#{root}/var/mysql", "--tmpdir=/tmp").ordered
+    runner = Homebrew::InstallSteps::Runner.new(context:)
 
-    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+    expect(runner).to receive(:run_command).with(root/"prefix/bin/initdb", "--locale=en_US.UTF-8", "-E", "UTF-8",
+                                                 root/"var/postgresql@16").ordered
+    expect(runner).to receive(:run_command).with(root/"prefix/bin/initdb", "--locale=C", "-E", "UTF-8",
+                                                 root/"var/postgresql@12").ordered
+    expect(runner).to receive(:run_command).with(root/"prefix/bin/mysqld", "--initialize-insecure",
+                                                 "--user=#{ENV.fetch("USER")}", "--basedir=#{root}/prefix",
+                                                 "--datadir=#{root}/var/mysql", "--tmpdir=/tmp").ordered
+    expect(runner).to receive(:run_command).with(root/"prefix/bin/mysql_install_db", "--verbose",
+                                                 "--user=#{ENV.fetch("USER")}", "--basedir=#{root}/prefix",
+                                                 "--datadir=#{root}/var/mysql", "--tmpdir=/tmp").ordered
+
+    runner.run(steps)
 
     expect(root/"var/postgresql@16").to be_a_directory
     expect(root/"var/postgresql@12").to be_a_directory
@@ -220,14 +222,16 @@ RSpec.describe Homebrew::InstallSteps do
       init_data_dir name, using: :postgresql_initdb
     end
 
-    expect(versioned_context).to receive(:safe_system) do |*args|
+    runner = Homebrew::InstallSteps::Runner.new(context: versioned_context)
+
+    expect(runner).to receive(:run_command) do |*args|
       expect(args).to eq([root/"prefix/bin/initdb", "--locale=en_US.UTF-8", "-E", "UTF-8",
                           root/"var/postgresql@17"])
       expect(homebrew_prefix/"share/postgresql@17").to be_a_directory
       expect(homebrew_prefix/"share/postgresql@17/postgres.bki").to be_a_symlink
     end
 
-    Homebrew::InstallSteps::Runner.new(context: versioned_context).run(steps)
+    runner.run(steps)
 
     %w[include lib share].each do |dir|
       expect(homebrew_prefix/dir/"postgresql@17/server").to be_a_directory
@@ -247,9 +251,11 @@ RSpec.describe Homebrew::InstallSteps do
     end
 
     ENV["HOMEBREW_GITHUB_ACTIONS"] = "1"
-    expect(context).not_to receive(:safe_system)
 
-    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+    runner = Homebrew::InstallSteps::Runner.new(context:)
+    expect(runner).not_to receive(:run_command)
+
+    runner.run(steps)
 
     expect(root/"var/postgresql@16").to be_a_directory
   end
@@ -261,9 +267,11 @@ RSpec.describe Homebrew::InstallSteps do
 
     (root/"var/mysql/mysql").mkpath
     (root/"var/mysql/mysql/general_log.CSM").write ""
-    expect(context).not_to receive(:safe_system)
 
-    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+    runner = Homebrew::InstallSteps::Runner.new(context:)
+    expect(runner).not_to receive(:run_command)
+
+    runner.run(steps)
 
     expect(root/"var/mysql").to be_a_directory
   end
@@ -294,17 +302,19 @@ RSpec.describe Homebrew::InstallSteps do
     allow(Formula).to receive(:[]).with("gdk-pixbuf").and_return(formula)
     allow(Formula).to receive(:[]).with("shared-mime-info").and_return(formula)
     allow(Formula).to receive(:[]).with("desktop-file-utils").and_return(formula)
-    expect(context).to receive(:safe_system).with(root/"opt/bin/glib-compile-schemas",
-                                                  HOMEBREW_PREFIX/"share/glib-2.0/schemas").ordered
-    expect(context).to receive(:safe_system).with(root/"opt/bin/gio-querymodules",
-                                                  HOMEBREW_PREFIX/"lib/gio/modules").ordered
-    expect(context).to receive(:safe_system).with(root/"opt/bin/gdk-pixbuf-query-loaders", "--update-cache").ordered
-    expect(context).to receive(:safe_system).with(root/"opt/bin/update-mime-database",
-                                                  HOMEBREW_PREFIX/"share/mime").ordered
-    expect(context).to receive(:safe_system).with(root/"opt/bin/update-desktop-database",
-                                                  HOMEBREW_PREFIX/"share/applications").ordered
 
-    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+    runner = Homebrew::InstallSteps::Runner.new(context:)
+    expect(runner).to receive(:run_command).with(root/"opt/bin/glib-compile-schemas",
+                                                 HOMEBREW_PREFIX/"share/glib-2.0/schemas").ordered
+    expect(runner).to receive(:run_command).with(root/"opt/bin/gio-querymodules",
+                                                 HOMEBREW_PREFIX/"lib/gio/modules").ordered
+    expect(runner).to receive(:run_command).with(root/"opt/bin/gdk-pixbuf-query-loaders", "--update-cache").ordered
+    expect(runner).to receive(:run_command).with(root/"opt/bin/update-mime-database",
+                                                 HOMEBREW_PREFIX/"share/mime").ordered
+    expect(runner).to receive(:run_command).with(root/"opt/bin/update-desktop-database",
+                                                 HOMEBREW_PREFIX/"share/applications").ordered
+
+    runner.run(steps)
   end
 
   describe "runs gtk_update_icon_cache rebuild action" do
@@ -318,17 +328,19 @@ RSpec.describe Homebrew::InstallSteps do
     it "with gtk4" do
       allow(Formula).to receive(:[]).with("gtk4").and_return(formula)
       allow(Utils::Path).to receive(:formula_any_version_installed?).with("gtk4").and_return(true)
-      expect(context).to receive(:safe_system).with(root/"opt/bin/gtk4-update-icon-cache", "-q", "-t", "-f",
-                                                    HOMEBREW_PREFIX/"share/icons/hicolor").ordered
-      Homebrew::InstallSteps::Runner.new(context:).run(steps)
+      runner = Homebrew::InstallSteps::Runner.new(context:)
+      expect(runner).to receive(:run_command).with(root/"opt/bin/gtk4-update-icon-cache", "-q", "-t", "-f",
+                                                   HOMEBREW_PREFIX/"share/icons/hicolor").ordered
+      runner.run(steps)
     end
 
     it "with gtk+3" do
       allow(Formula).to receive(:[]).with("gtk+3").and_return(formula)
       allow(Utils::Path).to receive(:formula_any_version_installed?).with("gtk4").and_return(false)
-      expect(context).to receive(:safe_system).with(root/"opt/bin/gtk3-update-icon-cache", "-q", "-t", "-f",
-                                                    HOMEBREW_PREFIX/"share/icons/hicolor").ordered
-      Homebrew::InstallSteps::Runner.new(context:).run(steps)
+      runner = Homebrew::InstallSteps::Runner.new(context:)
+      expect(runner).to receive(:run_command).with(root/"opt/bin/gtk3-update-icon-cache", "-q", "-t", "-f",
+                                                   HOMEBREW_PREFIX/"share/icons/hicolor").ordered
+      runner.run(steps)
     end
   end
 


### PR DESCRIPTION
Classic postinstall uses `Utils.safe_fork` which handles EUID/UID automatically. Fix `post_install_steps` so it handles it functionally the same way.

As an aside: something I did notice is we don't produce `post_install` logs to `~/Library/Logs/Homebrew` anymore with `post_install_steps` (because we used `safe_system` - which is not actually the formula `system` method). I don't know if that's intentional or not but in any case, this PR makes no functional change in terms of that.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
  - Not really possible to change EUID/UID unprivileged.
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
