### PR TITLE
cmd/source: support npm urls

### DIFF
--- a/Library/Homebrew/cmd/source.rb
+++ b/Library/Homebrew/cmd/source.rb
@@ -72,7 +72,8 @@ module Homebrew
           bitbucket_repo_url(url) ||
           codeberg_repo_url(url) ||
           sourcehut_repo_url(url) ||
-          pypi_repo_url(url)
+          pypi_repo_url(url) ||
+          npm_repo_url(url)
       end
 
       sig { params(url: String).returns(T.nilable(String)) }
@@ -179,6 +180,30 @@ module Homebrew
 
         project_urls["repository"] || project_urls["source"] ||
           url_to_repo(project_urls.fetch("homepage", "")) # Homepages often link to source repositories
+      rescue JSON::ParserError
+        nil
+      end
+
+      sig { params(url: String).returns(T.nilable(String)) }
+      def npm_repo_url(url)
+        regex = %r{
+          https?://registry\.npmjs\.org/
+          (?<package_name>(?:@[\w.-]+/)?[\w.-]+)/
+          (?:/.*)?
+        }x
+        match = url.match(regex)
+        return unless match
+
+        package_name = match[:package_name]
+        return unless package_name
+
+        api_url = "https://registry.npmjs.org/#{URI.encode_uri_component(package_name)}/latest"
+        curl_args = Utils::Curl.curl_args(show_error: false, retries: 2)
+        stdout, _, status = Utils::Curl.curl_output(*curl_args, api_url)
+        return unless status.success?
+
+        url = JSON.parse(stdout).dig("repository", "url")
+        url&.delete_prefix("git+")
       rescue JSON::ParserError
         nil
       end

--- a/Library/Homebrew/test/cmd/source_spec.rb
+++ b/Library/Homebrew/test/cmd/source_spec.rb
@@ -150,6 +150,49 @@ RSpec.describe Homebrew::Cmd::Source do
     end
   end
 
+  describe "#npm_repo_url" do
+    it "finds repository for npm URL" do
+      ["vite", "@org/vite"].each do |package|
+        encoded_package = URI.encode_uri_component(package)
+        expect(Utils::Curl).to receive(:curl_output)
+          .with(*Utils::Curl.curl_args(show_error: false, retries: 2), "https://registry.npmjs.org/#{encoded_package}/latest")
+          .and_return([
+            <<~JSON,
+              {
+                "repository": {
+                  "url": "git+https://github.com/vitejs/vite.git"
+                }
+              }
+            JSON
+            "",
+            instance_double(Process::Status, success?: true),
+          ])
+
+        expect(described_class.new([]).send(:npm_repo_url, "https://registry.npmjs.org/#{package}/-/vite-1.2.3.tgz"))
+          .to eq("https://github.com/vitejs/vite.git")
+      end
+    end
+
+    it "returns nil for npm package without repository information" do
+      expect(Utils::Curl).to receive(:curl_output)
+        .with(*Utils::Curl.curl_args(show_error: false, retries: 2), "https://registry.npmjs.org/vite/latest")
+        .and_return([
+          "{}",
+          "",
+          instance_double(Process::Status, success?: true),
+        ])
+
+      expect(described_class.new([])
+        .send(:npm_repo_url, "https://registry.npmjs.org/vite/-/vite-1.2.3.tgz"))
+        .to be_nil
+    end
+
+    it "returns nil for non-npm URLs" do
+      expect(described_class.new([]).send(:npm_repo_url, "https://example.com/repo.git"))
+        .to be_nil
+    end
+  end
+
   describe "#url_to_repo" do
     it "returns GitHub repo URL for GitHub URLs" do
       expect(described_class.new([]).send(:url_to_repo, "https://github.com/Homebrew/brew"))


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

This adds support for finding the git repo for an npm package, very similar to PyPI. Main difference is npm has both plain package names `vite` and org-scoped ones `@playwright/cli` while package metadata is served from https://registry.npmjs.org/vite/latest

After, these formulae now work as expected:

```bash
$ brew source vite
# opens https://github.com/vitejs/vite.git
$ brew source playwright-cli
# opens https://github.com/microsoft/playwright-cli.git
```