### PR TITLE
test_bot/formulae: only run subset of `brew tests` for portable Ruby

### DIFF
--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -916,11 +916,11 @@ module Homebrew
         test "brew", "typecheck", "--update"
 
         # Run the checks that gate a Homebrew/brew pull request.
-        test "brew", "style" if %w[actionlint shellcheck shfmt].all? { |f| bottled?(Formulary.factory(f)) }
+        test "brew", "style" unless OS.not_tier_one_configuration?
         test "brew", "typecheck"
         test "brew", "install-bundler-gems", "--groups=all"
         test "brew", "vendor-gems", "--non-bundler-gems", "--no-commit"
-        test "brew", "tests", "--online", "--coverage"
+        test "brew", "tests", "--online", "--coverage", "--only=cask,formula"
         test "brew", "update-test"
         test "brew", "update-test", "--to-tag"
         test "brew", "update-test", "--commit=HEAD"


### PR DESCRIPTION
Currently tests fail on all runners (Tier 1 Linux and Tier 3 macOS). It is difficult to align the setups used between Homebrew/brew and Homebrew/core so can limit to basic sanity of the cask and formula tests.

Also update `brew style` to run on Tier 1-only so that we don't have to manually update formula list and can keep independent from `brew style` implementation details.

Portable Ruby PRs have been broken for over a month now. Given we now have a new Ruby update (along with OpenSSL, etc.), this should unblock us:
- https://github.com/Homebrew/homebrew-core/pull/293046

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
