### PR TITLE
perf/config: gather system configuration concurrently (~31% faster)

### DIFF
--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -62,14 +62,22 @@ class DevelopmentTools
       Version::NULL
     end
 
+    sig { returns(T.nilable(String)) }
+    def clang_version_output
+      @clang_version_output ||= T.let(
+        if (path = locate("clang"))
+          `#{path} --version`
+        end, T.nilable(String)
+      )
+    end
+
     # Get the Clang version.
     #
     # @api public
     sig { returns(Version) }
     def clang_version
       @clang_version ||= T.let(
-        if (path = locate("clang")) &&
-           (build_version = `#{path} --version`[/(?:clang|LLVM) version (\d+\.\d(?:\.\d)?)/, 1])
+        if (build_version = clang_version_output&.[](/(?:clang|LLVM) version (\d+\.\d(?:\.\d)?)/, 1))
           Version.new(build_version)
         else
           Version::NULL
@@ -83,8 +91,7 @@ class DevelopmentTools
     sig { returns(Version) }
     def clang_build_version
       @clang_build_version ||= T.let(
-        if (path = locate("clang")) &&
-          (build_version = `#{path} --version`[%r{clang(-| version [^ ]+ \(tags/RELEASE_)(\d{2,})}, 2])
+        if (build_version = clang_version_output&.[](%r{clang(-| version [^ ]+ \(tags/RELEASE_)(\d{2,})}, 2))
           Version.new(build_version)
         else
           Version::NULL
@@ -134,6 +141,7 @@ class DevelopmentTools
 
     sig { void }
     def clear_version_cache
+      @clang_version_output = T.let(nil, T.nilable(String))
       @clang_version = @clang_build_version = T.let(nil, T.nilable(Version))
       @gcc_version = T.let({}, T.nilable(T::Hash[String, Version]))
     end

--- a/Library/Homebrew/extend/os/linux/system_config.rb
+++ b/Library/Homebrew/extend/os/linux/system_config.rb
@@ -104,10 +104,8 @@ module OS
         end
 
         sig { params(out: T.any(File, StringIO, IO)).void }
-        def dump_verbose_config(out = $stdout)
-          kernel = Utils.safe_popen_read("uname", "-mors").chomp
-          super
-          out.puts "Kernel: #{kernel}"
+        def linux_config(out = $stdout)
+          out.puts "Kernel: #{Utils.safe_popen_read("uname", "-mors").chomp}"
           out.puts "OS: #{OS::Linux.os_version}"
           if OS.wsl?
             out.puts "WSL: #{OS::Linux.wsl_version}"
@@ -121,6 +119,11 @@ module OS
           ["glibc", ::CompilerSelector.preferred_gcc, OS::LINUX_PREFERRED_GCC_RUNTIME_FORMULA, "xorg"].each do |f|
             out.puts "#{f}: #{formula_linked_version(f)}"
           end
+        end
+
+        sig { returns(T::Array[Symbol]) }
+        def config_sections
+          super + [:linux_config]
         end
       end
     end

--- a/Library/Homebrew/extend/os/mac/system_config.rb
+++ b/Library/Homebrew/extend/os/mac/system_config.rb
@@ -62,8 +62,7 @@ module OS
         end
 
         sig { params(out: T.any(File, StringIO, IO)).void }
-        def dump_verbose_config(out = $stdout)
-          super
+        def macos_config(out = $stdout)
           out.puts "macOS: #{MacOS.full_version}-#{kernel}"
           out.puts "CLT: #{clt || "N/A"}"
           out.puts "Xcode: #{xcode || "N/A"}"
@@ -72,6 +71,11 @@ module OS
             out.puts "Metal Toolchain: #{metal_toolchain || "N/A"}"
           end
           out.puts "Rosetta 2: #{::Hardware::CPU.in_rosetta2?}" if ::Hardware::CPU.physical_cpu_arm64?
+        end
+
+        sig { returns(T::Array[Symbol]) }
+        def config_sections
+          super + [:macos_config]
         end
       end
     end

--- a/Library/Homebrew/git_repository.rb
+++ b/Library/Homebrew/git_repository.rb
@@ -45,6 +45,19 @@ class GitRepository
     popen_git("show", "-s", "--format=%cr", "HEAD")
   end
 
+  # Gets the full commit hash of the HEAD commit, the relative date of the
+  # last commit and the currently checked-out branch (or HEAD if the
+  # repository is in a detached HEAD state) in a single Git invocation.
+  sig { returns([T.nilable(String), T.nilable(String), T.nilable(String)]) }
+  def head_info
+    output = popen_git("show", "-s", "--format=%H%n%cr%n%D", "HEAD")
+    return [nil, nil, nil] if output.nil?
+
+    head, last_committed, refs = output.lines(chomp: true)
+    branch = refs&.[](/\AHEAD -> ([^,\n]+)/, 1) || "HEAD"
+    [head, last_committed, branch]
+  end
+
   # Gets the name of the currently checked-out branch, or HEAD if the repository is in a detached HEAD state.
   sig { params(safe: T::Boolean).returns(T.nilable(String)) }
   def branch_name(safe: false)

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -42,19 +42,27 @@ module SystemConfig
       GitRepository.new(HOMEBREW_REPOSITORY)
     end
 
+    sig { returns([T.nilable(String), T.nilable(String), T.nilable(String)]) }
+    def homebrew_head_info
+      @homebrew_head_info ||= T.let(
+        homebrew_repo.head_info,
+        T.nilable([T.nilable(String), T.nilable(String), T.nilable(String)]),
+      )
+    end
+
     sig { returns(String) }
     def branch
-      homebrew_repo.branch_name || "(none)"
+      homebrew_head_info[2] || "(none)"
     end
 
     sig { returns(String) }
     def head
-      homebrew_repo.head_ref || "(none)"
+      homebrew_head_info[0] || "(none)"
     end
 
     sig { returns(String) }
     def last_commit
-      homebrew_repo.last_committed || "never"
+      homebrew_head_info[1] || "never"
     end
 
     sig { returns(String) }
@@ -127,10 +135,11 @@ module SystemConfig
 
       if tap.installed?
         out.puts "#{tap_name} origin: #{tap.remote}" if tap.remote != tap.default_remote
-        out.puts "#{tap_name} HEAD: #{tap.git_head || "(none)"}"
-        out.puts "#{tap_name} last commit: #{tap.git_last_commit || "never"}"
+        head, last_commit, branch = tap.git_repository.head_info
+        out.puts "#{tap_name} HEAD: #{head || "(none)"}"
+        out.puts "#{tap_name} last commit: #{last_commit || "never"}"
         default_branches = %w[main master].freeze
-        out.puts "#{tap_name} branch: #{tap.git_branch || "(none)"}" if default_branches.exclude?(tap.git_branch)
+        out.puts "#{tap_name} branch: #{branch || "(none)"}" if default_branches.exclude?(branch)
       end
 
       json_file = Homebrew::API::HOMEBREW_CACHE_API/json_file_name
@@ -194,12 +203,29 @@ module SystemConfig
     end
 
     sig { params(out: T.any(File, StringIO, IO)).void }
-    def dump_verbose_config(out = $stdout)
-      homebrew_config(out)
-      core_tap_config(out)
-      homebrew_env_config(out)
+    def hardware_config(out = $stdout)
+      hardware = self.hardware
       out.puts hardware if hardware
-      host_software_config(out)
+    end
+
+    sig { returns(T::Array[Symbol]) }
+    def config_sections
+      [:homebrew_config, :core_tap_config, :homebrew_env_config, :hardware_config, :host_software_config]
+    end
+
+    sig { params(out: T.any(File, StringIO, IO)).void }
+    def dump_verbose_config(out = $stdout)
+      # Most sections shell out for their values (Git, compilers, curl,
+      # etc.), so render them concurrently and print them in order.
+      threads = config_sections.map do |section|
+        Thread.new do
+          Thread.current.report_on_exception = false
+          io = StringIO.new
+          public_send(section, io)
+          io.string
+        end
+      end
+      threads.each { |thread| out.print thread.value }
     end
   end
 end

--- a/Library/Homebrew/test/cmd/config_spec.rb
+++ b/Library/Homebrew/test/cmd/config_spec.rb
@@ -69,6 +69,21 @@ RSpec.describe Homebrew::Cmd::Config do
     expect(output.string).to include("Windows: Windows 11 Pro (25H2) [26200.8457]\n")
   end
 
+  it "prints config sections in order" do
+    output = StringIO.new
+
+    allow(SystemConfig).to receive(:config_sections).and_return([:homebrew_config, :host_software_config])
+    allow(SystemConfig).to receive(:homebrew_config) do |io|
+      sleep(0.01)
+      io.puts "first"
+    end
+    allow(SystemConfig).to receive(:host_software_config) { |io| io.puts "second" }
+
+    SystemConfig.dump_verbose_config(output)
+
+    expect(output.string).to eq("first\nsecond\n")
+  end
+
   it "does not print HOMEBREW_EVAL_ALL unless it is directly set" do
     output = StringIO.new
 

--- a/Library/Homebrew/test/git_repository_spec.rb
+++ b/Library/Homebrew/test/git_repository_spec.rb
@@ -47,6 +47,19 @@ RSpec.describe GitRepository do
     end
   end
 
+  describe "#head_info" do
+    it "returns the HEAD commit hash, relative commit time and branch name in one Git invocation" do
+      expect(git_repo.head_info).to eq([git_repo.head_ref, git_repo.last_committed, branch_name])
+
+      clone_path.cd do
+        safe_system Utils::Git.git, "checkout", "--quiet", "--detach"
+      end
+      expect(git_repo.head_info[2]).to eq("HEAD")
+
+      expect(described_class.new(repo_root/"nonexistent").head_info).to eq([nil, nil, nil])
+    end
+  end
+
   describe "when the origin has a branch and tag with the same name" do
     it "disambiguates branch_name, origin_branch_name, and default_origin_branch?" do
       expect(git_repo.branch_name).to eq(branch_name)


### PR DESCRIPTION
## Summary

`config` is the 4th most-run `brew` command in the [last 365 days of analytics](https://formulae.brew.sh/analytics/brew-command-run-options/365d/) at 4.78% of all invocations (28.6M runs), and it is also what every bug report and `brew gist-logs` runs. Profiling with stackprof (`HOMEBREW_SORBET_RUNTIME` unset) attributed ~83% of its wall time to serial subprocess waits: four Git invocations for the Homebrew repository, three or four more for each installed core tap, two `clang --version` runs, plus `curl --version`, `pkgutil` and friends, all executed one after another.

## Changes

Three complementary reductions:

1. **Render config sections concurrently.** `SystemConfig.dump_verbose_config` now builds each section into a `StringIO` on its own thread (the same plain-`Thread` pattern as #22975) and prints them in order. The macOS/Linux prepends contribute `macos_config`/`linux_config` entries to a new `config_sections` list instead of overriding `dump_verbose_config`, which also makes the `extend/os` prepends thinner.
2. **One Git invocation instead of three per repository.** New `GitRepository#head_info` returns the HEAD commit hash, relative commit time and branch name from a single `git show -s --format=%H%n%cr%n%D HEAD` (with detached-HEAD handling matching `branch_name`). Used for the Homebrew repository and both core taps, this drops 9 of the 11 Git subprocesses to 3.
3. **One `clang --version` instead of two.** `DevelopmentTools.clang_version` and `clang_build_version` now parse a shared memoized output (cleared in `clear_version_cache`), which also saves a subprocess for every other command that queries both.

Output is byte-identical before and after (modulo the relative "last commit" timestamps aging between captures). The same dump also runs in `BuildError` reports, build logs and `brew gist-logs`, which all benefit.

**Benchmarks** (Hyperfine, 15 runs each, warmup 3, `HOMEBREW_SORBET_RUNTIME` unset, interleaved after/before/after):

| `brew config` | Mean | Range |
|---|---|---|
| Before | 716.3 ms ± 54.9 ms | 679.8-907.8 ms |
| After | 493.1 ms ± 21.1 ms | 471.1-545.2 ms |
| After (confirmation run) | 486.0 ms ± 17.5 ms | |

**~31% decrease in wall time** (~225 ms saved per run). The remaining time is mostly interpreter startup plus the slowest single section.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code was used to profile `brew config` with stackprof, identify the serial subprocess waits, implement the changes and write the new specs (section ordering, `head_info` including detached HEAD and non-repository paths). Verified by comparing before/after output for byte-identical results, interleaved Hyperfine benchmarks on clean trees and running `brew lgtm` locally.

-----
