### PR TITLE
version/parser: speed up StemParser

### DIFF
--- a/Library/Homebrew/test/version/parser_spec.rb
+++ b/Library/Homebrew/test/version/parser_spec.rb
@@ -46,19 +46,11 @@ RSpec.describe Version::Parser do
   end
 
   describe Version::StemParser do
-    before { Pathname("#{TEST_TMPDIR}/testdir-0.1.test").mkpath }
-
-    after { Pathname("#{TEST_TMPDIR}/testdir-0.1.test").unlink }
-
     specify "::new" do
       expect { described_class.new(/[._-](\d+(?:\.\d+)+)/) }.not_to raise_error
     end
 
     describe "::process_spec" do
-      it "works with directories" do
-        expect(described_class.process_spec(Pathname("#{TEST_TMPDIR}/testdir-0.1.test"))).to eq("testdir-0.1.test")
-      end
-
       it "works with SourceForge URLs with /download suffix" do
         expect(described_class.process_spec(Pathname("https://sourceforge.net/foo_bar-1.21.tar.gz/download")))
           .to eq("foo_bar-1.21")

--- a/Library/Homebrew/version/parser.rb
+++ b/Library/Homebrew/version/parser.rb
@@ -52,8 +52,6 @@ class Version
 
     sig { override.params(spec: Pathname).returns(String) }
     def self.process_spec(spec)
-      return spec.basename.to_s if spec.directory?
-
       spec_s = spec.to_s
       return spec.dirname.stem if spec_s.match?(SOURCEFORGE_DOWNLOAD_REGEX)
       return spec.basename.to_s if spec_s.match?(NO_FILE_EXTENSION_REGEX)


### PR DESCRIPTION
An I/O operation in a version parser is pretty unusual and, unsurprisingly, does show up in flame graphs when doing a lot of version parsing (though the I/O operation itself isn't too expensive).

The check was added in https://github.com/Homebrew/brew/commit/355bfc1751a53f35689ea42b40a4211a4f42b641 but seems obsolete to me after `extname` was adjusted in https://github.com/Homebrew/brew/commit/8b5fa6824b509ed11454b02026c49f821d742b10. It seems to have additionally also be handled with https://github.com/Homebrew/brew/commit/a5a1b2969fa6a515495b11f746f43ec005ed671b.

There was a unit test added in https://github.com/Homebrew/brew/commit/a06bd4e45df2a98a05e6752d7a662807176b3a77 that did test the behaviour I am removing but it seems to be very focussed on what `StemParser` previously did internally rather than what it was intended to do to the broader version parsing system. Indeed the version number actually returned from `Version.parse` on that test sample remains the same even with the special `StemParser` logic removed.

Removing the directory check should also avoid the scenario where version parsing behaved differently if you happen to have a directory in your PWD that matches the input to the parser.

For this change I did the following:

```bash
export HOMEBREW_NO_INSTALL_FROM_API=1

brew info --json=v2 --formulae | jq '.formulae[] | "\(.name) \(.versions.stable) \(.versions.head)"'
brew info --json=v2 --casks | jq '.casks[] | "\(.token) \(.version)"'
```

and did not find any changes between the outputs with and without this change.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
