### PR TITLE
Avoid trust errors for cask conflicts

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -216,10 +216,17 @@ on_request: true)
           next unless conflicting_cask_tap.installed?
         end
 
+        if (installed_caskfile = Caskroom.cask_installed_caskfile(conflicting_cask))
+          raise CaskConflictError.new(
+            @cask,
+            ::Cask::Cask.new(installed_caskfile.basename(installed_caskfile.extname).basename(".internal").to_s),
+          )
+        end
+
         conflicting_cask = CaskLoader.load(conflicting_cask)
         raise CaskConflictError.new(@cask, conflicting_cask) if conflicting_cask.installed?
-      rescue CaskUnavailableError
-        next # Ignore conflicting Casks that do not exist.
+      rescue CaskUnavailableError, Homebrew::UntrustedTapError
+        next # Ignore conflicting Casks that are unavailable or untrusted.
       end
     end
 

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -588,6 +588,57 @@ RSpec.describe Cask::DSL, :cask, :no_api do
 
       expect(with_conflicts_with).not_to be_installed
     end
+
+    it "ignores an uninstalled conflicting cask from an untrusted tap", :trust_store do
+      tap = Tap.fetch("thirdparty", "foo")
+      cask_file = tap.cask_dir/"conflicting-cask.rb"
+      cask_file.dirname.mkpath
+      cask_file.write <<~RUBY
+        cask "conflicting-cask" do
+          version "1.0"
+        end
+      RUBY
+
+      cask = Cask::Cask.new("requested-cask", tap:) do
+        version "1.0"
+        conflicts_with cask: "#{tap}/conflicting-cask"
+      end
+      Homebrew::Trust.trust!(:cask, "#{tap}/requested-cask")
+
+      with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+        expect { Cask::Installer.new(cask).check_conflicts }.not_to raise_error
+      end
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+
+    it "raises for an installed conflicting cask from an untrusted tap without loading it", :trust_store do
+      tap = Tap.fetch("thirdparty", "foo")
+      cask_file = tap.cask_dir/"conflicting-cask.rb"
+      cask_file.dirname.mkpath
+      cask_file.write <<~RUBY
+        raise "untrusted tap cask evaluated"
+      RUBY
+
+      installed_cask_dir = Cask::Caskroom.path/"conflicting-cask/.metadata/1.0/20250101000000.000/Casks"
+      installed_cask_dir.mkpath
+      (installed_cask_dir/"conflicting-cask.rb").write <<~RUBY
+        raise "untrusted installed cask evaluated"
+      RUBY
+
+      cask = Cask::Cask.new("requested-cask", tap:) do
+        version "1.0"
+        conflicts_with cask: "#{tap}/conflicting-cask"
+      end
+      Homebrew::Trust.trust!(:cask, "#{tap}/requested-cask")
+
+      with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+        expect { Cask::Installer.new(cask).check_conflicts }
+          .to raise_error(Cask::CaskConflictError, "Cask 'requested-cask' conflicts with 'conflicting-cask'.")
+      end
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
   end
 
   describe "conflicts_with stanza" do


### PR DESCRIPTION
- `conflicts_with` casks may be uninstalled candidates from third-party taps.
- Loading those tap casks forces trust for packages the user did not request.
- Prefer installed metadata so real conflicts still fail without trusting candidates.

Fixes https://github.com/Homebrew/brew/issues/23021

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
