### PR TITLE
test_bot/formulae: skip portable Ruby tests on macOS if same version

### DIFF
--- a/Library/Homebrew/extend/os/mac/test_bot.rb
+++ b/Library/Homebrew/extend/os/mac/test_bot.rb
@@ -40,6 +40,13 @@ module OS
           # We use gnu-tar with sparse files disabled when --only-json-tab is passed.
           ENV["HOMEBREW_BOTTLE_SUDO_PURGE"] = "1" if MacOS.version >= :catalina && !args.only_json_tab?
         end
+
+        sig { returns(T::Boolean) }
+        def integration_test_portable_ruby?
+          # tests fail on macOS when currently running portable Ruby is replaced using same path
+          portable_ruby_version = (HOMEBREW_LIBRARY_PATH/"vendor/portable-ruby-version").read.chomp
+          portable_ruby_version != ::Formula["portable-ruby"].pkg_version.to_s
+        end
       end
 
       module FormulaeDependents

--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -870,6 +870,7 @@ module Homebrew
         # We only do full testing on `portable-ruby` itself.
         return if formula_name != "portable-ruby"
         return if args.dry_run?
+        return unless integration_test_portable_ruby?
 
         bottle_file = bottle_glob(formula_name).first
         if bottle_file.nil?
@@ -949,6 +950,9 @@ module Homebrew
       def testing_portable_ruby?
         !!tap&.core_tap? && @testing_formulae.include?("portable-ruby")
       end
+
+      sig { returns(T::Boolean) }
+      def integration_test_portable_ruby? = true
     end
   end
 end


### PR DESCRIPTION
When portable Ruby version is unchanged, the integration tests all fail, https://github.com/Homebrew/homebrew-core/actions/runs/29179553748/job/86679226477?pr=292440#step:3:69
```
Error: 12 failed steps!
brew vendor-gems --no-commit --update=--ruby,--bundler=4.0.10
brew typecheck --update
brew style
brew typecheck
brew install-bundler-gems --groups=all
brew vendor-gems --non-bundler-gems --no-commit
brew tests --online --coverage
brew tests --generic --coverage
brew update-test
brew update-test --to-tag
brew update-test --commit=HEAD
brew test-bot --only-formulae --only-json-tab --test-default-formula
```

Can be seen comparing CI results for following:
- https://github.com/Homebrew/homebrew-core/pull/292440 (only libffi update, portable Ruby the same)
- https://github.com/Homebrew/homebrew-core/pull/292807 (portable Ruby test with revision bump. also previous runs without revision bump show same issue)

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
