### PR TITLE
Explain why we check for flat_namespace usage

### DIFF
--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -103,6 +103,7 @@ module OS
 
       sig { params(formula: ::Formula).returns(T.nilable(String)) }
       def check_flat_namespace(formula)
+        # See https://developer.apple.com/forums/thread/689991?answerId=687895022#687895022
         return unless formula.prefix.directory?
         return if formula.tap&.audit_exception(:flat_namespace_allowlist, formula.name)
 

--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -103,7 +103,6 @@ module OS
 
       sig { params(formula: ::Formula).returns(T.nilable(String)) }
       def check_flat_namespace(formula)
-        # See https://developer.apple.com/forums/thread/689991?answerId=687895022#687895022
         return unless formula.prefix.directory?
         return if formula.tap&.audit_exception(:flat_namespace_allowlist, formula.name)
 
@@ -125,6 +124,8 @@ module OS
           This can cause linker errors due to name collisions and
           is often due to a bug in detecting the macOS version.
             #{flat_namespace_files * "\n  "}
+           Learn more about this in:
+            #{Formatter.url("https://developer.apple.com/forums/thread/689991?answerId=687895022#687895022")}
         EOS
       end
 


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [ ] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
Since people have previously assumed that this is something Homebrew came up with and I couldn't find any reference to the original issue I think it would be good to reference why we check for this in the check itself.