### PR TITLE
Defer reinstall keg backup and silence analytics curl output

### DIFF
--- a/Library/Homebrew/reinstall/reinstall.rb
+++ b/Library/Homebrew/reinstall/reinstall.rb
@@ -10,6 +10,7 @@ module Homebrew
       const :keg, T.nilable(Keg)
       const :formula, Formula
       const :options, Options
+      const :link_keg, T::Boolean, default: false
     end
 
     class << self
@@ -41,7 +42,6 @@ module Homebrew
           link_keg = keg.linked?
           installed_on_request = tab.installed_on_request == true
           build_bottle = tab.built_bottle?
-          backup keg
         else
           link_keg = nil
           installed_on_request = true
@@ -72,7 +72,7 @@ module Homebrew
             verbose:,
           }.compact,
         )
-        InstallationContext.new(formula_installer:, keg:, formula:, options:)
+        InstallationContext.new(formula_installer:, keg:, formula:, options:, link_keg: link_keg == true)
       end
 
       sig { params(install_context: InstallationContext).void }
@@ -81,11 +81,14 @@ module Homebrew
         keg = install_context.keg
         formula = install_context.formula
         options = install_context.options
-        link_keg = keg&.linked?
+        link_keg = install_context.link_keg
         verbose = formula_installer.verbose?
+
+        formula_installer.check_installation_already_attempted
 
         oh1 "Reinstalling #{Formatter.identifier(formula.full_name)} #{options.to_a.join " "}"
 
+        backup keg if keg
         formula_installer.install
         formula_installer.finish
       rescue FormulaInstallationAlreadyAttemptedError

--- a/Library/Homebrew/test/reinstall_spec.rb
+++ b/Library/Homebrew/test/reinstall_spec.rb
@@ -4,6 +4,62 @@
 require "reinstall"
 
 RSpec.describe Homebrew::Reinstall do
+  describe ".build_install_context" do
+    it "leaves the current keg in place until reinstalling", :integration_test do
+      setup_test_formula "testball", tab_attributes: { installed_on_request: true }
+      formula = Formula["testball"]
+      keg = Keg.new(formula.prefix)
+      keg.link
+
+      context = described_class.build_install_context(formula, flags: [])
+
+      expect(context.keg&.to_s).to eq(keg.to_s)
+      expect(context.link_keg).to be(true)
+      expect(formula.prefix).to exist
+      expect(formula.opt_prefix).to be_a_directory
+      expect(Pathname.new("#{keg}.reinstall")).not_to exist
+    end
+  end
+
+  describe ".reinstall_formula" do
+    it "restores and relinks a backup keg when reinstalling fails", :integration_test do
+      setup_test_formula "testball", tab_attributes: { installed_on_request: true }
+      formula = Formula["testball"]
+      keg = Keg.new(formula.prefix)
+      (keg/"bin").mkpath
+      (keg/"bin/test").write("current")
+      keg.link
+
+      context = described_class.build_install_context(formula, flags: [])
+      allow(context.formula_installer).to receive(:install).and_raise(RuntimeError, "boom")
+
+      expect { described_class.reinstall_formula(context) }.to raise_error(RuntimeError, "boom")
+
+      expect((keg/"bin/test").read).to eq("current")
+      expect(keg.linked?).to be(true)
+    end
+
+    it "does not back up the keg when reinstall was already attempted", :integration_test do
+      setup_test_formula "testball", tab_attributes: { installed_on_request: true }
+      formula = Formula["testball"]
+      keg = Keg.new(formula.prefix)
+      (keg/"bin").mkpath
+      (keg/"bin/test").write("current")
+      keg.link
+
+      FormulaInstaller.attempted << formula
+      context = described_class.build_install_context(formula, flags: [])
+
+      described_class.reinstall_formula(context)
+
+      expect((keg/"bin/test").read).to eq("current")
+      expect(keg.linked?).to be(true)
+      expect(Pathname.new("#{keg}.reinstall")).not_to exist
+    ensure
+      FormulaInstaller.clear_attempted
+    end
+  end
+
   describe ".backup" do
     it "removes a stale reinstall backup keg" do
       keg_path = HOMEBREW_CELLAR/"testball/0.1"

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -150,6 +150,22 @@ RSpec.describe Utils::Analytics do
     end
   end
 
+  describe "::deferred_curl" do
+    it "forwards args and silences subprocess output outside debug mode" do
+      ENV.delete("HOMEBREW_ANALYTICS_DEBUG")
+
+      allow(Utils::Curl).to receive(:curl_executable).and_return("/usr/bin/curl")
+      allow(Utils::Curl).to receive(:curl_args) { |*args, **| args }
+      expect(described_class).to receive(:spawn)
+        .with("/usr/bin/curl", "--max-time", "3", "--silent", "--output", File::NULL, "https://example.com",
+              out: File::NULL, err: File::NULL)
+        .and_return(123)
+      expect(Process).to receive(:detach).with(123)
+
+      described_class.deferred_curl("https://example.com", ["--max-time", "3"])
+    end
+  end
+
   describe "::report_build_error" do
     context "when tap is installed" do
       let(:err) { BuildError.new(f, "badprg", %w[arg1 arg2], {}) }

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -68,7 +68,7 @@ module Utils
           puts "#{curl} #{args.join(" ")} \"#{url}\""
           puts Utils.popen_read(curl, *args, url)
         else
-          pid = spawn curl, *args, url
+          pid = spawn curl, *args, url, out: File::NULL, err: File::NULL
           Process.detach(pid)
         end
       end


### PR DESCRIPTION
With `HOMEBREW_FORCE_BREWED_CURL=1`, `brew reinstall openssl@3` printed a scary `dyld` loader error referencing the keg's `opt` path. The reinstall succeeded, but a best-effort analytics `curl` leaked its stderr while `opt` was temporarily missing.

`brew reinstall` moved the keg to `<keg>.reinstall` while building the installation context, before fetch, `--ask` and dependant planning, leaving `opt/<formula>` dangling for the whole planning window. The backup now happens in `reinstall_formula` once the reinstall actually starts. Non-debug analytics `curl` subprocesses also redirect stdout and stderr to `/dev/null`; they are detached and their exit status is never checked, so only loader noise is suppressed and `HOMEBREW_ANALYTICS_DEBUG` is unchanged.

Deferring the backup also fixes two latent bugs: a failed reinstall now relinks the restored keg (`link_keg` was previously recomputed after the keg was unlinked, so it was always false), and an already-attempted reinstall is skipped before any backup instead of stranding a `.reinstall` keg.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 4.8) reviewed and refined this change, hardening the reinstall specs into red/green regression tests and verifying they fail on the old code and pass with the fix; I reviewed the diff and ran `brew lgtm` plus the targeted `reinstall`, `cmd/reinstall` and `utils/analytics` specs.

-----
