### PR TITLE
Use sudo user's tap trust

### DIFF
--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -192,6 +192,27 @@ RSpec.describe Homebrew::Trust, :trust_store do
     trust_file.unlink if trust_file&.exist?
   end
 
+  it "uses the provided home when the trust file path is home-based" do
+    root_home = Pathname(TEST_TMPDIR)/"root-home"
+    sudo_home = Pathname(TEST_TMPDIR)/"sudo-home"
+    allow(Dir).to receive(:home).with(ENV.fetch("USER")).and_return(root_home.to_s)
+
+    with_env(HOMEBREW_USER_CONFIG_HOME: root_home/".homebrew") do
+      expect(described_class.trust_file(home: sudo_home)).to eq(sudo_home/".homebrew/trust.json")
+    end
+  end
+
+  it "keeps the configured trust file path when it is not home-based" do
+    root_home = Pathname(TEST_TMPDIR)/"root-home"
+    sudo_home = Pathname(TEST_TMPDIR)/"sudo-home"
+    config_home = Pathname(TEST_TMPDIR)/"xdg-config/homebrew"
+    allow(Dir).to receive(:home).with(ENV.fetch("USER")).and_return(root_home.to_s)
+
+    with_env(HOMEBREW_USER_CONFIG_HOME: config_home) do
+      expect(described_class.trust_file(home: sudo_home)).to eq(config_home/"trust.json")
+    end
+  end
+
   it "trusts a GitHub SSH-remote tap by its name" do
     tap = Tap.fetch("thirdparty", "foo")
     tap.path.mkpath
@@ -387,6 +408,89 @@ RSpec.describe Homebrew::Trust, :trust_store do
     expect(described_class.trusted?(:tap, "thirdparty/foo")).to be(false)
   ensure
     described_class.clear!(:tap)
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
+  it "reads the invoking user's trust store for sudoed services" do
+    root_home = Pathname(TEST_TMPDIR)/"root-home"
+    sudo_home = Pathname(TEST_TMPDIR)/"sudo-home"
+    (sudo_home/".homebrew").mkpath
+    (sudo_home/".homebrew/trust.json").write(JSON.generate({ trustedtaps: ["thirdparty/foo"] }))
+    tap = Tap.fetch("thirdparty", "foo")
+    formula_path = tap.formula_dir/"default-trust.rb"
+    formula_path.dirname.mkpath
+
+    allow(Homebrew).to receive(:running_as_root?).and_return(true)
+    allow(Dir).to receive(:home).with(ENV.fetch("USER")).and_return(root_home.to_s)
+    allow(Etc).to receive(:getpwnam).with("brewuser").and_return(double(dir: sudo_home.to_s))
+
+    with_env(HOME: root_home, HOMEBREW_SUDO_USER: "brewuser", HOMEBREW_USER_CONFIG_HOME: root_home/".homebrew") do
+      expect { described_class.require_trusted_formula!("default-trust", formula_path) }.not_to raise_error
+    end
+  ensure
+    FileUtils.rm_rf root_home if root_home
+    FileUtils.rm_rf sudo_home if sudo_home
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
+  it "reads the invoking user's XDG trust store under sudo" do
+    xdg_config_home = Pathname(TEST_TMPDIR)/"sudo-xdg-config"
+    (xdg_config_home/"homebrew").mkpath
+    (xdg_config_home/"homebrew/trust.json").write(JSON.generate({ trustedtaps: ["thirdparty/foo"] }))
+    tap = Tap.fetch("thirdparty", "foo")
+    formula_path = tap.formula_dir/"default-trust.rb"
+    formula_path.dirname.mkpath
+
+    allow(Homebrew).to receive(:running_as_root?).and_return(true)
+    allow(Etc).to receive(:getpwnam).with("brewuser").and_return(double(dir: "/nonexistent"))
+
+    with_env(HOMEBREW_SUDO_USER:        "brewuser",
+             HOMEBREW_USER_CONFIG_HOME: xdg_config_home/"homebrew",
+             XDG_CONFIG_HOME:           xdg_config_home) do
+      expect { described_class.require_trusted_formula!("default-trust", formula_path) }.not_to raise_error
+    end
+  ensure
+    FileUtils.rm_rf xdg_config_home if xdg_config_home
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
+  it "reads the invoking user's Homebrew XDG trust store under sudo" do
+    xdg_config_home = Pathname(TEST_TMPDIR)/"sudo-homebrew-xdg-config"
+    (xdg_config_home/"homebrew").mkpath
+    (xdg_config_home/"homebrew/trust.json").write(JSON.generate({ trustedtaps: ["thirdparty/foo"] }))
+    tap = Tap.fetch("thirdparty", "foo")
+    formula_path = tap.formula_dir/"default-trust.rb"
+    formula_path.dirname.mkpath
+
+    allow(Homebrew).to receive(:running_as_root?).and_return(true)
+    allow(Etc).to receive(:getpwnam).with("brewuser").and_return(double(dir: "/nonexistent"))
+
+    with_env(HOMEBREW_SUDO_USER:        "brewuser",
+             HOMEBREW_USER_CONFIG_HOME: xdg_config_home/"homebrew",
+             XDG_CONFIG_HOME:           nil,
+             HOMEBREW_XDG_CONFIG_HOME:  xdg_config_home) do
+      expect { described_class.require_trusted_formula!("default-trust", formula_path) }.not_to raise_error
+    end
+  ensure
+    FileUtils.rm_rf xdg_config_home if xdg_config_home
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
+  it "warns when the sudo user cannot be looked up" do
+    allow(Homebrew).to receive(:running_as_root?).and_return(true)
+    allow(Etc).to receive(:getpwnam).with("brewuser").and_raise(ArgumentError)
+
+    with_env(HOMEBREW_SUDO_USER: "brewuser") do
+      expect { expect(described_class.trusted?(:tap, "thirdparty/foo")).to be(false) }
+        .to output(
+          Regexp.new(
+            "Could not determine home directory for `\\$HOMEBREW_SUDO_USER` " \
+            "\\(brewuser\\); falling back to " \
+            "#{Regexp.escape(described_class.trust_file.to_s)}\\.",
+          ),
+        ).to_stderr
+    end
+  ensure
     FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
   end
 

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "env_config"
+require "etc"
 require "json"
 require "tap"
 require "utils"
@@ -22,9 +23,14 @@ module Homebrew
     }.freeze, T::Hash[Symbol, Symbol])
     private_constant :SETTING_KEYS
 
-    sig { returns(Pathname) }
-    def self.trust_file
-      Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME"))/"trust.json"
+    sig { params(home: T.any(String, Pathname)).returns(Pathname) }
+    def self.trust_file(home: Dir.home(ENV.fetch("USER")))
+      user_config_home = Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME"))
+      if user_config_home == Pathname.new(Dir.home(ENV.fetch("USER")))/".homebrew"
+        Pathname.new(home.to_s)/".homebrew/trust.json"
+      else
+        user_config_home/"trust.json"
+      end
     end
 
     sig { params(type: Symbol, name: T.any(String, Tap)).returns(T::Boolean) }
@@ -411,7 +417,25 @@ module Homebrew
 
     sig { returns(T::Hash[String, T::Array[String]]) }
     def self.trust_store
-      trust_path = trust_file
+      trust_path = if Homebrew.running_as_root? &&
+                      (sudo_user = ENV.fetch("HOMEBREW_SUDO_USER", nil).presence) &&
+                      sudo_user != "root"
+        passwd = begin
+          Etc.getpwnam(sudo_user)
+        rescue ArgumentError
+          nil
+        end
+
+        if passwd
+          trust_file(home: passwd.dir)
+        else
+          opoo "Could not determine home directory for `$HOMEBREW_SUDO_USER` (#{sudo_user}); " \
+               "falling back to #{trust_file}."
+          trust_file
+        end
+      else
+        trust_file
+      end
       return {} unless trust_path.exist?
 
       parsed_store = JSON.parse(trust_path.read)


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/22996

- Prevent sudoed commands from reading root's empty `trust.json` when `HOMEBREW_SUDO_USER` identifies the invoking user.
- Warn with the fallback `trust.json` path when the sudo user's home directory cannot be determined.
- Cover the service regression and lookup warning in `trust_spec.rb`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
