### PR TITLE
fix escaping in shellenv documentation

### DIFF
--- a/Library/Homebrew/cmd/shellenv.rb
+++ b/Library/Homebrew/cmd/shellenv.rb
@@ -20,7 +20,7 @@ module Homebrew
           querying them multiple times.
           To help guarantee idempotence, this command produces no output when Homebrew's `bin` and `sbin` directories
           are first and second respectively in your `$PATH`. Consider adding evaluation of this command's output to
-          your dotfiles (e.g. `~/.bash_profile` or ~/.zprofile` on macOS and ~/.bashrc` or ~/.zshrc` on Linux)
+          your dotfiles (e.g. `~/.bash_profile` or `~/.zprofile` on macOS and `~/.bashrc` or `~/.zshrc` on Linux)
           with e.g.:
             `eval "$(brew shellenv zsh)"` or `eval "$(brew shellenv bash)"`
 


### PR DESCRIPTION
I noticed that there were some missing ticks in this documentation.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [X] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [X] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [X] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
