### PR TITLE
bundle/parallel_installer: fix terminal output after interactive installs

### DIFF
--- a/Library/Homebrew/bundle/parallel_installer.rb
+++ b/Library/Homebrew/bundle/parallel_installer.rb
@@ -291,7 +291,7 @@ module Homebrew
           # Interactive installers can leave ONLCR disabled, so use CRLF to
           # ensure terminal status output returns to column 0.
           if stream.tty?
-            stream.print(message, "\r\n")
+            stream.write(message, "\r\n")
           else
             stream.puts(message)
           end

--- a/Library/Homebrew/bundle/parallel_installer.rb
+++ b/Library/Homebrew/bundle/parallel_installer.rb
@@ -287,7 +287,15 @@ module Homebrew
 
       sig { params(message: String, stream: IO).void }
       def write_output(message, stream: $stdout)
-        @output_mutex.synchronize { stream.puts(message) }
+        @output_mutex.synchronize do
+          # Interactive installers can leave ONLCR disabled, so use CRLF to
+          # ensure terminal status output returns to column 0.
+          if stream.tty?
+            stream.print(message, "\r\n")
+          else
+            stream.puts(message)
+          end
+        end
       end
 
       sig { void }

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -268,6 +268,35 @@ RSpec.describe Homebrew::Bundle::Installer do
       )
     end
 
+    describe "output" do
+      subject(:parallel_installer) do
+        Homebrew::Bundle::ParallelInstaller.new(
+          [],
+          jobs: 2, no_upgrade: false, verbose: false, force: false, quiet: false,
+        )
+      end
+
+      it "uses CRLF for terminal output" do
+        reader, writer = IO.pipe
+        allow(writer).to receive(:tty?).and_return(true)
+
+        parallel_installer.send(:write_output, "Installing alpha", stream: writer)
+        writer.close
+
+        expect(reader.read).to eq("Installing alpha\r\n")
+      end
+
+      it "uses LF for redirected output" do
+        reader, writer = IO.pipe
+        allow(writer).to receive(:tty?).and_return(false)
+
+        parallel_installer.send(:write_output, "Installing alpha", stream: writer)
+        writer.close
+
+        expect(reader.read).to eq("Installing alpha\n")
+      end
+    end
+
     it "installs independent formulae in parallel with jobs > 1" do
       allow(Homebrew::Bundle::Brew).to receive(:formulae_by_full_name).with("alpha").and_return({ dependencies: [] })
       allow(Homebrew::Bundle::Brew).to receive(:formulae_by_full_name).with("beta").and_return({ dependencies: [] })

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -277,23 +277,29 @@ RSpec.describe Homebrew::Bundle::Installer do
       end
 
       it "uses CRLF for terminal output" do
-        reader, writer = IO.pipe
-        allow(writer).to receive(:tty?).and_return(true)
+        output = IO.pipe do |reader, writer|
+          allow(writer).to receive(:tty?).and_return(true)
 
-        parallel_installer.send(:write_output, "Installing alpha", stream: writer)
-        writer.close
+          parallel_installer.send(:write_output, "Installing alpha", stream: writer)
+          writer.close
 
-        expect(reader.read).to eq("Installing alpha\r\n")
+          reader.read
+        end
+
+        expect(output).to eq("Installing alpha\r\n")
       end
 
       it "uses LF for redirected output" do
-        reader, writer = IO.pipe
-        allow(writer).to receive(:tty?).and_return(false)
+        output = IO.pipe do |reader, writer|
+          allow(writer).to receive(:tty?).and_return(false)
 
-        parallel_installer.send(:write_output, "Installing alpha", stream: writer)
-        writer.close
+          parallel_installer.send(:write_output, "Installing alpha", stream: writer)
+          writer.close
 
-        expect(reader.read).to eq("Installing alpha\n")
+          reader.read
+        end
+
+        expect(output).to eq("Installing alpha\n")
       end
     end
 


### PR DESCRIPTION
## Summary

- use explicit CRLF endings for terminal status output
- preserve LF endings for redirected output
- cover both behaviours with regression tests

## Context

Interactive installers can leave ONLCR disabled. In that state, LF moves the cursor down without returning it to column zero, causing parallel `brew bundle` status lines to drift diagonally across the terminal.

For example, output which should have been left-aligned appeared as:

```text
Using rustup
            Installing opam
                           Installing pnpm
                                          Installing ruby
```

Using CRLF for TTY output keeps each status line aligned whilst preserving standard Unix line endings for pipes and log files.

## Reproduction

1. Use a Brewfile containing several formulae and at least one cask that prompts for administrator access.
2. Disable the terminal's LF-to-CRLF conversion and run Bundle in parallel:

   ```sh
   stty -onlcr
   brew bundle --jobs=4
   stty onlcr
   ```

3. Before this change, each status line starts where the previous line ended instead of at column zero.

## Testing

- `bin/brew lgtm`
- `bin/brew tests --only=bundle/installer`

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI GPT-5.6 Sol was used to assist with diagnosis, implementation and PR prose. I reviewed the complete diff and verified it with the tests listed below.