### PR TITLE
Prewarm Bootsnap caches after `brew update`

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -252,6 +252,17 @@ module Homebrew
         link_completions_manpages_and_docs
         Tap.installed.each(&:link_completions_and_manpages)
 
+        # Only prewarm when the update changed `Library/Homebrew/vendor`:
+        # portable Ruby bumps rotate the whole Bootsnap cache key and
+        # vendored gem bumps rewrite gem trees this run never loads, while
+        # for code-only updates this run has already recompiled most of
+        # what the next command needs.
+        if !args.auto_update? && initial_revision != current_revision &&
+           !quiet_system("git", "-C", HOMEBREW_REPOSITORY.to_s, "diff", "--quiet",
+                         initial_revision, current_revision, "--", "Library/Homebrew/vendor")
+          Homebrew::Bootsnap.prewarm!
+        end
+
         failed_fetch_dirs = ENV["HOMEBREW_MISSING_REMOTE_REF_DIRS"]&.split("\n")
         if failed_fetch_dirs.present?
           failed_fetch_taps = failed_fetch_dirs.map { |dir| Tap.from_path(dir) }

--- a/Library/Homebrew/startup/bootsnap.rb
+++ b/Library/Homebrew/startup/bootsnap.rb
@@ -69,6 +69,25 @@ module Homebrew
       # The compile cache doesn't get unloaded so we don't need to load it again!
       load!(compile_cache: false)
     end
+
+    # Compile caches for the load graphs of common commands in a detached
+    # background process, so the next `brew` command doesn't pay the cost of
+    # compiling caches for Ruby files changed by e.g. `brew update`.
+    def self.prewarm!
+      return unless enabled?
+      return if ENV["HOMEBREW_TESTS"]
+
+      pid = Process.spawn(
+        *HOMEBREW_RUBY_EXEC_ARGS,
+        "-I", $LOAD_PATH.join(File::PATH_SEPARATOR),
+        "-rglobal", "-rcmd/install", "-rcmd/fetch", "-rcmd/upgrade",
+        "-e", "",
+        in: File::NULL, out: File::NULL, err: File::NULL, pgroup: true
+      )
+      Process.detach(pid)
+    rescue SystemCallError
+      nil
+    end
   end
 end
 

--- a/Library/Homebrew/test/startup/bootsnap_spec.rb
+++ b/Library/Homebrew/test/startup/bootsnap_spec.rb
@@ -9,4 +9,53 @@ RSpec.describe Homebrew::Bootsnap do
       end
     end
   end
+
+  describe "::prewarm!" do
+    it "compiles caches for common command load graphs in a detached background process" do
+      with_env(HOMEBREW_BOOTSNAP_GEM_PATH: "gem/path", HOMEBREW_NO_BOOTSNAP: nil, HOMEBREW_TESTS: nil) do
+        expect(Process).to receive(:spawn).with(
+          *HOMEBREW_RUBY_EXEC_ARGS, "-I", $LOAD_PATH.join(File::PATH_SEPARATOR),
+          "-rglobal", "-rcmd/install", "-rcmd/fetch", "-rcmd/upgrade", "-e", "",
+          hash_including(pgroup: true)
+        ).and_return(12345)
+        expect(Process).to receive(:detach).with(12345)
+
+        described_class.prewarm!
+      end
+    end
+
+    it "does nothing when Bootsnap is disabled" do
+      with_env(HOMEBREW_BOOTSNAP_GEM_PATH: "gem/path", HOMEBREW_NO_BOOTSNAP: "1", HOMEBREW_TESTS: nil) do
+        expect(Process).not_to receive(:spawn)
+
+        described_class.prewarm!
+      end
+    end
+
+    it "does not error when starting the prewarm process fails" do
+      with_env(HOMEBREW_BOOTSNAP_GEM_PATH: "gem/path", HOMEBREW_NO_BOOTSNAP: nil, HOMEBREW_TESTS: nil) do
+        expect(Process).to receive(:spawn).and_raise(Errno::EAGAIN)
+        expect(Process).not_to receive(:detach)
+
+        expect { described_class.prewarm! }.not_to raise_error
+      end
+    end
+
+    it "does not error when detaching the prewarm process fails" do
+      with_env(HOMEBREW_BOOTSNAP_GEM_PATH: "gem/path", HOMEBREW_NO_BOOTSNAP: nil, HOMEBREW_TESTS: nil) do
+        expect(Process).to receive(:spawn).and_return(12345)
+        expect(Process).to receive(:detach).with(12345).and_raise(Errno::ECHILD)
+
+        expect { described_class.prewarm! }.not_to raise_error
+      end
+    end
+
+    it "does nothing in tests" do
+      with_env(HOMEBREW_BOOTSNAP_GEM_PATH: "gem/path", HOMEBREW_NO_BOOTSNAP: nil, HOMEBREW_TESTS: "1") do
+        expect(Process).not_to receive(:spawn)
+
+        described_class.prewarm!
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Bootsnap compiles Ruby files into instruction sequence and YAML caches on first load, so an update that changes files leaves the next command to recompile them at startup, on the user's time.
- The cost is largest for updates under `Library/Homebrew/vendor`: portable Ruby bumps rotate the whole cache key (it hashes the Ruby version and gem directory listing), cold-starting every file at once, and vendored gem bumps rewrite entire gem trees, much of which `update-report`'s own run never loads and so cannot recompile as a side effect.
- Loading the `brew install` and `brew fetch` command graph with a fully cold cache took 0.91s vs 0.56s warm on an M-series Mac in this checkout, so ~350ms of pure cache compilation; the gap is a multiple of that on older machines.
- After an explicit `brew update` that changed `Library/Homebrew/vendor`, `update-report` now spawns a detached background Ruby that requires `global`, `cmd/install`, `cmd/fetch` and `cmd/upgrade`, recompiling the caches for the most common next commands while the user reads the update report.
- Code-only updates skip the prewarm: `update-report` has already recompiled most of what the next command loads (the residual was ~20-40ms here), so a background process is not worth it.
- Auto-update runs also skip it: the command that triggered them loads the same files immediately afterwards, so a parallel prewarm would only duplicate its work.
- `Homebrew::Bootsnap.prewarm!` reuses the existing `enabled?` gate, is skipped under `HOMEBREW_TESTS` and spawns the interpreter from `HOMEBREW_RUBY_EXEC_ARGS` with the parent's `$LOAD_PATH`, stdio on `/dev/null` and its own process group, then detaches, so the update exits immediately and a prewarm failure cannot break it.
- Verified: across a vendored gem bump a detached child appears once `update-report` exits and compiles whatever its run did not load (736 -> 1055 cache files after a minimal report run), while code-only updates, auto-update runs and `HOMEBREW_NO_BOOTSNAP=1` spawn no child.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Anthropic Fable 5 max with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
