### PR TITLE
test/install_steps_spec: clear HOMEBREW_GITHUB_ACTIONS to allow CI run

### DIFF
--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe Homebrew::InstallSteps do
     FileUtils.rm_rf root
   end
 
+  around do |example|
+    with_env(HOMEBREW_GITHUB_ACTIONS: nil) do
+      example.run
+    end
+  end
+
   specify "runs mkdir, touch, move and symlink steps", :aggregate_failures do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var, default_source_base: :staged_path,
                                               default_target_base: :staged_path) do


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Needed when run inside portable formulae PRs

https://github.com/Homebrew/homebrew-core/actions/runs/29179553748/job/86656464924#step:4:104
```
  Error: Homebrew::InstallSteps links remapped directories and children before running initdb
  
  Failure/Error:
    expect(runner).to receive(:run_command) do |*args|
      expect(args).to eq([root/"prefix/bin/initdb", "--locale=en_US.UTF-8", "-E", "UTF-8",
                          root/"var/postgresql@17"])
      expect(homebrew_prefix/"share/postgresql@17").to be_a_directory
      expect(homebrew_prefix/"share/postgresql@17/postgres.bki").to be_a_symlink
    end
  
    (#<Homebrew::InstallSteps::Runner:0x0000ffc263d1f968 @context=#<#<Class:0x0000ffc269b9beb0>:0x0000ffc263ba57e0>, @command=SystemCommand>).run_command(*(any args))
        expected: 1 time with any arguments
        received: 0 times with any arguments
```