### PR TITLE
Skip type evaluation in eager Pathname ivar initialisation

### DIFF
--- a/Library/Homebrew/extend/pathname/eager_initialize_extension.rb
+++ b/Library/Homebrew/extend/pathname/eager_initialize_extension.rb
@@ -13,12 +13,12 @@ module EagerInitializeExtension
 
   sig { params(args: T.untyped).void }
   def initialize(*args)
-    @magic_number = T.let(nil, T.nilable(String))
-    @file_type = T.let(nil, T.nilable(String))
-    @zipinfo = T.let(nil, T.nilable(T::Array[String]))
-    @which_install_info = T.let(nil, T.nilable(String))
-    @disk_usage = T.let(nil, T.nilable(Integer))
-    @file_count = T.let(nil, T.nilable(Integer))
+    @magic_number = T.let(nil, NilClass)
+    @file_type = T.let(nil, NilClass)
+    @zipinfo = T.let(nil, NilClass)
+    @which_install_info = T.let(nil, NilClass)
+    @disk_usage = T.let(nil, NilClass)
+    @file_count = T.let(nil, NilClass)
     super
   end
 end


### PR DESCRIPTION
## Summary

`EagerInitializeExtension#initialize` runs six `T.let(nil, T.nilable(...))` assignments on every `Pathname` allocation. Since Homebrew/brew#22978 the `T.let` dispatch itself is cheap with runtime checking disabled, but the type *arguments* still evaluate on every call: `T.nilable(String)` performs a sorbet union-pool lookup each time, and brew allocates Pathnames constantly (keg and tab scanning in particular).

These declarations are not statically load-bearing: Sorbet scopes instance variable declarations per lexical module, so the declarations here never interact with the real ones at each ivar's memoisation site (e.g. `@magic_number ||= T.let(nil, T.nilable(String))` in `extend/pathname.rb`). They exist only to keep every `Pathname` on one object shape. Verified empirically: substituting a deliberately wrong type here still typechecks.

## Changes

Declare the ivars as `T.let(nil, NilClass)` (Sorbet's own autocorrect suggestion for a plain `nil` assignment under `typed: strict`): a bare constant reference with no union-pool evaluation, preserving `typed: strict` and the shape-stability purpose.

`brew upgrade --dry-run` output verified byte-identical before and after.

**Benchmarks** (Hyperfine, 5-10 runs each, warmup 2-3, `HOMEBREW_SORBET_RUNTIME` unset, alternating before/after rounds on committed trees; ranks from the [last 365 days of analytics](https://formulae.brew.sh/analytics/brew-command-run-options/365d/)):

| Command | Before | After | Change |
|---|---|---|---|
| `brew upgrade --dry-run` (3rd most-run) | 3.494 s / 3.469 s ± ~0.05 s | 3.099 s / 3.015 s ± ~0.04 s | **~11-13% decrease** |
| `brew outdated --json` (12th most-run) | 807.4 / 819.9 ms ± 24-40 ms | 748.4 / 757.7 ms ± 7-16 ms | **~7.5% decrease** |

`install` no-ops and `info --installed --json=` showed no change beyond noise (fewer Pathname allocations on those paths).

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code was used to profile the commands, identify the per-allocation type evaluation and benchmark the change. Verified by byte-identical `brew upgrade --dry-run` output, alternating Hyperfine rounds on committed trees, an empirical check that the declarations are not statically load-bearing and `brew lgtm` locally. No new tests: the file has no behavior change to test and is exercised by the entire suite.

-----
