### PR TITLE
workflows/codeql: use ubuntu-latest

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ defaults:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
The CodeQL `analyze` job has run on `ubuntu-slim` since the December runner experiment, but that runner has a hard 15-minute job limit intended for lightweight automation and Ruby analysis routinely needs longer. Authenticated Actions data for July 4-11 shows 16 cancellations across 317 CodeQL runs. Push scans are the bulk of it: 15 of 86 (17.4%) were cancelled. Run 29122393436 was cancelled about 15 minutes after startup with only 29 of 44 queries completed.

This restores `ubuntu-latest`, the job's runner before that experiment and the one the heavier jobs already use. It has no 15-minute cap, so the full query suite finishes instead of being cancelled part-way and leaving code scanning without fresh results. It is a runner-only change with no effect on the analysis itself.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 4.8) reviewed the diff and the Actions cancellation data, confirming the `ubuntu-slim` 15-minute cap as the cause and `ubuntu-latest` as the fix; I made the change and verified with `brew lgtm`.

-----
