### PR TITLE
Start bottle downloads before dependency fetches

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -148,6 +148,7 @@ class FormulaInstaller
     @formula = T.let(T.must(previously_fetched_formula), Formula) if previously_fetched_formula
 
     @ran_prelude_fetch = T.let(false, T::Boolean)
+    @ran_prelude = T.let(false, T::Boolean)
   end
 
   sig { returns(T::Boolean) }
@@ -354,6 +355,7 @@ class FormulaInstaller
     check_install_sanity
 
     install_fetch_deps if !ignore_deps? && Homebrew::EnvConfig.download_concurrency <= 1
+    @ran_prelude = true
   end
 
   sig { void }
@@ -1499,33 +1501,44 @@ on_request: installed_on_request?, options:)
   def enqueue_fetch
     return if previously_fetched_formula
 
+    downloadable_object = T.let(nil, T.nilable(Downloadable))
+    bottle_download = T.let(nil, T.nilable(Downloadable))
+    check_attestation = T.let(false, T::Boolean)
+    local_bottle_path = formula.local_bottle_path
+    bottle_install = !only_deps? && local_bottle_path.nil? && pour_bottle?(output_warning: true)
+    # We skip `gh` to avoid a bootstrapping cycle, in the off-chance a user attempts
+    # to explicitly `brew install gh` without already having a version for bootstrapping.
+    # We also skip bottle installs from local bottle paths, as these are done in CI
+    # as part of the build lifecycle before attestations are produced.
+    verify_attestation = bottle_install &&
+                         Homebrew::EnvConfig.verify_attestations? &&
+                         (formula.tap&.core_tap? || false) &&
+                         formula.name != "gh"
+    if bottle_install && @ran_prelude
+      bottle_download = downloadable
+      check_attestation = verify_attestation && !bottle_download.cached_download.exist?
+      download_queue.enqueue(bottle_download, check_attestation:, stage: false)
+    end
+
     fetch_dependencies
 
     return if only_deps?
-    return if formula.local_bottle_path
+    return if local_bottle_path
 
-    downloadable_object = downloadable
-    check_attestation = if pour_bottle?(output_warning: true)
-      fetch_bottle_tab(enqueue: true)
-
-      !downloadable_object.cached_download.exist?
+    downloadable_object = bottle_download || downloadable
+    if bottle_install
+      if bottle_download.nil?
+        fetch_bottle_tab(enqueue: true)
+        check_attestation = verify_attestation && !downloadable_object.cached_download.exist?
+      end
     else
       @formula = Homebrew::API::Formula.source_download_formula(formula) if formula.loaded_from_api?
 
       formula.enqueue_resources_and_patches(download_queue:)
 
       downloadable_object = downloadable
-
-      false
     end
 
-    # We skip `gh` to avoid a bootstrapping cycle, in the off-chance a user attempts
-    # to explicitly `brew install gh` without already having a version for bootstrapping.
-    # We also skip bottle installs from local bottle paths, as these are done in CI
-    # as part of the build lifecycle before attestations are produced.
-    check_attestation &&= Homebrew::EnvConfig.verify_attestations? &&
-                          (formula.tap&.core_tap? || false) &&
-                          formula.name != "gh"
     # Check attestation after download completes.
     download_queue.enqueue(downloadable_object, check_attestation:)
 

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe Homebrew::DownloadQueue do
     download_queue.fetch
   end
 
+  it "promotes an in-flight download to queued staging" do
+    expect(retryable_download).to receive(:fetch).once.and_return(cached_download)
+    expect(downloadable).to receive(:stage_from_download_queue?).with(cached_download, pour: false).and_return(true)
+    expect(downloadable).to receive(:extracting!).ordered
+    expect(downloadable).to receive(:stage_from_download_queue).with(cached_download, pour: false).ordered
+    expect(downloadable).to receive(:downloaded!).ordered
+
+    download_queue.enqueue(downloadable)
+    download_queue.enqueue(downloadable, stage: true)
+    download_queue.fetch
+  end
+
   it "checks attestations for valid cached bottles" do
     bottle = Bottle.allocate
     allow(bottle).to receive_messages(

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -252,6 +252,44 @@ RSpec.describe FormulaInstaller do
     end
   end
 
+  describe "#enqueue_fetch" do
+    let(:formula) { TestballBottle.new }
+    let(:installer) { described_class.new(formula) }
+    let(:download_queue) { instance_double(Homebrew::DownloadQueue) }
+    let(:bottle) { instance_double(Bottle, cached_download: HOMEBREW_CACHE/"downloads/testball-bottle") }
+
+    before do
+      installer.download_queue = download_queue
+
+      allow(Homebrew::EnvConfig).to receive(:verify_attestations?).and_return(false)
+      allow(installer).to receive(:previously_fetched_formula)
+      allow(installer).to receive(:pour_bottle?).with(output_warning: true).and_return(true)
+      allow(installer).to receive(:downloadable).and_return(bottle)
+      allow(installer).to receive(:fetch_bottle_tab)
+    end
+
+    it "starts a bottle download before enqueueing dependencies after the prelude" do
+      installer.instance_variable_set(:@ran_prelude, true)
+
+      expect(download_queue).to receive(:enqueue)
+        .with(bottle, check_attestation: false, stage: false).ordered
+      expect(installer).to receive(:fetch_dependencies).ordered
+      expect(download_queue).to receive(:enqueue)
+        .with(bottle, check_attestation: false).ordered
+
+      installer.enqueue_fetch
+    end
+
+    it "resolves dependencies before enqueueing a bottle without the prelude" do
+      expect(installer).to receive(:fetch_dependencies).ordered
+      expect(installer).to receive(:fetch_bottle_tab).with(enqueue: true).ordered
+      expect(download_queue).to receive(:enqueue)
+        .with(bottle, check_attestation: false).ordered
+
+      installer.enqueue_fetch
+    end
+  end
+
   describe "linking defaults" do
     it "links non-keg-only formulae when link_keg is false" do
       ordinary_formula = formula "homebrew-link-default" do


### PR DESCRIPTION
- Start the requested bottle after `prelude` checks but before recursive dependency enqueueing so network I/O overlaps Ruby work.
- Reuse the cached-location future in `DownloadQueue` and defer staging until dependency enqueueing completes, avoiding duplicate transfers and early extraction.
- Preserve direct fetch ordering and existing attestation, source, local bottle and only-dependencies paths.
- This favours cold parallel downloads; warm or serial downloads gain little and later dependency failures can waste bandwidth.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 Sol max with local review and testing. 

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
