### PR TITLE
Show application of file and data patches

### DIFF
--- a/Library/Homebrew/data_patch.rb
+++ b/Library/Homebrew/data_patch.rb
@@ -15,6 +15,9 @@ class DATAPatch < EmbeddedPatch
   end
 
   sig { override.returns(String) }
+  def filename = "embedded DATA patch"
+
+  sig { override.returns(String) }
   def contents
     path = self.path
     raise ArgumentError, "DATAPatch#contents called before path was set!" unless path

--- a/Library/Homebrew/embedded_patch.rb
+++ b/Library/Homebrew/embedded_patch.rb
@@ -33,6 +33,9 @@ class EmbeddedPatch
   end
 
   sig { abstract.returns(String) }
+  def filename; end
+
+  sig { abstract.returns(String) }
   def contents; end
 
   sig { void }
@@ -43,6 +46,7 @@ class EmbeddedPatch
     if (subdirectory = directory.presence)
       dir /= subdirectory
     end
+    ohai "Applying #{filename}"
     Patch.ensure_targets_within!(data, strip:, base: dir)
     dir.cd do
       Utils.safe_popen_write("patch", *args) { |p| p.write(data) }

--- a/Library/Homebrew/local_patch.rb
+++ b/Library/Homebrew/local_patch.rb
@@ -47,6 +47,9 @@ class LocalPatch < EmbeddedPatch
   end
 
   sig { override.returns(String) }
+  def filename = file.to_s.delete_prefix("Patches/")
+
+  sig { override.returns(String) }
   def contents
     owner = self.owner
     raise ArgumentError, "LocalPatch#contents called before owner was set!" unless owner

--- a/Library/Homebrew/string_patch.rb
+++ b/Library/Homebrew/string_patch.rb
@@ -12,6 +12,9 @@ class StringPatch < EmbeddedPatch
   end
 
   sig { override.returns(String) }
+  def filename = "embedded string patch"
+
+  sig { override.returns(String) }
   def contents
     @str
   end


### PR DESCRIPTION
When applying a remote patch we print `Applying something.patch`. We didn't for file & DATA patches. When installing a formula like `libssh2`, this made you think it was applying less patches than it actually was.

This PR fixes the inconsistency.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
