### PR TITLE
Pre-stage cask downloads

### DIFF
--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -5,7 +5,9 @@ require "downloadable"
 require "fileutils"
 require "unpack_strategy"
 require "cask/cache"
+require "cask/caskroom"
 require "cask/quarantine"
+require "cask/utils"
 
 module Cask
   # A download corresponding to a {Cask}.
@@ -99,11 +101,11 @@ module Cask
       )
     end
 
-    sig { params(to: Pathname, verbose: T::Boolean).void }
-    def extract_primary_container(to:, verbose:)
+    sig { params(to: Pathname, verbose: T::Boolean, container: T.nilable(UnpackStrategy)).void }
+    def extract_primary_container(to:, verbose:, container: nil)
       odebug "Extracting primary container"
 
-      container = primary_container
+      container ||= primary_container
       raise "unexpected nil primary_container" unless container
 
       odebug "Using container class #{container.class} for #{container.path}"
@@ -138,6 +140,69 @@ module Cask
         odebug "Renaming #{rename_operation.from} to #{rename_operation.to}"
         rename_operation.perform_rename(target_dir)
       end
+    end
+
+    sig { returns(Pathname) }
+    def staged_path_from_download_queue
+      HOMEBREW_PREFIX/"var/homebrew/tmp/.caskroom"/cask.staged_path.relative_path_from(Caskroom.path)
+    end
+
+    sig { returns(Pathname) }
+    def staged_path_from_download_queue_marker
+      Pathname("#{staged_path_from_download_queue}.staged")
+    end
+
+    sig { params(command: T.class_of(SystemCommand)).void }
+    def purge_staged_from_download_queue(command: SystemCommand)
+      staged_marker = staged_path_from_download_queue_marker
+      Utils.gain_permissions_remove(staged_marker, command:) if staged_marker.symlink? || staged_marker.exist?
+
+      staged_path = staged_path_from_download_queue
+      Utils.gain_permissions_remove(staged_path, command:) if staged_path.exist?
+
+      staged_path.parent.rmdir_if_possible
+      staged_path.parent.parent.rmdir_if_possible
+    end
+
+    sig { override.params(download: Pathname, pour: T::Boolean).returns(T::Boolean) }
+    def stage_from_download_queue?(download, pour:)
+      return false unless pour
+      return false if cask.staged_path.exist? || staged_path_from_download_queue_marker.exist?
+
+      UnpackStrategy.detect(download, type:         cask.container&.type,
+                                      merge_xattrs: true).dependencies.all? do |dependency|
+        case dependency
+        when Formula
+          dependency.any_version_installed? && dependency.optlinked?
+        when Cask
+          dependency.installed?
+        end
+      end
+    end
+
+    sig { override.params(download: Pathname, pour: T::Boolean).void }
+    def stage_from_download_queue(download, pour:)
+      return unless stage_from_download_queue?(download, pour:)
+
+      purge_staged_from_download_queue
+      cask.download ||= download
+      extract_primary_container(
+        to:        staged_path_from_download_queue,
+        verbose:   false,
+        container: UnpackStrategy.detect(
+          download,
+          type:         cask.container&.type,
+          merge_xattrs: true,
+        ),
+      )
+      process_rename_operations(target_dir: staged_path_from_download_queue)
+      FileUtils.ln_s(staged_path_from_download_queue, staged_path_from_download_queue_marker)
+    # Catch any exception type here to clean up partial queued extractions.
+    rescue Exception # rubocop:disable Lint/RescueException
+      ignore_interrupts do
+        purge_staged_from_download_queue
+      end
+      raise
     end
 
     sig { override.returns(T::Boolean) }

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -132,10 +132,20 @@ module Cask
 
       Caskroom.ensure_caskroom_exists
 
-      extract_primary_container
-      process_rename_operations
+      queued_staged_path = downloader.staged_path_from_download_queue
+      queued_staged_marker = downloader.staged_path_from_download_queue_marker
+      if @defer_fetch && queued_staged_marker.exist? && !@cask.staged_path.exist?
+        @cask.staged_path.dirname.mkpath
+        FileUtils.mv(queued_staged_path, @cask.staged_path)
+        downloader.purge_staged_from_download_queue(command: @command)
+      else
+        downloader.purge_staged_from_download_queue(command: @command) if @defer_fetch
+        extract_primary_container
+        process_rename_operations
+      end
       save_caskfile
     rescue => e
+      downloader.purge_staged_from_download_queue(command: @command) if @defer_fetch
       purge_versioned_files
       raise e
     end

--- a/Library/Homebrew/test/cask/download_spec.rb
+++ b/Library/Homebrew/test/cask/download_spec.rb
@@ -57,6 +57,35 @@ RSpec.describe Cask::Download, :cask do
     end
   end
 
+  describe "#stage_from_download_queue?" do
+    it "does not mutate download state" do
+      cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+      download = described_class.new(cask)
+
+      expect(download).not_to receive(:primary_container)
+
+      expect(download.stage_from_download_queue?(TEST_FIXTURE_DIR/"cask/caffeine.zip", pour: true)).to be(true)
+      expect(cask.download).to be_nil
+    end
+  end
+
+  describe "#purge_staged_from_download_queue" do
+    it "removes stale markers with permission-aware removal" do
+      cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+      download = described_class.new(cask)
+      staged_marker = download.staged_path_from_download_queue_marker
+      staged_marker.dirname.mkpath
+      FileUtils.ln_s(download.staged_path_from_download_queue, staged_marker)
+
+      expect(Cask::Utils).to receive(:gain_permissions_remove).with(staged_marker,
+                                                                    command: SystemCommand).and_call_original
+
+      download.purge_staged_from_download_queue
+
+      expect(staged_marker).not_to exist
+    end
+  end
+
   describe "#downloaded_and_valid?" do
     it "quarantines valid cached downloads" do
       cached_download = HOMEBREW_CACHE/"downloads/cask.zip"

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -737,6 +737,56 @@ RSpec.describe Cask::Installer, :cask do
 
       installer.enqueue_downloads
     end
+
+    it "stages the main cask download outside Caskroom before install" do
+      cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+      download_queue = Homebrew::DownloadQueue.new(pour: true)
+      installer = described_class.new(cask, download_queue:, defer_fetch: true)
+      queued_staged_path = installer.downloader.staged_path_from_download_queue
+      queued_staged_marker = installer.downloader.staged_path_from_download_queue_marker
+
+      begin
+        installer.enqueue_downloads
+        download_queue.fetch
+      ensure
+        download_queue.shutdown
+      end
+
+      expect(cask.staged_path).not_to exist
+      expect(cask).not_to be_installed
+      expect(queued_staged_path/"Caffeine.app").to be_a_directory
+      expect(queued_staged_marker).to exist
+
+      expect(installer).not_to receive(:extract_primary_container)
+
+      installer.stage
+
+      expect(cask.staged_path/"Caffeine.app").to be_a_directory
+      expect(cask).to be_installed
+    end
+
+    it "does not stage queued downloads with missing unpack dependencies" do
+      cask = Cask::CaskLoader.load(cask_path("container-bzip2"))
+      download_queue = Homebrew::DownloadQueue.new(pour: true)
+      installer = described_class.new(cask, download_queue:, defer_fetch: true)
+      queued_staged_path = installer.downloader.staged_path_from_download_queue
+      queued_staged_marker = installer.downloader.staged_path_from_download_queue_marker
+
+      allow_any_instance_of(Formula).to receive(:any_version_installed?).and_return(false)
+      expect(installer).not_to receive(:extract_primary_container)
+
+      begin
+        installer.enqueue_downloads
+        download_queue.fetch
+      ensure
+        download_queue.shutdown
+      end
+
+      expect(cask.staged_path).not_to exist
+      expect(cask).not_to be_installed
+      expect(queued_staged_path).not_to exist
+      expect(queued_staged_marker).not_to exist
+    end
   end
 
   describe "rename operations" do


### PR DESCRIPTION
Needs https://github.com/Homebrew/brew/pull/23033

- Extract cask containers during queued fetches so installs spend less serial time in the staging phase.
- Keep receipt writing and artifact installation in the normal install path so installed state does not change early.
- Skip queued extraction when unpack dependencies are still missing so dependency installation ordering stays intact.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
