### PR TITLE
test_bot: avoid unbalanced shard

### DIFF
--- a/Library/Homebrew/test_bot/formulae_dependents.rb
+++ b/Library/Homebrew/test_bot/formulae_dependents.rb
@@ -306,8 +306,9 @@ module Homebrew
           end
         end
 
-        seen = T.let([], T::Array[String])
+        seen = T.let(Set.new, T::Set[String])
         groups = T.let([], T::Array[T::Array[DependentWithDependencies]])
+        max_group_size = (dependents.size / shard_count) + 1
 
         dependents.map(&:first).each do |dependent|
           next if seen.include?(dependent.full_name)
@@ -322,6 +323,8 @@ module Homebrew
 
             seen << name
             group << dependents_by_name.fetch(name)
+            break if group.size >= max_group_size
+
             queue.concat(edges.fetch(name).reject { |edge| seen.include?(edge) })
           end
 

--- a/Library/Homebrew/test_bot/formulae_dependents.rb
+++ b/Library/Homebrew/test_bot/formulae_dependents.rb
@@ -308,7 +308,7 @@ module Homebrew
 
         seen = T.let(Set.new, T::Set[String])
         groups = T.let([], T::Array[T::Array[DependentWithDependencies]])
-        max_group_size = (dependents.size / shard_count) + 1
+        max_group_size = (dependents.size + shard_count - 1) / shard_count
 
         dependents.map(&:first).each do |dependent|
           next if seen.include?(dependent.full_name)


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

When there is a commonly used dependent, one group can end up with a majority or tested dependents and result in unbalanced shard.

As naive fix, limit the group size to balanced size and defer handling of remaining dependents in queue to later iterations of loop.

---

For now, mainly trying to see if we can get something usable in Homebrew/core.

There are likely better ways to improve sharding in future. Clustering around the most similar dependency trees could be better at reusing cached downloads

Alternatively, I wonder if there is a noticeable difference from the most basic sorted split into 4 groups. This at least is better at minimizing impact of possible race conditions (e.g. a PR getting merged in between CI runners can lead to a different sharding which can cause dependents to be skipped).