### PR TITLE
Add cask permission steps

### DIFF
--- a/Library/Homebrew/cask/artifact/install_steps.rb
+++ b/Library/Homebrew/cask/artifact/install_steps.rb
@@ -28,47 +28,47 @@ module Cask
 
       private
 
-      sig { returns(Homebrew::InstallSteps::Runner) }
-      def runner
-        Homebrew::InstallSteps::Runner.new(context: cask)
+      sig { params(command: T.class_of(SystemCommand)).returns(Homebrew::InstallSteps::Runner) }
+      def runner(command)
+        Homebrew::InstallSteps::Runner.new(context: cask, command:)
       end
     end
 
     class PreflightSteps < AbstractInstallSteps
-      sig { params(_options: T.anything).void }
-      def install_phase(**_options)
-        runner.run(steps)
+      sig { params(command: T.class_of(SystemCommand), _options: T.anything).void }
+      def install_phase(command: SystemCommand, **_options)
+        runner(command).run(steps)
       end
 
-      sig { params(_options: T.anything).void }
-      def uninstall_phase(**_options)
-        runner.run(steps, phase: :uninstall)
+      sig { params(command: T.class_of(SystemCommand), _options: T.anything).void }
+      def uninstall_phase(command: SystemCommand, **_options)
+        runner(command).run(steps, phase: :uninstall)
       end
     end
 
     class PostflightSteps < AbstractInstallSteps
-      sig { params(_options: T.anything).void }
-      def install_phase(**_options)
-        runner.run(steps)
+      sig { params(command: T.class_of(SystemCommand), _options: T.anything).void }
+      def install_phase(command: SystemCommand, **_options)
+        runner(command).run(steps)
       end
 
-      sig { params(_options: T.anything).void }
-      def uninstall_phase(**_options)
-        runner.run(steps, phase: :uninstall)
+      sig { params(command: T.class_of(SystemCommand), _options: T.anything).void }
+      def uninstall_phase(command: SystemCommand, **_options)
+        runner(command).run(steps, phase: :uninstall)
       end
     end
 
     class UninstallPreflightSteps < AbstractInstallSteps
-      sig { params(_options: T.anything).void }
-      def uninstall_phase(**_options)
-        runner.run(steps)
+      sig { params(command: T.class_of(SystemCommand), _options: T.anything).void }
+      def uninstall_phase(command: SystemCommand, **_options)
+        runner(command).run(steps)
       end
     end
 
     class UninstallPostflightSteps < AbstractInstallSteps
-      sig { params(_options: T.anything).void }
-      def uninstall_phase(**_options)
-        runner.run(steps)
+      sig { params(command: T.class_of(SystemCommand), _options: T.anything).void }
+      def uninstall_phase(command: SystemCommand, **_options)
+        runner(command).run(steps)
       end
     end
   end

--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -2,16 +2,20 @@
 # frozen_string_literal: true
 
 require "system_command"
+require "utils/output"
 
 module Homebrew
   # Declarative install steps that can be serialised through the JSON APIs.
   module InstallSteps
     PathSpec = T.type_alias { T::Hash[String, String] }
-    StepValue = T.type_alias { T.any(String, T::Boolean, PathSpec) }
+    PathSpecs = T.type_alias { T::Array[PathSpec] }
+    StepValue = T.type_alias { T.any(String, T::Boolean, PathSpec, PathSpecs) }
     Step = T.type_alias { T::Hash[String, StepValue] }
     Steps = T.type_alias { T::Array[Step] }
+    Paths = T.type_alias { T.any(String, Pathname, T::Array[T.any(String, Pathname)]) }
     RawPathSpec = T.type_alias { T::Hash[T.any(String, Symbol), T.nilable(T.any(String, Symbol, Pathname))] }
-    RawStepValue = T.type_alias { T.nilable(T.any(String, Symbol, T::Boolean, Pathname, RawPathSpec)) }
+    RawPathSpecs = T.type_alias { T::Array[T.any(String, Symbol, Pathname, RawPathSpec)] }
+    RawStepValue = T.type_alias { T.nilable(T.any(String, Symbol, T::Boolean, Pathname, RawPathSpec, RawPathSpecs)) }
     RawStep = T.type_alias { T::Hash[T.any(String, Symbol), RawStepValue] }
     SystemCommandArg = T.type_alias { T.any(String, Pathname) }
     TemplateTokenValue = T.type_alias { T.any(String, Pathname) }
@@ -99,15 +103,28 @@ module Homebrew
         case obj
         when Symbol
           obj.to_s
+        when Array
+          obj.map { |value| normalise_path_value(value) } if key == "paths"
         when Hash
-          ::T.cast(obj.to_h { |key, value| [key.to_s, value&.to_s] }.compact_blank, PathSpec)
+          normalise_path_value(obj)
         when String, Pathname
-          %w[path source target matching_certificate].include?(key) ? { "path" => obj.to_s } : obj.to_s
+          %w[path source target matching_certificate].include?(key) ? normalise_path_value(obj) : obj.to_s
         else
           obj
         end
       end
       private_class_method :normalise_step_value
+
+      sig { params(obj: T.any(String, Symbol, Pathname, RawPathSpec)).returns(PathSpec) }
+      def self.normalise_path_value(obj)
+        case obj
+        when Hash
+          ::T.cast(obj.to_h { |key, value| [key.to_s, value&.to_s] }.compact_blank, PathSpec)
+        else
+          { "path" => obj.to_s }
+        end
+      end
+      private_class_method :normalise_path_value
 
       sig { params(path: ::T.any(::String, ::Pathname), base: ::T.nilable(::T.any(::String, ::Symbol))).void }
       def mkdir(path, base: nil)
@@ -319,6 +336,34 @@ module Homebrew
                    matching_certificate))
       end
 
+      sig {
+        params(
+          paths:       Paths,
+          permissions: ::String,
+          base:        ::T.nilable(::T.any(::String, ::Symbol)),
+        ).void
+      }
+      def set_permissions(paths, permissions, base: nil)
+        add_step("set_permissions",
+                 "paths"       => path_specs(paths, base:, default_base: @default_base),
+                 "permissions" => permissions)
+      end
+
+      sig {
+        params(
+          paths: Paths,
+          user:  ::T.nilable(::String),
+          group: ::String,
+          base:  ::T.nilable(::T.any(::String, ::Symbol)),
+        ).void
+      }
+      def set_ownership(paths, user: nil, group: "staff", base: nil)
+        add_step("set_ownership",
+                 "paths" => path_specs(paths, base:, default_base: @default_base),
+                 "user"  => user,
+                 "group" => group)
+      end
+
       private
 
       sig { params(type: ::String, fields: ::T.nilable(StepValue)).void }
@@ -351,6 +396,18 @@ module Homebrew
 
       sig {
         params(
+          paths:        Paths,
+          base:         ::T.nilable(::T.any(::String, ::Symbol)),
+          default_base: ::T.nilable(::T.any(::String, ::Symbol)),
+        ).returns(PathSpecs)
+      }
+      def path_specs(paths, base:, default_base:)
+        paths = [paths] unless paths.is_a?(Array)
+        paths.map { |path| path_spec(path, base:, default_base:) }
+      end
+
+      sig {
+        params(
           path:         ::T.any(::String, ::Pathname),
           default_base: ::T.nilable(::T.any(::String, ::Symbol)),
         ).returns(::T.nilable(::T.any(::String, ::Symbol)))
@@ -365,15 +422,17 @@ module Homebrew
 
     class Runner
       include SystemCommand::Mixin
+      include ::Utils::Output::Mixin
 
       # Path tokens reuse the step base resolution; formula metadata tokens are
       # resolved separately. Anything else is left verbatim so literal braces in
       # templates are never rewritten.
       CONTENT_PATH_TOKENS = %w[prefix opt_prefix bin var etc pkgetc staged_path appdir].freeze
 
-      sig { params(context: Object).void }
-      def initialize(context:)
+      sig { params(context: Object, command: T.class_of(SystemCommand)).void }
+      def initialize(context:, command: SystemCommand)
         @context = context
+        @command = T.let(command, T.class_of(SystemCommand))
       end
 
       sig { params(steps: Steps, phase: Symbol).void }
@@ -452,6 +511,10 @@ module Homebrew
             path.dirname.mkpath
             path.write(expand_template_tokens(content))
           end
+        when "set_permissions"
+          run_set_permissions(step)
+        when "set_ownership"
+          run_set_ownership(step)
         when "compile_gsettings_schemas"
           run_formula_tool("glib", "glib-compile-schemas", resolve_path(step_path(step, "path")))
         when "gio_querymodules"
@@ -506,6 +569,40 @@ module Homebrew
         else
           raise ArgumentError, "unknown install step: #{step.fetch("type")}"
         end
+      end
+
+      sig { params(step: Step).void }
+      def run_set_permissions(step)
+        paths = existing_step_paths(step)
+        return if paths.empty?
+
+        @command.run!("chmod", args: ["-R", "--", step_string(step, "permissions"), *paths], sudo: false)
+      end
+
+      sig { params(step: Step).void }
+      def run_set_ownership(step)
+        require "cask/quarantine"
+        require "utils/user"
+
+        paths = existing_step_paths(step)
+        return if paths.empty?
+
+        paths.each do |path|
+          next if ::Cask::Quarantine.app_management_permissions_granted?(app: path, command: @command)
+
+          raise ::Cask::CaskError, <<~EOS
+            Cannot change the ownership of '#{path}' because your terminal does not have App Management permissions.
+            macOS prevents modifying apps without these permissions, even when using `sudo`.
+            To fix this, approve the permissions prompt (if one was just shown) or go to
+            System Settings → Privacy & Security → App Management and add or enable your terminal.
+            Then run this command again.
+          EOS
+        end
+
+        ohai "Changing ownership of paths required by #{@context} with `sudo` (which may request your password)..."
+        @command.run!("chown", args: ["-R", "--", "#{step["user"] || ::User.current}:#{step["group"] || "staff"}",
+                                      *paths],
+                               sudo: true)
       end
 
       sig { params(step: Step).void }
@@ -583,6 +680,19 @@ module Homebrew
       sig { params(step: Step, key: String).returns(PathSpec) }
       def step_path(step, key)
         T.cast(step.fetch(key), PathSpec)
+      end
+
+      sig { params(step: Step, key: String).returns(PathSpecs) }
+      def step_paths(step, key)
+        T.cast(step.fetch(key), PathSpecs)
+      end
+
+      sig { params(step: Step).returns(T::Array[Pathname]) }
+      def existing_step_paths(step)
+        step_paths(step, "paths").filter_map do |spec|
+          path = resolve_path(spec).expand_path
+          path if path.exist?
+        end
       end
 
       sig { params(step: Step, key: String).returns(String) }
@@ -695,12 +805,12 @@ module Homebrew
 
       sig { params(command: SystemCommandArg, args: SystemCommandArg, sudo: T::Boolean).void }
       def run_command(command, *args, sudo: false)
-        system_command!(command, args: args, sudo:, print_stdout: true, print_stderr: true, reset_uid: true)
+        @command.run!(command, args: args, sudo:, print_stdout: true, print_stderr: true, reset_uid: true)
       end
 
       sig { params(command: SystemCommandArg, args: SystemCommandArg, sudo: T::Boolean).returns(String) }
       def run_command_output(command, *args, sudo: false)
-        system_command!(command, args: args, sudo:, print_stderr: true, reset_uid: true).stdout
+        @command.run!(command, args: args, sudo:, print_stderr: true, reset_uid: true).stdout
       end
     end
   end

--- a/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
+++ b/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
@@ -99,9 +99,15 @@ verify the changed taps with `./bin/brew style`, `./bin/brew audit` and
 5. Run targeted `./bin/brew style` and `./bin/brew audit` for changed formulae
    or casks, then tap-wide `./bin/brew readall homebrew/core` and
    `./bin/brew readall homebrew/cask`.
+6. If either tapped checkout has no modifications after the scan and
+   conversion pass, run `./bin/brew untap homebrew/core` or
+   `./bin/brew untap homebrew/cask` for the unmodified tap before finishing
+   the `Homebrew/brew` PR.
 
-If one tap has no applicable changes for an operation, record that with
-filenames from the scan rather than leaving the tap unchecked.
+Do this local tap pass while implementing the `Homebrew/brew` DSL PR so tap
+conversions are not left for a separate reminder. If one tap has no applicable
+changes for an operation, record that with filenames from the scan rather than
+leaving the tap unchecked.
 
 Long-term success for each operation PR means a tap conversion can remove the
 whole legacy hook for the case it targets. For formulae, the temporary bridge
@@ -421,12 +427,24 @@ is stripped during metadata serialisation.
   `source_base: :formula_pkgetc`; specialised trust store generation such as
   `ca-certificates` bundle regeneration and Mono `cert-sync` stays legacy Ruby
   because current repeated usage is below the named-variant threshold.
-- [ ] PR 8, cask permission and ownership actions.
+- [x] PR 8, cask permission and ownership actions.
+  Commit: `Add cask permission steps`.
   Estimated existing casks affected: about `21` casks change permissions and
   `36` change ownership.
-  Notes for implementation: match the existing flight mini-DSL
-  `set_permissions` and `set_ownership` semantics first; define sudo/root
-  requirements and uninstall behaviour before adding API output.
+  Scope: cask `set_permissions` and `set_ownership` steps, path-array API
+  normalisation, runner execution through `chmod` and `sudo chown`, cask
+  installer command routing, App Management checks before ownership changes,
+  cask step block allow-list entries, fixture/API loader coverage and cask
+  cookbook docs. The steps skip missing paths like the existing flight
+  mini-DSL. `set_ownership` defaults to the current user and `staff` group
+  unless `user:` or `group:` are provided.
+  Local tap work converted pure `set_permissions` and `set_ownership` flight
+  blocks in `48` `homebrew/cask` casks. `homebrew/core` had no matching
+  formula conversions for the cask-only DSL and was untapped after the clean
+  scan. Remaining cask legacy blocks are `Casks/s/starnet++.rb`,
+  `Casks/h/hummingbird.rb`, `Casks/m/mplabx-ide.rb` and
+  `Casks/p/proxy-audio-device.rb`; they depend on unsupported local variables,
+  architecture data or additional `system_command` work.
 - [ ] PR 9, cask language variations in API data.
   Estimated existing casks affected: `27` casks use language blocks, with large
   examples including `Casks/f/firefox.rb`,

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -13,13 +13,15 @@ module RuboCop
         [:compile_gsettings_schemas, :gio_querymodules, :gdk_pixbuf_query_loaders, :gtk_update_icon_cache,
          :update_mime_database, :update_desktop_database].freeze
       KEYCHAIN_STEP_METHODS = [:delete_keychain_certificate].freeze
+      PERMISSION_STEP_METHODS = [:set_permissions, :set_ownership].freeze
       ALLOWED_STEP_METHODS = T.let(
         [*FILE_PREPARATION_STEP_METHODS, *LINK_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *SERVICE_DATA_STEP_METHODS,
          *REBUILD_ACTION_STEP_METHODS].freeze,
         T::Array[Symbol],
       )
       CASK_ALLOWED_STEP_METHODS = T.let(
-        [*FILE_PREPARATION_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *KEYCHAIN_STEP_METHODS].freeze,
+        [*FILE_PREPARATION_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *KEYCHAIN_STEP_METHODS,
+         *PERMISSION_STEP_METHODS].freeze,
         T::Array[Symbol],
       )
 

--- a/Library/Homebrew/test/cask/artifact/install_steps_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/install_steps_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Cask::Artifact::AbstractInstallSteps, :cask do
 
       preflight_steps do
         mkdir_p "Prepared"
+        set_permissions "Prepared", "0755"
         touch "Prepared/touched"
       end
 
@@ -35,9 +36,15 @@ RSpec.describe Cask::Artifact::AbstractInstallSteps, :cask do
     (cask.staged_path/"move-source").write "moved"
 
     installer = Cask::Installer.new(cask, command: NeverSudoSystemCommand)
-    installer.install_artifacts
+    previous_umask = File.umask(077)
+    begin
+      installer.install_artifacts
+    ensure
+      File.umask(previous_umask)
+    end
 
     expect(cask.staged_path/"Prepared").to be_a_directory
+    expect((cask.staged_path/"Prepared").stat.mode & 0777).to eq(0755)
     expect(cask.staged_path/"Prepared/touched").to exist
     expect(cask.staged_path/"Prepared/moved").to exist
     expect(cask.staged_path/"PreparedLink").to be_a_symlink

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "install_steps"
+require "cask/quarantine"
 
 RSpec.describe Homebrew::InstallSteps do
   let(:root) { Pathname(TEST_TMPDIR)/"install-steps" }
@@ -91,6 +92,17 @@ RSpec.describe Homebrew::InstallSteps do
         name:                 "NodeMITMProxyCA",
         matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem",
       },
+      {
+        type:        :set_permissions,
+        paths:       ["Example.app"],
+        permissions: "0755",
+      },
+      {
+        type:  :set_ownership,
+        paths: [{ base: :staged_path, path: "Example.app" }],
+        user:  :root,
+        group: :wheel,
+      },
     ]
 
     expect(Homebrew::InstallSteps::DSL.normalise_steps(steps)).to contain_exactly(
@@ -107,6 +119,20 @@ RSpec.describe Homebrew::InstallSteps do
         "matching_certificate" => {
           "path" => "~/Library/Application Support/betwixt/ssl/certs/ca.pem",
         },
+      },
+      {
+        "type"        => "set_permissions",
+        "paths"       => [{ "path" => "Example.app" }],
+        "permissions" => "0755",
+      },
+      {
+        "type"  => "set_ownership",
+        "paths" => [{
+          "base" => "staged_path",
+          "path" => "Example.app",
+        }],
+        "user"  => "root",
+        "group" => "wheel",
       },
     )
   end
@@ -413,6 +439,44 @@ RSpec.describe Homebrew::InstallSteps do
     expect(runner).not_to receive(:run_command)
 
     runner.run(steps)
+  end
+
+  specify "sets permissions and ownership for existing cask step paths" do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :staged_path) do
+      set_permissions ["Prepared.app", "Missing.app"], "0755"
+      set_ownership "Owned.app", user: "root", group: "wheel"
+    end
+
+    command = class_double(SystemCommand)
+    (root/"stage/Prepared.app").mkpath
+    (root/"stage/Owned.app").mkpath
+
+    allow(Cask::Quarantine).to receive(:app_management_permissions_granted?)
+      .with(app: root/"stage/Owned.app", command:)
+      .and_return(true)
+    expect(command).to receive(:run!)
+      .with("chmod", args: ["-R", "--", "0755", root/"stage/Prepared.app"], sudo: false).ordered
+    expect(command).to receive(:run!)
+      .with("chown", args: ["-R", "--", "root:wheel", root/"stage/Owned.app"], sudo: true).ordered
+
+    Homebrew::InstallSteps::Runner.new(context:, command:).run(steps)
+  end
+
+  specify "raises when App Management permissions are missing for ownership steps" do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :staged_path) do
+      set_ownership "Owned.app"
+    end
+
+    command = class_double(SystemCommand)
+    (root/"stage/Owned.app").mkpath
+
+    allow(Cask::Quarantine).to receive(:app_management_permissions_granted?)
+      .with(app: root/"stage/Owned.app", command:)
+      .and_return(false)
+    expect(command).not_to receive(:run!)
+
+    expect { Homebrew::InstallSteps::Runner.new(context:, command:).run(steps) }
+      .to raise_error(Cask::CaskError, /App Management permissions/)
   end
 
   specify "does not add the default base to home paths" do

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           system "true"
-          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`.
+          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
         end
       end
     CASK
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           update_desktop_database
-          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`.
+          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
         end
       end
     CASK
@@ -63,6 +63,8 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
           move_children "source", "target"
           ln_sf "source", "target", source_base: :relative, uninstall: true
           write "foo.conf", "key = value\n"
+          set_permissions "Foo.app", "0755"
+          set_ownership "Foo.app", user: "root", group: "wheel"
           delete_keychain_certificate "Charles"
           delete_keychain_certificate "NodeMITMProxyCA", matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"
         end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-install-steps.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-install-steps.rb
@@ -14,6 +14,7 @@ cask "with-install-steps" do
 
   preflight_steps do
     mkdir_p "Prepared"
+    set_permissions "Prepared", "0755"
     touch "Prepared/touched"
   end
 
@@ -24,6 +25,7 @@ cask "with-install-steps" do
 
   uninstall_preflight_steps do
     mkdir "UninstallPrepared"
+    set_ownership "UninstallPrepared", user: "root", group: "wheel"
     touch "UninstallPrepared/touched"
   end
 

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -574,6 +574,7 @@ end
 postflight_steps do
   mv "payload", "Shared/payload"
   ln_s "Shared/payload", "Payload", source_base: :relative
+  set_permissions "Shared/payload", "0755"
 end
 
 uninstall_postflight_steps do
@@ -603,6 +604,8 @@ Relative paths default to `staged_path` for `base:`, `source_base:` and `target_
 * `write`: write literal content to a file unless it already exists; example: `write "Shared/foo.conf", "key = value"`. Pass `overwrite: true` to always replace the file. A trailing newline is appended unless the content already ends with one. Content may use the `{{staged_path}}`, `{{appdir}}` and `{{version}}` tokens, which are expanded at install time; any other `{{...}}` is left verbatim.
 * `delete_keychain_certificate`: delete macOS keychain certificates whose common name matches the argument; example: `delete_keychain_certificate "Charles"`. Pass `matching_certificate:` with a local certificate path to delete only the matching SHA-256 fingerprint; example:
   `delete_keychain_certificate "NodeMITMProxyCA", matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"`.
+* `set_permissions`: recursively change existing path permissions with `chmod`; example: `set_permissions "Shared/payload", "0755"`.
+* `set_ownership`: recursively change existing path ownership with `sudo chown`; example: `set_ownership "Shared/payload", user: "root", group: "wheel"`. Missing paths are ignored. When `user:` is omitted, the current user is used. When `group:` is omitted, `staff` is used.
 
 {% endraw %}
 


### PR DESCRIPTION
- `set_permissions` and `set_ownership` cover common cask flights
- JSON API casks can keep these operations in structured data
- Ownership keeps the existing App Management and sudo guardrails
- The plan now requires tap conversion checks before finishing

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
