### PR TITLE
test_bot/formulae: only run `brew style` if deps are bottled

### DIFF
--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -915,7 +915,7 @@ module Homebrew
         test "brew", "typecheck", "--update"
 
         # Run the checks that gate a Homebrew/brew pull request.
-        test "brew", "style"
+        test "brew", "style" if %w[actionlint shellcheck shfmt].all? { |f| bottled?(Formulary.factory(f)) }
         test "brew", "typecheck"
         test "brew", "install-bundler-gems", "--groups=all"
         test "brew", "vendor-gems", "--non-bundler-gems", "--no-commit"


### PR DESCRIPTION
`brew style` needs to install Homebrew/core formulae to run, but portable Ruby PRs run on Tier 3 machines resulting in attempting to source build multiple formulae and failing.

For now, skip `brew style` when bottles are not available (i.e. for macOS machines). We can consider splitting workflow to 2 separate runners if we want to test this, i.e. bottling on Tier 3 while running further tests on Tier 1.

See https://github.com/Homebrew/homebrew-core/actions/runs/29198762997/job/86666911890?pr=292807#step:3:264
```
  ==> Installing shellcheck dependency: ghc
  ==> ./configure --prefix=/private/tmp/ghc-20260712-30776-z6focn/ghc-9.14.1/binar
  ==> make install
  ==> cabal v2-update
  ==> ./configure --disable-numa --with-system-libffi --with-gmp-includes=/opt/hom
  ==> hadrian/build install -j4 --prefix=/opt/homebrew/Cellar/ghc/9.14.1 --flavour
  Last 150 lines from /Users/brew/actions-runner/_work/homebrew-core/homebrew-core/bottles/logs/ghc/05.build.log:
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
