### PR TITLE
Move `safe_system` off `Kernel`

### DIFF
--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -53,12 +53,9 @@ module Kernel
     ).void
   }
   def safe_system(cmd, argv0 = nil, *args, **options)
-    # TODO: migrate to utils.rb Homebrew.safe_system
-    require "utils"
+    require "homebrew"
 
-    return if Homebrew.system(cmd, argv0, *args, **options)
-
-    raise ErrorDuringExecution.new([cmd, argv0, *args], status: $CHILD_STATUS)
+    Homebrew.safe_system(cmd, argv0, *args, **options)
   end
 
   # Run a system command without any output.

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -53,6 +53,7 @@ module Kernel
     ).void
   }
   def safe_system(cmd, argv0 = nil, *args, **options)
+    # odeprecated: remove this method in a later release, use `Homebrew.safe_system` directly instead
     require "homebrew"
 
     Homebrew.safe_system(cmd, argv0, *args, **options)
@@ -69,6 +70,7 @@ module Kernel
     ).returns(T::Boolean)
   }
   def quiet_system(cmd, argv0 = nil, *args)
+    # odeprecated: remove this method in a later release, use `Homebrew.quiet_system` directly instead
     require "homebrew"
 
     Homebrew.quiet_system(cmd, argv0, *args)

--- a/Library/Homebrew/homebrew.rb
+++ b/Library/Homebrew/homebrew.rb
@@ -75,6 +75,20 @@ module Homebrew
 
   sig {
     params(
+      cmd:     T.nilable(T.any(Pathname, String, [String, String], T::Hash[String, T.nilable(String)])),
+      argv0:   T.nilable(T.any(Pathname, String, [String, String])),
+      args:    T.nilable(T.any(Pathname, String)),
+      options: T.untyped,
+    ).void
+  }
+  def self.safe_system(cmd, argv0 = nil, *args, **options)
+    return if system(cmd, argv0, *args, **options)
+
+    raise ErrorDuringExecution.new([cmd, argv0, *args], status: $CHILD_STATUS)
+  end
+
+  sig {
+    params(
       cmd:   T.nilable(T.any(Pathname, String, [String, String], T::Hash[String, T.nilable(String)])),
       argv0: T.nilable(T.any(String, [String, String])),
       args:  T.any(Pathname, String),

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -94,4 +94,11 @@ RSpec.describe Kernel do
       expect(quiet_system("true")).to be true
     end
   end
+
+  describe "#safe_system" do
+    it "delegates to Homebrew.safe_system" do
+      expect(Homebrew).to receive(:safe_system).with("true", nil)
+      safe_system("true")
+    end
+  end
 end

--- a/Library/Homebrew/test/homebrew_spec.rb
+++ b/Library/Homebrew/test/homebrew_spec.rb
@@ -79,5 +79,15 @@ RSpec.describe Homebrew do
       expect(described_class.quiet_system("false")).to be false
     end
   end
+
+  describe ".safe_system" do
+    it "does not raise for a successful command" do
+      expect { described_class.safe_system("true") }.not_to raise_error
+    end
+
+    it "raises for a failing command" do
+      expect { described_class.safe_system("false") }.to raise_error(ErrorDuringExecution)
+    end
+  end
 end
 # rubocop:enable Style/GlobalVars


### PR DESCRIPTION
Adds Homebrew.safe_system and makes Kernel#safe_system call it. This follows the same pattern already used for quiet_system. Behaviour does not change.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code found this TODO and wrote the change, copying a pattern I reviewed and approved earlier. I ran all checks manually.

-----
