### PR TITLE
Keep cask upgrades after approval failure

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -445,6 +445,10 @@ module Cask
           when :release
             new_cask.artifacts.grep(Artifact::App).each do |artifact|
               Quarantine.inherit_user_approval!(download_path: artifact.target)
+            rescue CaskQuarantineReleaseError => e
+              odebug e
+              opoo "Homebrew couldn't inherit #{new_cask.token}'s quarantine approval so macOS will prompt at " \
+                   "next launch."
             end
           when :signer_changed
             opoo "#{new_cask.token}'s signer changed so macOS will prompt at next launch."

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -583,6 +583,21 @@ RSpec.describe Cask::Upgrade, :cask do
       described_class.upgrade_casks!(local_caffeine, args:)
     end
 
+    it "continues the upgrade when quarantine approval cannot be inherited" do
+      identity = Cask::Quarantine::SigningIdentity.new(requirement: 'identifier "sh.brew.local-caffeine"')
+      allow(Cask::Quarantine).to receive_messages(
+        user_approved?:         true,
+        signing_identity:       identity,
+        signing_identity_match: true,
+      )
+      allow(Cask::Quarantine).to receive(:inherit_user_approval!)
+        .and_raise(Cask::CaskQuarantineReleaseError.new(local_caffeine_path, "Operation not permitted"))
+
+      expect do
+        described_class.upgrade_casks!(local_caffeine, args:)
+      end.to output(/couldn't inherit local-caffeine's quarantine approval so macOS will prompt/).to_stderr
+    end
+
     it "reports the skipped quarantine release under --verbose when approval is missing" do
       allow(Cask::Quarantine).to receive_messages(user_approved?: false, inherit_user_approval!: nil)
 


### PR DESCRIPTION
- Leave the app quarantined when macOS rejects approval inheritance.
- Warn about the next-launch prompt instead of rolling back the upgrade.

Fixes https://github.com/Homebrew/brew/issues/23131

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 Sol max with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
