### PR TITLE
Add `--ignore-main-package-cooldown` to `update-python-resources`

### DIFF
--- a/Library/Homebrew/dev-cmd/update-python-resources.rb
+++ b/Library/Homebrew/dev-cmd/update-python-resources.rb
@@ -20,6 +20,10 @@ module Homebrew
                             "This option is ignored for homebrew/core formulae."
         switch "--ignore-non-pypi-packages",
                description: "Don't fail if <formula> is not a PyPI package."
+        switch "--ignore-main-package-cooldown",
+               description: "Bypass the release cooldown for <formula>'s own package when resolving " \
+                            "resources. Its dependencies still respect the cooldown. This option is " \
+                            "ignored for official taps."
         switch "--install-dependencies",
                description: "Install missing dependencies required to update resources."
         flag   "--version=",
@@ -42,22 +46,22 @@ module Homebrew
         require "utils/pypi"
 
         args.named.to_formulae.each do |formula|
-          ignore_errors = if formula.tap&.official?
-            false
-          else
-            args.ignore_errors?
-          end
+          # These options may only be used on third-party taps.
+          official = formula.tap&.official?
+          ignore_errors = official ? false : args.ignore_errors?
+          ignore_main_package_cooldown = official ? false : args.ignore_main_package_cooldown?
           PyPI.update_python_resources! formula,
-                                        version:                  args.version,
-                                        package_name:             args.package_name,
-                                        extra_packages:           args.extra_packages,
-                                        exclude_packages:         args.exclude_packages,
-                                        install_dependencies:     args.install_dependencies?,
-                                        print_only:               args.print_only?,
-                                        quiet:                    args.quiet? || args.silent?,
-                                        verbose:                  args.verbose?,
-                                        ignore_errors:            ignore_errors,
-                                        ignore_non_pypi_packages: args.ignore_non_pypi_packages?
+                                        version:                      args.version,
+                                        package_name:                 args.package_name,
+                                        extra_packages:               args.extra_packages,
+                                        exclude_packages:             args.exclude_packages,
+                                        install_dependencies:         args.install_dependencies?,
+                                        print_only:                   args.print_only?,
+                                        quiet:                        args.quiet? || args.silent?,
+                                        verbose:                      args.verbose?,
+                                        ignore_errors:                ignore_errors,
+                                        ignore_non_pypi_packages:     args.ignore_non_pypi_packages?,
+                                        ignore_main_package_cooldown: ignore_main_package_cooldown
         end
       end
     end

--- a/Library/Homebrew/dev-cmd/update-python-resources.rb
+++ b/Library/Homebrew/dev-cmd/update-python-resources.rb
@@ -47,9 +47,13 @@ module Homebrew
 
         args.named.to_formulae.each do |formula|
           # These options may only be used on third-party taps.
-          official = formula.tap&.official?
-          ignore_errors = official ? false : args.ignore_errors?
-          ignore_main_package_cooldown = official ? false : args.ignore_main_package_cooldown?
+          if formula.tap&.official?
+            ignore_errors = false
+            ignore_main_package_cooldown = false
+          else
+            ignore_errors = args.ignore_errors?
+            ignore_main_package_cooldown = args.ignore_main_package_cooldown?
+          end
           PyPI.update_python_resources! formula,
                                         version:                      args.version,
                                         package_name:                 args.package_name,

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/update_python_resources.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/update_python_resources.rbi
@@ -21,6 +21,9 @@ class Homebrew::DevCmd::UpdatePythonResources::Args < Homebrew::CLI::Args
   def ignore_errors?; end
 
   sig { returns(T::Boolean) }
+  def ignore_main_package_cooldown?; end
+
+  sig { returns(T::Boolean) }
   def ignore_non_pypi_packages?; end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -249,6 +249,43 @@ RSpec.describe PyPI do
         end
       RUBY
     end
+
+    it "exempts the main package from the cooldown when requested" do
+      path = mktmpdir/"foo.rb"
+      contents = <<~RUBY
+        class Foo < Formula
+          url "https://files.pythonhosted.org/packages/foo-1.0.tar.gz"
+          sha256 "#{"a" * 64}"
+
+          resource "bar" do
+            url "https://files.pythonhosted.org/packages/bar-0.9.tar.gz"
+            sha256 "#{"b" * 64}"
+          end
+
+          def install
+            bin.install "foo"
+          end
+        end
+      RUBY
+      path.write(contents)
+      bar = PyPI::Package.new("bar==1.0")
+
+      allow(Formula).to receive(:[]).with("python").and_return(instance_double(Formula, ensure_installed!: true))
+      allow(bar).to receive(:pypi_info).and_return(
+        ["bar", "https://files.pythonhosted.org/packages/bar-1.0.tar.gz", "d" * 64, "1.0", nil],
+      )
+      exempted = T.let(nil, T.nilable(PyPI::Package))
+      allow(described_class).to receive(:pip_report) do |_packages, **kwargs|
+        exempted = kwargs[:ignore_cooldown_package] if kwargs.key?(:ignore_cooldown_package)
+        [PyPI::Package.new("foo==1.0"), bar]
+      end
+
+      described_class.update_python_resources!(Formulary.from_contents("foo", path, contents),
+                                               package_name: "foo", quiet: true,
+                                               ignore_main_package_cooldown: true)
+
+      expect(exempted&.name).to eq "foo"
+    end
   end
 
   describe "update_pypi_url", :needs_network do

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -168,6 +168,8 @@ RSpec.describe PyPI do
     end
 
     it "passes the ignored-cooldown package to pip by its direct URL" do
+      `true`
+
       main = PyPI::Package.new("snakemake==5.29.0")
       dependency = PyPI::Package.new("pyyaml==6.0")
       sdist_url = "https://files.pythonhosted.org/packages/snakemake-5.29.0.tar.gz"
@@ -185,6 +187,8 @@ RSpec.describe PyPI do
     end
 
     it "preserves extras on the ignored-cooldown package's direct URL" do
+      `true`
+
       main = PyPI::Package.new("snakemake[foo]==5.29.0")
       sdist_url = "https://files.pythonhosted.org/packages/snakemake-5.29.0.tar.gz"
       allow(main).to receive(:pypi_info).and_return(["snakemake", sdist_url, "a" * 64, "5.29.0"])
@@ -201,6 +205,8 @@ RSpec.describe PyPI do
     end
 
     it "keeps the ignored-cooldown package cooled when its sdist URL is unavailable" do
+      `true`
+
       main = PyPI::Package.new("snakemake==5.29.0")
       allow(main).to receive(:pypi_info).and_return(nil)
 

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -184,6 +184,22 @@ RSpec.describe PyPI do
       expect(described_class.pip_report([main, dependency], ignore_cooldown_package: main)).to eq([])
     end
 
+    it "preserves extras on the ignored-cooldown package's direct URL" do
+      main = PyPI::Package.new("snakemake[foo]==5.29.0")
+      sdist_url = "https://files.pythonhosted.org/packages/snakemake-5.29.0.tar.gz"
+      allow(main).to receive(:pypi_info).and_return(["snakemake", sdist_url, "a" * 64, "5.29.0"])
+
+      expect(Utils).to receive(:popen_read).with(
+        { "PIP_REQUIRE_VIRTUALENV" => "false" },
+        Utils::Path.formula_opt_libexec("python")/"bin/python", "-m", "pip", "install", "-q",
+        "--disable-pip-version-check", "--dry-run", "--ignore-installed",
+        "--uploaded-prior-to=P1D", "--report=/dev/stdout",
+        "snakemake[foo] @ #{sdist_url}"
+      ).and_return('{"install":[]}')
+
+      expect(described_class.pip_report([main], ignore_cooldown_package: main)).to eq([])
+    end
+
     it "keeps the ignored-cooldown package cooled when its sdist URL is unavailable" do
       main = PyPI::Package.new("snakemake==5.29.0")
       allow(main).to receive(:pypi_info).and_return(nil)

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -166,6 +166,23 @@ RSpec.describe PyPI do
 
       expect(described_class.pip_report([PyPI::Package.new("snakemake")])).to eq([])
     end
+
+    it "passes the ignored-cooldown package to pip by its direct URL" do
+      main = PyPI::Package.new("snakemake==5.29.0")
+      dependency = PyPI::Package.new("pyyaml==6.0")
+      sdist_url = "https://files.pythonhosted.org/packages/snakemake-5.29.0.tar.gz"
+      allow(main).to receive(:pypi_info).and_return(["snakemake", sdist_url, "a" * 64, "5.29.0"])
+
+      expect(Utils).to receive(:popen_read).with(
+        { "PIP_REQUIRE_VIRTUALENV" => "false" },
+        Utils::Path.formula_opt_libexec("python")/"bin/python", "-m", "pip", "install", "-q",
+        "--disable-pip-version-check", "--dry-run", "--ignore-installed",
+        "--uploaded-prior-to=P1D", "--report=/dev/stdout",
+        sdist_url, "pyyaml==6.0"
+      ).and_return('{"install":[]}')
+
+      expect(described_class.pip_report([main, dependency], ignore_cooldown_package: main)).to eq([])
+    end
   end
 
   describe ".update_python_resources!" do

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -183,6 +183,21 @@ RSpec.describe PyPI do
 
       expect(described_class.pip_report([main, dependency], ignore_cooldown_package: main)).to eq([])
     end
+
+    it "keeps the ignored-cooldown package cooled when its sdist URL is unavailable" do
+      main = PyPI::Package.new("snakemake==5.29.0")
+      allow(main).to receive(:pypi_info).and_return(nil)
+
+      expect(Utils).to receive(:popen_read).with(
+        { "PIP_REQUIRE_VIRTUALENV" => "false" },
+        Utils::Path.formula_opt_libexec("python")/"bin/python", "-m", "pip", "install", "-q",
+        "--disable-pip-version-check", "--dry-run", "--ignore-installed",
+        "--uploaded-prior-to=P1D", "--report=/dev/stdout",
+        "snakemake==5.29.0"
+      ).and_return('{"install":[]}')
+
+      expect(described_class.pip_report([main], ignore_cooldown_package: main)).to eq([])
+    end
   end
 
   describe ".update_python_resources!" do

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -503,12 +503,16 @@ module PyPI
     # index upload-time filter cannot hide a just-published release; its
     # dependencies stay index-resolved and cooled.
     requirements = packages.map do |package|
-      if ignore_cooldown_package && package == ignore_cooldown_package && package.valid_pypi_package?
-        _name, sdist_url = package.pypi_info
-        sdist_url.presence || package.to_s
-      else
-        package.to_s
-      end
+      exempt = ignore_cooldown_package && package == ignore_cooldown_package && package.valid_pypi_package?
+      next package.to_s unless exempt
+
+      name, sdist_url = package.pypi_info
+      next package.to_s if sdist_url.blank?
+
+      # PEP 508 direct reference. Any extras are preserved so their dependencies
+      # still resolve, while the URL bypasses the index upload-time filter.
+      extras = package.extras.presence
+      extras ? "#{name}[#{extras.join(",")}] @ #{sdist_url}" : sdist_url
     end
 
     command = [

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -227,24 +227,26 @@ module PyPI
   # Return true if resources were checked (even if no change).
   sig {
     params(
-      formula:                  Formula,
-      version:                  T.nilable(String),
-      package_name:             T.nilable(String),
-      extra_packages:           T.nilable(T::Array[String]),
-      exclude_packages:         T.nilable(T::Array[String]),
-      dependencies:             T.nilable(T::Array[String]),
-      install_dependencies:     T.nilable(T::Boolean),
-      print_only:               T.nilable(T::Boolean),
-      quiet:                    T.nilable(T::Boolean),
-      verbose:                  T.nilable(T::Boolean),
-      ignore_errors:            T.nilable(T::Boolean),
-      ignore_non_pypi_packages: T.nilable(T::Boolean),
+      formula:                      Formula,
+      version:                      T.nilable(String),
+      package_name:                 T.nilable(String),
+      extra_packages:               T.nilable(T::Array[String]),
+      exclude_packages:             T.nilable(T::Array[String]),
+      dependencies:                 T.nilable(T::Array[String]),
+      install_dependencies:         T.nilable(T::Boolean),
+      print_only:                   T.nilable(T::Boolean),
+      quiet:                        T.nilable(T::Boolean),
+      verbose:                      T.nilable(T::Boolean),
+      ignore_errors:                T.nilable(T::Boolean),
+      ignore_non_pypi_packages:     T.nilable(T::Boolean),
+      ignore_main_package_cooldown: T.nilable(T::Boolean),
     ).returns(T.nilable(T::Boolean))
   }
   def self.update_python_resources!(formula, version: nil, package_name: nil, extra_packages: nil,
                                     exclude_packages: nil, dependencies: nil, install_dependencies: false,
                                     print_only: false, quiet: false, verbose: false,
-                                    ignore_errors: false, ignore_non_pypi_packages: false)
+                                    ignore_errors: false, ignore_non_pypi_packages: false,
+                                    ignore_main_package_cooldown: false)
     if [package_name, extra_packages, exclude_packages, dependencies].all?(&:blank?)
       list_entry = formula.pypi_packages_info
 
@@ -353,7 +355,8 @@ module PyPI
     print_stderr = verbose && show_info
     print_stderr ||= false
 
-    found_packages = pip_report(input_packages, python_name:, print_stderr:)
+    found_packages = pip_report(input_packages, python_name:, print_stderr:,
+                                ignore_cooldown_package: (main_package if ignore_main_package_cooldown))
     # Resolve the dependency tree of excluded packages to prune the above
     exclude_packages.delete_if { |package| found_packages.exclude? package }
     if exclude_packages.present?

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -488,19 +488,32 @@ module PyPI
   sig {
     params(
       packages: T::Array[Package], python_name: String, print_stderr: T::Boolean,
+      ignore_cooldown_package: T.nilable(Package)
     ).returns(T::Array[Package])
   }
-  def self.pip_report(packages, python_name: "python", print_stderr: false)
+  def self.pip_report(packages, python_name: "python", print_stderr: false, ignore_cooldown_package: nil)
     return [] if packages.blank?
 
     # Delay packages published in the last day so resource resolution is less
-    # likely to pick a freshly compromised PyPI release.
+    # likely to pick a freshly compromised PyPI release. A cooldown-exempt main
+    # package (third-party taps only) is passed by its direct sdist URL so pip's
+    # index upload-time filter cannot hide a just-published release; its
+    # dependencies stay index-resolved and cooled.
+    requirements = packages.map do |package|
+      if ignore_cooldown_package && package == ignore_cooldown_package && package.valid_pypi_package?
+        _name, sdist_url = package.pypi_info
+        sdist_url.presence || package.to_s
+      else
+        package.to_s
+      end
+    end
+
     command = [
       Utils::Path.formula_opt_libexec(python_name)/"bin/python",
       "-m", "pip", "install", "-q", "--disable-pip-version-check",
       "--dry-run", "--ignore-installed",
       "--uploaded-prior-to=P#{Homebrew::RELEASE_COOLDOWN_DAYS}D",
-      "--report=/dev/stdout", *packages.map(&:to_s)
+      "--report=/dev/stdout", *requirements
     ]
     options = {}
     options[:err] = :err if print_stderr

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -355,8 +355,9 @@ module PyPI
     print_stderr = verbose && show_info
     print_stderr ||= false
 
+    ignore_cooldown_package = main_package if ignore_main_package_cooldown
     found_packages = pip_report(input_packages, python_name:, print_stderr:,
-                                ignore_cooldown_package: (main_package if ignore_main_package_cooldown))
+                                ignore_cooldown_package:)
     # Resolve the dependency tree of excluded packages to prune the above
     exclude_packages.delete_if { |package| found_packages.exclude? package }
     if exclude_packages.present?
@@ -512,7 +513,9 @@ module PyPI
       # PEP 508 direct reference. Any extras are preserved so their dependencies
       # still resolve, while the URL bypasses the index upload-time filter.
       extras = package.extras.presence
-      extras ? "#{name}[#{extras.join(",")}] @ #{sdist_url}" : sdist_url
+      next sdist_url unless extras
+
+      "#{name}[#{extras.join(",")}] @ #{sdist_url}"
     end
 
     command = [

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -3367,6 +3367,7 @@ _brew_update_python_resources() {
       --extra-packages
       --help
       --ignore-errors
+      --ignore-main-package-cooldown
       --ignore-non-pypi-packages
       --install-dependencies
       --package-name

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -2121,6 +2121,7 @@ __fish_brew_complete_arg 'update-python-resources' -l exclude-packages -d 'Exclu
 __fish_brew_complete_arg 'update-python-resources' -l extra-packages -d 'Include these additional packages when finding resources'
 __fish_brew_complete_arg 'update-python-resources' -l help -d 'Show this message'
 __fish_brew_complete_arg 'update-python-resources' -l ignore-errors -d 'Record all discovered resources, even those that can\'t be resolved successfully. This option is ignored for homebrew/core formulae'
+__fish_brew_complete_arg 'update-python-resources' -l ignore-main-package-cooldown -d 'Bypass the release cooldown for formula\'s own package when resolving resources. Its dependencies still respect the cooldown. This option is ignored for official taps'
 __fish_brew_complete_arg 'update-python-resources' -l ignore-non-pypi-packages -d 'Don\'t fail if formula is not a PyPI package'
 __fish_brew_complete_arg 'update-python-resources' -l install-dependencies -d 'Install missing dependencies required to update resources'
 __fish_brew_complete_arg 'update-python-resources' -l package-name -d 'Use the specified package-name when finding resources for formula. If no package name is specified, it will be inferred from the formula\'s stable URL'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -2717,6 +2717,7 @@ _brew_update_python_resources() {
     '--extra-packages[Include these additional packages when finding resources]' \
     '--help[Show this message]' \
     '--ignore-errors[Record all discovered resources, even those that can'\''t be resolved successfully. This option is ignored for homebrew/core formulae]' \
+    '--ignore-main-package-cooldown[Bypass the release cooldown for formula'\''s own package when resolving resources. Its dependencies still respect the cooldown. This option is ignored for official taps]' \
     '--ignore-non-pypi-packages[Don'\''t fail if formula is not a PyPI package]' \
     '--install-dependencies[Install missing dependencies required to update resources]' \
     '--package-name[Use the specified package-name when finding resources for formula. If no package name is specified, it will be inferred from the formula'\''s stable URL]' \

--- a/docs/Homebrew-Security-and-Supply-Chain.md
+++ b/docs/Homebrew-Security-and-Supply-Chain.md
@@ -209,6 +209,7 @@ Cooldowns have been added for:
 * [npm and PyPI in `bump`](https://github.com/Homebrew/brew/pull/21888)
 
 Homebrew applies these cooldowns narrowly, only to the language ecosystems that have actually suffered fast-moving supply-side attacks, rather than as a blanket delay on every package.
+Maintainers of third-party taps can pass `--ignore-main-package-cooldown` to `brew update-python-resources` to exempt a formula's own package (never its dependencies) from this cooldown when regenerating resources for a release they just published; the cooldown always applies on official taps.
 A blanket cooldown would trade a small, speculative reduction in supply-side risk for a real, across-the-board delay in shipping critical fixes: when a zero-day in something like OpenSSL is being exploited in the wild, Homebrew works to get the fix to users as fast as possible, and Homebrew's design means upgrading one package can require upgrading others.
 Across Homebrew's history far more users have been protected by shipping zero-day fixes quickly than have been exposed to npm-style token-theft or crypto-mining attacks, so a global cooldown would be a net negative for most users' security.
 The deeper reason Homebrew does not need a general cooldown is that, unlike language package managers, it already separates publishing from distribution: an upstream release does not reach users until it has passed human review, CI and checksum verification, which is the very review window that language-ecosystem cooldowns are trying to recreate.

--- a/docs/Homebrew-Security-and-Supply-Chain.md
+++ b/docs/Homebrew-Security-and-Supply-Chain.md
@@ -209,7 +209,6 @@ Cooldowns have been added for:
 * [npm and PyPI in `bump`](https://github.com/Homebrew/brew/pull/21888)
 
 Homebrew applies these cooldowns narrowly, only to the language ecosystems that have actually suffered fast-moving supply-side attacks, rather than as a blanket delay on every package.
-Maintainers of third-party taps can pass `--ignore-main-package-cooldown` to `brew update-python-resources` to exempt a formula's own package (never its dependencies) from this cooldown when regenerating resources for a release they just published; the cooldown always applies on official taps.
 A blanket cooldown would trade a small, speculative reduction in supply-side risk for a real, across-the-board delay in shipping critical fixes: when a zero-day in something like OpenSSL is being exploited in the wild, Homebrew works to get the fix to users as fast as possible, and Homebrew's design means upgrading one package can require upgrading others.
 Across Homebrew's history far more users have been protected by shipping zero-day fixes quickly than have been exposed to npm-style token-theft or crypto-mining attacks, so a global cooldown would be a net negative for most users' security.
 The deeper reason Homebrew does not need a general cooldown is that, unlike language package managers, it already separates publishing from distribution: an upstream release does not reach users until it has passed human review, CI and checksum verification, which is the very review window that language-ecosystem cooldowns are trying to recreate.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -3948,6 +3948,12 @@ Update versions for PyPI resource blocks in *`formula`*.
 
 : Don't fail if *`formula`* is not a PyPI package.
 
+`--ignore-main-package-cooldown`
+
+: Bypass the release cooldown for *`formula`*'s own package when resolving
+  resources. Its dependencies still respect the cooldown. This option is ignored
+  for official taps.
+
 `--install-dependencies`
 
 : Install missing dependencies required to update resources.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2518,6 +2518,9 @@ Record all discovered resources, even those that can\[u2019]t be resolved succes
 \fB\-\-ignore\-non\-pypi\-packages\fP
 Don\[u2019]t fail if \fIformula\fP is not a PyPI package\.
 .TP
+\fB\-\-ignore\-main\-package\-cooldown\fP
+Bypass the release cooldown for \fIformula\fP\[u2019]s own package when resolving resources\. Its dependencies still respect the cooldown\. This option is ignored for official taps\.
+.TP
 \fB\-\-install\-dependencies\fP
 Install missing dependencies required to update resources\.
 .TP


### PR DESCRIPTION
Adds an opt-in `--ignore-main-package-cooldown` switch to `brew update-python-resources`. It exempts a formula's **own** package from the PyPI release cooldown when regenerating resources, so a third-party tap maintainer can bump and rebuild immediately after publishing to PyPI instead of waiting out the cooldown. Dependencies are never exempted, and the switch is ignored on official taps.

Agreed here: https://github.com/orgs/Homebrew/discussions/6955#discussioncomment-17612052

**How it works:** the exempted main package is handed to pip as a PEP 508 direct reference (`name[extras] @ <sdist url>`, via `PyPI::Package#pypi_info`) instead of `name==version`. `--uploaded-prior-to` derives its timestamp from index metadata, so a direct-URL requirement bypasses it while every dependency stays index-resolved and cooled. Extras are preserved so their dependencies still resolve. If the sdist URL can't be resolved, it falls back to the cooled `name==version` form (fails closed).

**Guarantees:**
- Third-party taps only — forced off when `formula.tap.official?` (mirrors the existing `--ignore-errors` gate).
- Main package only — never dependencies or excluded packages.

**Verified** against pip 26.1.2 that `--uploaded-prior-to` does not filter direct-URL requirements: `idna==3.4` is dropped from the index at a pre-upload cutoff, yet installs by its sdist URL under the same cutoff.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude (Claude Code) drafted the implementation and tests under my direction; I reviewed every change. Verified with `brew lgtm` (typecheck, style, tests) and by empirically confirming that pip's `--uploaded-prior-to` does not filter direct-URL requirements.

-----
