### PR TITLE
Send bundle check failures to stderr

### DIFF
--- a/Library/Homebrew/bundle/subcommand/check.rb
+++ b/Library/Homebrew/bundle/subcommand/check.rb
@@ -42,7 +42,7 @@ module Homebrew
                                       .split
 
           if check_result.work_to_be_done
-            puts "brew bundle can't satisfy your Brewfile's dependencies." if check_missing_formulae.blank?
+            $stderr.puts "brew bundle can't satisfy your Brewfile's dependencies." if check_missing_formulae.blank?
 
             if output_errors
               check_result.errors.each do |error|
@@ -51,13 +51,13 @@ module Homebrew
                   next
                 end
 
-                puts "→ #{error}"
+                $stderr.puts "→ #{error}"
               end
             else
-              puts "Run `brew bundle check --verbose` to list unmet dependencies."
+              $stderr.puts "Run `brew bundle check --verbose` to list unmet dependencies."
             end
 
-            puts "Satisfy missing dependencies with `brew bundle install`."
+            $stderr.puts "Satisfy missing dependencies with `brew bundle install`."
             exit 1
           end
 

--- a/Library/Homebrew/test/cmd/bundle/check_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/check_subcommand_spec.rb
@@ -56,12 +56,13 @@ RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
   context "when formulae are not installed" do
     let(:verbose) { true }
 
-    it "raises an error and outputs to stdout" do
+    it "raises an error and outputs to stderr" do
       allow(Homebrew::Bundle::Cask).to receive(:casks).and_return([])
       allow(Homebrew::Bundle::Brew).to receive(:upgradable_formulae).and_return([])
       allow_any_instance_of(Pathname).to receive(:read).and_return("brew 'abc'")
       expect { do_check }.to raise_error(SystemExit).and \
-        output(/brew bundle can't satisfy your Brewfile's dependencies/).to_stdout
+        output(/brew bundle can't satisfy your Brewfile's dependencies/).to_stderr.and \
+          not_to_output(/brew bundle can't satisfy your Brewfile's dependencies/).to_stdout
     end
 
     it "partially outputs when HOMEBREW_BUNDLE_CHECK_ALREADY_OUTPUT_FORMULAE_ERRORS is set" do
@@ -70,7 +71,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
       allow_any_instance_of(Pathname).to receive(:read).and_return("brew 'abc'")
       ENV["HOMEBREW_BUNDLE_CHECK_ALREADY_OUTPUT_FORMULAE_ERRORS"] = "abc"
       expect { do_check }.to raise_error(SystemExit).and \
-        output("Satisfy missing dependencies with `brew bundle install`.\n").to_stdout
+        output("Satisfy missing dependencies with `brew bundle install`.\n").to_stderr
     end
 
     it "does not raise error on skippable formula" do
@@ -97,7 +98,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
       allow(Formula["abc"]).to receive_messages(linked?: false, keg_only?: false)
 
       expect { do_check }.to raise_error(SystemExit).and \
-        output(/Run `brew bundle check --verbose` to list unmet dependencies\./).to_stdout
+        output(/Run `brew bundle check --verbose` to list unmet dependencies\./).to_stderr
     end
 
     it "raises an error for an implicitly unlinked non-keg-only formula" do
@@ -106,7 +107,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
       allow(Formula["abc"]).to receive(:linked?).and_return(false)
 
       expect { do_check }.to raise_error(SystemExit).and \
-        output(/Run `brew bundle check --verbose` to list unmet dependencies\./).to_stdout
+        output(/Run `brew bundle check --verbose` to list unmet dependencies\./).to_stderr
     end
 
     it "does not raise an error when live link status satisfies an implicit check" do
@@ -125,7 +126,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
         allow(Formula["abc"]).to receive_messages(linked?: true, keg_only?: false)
 
         expect { do_check }.to raise_error(SystemExit).and \
-          output(/Formula abc needs to be unlinked\./).to_stdout
+          output(/Formula abc needs to be unlinked\./).to_stderr
       end
 
       it "outputs the implicit link status error" do
@@ -134,7 +135,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
         allow(Formula["abc"]).to receive(:linked?).and_return(true)
 
         expect { do_check }.to raise_error(SystemExit).and \
-          output(/Formula abc needs to be unlinked\./).to_stdout
+          output(/Formula abc needs to be unlinked\./).to_stderr
       end
     end
 
@@ -149,7 +150,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
 
         expect { Homebrew::Cmd::Bundle.dispatch(args, extensions: Homebrew::Bundle.extensions) }
           .to raise_error(SystemExit).and \
-            output(/Run `brew bundle check --verbose` to list unmet dependencies\./).to_stdout
+            output(/Run `brew bundle check --verbose` to list unmet dependencies\./).to_stderr
       end
     end
   end
@@ -210,7 +211,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
           .to receive(:read).and_return("brew 'abc', restart_service: true\nbrew 'def', restart_service: true")
         allow_any_instance_of(Homebrew::Bundle::MacAppStore)
           .to receive(:format_checkable).and_return(1 => "foo")
-        expect { do_check }.to raise_error(SystemExit).and output(expected_output).to_stdout
+        expect { do_check }.to raise_error(SystemExit).and output(expected_output).to_stderr
       end
     end
 
@@ -220,7 +221,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
           .to receive(:read).and_return("brew 'abc', start_service: true\nbrew 'def', start_service: true")
         allow_any_instance_of(Homebrew::Bundle::MacAppStore)
           .to receive(:format_checkable).and_return(1 => "foo")
-        expect { do_check }.to raise_error(SystemExit).and output(expected_output).to_stdout
+        expect { do_check }.to raise_error(SystemExit).and output(expected_output).to_stderr
       end
     end
   end
@@ -247,7 +248,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
       allow_any_instance_of(Pathname).to receive(:read).and_return("brew 'abc'")
       allow_any_instance_of(Homebrew::Bundle::MacAppStore).to \
         receive(:format_checkable).and_return(1 => "foo")
-      expect { do_check }.to raise_error(SystemExit).and output(expected_output).to_stdout
+      expect { do_check }.to raise_error(SystemExit).and output(expected_output).to_stderr
     end
   end
 
@@ -269,7 +270,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
 
     it "raises an error that doesn't mention upgrade" do
       allow_any_instance_of(Pathname).to receive(:read).and_return("vscode 'foo'")
-      expect { do_check }.to raise_error(SystemExit).and output(expected_output).to_stdout
+      expect { do_check }.to raise_error(SystemExit).and output(expected_output).to_stderr
     end
   end
 


### PR DESCRIPTION
- Keeps `brew bundle env --check` output usable for shell capture.
- Treats unmet dependency reports as diagnostics instead of data.
- Covers the failure stream contract in `check_subcommand_spec`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
