### PR TITLE
github_packages: truncate over-long licenses

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -336,13 +336,8 @@ class GitHubPackages
       formula_annotations_hash = image_index["annotations"]
       manifests = image_index["manifests"]
     else
-      image_license = if license.length <= 256
-        license
-      else
-        # TODO: Consider generating a truncated license when over the limit
-        require "utils/spdx"
-        SPDX.license_expression_to_string(:cannot_represent)
-      end
+      require "utils/spdx"
+      image_license = SPDX.truncate_license(license)
 
       formula_annotations_hash = {
         "com.github.package.type"                => GITHUB_PACKAGE_TYPE,

--- a/Library/Homebrew/test/utils/spdx_spec.rb
+++ b/Library/Homebrew/test/utils/spdx_spec.rb
@@ -198,6 +198,27 @@ RSpec.describe SPDX do
     end
   end
 
+  describe ".truncate_license" do
+    it "returns the license unchanged when within the limit" do
+      expect(described_class.truncate_license("MIT AND Apache-2.0")).to eq "MIT AND Apache-2.0"
+    end
+
+    it "truncates an over-long conjunction to a valid prefix with a marker" do
+      license = "MIT AND Apache-2.0 AND BSD-3-Clause AND GPL-2.0-only"
+      expect(described_class.truncate_license(license, limit: 40)).to eq "MIT AND LicenseRef-Homebrew-truncated"
+    end
+
+    it "falls back to :cannot_represent for over-long disjunctions" do
+      license = "MIT OR Apache-2.0 OR BSD-3-Clause OR GPL-2.0-only"
+      expect(described_class.truncate_license(license, limit: 40)).to eq "LicenseRef-Homebrew-cannot-represent"
+    end
+
+    it "falls back to :cannot_represent when even the first term does not fit" do
+      license = "Apache-2.0 AND MIT AND BSD-3-Clause AND ISC"
+      expect(described_class.truncate_license(license, limit: 20)).to eq "LicenseRef-Homebrew-cannot-represent"
+    end
+  end
+
   describe ".string_to_license_expression" do
     it "returns the correct result for 'and', 'or' and 'with'" do
       expr_string = "Apache-2.0 and (Apache-2.0 with LLVM-exception) and (MIT or NCSA)"

--- a/Library/Homebrew/utils/spdx.rb
+++ b/Library/Homebrew/utils/spdx.rb
@@ -14,6 +14,7 @@ module SPDX
   ALLOWED_LICENSE_SYMBOLS = [
     :public_domain,
     :cannot_represent,
+    :truncated,
   ].freeze
 
   sig { returns(T::Hash[String, T.untyped]) }
@@ -198,6 +199,43 @@ module SPDX
         ALLOWED_LICENSE_SYMBOLS.include?(license_sym) ? license_sym : result
       end
     end
+  end
+
+  # The `org.opencontainers.image.licenses` OCI annotation only accepts a limited
+  # length (`limit`), so shorten an over-long licence to a valid prefix rather than
+  # discarding it entirely. Only top-level `AND` expressions can be shortened safely:
+  # a prefix of "A AND B AND ..." still holds, whereas dropping `OR` alternatives
+  # would change the licence, so those fall back to `:cannot_represent`.
+  sig { params(license: String, limit: Integer).returns(String) }
+  def truncate_license(license, limit: 256)
+    return license if license.length <= limit
+
+    fallback = license_expression_to_string(:cannot_represent) || license
+
+    # Split on top-level `AND`, re-joining any segment split inside a bracketed
+    # sub-expression so each part stays a valid, balanced licence. A single part
+    # means a top-level `OR` (or a lone licence) that cannot be safely shortened.
+    parts = T.let([], T::Array[String])
+    license.split(" AND ").each do |segment|
+      previous = parts.last
+      if previous && previous.count("(") > previous.count(")")
+        parts[-1] = "#{previous} AND #{segment}"
+      else
+        parts << segment
+      end
+    end
+    return fallback if parts.length < 2
+
+    marker = license_expression_to_string(:truncated) || "truncated"
+    kept = T.let([], T::Array[String])
+    parts.each do |part|
+      break if [*kept, part, marker].join(" AND ").length > limit
+
+      kept << part
+    end
+    return fallback if kept.empty?
+
+    [*kept, marker].join(" AND ")
   end
 
   sig {


### PR DESCRIPTION
When a formula license is longer than the 256-character limit for the
`org.opencontainers.image.licenses` OCI annotation, we currently drop the whole
license and write `LicenseRef-Homebrew-cannot-represent`. This keeps as many
licenses as fit and adds a `LicenseRef-Homebrew-truncated` marker instead.

Example (`systemd`), before → after:

```
LicenseRef-Homebrew-cannot-represent
→
LGPL-2.1-or-later AND GPL-2.0-or-later AND CC0-1.0 AND ... AND LicenseRef-Homebrew-truncated
```

The full license is still saved in the `sh.brew.license` annotation, so Homebrew itself is not affected. But external tools (the ghcr.io UI, license scanners like Syft or Trivy) read the standard annotation and today see an "unknown" license; after this change, they can read the main licenses. 5 formulae are affected today: `systemd`, `krb5`, `mesa`, `qtwebengine`, `qtshadertools`.

Only top-level `AND` licenses are shortened because a prefix of "A AND B AND ..." is still true. Top-level `OR`, or cases where not even one license fits, fall back to `cannot_represent` (same as today). This resolves the existing
`# TODO: Consider generating a truncated license when over the limit`.
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g., "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

AI (Claude Code) helped find the affected formulae, design the truncation logic, and write the code and tests. I reviewed the change and ran `brew lgtm` locally and checked the output on all affected formulae.

-----
