### PR TITLE
docs: escape braces to avoid Liquid tag handling

### DIFF
--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -583,6 +583,8 @@ A steps block may only contain supported step calls with literal arguments; it c
 
 Relative paths default to `staged_path` for `base:`, `source_base:` and `target_base:`. Symlink steps can use `uninstall: true` to remove the symlink during uninstall.
 
+{% raw %}
+
 * `mkdir`: create one directory; example: `mkdir "Shared"`.
 * `mkdir_p`: create a directory and any missing parents; example: `mkdir_p "Shared"`.
 * `touch`: create or update a file timestamp; example: `touch "Shared/state"`.
@@ -593,6 +595,8 @@ Relative paths default to `staged_path` for `base:`, `source_base:` and `target_
 * `ln_s`: alias for `symlink`; example: `ln_s "Shared/payload", "Payload", source_base: :relative`.
 * `ln_sf`: create or replace a symlink; example: `ln_sf "Shared/payload", "Payload", source_base: :relative, uninstall: true`.
 * `write`: write literal content to a file unless it already exists; example: `write "Shared/foo.conf", "key = value"`. Pass `overwrite: true` to always replace the file. A trailing newline is appended unless the content already ends with one. Content may use the `{{staged_path}}`, `{{appdir}}` and `{{version}}` tokens, which are expanded at install time; any other `{{...}}` is left verbatim.
+
+{% endraw %}
 
 Flight blocks are not currently run in the cask sandbox. They should be written as though they may be sandboxed in the future: prefer the mini-DSL helpers below and keep filesystem writes limited to paths owned by the cask.
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1211,7 +1211,9 @@ represented by structured steps.
 
 A trailing newline is appended unless the content already ends with one, so written files end in a newline as POSIX expects.
 
+{% raw %}
 Content may use a fixed set of `{{...}}` tokens that are expanded at install time so paths are not hardcoded into the JSON API: `{{HOMEBREW_PREFIX}}`, `{{prefix}}`, `{{opt_prefix}}`, `{{bin}}`, `{{var}}`, `{{etc}}`, `{{pkgetc}}`, `{{version}}` and `{{version.major_minor}}`. Any other `{{...}}` is left verbatim, so literal braces are never rewritten. Use tokens instead of Ruby interpolation, for example `write "foo.conf", "prefix = {{HOMEBREW_PREFIX}}", base: :etc`.
+{% endraw %}
 
 #### Service data directory steps
 

--- a/docs/Homebrew-homebrew-core-Maintainer-Guide.md
+++ b/docs/Homebrew-homebrew-core-Maintainer-Guide.md
@@ -182,37 +182,6 @@ The following checklist is intended to help maintainers decide on whether to mer
   - celebrate any first-time contributors
 - suggest using `brew bump-formula-pr` next time if this was not the case
 
-## Common build failures and how to handle them
-
-### Test errors
-
-#### "undefined reference to ..."
-
-This error might pop up when parameters passed to `gcc` are in the wrong order.
-
-An example from `libmagic` formula:
-
-    ==> brew test libmagic --verbose
-    Testing libmagic
-    ==> /usr/bin/gcc -I/home/linuxbrew/.linuxbrew/Cellar/libmagic/5.38/include -L/home/linuxbrew/.linuxbrew/Cellar/libmagic/5.38/lib -lmagic test.c -o test
-    /tmp/ccNeDVRt.o: In function `main':
-    test.c:(.text+0x15): undefined reference to `magic_open'
-    test.c:(.text+0x4a): undefined reference to `magic_load'
-    test.c:(.text+0x81): undefined reference to `magic_file'
-    collect2: error: ld returned 1 exit status
-
-Solution:
-
-```ruby
-if OS.mac?
-  system ENV.cc, "-I#{include}", "-L#{lib}", "-lmagic", "test.c", "-o", "test"
-else
-  system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lmagic", "-o", "test"
-end
-```
-
-For an explanation of why this happens, read the [Ubuntu 11.04 Toolchain documentation](https://wiki.ubuntu.com/NattyNarwhal/ToolchainTransition).
-
 ## Staging Branches
 
 ### Summary


### PR DESCRIPTION
Can see missing text at https://docs.brew.sh/Cask-Cookbook#file-preparation-steps
> Content may use the , and tokens, which are expanded at install time; any other is left verbatim.

Also remove test error doc from old Linuxbrew. This information is better to find elsewhere and the Ubuntu wiki is being decommissioned
- https://discourse.ubuntu.com/t/a-new-ubuntu-wiki-part-1-announcement/72729

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
