### PR TITLE
Skip incompatible cask upgrades

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -119,6 +119,7 @@ module Cask
         summary_pinned:       T.nilable(T::Array[String]),
         summary_deprecated:   T.nilable(T::Array[String]),
         summary_disabled:     T.nilable(T::Array[String]),
+        prefetched_errors:    T.nilable(T::Array[StandardError]),
       ).returns(T::Boolean)
     }
     def self.upgrade_casks!(
@@ -142,7 +143,8 @@ module Cask
       summary_upgrades: nil,
       summary_pinned: nil,
       summary_deprecated: nil,
-      summary_disabled: nil
+      summary_disabled: nil,
+      prefetched_errors: nil
     )
       outdated_casks =
         self.outdated_casks(casks, args:, greedy:, greedy_latest:, greedy_auto_updates:, force:, quiet:,
@@ -208,13 +210,8 @@ module Cask
 
       return false if upgradable_casks.empty?
 
-      cask_upgrades = upgradable_casks.map do |(old_cask, new_cask)|
-        "#{new_cask.full_name} #{old_cask.version} -> #{new_cask.version}"
-      end
-      summary_upgrades&.concat(cask_upgrades) if dry_run
-      summary_deprecated&.concat(upgradable_casks.filter_map do |(_, new_cask)|
-        new_cask.full_name if new_cask.deprecated?
-      end)
+      caught_exceptions = []
+      caught_exceptions.concat(prefetched_errors) if prefetched_errors
 
       created_download_queue = T.let(false, T::Boolean)
       download_queue ||= if !dry_run && !skip_prefetch
@@ -225,31 +222,51 @@ module Cask
       if !dry_run && !skip_prefetch
         prefetch_download_queue = download_queue || Homebrew.default_download_queue
         begin
-          fetchable_casks = upgradable_casks.map(&:last)
-          fetchable_cask_installers = fetchable_casks.map do |cask|
+          fetchable_cask_installers = []
+          upgradable_casks.select! do |(_, cask)|
             # This is significantly easier given the weird difference in Sorbet signatures here.
             # rubocop:disable Style/DoubleNegation
-            Installer.new(cask, binaries: !!binaries, verbose: !!verbose, force: !!force,
-                                    skip_cask_deps: !!skip_cask_deps, require_sha: !!require_sha,
-                                    upgrade: true, quarantine: quarantine != false,
-                                    download_queue: prefetch_download_queue, defer_fetch: true)
+            installer = Installer.new(cask, binaries: !!binaries, verbose: !!verbose, force: !!force,
+                                             skip_cask_deps: !!skip_cask_deps, require_sha: !!require_sha,
+                                             upgrade: true, quarantine: quarantine != false,
+                                             download_queue: prefetch_download_queue, defer_fetch: true)
             # rubocop:enable Style/DoubleNegation
+            begin
+              installer.check_requirements
+            rescue CaskError => e
+              caught_exceptions << e
+              next false
+            end
+
+            fetchable_cask_installers << installer
+            true
           end
 
+          fetchable_casks = upgradable_casks.map(&:last)
           fetchable_casks_sentence = fetchable_casks.map { |cask| Formatter.identifier(cask.full_name) }.to_sentence
           Homebrew::Install.enqueue_cask_installers(fetchable_cask_installers,
                                                     download_queue: prefetch_download_queue)
-          oh1 "Fetching downloads for: #{fetchable_casks_sentence}", truncate: false
-          prefetch_download_queue.fetch
+          if fetchable_casks.any?
+            oh1 "Fetching downloads for: #{fetchable_casks_sentence}", truncate: false
+            prefetch_download_queue.fetch
+          end
         ensure
           prefetch_download_queue.shutdown if created_download_queue
         end
       end
 
+      return false if upgradable_casks.empty? && caught_exceptions.empty?
+
+      cask_upgrades = upgradable_casks.map do |(old_cask, new_cask)|
+        "#{new_cask.full_name} #{old_cask.version} -> #{new_cask.version}"
+      end
+      summary_upgrades&.concat(cask_upgrades) if dry_run
+      summary_deprecated&.concat(upgradable_casks.filter_map do |(_, new_cask)|
+        new_cask.full_name if new_cask.deprecated?
+      end)
+
       show_upgrade_summary(cask_upgrades, dry_run:) if show_upgrade_summary
       return true if dry_run
-
-      caught_exceptions = []
 
       download_queue ||= Homebrew.default_download_queue
 
@@ -268,6 +285,7 @@ module Cask
       end
 
       return true if caught_exceptions.empty?
+
       raise MultipleCaskErrors, caught_exceptions if caught_exceptions.count > 1
       raise caught_exceptions.fetch(0) if caught_exceptions.one?
 

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -181,6 +181,8 @@ module Homebrew
         prefetched_formulae_upgrades = T.let([], T::Array[String])
         prefetched_cask_names = T.let([], T::Array[String])
         prefetched_cask_upgrades = T.let([], T::Array[String])
+        prefetched_cask_upgrade_casks = T.let([], T::Array[Cask::Cask])
+        prefetched_cask_errors = T.let([], T::Array[StandardError])
         @final_upgrade_summary = T.let(FinalUpgradeSummary.new, T.nilable(FinalUpgradeSummary))
         @ask_prompt_required = false
         ask = !args.no_ask? && !args.dry_run?
@@ -273,6 +275,8 @@ module Homebrew
               download_queue:         shared_download_queue,
               prefetch_names:         prefetched_cask_names,
               prefetch_upgrades:      prefetched_cask_upgrades,
+              prefetch_casks:         prefetched_cask_upgrade_casks,
+              prefetch_errors:        prefetched_cask_errors,
               show_downloads_heading: false,
             )
             unless ask
@@ -303,12 +307,22 @@ module Homebrew
           )
         end
         if !only_upgrade_formulae && !skip_upgrades_after_failed_ask_preview
-          upgrade_outdated_casks!(
-            casks,
-            skip_prefetch:        prefetched_casks,
-            show_upgrade_summary: prefetched_cask_upgrades.blank? && !args.dry_run? && !ask,
-            download_queue:       nil,
-          )
+          if prefetched_casks
+            upgrade_outdated_casks!(
+              prefetched_cask_upgrade_casks,
+              skip_prefetch:          true,
+              show_upgrade_summary:   prefetched_cask_upgrades.blank? && !args.dry_run? && !ask,
+              download_queue:         nil,
+              prefetched_cask_errors: prefetched_cask_errors,
+            )
+          else
+            upgrade_outdated_casks!(
+              casks,
+              skip_prefetch:        false,
+              show_upgrade_summary: prefetched_cask_upgrades.blank? && !args.dry_run? && !ask,
+              download_queue:       nil,
+            )
+          end
         end
 
         unavailable_errors.each { |e| ofail e }
@@ -754,11 +768,13 @@ module Homebrew
         params(casks: T::Array[Cask::Cask], download_queue: Homebrew::DownloadQueue,
                prefetch_names: T.nilable(T::Array[String]),
                prefetch_upgrades: T.nilable(T::Array[String]),
+               prefetch_casks: T.nilable(T::Array[Cask::Cask]),
+               prefetch_errors: T.nilable(T::Array[StandardError]),
                show_downloads_heading: T::Boolean)
           .returns(T::Boolean)
       }
       def prefetch_outdated_casks!(casks, download_queue:, prefetch_names: nil,
-                                   prefetch_upgrades: nil,
+                                   prefetch_upgrades: nil, prefetch_casks: nil, prefetch_errors: nil,
                                    show_downloads_heading: true)
         return false if args.formula?
 
@@ -785,8 +801,9 @@ module Homebrew
         return false if outdated_casks.empty?
 
         require "cask/installer"
-        fetchable_cask_installers = outdated_casks.map do |cask|
-          Cask::Installer.new(
+        fetchable_cask_installers = []
+        outdated_casks.select! do |cask|
+          installer = Cask::Installer.new(
             cask,
             binaries:       args.binaries?,
             verbose:        args.verbose?,
@@ -797,7 +814,19 @@ module Homebrew
             download_queue:,
             defer_fetch:    true,
           )
+          begin
+            installer.check_requirements
+          rescue Cask::CaskError => e
+            prefetch_errors&.push(e)
+            next false
+          end
+
+          fetchable_cask_installers << installer
+          true
         end
+        prefetch_casks&.replace(outdated_casks)
+        return prefetch_errors.present? if outdated_casks.empty?
+
         cask_names = outdated_casks.map(&:full_name)
         Install.enqueue_cask_installers(fetchable_cask_installers, download_queue:)
         prefetch_names&.replace(cask_names)
@@ -815,17 +844,24 @@ module Homebrew
       sig {
         params(casks: T::Array[Cask::Cask], skip_prefetch: T::Boolean, show_upgrade_summary: T::Boolean,
                dry_run: T::Boolean,
-               download_queue: T.nilable(Homebrew::DownloadQueue))
+               download_queue: T.nilable(Homebrew::DownloadQueue),
+               prefetched_cask_errors: T.nilable(T::Array[StandardError]))
           .returns(T::Boolean)
       }
       def upgrade_outdated_casks!(casks, skip_prefetch: false, show_upgrade_summary: true,
                                   dry_run: args.dry_run?,
-                                  download_queue: nil)
+                                  download_queue: nil, prefetched_cask_errors: nil)
         return false if args.formula?
 
         quiet = args.quiet? || (dry_run && !args.dry_run?)
         casks = minimum_version_casks(casks, quiet:)
         return false if minimum_version.present? && casks.empty?
+
+        if skip_prefetch && casks.empty? && prefetched_cask_errors.present?
+          raise Cask::MultipleCaskErrors, prefetched_cask_errors if prefetched_cask_errors.count > 1
+
+          raise prefetched_cask_errors.fetch(0)
+        end
 
         Cask::Upgrade.upgrade_casks!(
           *casks,
@@ -847,6 +883,7 @@ module Homebrew
           summary_pinned:       final_upgrade_summary.pinned_casks,
           summary_deprecated:   final_upgrade_summary.deprecated,
           summary_disabled:     final_upgrade_summary.disabled,
+          prefetched_errors:    prefetched_cask_errors,
           args:,
         )
       rescue => e

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -476,7 +476,8 @@ RSpec.describe Cask::Upgrade, :cask do
     end
 
     it 'prefetches "auto_updates true" casks with quarantine until signed identity is checked' do
-      installer = instance_double(Cask::Installer, enqueue_downloads: nil, source_download_requires_pre_fetch?: false)
+      installer = instance_double(Cask::Installer, check_requirements: nil, enqueue_downloads: nil,
+                                                   source_download_requires_pre_fetch?: false)
 
       expect(Cask::Installer).to receive(:new) do |cask, **options|
         expect(cask).to eq(auto_updates)
@@ -834,6 +835,75 @@ RSpec.describe Cask::Upgrade, :cask do
       expect(bad_checksum_2_path).to be_a_file
       expect(bad_checksum_2.installed_version).to eq "1.2.2"
       expect(bad_checksum_2.staged_path).not_to exist
+    end
+  end
+
+  context "when an outdated cask is incompatible" do
+    before do
+      [
+        "outdated/local-caffeine",
+        "outdated/local-transmission-zip",
+      ].each do |cask|
+        InstallHelper.stub_cask_installation(Cask::CaskLoader.load(cask_path(cask)))
+      end
+    end
+
+    it "continues upgrading compatible casks" do
+      summary_upgrades = []
+      upgraded_tokens = []
+      incompatible_installer = instance_double(Cask::Installer, source_download_requires_pre_fetch?: false)
+      compatible_installer = instance_double(Cask::Installer, source_download_requires_pre_fetch?: false)
+
+      allow(incompatible_installer).to receive(:check_requirements)
+        .and_raise(Cask::CaskError, "local-caffeine: This cask does not run on macOS versions older than Tahoe.")
+      allow(compatible_installer).to receive_messages(check_requirements: nil, enqueue_downloads: nil)
+      allow(Cask::Installer).to receive(:new) do |cask, **|
+        (cask.token == "local-caffeine") ? incompatible_installer : compatible_installer
+      end
+      allow(described_class).to receive(:upgrade_cask) do |_, new_cask, **|
+        upgraded_tokens << new_cask.token
+      end
+
+      expect do
+        described_class.upgrade_casks!(
+          local_caffeine, local_transmission,
+          show_upgrade_summary: false,
+          summary_upgrades:,
+          args:
+        )
+      end.to raise_error(
+        Cask::CaskError,
+        "local-caffeine: This cask does not run on macOS versions older than Tahoe.",
+      )
+
+      expect(upgraded_tokens).to eq(["local-transmission-zip"])
+      expect(summary_upgrades).to eq(["local-transmission-zip 2.60 -> 2.61"])
+    end
+
+    it "raises prefetched requirement errors after compatible casks" do
+      summary_upgrades = []
+      upgraded_tokens = []
+      cask_error = Cask::CaskError.new(
+        "local-caffeine: This cask does not run on macOS versions older than Tahoe.",
+      )
+
+      allow(described_class).to receive(:upgrade_cask) do |_, new_cask, **|
+        upgraded_tokens << new_cask.token
+      end
+
+      expect do
+        described_class.upgrade_casks!(
+          local_transmission,
+          skip_prefetch:        true,
+          show_upgrade_summary: false,
+          summary_upgrades:,
+          prefetched_errors:    [cask_error],
+          args:,
+        )
+      end.to raise_error(Cask::CaskError, cask_error.message)
+
+      expect(upgraded_tokens).to eq(["local-transmission-zip"])
+      expect(summary_upgrades).to eq(["local-transmission-zip 2.60 -> 2.61"])
     end
   end
 end

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -365,6 +365,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
         download_queue:,
         prefetch_names:         [],
         prefetch_upgrades:      [],
+        prefetch_casks:         [],
+        prefetch_errors:        [],
         show_downloads_heading: false,
       )
       .ordered
@@ -375,7 +377,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       .ordered
       .and_return(true)
     expect(cmd).to receive(:upgrade_outdated_casks!)
-      .with([], skip_prefetch: true, show_upgrade_summary: false, download_queue: nil)
+      .with([], skip_prefetch: true, show_upgrade_summary: false, download_queue: nil,
+                prefetched_cask_errors: [])
       .ordered
       .and_return(true)
     allow(Homebrew::Cleanup).to receive(:periodic_clean!)
@@ -632,7 +635,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       installed_version: "0.117.0",
       version:           "0.118.0",
     )
-    installer = instance_double(Cask::Installer, enqueue_downloads: nil, source_download_requires_pre_fetch?: false)
+    installer = instance_double(Cask::Installer, check_requirements: nil, enqueue_downloads: nil,
+                                                 source_download_requires_pre_fetch?: false)
 
     expect(Homebrew::DownloadQueue).to receive(:new).once.and_return(download_queue)
     allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, prefetch_only: false,
@@ -678,7 +682,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       installed_version: "0.117.0",
       version:           "0.118.0",
     )
-    installer = instance_double(Cask::Installer, enqueue_downloads: nil, source_download_requires_pre_fetch?: false)
+    installer = instance_double(Cask::Installer, check_requirements: nil, enqueue_downloads: nil,
+                                                 source_download_requires_pre_fetch?: false)
 
     allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, dry_run: false, prefetch_only: false,
                                                               use_prefetched: false, prefetch_names: nil,
@@ -717,6 +722,39 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     cmd.run
   end
 
+  it "uses prefetched compatible casks and carries requirement errors into upgrade" do
+    cmd = described_class.new(["--yes"])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, fetch_failed: false, shutdown: nil)
+    cask = instance_double(Cask::Cask)
+    cask_error = Cask::CaskError.new("bad-cask: This cask requires Linux.")
+
+    allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, prefetch_only: false, **|
+      prefetch_only
+    end
+    expect(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
+    expect(cmd).to receive(:prefetch_outdated_casks!) do |_, prefetch_upgrades:, prefetch_casks:,
+                                                            prefetch_errors:, **|
+      prefetch_upgrades.replace(["codex 0.117.0 -> 0.118.0"])
+      prefetch_casks.replace([cask])
+      prefetch_errors << cask_error
+      true
+    end
+    expect(cmd).to receive(:upgrade_outdated_casks!)
+      .with(
+        [cask],
+        skip_prefetch:          true,
+        show_upgrade_summary:   false,
+        download_queue:         nil,
+        prefetched_cask_errors: [cask_error],
+      )
+      .and_return(true)
+    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
+    allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
+    allow(Homebrew.messages).to receive(:display_messages)
+
+    cmd.run
+  end
+
   it "prefetches language cask files before fetching combined downloads" do
     cmd = described_class.new(["--yes"])
     download_queue = instance_double(Homebrew::DownloadQueue, fetch_failed: false, shutdown: nil)
@@ -729,6 +767,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     )
     installer = instance_double(
       Cask::Installer,
+      check_requirements:                  nil,
       enqueue_downloads:                   nil,
       source_download_requires_pre_fetch?: true,
     )
@@ -767,6 +806,59 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     EOS
   end
 
+  it "skips incompatible casks during combined prefetch" do
+    cmd = described_class.new(["--yes"])
+    download_queue = instance_double(Homebrew::DownloadQueue)
+    incompatible_cask = instance_double(
+      Cask::Cask,
+      artifacts:         [],
+      full_name:         "bad-cask",
+      installed_version: "1.0",
+      token:             "bad-cask",
+      version:           "2.0",
+    )
+    compatible_cask = instance_double(
+      Cask::Cask,
+      artifacts:         [],
+      full_name:         "codex",
+      installed_version: "0.117.0",
+      token:             "codex",
+      version:           "0.118.0",
+    )
+    incompatible_installer = instance_double(Cask::Installer)
+    compatible_installer = instance_double(Cask::Installer, check_requirements: nil)
+    prefetch_names = []
+    prefetch_upgrades = []
+    prefetch_casks = []
+    prefetch_errors = []
+
+    allow(Cask::Upgrade).to receive(:outdated_casks).and_return([incompatible_cask, compatible_cask])
+    allow(incompatible_installer).to receive(:check_requirements)
+      .and_raise(Cask::CaskError, "bad-cask: This cask requires Linux.")
+    allow(Cask::Installer).to receive(:new) do |cask, **|
+      (cask == incompatible_cask) ? incompatible_installer : compatible_installer
+    end
+    expect(Homebrew::Install).to receive(:enqueue_cask_installers).with([compatible_installer], download_queue:)
+    expect(cmd).not_to receive(:ofail)
+
+    expect(
+      cmd.send(
+        :prefetch_outdated_casks!,
+        [],
+        download_queue:,
+        prefetch_names:,
+        prefetch_upgrades:,
+        prefetch_casks:,
+        prefetch_errors:,
+        show_downloads_heading: false,
+      ),
+    ).to be(true)
+    expect(prefetch_names).to eq(["codex"])
+    expect(prefetch_upgrades).to eq(["codex 0.117.0 -> 0.118.0"])
+    expect(prefetch_casks).to eq([compatible_cask])
+    expect(prefetch_errors.map(&:to_s)).to eq(["bad-cask: This cask requires Linux."])
+  end
+
   it "omits the cask file heading for cached language cask files" do
     cmd = described_class.new(["-y"])
     download_queue = instance_double(Homebrew::DownloadQueue, fetch_failed: false, shutdown: nil)
@@ -779,6 +871,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     )
     installer = instance_double(
       Cask::Installer,
+      check_requirements:                  nil,
       enqueue_downloads:                   nil,
       source_download_requires_pre_fetch?: true,
     )
@@ -868,7 +961,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       installed_version: "0.117.0",
       version:           "0.118.0",
     )
-    installer = instance_double(Cask::Installer, enqueue_downloads: nil, source_download_requires_pre_fetch?: false)
+    installer = instance_double(Cask::Installer, check_requirements: nil, enqueue_downloads: nil,
+                                                 source_download_requires_pre_fetch?: false)
 
     allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
     allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, prefetch_only: false,


### PR DESCRIPTION
- Batch upgrades should continue past casks whose requirements fail.
- Filtering them during prefetch avoids repeating the same cask error.
- Compatible casks still upgrade before the stored error makes `brew` fail.

Fixes #23010

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
