### PR TITLE
cask/quarantine: don't enable developer mode when copying xattrs

### DIFF
--- a/Library/Homebrew/cask/utils/copy_xattrs.rb
+++ b/Library/Homebrew/cask/utils/copy_xattrs.rb
@@ -1,0 +1,7 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "standalone"
+require "os/mac/ffi"
+
+OS::Mac::FFI.copy_xattrs(ARGV.fetch(0), ARGV.fetch(1))

--- a/Library/Homebrew/extend/os/mac/cask/quarantine.rb
+++ b/Library/Homebrew/extend/os/mac/cask/quarantine.rb
@@ -7,7 +7,7 @@ module OS
   module Mac
     module Cask
       module Quarantine
-        COPY_XATTRS_RUBY = "require \"os/mac/ffi\"; MacOS::FFI.copy_xattrs(ARGV.fetch(0), ARGV.fetch(1))"
+        COPY_XATTRS_SCRIPT = T.let((HOMEBREW_LIBRARY_PATH/"cask/utils/copy_xattrs.rb").freeze, ::Pathname)
 
         module ClassMethods
           extend T::Helpers
@@ -109,13 +109,13 @@ module OS
               return
             end
 
+            ruby, *args = HOMEBREW_RUBY_EXEC_ARGS
             command.run!(
-              HOMEBREW_BREW_FILE,
-              args: [
-                "ruby",
-                "--",
-                "-e",
-                COPY_XATTRS_RUBY,
+              ruby,
+              args: args + [
+                "-I",
+                $LOAD_PATH.join(File::PATH_SEPARATOR),
+                COPY_XATTRS_SCRIPT,
                 from,
                 to,
               ],

--- a/Library/Homebrew/test/cask/quarantine_spec.rb
+++ b/Library/Homebrew/test/cask/quarantine_spec.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require "open3"
+
 RSpec.describe Cask::Quarantine do
   let(:klass) { described_class }
 
@@ -120,21 +122,21 @@ RSpec.describe Cask::Quarantine do
       end
     end
 
-    it "uses FFI through brew ruby when the destination needs sudo" do
+    it "uses FFI through vendored Ruby when the destination needs sudo" do
       require "os/mac/ffi"
 
       source = Pathname("/tmp/Source.app")
       destination = Pathname("/tmp/Destination.app")
       command = class_double(SystemCommand)
+      ruby, *args = HOMEBREW_RUBY_EXEC_ARGS
 
       allow(destination).to receive(:writable?).and_return(false)
       expect(command).to receive(:run!).with(
-        HOMEBREW_BREW_FILE,
-        args: [
-          "ruby",
-          "--",
-          "-e",
-          OS::Mac::Cask::Quarantine::COPY_XATTRS_RUBY,
+        ruby,
+        args: args + [
+          "-I",
+          $LOAD_PATH.join(File::PATH_SEPARATOR),
+          OS::Mac::Cask::Quarantine::COPY_XATTRS_SCRIPT,
           source,
           destination,
         ],
@@ -143,6 +145,29 @@ RSpec.describe Cask::Quarantine do
 
       with_env(HOMEBREW_DEVELOPER: nil) do
         klass.copy_xattrs(source, destination, command:)
+      end
+    end
+
+    it "copies extended attributes when run as a standalone script" do
+      require "os/mac/ffi"
+
+      mktmpdir do |tmpdir|
+        source = tmpdir/"source"
+        destination = tmpdir/"destination"
+        source.write("source")
+        destination.write("destination")
+        MacOS::FFI.set_xattr(source.to_s, "com.homebrew.test.source", "source")
+
+        _, stderr, status = Open3.capture3(
+          *HOMEBREW_RUBY_EXEC_ARGS,
+          "-I", $LOAD_PATH.join(File::PATH_SEPARATOR),
+          OS::Mac::Cask::Quarantine::COPY_XATTRS_SCRIPT.to_s,
+          source.to_s,
+          destination.to_s
+        )
+
+        expect(status).to be_success, stderr
+        expect(MacOS::FFI.get_xattr(destination.to_s, "com.homebrew.test.source")).to eq("source")
       end
     end
   end


### PR DESCRIPTION
`brew ruby` is a dev-cmd. We shouldn't be running dev-cmds as a part of regular cask installs.

In this case, it wasn't really necessary as we can just use `HOMEBREW_RUBY_EXEC_ARGS`.

I also added test coverage for the actual ruby script run itself - previously we just stubbed it.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

For test changes only, human reviewed.

-----
