### PR TITLE
cask/api: default absent array fields when generating cask structs

### DIFF
--- a/Library/Homebrew/api/cask/cask_struct_generator.rb
+++ b/Library/Homebrew/api/cask/cask_struct_generator.rb
@@ -39,7 +39,12 @@ module Homebrew
             hash["disable_args"] = disable_args
           end
 
-          hash["names"] = hash["name"]
+          # Use explicit defaults rather than `nil` for absent keys: when runtime
+          # type checking is disabled, `CaskStruct.from_hash` does not apply the
+          # struct's prop defaults, so `nil` values would survive into the struct
+          # and crash consumers that iterate them (installed cask JSON files omit
+          # most keys).
+          hash["names"] = hash["name"] || []
 
           if (artifacts = hash["artifacts"])
             hash["raw_artifacts"] = process_artifacts(artifacts)
@@ -49,7 +54,7 @@ module Homebrew
 
           hash["renames"] = hash["rename"]&.map do |operation|
             [operation[:from], operation[:to]]
-          end
+          end || []
 
           hash["ruby_source_checksum"] = {
             sha256: hash.dig("ruby_source_checksum", :sha256),

--- a/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
+++ b/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
@@ -4,6 +4,19 @@
 require "api"
 
 RSpec.describe Homebrew::API::Cask::CaskStructGenerator do
+  describe "::generate_cask_struct_hash" do
+    it "passes explicit array defaults for keys absent from minimal installed caskfiles" do
+      # `CaskStruct.from_hash` only applies prop defaults when runtime type
+      # checking is enabled (it always is under RSpec, never for users), so
+      # `nil` here means `nil` props in production and crashes cask loading.
+      expect(Homebrew::API::CaskStruct).to receive(:from_hash)
+        .with(hash_including("names" => [], "renames" => []), ignore_types: true)
+        .and_call_original
+
+      described_class.generate_cask_struct_hash({ "version" => "1.0" }, ignore_types: true)
+    end
+  end
+
   describe ":process_depends_on" do
     let(:depends_on_non_macos) do
       {


### PR DESCRIPTION
Since 6.0.10 enabled the installed-cask metadata migration for all users (#22958), every upgrade of a previously-installed cask fails on my machine:

```
$ brew update   # to 6.0.10
$ brew upgrade
...
Warning: The cask 'calendr' cannot be upgraded as-is. To fix this, run:
brew reinstall --cask --force calendr
Warning: The cask 'whatsapp' cannot be upgraded as-is. To fix this, run:
brew reinstall --cask --force whatsapp
```

The cask is fetched but the upgrade is skipped, and the suggested `brew reinstall --cask --force` only helps until the next upgrade, because the reinstall writes the same minimal metadata that triggered the failure.

Root cause is an interaction between two changes that are each fine on their own. The migrated installed caskfiles are minimal JSON (often just `{}` — the real data lives in `INSTALL_RECEIPT.json`), so nearly every key is absent when they're loaded back. Meanwhile #23078's no-op type constructors make every prop of `CaskStruct` look nilable when runtime type checking is disabled, so `T::Struct.from_hash` no longer applies the declared prop defaults: `names` and `renames` deserialize to `nil` instead of `[]`. `load_from_struct` then crashes iterating them (`undefined method 'each' for nil`), the loader wraps that as `CaskUnreadableError`, and `Cask::Upgrade` declares the cask un-upgradeable. None of this reproduces in CI because RSpec runs with `HOMEBREW_SORBET_RUNTIME` set, where `from_hash` still applies the defaults — the failure exists only in the configuration users actually run.

The fix is for the generator to pass explicit empty arrays instead of `nil` for absent `name`/`rename` keys, which is what `from_hash` would have produced with runtime checking enabled. Same approach as #23084, which fixed the sibling `url_args` symptom of the same migration; the two don't overlap.

The new test asserts the generator's contract (explicit `[]`s handed to `from_hash`) rather than the loaded struct's values, since the struct comes out correct under RSpec either way — that's precisely how this escaped CI. Verified red against the unfixed generator and green with the fix.

I also verified the fix end-to-end on the affected machine: with these two lines applied to my live 6.0.10 installation, `brew upgrade --dry-run calendr whatsapp` planned both upgrades cleanly instead of warning, and the real `brew upgrade calendr whatsapp` completed — including, pleasingly, my first production sighting of #23060's approval inheritance on both casks.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Diagnosed and drafted working with Claude (Fable 5) in Claude Code. I verified the changes myself: the red/green test run against the unfixed and fixed generator, `brew lgtm` locally, and the live dry-run/upgrade verification on the affected machine described above.

-----
