### PR TITLE
Refactor away unnecessary T.must for first/last element access

### DIFF
--- a/Library/Homebrew/cask/artifact/generated_completion.rb
+++ b/Library/Homebrew/cask/artifact/generated_completion.rb
@@ -91,7 +91,7 @@ module Cask
 
       sig { params(_options: T.untyped).void }
       def install_phase(**_options)
-        executable = staged_path_join_executable(T.must(commands.first))
+        executable = staged_path_join_executable(commands.fetch(0))
 
         shells.each do |shell|
           popen_read_env = { "SHELL" => shell.to_s }
@@ -159,7 +159,7 @@ module Cask
       sig { returns(String) }
       def resolved_base_name
         @resolved_base_name ||= T.let(begin
-          executable = staged_path_join_executable(T.must(commands.first))
+          executable = staged_path_join_executable(commands.fetch(0))
           name = base_name || File.basename(executable.to_s)
           name = cask.token if name.empty?
           name

--- a/Library/Homebrew/descriptions.rb
+++ b/Library/Homebrew/descriptions.rb
@@ -80,7 +80,7 @@ class Descriptions
         names = description[0]
         next if description[1].nil?
 
-        description = T.must(description[1])
+        description = description.fetch(1)
         puts names.present? ? "#{display_name}: (#{names}) #{description}" : "#{display_name}: #{description}"
       else
         puts "#{display_name}: #{description}"

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -111,7 +111,7 @@ module Homebrew
         else
           PRIMARY_REPOS
         end
-        organisation ||= T.must(repositories.fetch(0).split("/").first)
+        organisation ||= repositories.fetch(0).split("/").fetch(0)
 
         users.each do |username|
           # TODO: Using the GitHub username to scan the `git log` undercounts some

--- a/Library/Homebrew/dev-cmd/generate-zap.rb
+++ b/Library/Homebrew/dev-cmd/generate-zap.rb
@@ -226,7 +226,7 @@ module Homebrew
           basenames = entries.map { |e| File.basename(e) }
           wildcarded = find_wildcard_groups(basenames)
 
-          dir = File.dirname(T.must(entries.first))
+          dir = File.dirname(entries.fetch(0))
           wildcarded.each do |name|
             result << File.join(dir, name)
           end

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -210,7 +210,7 @@ module Homebrew
           items = sort_items(filter_items(items_from_content(content)))
           return [] if items.empty?
 
-          item = T.must(items.first)
+          item = items.fetch(0)
 
           if block
             block_return_value = case block.parameters[0]

--- a/Library/Homebrew/rubocops/cask/uninstall_methods_order.rb
+++ b/Library/Homebrew/rubocops/cask/uninstall_methods_order.rb
@@ -132,7 +132,7 @@ module RuboCop
           end
 
           add_offense(on_upgrade_pair.key, message: USELESS_METADATA_MSG) do |corrector|
-            first_pair = T.must(remaining_pairs.first)
+            first_pair = remaining_pairs.fetch(0)
             indentation = " " * (start_column(first_pair.key) - line_start_column(first_pair.key))
 
             new_code = build_uninstall_body(remaining_pairs, comments, indentation)

--- a/Library/Homebrew/rubocops/extend/formula_cop.rb
+++ b/Library/Homebrew/rubocops/extend/formula_cop.rb
@@ -238,7 +238,7 @@ module RuboCop
         return false if @tap_style_exceptions.nil? || @tap_style_exceptions.none?
         return false unless @tap_style_exceptions.key? list
 
-        T.must(@tap_style_exceptions[list]).include?(formula || @formula_name)
+        @tap_style_exceptions.fetch(list).include?(formula || @formula_name)
       end
 
       private

--- a/Library/Homebrew/utils/ast.rb
+++ b/Library/Homebrew/utils/ast.rb
@@ -445,7 +445,7 @@ module Utils
         groups = T.let([], T::Array[T::Array[BlockNode]])
         resource_nodes.each do |resource_node|
           previous_group = groups.last
-          if previous_group.nil? || !resource_stanzas_contiguous?(T.must(previous_group.last), resource_node)
+          if previous_group.nil? || !resource_stanzas_contiguous?(previous_group.fetch(-1), resource_node)
             groups << [resource_node]
           else
             previous_group << resource_node
@@ -465,8 +465,8 @@ module Utils
 
       sig { params(group: T::Array[BlockNode]).returns(Parser::Source::Range) }
       def resource_stanza_group_range(group)
-        first_range = source_range_with_leading_resource_error_comments(T.must(group.first).source_range)
-        last_range = whole_line_range(T.must(group.last).source_range, include_following_blank_lines: true)
+        first_range = source_range_with_leading_resource_error_comments(group.fetch(0).source_range)
+        last_range = whole_line_range(group.fetch(-1).source_range, include_following_blank_lines: true)
         first_range.with(
           begin_pos: first_range.begin_pos - first_range.column,
           end_pos:   last_range.end_pos,


### PR DESCRIPTION
Several call sites used `T.must(...)` just to strip nilability off an
element that's known to be present: `T.must(array.first)`,
`T.must(array.last)` and `T.must(hash[key])`. These read as "trust me,
Sorbet" escape hatches when the real intent is "this element must exist".

This swaps them for `fetch`, which states the same non-nil guarantee
directly and raises a clear `IndexError`/`KeyError` if the assumption is
ever violated, rather than leaning on `T.must` and producing a less
obvious `TypeError`:

- `T.must(arr.first)` becomes `arr.fetch(0)`
- `T.must(arr.last)` becomes `arr.fetch(-1)`
- `T.must(hash[key])` becomes `hash.fetch(key)`

No behaviour change on the happy path. The affected code already
guaranteed the elements were present, either through `empty?`/`nil?`
guards or by being non-empty by construction.

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do?
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)?
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.
