### PR TITLE
cask: don't crash upgrade when staged version directory is missing

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -605,8 +605,10 @@ on_request: true)
       bmp = backup_metadata_path
       raise "unexpected nil backup_metadata_path" unless bmp
 
-      @cask.staged_path.rename bp.to_s
-      @cask.metadata_versioned_path.rename bmp.to_s
+      # The staged files may already be gone (e.g. an out-of-band cask update);
+      # skip the rename rather than raising and aborting the upgrade.
+      @cask.staged_path.rename bp.to_s if @cask.staged_path.exist?
+      @cask.metadata_versioned_path.rename bmp.to_s if @cask.metadata_versioned_path.exist?
     end
 
     sig { void }

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -424,6 +424,21 @@ RSpec.describe Cask::Installer, :cask do
     end
   end
 
+  describe "#backup" do
+    it "does not raise when the staged version directory is already missing" do
+      caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
+      installer = described_class.new(caffeine)
+      installer.install
+
+      FileUtils.rm_rf(caffeine.staged_path)
+      FileUtils.rm_rf(caffeine.metadata_versioned_path)
+
+      expect { installer.backup }.not_to raise_error
+      expect(installer.backup_path).not_to exist
+      expect(installer.backup_metadata_path).not_to exist
+    end
+  end
+
   describe "uninstall" do
     it "fully uninstalls a Cask" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))


### PR DESCRIPTION
Guard `Cask::Installer#backup` so a missing staged version directory is a no-op instead of a fatal error during `brew upgrade`.

## What

On upgrade, `#backup` renames the staged version directory to `<version>.upgrading` for rollback safety. If that directory is already gone while the receipt still lists the version, `Pathname#rename` raised `Errno::ENOENT` (`No such file or directory @ rb_file_s_rename`) and aborted the whole `brew upgrade`. This guards both renames with an existence check. `#restore_backup` is already defensive (`return if !bp.directory? || !bmp.directory?`), so skipping the backup makes the revert path a correct no-op and the target version installs cleanly.

## Why

Receipt↔Caskroom drift is common for `auto_updates true` casks (the app updates its own binary out-of-band, so the recorded version lags what's on disk) and after an interrupted `brew upgrade`/`brew cleanup`. Users then hit a hard crash on a routine upgrade and have to manually `brew uninstall --cask <cask> --force && brew install --cask <cask>` to recover — a single drifted cask also aborts the rest of the `brew upgrade` run.

The same `rb_file_s_rename` failure has been reported for years across many casks and closed as "just reinstall" (Homebrew/homebrew-cask#213685, #166367, #49512, #51021, and others), while the underlying non-defensive rename was never addressed. The receipt-vs-reality drift is acknowledged in #22617. `brew` should never crash on a missing old-version directory.

Closes #22998.

## Steps to reproduce

1. `brew install --cask claude-code` (any `auto_updates true` cask).
2. Make the receipt drift from disk: `rm -rf "$(brew --prefix)/Caskroom/claude-code/<installed_version>"` (or simply let the app self-update).
3. `brew upgrade claude-code`
4. Before: `Error: claude-code: No such file or directory @ rb_file_s_rename - (…/<version>, …/<version>.upgrading)`. After: the upgrade proceeds.

## Testing done locally

- `brew style Library/Homebrew/cask/installer.rb Library/Homebrew/test/cask/installer_spec.rb` — 2 files inspected, no offenses detected.
- `brew typecheck` (full) — `No errors! Great job.`
- `brew tests --only=cask/installer` — 60 examples, 0 failures, including the new `#backup` regression test.
- Syntax verified with Homebrew's Ruby 3.4.8.

(I ran the full `brew style` and `brew typecheck`, plus the tests for the affected area; the complete `brew tests` matrix runs in CI.)

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

An AI assistant helped draft the one-line guard, the regression test, and this description. I reviewed the diff, verified syntax on Homebrew's Ruby 3.4.8, and ran `brew style` (clean) and `brew tests --only=cask/installer` (60 examples, 0 failures, including the new test) locally.

-----
