### PR TITLE
Warn instead of aborting brew bundle on stale-tab dependency cycles

### DIFF
--- a/Library/Homebrew/bundle/brew.rb
+++ b/Library/Homebrew/bundle/brew.rb
@@ -4,6 +4,7 @@
 require "json"
 require "tsort"
 require "utils"
+require "utils/topological_hash"
 require "utils/output"
 require "bundle/package_type"
 require "trust"
@@ -426,19 +427,14 @@ module Homebrew
           raise "formulae_by_full_name is nil" if @formulae_by_full_name.nil?
           raise "formulae_by_name is nil" if @formulae_by_name.nil?
 
-          # Topo includes TSort. each_strongly_connected_component orders nodes
-          # dependency-first like tsort but, unlike tsort, does not raise on a cycle.
           # Stale keg-tab dependency data can form a cycle the live graph does not
           # have (Homebrew/homebrew-bundle#1513), so warn and continue rather than
           # aborting the whole bundle.
-          components = topo.each_strongly_connected_component.to_a
-
-          cyclic = components.select { |component| component.size > 1 }
-                             .flatten
-                             .filter_map { |name| @formulae_by_full_name[name] || @formulae_by_name[name] }
-                             .uniq { |f| f[:full_name] }
-                             .map { |f| f[:full_name] }
-          if cyclic.any?
+          sorted = topo.tsort_with_cycles do |cycles|
+            cyclic = cycles.flatten
+                           .filter_map { |name| @formulae_by_full_name[name] || @formulae_by_name[name] }
+                           .uniq { |f| f[:full_name] }
+                           .map { |f| f[:full_name] }
             opoo <<~EOS
               Formulae dependency graph sorting found a circular dependency:
                 #{cyclic.join(", ")}
@@ -450,9 +446,8 @@ module Homebrew
             EOS
           end
 
-          @formulae = components.flatten
-                                .map { |name| @formulae_by_full_name[name] || @formulae_by_name[name] }
-                                .uniq { |f| f[:full_name] }
+          @formulae = sorted.filter_map { |name| @formulae_by_full_name[name] || @formulae_by_name[name] }
+                            .uniq { |f| f[:full_name] }
         end
       end
 
@@ -782,6 +777,7 @@ module Homebrew
       class Topo < Hash
         extend T::Generic
         include TSort
+        include Utils::CycleTolerantTSort
 
         K = type_member { { fixed: String } }
         V = type_member { { fixed: T::Array[String] } }

--- a/Library/Homebrew/bundle/brew.rb
+++ b/Library/Homebrew/bundle/brew.rb
@@ -426,32 +426,33 @@ module Homebrew
           raise "formulae_by_full_name is nil" if @formulae_by_full_name.nil?
           raise "formulae_by_name is nil" if @formulae_by_name.nil?
 
-          sorted_names = begin
-            topo.tsort
-          rescue TSort::Cyclic
-            # The graph is built from runtime dependencies recorded in installed
-            # keg tabs, which can disagree with the current formulae and form a
-            # cycle the live graph does not have (see Homebrew/homebrew-bundle#1513).
-            # Warn and keep the bundle running with a best-effort order rather than
-            # aborting. The reinstall remedy below does not reliably clear such cycles.
-            cyclic = (topo.strongly_connected_components.find { |c| c.size > 1 } || [])
-                     .filter_map { |n| @formulae_by_full_name[n] || @formulae_by_name[n] }
-                     .uniq { |f| f[:full_name] }
-                     .map { |f| f[:full_name] }
+          # Topo includes TSort. each_strongly_connected_component orders nodes
+          # dependency-first like tsort but, unlike tsort, does not raise on a cycle.
+          # Stale keg-tab dependency data can form a cycle the live graph does not
+          # have (Homebrew/homebrew-bundle#1513), so warn and continue rather than
+          # aborting the whole bundle.
+          components = topo.each_strongly_connected_component.to_a
+
+          cyclic = components.select { |component| component.size > 1 }
+                             .flatten
+                             .filter_map { |name| @formulae_by_full_name[name] || @formulae_by_name[name] }
+                             .uniq { |f| f[:full_name] }
+                             .map { |f| f[:full_name] }
+          if cyclic.any?
             opoo <<~EOS
-              Formulae dependency graph sorting failed (likely due to a circular dependency):
+              Formulae dependency graph sorting found a circular dependency:
                 #{cyclic.join(", ")}
-              If this persists, run the following commands and try again:
+              This is usually caused by stale dependency data in installed keg tabs.
+              If it persists, run the following commands and try again:
                 brew update
                 brew uninstall --ignore-dependencies --force #{cyclic.join(" ")}
                 brew install #{cyclic.join(" ")}
             EOS
-            topo.each_strongly_connected_component.to_a.flatten
           end
 
-          @formulae = sorted_names
-                      .map { |name| @formulae_by_full_name[name] || @formulae_by_name[name] }
-                      .uniq { |f| f[:full_name] }
+          @formulae = components.flatten
+                                .map { |name| @formulae_by_full_name[name] || @formulae_by_name[name] }
+                                .uniq { |f| f[:full_name] }
         end
       end
 

--- a/Library/Homebrew/bundle/brew.rb
+++ b/Library/Homebrew/bundle/brew.rb
@@ -426,24 +426,32 @@ module Homebrew
           raise "formulae_by_full_name is nil" if @formulae_by_full_name.nil?
           raise "formulae_by_name is nil" if @formulae_by_name.nil?
 
-          @formulae = topo.tsort
-                          .map { |name| @formulae_by_full_name[name] || @formulae_by_name[name] }
-                          .uniq { |f| f[:full_name] }
-        rescue TSort::Cyclic => e
-          e.message =~ /\["([^"]*)".*"([^"]*)"\]/
-          cycle_first = Regexp.last_match(1)
-          cycle_last = Regexp.last_match(2)
-          odie e.message if !cycle_first || !cycle_last
+          sorted_names = begin
+            topo.tsort
+          rescue TSort::Cyclic
+            # The graph is built from runtime dependencies recorded in installed
+            # keg tabs, which can disagree with the current formulae and form a
+            # cycle the live graph does not have (see Homebrew/homebrew-bundle#1513).
+            # Warn and keep the bundle running with a best-effort order rather than
+            # aborting. The reinstall remedy below does not reliably clear such cycles.
+            cyclic = (topo.strongly_connected_components.find { |c| c.size > 1 } || [])
+                     .filter_map { |n| @formulae_by_full_name[n] || @formulae_by_name[n] }
+                     .uniq { |f| f[:full_name] }
+                     .map { |f| f[:full_name] }
+            opoo <<~EOS
+              Formulae dependency graph sorting failed (likely due to a circular dependency):
+                #{cyclic.join(", ")}
+              If this persists, run the following commands and try again:
+                brew update
+                brew uninstall --ignore-dependencies --force #{cyclic.join(" ")}
+                brew install #{cyclic.join(" ")}
+            EOS
+            topo.each_strongly_connected_component.to_a.flatten
+          end
 
-          odie <<~EOS
-            Formulae dependency graph sorting failed (likely due to a circular dependency):
-            #{cycle_first}: #{topo[cycle_first] if topo}
-            #{cycle_last}: #{topo[cycle_last] if topo}
-            Please run the following commands and try again:
-              brew update
-              brew uninstall --ignore-dependencies --force #{cycle_first} #{cycle_last}
-              brew install #{cycle_first} #{cycle_last}
-          EOS
+          @formulae = sorted_names
+                      .map { |name| @formulae_by_full_name[name] || @formulae_by_name[name] }
+                      .uniq { |f| f[:full_name] }
         end
       end
 

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -432,13 +432,10 @@ on_request: true)
 
       ::Utils::TopologicalHash.graph_package_dependencies(pc.dependencies, graph)
 
-      begin
-        @cask_and_formula_dependencies = graph.tsort - [@cask]
-      rescue TSort::Cyclic
-        strongly_connected_components = graph.strongly_connected_components.sort_by(&:count)
-        cyclic_dependencies = strongly_connected_components.last - [@cask]
+      @cask_and_formula_dependencies = graph.tsort_with_cycles do |cycles|
+        cyclic_dependencies = cycles.sort_by(&:count).fetch(-1) - [@cask]
         raise CaskCyclicDependencyError.new(@cask.token, cyclic_dependencies.to_sentence)
-      end
+      end - [@cask]
     end
 
     sig { returns(T::Array[T.any(Formula, ::Cask::Cask)]) }

--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Homebrew::Bundle::Brew do
         cyclic_bar = formula_double_depending_on("bar", "foo")
         expect(Formula).to receive(:installed).and_return([cyclic_foo, cyclic_bar])
 
-        expect { dumper.formulae_by_full_name }.to output(/dependency graph sorting failed/).to_stderr
+        expect { dumper.formulae_by_full_name }.to output(/found a circular dependency/).to_stderr
         expect(dumper.formulae.map { |f| f[:full_name] }).to contain_exactly("foo", "bar")
       end
 

--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -942,7 +942,9 @@ RSpec.describe Homebrew::Bundle::Brew do
       topo["a"] = ["b"]
       topo["b"] = ["a"]
 
-      expect(topo.each_strongly_connected_component.to_a.flatten).to contain_exactly("a", "b")
+      cycles = []
+      expect(topo.tsort_with_cycles { |c| cycles.concat(c) }).to contain_exactly("a", "b")
+      expect(cycles).to eq([["a", "b"]])
     end
   end
 end

--- a/Library/Homebrew/test/bundle/brew_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_spec.rb
@@ -160,6 +160,26 @@ RSpec.describe Homebrew::Bundle::Brew do
       }
     end
 
+    def formula_double_depending_on(name, dependency)
+      instance_double(Formula,
+                      name:,
+                      desc:                   name,
+                      oldnames:               [],
+                      full_name:              name,
+                      any_version_installed?: true,
+                      aliases:                [],
+                      runtime_dependencies:   [instance_double(Dependency, name: dependency)],
+                      deps:                   [],
+                      conflicts:              [],
+                      any_installed_prefix:   nil,
+                      linked?:                false,
+                      keg_only?:              true,
+                      pinned?:                false,
+                      outdated?:              false,
+                      stable:                 instance_double(SoftwareSpec, bottle_defined?: false, bottled?: false),
+                      tap:                    instance_double(Tap, official?: false))
+    end
+
     before do
       described_class.reset!
     end
@@ -180,13 +200,13 @@ RSpec.describe Homebrew::Bundle::Brew do
         expect(dumper.formulae_by_full_name("bar")).to eql({})
       end
 
-      it "exits on cyclic exceptions" do
-        expect(Formula).to receive(:installed).and_return([foo, bar, baz])
-        expect_any_instance_of(Homebrew::Bundle::Brew::Topo).to receive(:tsort).and_raise(
-          TSort::Cyclic,
-          'topological sort failed: ["foo", "bar"]',
-        )
-        expect { dumper.formulae_by_full_name }.to raise_error(SystemExit)
+      it "warns and continues on cyclic dependencies instead of exiting" do
+        cyclic_foo = formula_double_depending_on("foo", "bar")
+        cyclic_bar = formula_double_depending_on("bar", "foo")
+        expect(Formula).to receive(:installed).and_return([cyclic_foo, cyclic_bar])
+
+        expect { dumper.formulae_by_full_name }.to output(/dependency graph sorting failed/).to_stderr
+        expect(dumper.formulae.map { |f| f[:full_name] }).to contain_exactly("foo", "bar")
       end
 
       it "returns a hash for a formula" do
@@ -915,6 +935,14 @@ RSpec.describe Homebrew::Bundle::Brew do
       topo["b"] = ["libice"]
 
       expect(topo.tsort).to eq(["libice", "b", "a"])
+    end
+
+    it "flattens a cyclic graph via strongly connected components without raising" do
+      topo = described_class.new
+      topo["a"] = ["b"]
+      topo["b"] = ["a"]
+
+      expect(topo.each_strongly_connected_component.to_a.flatten).to contain_exactly("a", "b")
     end
   end
 end

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -93,13 +93,12 @@ module Homebrew
         end
 
         dependency_graph = Utils::TopologicalHash.graph_package_dependencies(formulae_to_install)
-        begin
-          formulae_to_install = dependency_graph.tsort & formulae_to_install
-        rescue TSort::Cyclic
-          if Homebrew::EnvConfig.developer?
-            raise CyclicDependencyError, dependency_graph.strongly_connected_components
-          end
+        sorted = dependency_graph.tsort_with_cycles do |cycles|
+          raise CyclicDependencyError, cycles if Homebrew::EnvConfig.developer?
+
+          odebug "Ignoring cyclic dependencies: #{cycles.map(&:to_sentence).join(", ")}"
         end
+        formulae_to_install = sorted & formulae_to_install
 
         # We need to fetch the bottle tabs ahead of the `Install.fetch_formulae`
         # pipeline because we need to first filter out those formulae with all

--- a/Library/Homebrew/utils/topological_hash.rb
+++ b/Library/Homebrew/utils/topological_hash.rb
@@ -4,10 +4,32 @@
 require "tsort"
 
 module Utils
+  # Cycle-tolerant ordering for graphs that include TSort.
+  module CycleTolerantTSort
+    extend T::Helpers
+
+    requires_ancestor { TSort }
+
+    # Orders nodes dependency-first like tsort but, unlike tsort, does not
+    # raise on a cycle: yields cyclic components (size > 1) to the block and
+    # returns the flattened component order.
+    sig {
+      params(on_cycle: T.proc.params(arg0: T::Array[T::Array[T.untyped]]).void)
+        .returns(T::Array[T.untyped])
+    }
+    def tsort_with_cycles(&on_cycle)
+      components = each_strongly_connected_component.to_a
+      cycles = components.select { |component| component.size > 1 }
+      yield(cycles) if cycles.any?
+      components.flatten
+    end
+  end
+
   # Topologically sortable hash map.
   class TopologicalHash < Hash
     extend T::Generic
     include TSort
+    include CycleTolerantTSort
 
     CaskOrFormula = T.type_alias { T.any(Cask::Cask, Formula) }
 


### PR DESCRIPTION
`brew bundle` sorts installed formulae into dependency order for display and iteration. The edges come from each installed keg's recorded runtime dependencies (`tab.json`), not the live formula graph. Those recorded closures are frozen at install time, so kegs of different vintages can disagree and form a cycle the current formulae don't have (e.g. a `webp` keg built when `webp` depended on `libtiff`, against today's `libtiff` -> `webp`).

I hit this here:

https://github.com/bendrucker/dotfiles/actions/runs/28981041126/job/85999630681#step:10:45

```
2004l25h1002l1003l1006l::error::Formulae dependency graph sorting failed (likely due to a circular dependency):%0Alibtiff: ["linux-headers@6.8", "glibc", "gmp", "isl", "mpfr", "libmpc", "lz4", "xz", "zlib-ng-compat", "zstd", "binutils", "gcc", "jpeg-turbo", "giflib", "libpng", "webp"]%0Awebp: ["linux-headers@6.8", "glibc", "gmp", "isl", "mpfr", "libmpc", "lz4", "xz", "zlib-ng-compat", "zstd", "binutils", "gcc", "giflib", "jpeg-turbo", "libpng", "libtiff"]%0APlease run the following commands and try again:%0A  brew update%0A  brew uninstall --ignore-dependencies --force libtiff webp%0A  brew install libtiff webp%0A
```

`sort!` responded to the cycle by `odie`ing the entire run, so one stale tab aborts `brew bundle` regardless of the Brewfile. But this sort only orders a display/iteration list. `brew install` resolves its own dependencies, so a degraded order is harmless, and `brew bundle` already tolerates this same tab-derived dependency data being cyclic elsewhere (`parallel_installer` falls back to sequential scheduling rather than failing).

This orders with `each_strongly_connected_component` instead. It yields nodes dependency-first like `tsort` but does not raise on a cycle, and for an acyclic graph the result is identical to `tsort`, so normal runs are unchanged. When a cycle exists it collapses into one component: `brew bundle` warns, names that component, and continues.

The warning now names the full cyclic component rather than the two endpoints the old code parsed out of the exception message. The stale edge can live on any member's tab, so reinstalling only the two named formulae often left the cycle in place ([homebrew-bundle#1513](https://github.com/Homebrew/homebrew-bundle/issues/1513)). Naming every member makes the suggested `uninstall`/`install` rewrite each tab in the cycle.

The flipped spec drives a real cycle through fixtures so it exercises the fallback end to end and fails if the hard exit returns.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code / Opus 4.8

Verification Steps:

- Regression test, red/green: against `main` the `odie` aborts and the example raises `SystemExit`; it passes with the fix.
- Acyclic path unchanged: for a non-cyclic graph `each_strongly_connected_component` yields the same dependencies-first order as `tsort`, and the `.map`/`.uniq` mapping is untouched, so normal runs produce identical output.
- Confirmed the live `webp`/`libtiff` formulae are one-directional, so the reported cycle comes from a stale keg tab rather than the current formulae.

An end-to-end repro needs an installed keg carrying a stale tab, which isn't practical in CI, so the flipped spec is the regression guard rather than an integration test.
