### PR TITLE
dev-cmd/bump-formula-pr: keep failures when downgrade fails

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -777,8 +777,12 @@ module Homebrew
           is_downgraded = Version.new(current_version) > Version.new(latest_version)
 
           begin
-            update_resource_block!(formula, resource, latest_version)
-            results[resource.name] = is_downgraded ? :downgraded : :success
+            result = update_resource_block!(formula, resource, latest_version)
+            results[resource.name] = if result == :success && is_downgraded
+              :downgraded
+            else
+              result
+            end
           rescue => e
             opoo "Failed to update resource \"#{resource.name}\": #{e}"
             results[resource.name] = :fetch_failed

--- a/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
@@ -219,4 +219,39 @@ RSpec.describe Homebrew::DevCmd::BumpFormulaPr do
       expect(bump_formula_pr.send(:update_matching_version_resources!, f, version:, resource_versions:)).to eq({})
     end
   end
+
+  describe "::update_resources!" do
+    let(:f) do
+      formula("test") do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/test-1.0.0.tgz"
+
+        resource "foo" do
+          url "https://brew.sh/foo-1.2.3.tar.gz"
+        end
+      end
+    end
+    let(:r) { f.resource("foo") }
+
+    it "updates to requested version" do
+      version = "2.1.0"
+      resource_versions = { "foo" => { current_version: "1.2.3", latest_version: version } }
+      expect(bump_formula_pr).to receive(:update_resource_block!).with(f, r, version).and_return(:success)
+      expect(bump_formula_pr.send(:update_resources!, f, resource_versions:)).to eq({ "foo" => :success })
+    end
+
+    it "downgrades to requested version" do
+      version = "0.1.2"
+      resource_versions = { "foo" => { current_version: "1.2.3", latest_version: version } }
+      expect(bump_formula_pr).to receive(:update_resource_block!).with(f, r, version).and_return(:success)
+      expect(bump_formula_pr.send(:update_resources!, f, resource_versions:)).to eq({ "foo" => :downgraded })
+    end
+
+    it "returns update failures" do
+      version = "0.1.2"
+      resource_versions = { "foo" => { current_version: "1.2.3", latest_version: version } }
+      expect(bump_formula_pr).to receive(:update_resource_block!).with(f, r, version).and_return(:url_unchanged)
+      expect(bump_formula_pr.send(:update_resources!, f, resource_versions:)).to eq({ "foo" => :url_unchanged })
+    end
+  end
 end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Previously, the `:url_unchanged` failure would get replaced by a successful result and not get reported in bump message which can lead to merging PR without resource updates.

This helps avoid missing revision bumps when not yet supported, e.g. git checkouts like:
- https://github.com/Homebrew/homebrew-core/pull/291736