### PR TITLE
readall: remove todo tasks

### DIFF
--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -17,9 +17,6 @@ module Readall
   # rubocop:disable Style/MutableConstant
   Cache = type_template { { fixed: T::Hash[Symbol, T.untyped] } }
   # rubocop:enable Style/MutableConstant
-  # TODO: remove this once the `MacOS` module is undefined on Linux
-  MACOS_MODULE_REGEX = /\b(MacOS|OS::Mac)(\.|::)\b/
-  private_constant :MACOS_MODULE_REGEX
 
   private_class_method :cache
 
@@ -72,9 +69,7 @@ module Readall
                                                      flags: [], ignore_errors: false)
       readall_formula = readall_formula_class.new(formula_name, file, :stable, tap:)
       readall_formula.to_hash
-      # TODO: Remove check for MACOS_MODULE_REGEX once the `MacOS` module is undefined on Linux
-      cache[:valid_formulae][file] = if readall_formula.on_system_blocks_exist? ||
-                                        formula_contents.match?(MACOS_MODULE_REGEX)
+      cache[:valid_formulae][file] = if readall_formula.on_system_blocks_exist?
         [bottle_tag, *cache[:valid_formulae][file]]
       else
         true


### PR DESCRIPTION
I think the `MacOS` module is now undefined on Linux so finishing TODO task.

Also minor touch up to use existing `valid` variable which is either an array or nil.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
