### PR TITLE
cask/audit: allow linux-only checksums and run audits on linux

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -561,6 +561,20 @@ module Cask
           :no_check
         when String
           Checksum.new(val)
+        when nil
+          # Checksums declared for only the other OS mean no checksum for the
+          # running OS, matching `sha256` inside an `on_macos`/`on_linux` block;
+          # `depends_on` governs whether the cask is usable there. A checksum
+          # declared for the running OS but missing the running architecture
+          # still raises.
+          running_os_checksums = if OnSystem.os_condition_met?(:linux)
+            [x86_64_linux, arm64_linux]
+          else
+            [arm, x86_64]
+          end
+          raise CaskInvalidError.new(cask, "invalid 'sha256' value: nil") if running_os_checksums.any?(&:present?)
+
+          nil
         else
           raise CaskInvalidError.new(cask, "invalid 'sha256' value: #{val.inspect}")
         end

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -263,8 +263,6 @@ module Homebrew
           path = cask.sourcefile_path
 
           errors = os_arch_combinations.flat_map do |os, arch|
-            next [] if os == :linux
-
             SimulateSystem.with(os:, arch:) do
               odebug "Auditing Cask #{cask} on os #{os} and arch #{arch}"
 

--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -91,6 +91,9 @@ module Readall
     end
     return true unless validating_linux
 
+    os_and_arch = "Linux"
+    os_and_arch += " on #{(arch == :intel) ? "Intel x86_64" : "ARM64"}" if arch
+
     success = T.let(true, T::Boolean)
     tap.cask_files.each do |file|
       next if file.read.match?(/^\s*depends_on(?:\s*\(\s*|\s+)(?::macos\b|macos:)/)
@@ -108,22 +111,30 @@ module Readall
       end
       next unless cask
 
-      if arch
-        Homebrew::SimulateSystem.with(os: :linux, arch:) { cask.refresh }
+      linux_sha256 = if arch
+        Homebrew::SimulateSystem.with(os: :linux, arch:) do
+          cask.refresh
+          cask.sha256
+        end
       else
-        Homebrew::SimulateSystem.with(os: :linux) { cask.refresh }
+        Homebrew::SimulateSystem.with(os: :linux) do
+          cask.refresh
+          cask.sha256
+        end
       end
+      # No `sha256` matched Linux, so the cask cannot be downloaded there
+      # despite not being marked macOS-only.
+      next unless linux_sha256.nil?
+
+      onoe "Invalid cask (#{os_and_arch}): #{file}"
+      $stderr.puts "Missing Linux stanzas can leave Linux `sha256` as nil. " \
+                   "Add `depends_on :macos` if this cask is macOS-only."
+      success = false
     rescue Interrupt
       raise
     # Handle all possible exceptions reading casks.
     rescue Exception => e # rubocop:disable Lint/RescueException
-      os_and_arch = "Linux"
-      os_and_arch += " on #{(arch == :intel) ? "Intel x86_64" : "ARM64"}" if arch
       onoe "Invalid cask (#{os_and_arch}): #{file}"
-      if e.message.include?("invalid 'sha256' value: nil")
-        $stderr.puts "Missing Linux stanzas can leave Linux `sha256` as nil. " \
-                     "Add `depends_on :macos` if this cask is macOS-only."
-      end
       $stderr.puts e
       success = false
     end

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -915,6 +915,16 @@ RSpec.describe Cask::Cask, :cask do
       expect(h["variations"]).to include(:x86_64_linux, :arm64_linux)
     end
 
+    it "emits Linux variations with checksums for a Linux-only cask" do
+      c = Cask::CaskLoader.load("sha256-linux-only")
+      h = c.to_hash_with_variations
+
+      expect(h["variations"].slice(:x86_64_linux, :arm64_linux).transform_values { |v| v["sha256"].to_s }).to eq(
+        x86_64_linux: "244d413861cecb3707cfbcc5c4346d5367daa827da5ea08fb3f3bc2b6276d239",
+        arm64_linux:  "9a1c0967baa46828930ccbbc88668d1b0db07e6edf778800ed4da073c00054f8",
+      )
+    end
+
     # NOTE: The calls to `Cask.generating_hash!` and `Cask.generated_hash!`
     #       are not idempotent so they can only be used in one test.
     it "returns the correct hash placeholders" do

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -153,6 +153,58 @@ RSpec.describe Cask::DSL, :cask, :no_api do
         end
       end
     end
+
+    context "with checksums for only one OS" do
+      it "has no checksum on macOS when only Linux checksums are set" do
+        Homebrew::SimulateSystem.with(os: :macos, arch: :arm) do
+          cask = Cask::Cask.new("checksum-cask") do
+            sha256 x86_64_linux: "imasha2intellinux", arm64_linux: "imasha2armlinux"
+          end
+
+          expect(cask.sha256).to be_nil
+        end
+      end
+
+      it "stores the matching checksum on Linux" do
+        Homebrew::SimulateSystem.with(os: :linux, arch: :intel) do
+          cask = Cask::Cask.new("checksum-cask") do
+            sha256 x86_64_linux: "imasha2intellinux", arm64_linux: "imasha2armlinux"
+          end
+
+          expect(cask.sha256).to eq("imasha2intellinux")
+        end
+      end
+
+      it "has no checksum on Linux when only macOS checksums are set" do
+        Homebrew::SimulateSystem.with(os: :linux, arch: :arm) do
+          cask = Cask::Cask.new("checksum-cask") do
+            sha256 arm: "imasha2arm", intel: "imasha2intel"
+          end
+
+          expect(cask.sha256).to be_nil
+        end
+      end
+
+      it "raises when the running-architecture macOS checksum is missing" do
+        Homebrew::SimulateSystem.with(os: :macos, arch: :intel) do
+          expect do
+            Cask::Cask.new("checksum-cask") do
+              sha256 arm: "imasha2arm", arm64_linux: "imasha2armlinux"
+            end
+          end.to raise_error(Cask::CaskInvalidError, /invalid 'sha256' value/)
+        end
+      end
+
+      it "raises when the running-architecture Linux checksum is missing" do
+        Homebrew::SimulateSystem.with(os: :linux, arch: :intel) do
+          expect do
+            Cask::Cask.new("checksum-cask") do
+              sha256 arm64_linux: "imasha2armlinux", intel: "imasha2intel"
+            end
+          end.to raise_error(Cask::CaskInvalidError, /invalid 'sha256' value/)
+        end
+      end
+    end
   end
 
   describe "no_autobump! stanze" do

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -51,9 +51,14 @@ RSpec.describe Homebrew::DevCmd::Audit do
       allow(Tap).to receive(:installed).and_return([])
     end
 
-    it "skips macOS-only casks when loading tap casks on Linux" do
+    it "audits Linux-supporting casks and skips macOS-only ones on Linux" do
+      problems = a_string_matching(
+        /\A(?=.*linux-example)(?=.*a sha256 stanza is required)(?!.*macos-only-example).*\z/m,
+      )
+
       Homebrew::SimulateSystem.with(os: :linux) do
-        expect { audit.run }.to raise_error(Cask::CaskInvalidError, /linux-example.*invalid 'sha256'/)
+        expect { audit.run }.to output(problems).to_stdout
+                                                .and output(/1 problem in 1 cask detected/).to_stderr
       end
     end
   end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-linux-only.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-linux-only.rb
@@ -1,0 +1,16 @@
+# typed: false
+
+cask "sha256-linux-only" do
+  arch arm: "arm", intel: "intel"
+
+  version "1.2.3"
+  sha256 x86_64_linux: "244d413861cecb3707cfbcc5c4346d5367daa827da5ea08fb3f3bc2b6276d239",
+         arm64_linux:  "9a1c0967baa46828930ccbbc88668d1b0db07e6edf778800ed4da073c00054f8"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine-#{arch}.zip"
+  homepage "https://brew.sh/"
+
+  depends_on :linux
+
+  app "Caffeine.app"
+end


### PR DESCRIPTION
A cask that only declares Linux checksums (sha256 arm64_linux:/x86_64_linux: with no macOS keys) can't be loaded at all on macOS. The cask DSL resolves the checksum for the running OS at load time and raises when it comes back `nil`, so every command that loads the cask fails. [Homebrew/homebrew-cask#274338](https://github.com/Homebrew/homebrew-cask/pull/274338) (the first Linux-only cask) is failing its generate_matrix job on exactly this, because `brew generate-cask-ci-matrix` loads the cask on a macOS runner:

```
brew ruby -e 'Cask::CaskLoader.load("./Casks/k/koreader.rb")'
Error: Cask 'koreader' definition is invalid: invalid 'sha256' value: nil
```

The change treats checksums declared only for the other OS as no checksum for the running OS and returns nil, matching the existing behaviour of a sha256 stanza inside an on_linux block. A checksum that is declared for the running OS but missing for the running architecture still raises. Linux variations are still emitted to the JSON API via sha256_set_for_linux?, and brew generate-cask-ci-matrix --casks koreader now generates a Linux-only matrix.

---

This PR also made the discovery the Linux casks were being skipped entirely on cask CI during `brew audit` - the changes update this 

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

I used `claude-code` with fable-5 to help create the fix and tests, and tested locally with the `koreader` cask.
