### PR TITLE
Fix test setup crash when multiple package APIs are cached

### DIFF
--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -299,24 +299,44 @@ RSpec.configure do |config|
     @__stdin = $stdin.clone
 
     # Link original API cache files to test cache directory.
-    Pathname("#{ENV.fetch("HOMEBREW_CACHE")}/api").glob("*.json").each do |path|
-      FileUtils.ln_s path, HOMEBREW_CACHE/"api/#{path.basename}"
-    end
-    Pathname("#{ENV.fetch("HOMEBREW_CACHE")}/api").glob("*.txt").each do |path|
-      FileUtils.cp path, HOMEBREW_CACHE/"api/#{path.basename}"
-    end
-    Pathname("#{ENV.fetch("HOMEBREW_CACHE")}/api/internal").glob("*.{json,txt}").each do |path|
-      target = HOMEBREW_CACHE/"api/internal/#{path.basename}"
-      target.dirname.mkpath
-      (path.extname == ".txt") ? FileUtils.cp(path, target) : FileUtils.ln(path, target)
-      next unless path.basename.to_s.start_with?("packages.")
+    source_api_cache = Pathname("#{ENV.fetch("HOMEBREW_CACHE")}/api")
 
+    source_api_cache.glob("*.json").each do |path|
+      target = HOMEBREW_CACHE/"api/#{path.basename}"
+      FileUtils.ln_s path, target unless target.exist?
+    end
+    source_api_cache.glob("*.txt").each do |path|
+      target = HOMEBREW_CACHE/"api/#{path.basename}"
+      FileUtils.cp path, target unless target.exist?
+    end
+
+    source_api_internal_cache = source_api_cache/"internal"
+    target_api_internal_cache = HOMEBREW_CACHE/"api/internal"
+    target_api_internal_cache.mkpath
+
+    # The real cache can hold package API files for multiple OS tags. Fan out
+    # from one source so generated test-cache aliases do not collide.
+    package_paths = source_api_internal_cache.glob("packages.*.jws.json")
+    package_path = package_paths.find do |path|
+      path.basename.to_s == "packages.#{Homebrew::SimulateSystem.current_tag}.jws.json"
+    end || package_paths.first
+
+    source_api_internal_cache.glob("*.{json,txt}").each do |path|
+      next if path.basename.to_s.start_with?("packages.")
+
+      target = target_api_internal_cache/path.basename
+      next if target.exist?
+
+      (path.extname == ".txt") ? FileUtils.cp(path, target) : FileUtils.ln(path, target)
+    end
+
+    if package_path
       [:generic, :linux, :macos, *MacOSVersion::SYMBOLS.keys].product([:arm, :intel]).each do |system, arch|
         tag = Utils::Bottles::Tag.new(system:, arch:)
         next unless tag.valid_combination?
 
-        target = HOMEBREW_CACHE/"api/internal/packages.#{tag}.jws.json"
-        FileUtils.ln path, target unless target.exist?
+        target = target_api_internal_cache/"packages.#{tag}.jws.json"
+        FileUtils.ln package_path, target unless target.exist?
       end
     end
 


### PR DESCRIPTION
The per-example RSpec setup links the real API cache into the sandbox cache. `Library/Homebrew/test/spec_helper.rb` treated every `packages.*.jws.json` in the source cache as a fan-out source, so when the real cache held more than one tag (for example `packages.arm64_golden_gate.jws.json` and `packages.arm64_tahoe.jws.json`) the first source created the alias for the second source's target, and linking the second source then raised `Errno::EEXIST` during setup and broke `brew tests`.

Setup now picks a single package source, preferring the running tag (`Homebrew::SimulateSystem.current_tag`) and falling back to the first available, skips `packages.*` files in the generic copy/link loop, and fans out the per-tag aliases once from that one source. Non-package cache files keep the existing copy/link behavior, now guarded by an existence check so a repeated setup pass is idempotent.

Holding package APIs for multiple tags is a legitimate cache state that any `--os`/`--arch` run or OS upgrade can produce, so this is test-helper resilience rather than a `brew cleanup` change.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 4.8) diagnosed the setup crash and produced the fix; I reviewed the diff and verified with `brew lgtm` plus targeted `dev-cmd/tests` and rubocop specs.

-----
