### PR TITLE
Include implicit dependencies in formula installer checks

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -474,8 +474,7 @@ class FormulaInstaller
 
     recursive_deps = if pour_bottle?
       # Include implicit dependencies (except duplicates) in formulae to check
-      active_spec = T.must(formula.stable? ? formula.stable : formula.head)
-      (formula.runtime_dependencies + active_spec.deps.required).uniq(&:name)
+      (formula.runtime_dependencies + formula.deps.select(&:implicit?)).uniq(&:name)
     else
       formula.recursive_dependencies
     end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -473,7 +473,9 @@ class FormulaInstaller
     end
 
     recursive_deps = if pour_bottle?
-      (formula.runtime_dependencies + (formula.stable&.deps&.required || [])).uniq(&:name)
+      # Include implicit dependencies (except duplicates) in formulae to check
+      active_spec = T.must(formula.stable? ? formula.stable : formula.head)
+      (formula.runtime_dependencies + active_spec.deps.required).uniq(&:name)
     else
       formula.recursive_dependencies
     end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -473,7 +473,7 @@ class FormulaInstaller
     end
 
     recursive_deps = if pour_bottle?
-      formula.runtime_dependencies
+      (formula.runtime_dependencies + (formula.stable&.deps&.required || [])).uniq(&:name)
     else
       formula.recursive_dependencies
     end


### PR DESCRIPTION
It seems that [the check for pinned dependencies before bottle install/upgrade](https://github.com/Homebrew/brew/blob/bcf1cfcdaf69d61a694365d2d9187bc934b30b1f/Library/Homebrew/formula_installer.rb#L475-L506) does not include implicit deps (or at least, [`gcc` implicit dep](https://github.com/Homebrew/brew/blob/60d0bf8ec72ff6b5496949b93f21ee5cb733816c/Library/Homebrew/extend/os/linux/formula.rb#L41). There seems to be an assumption that [implicit deps are only relevant when building from source](https://github.com/Homebrew/brew/blob/19ddb77168f9f5210062829dda887f4e9a69f17b/Library/Homebrew/formula.rb#L3154-L3156), which is [not true for some ~cursed~ tier-3 linux configurations](https://github.com/Homebrew/brew/issues/22917#issuecomment-4881953790) ([logic here](https://github.com/Homebrew/brew/blob/60d0bf8ec72ff6b5496949b93f21ee5cb733816c/Library/Homebrew/extend/os/linux/dependency_collector.rb#L21-L31)).
This is an attempt to include implicit dependencies in the list that's checked for pins, and therefore block installs that will fail. Closes #22917.

Before:
```
$ brew list --pinned --versions gcc
gcc 15.3.0

$ brew upgrade libffi -n
==> Would upgrade 1 dependency for libffi:
gcc 15.3.0 -> 16.1.0
==> Would upgrade 1 outdated package
libffi 3.5.2 -> 3.7.1 (304.8KB)
```
After:
```
$ brew list --pinned --versions gcc
gcc 15.3.0

$ brew upgrade libffi -n
Error: You must `brew unpin gcc` as installing libffi requires the latest version of pinned dependencies.
```

I admit I really don't understand the brew architecture here, nor idiomatic ruby. This is the smallest change I could make to fix this. Edits/suggestions very welcome.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug? (see #22917)
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- :x: AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
