### PR TITLE
cask: fix migration when the new cask is already installed

### DIFF
--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -85,7 +85,6 @@ module Cask
       _, _, cask_token = token.split("/", 3)
       cask_token || token
     end
-    private_class_method :token_from_full_token
 
     sig { void }
     def self.ensure_caskroom_exists
@@ -125,6 +124,9 @@ module Cask
 
     # Get all installed casks.
     #
+    # A Caskroom directory for a cask that has been renamed but not yet migrated loads
+    # as the cask it was renamed to, so deduplicate to avoid listing it twice.
+    #
     # @api internal
     sig { params(config: T.nilable(Config)).returns(T::Array[Cask]) }
     def self.casks(config: nil)
@@ -145,7 +147,7 @@ module Cask
       rescue
         # Don't blow up because of a single unavailable cask.
         nil
-      end.select(&:installed?)
+      end.select(&:installed?).uniq(&:full_name)
     end
   end
 end

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -31,7 +31,8 @@ module Cask
         skip_cask_deps: T::Boolean, binaries: T::Boolean, verbose: T::Boolean, zap: T::Boolean,
         require_sha: T::Boolean, upgrade: T::Boolean, reinstall: T::Boolean,
         installed_on_request: T::Boolean, quarantine: T::Boolean, verify_download_integrity: T::Boolean,
-        quiet: T::Boolean, download_queue: Homebrew::DownloadQueue, defer_fetch: T::Boolean
+        quiet: T::Boolean, download_queue: Homebrew::DownloadQueue, defer_fetch: T::Boolean,
+        default_uninstall_artifacts: T.nilable(ArtifactSet)
       ).void
     }
     def initialize(cask, command: SystemCommand, force: false, adopt: false,
@@ -39,7 +40,8 @@ module Cask
                    zap: false, require_sha: false, upgrade: false, reinstall: false,
                    installed_on_request: true,
                    quarantine: true, verify_download_integrity: true, quiet: false,
-                   download_queue: Homebrew.default_download_queue, defer_fetch: false)
+                   download_queue: Homebrew.default_download_queue, defer_fetch: false,
+                   default_uninstall_artifacts: nil)
       @cask = cask
       @command = command
       @force = force
@@ -58,7 +60,9 @@ module Cask
       @download_queue = download_queue
       @defer_fetch = defer_fetch
       @source_download = T.let(nil, T.nilable(Homebrew::API::SourceDownload))
-      @default_uninstall_artifacts = T.let(nil, T.nilable(ArtifactSet))
+      # Restricts what `#uninstall` removes, for artifacts that are shared with a cask
+      # which must be kept installed.
+      @default_uninstall_artifacts = default_uninstall_artifacts
       @ran_prelude_fetch = T.let(false, T::Boolean)
       @ran_prelude = T.let(false, T::Boolean)
       @cask_and_formula_dependencies = T.let(nil, T.nilable(T::Array[T.any(Formula, ::Cask::Cask)]))
@@ -1005,7 +1009,7 @@ on_request: true)
               end
             end
           end
-          @default_uninstall_artifacts = dsl.artifacts
+          @default_uninstall_artifacts ||= dsl.artifacts
           return
         end
 

--- a/Library/Homebrew/cask/migrator.rb
+++ b/Library/Homebrew/cask/migrator.rb
@@ -6,6 +6,7 @@ require "utils/output"
 
 module Cask
   class Migrator
+    extend ::Utils::Output::Mixin
     include ::Utils::Output::Mixin
 
     sig { returns(Cask) }
@@ -19,31 +20,125 @@ module Cask
       @new_cask = new_cask
     end
 
+    # The old tokens of `new_cask` that are still installed in their own Caskroom directory.
+    # A symlinked directory means the cask has already been migrated.
+    sig { params(new_cask: Cask).returns(T::Array[String]) }
+    def self.old_tokens_needing_migration(new_cask)
+      new_cask.old_tokens
+              .map { |old_token| Caskroom.token_from_full_token(old_token) }
+              .uniq
+              .select do |old_token|
+        next false if old_token == new_cask.token
+
+        old_caskroom_path = Caskroom.path/old_token
+        next false if old_caskroom_path.symlink? || !old_caskroom_path.directory?
+
+        if Caskroom.cask_installed_caskfile(old_token).nil?
+          old_caskroom_path.rmdir_if_possible
+          next false
+        end
+
+        true
+      end
+    end
+
     sig { params(new_cask: Cask, dry_run: T::Boolean).void }
     def self.migrate_if_needed(new_cask, dry_run: false)
-      old_tokens = new_cask.old_tokens
-      return if old_tokens.empty?
-
-      return unless (installed_caskfile = new_cask.installed_caskfile)
-
-      installed_token = installed_caskfile.basename(installed_caskfile.extname).to_s
-      return if new_cask.token == installed_token
-
-      old_cask = Cask.new(installed_token)
-      migrator = new(old_cask, new_cask)
-      migrator.migrate(dry_run:)
+      old_tokens_needing_migration(new_cask).each do |old_token|
+        new(Cask.new(old_token), new_cask).migrate(dry_run:)
+      rescue => e
+        onoe e
+      end
     end
 
     sig { params(dry_run: T::Boolean).void }
     def migrate(dry_run: false)
+      old_caskfile = old_cask.installed_caskfile
+      return if old_caskfile.nil?
+
+      new_caskroom_path = new_cask.caskroom_path
+      if new_caskroom_path.directory? && !new_caskroom_path.symlink?
+        uninstall_old_cask(old_caskfile, dry_run:)
+      else
+        move_old_cask(old_caskfile, dry_run:)
+      end
+    end
+
+    sig { params(path: Pathname, old_token: String, new_token: String).void }
+    def self.replace_caskfile_token(path, old_token, new_token)
+      case path.extname
+      when ".rb"
+        ::Utils::Inreplace.inreplace path, /\A\s*cask\s+"#{Regexp.escape(old_token)}"/, "cask #{new_token.inspect}"
+      when ".json"
+        json = JSON.parse(path.read)
+        json["token"] = new_token
+        path.atomic_write json.to_json
+      end
+    end
+
+    private
+
+    # The new cask is already installed under its own token, so the old cask is a
+    # separate installation that needs to be uninstalled rather than moved.
+    sig { params(old_caskfile: Pathname, dry_run: T::Boolean).void }
+    def uninstall_old_cask(old_caskfile, dry_run:)
       old_token = old_cask.token
       new_token = new_cask.token
 
       old_caskroom_path = old_cask.caskroom_path
       new_caskroom_path = new_cask.caskroom_path
 
-      old_caskfile = old_cask.installed_caskfile
-      return if old_caskfile.nil?
+      # Load the old cask from its own installed caskfile so that its artifacts (rather
+      # than the artifacts of the cask it was renamed to) are the ones uninstalled.
+      installed_old_cask = CaskLoader.load_from_installed_caskfile(old_caskfile)
+      uninstallable, shared = installed_old_cask.artifacts.partition do |artifact|
+        !shared_with_new_cask?(artifact)
+      end
+
+      if dry_run
+        oh1 "Would migrate cask #{Formatter.identifier(old_token)} to #{Formatter.identifier(new_token)}"
+
+        puts "#{new_token} is already installed, so #{old_token} would be uninstalled."
+        shared.each { |artifact| puts "#{artifact} would be kept as #{new_token} installs it too." }
+        puts "ln -s #{new_caskroom_path.basename} #{old_caskroom_path}"
+        return
+      end
+
+      oh1 "Migrating cask #{Formatter.identifier(old_token)} to #{Formatter.identifier(new_token)}"
+      puts "#{new_token} is already installed, so #{old_token} will be uninstalled."
+      shared.each { |artifact| puts "Keeping #{artifact} as #{new_token} installs it too." }
+
+      require "cask/installer"
+
+      installed_old_cask.unpin if installed_old_cask.pinned?
+      Installer.new(installed_old_cask, force: true, verbose: Context.current.verbose?,
+                    default_uninstall_artifacts: ArtifactSet.new(uninstallable)).uninstall
+
+      FileUtils.rm_rf old_caskroom_path
+      FileUtils.ln_s new_caskroom_path.basename, old_caskroom_path
+    end
+
+    # Artifacts the new cask installs too must be left alone: uninstalling them would
+    # remove them from the new cask, which stays installed.
+    sig { params(artifact: Artifact::AbstractArtifact).returns(T::Boolean) }
+    def shared_with_new_cask?(artifact)
+      new_cask.artifacts.any? do |new_artifact|
+        if artifact.is_a?(Artifact::Relocated)
+          # Compare the paths these end up at, which is all that matters on disk.
+          new_artifact.is_a?(Artifact::Relocated) && new_artifact.target == artifact.target
+        else
+          new_artifact.instance_of?(artifact.class) && new_artifact.to_args == artifact.to_args
+        end
+      end
+    end
+
+    sig { params(old_caskfile: Pathname, dry_run: T::Boolean).void }
+    def move_old_cask(old_caskfile, dry_run:)
+      old_token = old_cask.token
+      new_token = new_cask.token
+
+      old_caskroom_path = old_cask.caskroom_path
+      new_caskroom_path = new_cask.caskroom_path
 
       old_installed_caskfile = old_caskfile.relative_path_from(old_caskroom_path)
       new_installed_caskfile = old_installed_caskfile.dirname/old_installed_caskfile.basename.sub(
@@ -85,18 +180,6 @@ module Cask
             opoo "Failed to migrate cask pin from #{old_token} to #{new_token}: #{e}"
           end
         end
-      end
-    end
-
-    sig { params(path: Pathname, old_token: String, new_token: String).void }
-    def self.replace_caskfile_token(path, old_token, new_token)
-      case path.extname
-      when ".rb"
-        ::Utils::Inreplace.inreplace path, /\A\s*cask\s+"#{Regexp.escape(old_token)}"/, "cask #{new_token.inspect}"
-      when ".json"
-        json = JSON.parse(path.read)
-        json["token"] = new_token
-        path.atomic_write json.to_json
       end
     end
   end

--- a/Library/Homebrew/cask/migrator.rb
+++ b/Library/Homebrew/cask/migrator.rb
@@ -22,8 +22,8 @@ module Cask
 
     # The old tokens of `new_cask` that are still installed in their own Caskroom directory.
     # A symlinked directory means the cask has already been migrated.
-    sig { params(new_cask: Cask).returns(T::Array[String]) }
-    def self.old_tokens_needing_migration(new_cask)
+    sig { params(new_cask: Cask, dry_run: T::Boolean).returns(T::Array[String]) }
+    def self.old_tokens_needing_migration(new_cask, dry_run: false)
       new_cask.old_tokens
               .map { |old_token| Caskroom.token_from_full_token(old_token) }
               .uniq
@@ -34,7 +34,7 @@ module Cask
         next false if old_caskroom_path.symlink? || !old_caskroom_path.directory?
 
         if Caskroom.cask_installed_caskfile(old_token).nil?
-          old_caskroom_path.rmdir_if_possible
+          old_caskroom_path.rmdir_if_possible unless dry_run
           next false
         end
 

--- a/Library/Homebrew/test/cask/caskroom_spec.rb
+++ b/Library/Homebrew/test/cask/caskroom_spec.rb
@@ -177,6 +177,31 @@ RSpec.describe Cask::Caskroom do
       FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
     end
 
+    it "does not list a cask twice when it is also installed under an old token" do
+      tap = Tap.fetch("thirdparty", "foo")
+      cask_path = tap.cask_dir/"new-cask.rb"
+      cask_path.dirname.mkpath
+      cask_path.write <<~RUBY
+        cask "new-cask" do
+          version "2.0"
+        end
+      RUBY
+      (tap.path/"cask_renames.json").write JSON.generate("old-cask" => "new-cask")
+      tap.clear_cache
+      Homebrew::Trust.trust!(:tap, tap.name)
+
+      Dir.mktmpdir do |dir|
+        allow(described_class).to receive(:path).and_return(Pathname(dir))
+
+        setup_cask_metadata(Pathname(dir), "new-cask", tap:, version: "2.0")
+        setup_cask_metadata(Pathname(dir), "old-cask", tap:, version: "1.0")
+
+        expect(described_class.casks.map(&:token)).to eq(["new-cask"])
+      end
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+
     it "does not error for ambiguous installed casks when an ambiguous tap is untrusted" do
       token = "ambiguous-untrusted-cask"
       taps = [Tap.fetch("thirdparty", "foo"), Tap.fetch("thirdparty", "bar")]

--- a/Library/Homebrew/test/cask/migrator_spec.rb
+++ b/Library/Homebrew/test/cask/migrator_spec.rb
@@ -4,41 +4,127 @@
 require "cask/migrator"
 
 RSpec.describe Cask::Migrator do
-  describe ".migrate_if_needed" do
-    let(:new_cask) do
-      instance_double(
-        Cask::Cask,
-        old_tokens:         ["old-token"],
-        installed_caskfile:,
-        token:              new_token,
-      )
+  describe ".old_tokens_needing_migration" do
+    let(:new_cask) { instance_double(Cask::Cask, token: "new-token", old_tokens: ["old-token"]) }
+
+    def setup_installed_cask(dir, token)
+      casks_dir = dir/token/".metadata/1.0/20250101000000.000/Casks"
+      casks_dir.mkpath
+      (casks_dir/"#{token}.rb").write("cask \"#{token}\"\n")
     end
 
-    context "when the installed token matches the current token" do
-      let(:installed_caskfile) { Pathname("/tmp/Casks/docker-desktop.rb") }
-      let(:new_token) { "docker-desktop" }
+    it "returns old tokens that are still installed in their own Caskroom directory" do
+      Dir.mktmpdir do |dir|
+        allow(Cask::Caskroom).to receive(:path).and_return(Pathname(dir))
+        setup_installed_cask(Pathname(dir), "old-token")
 
-      it "returns without loading or migrating" do
-        expect(Cask::Cask).not_to receive(:new)
-        expect(described_class).not_to receive(:new)
-
-        described_class.migrate_if_needed(new_cask)
+        expect(described_class.old_tokens_needing_migration(new_cask)).to eq(["old-token"])
       end
     end
 
-    context "when the installed token differs from the current token" do
-      let(:installed_caskfile) { Pathname("/tmp/Casks/old-token.rb") }
-      let(:new_token) { "new-token" }
+    it "returns old tokens even when the new cask is installed under its own token" do
+      Dir.mktmpdir do |dir|
+        allow(Cask::Caskroom).to receive(:path).and_return(Pathname(dir))
+        setup_installed_cask(Pathname(dir), "old-token")
+        setup_installed_cask(Pathname(dir), "new-token")
 
-      it "migrates using the installed token from the caskfile path" do
-        old_cask = instance_double(Cask::Cask)
-        migrator = instance_double(described_class)
+        expect(described_class.old_tokens_needing_migration(new_cask)).to eq(["old-token"])
+      end
+    end
 
-        expect(Cask::Cask).to receive(:new).with("old-token").and_return(old_cask)
-        expect(described_class).to receive(:new).with(old_cask, new_cask).and_return(migrator)
-        expect(migrator).to receive(:migrate).with(dry_run: false)
+    it "ignores old tokens that have already been migrated" do
+      Dir.mktmpdir do |dir|
+        allow(Cask::Caskroom).to receive(:path).and_return(Pathname(dir))
+        setup_installed_cask(Pathname(dir), "new-token")
+        FileUtils.ln_s "new-token", Pathname(dir)/"old-token"
+
+        expect(described_class.old_tokens_needing_migration(new_cask)).to be_empty
+      end
+    end
+
+    it "removes an empty Caskroom directory for an old token" do
+      Dir.mktmpdir do |dir|
+        allow(Cask::Caskroom).to receive(:path).and_return(Pathname(dir))
+        old_caskroom_path = Pathname(dir)/"old-token"
+        old_caskroom_path.mkpath
+
+        expect([described_class.old_tokens_needing_migration(new_cask), old_caskroom_path.exist?])
+          .to eq([[], false])
+      end
+    end
+  end
+
+  describe ".migrate_if_needed", :cask do
+    let(:old_cask) { Cask::CaskLoader.load(cask_path("local-caffeine")) }
+    let(:new_cask) { Cask::CaskLoader.load(cask_path("local-transmission")) }
+    let(:old_caskroom_path) { Cask::Caskroom.path/"local-caffeine" }
+    let(:appdir) { Pathname(new_cask.config.appdir) }
+
+    # The new cask is renamed from the old cask, but stub this only once both casks are
+    # installed so that installing the new cask does not migrate the old cask itself.
+    def rename_old_cask_to_new_cask
+      allow(new_cask).to receive(:old_tokens).and_return(["local-caffeine"])
+    end
+
+    context "when the new cask is not installed" do
+      it "moves the old cask to the new token" do
+        InstallHelper.stub_cask_installation(old_cask)
+        rename_old_cask_to_new_cask
 
         described_class.migrate_if_needed(new_cask)
+
+        expect([old_caskroom_path.symlink?, new_cask.installed_version])
+          .to eq([true, old_cask.version.to_s])
+      end
+    end
+
+    context "when the new cask is already installed" do
+      before do
+        Cask::Installer.new(new_cask).install
+        Cask::Installer.new(old_cask).install
+        rename_old_cask_to_new_cask
+      end
+
+      it "uninstalls the old cask" do
+        expect { described_class.migrate_if_needed(new_cask) }
+          .to output(/Uninstalling Cask local-caffeine/).to_stdout
+
+        expect([
+          old_caskroom_path.symlink?,
+          (appdir/"Caffeine.app").exist?,
+          (appdir/"Transmission.app").exist?,
+          new_cask.installed?,
+        ]).to eq([true, false, true, true])
+      end
+
+      it "does not uninstall the old cask in a dry run" do
+        expect { described_class.migrate_if_needed(new_cask, dry_run: true) }
+          .to output(/local-transmission is already installed, so local-caffeine would be uninstalled/)
+          .to_stdout
+
+        expect([old_caskroom_path.directory?, (appdir/"Caffeine.app").exist?]).to eq([true, true])
+      end
+    end
+
+    context "when the new cask is already installed and shares an artifact with the old cask" do
+      let(:new_cask) { Cask::CaskLoader.load(cask_path("local-caffeine-clone")) }
+
+      before do
+        Cask::Installer.new(old_cask).install
+        # Both casks install `Caffeine.app`, so the second install has to overwrite it.
+        Cask::Installer.new(new_cask, force: true).install
+        rename_old_cask_to_new_cask
+      end
+
+      it "keeps the shared artifact installed for the new cask" do
+        expect { described_class.migrate_if_needed(new_cask) }
+          .to output(/Keeping Caffeine.app \(App\) as local-caffeine-clone installs it too/).to_stdout
+
+        expect([
+          old_caskroom_path.symlink?,
+          (appdir/"Caffeine.app").exist?,
+          new_cask.installed?,
+        ]).to eq([true, true, true])
       end
     end
   end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/local-caffeine-clone.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/local-caffeine-clone.rb
@@ -1,0 +1,12 @@
+# typed: false
+
+cask "local-caffeine-clone" do
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/"
+
+  # Same app as `local-caffeine`, to test casks which share artifacts.
+  app "Caffeine.app"
+end


### PR DESCRIPTION
When a cask is renamed to a cask that is already installed, the migration silently does nothing and the old cask is left behind in the Caskroom.

`Cask::Migrator.migrate_if_needed` worked out which token to migrate from `new_cask.installed_caskfile`. That lookup returns the first match, so with both casks installed it always found the new cask's own caskfile, saw that the installed token already matched, and returned early.

The leftover directory then loads as the cask it was renamed to, because the loader resolves the rename before it falls back to the installed caskfile. Cask::Caskroom.casks returns the same cask twice, so it gets listed, reported as outdated and upgraded twice:

```
==> Outdated Casks
chatgpt
chatgpt

==> Upgrading 2 outdated packages:
chatgpt 1.2026.183,1783607847 -> 26.707.51957
chatgpt 1.2026.183,1783607847 -> 26.707.51957
```

There's also no way out of that state, since brew uninstall --cask codex-app resolves the rename and uninstalls chatgpt instead.

Changes;
- Find the old tokens to migrate by scanning the Caskroom instead of going through installed_caskfile, the same way Migrator.oldnames_needing_migration does for formulae, and migrate all of them rather than just the first.
- When the new cask is already installed under its own token, the old cask is a separate installation that can't be moved to the new token, so uninstall it and leave behind the same Caskroom/<old_token> -> <new_token> symlink that a migration would. It's loaded from its own installed caskfile so that its own artifacts (Codex.app, not ChatGPT.app) are the ones removed. This is what already happens when only the old cask is installed, just earlier: today the migration moves the old staged payload under the new token, and the next brew upgrade uninstalls the old artifacts before installing the new ones.
- Deduplicate Cask::Caskroom.casks so that an old token which hasn't been migrated yet can't list the same cask twice while it's still there.
- Report errors per old token so that one failure can't abort brew update.
- Don't uninstall artifacts when they are shared between the two casks. Alternatively, we could have the migration always run `uninstall --> install` on migration, in the same way `brew upgrade` does.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Claude Opus 4.8 Max was used to debug the issue and implement the fix.
