### PR TITLE
cmd/update_report: format new formulae/casks as table

### DIFF
--- a/Library/Homebrew/cmd/update_report/reporter_hub.rb
+++ b/Library/Homebrew/cmd/update_report/reporter_hub.rb
@@ -103,13 +103,14 @@ class ReporterHub
     else
       true
     end
-    formulae.each do |formula|
+    items = formulae.map do |formula|
       if should_display_descriptions && (desc = description(formula))
-        puts "#{formula}: #{desc}"
+        [formula, desc]
       else
-        puts formula
+        [formula, ""]
       end
     end
+    print_table(items)
   end
 
   sig { void }
@@ -125,14 +126,15 @@ class ReporterHub
     else
       true
     end
-    casks.each do |cask|
+    items = casks.map do |cask|
       cask_token = Utils.name_from_full_name(cask)
       if should_display_descriptions && (desc = cask_description(cask))
-        puts "#{cask_token}: #{desc}"
+        [cask_token, desc]
       else
-        puts cask_token
+        [cask_token, ""]
       end
     end
+    print_table(items)
   end
 
   sig { void }
@@ -226,6 +228,20 @@ class ReporterHub
       all_cask_json.find { |f| f["token"] == cask }
                    &.fetch("desc", nil)
                    &.presence
+    end
+  end
+
+  sig { params(items: T::Array[[String, String]]).void }
+  def print_table(items)
+    return if items.blank?
+
+    name_width = (items.map { |name, _| name.length }.max || 0) + 2
+    items.each do |name, desc|
+      if desc.present?
+        puts format("%-#{name_width}s %s", name, desc)
+      else
+        puts name
+      end
     end
   end
 end

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -447,8 +447,8 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
       expect { hub.dump }.to output(<<~EOS).to_stdout
         ==> New Formulae
         bar
-        baz: baz desc
-        foo: foobly things
+        baz   baz desc
+        foo   foobly things
       EOS
     end
 
@@ -461,7 +461,7 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
       allow(Cask::Caskroom).to receive(:any_casks_installed?).and_return(true)
       expect { hub.dump }.to output(<<~EOS).to_stdout
         ==> New Casks
-        cask1: desc1
+        cask1   desc1
         cask2
         cask3
       EOS


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Very minor style tweak to print new formulae/casks as a table with evenly spaced columns. Generally, I am mainly glancing at the package names and then read the description for anything that catches my eye. Currently, the names/descriptions blend in and can be noisy to me, especially with a lots of new packages.

This PR tries to help readers quickly distinguish the name from the description, which I find more readable

Example:

```console
$ git -C $(brew --repo homebrew/core) checkout @{3.days.ago}
$ brew update
```

Before:

```
==> New Formulae
filtlong: Quality filtering of long noisy DNA sequencing reads
librefang: Self-hostable operating system for autonomous AI agents
netcode: Secure client/server protocol for multiplayer games built on top of UDP
opencv@4: Open source computer vision library
rawtoaces: Utility for converting camera RAW image files to ACES
reliable: Simple packet acknowledgement system for UDP-based protocols
salmon: Transcript-level quantification from RNA-seq reads
smithery-cli: Install and list Model Context Protocol servers from Smithery
soar: Fast, modern package manager for Static Binaries, Portable Formats and more
trim-galore: Quality and adapter trimming for FastQ sequencing reads
```

After:

```
==> New Formulae
filtlong       Quality filtering of long noisy DNA sequencing reads
librefang      Self-hostable operating system for autonomous AI agents
netcode        Secure client/server protocol for multiplayer games built on top of UDP
opencv@4       Open source computer vision library
rawtoaces      Utility for converting camera RAW image files to ACES
reliable       Simple packet acknowledgement system for UDP-based protocols
salmon         Transcript-level quantification from RNA-seq reads
smithery-cli   Install and list Model Context Protocol servers from Smithery
soar           Fast, modern package manager for Static Binaries, Portable Formats and more
trim-galore    Quality and adapter trimming for FastQ sequencing reads
```