### PR TITLE
test_bot/formulae: re-enable all tests on Tier 1

### DIFF
--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -911,16 +911,23 @@ module Homebrew
 
         test "brew", "vendor-install", "ruby"
 
+        no_github_actions_env = { "GITHUB_ACTIONS" => nil }
         bundler_version = Utils::PortableRuby.sync_bundler_version!(pkg_version)
-        test "brew", "vendor-gems", "--no-commit", "--update=--ruby,--bundler=#{bundler_version}"
+        test "brew", "vendor-gems", "--no-commit", "--update=--ruby,--bundler=#{bundler_version}",
+             env: no_github_actions_env
         test "brew", "typecheck", "--update"
 
         # Run the checks that gate a Homebrew/brew pull request.
         test "brew", "style" unless OS.not_tier_one_configuration?
         test "brew", "typecheck"
         test "brew", "install-bundler-gems", "--groups=all"
-        test "brew", "vendor-gems", "--non-bundler-gems", "--no-commit"
-        test "brew", "tests", "--online", "--coverage", "--only=cask,formula"
+        test "brew", "vendor-gems", "--non-bundler-gems", "--no-commit",
+             env: no_github_actions_env
+        if OS.not_tier_one_configuration?
+          test "brew", "tests", "--online", "--coverage", "--only=cask,formula"
+        else
+          test "brew", "tests", "--online", "--coverage"
+        end
         test "brew", "update-test"
         test "brew", "update-test", "--to-tag"
         test "brew", "update-test", "--commit=HEAD"
@@ -928,7 +935,7 @@ module Homebrew
         require "mktemp"
         Mktemp.new("homebrew-test-bot").run do |_|
           test "brew", "test-bot", "--only-formulae", "--only-json-tab", "--test-default-formula",
-               env: { "GITHUB_ACTIONS" => nil }
+               env: no_github_actions_env
         end
       end
 


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Restore running all tests on Linux. This attempts a fix of sticky bit issue by avoiding `chmod +t` within vendor-gems

Keep a minimal set of tests for Tier 3 macOS runners as they often fail from older versions of commands.