### PR TITLE
Scrub internal package API cache files on `brew cleanup -s`

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -62,6 +62,8 @@ module Homebrew
         return false unless pathname.resolved_path.file?
 
         case entry[:type]
+        when :api_package
+          scrub
         when :api_source
           stale_api_source?(pathname, scrub)
         when :cask
@@ -565,11 +567,18 @@ module Homebrew
     def cache_files
       files = cache.directory? ? cache.children : []
       cask_files = (cache/"Cask").directory? ? (cache/"Cask").children : []
+      api_internal = cache/"api/internal"
+      api_package_files = if scrub? && api_internal.directory?
+        api_internal.glob("packages.*.jws.json")
+      else
+        []
+      end
       api_source_files = (cache/"api-source").glob("*/*/*/**/*").select { |path| path.file? || path.symlink? }
       gh_actions_artifacts = (cache/"gh-actions-artifact").directory? ? (cache/"gh-actions-artifact").children : []
 
       cache_entries(files, type: nil) +
         cache_entries(cask_files, type: :cask) +
+        cache_entries(api_package_files, type: :api_package) +
         cache_entries(api_source_files, type: :api_source) +
         cache_entries(gh_actions_artifacts, type: :gh_actions_artifact)
     end

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -526,6 +526,45 @@ RSpec.describe Homebrew::Cleanup do
       expect(foo).to exist
     end
 
+    it "does not clean up internal package API files without scrub even when pruning" do
+      api_package_files = [
+        HOMEBREW_CACHE/"api/internal/packages.arm64_golden_gate.jws.json",
+        HOMEBREW_CACHE/"api/internal/packages.arm64_tahoe.jws.json",
+      ]
+      api_package_files.each do |api_package_file|
+        api_package_file.dirname.mkpath
+        FileUtils.touch api_package_file
+      end
+
+      described_class.new(days: 0).cleanup_cache
+
+      expect(api_package_files.map(&:exist?)).to eq([true, true])
+    end
+
+    it "cleans up internal package API files with scrub" do
+      api_package_files = [
+        HOMEBREW_CACHE/"api/internal/packages.arm64_golden_gate.jws.json",
+        HOMEBREW_CACHE/"api/internal/packages.arm64_tahoe.jws.json",
+      ]
+      api_jws_files = [
+        HOMEBREW_CACHE/"api/formula.jws.json",
+        HOMEBREW_CACHE/"api/cask.jws.json",
+      ]
+      api_package_files.each do |api_package_file|
+        api_package_file.dirname.mkpath
+        FileUtils.touch api_package_file
+      end
+      api_jws_files.each do |api_jws_file|
+        api_jws_file.dirname.mkpath
+        FileUtils.touch api_jws_file
+      end
+
+      described_class.new(scrub: true).cleanup_cache
+
+      expect(api_package_files.map(&:exist?)).to eq([false, false])
+      expect(api_jws_files.map(&:exist?)).to eq([true, true])
+    end
+
     it "cleans up API source files and symlinks at any depth without cleaning directories" do
       root_file = HOMEBREW_CACHE/"api-source/Homebrew/homebrew-core/abc123/README.md"
       nested_file = HOMEBREW_CACHE/"api-source/Homebrew/homebrew-core/abc123/Formula/a/testball.rb"


### PR DESCRIPTION
`brew cleanup` only enumerates `api` as a top-level cache directory, so the per-tag `api/internal/packages.<tag>.jws.json` files it downloads are never swept and accumulate as OS upgrades or `--os`/`--arch` runs add more tags. This is the `brew cleanup` follow-up to #23016, which handled the same multi-tag cache state in the test helper.

`brew cleanup -s` now removes every `api/internal/packages.*.jws.json` file while a normal `brew cleanup` leaves them untouched. The sweep is scrub-only and deterministic, with no tag, mtime or prune-day logic, and is scoped to `api/internal/packages.*` so `formula.jws.json`, `cask.jws.json` and the tap-migration files are left alone. These are download cache files, so removing them only forces a later re-download.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 4.8) wrote the cleanup change and specs; I reviewed the diff and verified with `brew lgtm` plus targeted `cleanup` specs.

-----
