### PR TITLE
Guard release against stale main

### DIFF
--- a/Library/Homebrew/dev-cmd/release.rb
+++ b/Library/Homebrew/dev-cmd/release.rb
@@ -135,6 +135,15 @@ module Homebrew
 
         # Get the current commit SHA
         current_sha = Utils.safe_popen_read("git", "-C", HOMEBREW_REPOSITORY, "rev-parse", "origin/main").strip
+        upstream_sha = begin
+          GitHub::API.commit("Homebrew", "brew")["sha"].to_s
+        rescue *GitHub::API::ERRORS => e
+          odie "Unable to check upstream Homebrew/brew main: #{e.message}!"
+        end
+        if current_sha != upstream_sha
+          odie "Local Homebrew/brew `origin/main` is not up-to-date with upstream `main`. " \
+               "Run `brew update` before `brew release --force`."
+        end
         release_workflow = "release.yml"
 
         dispatch_time = Time.now

--- a/Library/Homebrew/test/dev-cmd/release_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/release_spec.rb
@@ -7,6 +7,32 @@ require "dev-cmd/release"
 RSpec.describe Homebrew::DevCmd::Release do
   it_behaves_like "parseable arguments"
 
+  describe "#run" do
+    it "requires an up-to-date origin/main before triggering the release workflow" do
+      command = described_class.new(["--force"])
+
+      allow(Homebrew::EnvConfig).to receive(:no_auto_update?).and_return(false)
+      allow(GitHub).to receive_messages(
+        get_latest_release:     { "tag_name" => "1.2.3" },
+        generate_release_notes: { "body" => "Release notes" },
+      )
+      allow(Utils).to receive(:safe_popen_read).with(
+        "git", "-C", HOMEBREW_REPOSITORY, "rev-parse", "origin/main"
+      ).and_return("local-sha\n")
+      allow(GitHub::API).to receive(:open_rest).with(
+        "#{GitHub::API_URL}/repos/Homebrew/brew/releases?per_page=#{GitHub::MAX_PER_PAGE}",
+        request_method: :GET,
+        scopes:         GitHub::CREATE_ISSUE_FORK_OR_PR_SCOPES,
+      ).and_return([])
+      expect(GitHub::API).to receive(:commit).with("Homebrew", "brew").and_return({ "sha" => "upstream-sha" })
+      expect(GitHub).not_to receive(:workflow_dispatch_event)
+
+      expect { command.run }
+        .to raise_error(SystemExit)
+        .and output(/Run `brew update` before `brew release --force`\./).to_stderr
+    end
+  end
+
   describe "release lookup helpers" do
     let(:command) { described_class.new([]) }
     let(:releases) do

--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -4,6 +4,30 @@
 require "utils/github"
 
 RSpec.describe GitHub do
+  describe "::API.commit" do
+    it "fetches the main branch commit by default" do
+      commit = { "sha" => "abc123" }
+
+      expect(GitHub::API).to receive(:open_rest).with(
+        "https://api.github.com/repos/Homebrew/brew/commits/main",
+        request_method: :GET,
+      ).and_return(commit)
+
+      expect(GitHub::API.commit("Homebrew", "brew")).to eq(commit)
+    end
+
+    it "fetches a commit for a branch ref with path separators" do
+      commit = { "sha" => "def456" }
+
+      expect(GitHub::API).to receive(:open_rest).with(
+        "https://api.github.com/repos/Homebrew/brew/commits/feature%2Ffoo",
+        request_method: :GET,
+      ).and_return(commit)
+
+      expect(GitHub::API.commit("Homebrew", "brew", branch: "feature/foo")).to eq(commit)
+    end
+  end
+
   describe "::search_query_string" do
     it "builds a query with the given hash parameters formatted as key:value" do
       query = described_class.search_query_string(user: "Homebrew", repo: "brew")

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "system_command"
+require "uri"
 require "utils/output"
 require "utils/path"
 
@@ -343,6 +344,11 @@ module GitHub
       rescue JSON::ParserError => e
         raise Error, "Failed to parse JSON response\n#{e.message}", e.backtrace
       end
+    end
+
+    sig { params(user: String, repo: String, branch: String).returns(T::Hash[String, T.untyped]) }
+    def self.commit(user, repo, branch: "main")
+      open_rest("#{API_URL}/repos/#{user}/#{repo}/commits/#{URI.encode_uri_component(branch)}", request_method: :GET)
     end
 
     T::Sig::WithoutRuntime.sig {


### PR DESCRIPTION
- Prevent `brew release --force` from dispatching `release.yml` when local `origin/main` does not match GitHub's current `main` commit.
- Add `GitHub::API.commit` so commit endpoint lookups go through a shared helper with a default `main` branch.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
