### PR TITLE
perf/settings: read all settings with one git invocation per repository

### DIFF
--- a/Library/Homebrew/settings.rb
+++ b/Library/Homebrew/settings.rb
@@ -1,11 +1,20 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "cachable"
 require "utils/popen"
 
 module Homebrew
   # Helper functions for reading and writing settings.
   module Settings
+    extend T::Generic
+    extend Cachable
+
+    # Sorbet type members are mutable by design and cannot be frozen.
+    # rubocop:disable Style/MutableConstant
+    Cache = type_template { { fixed: T::Hash[Pathname, T::Hash[String, String]] } }
+    # rubocop:enable Style/MutableConstant
+
     sig {
       params(setting: T.any(String, Symbol), repo: Pathname)
         .returns(T.nilable(String))
@@ -13,9 +22,9 @@ module Homebrew
     def self.read(setting, repo: HOMEBREW_REPOSITORY)
       return unless (repo/".git/config").exist?
 
-      value = Utils.popen_read("git", "-C", repo.to_s, "config", "--get", "homebrew.#{setting}").chomp
+      value = all(repo)[setting.to_s]
 
-      return if value.strip.empty?
+      return if value.nil? || value.strip.empty?
 
       value
     end
@@ -29,6 +38,7 @@ module Homebrew
       return if read(setting, repo:) == value
 
       Kernel.system("git", "-C", repo.to_s, "config", "--replace-all", "homebrew.#{setting}", value, exception: true)
+      cache.delete(repo)
     end
 
     sig { params(setting: T.any(String, Symbol), repo: Pathname).void }
@@ -38,6 +48,19 @@ module Homebrew
       return if read(setting, repo:).nil?
 
       Kernel.system("git", "-C", repo.to_s, "config", "--unset-all", "homebrew.#{setting}", exception: true)
+      cache.delete(repo)
+    end
+
+    # All `homebrew.*` settings in `repo`, cached so that repeated reads cost
+    # one `git config` invocation per repository instead of one per setting.
+    sig { params(repo: Pathname).returns(T::Hash[String, String]) }
+    private_class_method def self.all(repo)
+      cache[repo] ||= Utils.popen_read(
+        "git", "-C", repo.to_s, "config", "--null", "--get-regexp", "^homebrew\\."
+      ).split("\0").to_h do |entry|
+        keyvalue = entry.split("\n", 2)
+        [keyvalue.fetch(0).delete_prefix("homebrew."), keyvalue.fetch(1, "")]
+      end
     end
   end
 end

--- a/Library/Homebrew/test/settings_spec.rb
+++ b/Library/Homebrew/test/settings_spec.rb
@@ -5,6 +5,7 @@ require "settings"
 
 RSpec.describe Homebrew::Settings do
   before do
+    described_class.clear_cache
     HOMEBREW_REPOSITORY.cd do
       system "git", "init"
     end
@@ -34,6 +35,16 @@ RSpec.describe Homebrew::Settings do
 
     it "runs on a repo without a configuration file" do
       expect { described_class.read("foo", repo: HOMEBREW_REPOSITORY/"bar") }.not_to raise_error
+    end
+
+    it "reads all settings with a single git invocation per repository" do
+      setup_setting
+      expect(Utils).to receive(:popen_read)
+        .with("git", "-C", HOMEBREW_REPOSITORY.to_s, "config", "--null", "--get-regexp", "^homebrew\\.")
+        .once.and_call_original
+
+      described_class.read(:foo)
+      described_class.read(:bar)
     end
   end
 


### PR DESCRIPTION
## Summary

`Homebrew::Settings.read` spawns one `git config --get` subprocess per setting. Several settings are read during startup of essentially every Ruby `brew` command (analytics state, `devcmdrun`, completions messages), and stackprof profiles of `brew --env`, `brew config`, `brew services list` and `brew upgrade --dry-run` all showed `Settings.read` among the largest subprocess costs, ~45-90 ms per command depending on how many settings are consulted.

## Changes

`Settings.read` now reads all `homebrew.*` settings for a repository at once with a single `git config --null --get-regexp '^homebrew\.'` invocation and answers subsequent reads from a per-repository cache. `write`/`delete` invalidate the repository's cache entry after mutating, and `Settings.clear_cache` is available for tests.

Semantics are unchanged, verified against a scratch repository: dotted subsection keys (`gcc-rpaths.fixed`, the one dotted key in use), multi-valued keys return the last value exactly as `--get` did, missing keys and whitespace-only values return `nil`, a missing `.git/config` short-circuits, and write-read-delete round-trips behave as before. The `--null` framing keeps parsing robust for values containing newlines. Bash-side setting reads (`utils/analytics.sh`) run before the Ruby process starts and are unaffected.

A new spec asserts that two reads cost exactly one `git` invocation (fails on the previous implementation); the existing specs clear the cache in setup since they write settings with raw `git config`.

**Benchmarks** (Hyperfine, 15 runs each, warmup 3, `HOMEBREW_SORBET_RUNTIME` unset, interleaved against main). The saving is a fixed cost per command, so lighter commands see the largest relative change; `--env --plain` is the 6th most-run command/options combination in the [last 365 days of analytics](https://formulae.brew.sh/analytics/brew-command-run-options/365d/) (4.44%, 26.6M runs):

| Command | Before | After | Change |
|---|---|---|---|
| `brew --env --plain` | 395.8 ms ± 5.6 ms | 353.0 ms ± 6.6 ms | **~11% decrease** |
| `brew commands` | 613.3 ms ± 17.6 ms | 551.1 ms ± 8.2 ms | **~10% decrease** |
| `brew outdated --json` | 844.0 ms ± 30.8 ms | 794.5 ms ± 12.3 ms | **~6% decrease** |

`brew --env --plain` output is byte-identical before and after.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code was used to identify `Settings.read` as a recurring subprocess cost across stackprof profiles, implement the cache and write the new spec. Verified by semantics comparison against a scratch repository (dotted keys, multi-valued keys, missing keys, round-trips), a red/green cycle for the new spec, byte-identical `brew --env --plain` output, interleaved Hyperfine benchmarks and `brew lgtm` locally.

-----
