### PR TITLE
Preserve cask container metadata

### DIFF
--- a/Library/Homebrew/api/cask_download.rb
+++ b/Library/Homebrew/api/cask_download.rb
@@ -30,6 +30,9 @@ module Homebrew
           sha256 cask_struct.sha256
           url(*cask_struct.url_args, **cask_struct.url_kwargs)
           homepage cask_struct.homepage if cask_struct.homepage?
+          if cask_struct.container?
+            container(nested: cask_struct.container_args[:nested], type: cask_struct.container_args[:type])
+          end
         end
 
         ::Cask::Download.new(cask, quarantine:, require_sha:)

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -765,6 +765,42 @@ RSpec.describe Cask::Installer, :cask do
       expect(cask).to be_installed
     end
 
+    it "stages nested containers for API-loaded casks" do
+      container_dir = mktmpdir
+      FileUtils.cp(TEST_FIXTURE_DIR/"cask/caffeine.zip", container_dir/"NestedApp.zip")
+      (container_dir/"README").write("NestedApp.zip contains the application")
+      download = mktmpdir/"api-nested-cask.tar.gz"
+      system "tar", "--create", "--gzip", "--file", download, "--directory", container_dir, "."
+      sha256 = download.sha256
+      cask = Cask::Cask.new("api-nested-cask", loaded_from_api: true, loaded_from_internal_api: true) do
+        version "1.2.3"
+        sha256 sha256
+        url "file://#{download}"
+        container nested: "NestedApp.zip"
+        app "Caffeine.app"
+      end
+      cask_struct = Homebrew::API::CaskStruct.new(
+        container_args:    { nested: "NestedApp.zip", type: nil },
+        container_present: true,
+        sha256:,
+        url_args:          ["file://#{download}"],
+        version:           "1.2.3",
+      )
+      allow(Homebrew::API::Internal).to receive(:cask_struct).with("api-nested-cask").and_return(cask_struct)
+      download_queue = Homebrew::DownloadQueue.new(pour: true)
+      installer = described_class.new(cask, download_queue:, defer_fetch: true)
+
+      begin
+        installer.enqueue_downloads
+        download_queue.fetch
+      ensure
+        download_queue.shutdown
+      end
+      installer.stage
+
+      expect(cask.staged_path/"Caffeine.app").to be_a_directory
+    end
+
     it "does not stage queued downloads with missing unpack dependencies" do
       cask = Cask::CaskLoader.load(cask_path("container-bzip2"))
       download_queue = Homebrew::DownloadQueue.new(pour: true)


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/23094

- Retain nested paths and explicit types for API-backed downloads.
- Ensure queued staging extracts the declared nested container.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
