### PR TITLE
Add install step enforcement cops

### DIFF
--- a/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
+++ b/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
@@ -378,7 +378,7 @@ is stripped during metadata serialisation.
     `{{appdir}}`-content flight writes all target a `shimscript` local that is
     also wired to a `binary` stanza, and the literal-path LibreOffice packs
     interpolate an unsupported language `token` and run `system_command`.
-- [x] PR 6, database and service data directory initialisation.
+- [x] PR 6.1, database and service data directory initialisation.
   Commit: `Add install step data directories`.
   Estimated existing formulae/casks affected: about `19` formulae initialise
   service data directories.
@@ -414,7 +414,16 @@ is stripped during metadata serialisation.
   `./bin/brew style homebrew/core`, targeted `./bin/brew audit --strict
   --online --formula ...` for the changed formulae and `./bin/brew readall
   homebrew/core`.
-- [x] PR 7, certificate and trust store actions.
+- [x] PR 6.2, database and link enforcement.
+  Commit: `Add install step enforcement cops`.
+  Scope: the formula install-step cop conservatively autocorrects recognised
+  PostgreSQL, MySQL and MariaDB bootstrap statements to `init_data_dir`, and
+  recognised PostgreSQL link maintenance to `link_dir` or `link_children`.
+  Partial conversions preserve existing `post_install_steps` ordering and
+  leave unsupported warning or maintenance work in `post_install`. Matching
+  Percona bootstrap hooks remain unchanged because they were not part of the
+  recorded MySQL formula conversion.
+- [x] PR 7.1, certificate and trust store actions.
   Commit: `Add install step keychain cleanup`.
   Estimated existing formulae/casks affected: about `17` formulae update
   certificate/trust state and `8` cask flight blocks invoke
@@ -427,7 +436,15 @@ is stripped during metadata serialisation.
   `source_base: :formula_pkgetc`; specialised trust store generation such as
   `ca-certificates` bundle regeneration and Mono `cert-sync` stays legacy Ruby
   because current repeated usage is below the named-variant threshold.
-- [x] PR 8, cask permission and ownership actions.
+- [x] PR 7.2, certificate and keychain enforcement.
+  Commit: `Add install step enforcement cops`.
+  Scope: the cask install-step cop converts fixed `/usr/bin/security`
+  certificate deletion flights to `delete_keychain_certificate`. The formula
+  cop converts the three direct `pkgetc` certificate bundle replacements to
+  forced `symlink` steps using `source_formula` and
+  `source_base: :formula_pkgetc`. Dynamic paths, altered commands and
+  specialised certificate generation remain unsupported.
+- [x] PR 8.1, cask permission and ownership actions.
   Commit: `Add cask permission steps`.
   Estimated existing casks affected: about `21` casks change permissions and
   `36` change ownership.
@@ -445,6 +462,11 @@ is stripped during metadata serialisation.
   `Casks/h/hummingbird.rb`, `Casks/m/mplabx-ide.rb` and
   `Casks/p/proxy-audio-device.rb`; they depend on unsupported local variables,
   architecture data or additional `system_command` work.
+- [x] PR 8.2, permission and ownership enforcement.
+  Commit: `Add install step enforcement cops`.
+  Scope: the cask install-step cop converts pure legacy flight blocks using
+  `set_permissions` and `set_ownership` to matching `*_steps` blocks. Mixed
+  flights, dynamic paths and unsupported arguments remain unchanged.
 - [ ] PR 9, cask language variations in API data.
   Estimated existing casks affected: `27` casks use language blocks, with large
   examples including `Casks/f/firefox.rb`,

--- a/Library/Homebrew/rubocops/cask/install_steps.rb
+++ b/Library/Homebrew/rubocops/cask/install_steps.rb
@@ -21,6 +21,37 @@ module RuboCop
           }.freeze,
           T::Hash[Symbol, Symbol],
         )
+        KEYCHAIN_HASHES_SOURCE =
+          'hashes = stdout.lines.grep(/^SHA-256 hash:/) { |l| l.split(":").second.strip }'
+        KEYCHAIN_DELETE_SOURCE = T.let(
+          <<~RUBY.gsub(/\s+/, " ").strip.freeze,
+            hashes.each do |h|
+              system_command "/usr/bin/security",
+                             args: ["delete-certificate", "-Z", h],
+                             sudo: true
+            end
+          RUBY
+          String,
+        )
+        CERTIFICATE_EXISTS_GUARD_SOURCE = "next unless cert.exist?"
+        CERTIFICATE_FINGERPRINT_SOURCE = T.let(
+          <<~RUBY.gsub(/\s+/, " ").strip.freeze,
+            stdout, * = system_command "/usr/bin/openssl",
+                                       args: ["x509", "-fingerprint", "-sha256", "-noout", "-in", cert]
+          RUBY
+          String,
+        )
+        CERTIFICATE_HASH_SOURCE = 'hash = stdout.lines.first.split("=").second.delete(":").strip'
+        CERTIFICATE_HASH_DELETE_SOURCE = T.let(
+          <<~RUBY.gsub(/\s+/, " ").strip.freeze,
+            if hashes.include?(hash)
+              system_command "/usr/bin/security",
+                             args: ["delete-certificate", "-Z", hash],
+                             sudo: true
+            end
+          RUBY
+          String,
+        )
 
         sig { override.params(cask_block: RuboCop::Cask::AST::CaskBlock).void }
         def on_cask(cask_block)
@@ -57,11 +88,13 @@ module RuboCop
           return unless flight_stanza.method_node.block_type?
 
           block_node = T.cast(flight_stanza.method_node, RuboCop::AST::BlockNode)
-          step_lines = simple_install_step_lines(block_node.body,
+          step_lines = keychain_certificate_step_lines(block_node.body) ||
+                       simple_install_step_lines(block_node.body,
                                                  default_base:        :staged_path,
                                                  default_source_base: :staged_path,
                                                  default_target_base: :staged_path,
-                                                 rebuild_actions:     false)
+                                                 rebuild_actions:     false,
+                                                 permission_actions:  true)
           return if step_lines.blank?
 
           add_offense(block_node.source_range,
@@ -71,6 +104,134 @@ module RuboCop
               install_steps_block_source(steps_block, step_lines, block_node.source_range.column),
             )
           end
+        end
+
+        sig { params(body_node: T.nilable(RuboCop::AST::Node)).returns(T.nilable(T::Array[String])) }
+        def keychain_certificate_step_lines(body_node)
+          direct_nodes = direct_install_step_nodes(body_node)
+          return fingerprint_keychain_step_lines(direct_nodes) if direct_nodes.length == 7
+
+          if (name_node = keychain_delete_sequence_name(direct_nodes))&.str_type?
+            return ["delete_keychain_certificate #{T.cast(name_node, RuboCop::AST::StrNode).str_content.inspect}"]
+          end
+
+          return if body_node.nil? || !body_node.block_type?
+
+          block_node = T.cast(body_node, RuboCop::AST::BlockNode)
+          send_node = block_node.send_node
+          names_node = send_node.receiver
+          return if send_node.method_name != :each || send_node.arguments.present? || !names_node&.array_type?
+
+          block_arguments = block_node.arguments.children
+          return if block_arguments.length != 1 || block_arguments.first&.children != [:cert_name]
+
+          name_nodes = names_node.child_nodes
+          return unless name_nodes.all?(&:str_type?)
+
+          sequence_name_node = keychain_delete_sequence_name(direct_install_step_nodes(block_node.body))
+          return unless sequence_name_node&.lvar_type?
+          return if sequence_name_node.children != [:cert_name]
+
+          name_nodes.map do |name|
+            "delete_keychain_certificate #{T.cast(name, RuboCop::AST::StrNode).str_content.inspect}"
+          end
+        end
+
+        sig { params(nodes: T::Array[RuboCop::AST::Node]).returns(T.nilable(RuboCop::AST::Node)) }
+        def keychain_delete_sequence_name(nodes)
+          return if nodes.length != 3
+
+          name_node = keychain_find_certificate_name(nodes.fetch(0))
+          return if name_node.nil?
+          return if normalised_install_step_source(nodes.fetch(1)) != KEYCHAIN_HASHES_SOURCE
+          return if normalised_install_step_source(nodes.fetch(2)) != KEYCHAIN_DELETE_SOURCE
+
+          name_node
+        end
+
+        sig { params(nodes: T::Array[RuboCop::AST::Node]).returns(T.nilable(T::Array[String])) }
+        def fingerprint_keychain_step_lines(nodes)
+          path_node = certificate_path(nodes.fetch(0))
+          return if path_node.nil?
+          return if normalised_install_step_source(nodes.fetch(1)) != CERTIFICATE_EXISTS_GUARD_SOURCE
+
+          fingerprint_source = normalised_install_step_source(nodes.fetch(2))
+                               .gsub(/\[\s+/, "[")
+                               .gsub(/\s+\]/, "]")
+          return if fingerprint_source != CERTIFICATE_FINGERPRINT_SOURCE
+          return if normalised_install_step_source(nodes.fetch(3)) != CERTIFICATE_HASH_SOURCE
+
+          name_node = keychain_find_certificate_name(nodes.fetch(4))
+          return if name_node.nil? || !name_node.str_type?
+          return if normalised_install_step_source(nodes.fetch(5)) != KEYCHAIN_HASHES_SOURCE
+          return if normalised_install_step_source(nodes.fetch(6)) != CERTIFICATE_HASH_DELETE_SOURCE
+
+          name = T.cast(name_node, RuboCop::AST::StrNode).str_content.inspect
+          path = T.cast(path_node, RuboCop::AST::StrNode).str_content.inspect
+          source = <<~RUBY.chomp
+            delete_keychain_certificate #{name},
+                                        matching_certificate: #{path}
+          RUBY
+          [source]
+        end
+
+        sig { params(node: RuboCop::AST::Node).returns(T.nilable(RuboCop::AST::Node)) }
+        def keychain_find_certificate_name(node)
+          return unless node.masgn_type?
+          return if node.child_nodes.length != 2
+
+          assignment = node.child_nodes.fetch(0)
+          command_node = node.child_nodes.fetch(1)
+          return if normalised_install_step_source(assignment) != "stdout, *"
+          return unless command_node.send_type?
+
+          command = T.cast(command_node, RuboCop::AST::SendNode)
+          return if command.receiver || command.method_name != :system_command || command.arguments.length != 2
+          return unless command.arguments.fetch(0).str_type?
+          return if T.cast(command.arguments.fetch(0), RuboCop::AST::StrNode).str_content != "/usr/bin/security"
+
+          options = command.arguments.fetch(1)
+          return unless options.hash_type?
+
+          pairs = T.cast(options, RuboCop::AST::HashNode).pairs
+          return if pairs.length != 2 || pairs.any? { |pair| !pair.key.sym_type? }
+          return if pairs.map { |pair| pair.key.value } != [:args, :sudo]
+          return unless pairs.fetch(1).value.true_type?
+
+          arguments = pairs.fetch(0).value
+          return unless arguments.array_type?
+
+          values = arguments.child_nodes
+          return if values.length != 5
+
+          fixed_value_nodes = [0, 1, 2, 4].map { |index| values.fetch(index) }
+          return unless fixed_value_nodes.all?(&:str_type?)
+
+          fixed_values = fixed_value_nodes.map do |value|
+            T.cast(value, RuboCop::AST::StrNode).str_content
+          end
+          return if fixed_values != ["find-certificate", "-a", "-c", "-Z"]
+
+          values.fetch(3)
+        end
+
+        sig { params(node: RuboCop::AST::Node).returns(T.nilable(RuboCop::AST::Node)) }
+        def certificate_path(node)
+          return unless node.lvasgn_type?
+          return if node.children.first != :cert
+
+          expand_node = node.child_nodes.first
+          return unless expand_node&.send_type?
+
+          expand = T.cast(expand_node, RuboCop::AST::SendNode)
+          return if expand.method_name != :expand_path || expand.arguments.present?
+          return unless expand.receiver&.send_type?
+
+          pathname = T.cast(expand.receiver, RuboCop::AST::SendNode)
+          return if pathname.receiver || pathname.method_name != :Pathname || pathname.arguments.length != 1
+
+          path = pathname.arguments.fetch(0)
+          path if path.str_type?
         end
       end
     end

--- a/Library/Homebrew/rubocops/install_steps.rb
+++ b/Library/Homebrew/rubocops/install_steps.rb
@@ -17,6 +17,62 @@ module RuboCop
         # CONFLICT_MSG = "`post_install` and `post_install_steps` cannot both be used."
         POST_INSTALL_STEPS_ORDER_MSG = "`post_install_steps` must appear before `post_install` to match run order."
         REDUNDANT_SERVICE_PATH_DIRS_MSG = "`%<block>s` only creates directories created by `brew services`."
+        CERTIFICATE_REMOVE_SOURCE = 'rm(pkgetc/"cert.pem") if (pkgetc/"cert.pem").exist?'
+        CERTIFICATE_INSTALL_SYMLINK_SOURCE =
+          'pkgetc.install_symlink Formula["ca-certificates"].pkgetc/"cert.pem"'
+        GITHUB_ACTIONS_GUARD_SOURCE = "return if ENV[\"HOMEBREW_GITHUB_ACTIONS\"]"
+        MYSQL_FORMULA_CLASS_REGEX = /\AMysql(?:AT\d+)?\z/
+        MYSQL_DATADIR_METHOD_SOURCE = "def datadir var/\"mysql\" end"
+        MYSQL_INITIALISE_SOURCE = T.let(
+          <<~'RUBY'.gsub(/\s+/, " ").strip.freeze,
+            unless (datadir/"mysql/general_log.CSM").exist?
+              ENV["TMPDIR"] = nil
+              system bin/"mysqld", "--initialize-insecure", "--user=#{ENV["USER"]}",
+                                   "--basedir=#{prefix}", "--datadir=#{datadir}", "--tmpdir=/tmp"
+            end
+          RUBY
+          String,
+        )
+        MARIADB_INITIALISE_SOURCE = T.let(
+          <<~'RUBY'.gsub(/\s+/, " ").strip.freeze,
+            unless File.exist? "#{var}/mysql/mysql/user.frm"
+              ENV["TMPDIR"] = nil
+              system bin/"mysql_install_db", "--verbose", "--user=#{ENV["USER"]}",
+                "--basedir=#{prefix}", "--datadir=#{var}/mysql", "--tmpdir=/tmp"
+            end
+          RUBY
+          String,
+        )
+        POSTGRESQL_DATADIR_METHOD_SOURCE = "def postgresql_datadir var/name end"
+        POSTGRESQL_MARKER_METHOD_SOURCE = "def pg_version_exists? (postgresql_datadir/\"PG_VERSION\").exist? end"
+        POSTGRESQL_INIT_SOURCE_REGEX = Regexp.new(
+          '\Asystem bin/"initdb", "--locale=(C|en_US\\.UTF-8)", "-E", "UTF-8", ' \
+          'postgresql_datadir unless pg_version_exists\\?\\z',
+        ).freeze
+        POSTGRESQL_LINK_DIR_SOURCE = T.let(
+          <<~RUBY.gsub(/\s+/, " ").strip.freeze,
+            %w[include lib share].each do |dir|
+              dst_dir = HOMEBREW_PREFIX/dir/name
+              src_dir = prefix/dir/"postgresql"
+              src_dir.find do |src|
+                dst = dst_dir/src.relative_path_from(src_dir)
+                next if dst.directory? && !dst.symlink? && src.directory? && !src.symlink?
+
+                rm_r(dst) if dst.exist? || dst.symlink?
+                if src.symlink? || src.file?
+                  Find.prune if src.basename.to_s == ".DS_Store"
+                  dst.parent.install_symlink src
+                elsif src.directory?
+                  dst.mkpath
+                end
+              end
+            end
+          RUBY
+          String,
+        )
+        POSTGRESQL_LINK_CHILDREN_SOURCE =
+          "bin.each_child { |f| (HOMEBREW_PREFIX/\"bin\").install_symlink " \
+          "f => \"\#{f.basename}-\#{version.major}\" }"
 
         sig { override.params(formula_nodes: FormulaNodes).void }
         def audit_formula(formula_nodes)
@@ -41,7 +97,10 @@ module RuboCop
                                    redundant_service_path_dirs_block?(post_install_method, service_path_dirs,
                                                                       :post_install)
           add_redundant_service_path_dirs_offense(post_install_method, service_path_dirs, :post_install)
-          audit_post_install_method(post_install_method) if post_install_steps_block.nil? && !redundant_post_install
+          return if redundant_post_install
+
+          audit_post_install_method(post_install_method, post_install_steps_block,
+                                    body_node, formula_nodes.class_node.const_name)
         end
 
         private
@@ -68,12 +127,39 @@ module RuboCop
           problem STEP_BLOCK_MSG
         end
 
-        sig { params(post_install_method: T.nilable(RuboCop::AST::Node)).void }
-        def audit_post_install_method(post_install_method)
+        sig {
+          params(
+            post_install_method:      T.nilable(RuboCop::AST::Node),
+            post_install_steps_block: T.nilable(RuboCop::AST::BlockNode),
+            formula_body:             RuboCop::AST::Node,
+            formula_class:            String,
+          ).void
+        }
+        def audit_post_install_method(post_install_method, post_install_steps_block, formula_body, formula_class)
           return if post_install_method.nil?
           return unless post_install_method.def_type?
 
           post_install_def = T.cast(post_install_method, RuboCop::AST::DefNode)
+          return if post_install_steps_block && post_install_steps_block.loc.line > post_install_def.loc.line
+
+          step_nodes = T.let({}, T::Hash[RuboCop::AST::Node, T::Array[String]])
+          removable_methods = T.let([], T::Array[RuboCop::AST::Node])
+          direct_nodes = direct_install_step_nodes(post_install_def.body)
+          add_postgresql_step_nodes(direct_nodes, formula_body, step_nodes, removable_methods)
+          if formula_class.match?(MYSQL_FORMULA_CLASS_REGEX)
+            add_mysql_step_nodes(direct_nodes, formula_body, step_nodes)
+          end
+          add_mariadb_step_nodes(direct_nodes, step_nodes)
+          add_postgresql_link_step_nodes(direct_nodes, step_nodes)
+          add_certificate_symlink_step_nodes(direct_nodes, step_nodes)
+          unless step_nodes.empty?
+            add_formula_step_conversion_offense(post_install_def, post_install_steps_block, direct_nodes, step_nodes,
+                                                removable_methods)
+            return
+          end
+
+          return if post_install_steps_block
+
           step_lines = simple_install_step_lines(post_install_def.body,
                                                  default_base:        :var,
                                                  default_source_base: :prefix,
@@ -87,6 +173,219 @@ module RuboCop
               install_steps_block_source(:post_install_steps, step_lines, post_install_method.source_range.column),
             )
           end
+        end
+
+        sig {
+          params(
+            direct_nodes:      T::Array[RuboCop::AST::Node],
+            formula_body:      RuboCop::AST::Node,
+            step_nodes:        T::Hash[RuboCop::AST::Node, T::Array[String]],
+            removable_methods: T::Array[RuboCop::AST::Node],
+          ).void
+        }
+        def add_postgresql_step_nodes(direct_nodes, formula_body, step_nodes, removable_methods)
+          log_node = direct_nodes.find { |node| normalised_install_step_source(node) == '(var/"log").mkpath' }
+          datadir_node = direct_nodes.find do |node|
+            normalised_install_step_source(node) == "postgresql_datadir.mkpath"
+          end
+          guard_node = direct_nodes.find do |node|
+            normalised_install_step_source(node) == GITHUB_ACTIONS_GUARD_SOURCE
+          end
+          init_node = direct_nodes.find do |node|
+            normalised_install_step_source(node).match?(POSTGRESQL_INIT_SOURCE_REGEX)
+          end
+          return if log_node.nil? || datadir_node.nil? || guard_node.nil? || init_node.nil?
+          return unless nodes_in_source_order?([log_node, datadir_node, guard_node, init_node])
+
+          datadir_method = find_method_def(formula_body, :postgresql_datadir)
+          marker_method = find_method_def(formula_body, :pg_version_exists?)
+          return if datadir_method.nil? || marker_method.nil?
+          return if normalised_install_step_source(datadir_method) != POSTGRESQL_DATADIR_METHOD_SOURCE
+          return if normalised_install_step_source(marker_method) != POSTGRESQL_MARKER_METHOD_SOURCE
+
+          match = normalised_install_step_source(init_node).match(POSTGRESQL_INIT_SOURCE_REGEX)
+          return if match.nil?
+
+          locale = match[1]
+          step_nodes[log_node] = ["mkdir_p \"log\""]
+          step_nodes[datadir_node] = []
+          step_nodes[guard_node] = []
+          init_step_line = "init_data_dir name, using: :postgresql_initdb"
+          init_step_line += ', locale: "C"' if locale == "C"
+          step_nodes[init_node] = [init_step_line]
+          pg_version_calls = formula_body.each_descendant(:send).count do |node|
+            T.cast(node, RuboCop::AST::SendNode).method_name == :pg_version_exists?
+          end
+          removable_methods << marker_method if pg_version_calls == 1
+        end
+
+        sig {
+          params(
+            direct_nodes: T::Array[RuboCop::AST::Node],
+            formula_body: RuboCop::AST::Node,
+            step_nodes:   T::Hash[RuboCop::AST::Node, T::Array[String]],
+          ).void
+        }
+        def add_mysql_step_nodes(direct_nodes, formula_body, step_nodes)
+          datadir_method = find_method_def(formula_body, :datadir)
+          return if datadir_method.nil?
+          return if normalised_install_step_source(datadir_method) != MYSQL_DATADIR_METHOD_SOURCE
+
+          add_mysql_data_step_nodes(direct_nodes, step_nodes, MYSQL_INITIALISE_SOURCE, :mysql_initialize)
+        end
+
+        sig {
+          params(
+            direct_nodes: T::Array[RuboCop::AST::Node],
+            step_nodes:   T::Hash[RuboCop::AST::Node, T::Array[String]],
+          ).void
+        }
+        def add_mariadb_step_nodes(direct_nodes, step_nodes)
+          add_mysql_data_step_nodes(direct_nodes, step_nodes, MARIADB_INITIALISE_SOURCE, :mariadb_install_db)
+        end
+
+        sig {
+          params(
+            direct_nodes:      T::Array[RuboCop::AST::Node],
+            step_nodes:        T::Hash[RuboCop::AST::Node, T::Array[String]],
+            initialise_source: String,
+            using:             Symbol,
+          ).void
+        }
+        def add_mysql_data_step_nodes(direct_nodes, step_nodes, initialise_source, using)
+          datadir_node = direct_nodes.find { |node| normalised_install_step_source(node) == '(var/"mysql").mkpath' }
+          guard_node = direct_nodes.find do |node|
+            normalised_install_step_source(node) == GITHUB_ACTIONS_GUARD_SOURCE
+          end
+          init_node = direct_nodes.find do |node|
+            normalised_install_step_source(node) == initialise_source
+          end
+          return if datadir_node.nil? || guard_node.nil? || init_node.nil?
+          return unless nodes_in_source_order?([datadir_node, guard_node, init_node])
+
+          step_nodes[datadir_node] = []
+          step_nodes[guard_node] = []
+          step_nodes[init_node] = ["init_data_dir \"mysql\", using: :#{using}"]
+        end
+
+        sig {
+          params(
+            direct_nodes: T::Array[RuboCop::AST::Node],
+            step_nodes:   T::Hash[RuboCop::AST::Node, T::Array[String]],
+          ).void
+        }
+        def add_postgresql_link_step_nodes(direct_nodes, step_nodes)
+          direct_nodes.each do |node|
+            case normalised_install_step_source(node)
+            when POSTGRESQL_LINK_DIR_SOURCE
+              step_nodes[node] = [
+                "link_dir \"include/postgresql\", \"include/\#{name}\"",
+                "link_dir \"lib/postgresql\", \"lib/\#{name}\"",
+                "link_dir \"share/postgresql\", \"share/\#{name}\"",
+              ]
+            when POSTGRESQL_LINK_CHILDREN_SOURCE
+              step_nodes[node] = ["link_children \"bin\", suffix: \"-\#{version.major}\""]
+            end
+          end
+        end
+
+        sig {
+          params(
+            direct_nodes: T::Array[RuboCop::AST::Node],
+            step_nodes:   T::Hash[RuboCop::AST::Node, T::Array[String]],
+          ).void
+        }
+        def add_certificate_symlink_step_nodes(direct_nodes, step_nodes)
+          (0...(direct_nodes.length - 1)).each do |index|
+            remove_node = direct_nodes.fetch(index)
+            symlink_node = direct_nodes.fetch(index + 1)
+            next if normalised_install_step_source(remove_node) != CERTIFICATE_REMOVE_SOURCE
+            next if normalised_install_step_source(symlink_node) != CERTIFICATE_INSTALL_SYMLINK_SOURCE
+
+            step_nodes[remove_node] = []
+            step_nodes[symlink_node] = [<<~RUBY.chomp]
+              symlink "cert.pem", "cert.pem",
+                      source_formula: "ca-certificates",
+                      source_base: :formula_pkgetc,
+                      target_base: :pkgetc,
+                      force: true
+            RUBY
+          end
+        end
+
+        sig { params(nodes: T::Array[RuboCop::AST::Node]).returns(T::Boolean) }
+        def nodes_in_source_order?(nodes)
+          nodes.each_index.all? do |index|
+            index.zero? || nodes.fetch(index - 1).source_range.begin_pos < nodes.fetch(index).source_range.begin_pos
+          end
+        end
+
+        sig {
+          params(
+            post_install_def:         RuboCop::AST::DefNode,
+            post_install_steps_block: T.nilable(RuboCop::AST::BlockNode),
+            direct_nodes:             T::Array[RuboCop::AST::Node],
+            step_nodes:               T::Hash[RuboCop::AST::Node, T::Array[String]],
+            removable_methods:        T::Array[RuboCop::AST::Node],
+          ).void
+        }
+        def add_formula_step_conversion_offense(post_install_def, post_install_steps_block, direct_nodes, step_nodes,
+                                                removable_methods)
+          step_lines = step_nodes.sort_by { |node, _| node.source_range.begin_pos }.flat_map(&:last)
+          remaining_nodes = direct_nodes.reject { |node| step_nodes.key?(node) }
+          add_offense(post_install_def,
+                      message: format(SIMPLE_STEP_CONVERSION_MSG, steps_block: "post_install_steps")) do |corrector|
+            if post_install_steps_block
+              append_install_step_lines(corrector, post_install_steps_block, step_lines)
+            elsif remaining_nodes.empty?
+              corrector.replace(
+                post_install_def.source_range,
+                install_steps_block_source(:post_install_steps, step_lines, post_install_def.source_range.column),
+              )
+            else
+              corrector.insert_before(
+                post_install_def.source_range,
+                "#{install_steps_block_source(:post_install_steps, step_lines,
+                                              post_install_def.source_range.column)}\n\n" \
+                "#{" " * post_install_def.source_range.column}",
+              )
+            end
+
+            if post_install_steps_block || remaining_nodes.present?
+              matched_install_step_node_groups(direct_nodes, step_nodes).each do |nodes|
+                corrector.remove(range_for_install_step_node_group(nodes))
+              end
+              if remaining_nodes.empty?
+                corrector.remove(range_with_surrounding_space(range: post_install_def.source_range, side: :left))
+              end
+            end
+            removable_methods.each do |method|
+              corrector.remove(range_with_surrounding_space(range: method.source_range, side: :left))
+            end
+          end
+        end
+
+        sig {
+          params(
+            direct_nodes: T::Array[RuboCop::AST::Node],
+            step_nodes:   T::Hash[RuboCop::AST::Node, T::Array[String]],
+          ).returns(T::Array[T::Array[RuboCop::AST::Node]])
+        }
+        def matched_install_step_node_groups(direct_nodes, step_nodes)
+          direct_nodes.chunk_while { |left, right| step_nodes.key?(left) && step_nodes.key?(right) }
+                      .select { |nodes| step_nodes.key?(nodes.fetch(0)) }
+        end
+
+        sig { params(nodes: T::Array[RuboCop::AST::Node]).returns(::Parser::Source::Range) }
+        def range_for_install_step_node_group(nodes)
+          first_range = range_by_whole_lines(nodes.fetch(0).source_range)
+          last_range = range_by_whole_lines(nodes.fetch(-1).source_range, include_final_newline: true)
+          range = ::Parser::Source::Range.new(processed_source.buffer, first_range.begin_pos, last_range.end_pos)
+          prefix = processed_source.buffer.source[...range.begin_pos]
+          preceding_blank_lines = prefix[/\n(?:[ \t]*\n)+\z/].to_s.length
+          preceding_blank_lines -= 1 if preceding_blank_lines.positive?
+          blank_lines = processed_source.buffer.source[range.end_pos..].to_s[/\A(?:[ \t]*\n)*/].to_s
+          range.adjust(begin_pos: -preceding_blank_lines, end_pos: blank_lines.length)
         end
 
         sig {

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -80,6 +80,7 @@ module RuboCop
       class InstallStepPath < T::Struct
         const :path, String
         const :base, T.nilable(Symbol)
+        const :source, T.nilable(String), default: nil
       end
 
       sig {
@@ -115,15 +116,17 @@ module RuboCop
           default_source_base: Symbol,
           default_target_base: Symbol,
           rebuild_actions:     T::Boolean,
+          permission_actions:  T::Boolean,
         ).returns(T.nilable(T::Array[String]))
       }
       def simple_install_step_lines(body_node, default_base:, default_source_base:, default_target_base:,
-                                    rebuild_actions: true)
+                                    rebuild_actions: true, permission_actions: false)
         return if body_node.nil?
 
         direct_nodes = body_node.begin_type? ? body_node.child_nodes : [body_node]
         step_lines = direct_nodes.map do |node|
-          simple_install_step_line(node, default_base:, default_source_base:, default_target_base:, rebuild_actions:)
+          simple_install_step_line(node, default_base:, default_source_base:, default_target_base:, rebuild_actions:,
+                                   permission_actions:)
         end
         return if step_lines.any?(&:nil?)
 
@@ -133,15 +136,53 @@ module RuboCop
       sig { params(block_name: Symbol, step_lines: T::Array[String], indent: Integer).returns(String) }
       def install_steps_block_source(block_name, step_lines, indent)
         block_indent = " " * indent
-        step_indent = " " * (indent + 2)
         [
           "#{block_name} do",
-          *step_lines.map { |step_line| "#{step_indent}#{step_line}" },
+          *indented_install_step_lines(step_lines, indent + 2),
           "#{block_indent}end",
         ].join("\n")
       end
 
+      sig {
+        params(
+          corrector:  RuboCop::Cop::Corrector,
+          block_node: RuboCop::AST::BlockNode,
+          step_lines: T::Array[String],
+        ).void
+      }
+      def append_install_step_lines(corrector, block_node, step_lines)
+        block_indent = block_node.source_range.column
+        step_source = indented_install_step_lines(step_lines, block_indent + 2).join("\n")
+        corrector.insert_before(
+          block_node.loc.end,
+          "#{step_source.delete_prefix(" " * block_indent)}\n#{" " * block_indent}",
+        )
+      end
+
+      sig { params(body_node: T.nilable(RuboCop::AST::Node)).returns(T::Array[RuboCop::AST::Node]) }
+      def direct_install_step_nodes(body_node)
+        return [] if body_node.nil?
+
+        body_node.begin_type? ? body_node.child_nodes : [body_node]
+      end
+
+      sig { params(node: RuboCop::AST::Node).returns(String) }
+      def normalised_install_step_source(node)
+        node.source.lines.reject { |line| line.lstrip.start_with?("#") }.join.gsub(/\s+/, " ").strip
+      end
+
       private
+
+      sig { params(step_lines: T::Array[String], indent: Integer).returns(T::Array[String]) }
+      def indented_install_step_lines(step_lines, indent)
+        step_lines.flat_map do |step_line|
+          if step_line.include?("<<~")
+            ["#{" " * indent}#{step_line}"]
+          else
+            step_line.lines(chomp: true).map { |line| "#{" " * indent}#{line}" }
+          end
+        end
+      end
 
       sig { params(node: RuboCop::AST::Node).returns(T::Boolean) }
       def allowed_step_argument_node?(node)
@@ -181,9 +222,11 @@ module RuboCop
           default_source_base: Symbol,
           default_target_base: Symbol,
           rebuild_actions:     T::Boolean,
+          permission_actions:  T::Boolean,
         ).returns(T.nilable(String))
       }
-      def simple_install_step_line(node, default_base:, default_source_base:, default_target_base:, rebuild_actions:)
+      def simple_install_step_line(node, default_base:, default_source_base:, default_target_base:, rebuild_actions:,
+                                   permission_actions:)
         return unless node.send_type?
 
         send_node = T.cast(node, RuboCop::AST::SendNode)
@@ -210,6 +253,15 @@ module RuboCop
           return if send_node.receiver.nil? || send_node.arguments.length != 1
 
           return write_step_line(install_step_path(send_node.receiver), send_node.arguments.fetch(0), default_base)
+        end
+
+        if permission_actions && send_node.receiver.nil?
+          case send_node.method_name
+          when :set_permissions
+            return set_permissions_step_line(send_node, default_base)
+          when :set_ownership
+            return set_ownership_step_line(send_node, default_base)
+          end
         end
 
         return unless fileutils_or_no_receiver?(send_node)
@@ -347,6 +399,156 @@ module RuboCop
                                          content_node.loc.expression.end_pos, heredoc_end.end_pos).source}"
       end
 
+      sig {
+        params(
+          send_node:    RuboCop::AST::SendNode,
+          default_base: Symbol,
+        ).returns(T.nilable(String))
+      }
+      def set_permissions_step_line(send_node, default_base)
+        return if send_node.arguments.length != 2
+
+        permissions_node = send_node.arguments.fetch(1)
+        return unless permissions_node.str_type?
+        return unless (paths = permission_paths_source(send_node.arguments.fetch(0), default_base))
+
+        path_source, base = paths
+        "set_permissions #{path_source}, #{permissions_node.source}" \
+          "#{install_step_path_keywords_for_base(base, default_base)}"
+      end
+
+      sig {
+        params(
+          send_node:    RuboCop::AST::SendNode,
+          default_base: Symbol,
+        ).returns(T.nilable(String))
+      }
+      def set_ownership_step_line(send_node, default_base)
+        return unless [1, 2].include?(send_node.arguments.length)
+        return unless (paths = permission_paths_source(send_node.arguments.fetch(0), default_base))
+
+        kwargs = T.let([], T::Array[String])
+        if send_node.arguments.length == 2
+          options = send_node.arguments.fetch(1)
+          return unless options.hash_type?
+
+          pairs = T.cast(options, RuboCop::AST::HashNode).pairs
+          return if pairs.empty?
+          return unless pairs.all? do |pair|
+            pair.key.sym_type? && [:user, :group].include?(pair.key.value) && pair.value.str_type?
+          end
+          return if pairs.map { |pair| pair.key.value }.uniq.length != pairs.length
+
+          kwargs.concat(pairs.map(&:source))
+        end
+
+        path_source, base = paths
+        kwargs << "base: :#{base}" if base && base != default_base
+        "set_ownership #{path_source}#{install_step_kwargs(kwargs)}"
+      end
+
+      sig {
+        params(
+          node:         RuboCop::AST::Node,
+          default_base: Symbol,
+        ).returns(T.nilable([String, T.nilable(Symbol)]))
+      }
+      def permission_paths_source(node, default_base)
+        path_nodes = node.array_type? ? node.child_nodes : [node]
+        return if path_nodes.empty?
+
+        paths = path_nodes.filter_map { |path_node| cask_permission_path(path_node) }
+        return if paths.length != path_nodes.length
+
+        absolute_paths, relative_paths = paths.partition { |path| absolute_install_step_path?(path) }
+        return if absolute_paths.present? && relative_paths.present?
+
+        base = if relative_paths.present?
+          bases = relative_paths.map { |path| path.base || default_base }.uniq
+          return if bases.length != 1
+
+          bases.fetch(0)
+        end
+        source = if node.array_type?
+          "[#{paths.map { |path| install_step_path_source(path) }.join(", ")}]"
+        else
+          install_step_path_source(paths.fetch(0))
+        end
+        [source, base]
+      end
+
+      sig { params(node: RuboCop::AST::Node).returns(T.nilable(InstallStepPath)) }
+      def cask_permission_path(node)
+        path = install_step_path(node)
+        return path if path
+        if normalised_install_step_source(node) == "staged_path.to_s"
+          return InstallStepPath.new(path: ".", base: :staged_path)
+        end
+        return unless node.dstr_type?
+
+        dstr_permission_path(T.cast(node, RuboCop::AST::DstrNode))
+      end
+
+      sig { params(node: RuboCop::AST::DstrNode).returns(T.nilable(InstallStepPath)) }
+      def dstr_permission_path(node)
+        children = node.child_nodes
+        return if children.empty?
+
+        base = interpolated_path_base(children.first)
+        children = children.drop(1) if base
+        return if children.empty? || !children.first.str_type?
+
+        first_content = T.cast(children.first, RuboCop::AST::StrNode).str_content
+        if base
+          return unless first_content.start_with?("/")
+
+          first_content = first_content.delete_prefix("/")
+        elsif !first_content.start_with?("/", "~/")
+          return
+        end
+
+        path = +first_content
+        source = +first_content.dump.delete_prefix('"').delete_suffix('"')
+        valid_children = children.drop(1).all? do |child|
+          if child.str_type?
+            content = T.cast(child, RuboCop::AST::StrNode).str_content
+            path << content
+            source << content.dump.delete_prefix('"').delete_suffix('"')
+            true
+          elsif child.begin_type? && allowed_step_template_node?(child)
+            interpolation = "\#{#{child.source}}"
+            path << interpolation
+            source << interpolation
+            true
+          else
+            false
+          end
+        end
+        return unless valid_children
+
+        InstallStepPath.new(path:, base:, source: "\"#{source}\"")
+      end
+
+      sig { params(node: RuboCop::AST::Node).returns(T.nilable(Symbol)) }
+      def interpolated_path_base(node)
+        return unless node.begin_type?
+        return if node.child_nodes.length != 1
+
+        value = node.child_nodes.first
+        return :homebrew_prefix if value.const_type? && value.const_name == "HOMEBREW_PREFIX"
+        return unless value.send_type?
+
+        send_node = T.cast(value, RuboCop::AST::SendNode)
+        return if send_node.receiver || send_node.arguments.present?
+
+        send_node.method_name if [:appdir, :staged_path].include?(send_node.method_name)
+      end
+
+      sig { params(base: T.nilable(Symbol), default_base: Symbol).returns(String) }
+      def install_step_path_keywords_for_base(base, default_base)
+        (base && base != default_base) ? ", base: :#{base}" : ""
+      end
+
       sig { params(send_node: RuboCop::AST::SendNode).returns(T::Boolean) }
       def fileutils_or_no_receiver?(send_node)
         receiver = send_node.receiver
@@ -381,7 +583,7 @@ module RuboCop
         return if send_node.receiver
 
         base = send_node.method_name
-        base if [:etc, :home, :opt_prefix, :pkgetc, :prefix, :staged_path, :var].include?(base)
+        base if [:appdir, :etc, :home, :opt_prefix, :pkgetc, :prefix, :staged_path, :var].include?(base)
       end
 
       sig { params(path: InstallStepPath).returns(T::Boolean) }
@@ -396,7 +598,7 @@ module RuboCop
 
       sig { params(path: InstallStepPath).returns(String) }
       def install_step_path_source(path)
-        path.path.inspect
+        path.source || path.path.inspect
       end
 
       sig { params(path: InstallStepPath, base: Symbol, keyword: Symbol).returns(String) }

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -128,6 +128,259 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
     CASK
   end
 
+  it "autocorrects fixed keychain certificate deletion flight blocks" do
+    expect_offense <<~CASK
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        preflight do
+        ^^^^^^^^^^^^ Use `preflight_steps` for simple file preparation.
+          stdout, * = system_command "/usr/bin/security",
+                                     args: ["find-certificate", "-a", "-c", "Charles", "-Z"],
+                                     sudo: true
+          hashes = stdout.lines.grep(/^SHA-256 hash:/) { |l| l.split(":").second.strip }
+          hashes.each do |h|
+            system_command "/usr/bin/security",
+                           args: ["delete-certificate", "-Z", h],
+                           sudo: true
+          end
+        end
+
+        postflight do
+        ^^^^^^^^^^^^^ Use `postflight_steps` for simple file preparation.
+          ["AutoFirma ROOT", "127.0.0.1"].each do |cert_name|
+            stdout, * = system_command "/usr/bin/security",
+                                       args: ["find-certificate", "-a", "-c", cert_name, "-Z"],
+                                       sudo: true
+            hashes = stdout.lines.grep(/^SHA-256 hash:/) { |l| l.split(":").second.strip }
+            hashes.each do |h|
+              system_command "/usr/bin/security",
+                             args: ["delete-certificate", "-Z", h],
+                             sudo: true
+            end
+          end
+        end
+
+        uninstall_postflight do
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `uninstall_postflight_steps` for simple file preparation.
+          cert = Pathname("~/Library/Application Support/betwixt/ssl/certs/ca.pem").expand_path
+          next unless cert.exist?
+
+          stdout, * = system_command "/usr/bin/openssl",
+                                     args: ["x509", "-fingerprint", "-sha256", "-noout", "-in", cert]
+          hash = stdout.lines.first.split("=").second.delete(":").strip
+          stdout, * = system_command "/usr/bin/security",
+                                     args: ["find-certificate", "-a", "-c", "NodeMITMProxyCA", "-Z"],
+                                     sudo: true
+          hashes = stdout.lines.grep(/^SHA-256 hash:/) { |l| l.split(":").second.strip }
+          if hashes.include?(hash)
+            system_command "/usr/bin/security",
+                           args: ["delete-certificate", "-Z", hash],
+                           sudo: true
+          end
+        end
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        preflight_steps do
+          delete_keychain_certificate "Charles"
+        end
+
+        postflight_steps do
+          delete_keychain_certificate "AutoFirma ROOT"
+          delete_keychain_certificate "127.0.0.1"
+        end
+
+        uninstall_postflight_steps do
+          delete_keychain_certificate "NodeMITMProxyCA",
+                                      matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"
+        end
+      end
+    CASK
+  end
+
+  it "does not autocorrect altered or mixed keychain deletion blocks" do
+    expect_no_offenses <<~CASK
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        uninstall_postflight do
+          stdout, * = system_command "/usr/local/bin/security",
+                                     args: ["find-certificate", "-a", "-c", "Charles", "-Z"],
+                                     sudo: true
+          hashes = stdout.lines.grep(/^SHA-256 hash:/) { |l| l.split(":").second.strip }
+          hashes.each do |h|
+            system_command "/usr/local/bin/security",
+                           args: ["delete-certificate", "-Z", h],
+                           sudo: true
+          end
+        end
+      end
+    CASK
+
+    expect_no_offenses <<~CASK
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        uninstall_postflight do
+          stdout, * = system_command "/usr/bin/security",
+                                     args: ["find-certificate", "-a", "-c", "Charles", "-Z", "login.keychain"],
+                                     sudo: true
+          hashes = stdout.lines.grep(/^SHA-256 hash:/) { |l| l.split(":").second.strip }
+          hashes.each do |h|
+            system_command "/usr/bin/security",
+                           args: ["delete-certificate", "-Z", h],
+                           sudo: true
+          end
+        end
+      end
+    CASK
+
+    expect_no_offenses <<~CASK
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        uninstall_postflight do
+          stdout, * = system_command "/usr/bin/security",
+                                     args: ["find-certificate", "-a", "-c", "Charles", "-Z"],
+                                     sudo: true
+          hashes = stdout.lines.grep(/^SHA-256 hash:/) { |l| l.split(":").second.strip }
+          hashes.each do |h|
+            system_command "/usr/bin/security",
+                           args: ["delete-certificate", "-Z", h],
+                           sudo: true
+          end
+          system_command "/usr/bin/true"
+        end
+      end
+    CASK
+  end
+
+  it "does not re-report declarative keychain, permission or ownership steps" do
+    expect_no_offenses <<~CASK
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        uninstall_postflight_steps do
+          delete_keychain_certificate "Charles"
+          set_permissions "Foo.app", "0755"
+          set_ownership "Foo.app", user: "root", group: "wheel"
+        end
+      end
+    CASK
+  end
+
+  it "autocorrects pure permission and ownership flight blocks" do
+    expect_offense <<~'CASK'
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        preflight do
+        ^^^^^^^^^^^^ Use `preflight_steps` for simple file preparation.
+          set_permissions "#{staged_path}/Foo.app", "0755"
+        end
+
+        postflight do
+        ^^^^^^^^^^^^^ Use `postflight_steps` for simple file preparation.
+          set_permissions "#{appdir}/Foo.app", "0555"
+          set_ownership "#{HOMEBREW_PREFIX}/foo"
+        end
+
+        uninstall_preflight do
+        ^^^^^^^^^^^^^^^^^^^^^^ Use `uninstall_preflight_steps` for simple file preparation.
+          set_ownership ["/usr/local/include", "/usr/local/lib"], user: "root", group: "wheel"
+        end
+
+        uninstall_postflight do
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `uninstall_postflight_steps` for simple file preparation.
+          set_ownership staged_path.to_s
+        end
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        preflight_steps do
+          set_permissions "Foo.app", "0755"
+        end
+
+        postflight_steps do
+          set_permissions "Foo.app", "0555", base: :appdir
+          set_ownership "foo", base: :homebrew_prefix
+        end
+
+        uninstall_preflight_steps do
+          set_ownership ["/usr/local/include", "/usr/local/lib"], user: "root", group: "wheel"
+        end
+
+        uninstall_postflight_steps do
+          set_ownership "."
+        end
+      end
+    CASK
+  end
+
+  it "does not autocorrect dynamic, unsupported or mixed permission work" do
+    expect_no_offenses <<~'CASK'
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        postflight do
+          set_ownership "#{staged_path}/foo-#{arch}"
+        end
+      end
+    CASK
+
+    expect_no_offenses <<~'CASK'
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        postflight do
+          set_permissions "#{staged_path}/Foo.app", "0755", recursive: false
+        end
+      end
+    CASK
+
+    expect_no_offenses <<~'CASK'
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        postflight do
+          set_ownership ["#{staged_path}/Foo.app", "#{appdir}/Foo.app"]
+        end
+      end
+    CASK
+
+    expect_no_offenses <<~'CASK'
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        postflight do
+          set_permissions "#{staged_path}/Foo.app", "0755"
+          system_command "/usr/bin/true"
+        end
+      end
+    CASK
+  end
+
   it "does not autocorrect config writes without trailing newlines" do
     expect_no_offenses <<~CASK
       cask "foo" do

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -193,6 +193,290 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
     RUBY
   end
 
+  it "autocorrects PostgreSQL bootstrap and link sequences into existing steps" do
+    expect_offense(<<~'RUBY')
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        post_install_steps do
+          touch "postgresql/state"
+        end
+
+        def post_install
+        ^^^^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Use `post_install_steps` for simple file preparation.
+          (var/"log").mkpath
+          postgresql_datadir.mkpath
+
+          %w[include lib share].each do |dir|
+            dst_dir = HOMEBREW_PREFIX/dir/name
+            src_dir = prefix/dir/"postgresql"
+            src_dir.find do |src|
+              dst = dst_dir/src.relative_path_from(src_dir)
+              next if dst.directory? && !dst.symlink? && src.directory? && !src.symlink?
+
+              rm_r(dst) if dst.exist? || dst.symlink?
+              if src.symlink? || src.file?
+                Find.prune if src.basename.to_s == ".DS_Store"
+                dst.parent.install_symlink src
+              elsif src.directory?
+                dst.mkpath
+              end
+            end
+          end
+
+          bin.each_child { |f| (HOMEBREW_PREFIX/"bin").install_symlink f => "#{f.basename}-#{version.major}" }
+          return if ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+          system bin/"initdb", "--locale=en_US.UTF-8", "-E", "UTF-8", postgresql_datadir unless pg_version_exists?
+          opoo "keep this legacy work"
+        end
+
+        def postgresql_datadir
+          var/name
+        end
+
+        def pg_version_exists?
+          (postgresql_datadir/"PG_VERSION").exist?
+        end
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        post_install_steps do
+          touch "postgresql/state"
+          mkdir_p "log"
+          link_dir "include/postgresql", "include/#{name}"
+          link_dir "lib/postgresql", "lib/#{name}"
+          link_dir "share/postgresql", "share/#{name}"
+          link_children "bin", suffix: "-#{version.major}"
+          init_data_dir name, using: :postgresql_initdb
+        end
+
+        def post_install
+          opoo "keep this legacy work"
+        end
+
+        def postgresql_datadir
+          var/name
+        end
+      end
+    RUBY
+  end
+
+  it "autocorrects MySQL bootstrap while retaining its warning" do
+    expect_offense(<<~'RUBY')
+      class Mysql < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        def post_install
+        ^^^^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Use `post_install_steps` for simple file preparation.
+          (var/"mysql").mkpath
+
+          if File.exist? "/etc/my.cnf"
+            opoo "existing configuration"
+          end
+
+          return if ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+          unless (datadir/"mysql/general_log.CSM").exist?
+            ENV["TMPDIR"] = nil
+            system bin/"mysqld", "--initialize-insecure", "--user=#{ENV["USER"]}",
+                                 "--basedir=#{prefix}", "--datadir=#{datadir}", "--tmpdir=/tmp"
+          end
+        end
+
+        def datadir
+          var/"mysql"
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Mysql < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        post_install_steps do
+          init_data_dir "mysql", using: :mysql_initialize
+        end
+
+        def post_install
+          if File.exist? "/etc/my.cnf"
+            opoo "existing configuration"
+          end
+        end
+
+        def datadir
+          var/"mysql"
+        end
+      end
+    RUBY
+  end
+
+  it "autocorrects MariaDB bootstrap-only hooks" do
+    expect_offense(<<~'RUBY')
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        def post_install
+        ^^^^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Use `post_install_steps` for simple file preparation.
+          (var/"mysql").mkpath
+          return if ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+          unless File.exist? "#{var}/mysql/mysql/user.frm"
+            ENV["TMPDIR"] = nil
+            system bin/"mysql_install_db", "--verbose", "--user=#{ENV["USER"]}",
+              "--basedir=#{prefix}", "--datadir=#{var}/mysql", "--tmpdir=/tmp"
+          end
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        post_install_steps do
+          init_data_dir "mysql", using: :mariadb_install_db
+        end
+      end
+    RUBY
+  end
+
+  it "does not autocorrect dynamic or unsupported database and link work" do
+    expect_no_offenses(<<~'RUBY')
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        def post_install
+          return if ENV["HOMEBREW_GITHUB_ACTIONS"]
+          system bin/"initdb", "--locale=#{ENV.fetch("LC_ALL")}", "-E", "UTF-8", postgresql_datadir
+        end
+      end
+    RUBY
+
+    expect_no_offenses(<<~'RUBY')
+      class PerconaServer < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        def post_install
+          (var/"mysql").mkpath
+          return if ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+          unless (datadir/"mysql/general_log.CSM").exist?
+            ENV["TMPDIR"] = nil
+            system bin/"mysqld", "--initialize-insecure", "--user=#{ENV["USER"]}",
+                                 "--basedir=#{prefix}", "--datadir=#{datadir}", "--tmpdir=/tmp"
+          end
+        end
+
+        def datadir
+          var/"mysql"
+        end
+      end
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      class Mysql < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        def post_install
+          (var/"mysql").mkpath
+          return if ENV["HOMEBREW_GITHUB_ACTIONS"]
+          system bin/"mysqld", "--initialize-insecure", "--skip-grant-tables"
+        end
+      end
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        def post_install
+          lib.each_child { |child| dynamic_target.install_symlink child }
+        end
+      end
+    RUBY
+  end
+
+  it "does not re-report declarative database and link steps" do
+    expect_no_offenses(<<~'RUBY')
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        post_install_steps do
+          link_dir "include/postgresql", "include/#{name}"
+          link_children "bin", suffix: "-#{version.major}"
+          init_data_dir name, using: :postgresql_initdb
+          symlink "cert.pem", "cert.pem",
+                  source_formula: "ca-certificates",
+                  source_base:    :formula_pkgetc,
+                  target_base:    :pkgetc,
+                  force:          true
+        end
+      end
+    RUBY
+  end
+
+  it "autocorrects direct certificate bundle symlinks while retaining legacy work" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        def post_install
+        ^^^^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Use `post_install_steps` for simple file preparation.
+          rm(pkgetc/"cert.pem") if (pkgetc/"cert.pem").exist?
+          pkgetc.install_symlink Formula["ca-certificates"].pkgetc/"cert.pem"
+          opoo "keep this legacy work"
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        post_install_steps do
+          symlink "cert.pem", "cert.pem",
+                  source_formula: "ca-certificates",
+                  source_base: :formula_pkgetc,
+                  target_base: :pkgetc,
+                  force: true
+        end
+
+        def post_install
+          opoo "keep this legacy work"
+        end
+      end
+    RUBY
+  end
+
+  it "does not autocorrect dynamic or unsupported certificate symlinks" do
+    expect_no_offenses(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        def post_install
+          rm(openssldir/"cert.pem") if (openssldir/"cert.pem").exist?
+          openssldir.install_symlink Formula["ca-certificates"].pkgetc/"cert.pem"
+        end
+      end
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        def post_install
+          rm(pkgetc/"cert.pem") if (pkgetc/"cert.pem").exist?
+          pkgetc.install_symlink Formula["custom-ca"].pkgetc/"cert.pem"
+        end
+      end
+    RUBY
+  end
+
   it "does not autocorrect non-file preparation in `post_install`" do
     expect_no_offenses(<<~RUBY)
       class Foo < Formula


### PR DESCRIPTION
- Enforce converted database and certificate formula hooks
- Enforce pure keychain, permission and ownership cask flights
- Preserve mixed legacy work through the incremental bridge

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 Sol max with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
