### PR TITLE
Skip rewriting Mach-O binaries when delete_rpath changes nothing

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg.rb
+++ b/Library/Homebrew/extend/os/mac/keg.rb
@@ -93,8 +93,7 @@ module OS
       sig { params(rpath: String, file: MachOShim).returns(T::Boolean) }
       def delete_rpath(rpath, file)
         odebug "Deleting rpath #{rpath} in #{file}"
-        file.delete_rpath(rpath, strict: false)
-        true
+        !file.delete_rpath(rpath, strict: false).nil?
       rescue MachO::MachOError
         onoe <<~EOS
           Failed deleting rpath #{rpath} in #{file}

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -69,9 +69,8 @@ module MachOShim
   end
   private :mach_data
 
-  # TODO: See if the `#write!` call can be delayed until
-  #       we know we're not making any changes to the rpaths.
-  sig { params(rpath: String, strict: T::Boolean).void }
+  # Returns the deleted rpath, or nil when there's nothing to delete.
+  sig { params(rpath: String, strict: T::Boolean).returns(T.nilable(String)) }
   def delete_rpath(rpath, strict: true)
     candidates = rpaths(resolve_variable_references: false).select do |r|
       resolve_variable_name(r) == resolve_variable_name(rpath)
@@ -79,9 +78,12 @@ module MachOShim
 
     # Delete the last instance to avoid changing the order in which rpaths are searched.
     rpath_to_delete = candidates.last
+    # Avoid writing the whole binary back to disk when there's nothing to delete.
+    return if rpath_to_delete.nil?
 
     macho.delete_rpath(rpath_to_delete, { last: true, strict: })
     macho.write!
+    rpath_to_delete
   end
 
   sig { params(old: String, new: String, uniq: T::Boolean, last: T::Boolean, strict: T::Boolean).void }

--- a/Library/Homebrew/test/os/mac/mach_spec.rb
+++ b/Library/Homebrew/test/os/mac/mach_spec.rb
@@ -109,6 +109,15 @@ RSpec.describe MachOShim do
     end
   end
 
+  describe "#delete_rpath" do
+    specify "returns nil without rewriting the binary when no rpath matches" do
+      pn = dylib_path("x86_64")
+      contents = pn.read
+      expect(pn.delete_rpath("/nonexistent", strict: false)).to be_nil
+      expect(pn.read).to eq(contents)
+    end
+  end
+
   describe "text executables" do
     let(:pn) { MachOPathname.wrap(HOMEBREW_PREFIX/"an_executable") }
 


### PR DESCRIPTION
`MachOShim#delete_rpath` always wrote the whole binary back to disk, even when there was no matching rpath to remove. 
This change makes it return early when there is nothing to delete, so it no longer writes the file for a no-op. It now returns the deleted rpath, or `nil` when nothing was deleted, which matches how `Array#delete` and `Hash#delete` behave. 
`Keg#delete_rpath` turns that value into a boolean, so the relocation step no longer codesigns files that were never modified. This resolves the `TODO` that asked to delay the `write!` call until we know we are changing the rpaths.


-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
AI (Claude Code) assisted in writing the code and tests.
I reviewed the change and ran brew lgtm locally 