### PR TITLE
perf: add Utils.parallel_map, use it in tap-info and services list

### DIFF
--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -45,16 +45,14 @@ module Homebrew
       sig { params(taps: T::Array[Tap]).void }
       def print_tap_info(taps)
         if taps.none?
-          tap_count = 0
-          formula_count = 0
-          command_count = 0
-          private_count = 0
-          Tap.installed.each do |tap|
-            tap_count += 1
-            formula_count += tap.formula_files.size
-            command_count += tap.command_files.size
-            private_count += 1 if tap.private?
+          # Tap#private? queries the GitHub API for each non-core tap.
+          tap_stats = Utils.parallel_map(Tap.installed) do |tap|
+            [tap.formula_files.size, tap.command_files.size, tap.private?]
           end
+          tap_count = tap_stats.count
+          formula_count = tap_stats.sum(&:first)
+          command_count = tap_stats.sum { |_, command_files_count, _| command_files_count }
+          private_count = tap_stats.count { |_, _, private_tap| private_tap }
           info = Utils.pluralize("tap", tap_count, include_count: true)
           info += ", #{private_count} private"
           info += ", #{Utils.pluralize("formula", formula_count, include_count: true)}"
@@ -184,11 +182,8 @@ module Homebrew
 
       sig { params(taps: T::Array[Tap]).void }
       def print_tap_json(taps)
-        # Tap#to_hash shells out to Git and queries the GitHub API, so
-        # generate the hashes concurrently to avoid serial subprocess and
-        # network waits. `Thread#value` re-raises if one fails, but the other
-        # taps' read-only queries may still run to completion first.
-        hashes = taps.map { |tap| Thread.new { tap.to_hash } }.map(&:value)
+        # Tap#to_hash shells out to Git and queries the GitHub API.
+        hashes = Utils.parallel_map(taps, &:to_hash)
 
         puts JSON.pretty_generate(hashes)
       end

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -217,15 +217,12 @@ module SystemConfig
     def dump_verbose_config(out = $stdout)
       # Most sections shell out for their values (Git, compilers, curl,
       # etc.), so render them concurrently and print them in order.
-      threads = config_sections.map do |section|
-        Thread.new do
-          Thread.current.report_on_exception = false
-          io = StringIO.new
-          public_send(section, io)
-          io.string
-        end
+      sections = Utils.parallel_map(config_sections) do |section|
+        io = StringIO.new
+        public_send(section, io)
+        io.string
       end
-      threads.each { |thread| out.print thread.value }
+      sections.each { |section| out.print section }
     end
   end
 end

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -1,9 +1,42 @@
 # typed: true
 # frozen_string_literal: true
 
+require "timeout"
 require "utils"
 
 RSpec.describe Utils do
+  describe ".parallel_map" do
+    it "runs all blocks concurrently" do
+      # A barrier no block passes until every block has started: this
+      # deadlocks (and times out) if the blocks run serially.
+      mutex = Mutex.new
+      condvar = ConditionVariable.new
+      started = 0
+      results = Timeout.timeout(5) do
+        described_class.parallel_map([1, 2, 3]) do |i|
+          mutex.synchronize do
+            started += 1
+            condvar.broadcast
+            condvar.wait(mutex) while started < 3
+          end
+          i * 10
+        end
+      end
+      expect(results).to eq [10, 20, 30]
+    end
+
+    it "returns results in input order, not completion order" do
+      expect(described_class.parallel_map([3, 1, 2]) do |i|
+        sleep(0.05 - (i * 0.01))
+        i * 10
+      end).to eq [30, 10, 20]
+    end
+
+    it "re-raises an exception from a block" do
+      expect { described_class.parallel_map([1]) { raise "boom" } }.to raise_error("boom")
+    end
+  end
+
   describe ".deconstantize" do
     it "removes the rightmost segment from the constant expression in the string" do
       expect(described_class.deconstantize("Net::HTTP")).to eq("Net")

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -66,6 +66,31 @@ module Utils
     full_name.count("/") == 2
   end
 
+  # Maps `items` to `block` results with one thread per item, so that
+  # blocking waits (subprocesses, network requests) overlap instead of
+  # accumulating serially. Results keep the order of `items`. If multiple
+  # blocks raise, the exception re-raised by `Thread#value` is the earliest
+  # in `items` order (not necessarily the chronologically first failure) and
+  # other blocks may still run to completion. Only worthwhile when each block
+  # spends its time waiting: the GVL serializes Ruby execution.
+  sig {
+    type_parameters(:Item, :Result)
+      .params(
+        items: T::Enumerable[T.type_parameter(:Item)],
+        block: T.proc.params(item: T.type_parameter(:Item)).returns(T.type_parameter(:Result)),
+      ).returns(T::Array[T.type_parameter(:Result)])
+  }
+  def self.parallel_map(items, &block)
+    threads = items.map do |item|
+      Thread.new do
+        # The exception is re-raised by `Thread#value`; don't also report it.
+        Thread.current.report_on_exception = false
+        yield(item)
+      end
+    end
+    threads.map { |thread| T.cast(thread.value, T.type_parameter(:Result)) }
+  end
+
   # A lightweight alternative to `ActiveSupport::Inflector.pluralize`:
   # Combines `stem` with the `singular` or `plural` suffix based on `count`.
   # Adds a prefix of the count value if `include_count` is set to true.


### PR DESCRIPTION
## Summary

In Homebrew/brew#22975 the per-tap `Tap#to_hash` calls were made concurrent with one plain `Thread` per tap, and review suggested extracting a single block helper if the approach got reused. This PR adds that helper, applies it to the serial GitHub API loop in bare `brew tap-info` and retrofits the inline-thread call sites from Homebrew/brew#22975 and Homebrew/brew#22989.

## Changes

- **`Utils.parallel_map(items, &block)`**: one thread per item, results in input order, first exception re-raised by `Thread#value` (with `report_on_exception` disabled so it isn't also printed to stderr). The docstring notes it is only worthwhile for blocking waits, since the GVL serializes Ruby execution.
- **`brew tap-info` (no arguments)**: the statistics loop called `Tap#private?` serially, one GitHub API request per non-core tap, plus per-tap file counting.
- **`brew tap-info --installed --json`**: retrofitted to use the helper; behavior and performance unchanged from Homebrew/brew#22975.
- **`SystemConfig.dump_verbose_config`**: retrofitted the inline-thread section rendering from Homebrew/brew#22989 (merged after this PR was opened); behavior and performance unchanged, `brew config` output verified identical.

Per review, an earlier `brew services list` conversion was dropped: its benchmark was within noise at typical service counts.

Output is byte-identical before and after.

**Benchmarks** (Hyperfine, 10 runs each, warmup 2, `HOMEBREW_SORBET_RUNTIME` unset, 9 taps of which 7 need a GitHub API call):

| Command | Before | After | Change |
|---|---|---|---|
| `brew tap-info` | 3.295 s ± 0.160 s | 1.602 s ± 0.069 s | **~51% decrease** |

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code was used to profile the commands, implement the helper and call sites and write the helper specs (ordering under staggered sleeps, exception propagation). Verified by byte-identical before/after output, interleaved Hyperfine benchmarks on clean trees and running `brew lgtm` locally.

-----
