### PR TITLE
Recover legacy Cask metadata

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -153,7 +153,7 @@ module Cask
 
         path = Pathname(path).expand_path
 
-        @token = T.let(path.basename(path.extname).basename(".internal").to_s, String)
+        @token = T.let(CaskLoader.token_from_path(path), String)
         @path = T.let(path, Pathname)
         @tap = T.let(Tap.from_path(path) || Homebrew::API.tap_from_source_download(path), T.nilable(Tap))
         @from_installed_caskfile = T.let(false, T::Boolean)
@@ -459,11 +459,15 @@ module Cask
       def load_from_json(config:, api_source:)
         if @from_installed_caskfile
           api_source = api_source.dup
-          installed_tab = Cask.new(token).tab
-          api_source["version"] = api_source["version"].presence ||
-                                  @sourcefile_path.dirname.dirname.dirname.basename.to_s.presence ||
-                                  installed_tab.version.presence
-          api_source["artifacts"] ||= installed_tab.uninstall_artifacts || []
+          api_source["version"] = api_source["version"].presence
+          api_source["version"] ||= @sourcefile_path.dirname.dirname.dirname.basename.to_s.presence
+          if api_source["version"].nil? || api_source["artifacts"].nil?
+            installed_tab = CaskLoader.load_installed_tab(token)
+            api_source["version"] ||= installed_tab.version.presence
+            api_source["artifacts"] ||= CaskLoader.resolve_installed_artifacts(
+              token, installed_tab.uninstall_artifacts
+            )
+          end
         end
 
         tap_git_head = api_source["tap_git_head"]
@@ -616,7 +620,7 @@ module Cask
         token = if ref.is_a?(String)
           ref
         elsif ref.is_a?(Pathname)
-          ref.basename(ref.extname).basename(".internal").to_s
+          CaskLoader.token_from_path(ref)
         end
         return unless token
 
@@ -776,6 +780,103 @@ module Cask
       loader ||= NullLoader.new(path)
 
       loader.load(config:)
+    end
+
+    sig { params(path: Pathname).returns(String) }
+    def self.token_from_path(path)
+      path.basename(path.extname).basename(".internal").to_s
+    end
+
+    # Legacy `.internal.json` files contain full API data rather than the compact installed JSON format.
+    sig { params(path: Pathname).returns(T::Boolean) }
+    def self.installed_json_caskfile?(path)
+      path.extname == ".json" && !path.basename.to_s.end_with?(".internal.json")
+    end
+
+    sig { params(path: Pathname).returns(T.nilable(T::Hash[String, T.untyped])) }
+    def self.load_installed_json(path)
+      return unless installed_json_caskfile?(path)
+
+      json = JSON.parse(path.read)
+      json if json.is_a?(Hash)
+    rescue JSON::ParserError
+      nil
+    end
+
+    sig { params(cask_or_token: T.any(Cask, String)).returns(Tab) }
+    def self.load_installed_tab(cask_or_token)
+      cask = if cask_or_token.is_a?(Cask)
+        cask_or_token
+      else
+        Cask.new(cask_or_token)
+      end
+      cask.tab
+    rescue JSON::ParserError, NoMethodError, TypeError
+      Tab.empty
+    end
+
+    sig { params(token: String, artifacts: T.nilable(T::Array[T.untyped])).returns(T::Array[T.untyped]) }
+    def self.resolve_installed_artifacts(token, artifacts)
+      artifacts = artifacts.presence
+      # API fetch failures must not abort best-effort installed metadata recovery.
+      artifacts ||= begin
+        Homebrew::API::Cask.cask_json(token)["artifacts"]
+      rescue SystemExit
+        nil
+      end
+      artifacts ||= []
+      artifacts
+    end
+
+    sig {
+      params(
+        path:          Pathname,
+        tab:           T.nilable(Tab),
+        fallback_cask: T.nilable(Cask),
+        config:        T.nilable(Config),
+      ).returns(T.nilable(Cask))
+    }
+    def self.recover_from_installed_caskfile(path, tab: nil, fallback_cask: nil, config: nil)
+      # Only installed metadata has the versioned path layout used to rebuild the cask below.
+      return if path.dirname.basename.to_s != "Casks"
+
+      # Read any usable receipt, while retaining the current cask as a fallback for missing receipt data.
+      token = token_from_path(path)
+      tab ||= load_installed_tab(fallback_cask || token)
+
+      # Ruby uninstall flight blocks cannot be represented by installed JSON and must not be approximated.
+      return if tab.uninstall_flight_blocks
+      return if fallback_cask&.uninstall_flight_blocks?
+
+      # Prefer exact receipt artifacts, then the current cask and finally the current API definition.
+      artifacts = tab.uninstall_artifacts.presence
+      artifacts ||= fallback_cask.artifacts_list(uninstall_only: true) if fallback_cask
+      artifacts ||= resolve_installed_artifacts(token, nil)
+
+      # Rebuild the installed version from its metadata directory and retain current source path information.
+      api_source = {
+        "version"   => path.dirname.dirname.dirname.basename.to_s,
+        "artifacts" => artifacts,
+      }
+      api_source["url_specs"] ||= fallback_cask.to_installed_json_hash["url_specs"] if fallback_cask
+
+      # Prefer the installed JSON's source path because it belongs to the installed version.
+      if (source_json = load_installed_json(path))
+        source_url_specs = source_json["url_specs"]
+        api_source["url_specs"] = source_url_specs if source_url_specs.is_a?(Hash)
+      end
+
+      # Load through the installed-JSON path so reconstructed artifacts have normal installed paths and behaviour.
+      recovered_cask = FromAPILoader.new(
+        token,
+        from_json:               api_source,
+        path:,
+        from_installed_caskfile: true,
+      ).load(config:)
+      recovered_cask unless recovered_cask.uninstall_flight_blocks?
+    rescue CaskInvalidError, CaskUnavailableError, MethodDeprecatedError, JSON::ParserError
+      # Recovery is best effort; callers treat nil as an unavailable installed cask and use their existing fallback.
+      nil
     end
 
     sig { params(token: T.any(String, Symbol)).returns(Pathname) }

--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -68,6 +68,81 @@ module Cask
       caskfile.dirname.dirname.dirname.basename.to_s
     end
 
+    sig { params(caskfile: Pathname).void }
+    def self.migrate_caskfile_to_json(caskfile)
+      # Parse regular installed JSON so current files can be skipped and useful URL data can survive repairs.
+      token = CaskLoader.token_from_path(caskfile)
+      installed_json_caskfile = CaskLoader.installed_json_caskfile?(caskfile)
+      source_json = CaskLoader.load_installed_json(caskfile)
+
+      source_artifacts = nil
+      source_url_specs = nil
+      current_json = false
+      if source_json
+        raw_source_artifacts = source_json["artifacts"]
+        raw_source_version = source_json["version"]
+        raw_source_url_specs = source_json["url_specs"]
+        source_artifacts = raw_source_artifacts if raw_source_artifacts.is_a?(Array)
+        source_url_specs = raw_source_url_specs if raw_source_url_specs.is_a?(Hash)
+
+        # Installed JSON only supplements metadata available from the path or receipt: artifacts and version preserve
+        # otherwise-lost installed values, while url_specs preserves an artifact's staged source path.
+        current_json = (source_json.keys - %w[artifacts url_specs version]).empty? &&
+                       (raw_source_artifacts.nil? || !source_artifacts.nil?) &&
+                       (raw_source_version.nil? || raw_source_version.is_a?(String)) &&
+                       (raw_source_url_specs.nil? || !source_url_specs.nil?)
+      end
+
+      # Recover missing receipt and legacy caskfile data before deciding what must be stored in the JSON.
+      tab = CaskLoader.load_installed_tab(token)
+
+      cask = begin
+        if installed_json_caskfile
+          CaskLoader.load_from_installed_caskfile(caskfile)
+        else
+          CaskLoader.load(caskfile, warn: false)
+        end
+      rescue CaskInvalidError, CaskUnavailableError, MethodDeprecatedError, JSON::ParserError, NoMethodError,
+             TypeError
+        nil
+      end
+      return if current_json && cask && (!source_artifacts.nil? || tab.uninstall_artifacts.present?)
+      return if cask&.uninstall_flight_blocks? || tab.uninstall_flight_blocks
+
+      cask ||= CaskLoader.recover_from_installed_caskfile(caskfile, tab:)
+      return unless cask
+
+      # Preserve the original version and artifacts whenever the receipt cannot reproduce them.
+      version = cask.version.to_s
+      json_uninstall_artifacts = JSON.parse(JSON.generate(cask.artifacts_list(uninstall_only: true)))
+      installed_json = cask.to_installed_json_hash
+      installed_json["url_specs"] ||= source_url_specs if source_url_specs
+      if tab.uninstall_artifacts.presence != json_uninstall_artifacts
+        installed_json["artifacts"] = json_uninstall_artifacts
+      end
+      installed_json["version"] = version if caskfile.dirname.dirname.dirname.basename.to_s != version
+
+      # Replace the old metadata only after the new JSON reloads with the selected version and artifacts.
+      json_caskfile = caskfile.dirname/"#{token}.json"
+      original_contents = caskfile.read if caskfile == json_caskfile
+      json_caskfile.atomic_write(JSON.pretty_generate(installed_json))
+      begin
+        migrated_cask = CaskLoader.load_from_installed_caskfile(json_caskfile)
+        if migrated_cask.version.to_s != version ||
+           JSON.parse(JSON.generate(migrated_cask.artifacts_list(uninstall_only: true))) != json_uninstall_artifacts
+          raise "migrated Cask metadata differs from the original after preserving version and artifacts"
+        end
+      rescue
+        if original_contents
+          json_caskfile.atomic_write(original_contents)
+        elsif json_caskfile.exist?
+          json_caskfile.unlink
+        end
+        raise
+      end
+      caskfile.unlink if caskfile != json_caskfile
+    end
+
     # Return tokens for Caskroom directories missing expected installed metadata.
     sig { returns(T::Array[String]) }
     def self.corrupt_cask_dirs

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -233,7 +233,7 @@ on_request: true)
         if (installed_caskfile = Caskroom.cask_installed_caskfile(conflicting_cask))
           raise CaskConflictError.new(
             @cask,
-            ::Cask::Cask.new(installed_caskfile.basename(installed_caskfile.extname).basename(".internal").to_s),
+            ::Cask::Cask.new(CaskLoader.token_from_path(installed_caskfile)),
           )
         end
 
@@ -520,7 +520,9 @@ on_request: true)
       if @cask.uninstall_flight_blocks?
         (metadata_subdir/"#{@cask.token}.rb").write @cask.source.to_s
       else
-        (metadata_subdir/"#{@cask.token}.json").write JSON.pretty_generate(@cask.to_installed_json_hash)
+        installed_json = @cask.to_installed_json_hash
+        installed_json["artifacts"] = [] if @cask.artifacts_list(uninstall_only: true).empty?
+        (metadata_subdir/"#{@cask.token}.json").write JSON.pretty_generate(installed_json)
       end
 
       FileUtils.rm_r(old_savedir) if old_savedir
@@ -949,24 +951,6 @@ on_request: true)
       download_queue.enqueue(downloader)
     end
 
-    private
-
-    sig { void }
-    def check_prelude_requirements
-      check_deprecate_disable
-      check_conflicts
-      check_requirements
-      # Run the cask-self forbidden checks before loading the caskfile from the
-      # Source API so a forbidden cask never triggers a network fetch.
-      forbidden_tap_check(cask_only: true)
-      forbidden_cask_and_formula_check(cask_only: true)
-    end
-
-    sig { returns(Homebrew::API::SourceDownload) }
-    def source_download
-      @source_download ||= Homebrew::API::Cask.source_download_for(@cask)
-    end
-
     # load the same cask file that was used for installation, if possible
     sig { void }
     def load_installed_caskfile!
@@ -975,8 +959,9 @@ on_request: true)
       installed_caskfile = @cask.installed_caskfile
 
       if installed_caskfile&.exist?
-        tab = @cask.tab
+        tab = CaskLoader.load_installed_tab(@cask)
         tap = tab.tap
+        tap ||= @cask.tap
         if installed_caskfile.extname == ".rb" &&
            Homebrew::EnvConfig.require_tap_trust? &&
            tap &&
@@ -1019,10 +1004,34 @@ on_request: true)
         rescue CaskInvalidError, CaskUnavailableError, MethodDeprecatedError
           # could be caused by trying to load outdated or deleted caskfile
         end
+
+        recovered_cask = CaskLoader.recover_from_installed_caskfile(installed_caskfile, tab:, fallback_cask: @cask)
+        if recovered_cask
+          @cask = recovered_cask
+          return
+        end
       end
 
       load_cask_from_source_api! if cask_from_source_api?
       # otherwise we default to the current cask
+    end
+
+    private
+
+    sig { void }
+    def check_prelude_requirements
+      check_deprecate_disable
+      check_conflicts
+      check_requirements
+      # Run the cask-self forbidden checks before loading the caskfile from the
+      # Source API so a forbidden cask never triggers a network fetch.
+      forbidden_tap_check(cask_only: true)
+      forbidden_cask_and_formula_check(cask_only: true)
+    end
+
+    sig { returns(Homebrew::API::SourceDownload) }
+    def source_download
+      @source_download ||= Homebrew::API::Cask.source_download_for(@cask)
     end
 
     sig { void }

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -193,7 +193,7 @@ module Cask
           begin
             CaskLoader.load_from_installed_caskfile(installed_caskfile)
           rescue CaskInvalidError, CaskUnavailableError, MethodDeprecatedError
-            nil
+            CaskLoader.recover_from_installed_caskfile(installed_caskfile, fallback_cask: c)
           end
         end
 

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -368,12 +368,8 @@ module Homebrew
       def migrate_caskroom_caskfiles_to_json
         return unless Cask::Caskroom.path.directory?
 
-        Cask::Caskroom.path.glob("*/.metadata/*/*/Casks/*.{internal.json,rb}").each do |caskfile|
-          cask = Cask::CaskLoader.load(caskfile, warn: false)
-          next if cask.uninstall_flight_blocks?
-
-          (caskfile.dirname/"#{cask.token}.json").atomic_write(JSON.pretty_generate(cask.to_installed_json_hash))
-          caskfile.unlink
+        Cask::Caskroom.path.glob("*/.metadata/*/*/Casks/*.{json,rb}").each do |caskfile|
+          Cask::Caskroom.migrate_caskfile_to_json(caskfile)
         rescue => e
           opoo "Failed to migrate #{caskfile} to JSON metadata: #{e}"
         end

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -183,6 +183,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
       token = "url-less-installed-cask"
       caskroom = mktmpdir
       allow(Cask::Caskroom).to receive(:path).and_return(caskroom)
+      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({ "artifacts" => [] })
       path = caskroom/token/".metadata/latest/20260713000000.000/Casks/#{token}.json"
       cask = described_class.new(token, from_json: {}, path:, from_installed_caskfile: true).load(config: nil)
       allow(cask).to receive(:installed_version).and_return("latest")
@@ -190,6 +191,50 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
       cask.download_sha_path.write("old-download-sha")
 
       expect(cask.outdated?(greedy: true)).to be(true)
+    end
+
+    it "uses current API artifacts for installed metadata without receipt artifacts" do
+      token = "receipt-less-installed-cask"
+      caskroom = mktmpdir
+      allow(Cask::Caskroom).to receive(:path).and_return(caskroom)
+      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({
+        "artifacts" => [
+          { "app" => ["Receipt-less.app"] },
+          { "uninstall" => [{ "quit" => "com.example.receipt-less" }] },
+          { "zap" => [{ "trash" => "~/Library/Preferences/com.example.receipt-less.plist" }] },
+        ],
+      })
+      path = caskroom/token/".metadata/1.0/20260713000000.000/Casks/#{token}.json"
+
+      cask = described_class.new(token, from_json: {}, path:, from_installed_caskfile: true).load(config: nil)
+
+      expect(cask.artifacts_list(uninstall_only: true)).to eq([
+        { uninstall: [{ quit: "com.example.receipt-less" }] },
+        { app: ["Receipt-less.app"] },
+        { zap: [{ trash: "~/Library/Preferences/com.example.receipt-less.plist" }] },
+      ])
+    end
+
+    it "does not read a malformed receipt when installed metadata is self-contained" do
+      token = "self-contained-installed-cask"
+      caskroom = mktmpdir
+      allow(Cask::Caskroom).to receive(:path).and_return(caskroom)
+      receipt = caskroom/token/".metadata/INSTALL_RECEIPT.json"
+      receipt.dirname.mkpath
+      receipt.write("{")
+      path = caskroom/token/".metadata/1.0/20260713000000.000/Casks/#{token}.json"
+
+      cask = described_class.new(
+        token,
+        from_json:               {
+          "version"   => "1.0",
+          "artifacts" => [{ "app" => ["Self-contained.app"] }],
+        },
+        path:,
+        from_installed_caskfile: true,
+      ).load(config: nil)
+
+      expect(cask.artifacts_list(uninstall_only: true)).to eq([{ app: ["Self-contained.app"] }])
     end
 
     shared_examples "loads from API" do |cask_token, caskfile_only:|

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -540,4 +540,71 @@ RSpec.describe Cask::CaskLoader, :cask do
       end
     end
   end
+
+  describe "::resolve_installed_artifacts" do
+    it "returns empty artifacts when the API cannot be loaded" do
+      allow(Homebrew::API::Cask).to receive(:cask_json).with("unavailable").and_raise(SystemExit.new(1))
+
+      expect(described_class.resolve_installed_artifacts("unavailable", nil)).to eq([])
+    end
+  end
+
+  describe "::recover_from_installed_caskfile" do
+    let(:caskroom) { mktmpdir/"Caskroom" }
+
+    before { allow(Cask::Caskroom).to receive(:path).and_return(caskroom) }
+
+    it "reconstructs the installed version and artifacts from its receipt" do
+      token = "recoverable"
+      caskfile = caskroom/token/".metadata/1.0/20250101000000.000/Casks/#{token}.rb"
+      caskfile.dirname.mkpath
+      caskfile.write("unreadable")
+      (caskroom/token/".metadata/INSTALL_RECEIPT.json").write JSON.generate({
+        "source"                  => { "version" => "1.0" },
+        "uninstall_flight_blocks" => false,
+        "uninstall_artifacts"     => [{ "app" => ["Recoverable.app"] }],
+      })
+      expect(Homebrew::API::Cask).not_to receive(:cask_json)
+
+      recovered_cask = described_class.recover_from_installed_caskfile(caskfile)
+
+      expect([
+        recovered_cask&.version&.to_s,
+        recovered_cask&.artifacts_list(uninstall_only: true),
+      ]).to eq([
+        "1.0",
+        [{ app: ["Recoverable.app"] }],
+      ])
+    end
+
+    it "does not reconstruct missing uninstall flight blocks" do
+      token = "flight-block"
+      caskfile = caskroom/token/".metadata/1.0/20250101000000.000/Casks/#{token}.rb"
+      caskfile.dirname.mkpath
+      caskfile.write("unreadable")
+      (caskroom/token/".metadata/INSTALL_RECEIPT.json").write JSON.generate({
+        "source"                  => { "version" => "1.0" },
+        "uninstall_flight_blocks" => true,
+        "uninstall_artifacts"     => [{ "uninstall_preflight" => nil }],
+      })
+      expect(Homebrew::API::Cask).not_to receive(:cask_json)
+
+      expect(described_class.recover_from_installed_caskfile(caskfile)).to be_nil
+    end
+
+    it "returns nil when the reconstructed metadata remains invalid" do
+      token = "still-invalid"
+      caskfile = caskroom/token/".metadata/1.0/20250101000000.000/Casks/#{token}.rb"
+      caskfile.dirname.mkpath
+      caskfile.write("unreadable")
+      (caskroom/token/".metadata/INSTALL_RECEIPT.json").write JSON.generate({
+        "source"              => { "version" => "1.0" },
+        "uninstall_artifacts" => [{ "app" => ["Still Invalid.app"] }],
+      })
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:new)
+        .and_raise(Cask::CaskInvalidError.new(token, "invalid recovered metadata"))
+
+      expect(described_class.recover_from_installed_caskfile(caskfile)).to be_nil
+    end
+  end
 end

--- a/Library/Homebrew/test/cask/caskroom_spec.rb
+++ b/Library/Homebrew/test/cask/caskroom_spec.rb
@@ -230,6 +230,147 @@ RSpec.describe Cask::Caskroom do
     end
   end
 
+  describe ".migrate_caskfile_to_json" do
+    sig { returns(Pathname) }
+    let(:caskroom) { mktmpdir/"Caskroom" }
+
+    before { allow(described_class).to receive(:path).and_return(caskroom) }
+
+    sig { params(token: String, contents: String, extension: String).returns(Pathname) }
+    def write_installed_caskfile(token, contents, extension: "rb")
+      caskfile = caskroom/token/".metadata/1.0/20250101000000.000/Casks/#{token}.#{extension}"
+      caskfile.dirname.mkpath
+      caskfile.write(contents)
+      caskfile
+    end
+
+    sig { params(token: String, artifacts: T::Array[T::Hash[String, T.untyped]]).void }
+    def write_receipt(token, artifacts)
+      (caskroom/token/".metadata/INSTALL_RECEIPT.json").write JSON.pretty_generate({
+        "source"              => { "version" => "1.0" },
+        "uninstall_artifacts" => artifacts,
+      })
+    end
+
+    it "uses receipt metadata when a Ruby caskfile is unreadable" do
+      token = "unreadable"
+      caskfile = write_installed_caskfile(token, "this is not Ruby")
+      write_receipt(token, [{ "app" => ["Unreadable.app"] }])
+
+      described_class.migrate_caskfile_to_json(caskfile)
+
+      json_caskfile = caskfile.sub_ext(".json")
+      migrated_cask = Cask::CaskLoader.load_from_installed_caskfile(json_caskfile)
+      expect([
+        caskfile.exist?,
+        JSON.parse(json_caskfile.read),
+        migrated_cask.version.to_s,
+        migrated_cask.artifacts_list(uninstall_only: true),
+      ]).to eq([
+        false,
+        {},
+        "1.0",
+        [{ app: ["Unreadable.app"] }],
+      ])
+    end
+
+    it "uses API metadata when a Ruby caskfile contains a removed method" do
+      token = "removed-method"
+      caskfile = write_installed_caskfile(token, <<~RUBY)
+        cask "#{token}" do
+          version "1.0"
+          appcast "https://example.com/appcast.xml"
+          app "Old.app"
+        end
+      RUBY
+      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({
+        "artifacts" => [{ "app" => ["Current.app"] }],
+      })
+
+      described_class.migrate_caskfile_to_json(caskfile)
+
+      expect(JSON.parse(caskfile.sub_ext(".json").read)).to eq({
+        "artifacts" => [{ "app" => ["Current.app"] }],
+      })
+    end
+
+    it "uses API metadata when a Ruby caskfile contains a deprecated method" do
+      token = "deprecated-method"
+      caskfile = write_installed_caskfile(token, <<~RUBY)
+        cask "#{token}" do
+          version "1.0"
+          app "Old.app"
+        end
+      RUBY
+      allow(Cask::CaskLoader).to receive(:load)
+        .with(caskfile, warn: false)
+        .and_raise(MethodDeprecatedError.new)
+      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({
+        "artifacts" => [{ "app" => ["Current.app"] }],
+      })
+
+      described_class.migrate_caskfile_to_json(caskfile)
+
+      expect(JSON.parse(caskfile.sub_ext(".json").read)).to eq({
+        "artifacts" => [{ "app" => ["Current.app"] }],
+      })
+    end
+
+    it "preserves artifacts when the install receipt is empty" do
+      token = "empty-receipt"
+      caskfile = write_installed_caskfile(token, <<~RUBY)
+        cask "#{token}" do
+          version "1.0"
+          app "Empty Receipt.app"
+        end
+      RUBY
+      (caskroom/token/".metadata/INSTALL_RECEIPT.json").write("")
+
+      described_class.migrate_caskfile_to_json(caskfile)
+
+      expect(JSON.parse(caskfile.sub_ext(".json").read)).to eq({
+        "artifacts" => [{ "app" => ["Empty Receipt.app"] }],
+      })
+    end
+
+    it "replaces malformed installed JSON using API metadata" do
+      token = "malformed-json"
+      caskfile = write_installed_caskfile(token, "{", extension: "json")
+      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({
+        "artifacts" => [{ "app" => ["Current.app"] }],
+      })
+
+      described_class.migrate_caskfile_to_json(caskfile)
+
+      expect(JSON.parse(caskfile.read)).to eq({
+        "artifacts" => [{ "app" => ["Current.app"] }],
+      })
+    end
+
+    it "replaces invalid artifact data in installed JSON using API metadata" do
+      token = "invalid-artifacts"
+      caskfile = write_installed_caskfile(token, JSON.generate({ "artifacts" => ["invalid"] }), extension: "json")
+      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({
+        "artifacts" => [{ "app" => ["Current.app"] }],
+      })
+
+      described_class.migrate_caskfile_to_json(caskfile)
+
+      expect(JSON.parse(caskfile.read)).to eq({
+        "artifacts" => [{ "app" => ["Current.app"] }],
+      })
+    end
+
+    it "keeps intentional empty artifacts in installed JSON" do
+      caskfile = write_installed_caskfile("stage-only", JSON.generate({ "artifacts" => [] }), extension: "json")
+      expect(Homebrew::API::Cask).not_to receive(:cask_json)
+
+      described_class.migrate_caskfile_to_json(caskfile)
+
+      expect(JSON.parse(caskfile.read)).to eq({ "artifacts" => [] })
+    end
+  end
+
   describe ".corrupt_cask_dirs" do
     it "returns tokens for directories without valid caskfiles" do
       Dir.mktmpdir do |dir|

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Cask::Installer, :cask do
       cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
 
       described_class.new(cask).save_caskfile
+      Cask::Tab.create(cask).write
 
       expect([
         cask.installed_caskfile&.basename&.to_s,
@@ -44,12 +45,20 @@ RSpec.describe Cask::Installer, :cask do
       ])
     end
 
-    it "strips legacy install flight blocks from JSON metadata" do
+    it "strips legacy install flight blocks and records empty artifacts in JSON metadata" do
       cask = Cask::CaskLoader.load(cask_path("with-preflight"))
 
       described_class.new(cask).save_caskfile
 
-      expect(JSON.parse(cask.installed_caskfile.read).keys).to be_empty
+      expect(JSON.parse(cask.installed_caskfile.read)).to eq({ "artifacts" => [] })
+    end
+
+    it "stores intentional empty artifacts in JSON metadata" do
+      cask = Cask::CaskLoader.load(cask_path("stage-only"))
+
+      described_class.new(cask).save_caskfile
+
+      expect(JSON.parse(cask.installed_caskfile.read)).to eq({ "artifacts" => [] })
     end
 
     it "stores legacy uninstall flight block casks as Ruby metadata" do
@@ -92,6 +101,7 @@ RSpec.describe Cask::Installer, :cask do
       end
 
       described_class.new(cask).save_caskfile
+      Cask::Tab.create(cask).write
 
       loaded_cask = Cask::CaskLoader.load_from_installed_caskfile(cask.installed_caskfile)
       expect([
@@ -822,6 +832,31 @@ RSpec.describe Cask::Installer, :cask do
       expect(cask).not_to be_installed
       expect(queued_staged_path).not_to exist
       expect(queued_staged_marker).not_to exist
+    end
+  end
+
+  describe "#load_installed_caskfile!" do
+    it "uses recovered installed metadata before falling back to the current cask" do
+      cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+      recovered_cask = Cask::Cask.new(cask.token) do
+        version "1.0"
+        app "Recovered.app"
+      end
+      installed_caskfile = mktmpdir/"local-caffeine.json"
+      installed_caskfile.write("{}")
+      allow(Cask::Migrator).to receive(:migrate_if_needed)
+      allow(cask).to receive(:installed_caskfile).and_return(installed_caskfile)
+      allow(Cask::CaskLoader).to receive(:load_from_installed_caskfile)
+        .with(installed_caskfile)
+        .and_raise(Cask::CaskInvalidError.new(cask.token, "broken DSL"))
+      expect(Cask::CaskLoader).to receive(:recover_from_installed_caskfile)
+        .with(installed_caskfile, tab: an_instance_of(Cask::Tab), fallback_cask: cask)
+        .and_return(recovered_cask)
+
+      installer = described_class.new(cask)
+      installer.load_installed_caskfile!
+
+      expect(installer.cask).to equal(recovered_cask)
     end
   end
 

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -397,18 +397,23 @@ RSpec.describe Cask::Upgrade, :cask do
       end
 
       write_info_plist(auto_updates_path, short_version: "2.57", bundle_version: "2057")
+      allow(Cask::CaskLoader).to receive(:recover_from_installed_caskfile).and_return(nil)
     end
 
-    it "warns and skips when the installed caskfile raises CaskInvalidError" do
+    it "recovers when the installed caskfile raises CaskInvalidError" do
       allow(Cask::CaskLoader).to receive(:load_from_installed_caskfile).and_call_original
       allow(Cask::CaskLoader)
         .to receive(:load_from_installed_caskfile)
         .with(auto_updates.installed_caskfile)
         .and_raise(Cask::CaskInvalidError.new(auto_updates.token, "broken DSL"))
+      expect(Cask::CaskLoader)
+        .to receive(:recover_from_installed_caskfile)
+        .with(auto_updates.installed_caskfile, fallback_cask: auto_updates)
+        .and_return(auto_updates)
 
       expect do
-        described_class.upgrade_casks!(dry_run: true, args:)
-      end.to output(/The cask 'auto-updates' cannot be upgraded as-is/).to_stderr
+        described_class.upgrade_casks!(auto_updates, dry_run: true, args:)
+      end.not_to output(/The cask 'auto-updates' cannot be upgraded as-is/).to_stderr
     end
 
     it "warns and skips when the installed caskfile raises CaskUnreadableError" do
@@ -666,10 +671,14 @@ RSpec.describe Cask::Upgrade, :cask do
 
     it "uses the forced upgrade metadata for the next upgrade" do
       receipt_path = local_caffeine.metadata_main_container_path/AbstractTab::FILENAME
+      receipt_path.unlink
+      allow(Homebrew::API::Cask).to receive(:cask_json).with("local-caffeine").and_return({
+        "artifacts" => [{ "app" => ["Caffeine.app"] }],
+      })
 
       expect(receipt_path).not_to exist
       expect(Cask::CaskLoader.load_from_installed_caskfile(local_caffeine.installed_caskfile).artifacts)
-        .to be_empty
+        .to include(an_instance_of(Cask::Artifact::App))
 
       described_class.upgrade_casks!(local_caffeine, force: true, args:)
 

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
     [tap, before_revision, branch]
   end
 
+  def run_quiet_update_report
+    with_env(
+      HOMEBREW_UPDATE_BEFORE: "abc",
+      HOMEBREW_UPDATE_AFTER:  "abc",
+      HOMEBREW_UPDATE_TEST:   "1",
+    ) { described_class.new(["--quiet"]).run }
+  end
+
   it "copies update revisions for redirected tap names" do
     redirected_remotes_file = mktmpdir/"redirected-remotes"
     redirected_remotes_file.write("/tmp/homebrew-foo\thttps://github.com/new/homebrew-foo.git\n")
@@ -159,6 +167,9 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
     json_caskfile = rb_caskfile.sub_ext(".json")
     uninstall_flight_caskfile =
       caskroom/"with-uninstall-preflight/.metadata/1.0/20250101000000.000/Casks/with-uninstall-preflight.rb"
+    receiptless_caskfile =
+      caskroom/"receiptless-cask/.metadata/1.0/20250101000000.000/Casks/receiptless-cask.rb"
+    receiptless_json_caskfile = receiptless_caskfile.sub_ext(".json")
     internal_json_caskfile = caskroom/"api-cask/.metadata/1.0/20250101000000.000/Casks/api-cask.internal.json"
     api_caskfile = internal_json_caskfile.dirname/"api-cask.json"
     rb_caskfile.dirname.mkpath
@@ -187,6 +198,20 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
         end
       end
     RUBY
+    receiptless_caskfile.dirname.mkpath
+    receiptless_caskfile.write <<~RUBY
+      cask "receiptless-cask" do
+        version "1.0"
+        sha256 :no_check
+        url "https://example.com/receiptless-cask.zip"
+        name "Receipt-less Cask"
+        homepage "https://example.com/receiptless-cask"
+        app "Receipt-less Cask.app"
+
+        uninstall quit: "com.example.receiptless-cask"
+        zap trash: "~/Library/Preferences/com.example.receiptless-cask.plist"
+      end
+    RUBY
     (caskroom/"local-caffeine/.metadata/INSTALL_RECEIPT.json").write JSON.pretty_generate({
       "source"              => { "version" => "1.0" },
       "uninstall_artifacts" => [{ "app" => ["Caffeine.app"] }],
@@ -209,13 +234,10 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
     allow(Homebrew::EnvConfig).to receive_messages(developer?: false, disable_load_formula?: true,
                                                    no_install_from_api?: true)
 
-    with_env(
-      HOMEBREW_UPDATE_BEFORE: "abc",
-      HOMEBREW_UPDATE_AFTER:  "abc",
-      HOMEBREW_UPDATE_TEST:   "1",
-    ) { described_class.new(["--quiet"]).run }
+    run_quiet_update_report
 
     loaded_cask = Cask::CaskLoader.load_from_installed_caskfile(json_caskfile)
+    loaded_receiptless_cask = Cask::CaskLoader.load_from_installed_caskfile(receiptless_json_caskfile)
     loaded_api_cask = Cask::CaskLoader.load_from_installed_caskfile(api_caskfile)
     expect([
       rb_caskfile.exist?,
@@ -225,11 +247,96 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
       uninstall_flight_caskfile.exist?,
       uninstall_flight_caskfile.sub_ext(".json").exist?,
       Cask::CaskLoader.load_from_installed_caskfile(uninstall_flight_caskfile).uninstall_flight_blocks?,
+      receiptless_caskfile.exist?,
+      JSON.parse(receiptless_json_caskfile.read).fetch("artifacts"),
+      loaded_receiptless_cask.artifacts_list(uninstall_only: true),
       internal_json_caskfile.exist?,
       JSON.parse(api_caskfile.read).keys,
       loaded_api_cask.loaded_from_internal_api?,
       loaded_api_cask.artifacts.grep(Cask::Artifact::App).count,
-    ]).to eq([false, [], "1.0", 1, true, false, true, false, [], false, 1])
+    ]).to eq([
+      false,
+      [],
+      "1.0",
+      1,
+      true,
+      false,
+      true,
+      false,
+      [
+        { "uninstall" => [{ "quit" => "com.example.receiptless-cask" }] },
+        { "app" => ["Receipt-less Cask.app"] },
+        { "zap" => [{ "trash" => "~/Library/Preferences/com.example.receiptless-cask.plist" }] },
+      ],
+      [
+        { uninstall: [{ quit: "com.example.receiptless-cask" }] },
+        { app: ["Receipt-less Cask.app"] },
+        { zap: [{ trash: "~/Library/Preferences/com.example.receiptless-cask.plist" }] },
+      ],
+      false,
+      [],
+      false,
+      1,
+    ])
+  end
+
+  it "repairs migrated Cask metadata that differs" do
+    caskroom = mktmpdir/"Caskroom"
+    caskfile = caskroom/"mismatched/.metadata/1.0/20250101000000.000/Casks/mismatched.rb"
+    json_caskfile = caskfile.sub_ext(".json")
+    caskfile.dirname.mkpath
+    caskfile.write <<~RUBY
+      cask "mismatched" do
+        version "2.0"
+        sha256 :no_check
+        url "https://example.com/mismatched.zip"
+        name "Mismatched"
+        homepage "https://example.com/mismatched"
+        app "Mismatched.app"
+      end
+    RUBY
+    (caskroom/"mismatched/.metadata/INSTALL_RECEIPT.json").write JSON.pretty_generate({
+      "source"              => { "version" => "1.0" },
+      "uninstall_artifacts" => [{ "app" => ["Wrong.app"] }],
+    })
+    allow(Cask::Caskroom).to receive(:path).and_return(caskroom)
+    allow(Homebrew::EnvConfig).to receive_messages(developer?: false, disable_load_formula?: true,
+                                                   no_install_from_api?: true)
+
+    2.times { run_quiet_update_report }
+    migrated_cask = Cask::CaskLoader.load_from_installed_caskfile(json_caskfile)
+    expect([
+      caskfile.exist?,
+      JSON.parse(json_caskfile.read),
+      migrated_cask.version.to_s,
+      migrated_cask.artifacts_list(uninstall_only: true),
+    ]).to eq([
+      false,
+      {
+        "version"   => "2.0",
+        "artifacts" => [{ "app" => ["Mismatched.app"] }],
+      },
+      "2.0",
+      [{ app: ["Mismatched.app"] }],
+    ])
+  end
+
+  it "repairs existing JSON metadata once" do
+    caskroom = mktmpdir/"Caskroom"
+    caskfile = caskroom/"stubbed/.metadata/1.0/20250101000000.000/Casks/stubbed.json"
+    caskfile.dirname.mkpath
+    caskfile.write("{}")
+    allow(Cask::Caskroom).to receive(:path).and_return(caskroom)
+    allow(Homebrew::EnvConfig).to receive_messages(developer?: false, disable_load_formula?: true,
+                                                   no_install_from_api?: true)
+    expect(Homebrew::API::Cask).to receive(:cask_json).once.with("stubbed").and_return({
+      "artifacts" => [{ "app" => ["Stubbed.app"] }],
+    })
+
+    2.times { run_quiet_update_report }
+    expect(JSON.parse(caskfile.read)).to eq({
+      "artifacts" => [{ "app" => ["Stubbed.app"] }],
+    })
   end
 
   describe Reporter do

--- a/Library/Homebrew/test/support/helper/cask/install_helper.rb
+++ b/Library/Homebrew/test/support/helper/cask/install_helper.rb
@@ -35,9 +35,12 @@ module InstallHelper
     # Create the staged_path (version directory)
     cask.staged_path.mkpath
 
-    # Create metadata directory structure and save caskfile
+    # Create metadata directory structure and save the caskfile and receipt
     # This makes installed? and installed_version work
     Cask::Installer.new(cask).save_caskfile
+    tab = Cask::Tab.create(cask)
+    tab.installed_on_request = true
+    tab.write
 
     return unless create_app_dirs
 


### PR DESCRIPTION
- preserve artifacts when receipts or metadata are missing
- share recovery between migration, upgrade and reinstall
- verify rewritten JSON before deleting legacy metadata

Closes https://github.com/Homebrew/brew/pull/23128

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 Sol max with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
