### PR TITLE
Revert "Return a shared type instance from type constructors when runtime checking is disabled"

### DIFF
--- a/Library/Homebrew/standalone/sorbet.rb
+++ b/Library/Homebrew/standalone/sorbet.rb
@@ -83,43 +83,10 @@ else
     end
   end
 
-  # Redefine type constructors to return a shared untyped instance: their
-  # results are only consumed by runtime checking, which is disabled.
-  # @private
-  module TNoOpTypeConstructors
-    # A union with NilClass rather than plain untyped: `prop`/`const` infer
-    # optionality from their type argument, so nilable props must still look
-    # nilable or serialising them while nil raises.
-    # Not frozen: `Union` memoises internally on first use.
-    # rubocop:disable Style/MutableConstant
-    UNTYPED = T::Types::Union.new([T::Types::Untyped.new, T::Types::Simple.new(NilClass)])
-    # rubocop:enable Style/MutableConstant
-
-    def nilable(_type) = UNTYPED
-    def any(*_types) = UNTYPED
-    def all(*_types) = UNTYPED
-    def class_of(_klass) = UNTYPED
-    def untyped = UNTYPED
-    def anything = UNTYPED
-    def self_type = UNTYPED
-    def attached_class = UNTYPED
-    def type_parameter(_name) = UNTYPED
-  end
-
-  # @private
-  module TNoOpTypeIndex
-    def [](*_types) = TNoOpTypeConstructors::UNTYPED
-  end
-
-  [T::Array, T::Hash, T::Set, T::Range, T::Enumerable, T::Enumerator].each do |mod|
-    mod.singleton_class.prepend(TNoOpTypeIndex)
-  end
-
   # @private
   module T
     class << self
       prepend TNoChecks
-      prepend TNoOpTypeConstructors
     end
 
     # Redefine `T.sig` to be a no-op.


### PR DESCRIPTION
## Summary

Reverts #23078 ("Return a shared type instance from type constructors when runtime checking is disabled").

## Changes

Reverts the 33-line change to `Library/Homebrew/standalone/sorbet.rb` in full, restoring the original type constructor behaviour when `$HOMEBREW_SORBET_RUNTIME` is unset.

-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.
