### PR TITLE
downloadable: skip repeated checksum verification of the same file

### DIFF
--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -14,6 +14,48 @@ module Downloadable
   abstract!
   requires_ancestor { Kernel }
 
+  class << self
+    sig { params(filename: Pathname, checksum: T.nilable(Checksum)).returns(T::Boolean) }
+    def already_verified?(filename, checksum)
+      key = verification_key(filename, checksum)
+      return false if key.nil?
+
+      verification_lock.synchronize { verified_downloads.include?(key) }
+    end
+
+    sig { params(filename: Pathname, checksum: T.nilable(Checksum)).void }
+    def record_verification(filename, checksum)
+      key = verification_key(filename, checksum)
+      return if key.nil?
+
+      verification_lock.synchronize { verified_downloads.add(key) }
+    end
+
+    private
+
+    # The size and modification time ensure a file downloaded again to the
+    # same path (e.g. after `--force` cleared the cache) is verified again.
+    sig { params(filename: Pathname, checksum: T.nilable(Checksum)).returns(T.nilable(String)) }
+    def verification_key(filename, checksum)
+      return if checksum.nil?
+
+      stat = filename.stat
+      "#{filename.expand_path}|#{checksum.hexdigest}|#{stat.size}|#{stat.mtime.to_f}"
+    rescue SystemCallError
+      nil
+    end
+
+    sig { returns(T::Set[String]) }
+    def verified_downloads
+      @verified_downloads ||= T.let(Set.new, T.nilable(T::Set[String]))
+    end
+
+    sig { returns(Mutex) }
+    def verification_lock
+      @verification_lock ||= T.let(Mutex.new, T.nilable(Mutex))
+    end
+  end
+
   sig { overridable.returns(T.nilable(T.any(String, URL))) }
   attr_reader :url
 
@@ -181,8 +223,13 @@ module Downloadable
     verifying!
 
     if filename.file?
-      ohai "Verifying checksum for '#{filename.basename}'" if verbose?
-      filename.verify_checksum(checksum)
+      if Downloadable.already_verified?(filename, checksum)
+        odebug "Skipping checksum verification for '#{filename.basename}' (already verified in this run)"
+      else
+        ohai "Verifying checksum for '#{filename.basename}'" if verbose?
+        filename.verify_checksum(checksum)
+        Downloadable.record_verification(filename, checksum)
+      end
       verified!
     end
   rescue ChecksumMissingError

--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "concurrent/set"
 require "url"
 require "checksum"
 require "download_strategy"
@@ -23,8 +24,7 @@ module Downloadable
 
     sig { void }
     def initialize
-      @verified = T.let(Set.new, T::Set[String])
-      @lock = T.let(Mutex.new, Mutex)
+      @verified = T.let(Concurrent::Set.new, Concurrent::Set)
     end
 
     # Verifies the file against the checksum unless this file, in this
@@ -33,7 +33,7 @@ module Downloadable
     def verify(filename, checksum)
       key = key_for(filename, checksum)
 
-      if key && @lock.synchronize { @verified.include?(key) }
+      if key && @verified.include?(key)
         odebug "Skipping checksum verification for '#{filename.basename}' (already verified in this run)"
         return
       end
@@ -41,7 +41,7 @@ module Downloadable
       ohai "Verifying checksum for '#{filename.basename}'" if verbose?
       filename.verify_checksum(checksum)
 
-      @lock.synchronize { @verified.add(key) } if key
+      @verified.add(key) if key
     end
 
     private

--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -14,21 +14,34 @@ module Downloadable
   abstract!
   requires_ancestor { Kernel }
 
-  class << self
-    sig { params(filename: Pathname, checksum: T.nilable(Checksum)).returns(T::Boolean) }
-    def already_verified?(filename, checksum)
-      key = verification_key(filename, checksum)
-      return false if key.nil?
+  # Remembers which files have already been checksum-verified in this process,
+  # so the same unchanged file is not hashed once per download object that
+  # references it.
+  class VerificationCache
+    include Context
+    include Utils::Output::Mixin
 
-      verification_lock.synchronize { verified_downloads.include?(key) }
+    sig { void }
+    def initialize
+      @verified = T.let(Set.new, T::Set[String])
+      @lock = T.let(Mutex.new, Mutex)
     end
 
+    # Verifies the file against the checksum unless this file, in this
+    # state, has already been verified against it in this process.
     sig { params(filename: Pathname, checksum: T.nilable(Checksum)).void }
-    def record_verification(filename, checksum)
-      key = verification_key(filename, checksum)
-      return if key.nil?
+    def verify(filename, checksum)
+      key = key_for(filename, checksum)
 
-      verification_lock.synchronize { verified_downloads.add(key) }
+      if key && @lock.synchronize { @verified.include?(key) }
+        odebug "Skipping checksum verification for '#{filename.basename}' (already verified in this run)"
+        return
+      end
+
+      ohai "Verifying checksum for '#{filename.basename}'" if verbose?
+      filename.verify_checksum(checksum)
+
+      @lock.synchronize { @verified.add(key) } if key
     end
 
     private
@@ -36,7 +49,7 @@ module Downloadable
     # The size and modification time ensure a file downloaded again to the
     # same path (e.g. after `--force` cleared the cache) is verified again.
     sig { params(filename: Pathname, checksum: T.nilable(Checksum)).returns(T.nilable(String)) }
-    def verification_key(filename, checksum)
+    def key_for(filename, checksum)
       return if checksum.nil?
 
       stat = filename.stat
@@ -44,15 +57,12 @@ module Downloadable
     rescue SystemCallError
       nil
     end
+  end
 
-    sig { returns(T::Set[String]) }
-    def verified_downloads
-      @verified_downloads ||= T.let(Set.new, T.nilable(T::Set[String]))
-    end
-
-    sig { returns(Mutex) }
-    def verification_lock
-      @verification_lock ||= T.let(Mutex.new, T.nilable(Mutex))
+  class << self
+    sig { returns(VerificationCache) }
+    def verification_cache
+      @verification_cache ||= T.let(VerificationCache.new, T.nilable(VerificationCache))
     end
   end
 
@@ -223,13 +233,7 @@ module Downloadable
     verifying!
 
     if filename.file?
-      if Downloadable.already_verified?(filename, checksum)
-        odebug "Skipping checksum verification for '#{filename.basename}' (already verified in this run)"
-      else
-        ohai "Verifying checksum for '#{filename.basename}'" if verbose?
-        filename.verify_checksum(checksum)
-        Downloadable.record_verification(filename, checksum)
-      end
+      Downloadable.verification_cache.verify(filename, checksum)
       verified!
     end
   rescue ChecksumMissingError

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -301,6 +301,21 @@ RSpec.describe Resource do
     end
   end
 
+  specify "#verify_download_integrity skips files already verified in this process" do
+    fn = mktmpdir/"test.tar.gz"
+    fn.write "content"
+    digest = Digest::SHA256.hexdigest("content")
+    resource.sha256(digest)
+
+    other_resource = described_class.new("other")
+    other_resource.sha256(digest)
+
+    expect(fn).to receive(:verify_checksum).once.and_call_original
+
+    resource.verify_download_integrity(fn)
+    other_resource.verify_download_integrity(fn)
+  end
+
   specify "#verify_download_integrity_missing" do
     fn = Pathname.new("test")
 
@@ -312,7 +327,8 @@ RSpec.describe Resource do
   end
 
   specify "#verify_download_integrity_mismatch" do
-    fn = instance_double(Pathname, file?: true, basename: "foo")
+    fn = Pathname.new("foo")
+    allow(fn).to receive(:file?).and_return(true)
     checksum = resource.sha256(TEST_SHA256)
 
     expect(fn).to receive(:verify_checksum)


### PR DESCRIPTION
A cask upgrade SHA-256 hashes the same download up to three times, evidenced by duplicated `Verifying checksum` lines in verbose mode. This morning's `brew upgrade --greedy` hashed docker-desktop's 541MB dmg three times.

_Note, this was motivated by seeing many duplicated lines in verbose mode and wondering whether this unusual sight indicated some significant error. It's really about that, not the sub-second speed-up._

The cause is that separate download objects reference the same cached file (the prefetch queue's, the installer's, and the synthetic cask `Homebrew::API::CaskDownload` builds) and none knows the others have already verified it. This PR remembers successful verifications for the lifetime of the process, keyed on path, checksum, size and mtime so a file re-downloaded to the same path (e.g. after `--force` clears the cache) is verified afresh. Skipped repeats log a debug line instead.

To reproduce: upgrade any outdated JSON-API cask with `--verbose` and count the `Verifying checksum` lines for it.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Written with Claude in Claude Code under my direction and review. I verified the change myself: red/green on the new spec, plus a two-download-objects check against a real cached download in `brew ruby` (upstream code hashes twice, this branch hashes once), and `brew lgtm` locally.

## AI bits

Questions I put to Claude about the design, with its answers:

<details><summary>What are the criteria for not rechecking a file?</summary>

All four parts of the memo key must match a verification that already succeeded in the same process: expanded path, expected sha256, file size, and mtime (sub-second precision). Change any one (a re-download to the same path, a different expected checksum, the file touched or replaced) and it's hashed again. Files with no defined checksum are never remembered, and if the file can't be `stat`ed the memo is bypassed, so failure modes all fall back to verifying.
</details>

<details><summary>Why "the expected sha256" and not just "the sha256"?</summary>

The key stores what the file was verified against, not what it hashed to. If a second download object expects a different checksum for the same path, a remembered success against the old expectation proves nothing about the new one; the keys differ, the file is hashed for real and the comparison decides.
</details>

<details><summary>Does this prove the file hasn't changed, or assume it?</summary>

Assumes. Size and mtime match is evidence, not proof: both are forgeable, and padding a payload to an exact size is trivial. But the previous repeated hashing gave no bytes-at-use proof either, because verification and extraction are separate steps with a time-of-check-to-time-of-use window between them. The memo drops no guarantee the code actually had; the size/mtime key exists to catch legitimate change (`--force` re-downloads, resumed partials), not adversaries.
</details>

<details><summary>Any risk of lock contention, slow-down or deadlock?</summary>

No. The critical sections are a Set lookup and a Set insert; the hashing happens outside the lock, so the expensive work is never serialised. The mutex is a leaf (nothing is called inside `synchronize` except the Set operation) so there is no deadlock path. If two download-queue threads verify the same file at the same moment, both can miss the memo and both hash it: a benign race costing one duplicate hash. Holding the lock across the hash would close that gap, but with a single global mutex it would serialise unrelated files, and per-file locking means a mutex registry — more machinery than one rare duplicate hash justifies.
</details>

<details><summary>How long does a hash actually take?</summary>

Measured on an M-series Mac with warm file cache, via `Digest::SHA256.file` (the implementation `Pathname#verify_checksum` uses): docker-desktop's 541MB dmg takes ~0.3s. So the saving is sub-second per cask; this is about not doing redundant work rather than a big speedup.
</details>

<details><summary>Is the memo persistent?</summary>

No, it's a Set in process memory, gone on exit; every `brew` invocation verifies everything once. Persisting it would extend the assumed-unchanged window from minutes inside one run to days across runs, which is a different trust proposition.
</details>
