### PR TITLE
Keep generic tool caches out of the sandboxed test home

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -343,6 +343,8 @@ module Homebrew
         # Avoid local configuration messing with tests, e.g. git being configured
         # to use GPG to sign by default
         ENV["HOME"] = "#{HOMEBREW_LIBRARY_PATH}/test"
+        # Keep generic tool caches (e.g. RuboCop) out of the sandboxed test home.
+        ENV["XDG_CACHE_HOME"] = "#{HOMEBREW_CACHE}/tests"
         # Sandbox the config home too, so the spec teardown can't delete the real `trust.json`.
         ENV["HOMEBREW_USER_CONFIG_HOME"] = "#{Dir.home}/.homebrew"
 

--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -53,6 +53,23 @@ RSpec.describe Homebrew::DevCmd::Tests do
     end
   end
 
+  describe "#setup_environment!" do
+    subject(:tests) { described_class.new([]) }
+
+    before do
+      require "api"
+
+      allow(Homebrew::API).to receive(:fetch_api_files!)
+    end
+
+    it "keeps generic cache files out of the sandboxed test home" do
+      tests.send(:setup_environment!)
+
+      expect(ENV.fetch("XDG_CACHE_HOME")).to eq("#{HOMEBREW_CACHE}/tests")
+      expect(ENV.fetch("XDG_CACHE_HOME")).not_to start_with("#{Dir.home}/")
+    end
+  end
+
   describe "#changed_test_files" do
     subject(:changed_test_files) { tests.send(:changed_test_files) }
 


### PR DESCRIPTION
`brew tests` points `HOME` at `Library/Homebrew/test` to sandbox local configuration, but leaves `XDG_CACHE_HOME` unset. Tools that honor the XDG defaults, e.g. RuboCop, then resolve their cache to `$HOME/.cache` and leave a stray `Library/Homebrew/test/.cache` directory inside the working tree after a test run.

`setup_environment!` now pins `XDG_CACHE_HOME` to `HOMEBREW_CACHE/tests` right after it sandboxes `HOME`, mirroring how `brew style` already redirects RuboCop's cache to `HOMEBREW_CACHE/style`. A regression spec asserts the value and that it does not live under the sandboxed home.

This only steers third-party tools that honor `XDG_CACHE_HOME`; Homebrew's own cache is unaffected because `HOMEBREW_CACHE` is always exported and takes precedence over the XDG-derived default. The cache now lives outside the git tree, so a test run no longer pollutes the checkout.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 4.8) reviewed the change and suggested the explanatory comment; I wrote the fix and specs and verified with `brew lgtm --online` plus targeted `dev-cmd/tests` specs.

-----
