### PR TITLE
Keep the current internal package API file on `brew cleanup -s`

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -569,7 +569,8 @@ module Homebrew
       cask_files = (cache/"Cask").directory? ? (cache/"Cask").children : []
       api_internal = cache/"api/internal"
       api_package_files = if scrub? && api_internal.directory?
-        api_internal.glob("packages.*.jws.json")
+        current_api_package_basename = Homebrew::API::Internal.cached_packages_json_file_path.basename
+        api_internal.glob("packages.*.jws.json").reject { |path| path.basename == current_api_package_basename }
       else
         []
       end

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -541,14 +541,15 @@ RSpec.describe Homebrew::Cleanup do
       expect(api_package_files.map(&:exist?)).to eq([true, true])
     end
 
-    it "cleans up internal package API files with scrub" do
-      api_package_files = [
-        HOMEBREW_CACHE/"api/internal/packages.arm64_golden_gate.jws.json",
-        HOMEBREW_CACHE/"api/internal/packages.arm64_tahoe.jws.json",
-      ]
+    it "cleans up non-current internal package API files with scrub" do
+      cache = mktmpdir/"cache"
+      api_internal = cache/"api/internal"
+      current_api_package_file = api_internal/Homebrew::API::Internal.cached_packages_json_file_path.basename
+      stale_api_package_file = api_internal/"packages.stale.jws.json"
+      api_package_files = [current_api_package_file, stale_api_package_file]
       api_jws_files = [
-        HOMEBREW_CACHE/"api/formula.jws.json",
-        HOMEBREW_CACHE/"api/cask.jws.json",
+        cache/"api/formula.jws.json",
+        cache/"api/cask.jws.json",
       ]
       api_package_files.each do |api_package_file|
         api_package_file.dirname.mkpath
@@ -559,10 +560,9 @@ RSpec.describe Homebrew::Cleanup do
         FileUtils.touch api_jws_file
       end
 
-      described_class.new(scrub: true).cleanup_cache
+      described_class.new(scrub: true, cache:).cleanup_cache
 
-      expect(api_package_files.map(&:exist?)).to eq([false, false])
-      expect(api_jws_files.map(&:exist?)).to eq([true, true])
+      expect([*api_package_files, *api_jws_files].map(&:exist?)).to eq([true, false, true, true])
     end
 
     it "cleans up API source files and symlinks at any depth without cleaning directories" do


### PR DESCRIPTION
Every internal Ruby command fetches the current `api/internal/packages.<tag>.jws.json` before it runs, but #23022 made `brew cleanup -s` remove every `packages.*.jws.json` file. A standalone `brew cleanup -s` therefore deletes the file it just downloaded, and each rerun re-downloads then re-deletes it. Follow-up to #23022, discussed in https://github.com/orgs/Homebrew/discussions/6962.

`brew cleanup -s` now keeps the `packages.*.jws.json` file for the current effective tag and only sweeps the others left by older OSes or `--os`/`--arch` runs. The kept file is matched by the basename of `Homebrew::API::Internal.cached_packages_json_file_path`, so an injected cache root still resolves it. This mirrors `brew update`, which retains the current bottle-tag package file and prunes previous-tag ones. Normal `brew cleanup` still leaves every file untouched, and `formula.jws.json` and `cask.jws.json` are unaffected.

The regression test seeds an injected cache with the current-tag file and a stale one, then asserts scrub keeps the current file, removes the stale one, and leaves `formula.jws.json` and `cask.jws.json` in place.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 4.8) wrote the cleanup change and spec; I reviewed the diff and verified with `brew lgtm` plus targeted `cleanup` specs.

-----
