### PR TITLE
download_queue: wake on completed downloads

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -5,6 +5,7 @@ require "downloadable"
 require "concurrent/promises"
 require "concurrent/executors"
 require "concurrent/atomic/atomic_boolean"
+require "concurrent/atomic/event"
 require "retryable_download"
 require "concurrent/set"
 require "resource"
@@ -118,6 +119,9 @@ module Homebrew
         remaining_downloads = downloads.dup.to_a
         previous_pending_line_count = 0
 
+        resolution = Concurrent::Event.new
+        downloads.each_value { |future| future.on_resolution! { resolution.set } }
+
         begin
           stdout_print_and_flush_if_tty Tty.hide_cursor
 
@@ -200,7 +204,16 @@ module Homebrew
                 end
               end
 
-              sleep 0.05
+              next if remaining_downloads.empty?
+
+              resolution.reset
+              # A download may resolve between the partition above and this
+              # reset: re-check before waiting to avoid a lost wakeup.
+              next if remaining_downloads.any? { |_, future| finished_states.include?(future.state) }
+
+              # Wake as soon as any download resolves; the timeout only sets
+              # the redraw cadence for spinner and progress bars on TTYs.
+              resolution.wait(tty_with_cursor_move_support? ? 0.05 : 1)
             # We want to catch all exceptions to ensure we can cancel any
             # running downloads and flush the TTY.
             rescue Exception # rubocop:disable Lint/RescueException

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe Homebrew::DownloadQueue do
     expect(Homebrew).to have_failed
   end
 
+  it "wakes when downloads complete instead of polling with sleep" do
+    allow($stdout).to receive(:tty?).and_return(false)
+    allow(retryable_download).to receive(:fetch) { sleep(0.1) }
+
+    expect(download_queue).not_to receive(:sleep)
+
+    expect do
+      download_queue.enqueue(downloadable)
+      download_queue.fetch
+    end.to output(/✔︎ Bottle testball/).to_stderr
+  end
+
   it "skips fetching already downloaded files with a valid checksum" do
     cached_download.dirname.mkpath
     cached_download.write("already downloaded")


### PR DESCRIPTION
- The parallel fetch loop paused a fixed 50ms per iteration, even when every download had already finished: `Kernel#sleep` was 27% of wall samples (~100ms) in `brew prof --stackprof fetch` for an already-cached formula, the largest single frame ahead of `Kernel#require`.
- Warm-cache downloads resolve in microseconds, so almost all of that sleeping was wasted on every `brew fetch`, `brew install` and `brew upgrade`, interactive or scripted, and even the final iteration slept after the last download had finished.
- Warm-cache `brew fetch` of a cached formula drops from 0.63-0.70s to 0.45-0.52s (~200ms, ~25-30%), measured both on a TTY and piped, and `Kernel#sleep` disappears from its profile entirely.
- Completed downloads are reported as they finish instead of on the next 50ms poll tick.
- Skip the end-of-iteration pause entirely when the partition left no downloads pending; previously even the final iteration slept.
- Wait on a `Concurrent::Event` signalled by an `on_resolution!` callback on every download future instead of sleeping, so warm caches never pay a poll interval.
- On animated TTYs the wait times out after 50ms, purely to keep redrawing the spinner and progress bars at a steady cadence while downloads are in flight; otherwise after 1s as a safety net.
- The event is reset before each wait and the remaining futures are re-checked in between, so a download resolving between the partition and the reset cannot cause a lost wakeup.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Anthropic Fable 5 max with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
