### PR TITLE
Return a shared type instance from type constructors when runtime checking is disabled

### DIFF
--- a/Library/Homebrew/standalone/sorbet.rb
+++ b/Library/Homebrew/standalone/sorbet.rb
@@ -83,10 +83,43 @@ else
     end
   end
 
+  # Redefine type constructors to return a shared untyped instance: their
+  # results are only consumed by runtime checking, which is disabled.
+  # @private
+  module TNoOpTypeConstructors
+    # A union with NilClass rather than plain untyped: `prop`/`const` infer
+    # optionality from their type argument, so nilable props must still look
+    # nilable or serialising them while nil raises.
+    # Not frozen: `Union` memoises internally on first use.
+    # rubocop:disable Style/MutableConstant
+    UNTYPED = T::Types::Union.new([T::Types::Untyped.new, T::Types::Simple.new(NilClass)])
+    # rubocop:enable Style/MutableConstant
+
+    def nilable(_type) = UNTYPED
+    def any(*_types) = UNTYPED
+    def all(*_types) = UNTYPED
+    def class_of(_klass) = UNTYPED
+    def untyped = UNTYPED
+    def anything = UNTYPED
+    def self_type = UNTYPED
+    def attached_class = UNTYPED
+    def type_parameter(_name) = UNTYPED
+  end
+
+  # @private
+  module TNoOpTypeIndex
+    def [](*_types) = TNoOpTypeConstructors::UNTYPED
+  end
+
+  [T::Array, T::Hash, T::Set, T::Range, T::Enumerable, T::Enumerator].each do |mod|
+    mod.singleton_class.prepend(TNoOpTypeIndex)
+  end
+
   # @private
   module T
     class << self
       prepend TNoChecks
+      prepend TNoOpTypeConstructors
     end
 
     # Redefine `T.sig` to be a no-op.


### PR DESCRIPTION
## Summary

With `$HOMEBREW_SORBET_RUNTIME` unset, `standalone/sorbet.rb` already disables signature checking (`sig` is a no-op) and `T.let`/`T.cast` validation. But the type *constructor* calls still run in full: every executed `T.let(x, T.nilable(String))` evaluates its type argument through sorbet-runtime's union pool, and `T::Array[String]` builds a typed-array object, only for the result to be discarded by the disabled checks. Profiles of `brew upgrade --dry-run` and `brew outdated --json` show this evaluation among the largest remaining CPU costs (e.g. six `T.let`s run on every `Pathname` allocation).

## Changes

When the runtime is disabled, redefine the type constructors (`T.nilable`, `T.any`, `T.all`, `T.class_of`, `T.untyped`, `T.anything`, `T.self_type`, `T.attached_class`, `T.type_parameter` and `T::Array`/`T::Hash`/`T::Set`/`T::Range`/`T::Enumerable`/`T::Enumerator` element lookups) to return a single shared type instance. The runtime-enabled branch (CI, `brew tests`, `brew typecheck`) is untouched.

The shared instance is `Union[Untyped, NilClass]` rather than plain untyped because one structural consumer of type objects remains active with checking disabled: `T::Props` infers prop *optionality* from the type argument, and reducing `T.nilable(...)` props to non-nilable untyped made serialising a nil-valued prop raise (caught via `GitHubRunner#serialize` with a nil `macos_version`). With the nilable-union instance, `T::Struct` serialisation matches current behaviour exactly. Prop construction-time type checking is already inert on current `main` with the runtime disabled (verified: a `String` prop accepts an `Integer`), so this changes no validation behaviour.

Verified with the runtime disabled: `brew outdated --json` and `brew info --installed --json=v2` output byte-identical to main, `GitHubRunner`/`LinuxRunnerSpec` serialisation identical, and with the runtime enabled: wrong-typed props still raise `TypeError` and commands behave as before.

**Benchmarks** (Hyperfine, 5 runs each, warmup 2, `$HOMEBREW_SORBET_RUNTIME` unset, two alternating before/after rounds on committed trees; ranks from the [last 365 days of analytics](https://formulae.brew.sh/analytics/brew-command-run-options/365d/)):

| Command | Before | After | Change |
|---|---|---|---|
| `brew upgrade --dry-run` (3rd most-run) | 3.544 s / 3.448 s | 2.773 s / 2.951 s | **~17-21% decrease** |
| `brew outdated --json` (12th most-run) | 772.1 / 766.6 ms | 699.4 / 696.3 ms | **~9.5% decrease** |
| `brew install <installed formula>` (2nd most-run) | 528.3 / 538.7 ms | 481.2 / 502.4 ms | **~7-9% decrease** |

Startup-dominated commands (`config`, `--env`) are unchanged: their time goes to requires and subprocesses, not executed type declarations.

For comparison, a full conversion of the ~1,750 convertible `T.let` declarations to [RBS inline annotation comments](https://sorbet.org/docs/rbs-support) measures slightly better still (`upgrade --dry-run` ~23% faster) by also removing the `T.let` dispatch, at the cost of a 364-file diff and enabling an experimental Sorbet feature; this patch captures most of that win in one file and does not preclude that direction later.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code was used to profile the commands, implement the change, probe the `T::Props` interaction and run the benchmarks; the human author identified the need to preserve prop optionality and reviewed a frozen-constant regression. Verified by byte-identical JSON output, serialisation probes on both runtime modes, alternating Hyperfine rounds on committed trees and `brew lgtm` locally. No new tests: the changed branch only loads when `$HOMEBREW_SORBET_RUNTIME` is unset and `brew tests` always sets it.

-----
