### PR TITLE
u/g/api.rb: support GitHub App JWTs

### DIFF
--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -34,8 +34,14 @@ module GitHub
   ALL_SCOPES = T.let((CREATE_GIST_SCOPES + CREATE_ISSUE_FORK_OR_PR_SCOPES + CREATE_WORKFLOW_SCOPES).freeze,
                      T::Array[String])
   private_constant :ALL_SCOPES
-  GITHUB_PERSONAL_ACCESS_TOKEN_REGEX = /^(?:[a-f0-9]{40}|(?:gh[pousr]|github_pat)_\w{36,251})$/
-  private_constant :GITHUB_PERSONAL_ACCESS_TOKEN_REGEX
+  GITHUB_ACCESS_TOKEN_REGEX = %r{
+    ^(?:
+      [a-f0-9]{40}                       | # legacy 40-char hex PAT
+      (?:gh[pour]|github_pat)_\w{36,251} | # PAT / OAuth / user / refresh tokens
+      ghs_[A-Za-z0-9.\-_]{36,}             # GitHub App installation token
+    )$
+  }x
+  private_constant :GITHUB_ACCESS_TOKEN_REGEX
 
   # Helper functions for accessing the GitHub API.
   #
@@ -180,7 +186,7 @@ module GitHub
     end
 
     # Gets the password field from `git-credential-osxkeychain` for github.com,
-    # but only if that password looks like a GitHub Personal Access Token.
+    # but only if that password looks like a GitHub access Token.
     sig { returns(T.nilable(String)) }
     def self.keychain_username_password
       require "utils/uid"
@@ -198,9 +204,9 @@ module GitHub
       return unless github_username
 
       # Don't use passwords from the keychain unless they look like
-      # GitHub Personal Access Tokens:
+      # GitHub access tokens:
       #   https://github.com/Homebrew/brew/issues/6862#issuecomment-572610344
-      return unless GITHUB_PERSONAL_ACCESS_TOKEN_REGEX.match?(github_password)
+      return unless GITHUB_ACCESS_TOKEN_REGEX.match?(github_password)
 
       github_password.presence
     end

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -186,7 +186,7 @@ module GitHub
     end
 
     # Gets the password field from `git-credential-osxkeychain` for github.com,
-    # but only if that password looks like a GitHub access Token.
+    # but only if that password looks like a GitHub access token.
     sig { returns(T.nilable(String)) }
     def self.keychain_username_password
       require "utils/uid"


### PR DESCRIPTION
Accept GitHub's new `ghs_` JWT token format alongside existing token types.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Sonnet 4.6 broke up the long line to satisfy `brew style`. `brew lgtm` passes locally.

-----

https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header/ :
>As [announced in April 2026](https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens), GitHub is rolling out a new token format for GitHub App installation tokens.

>A stateless token is a `ghs_`-prefixed JWT. It is longer (~520 characters) and contains two dots. In contrast, a stateful token is a short opaque string with no dots.

>Any regex used to validate an installation token is updated to handle additional underscores and the presence of a JWT. Our recommended regex to match both new and current format tokens is `ghs_[A-Za-z0-9\.\-_]{36,}`.

---

While here, update `GITHUB_PERSONAL_ACCESS_TOKEN_REGEX` -> `GITHUB_ACCESS_TOKEN_REGEX` to match the new reality. `grep -r $(brew --repo)` finds only three matches, and they're all in this file.