### PR TITLE
attestation: treat empty results as a missing attestation

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -137,7 +137,9 @@ module Homebrew
           raise GhAuthInvalid, "invalid credentials"
         end
 
-        raise MissingAttestationError, "attestation not found: #{e}" if e.stderr.include?("HTTP 404: Not Found")
+        missing_attestation = e.stderr.include?("HTTP 404: Not Found") ||
+                              e.stderr.include?("no attestations found")
+        raise MissingAttestationError, "attestation not found: #{e}" if missing_attestation
 
         raise InvalidAttestationError, "attestation verification failed: #{e}"
       end
@@ -254,7 +256,7 @@ module Homebrew
       end
 
       backfill_attestation
-    rescue InvalidAttestationError
+    rescue InvalidAttestationError, MissingAttestationError
       @attestation_retry_count ||= T.let(Hash.new(0), T.nilable(T::Hash[Bottle, Integer]))
       raise if @attestation_retry_count[bottle] >= ATTESTATION_MAX_RETRIES
 

--- a/Library/Homebrew/dev-cmd/verify.rb
+++ b/Library/Homebrew/dev-cmd/verify.rb
@@ -62,7 +62,8 @@ module Homebrew
                   attestation = Homebrew::Attestation.check_core_attestation bottle
                   oh1 "#{bottle.filename} has a valid attestation"
                   json_results.push(attestation)
-                rescue Homebrew::Attestation::InvalidAttestationError => e
+                rescue Homebrew::Attestation::MissingAttestationError,
+                       Homebrew::Attestation::InvalidAttestationError => e
                   ofail <<~ERR
                     Failed to verify #{bottle.filename} with tag #{bottle_tag} due to error:
 

--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -157,6 +157,24 @@ RSpec.describe Homebrew::Attestation do
       end.to raise_error(Homebrew::Attestation::InvalidAttestationError)
     end
 
+    it "raises a missing attestation error when gh returns a 404" do
+      expect(GitHub::API).to receive(:credentials)
+        .and_return(fake_gh_creds)
+
+      expect(described_class).to receive(:system_command!)
+        .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
+                              Homebrew::Attestation::HOMEBREW_CORE_REPO, "--format", "json"],
+              env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
+              print_stderr: false, chdir: HOMEBREW_TEMP)
+        .and_raise(ErrorDuringExecution.new(["gh"], status: fake_error_status,
+                                                    output: [[:stderr, "HTTP 404: Not Found\n"]]))
+
+      expect do
+        described_class.check_attestation fake_bottle,
+                                          Homebrew::Attestation::HOMEBREW_CORE_REPO
+      end.to raise_error(Homebrew::Attestation::MissingAttestationError)
+    end
+
     it "raises auth error when gh subprocess fails with auth exit code" do
       expect(GitHub::API).to receive(:credentials)
         .and_return(fake_gh_creds)
@@ -261,7 +279,8 @@ RSpec.describe Homebrew::Attestation do
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .once
-        .and_raise(Homebrew::Attestation::MissingAttestationError)
+        .and_raise(ErrorDuringExecution.new(["gh"], status: fake_error_status,
+                                                    output: [[:stderr, "Error: no attestations found\n"]]))
 
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
@@ -269,6 +288,23 @@ RSpec.describe Homebrew::Attestation do
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_json_resp_backfill)
+
+      described_class.check_core_attestation fake_bottle
+    end
+
+    it "retries homebrew-core when the backfilled attestation is also missing" do
+      expect(described_class).to receive(:check_attestation)
+        .with(fake_bottle, Homebrew::Attestation::HOMEBREW_CORE_REPO)
+        .ordered
+        .and_raise(Homebrew::Attestation::MissingAttestationError)
+      expect(described_class).to receive(:check_attestation)
+        .with(fake_bottle, Homebrew::Attestation::BACKFILL_REPO, nil, anything)
+        .ordered
+        .and_raise(Homebrew::Attestation::MissingAttestationError)
+      expect(described_class).to receive(:check_attestation)
+        .with(fake_bottle, Homebrew::Attestation::HOMEBREW_CORE_REPO)
+        .ordered
+        .and_return({})
 
       described_class.check_core_attestation fake_bottle
     end

--- a/Library/Homebrew/test/dev-cmd/verify_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/verify_spec.rb
@@ -6,4 +6,27 @@ require "dev-cmd/verify"
 
 RSpec.describe Homebrew::DevCmd::Verify do
   it_behaves_like "parseable arguments"
+
+  it "reports missing attestations as verification failures" do
+    command = described_class.new(["fakebottle"])
+    formula = instance_double(Formula)
+    bottle = instance_double(Bottle, fetch: nil, filename: "fakebottle--1.0.faketag.bottle.tar.gz")
+    bottle_tag = instance_double(Utils::Bottles::Tag)
+    named_args = instance_double(Homebrew::CLI::NamedArgs, to_formulae: [formula])
+    args = double(deps?: false, named: named_args, os_arch_combinations: [[nil, nil]], bottle_tag: nil,
+                  force?: false, json?: false)
+
+    allow(command).to receive(:args).and_return(args)
+    allow(Homebrew::SimulateSystem).to receive(:with).and_yield
+    allow(Utils::Bottles::Tag).to receive(:from_arg).and_return(bottle_tag)
+    allow(formula).to receive(:bottle_for_tag).with(bottle_tag).and_return(bottle)
+    allow(Homebrew::Attestation).to receive(:check_core_attestation)
+      .with(bottle)
+      .and_raise(Homebrew::Attestation::MissingAttestationError, "attestation not found")
+
+    expect(command).to receive(:ofail)
+      .with(include("Failed to verify fakebottle--1.0.faketag.bottle.tar.gz", "attestation not found"))
+
+    command.run
+  end
 end


### PR DESCRIPTION
GitHub's artifact attestation API now returns `HTTP 200` with an empty `{"attestations":[]}` body for digests that have no attestation, which `gh attestation verify` reports as `no attestations found`. We only treated `HTTP 404: Not Found` as a missing attestation, so these empty responses were misclassified as verification failures and never reached the homebrew-core backfill fallback, producing spurious build-provenance errors for bottles that depend on backfilled signatures.

This classifies both the `404` and `no attestations found` forms as missing so the backfill fallback runs. It also retries the whole lookup when the primary and backfill are both missing (that case previously bypassed the existing retry/backoff), and makes `brew verify` report a missing attestation as a normal verification failure rather than an uncaught error.

The fallback still fully verifies the backfilled signature against the cutoff date, so an empty response cannot cause an unsigned bottle to be accepted. New specs cover the `404` and empty-result classification, the both-missing retry, and the `brew verify` path.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 4.8) reviewed the change and flagged the missing retry path and the `brew verify` gap; I implemented the fixes and verified with `brew lgtm` and the attestation and verify specs.

-----
