### PR TITLE
Test fixes for portable Ruby macOS runners

### DIFF
--- a/Library/Homebrew/test/cask/depends_on_spec.rb
+++ b/Library/Homebrew/test/cask/depends_on_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe "Satisfy Dependencies and Requirements", :cask do
       let(:cask) { Cask::CaskLoader.load(cask_path("with-depends-on-macos-failure")) }
 
       it "raises an error" do
+        allow(OS::Mac).to receive(:version).and_return(MacOSVersion.new(HOMEBREW_MACOS_NEWEST_SUPPORTED))
         expect { install }.to raise_error(Cask::CaskError)
       end
     end

--- a/Library/Homebrew/test/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cmd/list_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Homebrew::Cmd::List do
     end
   end
 
-  it "covers Bash list output and errors", :cask do
+  it "covers Bash list output and errors", :cask, :needs_jq do
     install_formula_version "testball", "0.1"
     install_formula_version "testball", "0.2"
     (HOMEBREW_PREFIX/"var/homebrew/linked").mkpath

--- a/Library/Homebrew/test/os/mac/formula_installer_spec.rb
+++ b/Library/Homebrew/test/os/mac/formula_installer_spec.rb
@@ -12,19 +12,23 @@ RSpec.describe FormulaInstaller do
   describe "#fresh_install" do
     subject(:formula_installer) { described_class.new(Testball.new) }
 
-    it "is true by default" do
+    it "is true when non-developer and non-outdated" do
       formula = Testball.new
+      allow(Homebrew::EnvConfig).to receive_messages(developer?: false)
+      allow(OS::Mac.version).to receive_messages(outdated_release?: false)
       expect(formula_installer.fresh_install?(formula)).to be true
     end
 
     it "is false in developer mode" do
       formula = Testball.new
       allow(Homebrew::EnvConfig).to receive_messages(developer?: true)
+      allow(OS::Mac.version).to receive_messages(outdated_release?: false)
       expect(formula_installer.fresh_install?(formula)).to be false
     end
 
     it "is false on outdated releases" do
       formula = Testball.new
+      allow(Homebrew::EnvConfig).to receive_messages(developer?: false)
       allow(OS::Mac.version).to receive_messages(outdated_release?: true)
       expect(formula_installer.fresh_install?(formula)).to be false
     end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -172,6 +172,10 @@ RSpec.configure do |config|
     skip "Java is not installed." unless which("java")
   end
 
+  config.before(:each, :needs_jq) do
+    skip "jq is not installed." unless which("jq")
+  end
+
   config.before(:each, :needs_python) do
     skip "Python is not installed." if !which("python3") && !which("python")
   end

--- a/Library/Homebrew/test/support/fixtures/bottles/testball_bottle-0.1.arm64_macintosh.bottle.tar.gz
+++ b/Library/Homebrew/test/support/fixtures/bottles/testball_bottle-0.1.arm64_macintosh.bottle.tar.gz
@@ -1,0 +1,1 @@
+testball_bottle-0.1.yosemite.bottle.tar.gz

--- a/Library/Homebrew/test/support/fixtures/bottles/testball_bottle-0.1.macintosh.bottle.tar.gz
+++ b/Library/Homebrew/test/support/fixtures/bottles/testball_bottle-0.1.macintosh.bottle.tar.gz
@@ -1,0 +1,1 @@
+testball_bottle-0.1.yosemite.bottle.tar.gz


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Handle some test failures from https://github.com/Homebrew/homebrew-core/actions/runs/29250465341/job/86819000497?pr=292807

```
  Error: Satisfy Dependencies and Requirements depends_on macos when not satisfied raises an error
  
  Failure/Error: expect { install }.to raise_error(Cask::CaskError)
    expected Cask::CaskError but nothing was raised
```
```
  Failure/Error:
    expect do
      expect(run_list_bash(
               "EMPTY_CASKROOM"        => empty_caskroom.to_s,
               "EMPTY_CELLAR"          => empty_cellar.to_s,
               "EXPECTED_CASK_JSON"    => list_versions_json(casks: casks_json),
               "EXPECTED_EMPTY_JSON"   => list_versions_json,
               "EXPECTED_FORMULA_JSON" => list_versions_json(formulae: formulae_json),
               "EXPECTED_JSON"         => list_versions_json(formulae: formulae_json, casks: casks_json),
               "EXPECTED_PLAIN"        => "testball\nlocal-caffeine\n",
               "NO_JQ_CASKROOM"        => no_jq_caskroom.to_s,
  
    expected block to not output to stderr, but output "formula and cask versions JSON: expected status 0, got 1\nformula versions JSON: expected status 0, got 1\ncask versions JSON: expected status 0, got 1\nempty versions JSON: expected status 0, got 1\n"
```
```
  Error: FormulaInstaller basic bottle install with cellar information on sha256 line
  
  Failure/Error: fi.install
  
  Errno::ENOENT:
    No such file or directory @ rb_sysopen - /private/tmp/homebrew-tests-20260713-19056-47p9iy/cache/downloads/24c78dbf48a1b9293ccaa23684270ec9e736fd40656c8fd7fdb516c5f0c4c019--testball_bottle-0.1.arm64_macintosh.bottle.tar.gz
```