### PR TITLE
github_runner_matrix: unique runner for each shard

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -84,6 +84,7 @@ class GitHubRunnerMatrix
       (1..@dependent_shards).map do |shard|
         spec.merge(
           name:                      "#{spec.fetch(:name)} shard #{shard}/#{@dependent_shards}",
+          runner:                    spec.fetch(:runner).sub("-deps", "-deps#{shard}").to_s,
           formulae_dependents_shard: "#{shard}/#{@dependent_shards}",
         )
       end

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -177,6 +177,13 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
           end
 
           it "splits active runners into shards" do
+            macos = GitHubRunnerMatrix::NEWEST_HOMEBREW_CORE_MACOS_RUNNER
+            macos_version = MacOSVersion.from_symbol(macos)
+            stub_const("GitHubRunnerMatrix::OLDEST_HOMEBREW_CORE_MACOS_RUNNER", macos)
+            stub_const("OS::LINUX_CI_ARM_RUNNER", "ubuntu-24.04-arm")
+
+            allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_LONG_TIMEOUT", "false").and_return("true")
+            allow(ENV).to receive(:key?).with("GITHUB_ACTIONS").and_return(true)
             allow(Formula).to receive(:all).and_return([testball, testball_depender].map(&:formula))
 
             runners = described_class.new([testball], [],
@@ -188,6 +195,14 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
             expect(runners).to all(include(:formulae_dependents_shard))
             expect(runners.map { |runner| runner.fetch(:formulae_dependents_shard) }.uniq).to eq(["1/2", "2/2"])
             expect(runners.map { |runner| runner.fetch(:name) }).to all(match(%r{ shard [12]/2\z}))
+            expect(runners.map { |runner| runner.fetch(:runner) }).to eq([
+              "ubuntu-latest",
+              "ubuntu-latest",
+              "ubuntu-24.04-arm",
+              "ubuntu-24.04-arm",
+              "#{macos_version}-arm64-12345-deps1-long",
+              "#{macos_version}-arm64-12345-deps2-long",
+            ])
           end
         end
 


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Allow running multiple parallel self-hosted instances when sharding dependents.

This will need orchestrator changes first.