### PR TITLE
cask/upgrade: make the post-install quarantine release actually run

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -294,7 +294,12 @@ module Cask
       signer_changed = approved.any? do |artifact, index|
         old_identity = old_signing_identities[artifact.target.to_s]
         new_identity = Quarantine.signing_identity(new_app_artifacts.fetch(index).target)
-        signing_identity_changed?(old_identity, new_identity)
+        [
+          [old_identity&.identifier, new_identity&.identifier],
+          [old_identity&.team_identifier, new_identity&.team_identifier],
+        ].any? do |old_value, new_value|
+          !old_value.nil? && !new_value.nil? && old_value != new_value
+        end
       end
 
       return :signer_changed if signer_changed
@@ -304,22 +309,6 @@ module Cask
     rescue
       :skip
     end
-
-    sig {
-      params(
-        old_identity: T.nilable(Quarantine::SigningIdentity),
-        new_identity: T.nilable(Quarantine::SigningIdentity),
-      ).returns(T::Boolean)
-    }
-    def self.signing_identity_changed?(old_identity, new_identity)
-      [
-        [old_identity&.identifier, new_identity&.identifier],
-        [old_identity&.team_identifier, new_identity&.team_identifier],
-      ].any? do |old_value, new_value|
-        !old_value.nil? && !new_value.nil? && old_value != new_value
-      end
-    end
-    private_class_method :signing_identity_changed?
 
     sig { params(old_cask: Cask, new_cask: Cask).void }
     def self.reopen_apps_after_upgrade(old_cask, new_cask)
@@ -447,8 +436,8 @@ module Cask
           when :signer_changed
             opoo "#{new_cask.token}'s signer changed so macOS will prompt at next launch."
           when :unapproved
-            message = "Not releasing #{new_cask.token} from quarantine: the previous version wasn't " \
-                      "approved, so macOS may prompt before it opens the first time."
+            message = "#{new_cask.token} wasn't quarantine approved so not approving now. " \
+                      "macOS will prompt at next launch."
             if verbose
               ohai message
             else

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -445,8 +445,7 @@ module Cask
               Quarantine.release!(download_path: artifact.target)
             end
           when :signer_changed
-            opoo "#{new_cask.token}'s signer changed since you approved it, so macOS will prompt at " \
-                 "next launch. Upgrades open silently while the signer is unchanged."
+            opoo "#{new_cask.token}'s signer changed so macOS will prompt at next launch."
           when :unapproved
             message = "Not releasing #{new_cask.token} from quarantine: the previous version wasn't " \
                       "approved, so macOS may prompt before it opens the first time."

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -144,8 +144,6 @@ module Cask
       summary_deprecated: nil,
       summary_disabled: nil
     )
-      quarantine = true if quarantine.nil?
-
       outdated_casks =
         self.outdated_casks(casks, args:, greedy:, greedy_latest:, greedy_auto_updates:, force:, quiet:,
                                    summary_pinned:, summary_disabled:)
@@ -282,29 +280,46 @@ module Cask
         new_cask:               Cask,
         old_signing_identities: T::Hash[String, T.nilable(Quarantine::SigningIdentity)],
         old_user_approved:      T::Hash[String, T::Boolean],
-      ).returns(T::Boolean)
+      ).returns(Symbol)
     }
-    def self.release_app_upgrade_quarantine?(old_cask, new_cask, old_signing_identities, old_user_approved)
+    def self.quarantine_release_decision(old_cask, new_cask, old_signing_identities, old_user_approved)
       old_app_artifacts = old_cask.artifacts.grep(Artifact::App)
       new_app_artifacts = new_cask.artifacts.grep(Artifact::App)
-      return false if old_app_artifacts.empty? || old_app_artifacts.length != new_app_artifacts.length
+      return :skip if old_app_artifacts.empty? || old_app_artifacts.length != new_app_artifacts.length
 
-      old_app_artifacts.each_with_index.all? do |artifact, index|
-        next false unless old_user_approved.fetch(artifact.target.to_s, false)
+      approved = old_app_artifacts.each_with_index.select do |artifact, _index|
+        old_user_approved.fetch(artifact.target.to_s, false)
+      end
 
+      signer_changed = approved.any? do |artifact, index|
         old_identity = old_signing_identities[artifact.target.to_s]
         new_identity = Quarantine.signing_identity(new_app_artifacts.fetch(index).target)
-
-        [
-          [old_identity&.identifier, new_identity&.identifier],
-          [old_identity&.team_identifier, new_identity&.team_identifier],
-        ].none? do |old_value, new_value|
-          !old_value.nil? && !new_value.nil? && old_value != new_value
-        end
+        signing_identity_changed?(old_identity, new_identity)
       end
+
+      return :signer_changed if signer_changed
+      return :unapproved if approved.length != old_app_artifacts.length
+
+      :release
     rescue
-      false
+      :skip
     end
+
+    sig {
+      params(
+        old_identity: T.nilable(Quarantine::SigningIdentity),
+        new_identity: T.nilable(Quarantine::SigningIdentity),
+      ).returns(T::Boolean)
+    }
+    def self.signing_identity_changed?(old_identity, new_identity)
+      [
+        [old_identity&.identifier, new_identity&.identifier],
+        [old_identity&.team_identifier, new_identity&.team_identifier],
+      ].any? do |old_value, new_value|
+        !old_value.nil? && !new_value.nil? && old_value != new_value
+      end
+    end
+    private_class_method :signing_identity_changed?
 
     sig { params(old_cask: Cask, new_cask: Cask).void }
     def self.reopen_apps_after_upgrade(old_cask, new_cask)
@@ -423,11 +438,23 @@ module Cask
         new_cask_installer.install_artifacts(predecessor: old_cask)
         new_artifacts_installed = true
 
-        if quarantine.nil? &&
-           Quarantine.available? &&
-           release_app_upgrade_quarantine?(old_cask, new_cask, old_signing_identities, old_user_approved)
-          new_cask.artifacts.grep(Artifact::App).each do |artifact|
-            Quarantine.release!(download_path: artifact.target)
+        if quarantine.nil? && Quarantine.available?
+          case quarantine_release_decision(old_cask, new_cask, old_signing_identities, old_user_approved)
+          when :release
+            new_cask.artifacts.grep(Artifact::App).each do |artifact|
+              Quarantine.release!(download_path: artifact.target)
+            end
+          when :signer_changed
+            opoo "#{new_cask.token}'s signer changed since you approved it, so macOS will prompt at " \
+                 "next launch. Upgrades open silently while the signer is unchanged."
+          when :unapproved
+            message = "Not releasing #{new_cask.token} from quarantine: the previous version wasn't " \
+                      "approved, so macOS may prompt before it opens the first time."
+            if verbose
+              ohai message
+            else
+              odebug message
+            end
           end
         end
 

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -491,60 +491,60 @@ RSpec.describe Cask::Upgrade, :cask do
     it "releases quarantine when Gatekeeper was already approved and identity matches" do
       allow(Cask::Quarantine).to receive(:signing_identity).with(auto_updates_path).and_return(auto_updates_identity)
 
-      expect(described_class.release_app_upgrade_quarantine?(
+      expect(described_class.quarantine_release_decision(
                outdated_auto_updates,
                auto_updates,
                { auto_updates_path.to_s => auto_updates_identity },
                { auto_updates_path.to_s => true },
-             )).to be(true)
+             )).to eq(:release)
     end
 
-    it "still keeps quarantine when the Team ID changes" do
+    it "reports a changed signer when the Team ID changes" do
       allow(Cask::Quarantine).to receive(:signing_identity).with(auto_updates_path)
                                                            .and_return(auto_updates_changed_team_identity)
 
-      expect(described_class.release_app_upgrade_quarantine?(
+      expect(described_class.quarantine_release_decision(
                outdated_auto_updates,
                auto_updates,
                { auto_updates_path.to_s => auto_updates_identity },
                { auto_updates_path.to_s => true },
-             )).to be(false)
+             )).to eq(:signer_changed)
     end
 
-    it "still keeps quarantine when the signed identifier changes" do
+    it "reports a changed signer when the signed identifier changes" do
       allow(Cask::Quarantine).to receive(:signing_identity).with(auto_updates_path)
                                                            .and_return(auto_updates_changed_identifier_identity)
 
-      expect(described_class.release_app_upgrade_quarantine?(
+      expect(described_class.quarantine_release_decision(
                outdated_auto_updates,
                auto_updates,
                { auto_updates_path.to_s => auto_updates_identity },
                { auto_updates_path.to_s => true },
-             )).to be(false)
+             )).to eq(:signer_changed)
     end
 
     it "releases quarantine when signed fields are unset before or after the upgrade" do
       allow(Cask::Quarantine).to receive(:signing_identity).with(auto_updates_path)
                                                            .and_return(auto_updates_identity)
 
-      expect(described_class.release_app_upgrade_quarantine?(
+      expect(described_class.quarantine_release_decision(
                outdated_auto_updates,
                auto_updates,
                { auto_updates_path.to_s => Cask::Quarantine::SigningIdentity.new(identifier:      nil,
                                                                                  team_identifier: nil) },
                { auto_updates_path.to_s => true },
-             )).to be(true)
+             )).to eq(:release)
     end
 
-    it "still keeps quarantine when Gatekeeper was not approved" do
+    it "reports missing approval when Gatekeeper was not approved" do
       allow(Cask::Quarantine).to receive(:signing_identity).with(auto_updates_path).and_return(auto_updates_identity)
 
-      expect(described_class.release_app_upgrade_quarantine?(
+      expect(described_class.quarantine_release_decision(
                outdated_auto_updates,
                auto_updates,
                { auto_updates_path.to_s => auto_updates_identity },
                { auto_updates_path.to_s => false },
-             )).to be(false)
+             )).to eq(:unapproved)
     end
 
     it "releases quarantine for casks without auto_updates when Gatekeeper was already approved " \
@@ -552,24 +552,60 @@ RSpec.describe Cask::Upgrade, :cask do
       allow(Cask::Quarantine).to receive(:signing_identity).with(local_caffeine_path)
                                                            .and_return(local_caffeine_identity)
 
-      expect(described_class.release_app_upgrade_quarantine?(
+      expect(described_class.quarantine_release_decision(
                outdated_local_caffeine,
                local_caffeine,
                { local_caffeine_path.to_s => local_caffeine_identity },
                { local_caffeine_path.to_s => true },
-             )).to be(true)
+             )).to eq(:release)
     end
 
-    it "still keeps quarantine for casks without auto_updates when Gatekeeper was not approved" do
+    it "reports missing approval for casks without auto_updates when Gatekeeper was not approved" do
       allow(Cask::Quarantine).to receive(:signing_identity).with(local_caffeine_path)
                                                            .and_return(local_caffeine_identity)
 
-      expect(described_class.release_app_upgrade_quarantine?(
+      expect(described_class.quarantine_release_decision(
                outdated_local_caffeine,
                local_caffeine,
                { local_caffeine_path.to_s => local_caffeine_identity },
                { local_caffeine_path.to_s => false },
-             )).to be(false)
+             )).to eq(:unapproved)
+    end
+  end
+
+  context "when an upgrade decides on quarantine after install" do
+    before do
+      Cask::Installer.new(Cask::CaskLoader.load(cask_path("outdated/local-caffeine"))).install
+      allow(Cask::Quarantine).to receive_messages(available?: true, signing_identity: nil)
+    end
+
+    it "releases the app from quarantine when the previous version was already approved" do
+      allow(Cask::Quarantine).to receive(:user_approved?).and_return(true)
+
+      expect(Cask::Quarantine).to receive(:release!).with(download_path: local_caffeine_path)
+
+      described_class.upgrade_casks!(local_caffeine, args:)
+    end
+
+    it "reports the skipped quarantine release under --verbose when approval is missing" do
+      allow(Cask::Quarantine).to receive_messages(user_approved?: false, release!: nil)
+
+      expect do
+        described_class.upgrade_casks!(local_caffeine, verbose: true, args:)
+      end.to output(/Not releasing local-caffeine from quarantine/).to_stdout
+    end
+
+    it "reports a changed signer by default so the returning Gatekeeper prompt is explained" do
+      old_identity = Cask::Quarantine::SigningIdentity.new(identifier:      "sh.brew.local-caffeine",
+                                                           team_identifier: "ABCDE12345")
+      new_identity = Cask::Quarantine::SigningIdentity.new(identifier:      "sh.brew.local-caffeine",
+                                                           team_identifier: "VWXYZ98765")
+      allow(Cask::Quarantine).to receive_messages(user_approved?: true, release!: nil)
+      allow(Cask::Quarantine).to receive(:signing_identity).and_return(old_identity, new_identity)
+
+      expect do
+        described_class.upgrade_casks!(local_caffeine, args:)
+      end.to output(/local-caffeine's signer changed since you approved it/).to_stderr
     end
   end
 

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -592,7 +592,7 @@ RSpec.describe Cask::Upgrade, :cask do
 
       expect do
         described_class.upgrade_casks!(local_caffeine, verbose: true, args:)
-      end.to output(/Not releasing local-caffeine from quarantine/).to_stdout
+      end.to output(/local-caffeine wasn't quarantine approved/).to_stdout
     end
 
     it "reports a changed signer by default so the returning Gatekeeper prompt is explained" do
@@ -605,7 +605,7 @@ RSpec.describe Cask::Upgrade, :cask do
 
       expect do
         described_class.upgrade_casks!(local_caffeine, args:)
-      end.to output(/local-caffeine's signer changed since you approved it/).to_stderr
+      end.to output(/local-caffeine's signer changed so macOS will prompt/).to_stderr
     end
   end
 


### PR DESCRIPTION
-----

By design the post-install quarantine release from #22053 only runs when `quarantine` is `nil` in `upgrade_cask` — the case where the user passed neither `--quarantine` nor `--no-quarantine`. But `upgrade_cask`'s only caller, `upgrade_casks!` coerces with `quarantine = true if quarantine.nil?` before calling it, so the new release code never runs. It's currently dead code. Delete the coercion and it runs as intended.

Reporting when the release is held back is what I originally set out to add — so a fresh Gatekeeper prompt after an upgrade isn't a mystery — and wiring it up is how I hit the dead branch. A missing prior approval stays at `--verbose` (`odebug` otherwise), since a prompt there is unsurprising. A changed signer prints by default: that's the case where an app that upgraded silently for months suddenly shows Gatekeeper again, and a line in the upgrade log saying the signer changed is what lets you read the prompt as expected rather than a compromise. It's an `opoo` because it's unusual and worth spotting on scrollback, but worded to explain rather than alarm.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code found the dead branch while we were adding the signature-changed message. It wrote the fix and the specs, and drafted this before I edited it by hand. Typechecking, style and the specs pass locally; the specs fail with the coercion in place and pass without it, so they reproduce the bug directly. I reviewed the change and its reasoning. Reproducing it by hand needs a signed cask and a real first-launch approval, so I've leant on the specs rather than run that.

-----
