### PR TITLE
utils/pypi: use relative cooldown

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2183,7 +2183,7 @@ class Formula
     args = ["--verbose", "--no-deps", "--no-binary=:all:", "--ignore-installed", "--no-compile"]
     # Delay packages published in the last day so builds are less likely to
     # install a freshly compromised PyPI release.
-    args << "--uploaded-prior-to=#{(Time.now.utc - Homebrew::RELEASE_COOLDOWN_SECONDS).iso8601(0)}"
+    args << "--uploaded-prior-to=P#{Homebrew::RELEASE_COOLDOWN_DAYS}D"
     args << "--prefix=#{prefix}" if prefix
     args << "--no-build-isolation" unless build_isolation
     args

--- a/Library/Homebrew/release_cooldown.rb
+++ b/Library/Homebrew/release_cooldown.rb
@@ -3,5 +3,4 @@
 
 module Homebrew
   RELEASE_COOLDOWN_DAYS = 1
-  RELEASE_COOLDOWN_SECONDS = T.let(RELEASE_COOLDOWN_DAYS * 24 * 60 * 60, Integer)
 end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -3206,9 +3206,7 @@ RSpec.describe Formula do
     end
 
     it "filters packages uploaded within the last day" do
-      allow(Time).to receive(:now).and_return(Time.utc(2026, 4, 4, 12, 0, 0))
-
-      expect(f.std_pip_args).to include("--uploaded-prior-to=2026-04-03T12:00:00Z")
+      expect(f.std_pip_args).to include("--uploaded-prior-to=P1D")
     end
   end
 

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -155,14 +155,13 @@ RSpec.describe PyPI do
 
   describe ".pip_report" do
     it "filters packages uploaded within the last day" do
-      allow(Time).to receive(:now).and_return(Time.utc(2026, 4, 4, 12, 0, 0))
       `true`
 
       expect(Utils).to receive(:popen_read).with(
         { "PIP_REQUIRE_VIRTUALENV" => "false" },
         Utils::Path.formula_opt_libexec("python")/"bin/python", "-m", "pip", "install", "-q",
         "--disable-pip-version-check", "--dry-run", "--ignore-installed",
-        "--uploaded-prior-to=2026-04-03T12:00:00Z", "--report=/dev/stdout", "snakemake"
+        "--uploaded-prior-to=P1D", "--report=/dev/stdout", "snakemake"
       ).and_return('{"install":[]}')
 
       expect(described_class.pip_report([PyPI::Package.new("snakemake")])).to eq([])

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -499,7 +499,7 @@ module PyPI
       Utils::Path.formula_opt_libexec(python_name)/"bin/python",
       "-m", "pip", "install", "-q", "--disable-pip-version-check",
       "--dry-run", "--ignore-installed",
-      "--uploaded-prior-to=#{(Time.now.utc - Homebrew::RELEASE_COOLDOWN_SECONDS).iso8601(0)}",
+      "--uploaded-prior-to=P#{Homebrew::RELEASE_COOLDOWN_DAYS}D",
       "--report=/dev/stdout", *packages.map(&:to_s)
     ]
     options = {}


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

pip added support for relative cooldown durations in https://github.com/pypa/pip/commit/8c5468dc9695c023c0a6428e630126aa14c9db4e (released in `26.1` back in April), which matches other package managers and simplifies our handling a bit