### PR TITLE
test/cask/audit_spec: fix min OS for Intel

### DIFF
--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -1116,7 +1116,7 @@ RSpec.describe Cask::Audit, :cask do
           homepage "https://brew.sh/"
 
           on_arm do
-            depends_on macos: :big_sur
+            depends_on macos: :sequoia
           end
 
           depends_on :macos
@@ -1126,11 +1126,29 @@ RSpec.describe Cask::Audit, :cask do
       end
 
       before do
-        allow(audit).to receive_messages(cask_bundle_min_os:  MacOSVersion.from_symbol(:big_sur),
+        allow(audit).to receive_messages(cask_bundle_min_os:  MacOSVersion.from_symbol(:sequoia),
                                          cask_sparkle_min_os: nil)
       end
 
-      it { is_expected.to pass }
+      context "when running on arm" do
+        around do |example|
+          Homebrew::SimulateSystem.with(arch: :arm) do
+            example.run
+          end
+        end
+
+        it { is_expected.to pass }
+      end
+
+      context "when running on intel" do
+        around do |example|
+          Homebrew::SimulateSystem.with(arch: :intel) do
+            example.run
+          end
+        end
+
+        it { is_expected.to error_with(/cask declared no minimum macOS version/) }
+      end
 
       it "normalizes 10.16.0 minimum macOS to Big Sur" do
         expect(audit.send(:normalize_min_os, "10.16.0")).to eq(MacOSVersion.from_symbol(:big_sur))


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

To fix https://github.com/Homebrew/homebrew-core/actions/runs/29250465341/job/86819000502#step:3:255
```
  Error: Cask::Audit#run! minimum OS checks is expected to pass
  
  Failure/Error: it { is_expected.to pass }
    expected to pass, but errored with "Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version"
  ...................................................................................................................................................................
  
  Failures:
  
    1) Cask::Audit#run! minimum OS checks is expected to pass
       Failure/Error: it { is_expected.to pass }
         expected to pass, but errored with "Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version"
       # ./test/cask/audit_spec.rb:1133:in 'block (4 levels) in <top (required)>'
       # ./test/support/helper/spec/shared_context/homebrew_cask.rb:68:in 'block (2 levels) in <top (required)>'
```

Also moving up test minimum as `:big_sur` will soon be oldest.