### PR TITLE
Fix more test failures

### DIFF
--- a/Library/Homebrew/test/cask/caskroom_spec.rb
+++ b/Library/Homebrew/test/cask/caskroom_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Cask::Caskroom do
       FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
     end
 
-    it "does not list a cask twice when it is also installed under an old token" do
+    it "does not list a cask twice when it is also installed under an old token", :trust_store do
       tap = Tap.fetch("thirdparty", "foo")
       cask_path = tap.cask_dir/"new-cask.rb"
       cask_path.dirname.mkpath

--- a/Library/Homebrew/test/cmd/exec_spec.rb
+++ b/Library/Homebrew/test/cmd/exec_spec.rb
@@ -10,13 +10,7 @@ RSpec.describe Homebrew::Cmd::Exec do
   describe "exec" do
     let(:formula_name) { "test-executable" }
     let(:executable_name) { "test-executable-tool" }
-    let(:shell_cellar) do
-      if (HOMEBREW_LIBRARY_PATH.parent.parent/"Cellar").directory?
-        HOMEBREW_LIBRARY_PATH.parent.parent/"Cellar"
-      else
-        HOMEBREW_CELLAR
-      end
-    end
+    let(:shell_cellar) { HOMEBREW_CELLAR }
     let(:db) { HOMEBREW_CACHE/"api/internal/executables.txt" }
     let(:active_executable) { shell_cellar/"#{formula_name}/2.10/bin/#{executable_name}" }
     let(:env_formula_name) { "test-env" }

--- a/Library/Homebrew/test/macos_version_spec.rb
+++ b/Library/Homebrew/test/macos_version_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe MacOSVersion do
     end
 
     it "matches the major version returned by OS.kernel_version", :needs_macos do
+      ENV["HOMEBREW_FAKE_MACOS"] = nil
       expect(described_class.kernel_major_version(OS::Mac.version)).to eq OS.kernel_version.major
     end
   end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

More test failure fixes.

https://github.com/Homebrew/homebrew-core/actions/runs/29278992918/job/86917281683?pr=292807#step:3:231
```
  Error: Cask::Caskroom.casks does not list a cask twice when it is also installed under an old token
  
  Failure/Error: expect(described_class.casks.map(&:token)).to eq(["new-cask"])
  
    expected: ["new-cask"]
         got: ["new-cask", "old-cask"]
```

https://github.com/Homebrew/homebrew-core/actions/runs/29278992918/job/86917281683?pr=292807#step:3:100
```
  Error: MacOSVersion::kernel_major_version matches the major version returned by OS.kernel_version
  
  Failure/Error: expect(described_class.kernel_major_version(OS::Mac.version)).to eq OS.kernel_version.major
  
    expected: #<Version::NumericToken 21>
         got: #<Version 20>
```