### PR TITLE
Install shell completions after artifacts are ready

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_artifact.rb
+++ b/Library/Homebrew/cask/artifact/abstract_artifact.rb
@@ -104,6 +104,11 @@ module Cask
             ],
             Binary,
             Manpage,
+            [
+              BashCompletion,
+              FishCompletion,
+              ZshCompletion,
+            ],
             PostflightSteps,
             UninstallPostflightSteps,
             PostflightBlock,


### PR DESCRIPTION
I encountered this issue while working on modified Docker Desktop Cask. I had following stanzas in my Cask:
```ruby
app "Docker.app"
bash_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.bash-completion"
bash_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker.bash-completion"
fish_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.fish-completion"
fish_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker.fish-completion"
zsh_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.zsh-completion"
zsh_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker.zsh-completion"
```
(basically I just removed all `binary` stanzas between `app` and first `bash_completion` from [the original Cask](https://github.com/Homebrew/homebrew-cask/blob/main/Casks/d/docker-desktop.rb#L29))

I expected this to just work. Cask seemed reasonable: copy `Docker.app` then make symlinks to shell completion scripts. However, in practice, `bash_completion` stanza was executing before `app`, so brew tried to create a symlink to nonexistent target:
```
Error: It seems the symlink source '/Applications/Docker.app/Contents/Resources/etc/docker-compose.bash-completion' is not there.
Error: Process completed with exit code 1.
```

I double checked `Docker.app` and the `docker-compose.bash-completion` (as well as other shell completion scripts) were present and in correct locations. The problem was that `Docker.app` was not yet copied into `/Applications` folder. The changes proposed in this PR solved the issue for me locally. It's a very small change, so hopefully it doesn't break anything.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
