### PR TITLE
Fix `brew bundle cleanup --force` not cleaning cache when `brew cleanup` warns

### DIFF
--- a/Library/Homebrew/bundle/subcommand/cleanup.rb
+++ b/Library/Homebrew/bundle/subcommand/cleanup.rb
@@ -372,7 +372,7 @@ module Homebrew
 
         sig { params(cmd: T.any(Pathname, String), args: T.anything).returns(String) }
         def self.system_output_no_stderr(cmd, *args)
-          IO.popen([cmd, *args], err: :close).read
+          Utils.safe_popen_read(cmd, *args, err: File::NULL)
         end
       end
     end

--- a/Library/Homebrew/test/cmd/bundle/cleanup_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/cleanup_subcommand_spec.rb
@@ -578,9 +578,23 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
   end
 
   describe "#system_output_no_stderr" do
-    it "shells out" do
-      expect(IO).to receive(:popen).and_return(StringIO.new("true"))
-      described_class.system_output_no_stderr("true")
+    it "discards stderr without closing it" do
+      stdout = nil
+      expect do
+        stdout = described_class.system_output_no_stderr(
+          RUBY_PATH,
+          "-e",
+          '$stderr.puts "warning"; $stdout.puts "cleaned"',
+        )
+      end.not_to output.to_stderr_from_any_process
+
+      expect(stdout).to eq("cleaned\n")
+    end
+
+    it "raises when the command fails" do
+      expect do
+        described_class.system_output_no_stderr(RUBY_PATH, "-e", "exit 1")
+      end.to raise_error(ErrorDuringExecution)
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/23053

`brew bundle cleanup --force` runs its final `brew cleanup` through `system_output_no_stderr`, which spawned the child with `IO.popen([cmd, *args], err: :close)`. Closing file descriptor 2 means the child hits `Errno::EBADF` the moment `brew cleanup` writes a warning to stderr, so it aborts before removing anything. The parent never checks the child status, so `brew bundle cleanup` reports success while the advertised cache files are still on disk (reported in #23053).

This redirects stderr to `File::NULL` instead of closing it, keeping the intent to suppress `brew cleanup`'s stderr while leaving a writable descriptor so a warning is discarded rather than fatal. It is the same idiom `Utils.popen` already uses for its default stderr handling.

The old unit test only asserted that `IO.popen` was called, so it could not catch this. It is replaced with a behavioral test that runs a child which writes to stderr and then stdout, and asserts the stdout is still returned, which distinguishes a discarded stderr from a closed one.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 4.8) diagnosed the closed-stderr failure and wrote the fix and regression test; I reviewed the diff and verified with `brew lgtm` plus the targeted `cmd/bundle/cleanup_subcommand` spec.

-----
