### PR TITLE
Write cask receipts on upgrade

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -366,6 +366,7 @@ module Cask
 
       old_cask_installer =
         Installer.new(old_cask, **old_options)
+      old_tab = old_cask.tab
 
       new_cask.config = new_cask.default_config.merge(old_config)
 
@@ -441,6 +442,12 @@ module Cask
         old_cask_installer.revert_upgrade(predecessor: new_cask) if started_upgrade
         raise e
       end
+
+      # Wait until rollback is no longer possible so failures keep the old
+      # receipt, while successful upgrades can load artifacts next time.
+      tab = Tab.create(new_cask)
+      tab.installed_on_request = old_tab.tabfile.nil? || old_tab.installed_on_request
+      tab.write
 
       end_time = Time.now
       Homebrew.messages.package_installed(new_cask.token, end_time - start_time)

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -612,6 +612,64 @@ RSpec.describe Cask::Upgrade, :cask do
     end
   end
 
+  context "when upgrading after a forced upgrade without a cask receipt" do
+    before do
+      InstallHelper.stub_cask_installation(Cask::CaskLoader.load(cask_path("outdated/local-caffeine")))
+    end
+
+    it "uses the forced upgrade metadata for the next upgrade" do
+      receipt_path = local_caffeine.metadata_main_container_path/AbstractTab::FILENAME
+
+      expect(receipt_path).not_to exist
+      expect(Cask::CaskLoader.load_from_installed_caskfile(local_caffeine.installed_caskfile).artifacts)
+        .to be_empty
+
+      described_class.upgrade_casks!(local_caffeine, force: true, args:)
+
+      expect(receipt_path).to exist
+      expect(local_caffeine.tab.installed_on_request).to be(true)
+      expect(Cask::CaskLoader.load_from_installed_caskfile(local_caffeine.installed_caskfile).artifacts)
+        .to include(an_instance_of(Cask::Artifact::App))
+
+      newer_cask = Cask::CaskLoader::FromContentLoader.new(<<~RUBY).load(config: nil)
+        cask "local-caffeine" do
+          version "1.2.4"
+          sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+          url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+          homepage "https://brew.sh/"
+
+          app "Caffeine.app"
+        end
+      RUBY
+
+      expect do
+        described_class.upgrade_casks!(newer_cask, args:)
+      end.to change(newer_cask, :installed_version).from("1.2.3").to("1.2.4")
+    end
+  end
+
+  context "when an upgrade fails after installing artifacts" do
+    before do
+      Cask::Installer.new(Cask::CaskLoader.load(cask_path("outdated/local-caffeine"))).install
+    end
+
+    it "keeps the old cask receipt" do
+      receipt_path = local_caffeine.metadata_main_container_path/AbstractTab::FILENAME
+
+      expect(JSON.parse(receipt_path.read).dig("source", "version")).to eq("1.2.2")
+
+      allow_any_instance_of(Cask::Installer).to receive(:finalize_upgrade)
+        .and_raise(Cask::CaskError, "finalize failed")
+
+      expect do
+        described_class.upgrade_casks!(local_caffeine, args:)
+      end.to raise_error(Cask::CaskError)
+
+      expect(JSON.parse(receipt_path.read).dig("source", "version")).to eq("1.2.2")
+    end
+  end
+
   context "when an upgrade failed" do
     # These tests perform actual upgrades and test rollback behavior,
     # so they need full real installations.


### PR DESCRIPTION
- JSON cask metadata no longer carries installed artifacts.
- Successful upgrades need a fresh receipt so later upgrades can remove the app artifacts they previously installed.
- Forced upgrades should repair installs whose old receipt is already missing instead of leaving the next upgrade broken.

Fixes #22993.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
