### PR TITLE
test/unpack_strategy: use Mktemp to set group

### DIFF
--- a/Library/Homebrew/test/unpack_strategy/shared_examples.rb
+++ b/Library/Homebrew/test/unpack_strategy/shared_examples.rb
@@ -1,6 +1,7 @@
 # typed: false
 # frozen_string_literal: true
 
+require "mktemp"
 require "unpack_strategy"
 
 RSpec.shared_examples "UnpackStrategy::detect" do
@@ -11,7 +12,8 @@ end
 
 RSpec.shared_examples "#extract" do |children: [], verbose: false|
   specify "#extract" do
-    mktmpdir do |unpack_dir|
+    Mktemp.new("homebrew-test-unpack").run(chdir: false) do |mktemp|
+      unpack_dir = T.must(mktemp.tmpdir)
       described_class.new(path).extract(to: unpack_dir, verbose:)
       expect(unpack_dir.children(false).map(&:to_s)).to match_array children
     end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

After enabling verbose in https://github.com/Homebrew/brew/pull/23070, re-running portable formula PR showed:
```
  ErrorDuringExecution:
    Failure while executing; `/usr/bin/env gunzip -N -- /var/tmp/homebrew-tests-20260713-93575-44auwn/temp/d20260713-93575-6g31ja/container.gz` exited with 2. Here's the output:
    gzip: /var/tmp/homebrew-tests-20260713-93575-44auwn/temp/d20260713-93575-6g31ja/container.gz has the sticky bit set - file ignored
  Shared Example Group: "#extract" called from ./test/unpack_strategy/gzip_spec.rb:10
```

Not sure if this PR will help (as I haven't found how to reproduce error) but at least it follows the same logic we use in
https://github.com/Homebrew/brew/blob/0eb3803bf27f4a9bb26f2866dc1b50453ba7c938/Library/Homebrew/unpack_strategy.rb#L167-L168

---

As note, this error was happening before we enabled Bubblewrap in container so at least I don't think it is related to Sandbox
- https://github.com/Homebrew/homebrew-core/actions/runs/28336093429/job/83943680181#step:4:261