### PR TITLE
Add install step keychain cleanup

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -102,7 +102,7 @@ module Homebrew
         when Hash
           ::T.cast(obj.to_h { |key, value| [key.to_s, value&.to_s] }.compact_blank, PathSpec)
         when String, Pathname
-          %w[path source target].include?(key) ? { "path" => obj.to_s } : obj.to_s
+          %w[path source target matching_certificate].include?(key) ? { "path" => obj.to_s } : obj.to_s
         else
           obj
         end
@@ -305,6 +305,20 @@ module Homebrew
         add_rebuild_action("update_desktop_database", "share/applications")
       end
 
+      sig {
+        params(
+          name:                 ::String,
+          matching_certificate: ::T.nilable(::T.any(::String, ::Pathname)),
+          base:                 ::T.nilable(::T.any(::String, ::Symbol)),
+        ).void
+      }
+      def delete_keychain_certificate(name, matching_certificate: nil, base: nil)
+        add_step("delete_keychain_certificate",
+                 "name"                 => name,
+                 "matching_certificate" => (path_spec(matching_certificate, base:, default_base: nil) if
+                   matching_certificate))
+      end
+
       private
 
       sig { params(type: ::String, fields: ::T.nilable(StepValue)).void }
@@ -457,6 +471,38 @@ module Homebrew
           run_formula_tool("shared-mime-info", "update-mime-database", resolve_path(step_path(step, "path")))
         when "update_desktop_database"
           run_formula_tool("desktop-file-utils", "update-desktop-database", resolve_path(step_path(step, "path")))
+        when "delete_keychain_certificate"
+          certificate_hash = nil
+          if step.key?("matching_certificate")
+            certificate = resolve_path(step_path(step, "matching_certificate"))
+            return unless certificate.exist?
+
+            certificate_hash = run_command_output("/usr/bin/openssl", "x509", "-fingerprint", "-sha256", "-noout",
+                                                  "-in", certificate)
+                               .lines
+                               .first
+                               .to_s
+                               .split("=", 2)[1]
+                               .to_s
+                               .delete(":")
+                               .strip
+                               .upcase
+            return if certificate_hash.blank?
+          end
+
+          certificate_hashes = run_command_output(
+            "/usr/bin/security", "find-certificate", "-a", "-c", step_string(step, "name"), "-Z",
+            sudo: true
+          ).lines.filter_map { |line| line[/\ASHA-256 hash:\s*(\S+)/, 1]&.upcase }
+
+          if certificate_hash
+            run_command "/usr/bin/security", "delete-certificate", "-Z", certificate_hash, sudo: true if
+              certificate_hashes.include?(certificate_hash)
+          else
+            certificate_hashes.each do |matching_certificate_hash|
+              run_command "/usr/bin/security", "delete-certificate", "-Z", matching_certificate_hash, sudo: true
+            end
+          end
         else
           raise ArgumentError, "unknown install step: #{step.fetch("type")}"
         end
@@ -647,9 +693,14 @@ module Homebrew
         config.public_send(method) if config.respond_to?(method)
       end
 
-      sig { params(command: SystemCommandArg, args: SystemCommandArg).void }
-      def run_command(command, *args)
-        system_command!(command, args: args, print_stdout: true, print_stderr: true, reset_uid: true)
+      sig { params(command: SystemCommandArg, args: SystemCommandArg, sudo: T::Boolean).void }
+      def run_command(command, *args, sudo: false)
+        system_command!(command, args: args, sudo:, print_stdout: true, print_stderr: true, reset_uid: true)
+      end
+
+      sig { params(command: SystemCommandArg, args: SystemCommandArg, sudo: T::Boolean).returns(String) }
+      def run_command_output(command, *args, sudo: false)
+        system_command!(command, args: args, sudo:, print_stderr: true, reset_uid: true).stdout
       end
     end
   end

--- a/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
+++ b/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
@@ -408,13 +408,19 @@ is stripped during metadata serialisation.
   `./bin/brew style homebrew/core`, targeted `./bin/brew audit --strict
   --online --formula ...` for the changed formulae and `./bin/brew readall
   homebrew/core`.
-- [ ] PR 7, certificate and trust store actions.
+- [x] PR 7, certificate and trust store actions.
+  Commit: `Add install step keychain cleanup`.
   Estimated existing formulae/casks affected: about `17` formulae update
   certificate/trust state and `8` cask flight blocks invoke
   `/usr/bin/security` for keychain certificate cleanup.
-  Notes for implementation: separate formula-owned symlinked certificate
-  actions from keychain mutations; keychain work likely counts as non-Homebrew
-  code and should be prepared for sandbox policy decisions.
+  Scope: cask `delete_keychain_certificate` step, runner execution through
+  fixed `/usr/bin/security find-certificate` and `delete-certificate` calls,
+  optional local certificate fingerprint matching for selective deletion,
+  cask step block allow-list entries and docs. Formula-owned `cert.pem`
+  symlinks use the existing `ln_sf` step with `source_formula` and
+  `source_base: :formula_pkgetc`; specialised trust store generation such as
+  `ca-certificates` bundle regeneration and Mono `cert-sync` stays legacy Ruby
+  because current repeated usage is below the named-variant threshold.
 - [ ] PR 8, cask permission and ownership actions.
   Estimated existing casks affected: about `21` casks change permissions and
   `36` change ownership.

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -12,13 +12,14 @@ module RuboCop
       REBUILD_ACTION_STEP_METHODS =
         [:compile_gsettings_schemas, :gio_querymodules, :gdk_pixbuf_query_loaders, :gtk_update_icon_cache,
          :update_mime_database, :update_desktop_database].freeze
+      KEYCHAIN_STEP_METHODS = [:delete_keychain_certificate].freeze
       ALLOWED_STEP_METHODS = T.let(
         [*FILE_PREPARATION_STEP_METHODS, *LINK_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *SERVICE_DATA_STEP_METHODS,
          *REBUILD_ACTION_STEP_METHODS].freeze,
         T::Array[Symbol],
       )
       CASK_ALLOWED_STEP_METHODS = T.let(
-        [*FILE_PREPARATION_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS].freeze,
+        [*FILE_PREPARATION_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *KEYCHAIN_STEP_METHODS].freeze,
         T::Array[Symbol],
       )
 

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -86,13 +86,27 @@ RSpec.describe Homebrew::InstallSteps do
           path: "nested/example",
         },
       },
+      {
+        type:                 :delete_keychain_certificate,
+        name:                 "NodeMITMProxyCA",
+        matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem",
+      },
     ]
 
     expect(Homebrew::InstallSteps::DSL.normalise_steps(steps)).to contain_exactly(
-      "type" => "mkdir_p",
-      "path" => {
-        "base" => "var",
-        "path" => "nested/example",
+      {
+        "type" => "mkdir_p",
+        "path" => {
+          "base" => "var",
+          "path" => "nested/example",
+        },
+      },
+      {
+        "type"                 => "delete_keychain_certificate",
+        "name"                 => "NodeMITMProxyCA",
+        "matching_certificate" => {
+          "path" => "~/Library/Application Support/betwixt/ssl/certs/ca.pem",
+        },
       },
     )
   end
@@ -342,6 +356,63 @@ RSpec.describe Homebrew::InstallSteps do
                                                    HOMEBREW_PREFIX/"share/icons/hicolor").ordered
       runner.run(steps)
     end
+  end
+
+  specify "deletes matching keychain certificates by SHA-256 hash" do
+    steps = Homebrew::InstallSteps::DSL.build do
+      delete_keychain_certificate "Charles"
+    end
+
+    runner = Homebrew::InstallSteps::Runner.new(context:)
+    expect(runner).to receive(:run_command_output)
+      .with("/usr/bin/security", "find-certificate", "-a", "-c", "Charles", "-Z", sudo: true)
+      .and_return(<<~EOS)
+        SHA-256 hash: ABC123
+        SHA-256 hash: DEF456
+      EOS
+    expect(runner).to receive(:run_command)
+      .with("/usr/bin/security", "delete-certificate", "-Z", "ABC123", sudo: true).ordered
+    expect(runner).to receive(:run_command)
+      .with("/usr/bin/security", "delete-certificate", "-Z", "DEF456", sudo: true).ordered
+
+    runner.run(steps)
+  end
+
+  specify "only deletes the keychain certificate matching a local certificate" do
+    certificate = root/"home/Library/Application Support/betwixt/ssl/certs/ca.pem"
+    certificate.dirname.mkpath
+    certificate.write "certificate"
+    steps = Homebrew::InstallSteps::DSL.build do
+      delete_keychain_certificate "NodeMITMProxyCA", matching_certificate: certificate
+    end
+
+    runner = Homebrew::InstallSteps::Runner.new(context:)
+    expect(runner).to receive(:run_command_output)
+      .with("/usr/bin/openssl", "x509", "-fingerprint", "-sha256", "-noout", "-in", certificate)
+      .and_return("sha256 Fingerprint=AB:CD:EF\n")
+    expect(runner).to receive(:run_command_output)
+      .with("/usr/bin/security", "find-certificate", "-a", "-c", "NodeMITMProxyCA", "-Z", sudo: true)
+      .and_return(<<~EOS)
+        SHA-256 hash: ABCDEF
+        SHA-256 hash: FEDCBA
+      EOS
+    expect(runner).to receive(:run_command)
+      .with("/usr/bin/security", "delete-certificate", "-Z", "ABCDEF", sudo: true)
+
+    runner.run(steps)
+  end
+
+  specify "skips keychain certificate deletion when a local certificate is missing" do
+    certificate = root/"missing.pem"
+    steps = Homebrew::InstallSteps::DSL.build do
+      delete_keychain_certificate "NodeMITMProxyCA", matching_certificate: certificate
+    end
+
+    runner = Homebrew::InstallSteps::Runner.new(context:)
+    expect(runner).not_to receive(:run_command_output)
+    expect(runner).not_to receive(:run_command)
+
+    runner.run(steps)
   end
 
   specify "does not add the default base to home paths" do

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           system "true"
-          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`.
+          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`.
         end
       end
     CASK
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           update_desktop_database
-          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`.
+          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`.
         end
       end
     CASK
@@ -63,6 +63,8 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
           move_children "source", "target"
           ln_sf "source", "target", source_base: :relative, uninstall: true
           write "foo.conf", "key = value\n"
+          delete_keychain_certificate "Charles"
+          delete_keychain_certificate "NodeMITMProxyCA", matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"
         end
       end
     CASK

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -575,6 +575,12 @@ postflight_steps do
   mv "payload", "Shared/payload"
   ln_s "Shared/payload", "Payload", source_base: :relative
 end
+
+uninstall_postflight_steps do
+  delete_keychain_certificate "Charles"
+  delete_keychain_certificate "NodeMITMProxyCA",
+                              matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"
+end
 ```
 
 A steps block may only contain supported step calls with literal arguments; it cannot call the wider cask DSL or arbitrary Ruby code. Each phase may define either its Ruby flight block or its matching steps block, not both.
@@ -595,6 +601,8 @@ Relative paths default to `staged_path` for `base:`, `source_base:` and `target_
 * `ln_s`: alias for `symlink`; example: `ln_s "Shared/payload", "Payload", source_base: :relative`.
 * `ln_sf`: create or replace a symlink; example: `ln_sf "Shared/payload", "Payload", source_base: :relative, uninstall: true`.
 * `write`: write literal content to a file unless it already exists; example: `write "Shared/foo.conf", "key = value"`. Pass `overwrite: true` to always replace the file. A trailing newline is appended unless the content already ends with one. Content may use the `{{staged_path}}`, `{{appdir}}` and `{{version}}` tokens, which are expanded at install time; any other `{{...}}` is left verbatim.
+* `delete_keychain_certificate`: delete macOS keychain certificates whose common name matches the argument; example: `delete_keychain_certificate "Charles"`. Pass `matching_certificate:` with a local certificate path to delete only the matching SHA-256 fingerprint; example:
+  `delete_keychain_certificate "NodeMITMProxyCA", matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"`.
 
 {% endraw %}
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1259,9 +1259,11 @@ class Foo < Formula
   # ...
   url "https://example.com/foo-1.0.tar.gz"
 
-  def post_install
-    rm pkgetc/"cert.pem" if File.exist?(pkgetc/"cert.pem")
-    pkgetc.install_symlink Formula["ca-certificates"].pkgetc/"cert.pem"
+  post_install_steps do
+    ln_sf "cert.pem", "cert.pem",
+          source_formula: "ca-certificates",
+          source_base:    :formula_pkgetc,
+          target_base:    :pkgetc
   end
   # ...
 end


### PR DESCRIPTION
- Let cask uninstall steps remove keychain certificates without loading Ruby flight blocks from API installs.
- Keep the JSON payload to a certificate common name, with optional `matching_certificate` fingerprint narrowing for shared names.
- Document formula certificate symlinks as structured `ln_sf` steps and leave one-off trust store generation in legacy Ruby.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
