### PR TITLE
dependency: use same cache on recursive expand

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -190,12 +190,8 @@ class Dependency
       @expand_stack.push dependent.name
 
       begin
-        if cache_key.present?
-          cache_key = "#{cache_key}-#{cache_timestamp}" if cache_timestamp
-
-          if (entry = cache(cache_key, cache_timestamp:)[cache_id dependent])
-            return entry.dup
-          end
+        if cache_key.present? && (entry = cache(cache_key, cache_timestamp:)[cache_id dependent])
+          return entry.dup
         end
 
         expanded_deps = []
@@ -209,7 +205,8 @@ class Dependency
           when Dependable::SKIP
             next if @expand_stack.include? dep.name
 
-            expanded_deps.concat(expand(formula_for_dependency(dep, formula_cache), cache_key:, formula_cache:,
+            expanded_deps.concat(expand(formula_for_dependency(dep, formula_cache),
+                                        cache_key:, cache_timestamp:, formula_cache:,
                                         &block))
           when Dependable::KEEP_BUT_PRUNE_RECURSIVE_DEPS
             expanded_deps << dep
@@ -217,7 +214,7 @@ class Dependency
             next if @expand_stack.include? dep.name
 
             dep_formula = formula_for_dependency(dep, formula_cache)
-            expanded_deps.concat(expand(dep_formula, cache_key:, formula_cache:, &block))
+            expanded_deps.concat(expand(dep_formula, cache_key:, cache_timestamp:, formula_cache:, &block))
 
             # Fixes names for renamed/aliased formulae.
             dep = dep.dup_with_formula_name(dep_formula)


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Recursive calls to `expand` would switch from using timestamped cache to non-timestamped (with modified key). Also the key modification would break clearing stale entry

https://github.com/Homebrew/brew/blob/2d8bd600617332090b629c085eef4d18e1c27035/Library/Homebrew/formula.rb#L2709

https://github.com/Homebrew/brew/blob/2d8bd600617332090b629c085eef4d18e1c27035/Library/Homebrew/dependency.rb#L294-L296