### PR TITLE
readline_nonblock: use larger buffer and retain state

### DIFF
--- a/Library/Homebrew/readline_nonblock.rb
+++ b/Library/Homebrew/readline_nonblock.rb
@@ -2,24 +2,35 @@
 # frozen_string_literal: true
 
 class ReadlineNonblock
-  sig { params(io: IO).returns(String) }
-  def self.read(io)
-    line = +""
-    buffer = +""
+  BUFFER_SIZE = 4096
+  private_constant :BUFFER_SIZE
 
+  sig { params(io: IO).void }
+  def initialize(io)
+    @io = io
+    @buffer = T.let(+"", String)
+    @line = T.let(+"", String)
+  end
+
+  sig { returns(String) }
+  def read
     begin
+      index = T.let(nil, T.nilable(Integer))
       loop do
-        break if buffer == $INPUT_RECORD_SEPARATOR
+        index = @buffer.index($INPUT_RECORD_SEPARATOR)
+        break unless index.nil?
 
-        io.read_nonblock(1, buffer)
-        line.concat(buffer)
+        @line.concat(@buffer)
+        @buffer.clear
+        @io.read_nonblock(BUFFER_SIZE, @buffer)
       end
-
-      line.freeze
-    rescue IO::WaitReadable, EOFError
-      raise if line.empty?
-
-      line.freeze
+      @line.concat(@buffer.slice!(0..index).to_s)
+    rescue EOFError
+      raise if @line.empty?
     end
+
+    line = @line.freeze
+    @line = +""
+    line
   end
 end

--- a/Library/Homebrew/readline_nonblock.rb
+++ b/Library/Homebrew/readline_nonblock.rb
@@ -1,6 +1,9 @@
 # typed: strict
 # frozen_string_literal: true
 
+# An {IO} wrapper class that allows performing non-blocking line reads on the
+# provided instance. It is undefined behaviour to run this with other modifying
+# {IO} operations, e.g. {IO#read} or #{IO#seek}, on the same instance.
 class ReadlineNonblock
   BUFFER_SIZE = 4096
   private_constant :BUFFER_SIZE
@@ -12,19 +15,29 @@ class ReadlineNonblock
     @line = T.let(+"", String)
   end
 
+  # Reads and returns a line ending with `"\n"` or remaining text before EOF.
+  # Non-blocking reads should return similar output as `io.readline("\n")` while
+  # blocking reads raise {IO::WaitReadable}.
+  #
+  # Note that this method does not support the global line separator `$/`.
+  # Also it does not modify `$_`.
+  #
+  # @return the next line
+  # @raise [IO::WaitReadable] if read would block
+  # @raise [EOFError] on EOF
   sig { returns(String) }
   def read
     begin
-      index = T.let(nil, T.nilable(Integer))
       loop do
-        index = @buffer.index($INPUT_RECORD_SEPARATOR)
-        break unless index.nil?
+        if (index = @buffer.index("\n"))
+          @line.concat(@buffer.slice!(0..index).to_s)
+          break
+        end
 
         @line.concat(@buffer)
         @buffer.clear
         @io.read_nonblock(BUFFER_SIZE, @buffer)
       end
-      @line.concat(@buffer.slice!(0..index).to_s)
     rescue EOFError
       raise if @line.empty?
     end

--- a/Library/Homebrew/readline_nonblock.rb
+++ b/Library/Homebrew/readline_nonblock.rb
@@ -3,7 +3,7 @@
 
 # An {IO} wrapper class that allows performing non-blocking line reads on the
 # provided instance. It is undefined behaviour to run this with other modifying
-# {IO} operations, e.g. {IO#read} or #{IO#seek}, on the same instance.
+# {IO} operations, e.g. {IO#read} or {IO#seek}, on the same instance.
 class ReadlineNonblock
   BUFFER_SIZE = 4096
   private_constant :BUFFER_SIZE
@@ -16,8 +16,8 @@ class ReadlineNonblock
   end
 
   # Reads and returns a line ending with `"\n"` or remaining text before EOF.
-  # Non-blocking reads should return similar output as `io.readline("\n")` while
-  # blocking reads raise {IO::WaitReadable}.
+  # Non-blocking reads should return similar output as {IO#readline} with `"\n"`,
+  # while reads that would block raise {IO::WaitReadable}.
   #
   # Note that this method does not support the global line separator `$/`.
   # Also it does not modify `$_`.

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -456,7 +456,7 @@ class SystemCommand
       sources[0] => :stdout,
       sources[1] => :stderr,
     }
-    readers = {}
+    readers = T.let({}, T::Hash[IO, ReadlineNonblock])
 
     pending_interrupt = T.let(false, T::Boolean)
 

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -456,6 +456,7 @@ class SystemCommand
       sources[0] => :stdout,
       sources[1] => :stderr,
     }
+    readers = {}
 
     pending_interrupt = T.let(false, T::Boolean)
 
@@ -471,8 +472,9 @@ class SystemCommand
       end
 
       readable_sources.each do |source|
+        reader = readers[source] ||= ReadlineNonblock.new(source)
         loop do
-          line = ReadlineNonblock.read(source)
+          line = reader.read
           yield(sources.fetch(source), line)
         end
       rescue EOFError

--- a/Library/Homebrew/test/readline_nonblock_spec.rb
+++ b/Library/Homebrew/test/readline_nonblock_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe ReadlineNonblock do
           end
         end
         expect(lines).to eq(File.readlines(tmpdir/"test.txt"))
+        expect(lines).to eq ["First line\n", "Second line\n", "\n", "Fourth line\n", "Fifth line"]
       end
     end
 

--- a/Library/Homebrew/test/readline_nonblock_spec.rb
+++ b/Library/Homebrew/test/readline_nonblock_spec.rb
@@ -1,0 +1,58 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "readline_nonblock"
+
+RSpec.describe ReadlineNonblock do
+  describe "#read", timeout: 10 do
+    it "returns only full lines", :aggregate_failures do
+      IO.pipe do |read_io, write_io|
+        reader = described_class.new(read_io)
+        expect { reader.read }.to raise_error(IO::WaitReadable)
+        write_io.write "Test"
+        expect { reader.read }.to raise_error(IO::WaitReadable)
+        write_io.write "1\n2"
+        expect(reader.read).to eq("Test1\n")
+        write_io.close
+        expect(reader.read).to eq("2")
+        expect { reader.read }.to raise_error(EOFError)
+      end
+    end
+
+    it "returns same lines from file as File.readlines" do
+      mktmpdir do |tmpdir|
+        (tmpdir/"test.txt").write <<~EOS.chomp
+          First line
+          Second line
+
+          Fourth line
+          Fifth line
+        EOS
+
+        lines = []
+        (tmpdir/"test.txt").open do |file|
+          reader = described_class.new(file)
+          loop do
+            lines << reader.read
+          rescue IO::WaitReadable
+            file.wait_readable
+          rescue EOFError
+            break
+          end
+        end
+        expect(lines).to eq(File.readlines(tmpdir/"test.txt"))
+      end
+    end
+
+    it "handles long lines" do
+      IO.pipe do |read_io, write_io|
+        line_length = 10000
+        write_io.write("a" * line_length)
+        write_io.close
+        reader = described_class.new(read_io)
+        expect(reader.read.length).to eq line_length
+        expect { reader.read }.to raise_error(EOFError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Original single byte reads scale poorly when handling very long lines, e.g. the output of npm releases which can be MBs in size can take over 10x longer to read compared to using a more standard buffer size.

Also make the method always output a full line. In the case that IO would block, the method may end up returning a partial line so the resulting lines could changed based on race conditions.

---

For average commands, this shouldn't have much impact.

However, npm cooldown is one location where it will:
https://github.com/Homebrew/brew/blob/62e6faa098300ce885f5c17d9fe9a841de396842/Library/Homebrew/dev-cmd/bump.rb#L939

Using https://registry.npmjs.org/wrangler as example in simplified test:
```rb
Utils::Curl.curl_output("--compressed", "--location", "--silent", "https://registry.npmjs.org/wrangler")
```

And running via 
```
hyperfine \
--command-name main --prepare 'git checkout main' 'brew ruby t.rb' \
--command-name readline_nonblock-buffer --prepare 'git checkout readline_nonblock-buffer' 'brew ruby t.rb'
```

```
Benchmark 1: main
  Time (mean ± σ):     35.978 s ±  1.119 s    [User: 16.947 s, System: 28.888 s]
  Range (min … max):   34.981 s … 38.801 s    10 runs

Benchmark 2: readline_nonblock-buffer
  Time (mean ± σ):      1.293 s ±  0.097 s    [User: 0.452 s, System: 0.215 s]
  Range (min … max):    1.186 s …  1.502 s    10 runs

Summary
  readline_nonblock-buffer ran
   27.82 ± 2.26 times faster than main
```

Also verified the output of `.stdout` was equivalent between these.
