### PR TITLE
Stop silently ignoring bottle manifest download failures

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -99,9 +99,8 @@ module Homebrew
     sig { void }
     def fetch
       @fetch_failed = false
-      return if downloads.empty?
-
       context_before_fetch = Context.current
+      return if downloads.empty?
 
       if concurrency == 1
         downloads.each do |downloadable, promise|
@@ -111,8 +110,11 @@ module Homebrew
         rescue ChecksumMismatchError => e
           @fetch_failed = true
           ofail "#{downloadable.download_queue_type} reports different checksum: #{e.expected}"
-        rescue => e
-          raise e unless bottle_manifest_error?(downloadable, e)
+        # Cancel downloads still running in the background before a fatal error
+        # (e.g. a missing bottle manifest) aborts the fetch.
+        rescue
+          cancel
+          raise
         end
       else
         message_length_max = downloads.keys.map { |download| download.download_queue_message.length }.max || 0
@@ -129,7 +131,6 @@ module Homebrew
             status = status_from_future(future)
             exception = future.reason if future.rejected?
             next 1 if exception.is_a?(CancelledDownloadError)
-            next 1 if bottle_manifest_error?(downloadable, exception)
 
             message = downloadable.download_queue_message
             if tty_with_cursor_move_support?
@@ -151,6 +152,11 @@ module Homebrew
               elsif exception.is_a?(CannotInstallFormulaError)
                 cached_download = downloadable.cached_download
                 cached_download.unlink if cached_download&.exist?
+                raise exception
+              elsif bottle_manifest_error?(downloadable, exception)
+                # Fatal: unlike a missing blob (which then fails to stage), a
+                # stale blob would still pour without the manifest tab that
+                # drives relocation, so abort rather than stage a broken keg.
                 raise exception
               else
                 message = if exception.is_a?(DownloadError) && exception.cause.is_a?(ErrorDuringExecution)
@@ -230,9 +236,11 @@ module Homebrew
           stdout_print_and_flush_if_tty Tty.show_cursor
         end
       end
-
-      # Restore the pre-parallel fetch context to avoid e.g. quiet state bleeding out from threads.
-      Context.current = context_before_fetch
+    ensure
+      # Restore the pre-parallel fetch context to avoid quiet state bleeding out
+      # from threads, and clear queue state even when a fatal download error
+      # aborts the fetch above.
+      Context.current = context_before_fetch if context_before_fetch
 
       downloads.clear
       @downloads_by_location.clear

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -41,6 +41,25 @@ RSpec.describe Homebrew::DownloadQueue do
     expect(Homebrew).to have_failed
   end
 
+  it "raises and clears queue state on a bottle manifest failure in parallel mode" do
+    allow(retryable_download).to receive(:fetch).and_raise(Resource::BottleManifest::Error.new("manifest missing"))
+
+    download_queue.enqueue(downloadable)
+
+    expect { download_queue.fetch }.to raise_error(Resource::BottleManifest::Error, /manifest missing/)
+    expect(download_queue.send(:downloads)).to be_empty
+  end
+
+  it "cancels remaining downloads and raises on a bottle manifest failure in serial mode" do
+    allow(Homebrew::EnvConfig).to receive(:download_concurrency).and_return(1)
+    allow(retryable_download).to receive(:fetch).and_raise(Resource::BottleManifest::Error.new("manifest missing"))
+
+    download_queue.enqueue(downloadable)
+
+    expect(download_queue).to receive(:cancel)
+    expect { download_queue.fetch }.to raise_error(Resource::BottleManifest::Error, /manifest missing/)
+  end
+
   it "wakes when downloads complete instead of polling with sleep" do
     allow($stdout).to receive(:tty?).and_return(false)
     allow(retryable_download).to receive(:fetch) { sleep(0.1) }


### PR DESCRIPTION
<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Opus 4.8 with manual review and testing.

-----

A missing manifest file can be due to a version/revision bump PR being merged
without bottles. Ignoring this error causes the bottles fetch test in
Homebrew/core CI to erroneously pass, and a broken unrelocated install of the
old formula version in the Cellar.

Let's fix that by making failed manifest fetches fatal, and refusing to pour
bottles that we failed to fetch manifests for whenever there should have been
one.

For previous issues on merged version bump PRs with unpublished bottles, see,
for example, Homebrew/homebrew-core#293511, Homebrew/discussions#6948, and #23133.