### PR TITLE
Enable privileged tap CI containers

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -91,6 +91,7 @@ module Homebrew
                       container: ghcr.io/homebrew/brew:main
               runs-on: ${{ matrix.os }}
               container: ${{ matrix.container }}
+              options: ${{ matrix.container != '' && '--privileged' }}
               permissions:
                 actions: read
                 checks: read

--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -168,7 +168,9 @@ module OS
         sig { returns(T.nilable(String)) }
         def check_linux_sandbox
           return unless Homebrew::EnvConfig.sandbox_linux?
-          return if OS::Linux.inside_docker?
+
+          inside_docker = OS::Linux.inside_docker?
+          return if inside_docker && !GitHub::Actions.env_set?
 
           state = ::Sandbox.state
           return if [:disabled, :available].include?(state)
@@ -202,6 +204,11 @@ module OS
             ]
           else
             [reason]
+          end
+          if state == :unavailable && inside_docker && GitHub::Actions.env_set?
+            lines.push("",
+                       "If this is a GitHub Actions container, add `options: --privileged` to the job's " \
+                       "`container` configuration.")
           end
 
           "#{[

--- a/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Homebrew::DevCmd::TapNew do
     expect(HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/tests.yml").to exist
     expect((HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/tests.yml").read)
       .not_to include("HOMEBREW_DEVELOPER")
+    expect((HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/tests.yml").read)
+      .to include("options: ${{ matrix.container != '' && '--privileged' }}")
     publish_yml = (HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/publish.yml").read
     expect(publish_yml).not_to include("HOMEBREW_DEVELOPER")
     expect(publish_yml).not_to include("pull_request_target")

--- a/Library/Homebrew/test/os/linux/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/linux/diagnostic_spec.rb
@@ -79,11 +79,11 @@ RSpec.describe Homebrew::Diagnostic::Checks do
     end
   end
 
-  specify "#check_linux_sandbox returns nil inside Docker" do
+  specify "#check_linux_sandbox returns nil inside Docker outside GitHub Actions" do
     allow(OS::Linux).to receive(:inside_docker?).and_return(true)
     expect(Sandbox).not_to receive(:state)
 
-    with_env(HOMEBREW_NO_SANDBOX_LINUX: nil) do
+    with_env(GITHUB_ACTIONS: nil, HOMEBREW_NO_SANDBOX_LINUX: nil) do
       expect(checks.check_linux_sandbox).to be_nil
     end
   end
@@ -154,6 +154,20 @@ RSpec.describe Homebrew::Diagnostic::Checks do
           "export HOMEBREW_NO_SANDBOX_LINUX=1",
         )
       expect(message).to end_with("  export HOMEBREW_NO_SANDBOX_LINUX=1\n")
+    end
+  end
+
+  specify "#check_linux_sandbox suggests privileged GitHub Actions containers" do
+    allow(OS::Linux).to receive(:inside_docker?).and_return(true)
+    allow(Sandbox).to receive_messages(
+      state:          :unavailable,
+      failure_reason: "Bubblewrap is installed but cannot create a rootless sandbox.",
+    )
+
+    with_env(GITHUB_ACTIONS: "true", HOMEBREW_NO_SANDBOX_LINUX: nil) do
+      expect(checks.check_linux_sandbox).to include(
+        "If this is a GitHub Actions container, add `options: --privileged` to the job's `container` configuration.",
+      )
     end
   end
 


### PR DESCRIPTION
- Allow Bubblewrap user namespaces in generated GitHub Actions container jobs.
- Direct GitHub Actions sandbox failures to the matching container configuration.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 Terra high with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
