### PR TITLE
Don't require tap trust in casks/formulae shell specs

### DIFF
--- a/Library/Homebrew/test/cmd/casks_spec.rb
+++ b/Library/Homebrew/test/cmd/casks_spec.rb
@@ -3,7 +3,7 @@
 
 RSpec.describe "brew casks", type: :system do
   it "prints all installed Casks", :integration_test do
-    expect { brew_sh "casks" }
+    expect { brew_sh "casks", "HOMEBREW_NO_REQUIRE_TAP_TRUST" => "1" }
       .to be_a_success
       .and not_to_output.to_stderr
   end

--- a/Library/Homebrew/test/cmd/formulae_spec.rb
+++ b/Library/Homebrew/test/cmd/formulae_spec.rb
@@ -3,7 +3,7 @@
 
 RSpec.describe "brew formulae", type: :system do
   it "prints all installed Formulae", :integration_test do
-    expect { brew_sh "formulae" }
+    expect { brew_sh "formulae", "HOMEBREW_NO_REQUIRE_TAP_TRUST" => "1" }
       .to be_a_success
       .and not_to_output.to_stderr
   end


### PR DESCRIPTION
The `brew casks` and `brew formulae` shell smoke specs run the real `brew` through `brew_sh`, which scans the installed `Library/Taps` rather than a sandboxed copy (`bin/brew` derives `HOMEBREW_REPOSITORY` from its own location, so the taps directory cannot be redirected via the environment). With tap trust required by default, any locally installed third-party tap makes these specs print `Skipping <tap> because it is not trusted` to stderr and fail the `not_to_output.to_stderr` expectation. CI only has the trusted official taps, so it passes there while developer machines with extra taps do not.

This passes `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` to the `brew_sh` runs in both specs so they no longer depend on the developer's local tap trust state. The specs only assert that the commands run cleanly; tap trust itself is covered by dedicated specs.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 4.8) reviewed the change and confirmed its scope; I wrote it and verified with `brew lgtm` plus the targeted `cmd/casks` and `cmd/formulae` specs, which fail before the change and pass after.

-----
