### PR TITLE
test_bot fixes for portable formulae

### DIFF
--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -924,8 +924,12 @@ module Homebrew
         test "brew", "update-test"
         test "brew", "update-test", "--to-tag"
         test "brew", "update-test", "--commit=HEAD"
-        test "brew", "test-bot", "--only-formulae", "--only-json-tab", "--test-default-formula",
-             env: { "GITHUB_ACTIONS" => nil }
+
+        require "mktemp"
+        Mktemp.new("homebrew-test-bot").run do |_tmpdir|
+          test "brew", "test-bot", "--only-formulae", "--only-json-tab", "--test-default-formula",
+               env: { "GITHUB_ACTIONS" => nil }
+        end
       end
 
       sig { params(formula_name: String).void }

--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -926,7 +926,7 @@ module Homebrew
         test "brew", "update-test", "--commit=HEAD"
 
         require "mktemp"
-        Mktemp.new("homebrew-test-bot").run do |_tmpdir|
+        Mktemp.new("homebrew-test-bot").run do |_|
           test "brew", "test-bot", "--only-formulae", "--only-json-tab", "--test-default-formula",
                env: { "GITHUB_ACTIONS" => nil }
         end

--- a/Library/Homebrew/test_bot/formulae_detect.rb
+++ b/Library/Homebrew/test_bot/formulae_detect.rb
@@ -164,6 +164,8 @@ module Homebrew
         modified_formulae += added_and_deleted_formulae
 
         if args.test_default_formula?
+          @added_formulae.reject! { |formula| formula.start_with?("portable-") }
+          modified_formulae.reject! { |formula| formula.start_with?("portable-") }
           # Build the default test formulae.
           modified_formulae += DEFAULT_TEST_FORMULAE
         elsif @added_formulae.present? &&


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

### test_bot/formulae: run nested test-bot in temporary dir

This provides a clean directory to test bottling so that previously built bottles don't cause "Unexpected bottle" errors

https://github.com/Homebrew/homebrew-core/actions/runs/29179553748/job/86656464924#step:4:1833
```
 ==> Running Formulae#run!
  Error: Unexpected bottle JSON: /github/home/bottles/portable-ruby--4.0.5_1.arm64_linux.bottle.json
  Error: Unexpected bottle tarball: /github/home/bottles/portable-ruby--4.0.5_1.arm64_linux.bottle.tar.gz
```

`Mktemp#run` should be similar to `Dir.mktmpdir { Dir.chdir { ... } }`. Could use latter if preferred (need to change directory so that `Pathname.pwd` runs in clean directory).

---

### test_bot/formulae_detect: exclude portable when testing default

This avoids trying to rebuild portable formulae again within the nested test-bot run which may the cause of stalled runs