### PR TITLE
Fix autosquash behavior to default cherry_picked to false and add tes…

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -379,12 +379,11 @@ module Homebrew
         ohai bump_subject
       end
 
-      # TODO: fix test in `test/dev-cmd/pr-pull_spec.rb` and assume `cherry_picked: false`.
       sig {
         params(original_commit: String, tap: Tap, reason: T.nilable(String), verbose: T::Boolean, resolve: T::Boolean,
                cherry_picked: T::Boolean).void
       }
-      def autosquash!(original_commit, tap:, reason: "", verbose: false, resolve: false, cherry_picked: true)
+      def autosquash!(original_commit, tap:, reason: "", verbose: false, resolve: false, cherry_picked: false)
         git_repo = tap.git_repository
 
         commits = Utils.safe_popen_read("git", "-C", tap.path, "rev-list",

--- a/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
@@ -130,6 +130,49 @@ RSpec.describe Homebrew::DevCmd::PrPull do
         expect(git_repo.commit_message).to include("Co-authored-by: #{secondary_author}")
       end
     end
+
+    context "when squashing raises an error" do
+      let!(:original_hash) do
+        (tap.path/"Formula").mkpath
+        formula_file.write(formula)
+        cd(tap.path) do
+          safe_system Utils::Git.git, "init"
+          safe_system Utils::Git.git, "add", formula_file
+          safe_system Utils::Git.git, "commit", "-m", "foo 1.0 (new formula)"
+          `git rev-parse HEAD`.chomp
+        end
+      end
+
+      before do
+        cd tap.path do
+          File.write(formula_file, formula_revision)
+          safe_system Utils::Git.git, "commit", formula_file, "-m", "revision"
+        end
+        allow(Utils::Git).to receive(:cherry_pick!).and_raise(
+          ErrorDuringExecution.new(["git", "cherry-pick"], status: 1),
+        )
+      end
+
+      it "aborts the cherry-pick when cherry_picked is true" do
+        cd(tap.path) do
+          allow(pr_pull).to receive(:system).and_call_original
+          expect(pr_pull).to receive(:system).with("git", "-C", tap.path.to_s, "cherry-pick", "--abort")
+          expect do
+            pr_pull.autosquash!(original_hash, tap:, cherry_picked: true)
+          end.to raise_error(ErrorDuringExecution)
+        end
+      end
+
+      it "does not abort the cherry-pick when cherry_picked is false" do
+        cd(tap.path) do
+          allow(pr_pull).to receive(:system).and_call_original
+          expect(pr_pull).not_to receive(:system).with("git", "-C", tap.path.to_s, "cherry-pick", "--abort")
+          expect do
+            pr_pull.autosquash!(original_hash, tap:, cherry_picked: false)
+          end.to raise_error(ErrorDuringExecution)
+        end
+      end
+    end
   end
 
   describe "#signoff!" do


### PR DESCRIPTION
Adds missing test coverage for autosquash!'s rescue branch (whether cherry-pick --abort runs), then flips its cherry_picked default from true to false and removes the long-standing TODO.

The only caller already passes cherry_picked explicitly, so behaviour is unchanged. The default was left as true because the rescue branch had no test coverage; adding it makes the flip safe to verify.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code scaffolded the new test; I wrote and verified the core assertions and ran all checks manually.


-----
