### PR TITLE
vulns/osv_export: merge into existing records instead of overwriting

### DIFF
--- a/Library/Homebrew/test/vulns/osv_export_spec.rb
+++ b/Library/Homebrew/test/vulns/osv_export_spec.rb
@@ -287,6 +287,21 @@ RSpec.describe Homebrew::Vulns::OsvExport do
         end
       end
 
+      it "backfills published from an existing modified when the record predates the published field" do
+        Dir.mktmpdir do |dir|
+          seed(dir, nvi)
+          path = "#{dir}/BREW-nvi-CVE-2015-2305.json"
+          legacy = JSON.parse(File.read(path)).tap { |h| h.delete("published") }
+          File.write(path, "#{JSON.pretty_generate(legacy)}\n")
+
+          described_class.run([[nvi, nvi.serialized_patches]], dir, now:)
+
+          record = JSON.parse(File.read(path))
+          expect(record["published"]).to eq "2026-06-01T00:00:00Z"
+          expect(record["modified"]).to eq "2026-06-28T12:00:00Z"
+        end
+      end
+
       it "does not rewrite when the existing file has a different key order" do
         Dir.mktmpdir do |dir|
           seed(dir, nvi)

--- a/Library/Homebrew/test/vulns/osv_export_spec.rb
+++ b/Library/Homebrew/test/vulns/osv_export_spec.rb
@@ -42,8 +42,10 @@ RSpec.describe Homebrew::Vulns::OsvExport do
 
       expect(record[:schema_version]).to eq "1.7.3"
       expect(record[:id]).to eq "BREW-nvi-CVE-2015-2305"
+      expect(record[:published]).to eq "2026-06-28T12:00:00Z"
       expect(record[:modified]).to eq "2026-06-28T12:00:00Z"
       expect(record[:upstream]).to eq ["CVE-2015-2305"]
+      expect(record[:database_specific]).to eq({ source: "generated" })
       expect(record).not_to have_key(:summary)
       expect(record).not_to have_key(:references)
     end
@@ -200,6 +202,119 @@ RSpec.describe Homebrew::Vulns::OsvExport do
         written = described_class.run([[a, shared], [b, shared]], dir, now:)
         expect(written.map { |p| File.basename(p) }.sort)
           .to eq ["BREW-a-CVE-2024-9999.json", "BREW-b-CVE-2024-9999.json"]
+      end
+    end
+
+    context "with an existing record on disk" do
+      let(:earlier) { Time.utc(2026, 6, 1, 0, 0, 0) }
+      let(:nvi_bumped) do
+        formula("nvi") do
+          url "https://deb.debian.org/debian/pool/main/n/nvi/nvi_1.81.6.orig.tar.gz"
+          version "1.81.6"
+          revision 7
+          patch do
+            url "https://deb.debian.org/debian/pool/main/n/nvi/nvi_1.81.6-17.debian.tar.xz"
+            sha256 "abc"
+            type :backport
+            apply "patches/31regex_heap_overflow.patch"
+            resolves "CVE-2015-2305"
+          end
+        end
+      end
+
+      before do
+        allow(Homebrew::Vulns::OSV).to receive(:vulnerability).and_return({})
+      end
+
+      def seed(dir, formula)
+        described_class.run([[formula, formula.serialized_patches]], dir, now: earlier)
+      end
+
+      it "preserves the existing fixed boundary and published timestamp when core bumps the version" do
+        Dir.mktmpdir do |dir|
+          seed(dir, nvi)
+          expect(nvi_bumped.pkg_version.to_s).to eq "1.81.6_7"
+
+          described_class.run([[nvi_bumped, nvi_bumped.serialized_patches]], dir, now:)
+
+          record = JSON.parse(File.read("#{dir}/BREW-nvi-CVE-2015-2305.json"))
+          expect(record["published"]).to eq "2026-06-01T00:00:00Z"
+          expect(record["affected"][0]["ranges"][0]["events"][1]).to eq({ "fixed" => "1.81.6_6" })
+        end
+      end
+
+      it "does not rewrite when nothing has changed" do
+        Dir.mktmpdir do |dir|
+          seed(dir, nvi)
+
+          written = described_class.run([[nvi, nvi.serialized_patches]], dir, now:)
+
+          expect(written).to eq []
+          record = JSON.parse(File.read("#{dir}/BREW-nvi-CVE-2015-2305.json"))
+          expect(record["modified"]).to eq "2026-06-01T00:00:00Z"
+        end
+      end
+
+      it "updates modified when refreshed upstream data differs" do
+        Dir.mktmpdir do |dir|
+          seed(dir, nvi)
+          allow(Homebrew::Vulns::OSV).to receive(:vulnerability)
+            .and_return({ "summary" => "New summary" })
+
+          written = described_class.run([[nvi, nvi.serialized_patches]], dir, now:)
+
+          expect(written).to eq ["#{dir}/BREW-nvi-CVE-2015-2305.json"]
+          record = JSON.parse(File.read(written.first))
+          expect(record["summary"]).to eq "New summary"
+          expect(record["published"]).to eq "2026-06-01T00:00:00Z"
+          expect(record["modified"]).to eq "2026-06-28T12:00:00Z"
+        end
+      end
+
+      it "leaves an existing enriched record untouched when the upstream fetch fails" do
+        Dir.mktmpdir do |dir|
+          allow(Homebrew::Vulns::OSV).to receive(:vulnerability)
+            .and_return({ "summary" => "Cached summary", "aliases" => ["GHSA-aaaa-bbbb-cccc"] })
+          seed(dir, nvi)
+          before = File.read("#{dir}/BREW-nvi-CVE-2015-2305.json")
+          expect(JSON.parse(before)["summary"]).to eq "Cached summary"
+
+          allow(Homebrew::Vulns::OSV).to receive(:vulnerability).and_raise(Homebrew::Vulns::OSV::ApiError)
+          written = described_class.run([[nvi, nvi.serialized_patches]], dir, now:)
+
+          expect(written).to eq []
+          expect(File.read("#{dir}/BREW-nvi-CVE-2015-2305.json")).to eq before
+        end
+      end
+
+      it "does not rewrite when the existing file has a different key order" do
+        Dir.mktmpdir do |dir|
+          seed(dir, nvi)
+          path = "#{dir}/BREW-nvi-CVE-2015-2305.json"
+          reordered = JSON.parse(File.read(path)).sort.reverse.to_h
+          File.write(path, "#{JSON.pretty_generate(reordered)}\n")
+          expect(reordered.keys.first).to eq "upstream"
+
+          written = described_class.run([[nvi, nvi.serialized_patches]], dir, now:)
+
+          expect(written).to eq []
+          expect(JSON.parse(File.read(path))["modified"]).to eq "2026-06-01T00:00:00Z"
+        end
+      end
+
+      it "leaves other files in the directory untouched" do
+        Dir.mktmpdir do |dir|
+          curated = "#{dir}/BREW-2026-0001.json"
+          File.write(curated, JSON.generate(id: "BREW-2026-0001"))
+          orphan = "#{dir}/BREW-gone-CVE-2020-0001.json"
+          File.write(orphan, JSON.generate(id:                "BREW-gone-CVE-2020-0001",
+                                           database_specific: { source: "generated" }))
+
+          described_class.run([[nvi, nvi.serialized_patches]], dir, now:)
+
+          expect(File.read(curated)).to eq JSON.generate(id: "BREW-2026-0001")
+          expect(File.exist?(orphan)).to be true
+        end
       end
     end
 

--- a/Library/Homebrew/vulns/osv_export.rb
+++ b/Library/Homebrew/vulns/osv_export.rb
@@ -46,19 +46,60 @@ module Homebrew
       def self.run(annotated, dir, now: Time.now.utc)
         FileUtils.mkdir_p(dir)
         written = []
-        upstream_cache = T.let({}, T::Hash[String, T.nilable(T::Hash[String, T.untyped])])
+        upstream_cache = T.let({}, T::Hash[String, T.any(T::Hash[String, T.untyped], Symbol)])
 
         annotated.each do |formula, patches|
           Scanner.resolved_ids(patches).each do |vuln_id|
             upstream = upstream_cache.fetch(vuln_id) { upstream_cache[vuln_id] = fetch_upstream(vuln_id) }
-            record = record_for(formula, vuln_id, patches:, upstream:, now:)
-            path = File.join(dir, "#{record.fetch(:id)}.json")
-            File.write(path, "#{JSON.pretty_generate(record)}\n")
+            path = File.join(dir, "#{ID_PREFIX}-#{formula.name}-#{vuln_id}.json")
+            # A transient OSV outage would otherwise strip summary/severity/etc.
+            # from an existing enriched record; leave it untouched instead.
+            if upstream == :failed
+              next if File.file?(path)
+
+              upstream = nil
+            end
+
+            record = record_for(formula, vuln_id, patches:,
+                                upstream: T.cast(upstream, T.nilable(T::Hash[String, T.untyped])), now:)
+            merged = merge_existing(path, record)
+            next if merged.nil?
+
+            File.write(path, "#{JSON.pretty_generate(merged)}\n")
             written << path
           end
         end
 
         written
+      end
+
+      # If a record already exists at `path`, carry forward its `published`
+      # timestamp and `affected[].ranges` (so the `fixed` boundary reflects when
+      # the annotation was first observed rather than drifting to today's
+      # `pkg_version`), and skip the write entirely when nothing else has
+      # changed. Records for annotations no longer in core are simply not
+      # visited, so they persist.
+      sig {
+        params(path: String, record: T::Hash[Symbol, T.untyped]).returns(T.nilable(T::Hash[Symbol, T.untyped]))
+      }
+      def self.merge_existing(path, record)
+        return record unless File.file?(path)
+
+        existing = JSON.parse(File.read(path))
+        record[:published] = existing["published"] if existing["published"]
+        Array(record[:affected]).each_with_index do |affected, index|
+          existing_ranges = existing.dig("affected", index, "ranges")
+          affected[:ranges] = existing_ranges if existing_ranges
+        end
+
+        # Compare as parsed structures so key ordering (which JSON does not
+        # define but Ruby serialisation preserves) does not cause spurious
+        # rewrites of a hand-formatted or differently-serialised existing file.
+        return if JSON.parse(JSON.generate(record)).except("modified") == existing.except("modified")
+
+        record
+      rescue JSON::ParserError
+        record
       end
 
       sig {
@@ -67,12 +108,15 @@ module Homebrew
           .returns(T::Hash[Symbol, T.untyped])
       }
       def self.record_for(formula, vuln_id, patches: formula.serialized_patches, upstream: nil, now: Time.now.utc)
+        timestamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
         record = T.let({
-          schema_version: SCHEMA_VERSION,
-          id:             "#{ID_PREFIX}-#{formula.name}-#{vuln_id}",
-          modified:       now.strftime("%Y-%m-%dT%H:%M:%SZ"),
-          upstream:       [vuln_id],
-          affected:       [affected_entry(formula, vuln_id, patches)],
+          schema_version:    SCHEMA_VERSION,
+          id:                "#{ID_PREFIX}-#{formula.name}-#{vuln_id}",
+          published:         timestamp,
+          modified:          timestamp,
+          upstream:          [vuln_id],
+          affected:          [affected_entry(formula, vuln_id, patches)],
+          database_specific: { source: "generated" },
         }, T::Hash[Symbol, T.untyped])
 
         if upstream
@@ -145,11 +189,13 @@ module Homebrew
         ref.presence
       end
 
-      sig { params(vuln_id: String).returns(T.nilable(T::Hash[String, T.untyped])) }
+      # Returns `:failed` (not `nil`) on error so callers can distinguish a
+      # transient outage from a successful fetch that returned no enrichment.
+      sig { params(vuln_id: String).returns(T.any(T::Hash[String, T.untyped], Symbol)) }
       def self.fetch_upstream(vuln_id)
         OSV.vulnerability(vuln_id)
       rescue OSV::Error
-        nil
+        :failed
       end
     end
   end

--- a/Library/Homebrew/vulns/osv_export.rb
+++ b/Library/Homebrew/vulns/osv_export.rb
@@ -54,14 +54,10 @@ module Homebrew
             path = File.join(dir, "#{ID_PREFIX}-#{formula.name}-#{vuln_id}.json")
             # A transient OSV outage would otherwise strip summary/severity/etc.
             # from an existing enriched record; leave it untouched instead.
-            if upstream == :failed
-              next if File.file?(path)
-
-              upstream = nil
-            end
+            next if upstream == :failed && File.file?(path)
 
             record = record_for(formula, vuln_id, patches:,
-                                upstream: T.cast(upstream, T.nilable(T::Hash[String, T.untyped])), now:)
+                                upstream: upstream.is_a?(Hash) ? upstream : nil, now:)
             merged = merge_existing(path, record)
             next if merged.nil?
 
@@ -86,7 +82,12 @@ module Homebrew
         return record unless File.file?(path)
 
         existing = JSON.parse(File.read(path))
-        record[:published] = existing["published"] if existing["published"]
+        # Records written before `published` was introduced only have
+        # `modified`; use it as the migration value so `published` does not
+        # jump forward to today on first rewrite.
+        if (existing_published = existing["published"] || existing["modified"])
+          record[:published] = existing_published
+        end
         Array(record[:affected]).each_with_index do |affected, index|
           existing_ranges = existing.dig("affected", index, "ranges")
           affected[:ranges] = existing_ranges if existing_ranges


### PR DESCRIPTION
Follow-up to #23106 so `Homebrew/homebrew-advisory-database` can be an accumulating source of truth rather than a daily snapshot (per the outcome of Homebrew/homebrew-brew-vulns#111).

`OsvExport.run` now merges into the target directory instead of blindly writing. For each generated record, if an `<id>.json` already exists its `published` timestamp and `affected[].ranges` are carried forward, so the `fixed` boundary reflects when the annotation was first observed rather than drifting to today's `pkg_version` on every run; the write is skipped entirely when nothing else has changed. Records for annotations no longer in `homebrew/core` are simply not visited, so they persist on the default branch. Curated records (which use a different id shape) are never touched.

Because `ranges` is preserved from disk, a hand-corrected `fixed` boundary (e.g. backdating `libquicktime` to `_4`) survives subsequent runs. A transient OSV.dev failure leaves an existing enriched record untouched rather than stripping its `summary`/`severity`/`references`; a new record with no existing file is still written without enrichment. The unchanged comparison uses parsed hashes so key ordering in a hand-formatted file does not cause spurious rewrites.

Records also gain `published` and `database_specific: {source: "generated"}` per the draft `CONTRIBUTING.md` in Homebrew/homebrew-advisory-database#3. `regenerate.yml` in that repo drops its `rm -f advisories/*.json` in Homebrew/homebrew-advisory-database#2.

-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Written with Claude Code following the discussion on Homebrew/homebrew-brew-vulns#111 and Homebrew/discussions#6869, with a codex review pass that caught the transient-outage stripping and key-order comparison issues. I read the diff and ran `brew lgtm` locally.

-----
