### PR TITLE
cmd/upgrade: don't show upgrade size with --build-from-source

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -668,6 +668,8 @@ module Homebrew
 
       sig { params(formula: Formula).returns(String) }
       def formula_upgrade_size(formula)
+        return "" if args.build_from_source_formulae.include?(formula.name)
+
         bottle = formula.bottle
         return "" unless bottle
 

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -564,6 +564,24 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       .to eq(["testball 0.1 -> 0.2 (500B)"])
   end
 
+  it "omits formula download sizes in dry-run source build upgrade summaries" do
+    write_formula "testball", <<~RUBY
+      url "https://brew.sh/testball-0.2"
+    RUBY
+
+    cmd = described_class.new(["--dry-run", "--build-from-source", "testball"])
+    formula = Formula["testball"]
+    bottle = instance_double(Bottle)
+    keg = instance_double(Keg, version: PkgVersion.parse("0.1"), disk_usage: 1000)
+
+    allow(formula).to receive_messages(optlinked?: true, opt_prefix: HOMEBREW_PREFIX/"opt/testball", bottle:)
+    allow(Keg).to receive(:new).with(HOMEBREW_PREFIX/"opt/testball").and_return(keg)
+    expect(bottle).not_to receive(:fetch_tab)
+
+    expect(cmd.send(:formula_upgrade_descriptions, [formula], include_sizes: true))
+      .to eq(["testball 0.1 -> 0.2"])
+  end
+
   it "prints dry-run cleanup output from one formula cleanup run" do
     formula = formula("testball") do
       T.bind(self, T.class_of(Formula))


### PR DESCRIPTION
* For developers, this would cause an error if you edited a version/revision bump locally and were testing it.
* For users that weren't editing the formula, it wouldn't error but it would be inaccurate as it shows the bottle size despite not installing the bottle.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
