### PR TITLE
test/unpack_strategy: run extract with verbose

### DIFF
--- a/Library/Homebrew/test/unpack_strategy/gzip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/gzip_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe UnpackStrategy::Gzip do
   let(:path) { TEST_FIXTURE_DIR/"cask/container.gz" }
 
   include_examples "UnpackStrategy::detect"
-  include_examples "#extract", children: ["container"]
+  include_examples "#extract", children: ["container"], verbose: true
 end

--- a/Library/Homebrew/test/unpack_strategy/shared_examples.rb
+++ b/Library/Homebrew/test/unpack_strategy/shared_examples.rb
@@ -9,10 +9,10 @@ RSpec.shared_examples "UnpackStrategy::detect" do
   end
 end
 
-RSpec.shared_examples "#extract" do |children: []|
+RSpec.shared_examples "#extract" do |children: [], verbose: false|
   specify "#extract" do
     mktmpdir do |unpack_dir|
-      described_class.new(path).extract(to: unpack_dir)
+      described_class.new(path).extract(to: unpack_dir, verbose:)
       expect(unpack_dir.children(false).map(&:to_s)).to match_array children
     end
   end


### PR DESCRIPTION
Currently Gzip is failing in portable PRs but I can't reproduce it. Adding verbose to see if it gives more useful information

https://github.com/Homebrew/homebrew-core/actions/runs/29179553748/job/86656464924#step:4:322
```
  Error: UnpackStrategy::Gzip #extract
  
  Failure/Error: raise ErrorDuringExecution.new(command, status: @status, output: @output, secrets: @secrets)
  
  ErrorDuringExecution:
    Failure while executing; `/usr/bin/env gunzip -q -N -- /var/tmp/homebrew-tests-20260712-93573-91qu2m/temp/d20260712-93573-c36fsq/container.gz` exited with 2.
  Shared Example Group: "#extract" called from ./test/unpack_strategy/gzip_spec.rb:10
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
