### PR TITLE
Remove dead API methods and move generated_hash! to tests

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -385,11 +385,6 @@ module Homebrew
       Homebrew::API::Internal.formula_tap_migrations
     end
 
-    sig { returns(Pathname) }
-    def self.cached_formula_json_file_path
-      Homebrew::API::Internal.cached_packages_json_file_path
-    end
-
     sig { returns(T::Array[String]) }
     def self.cask_tokens
       Homebrew::API::Internal.cask_hashes.keys

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -134,16 +134,6 @@ module Homebrew
         cache.fetch("casks")
       end
 
-      sig { returns(T::Hash[String, String]) }
-      def self.all_renames
-        unless cache.key?("renames")
-          json_updated = download_and_cache_data!
-          write_names(regenerate: json_updated)
-        end
-
-        cache.fetch("renames")
-      end
-
       sig { returns(T::Hash[String, T.untyped]) }
       def self.tap_migrations
         unless cache.key?("tap_migrations")

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -178,16 +178,6 @@ module Homebrew
         cache.fetch("aliases")
       end
 
-      sig { returns(T::Hash[String, String]) }
-      def self.all_renames
-        unless cache.key?("renames")
-          json_updated = download_and_cache_data!
-          write_names_and_aliases(regenerate: json_updated)
-        end
-
-        cache.fetch("renames")
-      end
-
       sig { returns(T::Hash[String, T.untyped]) }
       def self.tap_migrations
         unless cache.key?("tap_migrations")

--- a/Library/Homebrew/api_hashable.rb
+++ b/Library/Homebrew/api_hashable.rb
@@ -20,19 +20,6 @@ module APIHashable
     @generating_hash = T.let(true, T.nilable(T::Boolean))
   end
 
-  sig { void }
-  def generated_hash!
-    return unless generating_hash?
-
-    # Revert monkeypatches for API generation
-    Object.send(:remove_const, :HOMEBREW_PREFIX)
-    Object.const_set(:HOMEBREW_PREFIX, @old_homebrew_prefix)
-    ENV["HOME"] = @old_home
-    ENV["GIT_CONFIG_GLOBAL"] = @old_git_config_global
-
-    @generating_hash = false
-  end
-
   sig { returns(T::Boolean) }
   def generating_hash?
     @generating_hash ||= false

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
     before do
       allow(Homebrew::API).to receive_messages(cask_tokens: casks_from_api_hash.keys, cask_renames: {})
       allow(Homebrew::API).to receive(:cask_token?) { |token| casks_from_api_hash.key?(token) }
-      allow(Homebrew::API::Cask)
-        .to receive_messages(all_casks: casks_from_api_hash, all_renames: {})
+      allow(Homebrew::API::Cask).to receive(:all_casks).and_return(casks_from_api_hash)
 
       # The call to `Cask::CaskLoader.load` above sets the Tap cache prematurely.
       Tap.clear_cache

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -558,7 +558,7 @@ RSpec.describe Formulary do
           )
         end
         allow(Homebrew::API::Internal).to receive(:formula_tap_git_head).and_return("")
-        allow(Homebrew::API::Formula).to receive_messages(all_aliases: {}, all_renames: {})
+        allow(Homebrew::API::Formula).to receive(:all_aliases).and_return({})
         allow(CoreTap.instance).to receive(:tap_migrations).and_return({})
         allow(CoreCaskTap.instance).to receive(:tap_migrations).and_return({})
 

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -48,6 +48,7 @@ require_relative "../global"
 require "debug" if ENV["HOMEBREW_DEBUG"]
 
 require "test/support/quiet_progress_formatter"
+require "test/support/helper/api_hashable"
 require "test/support/helper/cask"
 require "test/support/helper/files"
 require "test/support/helper/fixtures"

--- a/Library/Homebrew/test/support/helper/api_hashable.rb
+++ b/Library/Homebrew/test/support/helper/api_hashable.rb
@@ -1,0 +1,20 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "api_hashable"
+
+# `generating_hash!` monkeypatches global state for API generation. The commands
+# that generate the API exit once they are done, so only tests need to revert it.
+module APIHashable
+  sig { void }
+  def generated_hash!
+    return unless generating_hash?
+
+    Object.send(:remove_const, :HOMEBREW_PREFIX)
+    Object.const_set(:HOMEBREW_PREFIX, @old_homebrew_prefix)
+    ENV["HOME"] = @old_home
+    ENV["GIT_CONFIG_GLOBAL"] = @old_git_config_global
+
+    @generating_hash = false
+  end
+end


### PR DESCRIPTION
Another extraction from my `typecheck-deadcode` branch (following #22733), which runs [Spoom](https://github.com/Shopify/spoom)'s dead code analysis over `Library/Homebrew`. This slice covers the `Homebrew::API` files.

### What this removes

Four methods with no callers anywhere:

| Method | Callers in `brew` | Callers in `homebrew-core` / `homebrew-cask` | Callers on GitHub |
| --- | --- | --- | --- |
| `Homebrew::API.cached_formula_json_file_path` | 0 | 0 | 0 |
| `Homebrew::API::Cask.all_renames` | 0 (2 RSpec stubs) | 0 | 0 |
| `Homebrew::API::Formula.all_renames` | 0 (2 RSpec stubs) | 0 | 0 |
| `APIHashable#generated_hash!` | 0 (tests only) | 0 | 0 |

The GitHub code search for `cached_formula_json_file_path` returns hits only in vendored copies and forks of `brew` itself, i.e. the definition site, so there are no third-party consumers.

### Why `all_renames` is dead

Renames are resolved through `Homebrew::API.formula_renames` and `Homebrew::API.cask_renames`, which read the internal API (`Homebrew::API::Internal`). Those are the methods `Formulary`, `Cask::CaskLoader`, `CoreTap`, `CoreCaskTap` and `bundle` actually call. The `all_renames` pair on the JSON API classes is left over from before that path existed, and nothing reaches it. Its only remaining references were two RSpec stubs that stub a method no code under test calls, so those go too.

### Why `generated_hash!` moves to a test helper instead

`generating_hash!` applies global monkeypatches (it swaps out `HOMEBREW_PREFIX` and sets `HOME` and `GIT_CONFIG_GLOBAL`) so that generated JSON contains placeholders. `generated_hash!` is the inverse, reverting them.

In production nothing ever reverts: `brew generate-formula-api`, `brew generate-cask-api` and `brew generate-internal-api` call `generating_hash!` and then exit, so the process dies with the monkeypatches still applied. The only callers of `generated_hash!` are two specs, which need it precisely so that the monkeypatching does not leak into other examples.

That makes it a test helper living in production code, so I moved it to `test/support/helper/api_hashable.rb` rather than deleting it outright. Behaviour is unchanged, and the two specs still pass.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code was used to run the dead code analysis, audit each candidate for callers (inside `brew`, in `homebrew-core` and `homebrew-cask` checkouts, and via GitHub code search), and prepare the diff. I reviewed the result and verified it locally with `brew lgtm`.

No new tests are added because this is a removal. The existing specs are the check: they exercise every method touched here, and they were run before and after. The `all_renames` stub removals and the `generated_hash!` move are both covered by `test/formulary_spec.rb`, `test/cask/cask_loader/from_api_loader_spec.rb`, `test/cask/cask_spec.rb` and `test/service_spec.rb`.

-----
