### PR TITLE
Serialise cask language variations

### DIFF
--- a/Library/Homebrew/api/cask/cask_struct_generator.rb
+++ b/Library/Homebrew/api/cask/cask_struct_generator.rb
@@ -13,6 +13,14 @@ module Homebrew
         sig { params(hash: T::Hash[String, T.untyped], bottle_tag: Utils::Bottles::Tag, ignore_types: T::Boolean).returns(CaskStruct) }
         def generate_cask_struct_hash(hash, bottle_tag: Homebrew::SimulateSystem.current_tag, ignore_types: false)
           hash = Homebrew::API.merge_variations(hash, bottle_tag:).dup.deep_symbolize_keys.transform_keys(&:to_s)
+          language_variations = T.cast(
+            hash.delete("language_variations"),
+            T.nilable(T::Array[T::Hash[Symbol, T.untyped]]),
+          )
+          language_structs = language_variations&.map do |variation|
+            language_hash = hash.merge(variation.except(:languages, :default, :value).transform_keys(&:to_s))
+            [variation, generate_cask_struct_hash(language_hash, bottle_tag:, ignore_types:)]
+          end
 
           hash["conflicts_with_args"] = hash["conflicts_with"]&.to_h
 
@@ -79,7 +87,23 @@ module Homebrew
           hash["disable_present"] = hash["disable_args"].present?
           hash["homepage_present"] = hash["homepage"].present?
 
-          CaskStruct.from_hash(hash, ignore_types:)
+          cask_struct = CaskStruct.from_hash(hash, ignore_types:)
+          return cask_struct if language_structs.blank?
+
+          serialised_cask = cask_struct.serialize
+          processed_language_variations = language_structs.map do |variation, language_struct|
+            language_data = language_struct.serialize.reject do |key, value|
+              serialised_cask[key] == value
+            end
+            {
+              languages: T.cast(variation[:languages], T::Array[String]),
+              default:   variation[:default] == true,
+              value:     T.cast(variation[:value], T.nilable(String)),
+              overrides: language_data,
+            }
+          end
+
+          CaskStruct.deserialize(serialised_cask.merge("language_variations" => processed_language_variations))
         end
 
         sig { params(depends_on: T::Hash[Symbol, T.untyped]).returns(CaskStruct::DependsOnArgs) }

--- a/Library/Homebrew/api/cask_download.rb
+++ b/Library/Homebrew/api/cask_download.rb
@@ -12,12 +12,15 @@ module Homebrew
         params(
           token:       String,
           cask_struct: Homebrew::API::CaskStruct,
+          languages:   T.nilable(T::Array[String]),
           quarantine:  T.nilable(T::Boolean),
           require_sha: T::Boolean,
         ).returns(T.nilable(::Cask::Download))
       }
-      def self.download(token:, cask_struct:, quarantine: nil, require_sha: false)
-        return if cask_struct.languages.any?
+      def self.download(token:, cask_struct:, languages: nil, quarantine: nil, require_sha: false)
+        languages ||= cask_struct.languages.empty? ? [] : ::Cask::Config.new.languages
+        cask_struct = cask_struct.localise(languages)
+        return if cask_struct.languages.any? && cask_struct.language_variations.empty?
         return if cask_struct.url_args.empty?
 
         cask = ::Cask::Cask.new(

--- a/Library/Homebrew/api/cask_struct.rb
+++ b/Library/Homebrew/api/cask_struct.rb
@@ -1,8 +1,11 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "locale"
+
 module Homebrew
   module API
+    # Typed representation of cask API data.
     class CaskStruct < T::Struct
       sig { params(cask_hash: T::Hash[String, T.untyped], ignore_types: T::Boolean).returns(CaskStruct) }
       def self.from_hash(cask_hash, ignore_types: false)
@@ -38,6 +41,8 @@ module Homebrew
           T.nilable(T.proc.void),
         ]
       end
+
+      LanguageVariation = T.type_alias { T::Hash[Symbol, T.anything] }
 
       PREDICATES.each do |predicate_name|
         present_method_name = :"#{predicate_name}_present"
@@ -78,6 +83,7 @@ module Homebrew
       const :disable_args, T::Hash[Symbol, T.nilable(T.any(String, Symbol))], default: {}
       const :homepage, T.nilable(String)
       const :languages, T::Array[String], default: []
+      const :language_variations, T::Array[LanguageVariation], default: []
       const :names, T::Array[String], default: []
       const :renames, T::Array[[String, String]], default: []
       const :ruby_source_checksum, T::Hash[Symbol, T.nilable(String)], default: { sha256: nil }
@@ -106,6 +112,23 @@ module Homebrew
       sig { params(appdir: T.any(Pathname, String)).returns(T.nilable(String)) }
       def caveats(appdir:)
         deep_remove_placeholders(raw_caveats, appdir.to_s)
+      end
+
+      sig { params(languages: T::Array[String]).returns(CaskStruct) }
+      def localise(languages)
+        variation = language_variation(languages)
+        return self if variation.nil?
+
+        overrides = T.cast(variation[:overrides], T.nilable(T::Hash[String, T.anything]))
+        return self if overrides.blank?
+
+        serialised_overrides = T.cast(::Utils.deep_stringify_symbols(overrides), T::Hash[String, T.untyped])
+        self.class.deserialize(serialize.merge(serialised_overrides))
+      end
+
+      sig { params(languages: T::Array[String]).returns(T.nilable(String)) }
+      def language(languages)
+        T.cast(language_variation(languages)&.[](:value), T.nilable(String))
       end
 
       sig { returns(T::Hash[String, T.untyped]) }
@@ -193,6 +216,28 @@ module Homebrew
       end
 
       private
+
+      sig { params(languages: T::Array[String]).returns(T.nilable(LanguageVariation)) }
+      def language_variation(languages)
+        locale_groups = language_variations.map do |variation|
+          T.cast(variation[:languages], T::Array[String])
+        end
+        languages.each do |language|
+          locale = Locale.parse(language)
+          group = T.cast(locale.detect(locale_groups), T.nilable(T::Array[String]))
+          if group
+            return language_variations.find do |variation|
+              T.cast(variation[:languages], T::Array[String]) == group
+            end
+          end
+        rescue Locale::ParserError
+          next
+        end
+
+        language_variations.find do |variation|
+          T.cast(variation[:default], T.nilable(T::Boolean)) == true
+        end
+      end
 
       const :raw_artifacts, T::Array[ArtifactArgs], default: []
       const :raw_caveats, T.nilable(String)

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -112,6 +112,8 @@ module Cask
       @loaded_from_api = loaded_from_api
       @loaded_from_internal_api = loaded_from_internal_api
       @api_source = api_source
+      @language_variations_available = T.let(false, T::Boolean)
+      @language_evaluator = T.let(nil, T.nilable(T.proc.params(languages: T::Array[String]).returns(T.nilable(String))))
       @loader = loader
       # Sorbet has trouble with bound procs assigned to instance variables:
       # https://github.com/sorbet/sorbet/issues/6843
@@ -193,7 +195,20 @@ module Cask
       nil
     end
 
-    def_delegators :@dsl, *::Cask::DSL::DSL_METHODS
+    def_delegators :@dsl, *(::Cask::DSL::DSL_METHODS - [:language])
+
+    sig {
+      params(
+        args:    String,
+        default: T::Boolean,
+        block:   T.nilable(T.proc.returns(String)),
+      ).returns(T.nilable(String))
+    }
+    def language(*args, default: false, &block)
+      return @language_evaluator.call(config.languages) if args.empty? && block.nil? && @language_evaluator
+
+      dsl!.language(*args, default:, &block)
+    end
 
     sig { returns(DSL::Caveats) }
     def caveats_object = dsl!.caveats_object
@@ -250,11 +265,11 @@ module Cask
       !depends_on.requires_linux?
     end
 
-    # The caskfile is needed during installation when there are
-    # `*flight` blocks or the cask has multiple languages
+    # The caskfile is needed during installation when there are legacy
+    # `*flight` blocks or language variations missing from API data.
     sig { returns(T::Boolean) }
     def caskfile_only?
-      languages.any? || artifacts.any?(Artifact::AbstractFlightBlock)
+      (languages.any? && !@language_variations_available) || artifacts.any?(Artifact::AbstractFlightBlock)
     end
 
     sig { returns(T::Boolean) }
@@ -496,6 +511,8 @@ module Cask
       raise ArgumentError, "Expected cask to be loaded from the API" unless loaded_from_api?
 
       @languages = cask_struct.languages
+      @language_variations_available = cask_struct.language_variations.any?
+      @language_evaluator = ->(languages) { cask_struct.language(languages) }
       @tap_git_head = tap_git_head
       @ruby_source_path = cask_struct.ruby_source_path
       @ruby_source_checksum = cask_struct.ruby_source_checksum
@@ -590,7 +607,7 @@ module Cask
         return api_to_local_hash(json_cask.dup)
       end
 
-      hash = to_h
+      hash = to_h_with_language_variations
       variations = {}
 
       if dsl!.on_system_blocks_exist?
@@ -605,7 +622,7 @@ module Cask
                     macos_requirements.any? { |requirement| !requirement.allows?(bottle_tag.to_macos_version) }
 
             refresh_for_tag(bottle_tag) do
-              to_h.each do |key, value|
+              to_h_with_language_variations.each do |key, value|
                 next if HASH_KEYS_TO_SKIP.include? key
                 next if value.to_s == hash[key].to_s
 
@@ -621,6 +638,42 @@ module Cask
 
       hash["variations"] = variations
       hash
+    end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def to_h_with_language_variations
+      language_groups = dsl!.language_groups
+      return to_h if language_groups.empty?
+
+      default_language_group = dsl!.default_language_group
+      raise CaskInvalidError.new(self, "No default language specified.") if default_language_group.nil?
+
+      original_config = config
+      language_hashes = language_groups.to_h do |languages|
+        localised_config = original_config.dup
+        localised_config.explicit = original_config.explicit.dup
+        localised_config.languages = [languages.fetch(0)]
+        self.config = localised_config
+        [languages, [to_h, dsl!.language_eval]]
+      end
+      hash = language_hashes.fetch(default_language_group).first
+      hash["language_variations"] = language_hashes.map do |languages, (language_hash, value)|
+        variation = {
+          "languages" => languages,
+          "default"   => languages == default_language_group,
+          "value"     => value,
+        }
+        language_hash.each do |key, language_value|
+          next if HASH_KEYS_TO_SKIP.include? key
+          next if language_value.to_s == hash[key].to_s
+
+          variation[key] = language_value
+        end
+        variation
+      end
+      hash
+    ensure
+      self.config = original_config if original_config
     end
 
     sig { returns(T::Hash[String, T.untyped]) }

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -512,28 +512,34 @@ module Cask
         end
 
         api_cask = Cask.new(token, **cask_options) do
-          version cask_struct.version
-          sha256 cask_struct.sha256
+          localised_cask_struct = if cask_struct.language_variations.empty?
+            cask_struct
+          else
+            cask_struct.localise(cask.config.languages)
+          end
 
-          url(*cask_struct.url_args, **cask_struct.url_kwargs)
-          cask_struct.names.each do |cask_name|
+          version localised_cask_struct.version
+          sha256 localised_cask_struct.sha256
+
+          url(*localised_cask_struct.url_args, **localised_cask_struct.url_kwargs)
+          localised_cask_struct.names.each do |cask_name|
             name cask_name
           end
-          desc cask_struct.desc if cask_struct.desc?
-          homepage cask_struct.homepage if cask_struct.homepage?
+          desc localised_cask_struct.desc if localised_cask_struct.desc?
+          homepage localised_cask_struct.homepage if localised_cask_struct.homepage?
 
-          deprecate!(**cask_struct.deprecate_args) if cask_struct.deprecate?
-          disable!(**cask_struct.disable_args) if cask_struct.disable?
+          deprecate!(**localised_cask_struct.deprecate_args) if localised_cask_struct.deprecate?
+          disable!(**localised_cask_struct.disable_args) if localised_cask_struct.disable?
 
-          auto_updates cask_struct.auto_updates if cask_struct.auto_updates?
-          conflicts_with(**cask_struct.conflicts_with_args) if cask_struct.conflicts?
+          auto_updates localised_cask_struct.auto_updates if localised_cask_struct.auto_updates?
+          conflicts_with(**localised_cask_struct.conflicts_with_args) if localised_cask_struct.conflicts?
 
-          cask_struct.renames.each do |from, to|
+          localised_cask_struct.renames.each do |from, to|
             rename from, to
           end
 
-          if cask_struct.depends_on?
-            args = cask_struct.depends_on_args
+          if localised_cask_struct.depends_on?
+            args = localised_cask_struct.depends_on_args
             begin
               depends_on(**args)
             rescue MacOSVersion::Error => e
@@ -542,17 +548,18 @@ module Cask
             end
           end
 
-          if cask_struct.container?
-            container(nested: cask_struct.container_args[:nested], type: cask_struct.container_args[:type])
+          if localised_cask_struct.container?
+            container(nested: localised_cask_struct.container_args[:nested],
+                      type:   localised_cask_struct.container_args[:type])
           end
 
-          cask_struct.artifacts(appdir:).each do |key, args, kwargs, block|
+          localised_cask_struct.artifacts(appdir:).each do |key, args, kwargs, block|
             send(key, *args, **kwargs, &block)
           end
 
-          caveats T.must(cask_struct.caveats(appdir:)) if cask_struct.caveats?
+          caveats T.must(localised_cask_struct.caveats(appdir:)) if localised_cask_struct.caveats?
 
-          if cask_struct.caveats_rosetta
+          if localised_cask_struct.caveats_rosetta
             caveats do
               # Dynamically defined via `caveat :requires_rosetta` — Sorbet can't resolve it.
               T.unsafe(self).requires_rosetta

--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -36,10 +36,10 @@ module Cask
     )
 
     # runtime recursive evaluation forces the LazyObject to be evaluated
-    T::Sig::WithoutRuntime.sig { returns(T::Hash[Symbol, T.any(LazyObject, String)]) }
+    T::Sig::WithoutRuntime.sig { returns(ConfigHash) }
     def self.defaults
       {
-        languages: LazyObject.new { ::OS::Mac.languages },
+        languages: T.let([], T::Array[String]),
       }.merge(DEFAULT_DIRS).freeze
     end
 

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -411,6 +411,19 @@ module Cask
       @language_blocks.keys.flatten
     end
 
+    sig { returns(T::Array[T::Array[String]]) }
+    def language_groups
+      @language_blocks.keys
+    end
+
+    sig { returns(T.nilable(T::Array[String])) }
+    def default_language_group
+      default_language_block = @language_blocks.default
+      return if default_language_block.nil?
+
+      @language_blocks.key(default_language_block)
+    end
+
     # Sets the cask's download URL.
     #
     # ### Example

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -268,6 +268,7 @@ on_request: true)
            Homebrew::API::CaskDownload.download(
              token:       @cask.token,
              cask_struct: Homebrew::API::Internal.cask_struct(@cask.token),
+             languages:   @cask.config.languages,
              quarantine:  quarantine?,
              require_sha: require_sha? && !force?,
            )
@@ -936,8 +937,6 @@ on_request: true)
       download_queue = @download_queue
       prelude_fetch(download_queue:) unless @ran_prelude_fetch
 
-      # FIXME: We need to load Cask source before enqueuing to support
-      # language-specific URLs, but this will block the main process.
       if source_download_requires_pre_fetch?
         load_cask_from_source_api!
       elsif cask_from_source_api?

--- a/Library/Homebrew/extend/os/cask/config.rb
+++ b/Library/Homebrew/extend/os/cask/config.rb
@@ -1,4 +1,5 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "extend/os/mac/cask/config" if OS.mac?
 require "extend/os/linux/cask/config" if OS.linux?

--- a/Library/Homebrew/extend/os/mac/cask/config.rb
+++ b/Library/Homebrew/extend/os/mac/cask/config.rb
@@ -1,0 +1,23 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "os/mac"
+
+module OS
+  module Mac
+    module Cask
+      module Config
+        module ClassMethods
+          T::Sig::WithoutRuntime.sig { returns(::Cask::Config::ConfigHash) }
+          def defaults
+            {
+              languages: LazyObject.new { Mac.languages },
+            }.merge(::Cask::Config::DEFAULT_DIRS).freeze
+          end
+        end
+      end
+    end
+  end
+end
+
+Cask::Config.singleton_class.prepend(OS::Mac::Cask::Config::ClassMethods)

--- a/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
+++ b/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
@@ -86,6 +86,13 @@ does not flag formulae or casks before the DSL is widely available. After PR `1`
 is merged and before PRs `3` and `4` are merged, cut a new `Homebrew/brew`
 stable release so `homebrew/core` and `homebrew/cask` CI have the new DSL.
 
+These four PRs are also a stage gate. Before starting the next numbered DSL
+operation, implement and test the current operation's enforcing/autocorrecting
+PR `2`, record its commit in this plan and run its cops across both taps. The
+cop can still merge last, but an operation is not complete while its PR `2` is
+missing. If no safe legacy pattern exists, record the tap scan, representative
+filenames and negative cop coverage instead of silently omitting the PR.
+
 Each operation PR should also clone, or create clean local worktrees for,
 `homebrew/core` and `homebrew/cask`, make the corresponding tap changes and
 verify the changed taps with `./bin/brew style`, `./bin/brew audit` and
@@ -171,10 +178,13 @@ Local all-file scan source: `homebrew/cask` at `4eee0394c96c`. The scan read
 all `7,741` files under `Casks/`. Pattern buckets overlap because one flight
 block can prepare files, change permissions and run commands.
 
-- `193` of `7,741` casks currently require the Ruby source at install time
-  through `Cask#caskfile_only?`: `170` because of legacy `*flight` blocks and
-  `23` because of language blocks only. `27` casks have language blocks in
-  total, so `4` have both language blocks and legacy `*flight` blocks.
+- Before language variations were serialised, `193` of `7,741` casks required
+  the Ruby source at install time through `Cask#caskfile_only?`: `170` because
+  of legacy `*flight` blocks and `23` because of language blocks only. `27`
+  casks had language blocks in total, so `4` had both language blocks and
+  legacy `*flight` blocks. Language variation API data removes language blocks
+  as a source download gate; the `4` overlapping casks still need source for
+  their legacy flight blocks.
 - I did not find other current cask install-time Ruby source download gates.
   Ordinary artifacts, uninstall/zap directives, caveats, dependencies and
   `on_*` variations are serialised through API data. `*_steps` artifacts are
@@ -215,13 +225,13 @@ handling use `Homebrew::API::Formula.source_download_formula` for build-time
 reasons outside this post-install DSL work.
 
 Cask JSON API installs use `Homebrew::API::Cask.source_download_cask` when
-`Cask#caskfile_only?` is true. Today that is true when a cask has any legacy
-`preflight`, `postflight`, `uninstall_preflight` or `uninstall_postflight`
-block, or when it has language blocks. Legacy flight blocks need the source
-because API data only records that a block exists, not the Ruby body. Language
-blocks need the source because the API stores available language codes, but not
-the selected block return value or stanza effects; language-specific URLs must
-be resolved before the download can be enqueued.
+`Cask#caskfile_only?` is true. Legacy `preflight`, `postflight`,
+`uninstall_preflight` and `uninstall_postflight` blocks need the source because
+API data only records that a block exists, not the Ruby body. Current API data
+stores each language block's locale group, default marker, return value and
+resulting stanza differences, so language-specific URLs can be resolved before
+the download is enqueued. Older API data with only the flat `languages` array
+continues to download source as a compatibility fallback.
 
 ## Installed Cask Metadata Format
 
@@ -467,10 +477,15 @@ is stripped during metadata serialisation.
   Scope: the cask install-step cop converts pure legacy flight blocks using
   `set_permissions` and `set_ownership` to matching `*_steps` blocks. Mixed
   flights, dynamic paths and unsupported arguments remain unchanged.
-- [ ] PR 9, cask language variations in API data.
+- [x] PR 9, cask language variations in API data.
+  Commit: `Serialise cask language variations`.
   Estimated existing casks affected: `27` casks use language blocks, with large
   examples including `Casks/f/firefox.rb`,
   `Casks/l/libreoffice-language-pack.rb` and `Casks/t/thunderbird.rb`.
-  Notes for implementation: represent language-specific URLs, checksums and
-  returned values without evaluating cask Ruby before fetch; keep the public API
-  shape friendly to clients that need to choose one language deterministically.
+  Scope: serialise a deterministic default plus ordered language variation
+  deltas containing locale groups, the default marker, return values and all
+  resulting API stanza changes. Public and internal API loaders select exact or
+  partial locale matches and fall back to the default. Cask downloads use the
+  selected URL and checksum directly, while older API data still falls back to
+  source. Artifact differences are included so all `27` current language casks,
+  including `cave-story` and `wondershare-edrawmax`, can use API data.

--- a/Library/Homebrew/sorbet/rbi/dsl/cask/cask.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/cask/cask.rbi
@@ -130,9 +130,6 @@ class Cask::Cask
   def keyboard_layout(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
-  def language(*args, &block); end
-
-  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def livecheck(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T::Boolean) }

--- a/Library/Homebrew/sorbet/rbi/dsl/r_spec/matchers.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/r_spec/matchers.rbi
@@ -79,6 +79,9 @@ module RSpec::Matchers
   def be_cask_file(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def be_caskfile_only(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def be_custom_remote(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }

--- a/Library/Homebrew/test/api/cask_struct_spec.rb
+++ b/Library/Homebrew/test/api/cask_struct_spec.rb
@@ -122,6 +122,39 @@ RSpec.describe Homebrew::API::CaskStruct do
     end
   end
 
+  describe "#localise" do
+    it "selects matching locale groups and falls back to the default" do
+      struct = described_class.new(
+        sha256:              "english",
+        version:             "1.0.0",
+        url_args:            ["https://example.com/en.dmg"],
+        language_variations: [
+          {
+            languages: ["zh", "CN"],
+            value:     "zh-CN",
+            overrides: {
+              "sha256"   => "chinese",
+              "url_args" => ["https://example.com/zh.dmg"],
+              "names"    => [":Chinese"],
+            },
+          },
+          { languages: ["en"], default: true, value: "en-US", overrides: {} },
+        ],
+      )
+
+      chinese = struct.localise(["zh-Hans-CN"])
+      default = struct.localise(["fr"])
+
+      expect([
+        [chinese.sha256, chinese.url_args, chinese.names, struct.language(["zh-Hans-CN"])],
+        [default.sha256, default.url_args, struct.language(["fr"])],
+      ]).to eq([
+        ["chinese", ["https://example.com/zh.dmg"], [":Chinese"], "zh-CN"],
+        ["english", ["https://example.com/en.dmg"], "en-US"],
+      ])
+    end
+  end
+
   specify "#serialize_artifact_args", :aggregate_failures do
     struct = described_class.new(
       sha256:               "abc123",

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -330,7 +330,27 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
     end
 
     context "with a language stanza" do
-      include_examples "loads from API", "with-languages", caskfile_only: true
+      include_examples "loads from API", "with-languages", caskfile_only: false
+
+      it "loads the selected language variation from both APIs" do
+        config = Cask::Config.new(explicit: { languages: ["zh"] })
+        casks = [api_loader.load(config:), internal_api_loader.load(config:)]
+
+        expect(casks.map do |cask|
+          [cask.language, cask.url.to_s, cask.sha256.to_s, cask.artifacts.first.to_args]
+        end).to all(eq([
+          "zh-CN",
+          "file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz",
+          "fab685fabf73d5a9382581ce8698fce9408f5feaa49fa10d9bc6c510493300f5",
+          ["Container.app"],
+        ]))
+      end
+
+      it "keeps the source fallback for old API data" do
+        cask = described_class.new(api_token, from_json: cask_json.except("language_variations")).load(config: nil)
+
+        expect(cask).to be_caskfile_only
+      end
     end
   end
 end

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -842,6 +842,40 @@ RSpec.describe Cask::Cask, :cask do
       MacOS.full_version = original_macos_version
     end
 
+    it "returns language variations with a deterministic default" do
+      hash = JSON.parse(JSON.generate(Cask::CaskLoader.load("with-languages").to_hash_with_variations))
+
+      expect(hash.slice("url", "sha256", "language_variations")).to eq({
+        "url"                 => "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip",
+        "sha256"              => "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",
+        "language_variations" => [
+          {
+            "languages" => ["zh"],
+            "default"   => false,
+            "value"     => "zh-CN",
+            "url"       => "file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz",
+            "sha256"    => "fab685fabf73d5a9382581ce8698fce9408f5feaa49fa10d9bc6c510493300f5",
+            "artifacts" => [{
+              "app"    => ["Container.app"],
+              "target" => "#{TEST_TMPDIR}/cask-appdir/Container.app",
+            }],
+          },
+          { "languages" => ["en-US"], "default" => true, "value" => "en-US" },
+        ],
+      })
+    end
+
+    it "preserves the cask configuration while generating language variations" do
+      appdir = Pathname(TEST_TMPDIR)/"configured-appdir"
+      config = Cask::Config.from_json({ default: { appdir:, languages: ["en-US"] } }.to_json)
+      hash = Cask::CaskLoader.load("with-languages", config:).to_hash_with_variations
+
+      expect([
+        hash.dig("artifacts", 0, :target),
+        hash.dig("language_variations", 0, "artifacts", 0, :target),
+      ]).to eq([appdir/"Caffeine.app", appdir/"Container.app"].map(&:to_s))
+    end
+
     it "returns the correct variations hash for a cask with multiple versions" do
       c = Cask::CaskLoader.load("multiple-versions")
       h = c.to_hash_with_variations

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -716,6 +716,29 @@ RSpec.describe Cask::Installer, :cask do
       installer.enqueue_downloads
     end
 
+    it "enqueues the selected language download from API data" do
+      source_cask = Cask::CaskLoader.load("with-languages")
+      cask_struct = Homebrew::API::Cask::CaskStructGenerator.generate_cask_struct_hash(
+        source_cask.to_hash_with_variations,
+      )
+      config = Cask::Config.new(explicit: { languages: ["zh"] })
+      cask = Cask::CaskLoader::FromAPILoader.new(
+        "language-api-cask",
+        from_json:          cask_struct.serialize,
+        from_internal_json: true,
+      ).load(config:)
+      download_queue = instance_double(Homebrew::DownloadQueue)
+      installer = described_class.new(cask, download_queue:)
+
+      allow(Homebrew::API::Internal).to receive(:cask_struct).with("language-api-cask").and_return(cask_struct)
+      expect(Homebrew::API::Cask).not_to receive(:source_download)
+      expect(download_queue).to receive(:enqueue) do |download|
+        expect(download.url.to_s).to eq("file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz")
+      end
+
+      installer.enqueue_downloads
+    end
+
     it "enqueues source API caskfiles before the main cask download" do
       cask = Cask::Cask.new("source-api-cask") do
         url "file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz"

--- a/Library/Homebrew/test/cask_config_spec.rb
+++ b/Library/Homebrew/test/cask_config_spec.rb
@@ -1,0 +1,22 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "cask/config"
+
+RSpec.describe Cask::Config do
+  describe "#languages" do
+    it "uses the current operating system language provider" do
+      expected_languages = if OS.mac?
+        allow(OS::Mac).to receive(:languages).and_return(["en-US"])
+        ["en-US"]
+      elsif OS.linux?
+        allow(OS::Linux).to receive(:languages).and_return(["en-US"])
+        ["en-US"]
+      else
+        []
+      end
+
+      expect(described_class.new.languages).to eq(expected_languages)
+    end
+  end
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
@@ -4,19 +4,20 @@ cask "with-languages" do
   version "1.2.3"
 
   language "zh" do
-    sha256 :no_check
+    sha256 "fab685fabf73d5a9382581ce8698fce9408f5feaa49fa10d9bc6c510493300f5"
+    app "Container.app"
     "zh-CN"
   end
   language "en-US", default: true do
-    sha256 :no_check
+    sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+    app "Caffeine.app"
     "en-US"
   end
 
-  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  archive = (language == "zh-CN") ? "container.tar.gz" : "caffeine.zip"
+  url "file://#{TEST_FIXTURE_DIR}/cask/#{archive}"
   name "Caffeine"
   homepage "https://brew.sh/"
 
   depends_on macos: :catalina
-
-  app "Caffeine.app"
 end

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -749,6 +749,9 @@ The return value of the matching `language` block can be accessed by simply call
 homepage "https://example.org/#{language}"
 ```
 
+The JSON API stores the return value and resulting stanza changes for every language block.
+API installs select the matching snapshot from the preferred locales, falling back to the declared default, without evaluating the cask's Ruby source.
+
 Examples: [firefox.rb](https://github.com/Homebrew/homebrew-cask/blob/939b4331dc2a6860350d66a1b2c7b3f22442cc08/Casks/f/firefox.rb#L4-L207), [battle-net.rb](https://github.com/Homebrew/homebrew-cask/blob/e039d079560cf2f77b671f7dda4752a053341180/Casks/b/battle-net.rb#L5-L10)
 
 #### Installation


### PR DESCRIPTION
- store deterministic language deltas in public and internal API data
- select URLs, checksums and artifacts without loading cask Ruby
- retain source fallback for older API data and legacy flight blocks

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI 5.6 Sol max with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
