### PR TITLE
cask/upgrade: don't lose the original exception when rollback itself fails

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -436,9 +436,17 @@ module Cask
 
         reopen_apps_after_upgrade(old_cask, new_cask) if quit
       rescue => e
-        new_cask_installer.uninstall_artifacts(successor: old_cask, quit:) if new_artifacts_installed
-        new_cask_installer.purge_versioned_files
-        old_cask_installer.revert_upgrade(predecessor: new_cask) if started_upgrade
+        begin
+          new_cask_installer.uninstall_artifacts(successor: old_cask, quit:) if new_artifacts_installed
+          new_cask_installer.purge_versioned_files
+          old_cask_installer.revert_upgrade(predecessor: new_cask) if started_upgrade
+        rescue => rollback_error
+          opoo "Rolling back the failed upgrade of #{old_cask.token} also failed: " \
+               "#{rollback_error.class}: #{rollback_error.message}"
+          if (rollback_backtrace = rollback_error.backtrace)
+            odebug "Rollback backtrace:", rollback_backtrace
+          end
+        end
         raise e
       end
 

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -624,6 +624,15 @@ RSpec.describe Cask::Upgrade, :cask do
       expect(bad_checksum.installed_version).to eq "1.2.2"
       expect(bad_checksum.staged_path).not_to exist
     end
+
+    it "raises the original upgrade error, not a failure that occurs while rolling back" do
+      will_fail_if_upgraded = Cask::CaskLoader.load("will-fail-if-upgraded")
+      allow_any_instance_of(Cask::Installer).to receive(:revert_upgrade).and_raise("rollback failed")
+
+      expect do
+        described_class.upgrade_casks!(will_fail_if_upgraded, args:)
+      end.to raise_error(Cask::CaskError)
+    end
   end
 
   context "when there were multiple failures" do


### PR DESCRIPTION
A cask upgrade that fails after the new version's app has been moved into `/Applications` sets aside the exception while it triggers a rollback (remove new, purge, restore old) then re-raises the exception so the user can see what went wrong.

But if the rollback itself fails, that second exception replaces the original (btw often the new error is `It seems there is already an App at '/Applications/…'`). Original exception lost.

The fix wraps the rollback in its own rescue. If an exception is raised in the rollback block, it's surfaced as a warning (class + message, backtrace under `--debug`), and the original exception is always the one raised.

I hit this on a real `whatsapp` upgrade. The new app moved into `/Applications` fine, but a later step — after the move, before Homebrew finalised the upgrade — failed and fired the rollback, whose "already an App" error masked the true cause. I never got to see it; now the next person will. (That step is where the quarantine / code-signing-identity release runs, so likely there, but I couldn't capture the actual exception.) This masking is long-standing and independent of #22952 which is part of a hot cluster of casks reverting with "already an App" (the just-mentioned #22952 introduced it for third-party taps; #22983 and #22986 fixed parts; #22993 analysed it). I'm not touching those — but their rollbacks fail the same way, so this change would surface the real cause instead of the masking message, potentially making them easier to diagnose. I am not attempting to address the cause of the original failure since I don't have the error info, but note, with respect to issue #22993, that it did not happen in a third-party cask but in a Homebrew one - `whatsapp`.

Open question: I've put the rollback backtrace behind `--debug` to keep normal output clean — but this kind of failure can be unreproducible (mine was; the original exception was already gone before I could re-run with `--debug`). A debug-only backtrace risks being missed exactly when it would be most useful. Is `--debug` the right call here, or should the rollback backtrace be shown whenever it fires?


-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Anthropic) traced the cause through the source, wrote the fix and the regression test, and drafted this description which I then edited. I reviewed every step and verified locally: red/green on the new spec (fails against the old code, passes with the fix) and a clean `brew lgtm` (style, typecheck, tests). The original failure that triggered this was not reproducible (the exception was already lost), which is the point of the fix — so I could not give step-by-step repro commands.

-----
