### PR TITLE
Use tap sources for cask metadata

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -469,7 +469,7 @@ module Cask
             installed_tab = CaskLoader.load_installed_tab(token)
             api_source["version"] ||= installed_tab.version.presence
             api_source["artifacts"] ||= CaskLoader.resolve_installed_artifacts(
-              token, installed_tab.uninstall_artifacts, api_fallback: @api_fallback
+              token, installed_tab.uninstall_artifacts, tap: installed_tab.tap, api_fallback: @api_fallback
             )
           end
         end
@@ -831,18 +831,35 @@ module Cask
     end
 
     sig {
-      params(token: String, artifacts: T.nilable(T::Array[T.untyped]), api_fallback: T::Boolean)
-        .returns(T::Array[T.untyped])
+      params(
+        token:        String,
+        artifacts:    T.nilable(T::Array[T::Hash[T.any(String, Symbol), T.anything]]),
+        tap:          T.nilable(Tap),
+        api_fallback: T::Boolean,
+      ).returns(T::Array[T::Hash[T.any(String, Symbol), T.anything]])
     }
-    def self.resolve_installed_artifacts(token, artifacts, api_fallback: true)
+    def self.resolve_installed_artifacts(token, artifacts, tap: nil, api_fallback: true)
       artifacts = artifacts.presence
-      if artifacts.nil? && api_fallback
-        # API fetch failures must not abort best-effort installed metadata recovery.
-        artifacts = begin
-          Homebrew::API::Cask.cask_json(token)["artifacts"]
-        rescue SystemExit
-          nil
+      return artifacts if artifacts
+      return [] unless api_fallback
+
+      artifacts ||= begin
+        tap_loader = (FromNameLoader.try_new(token, warn: false) if tap.nil? && FromAPILoader.try_new(token).nil?)
+
+        if tap && !tap.core_cask_tap?
+          load("#{tap}/#{token}", warn: false).artifacts_list(uninstall_only: true)
+        elsif tap_loader
+          tap_loader.load(config: nil).artifacts_list(uninstall_only: true)
         end
+      rescue CaskError, MethodDeprecatedError, JSON::ParserError
+        nil
+      end
+
+      # API fetch failures must not abort best-effort installed metadata recovery.
+      artifacts ||= begin
+        Homebrew::API::Cask.cask_json(token)["artifacts"]
+      rescue SystemExit
+        nil
       end
       artifacts ||= []
       artifacts
@@ -868,10 +885,10 @@ module Cask
       return if tab.uninstall_flight_blocks
       return if fallback_cask&.uninstall_flight_blocks?
 
-      # Prefer exact receipt artifacts, then the current cask and finally the current API definition.
+      # Prefer exact receipt artifacts, then the current cask and finally the current source definition.
       artifacts = tab.uninstall_artifacts.presence
       artifacts ||= fallback_cask.artifacts_list(uninstall_only: true) if fallback_cask
-      artifacts ||= resolve_installed_artifacts(token, nil)
+      artifacts ||= resolve_installed_artifacts(token, nil, tap: tab.tap)
 
       # Rebuild the installed version from its metadata directory and retain current source path information.
       api_source = {

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -571,6 +571,28 @@ RSpec.describe Cask::CaskLoader, :cask do
 
       expect(described_class.resolve_installed_artifacts("unavailable", nil)).to eq([])
     end
+
+    it "falls back to API artifacts when tap lookup is ambiguous" do
+      token = "ambiguous"
+      api_artifacts = [{ "app" => ["API.app"] }]
+      allow(Cask::CaskLoader::FromNameLoader).to receive(:try_new)
+        .with(token, warn: false)
+        .and_raise(Cask::TapCaskAmbiguityError.new(token, []))
+      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({ "artifacts" => api_artifacts })
+
+      expect(described_class.resolve_installed_artifacts(token, nil)).to eq(api_artifacts)
+    end
+
+    it "returns empty artifacts when the installed tap and API are unavailable" do
+      token = "unavailable-tap"
+      tap = Tap.fetch("thirdparty", "missing")
+      allow(described_class).to receive(:load)
+        .with("#{tap}/#{token}", warn: false)
+        .and_raise(Cask::TapCaskUnavailableError.new(tap, token))
+      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_raise(SystemExit.new(1))
+
+      expect(described_class.resolve_installed_artifacts(token, nil, tap:)).to eq([])
+    end
   end
 
   describe "::recover_from_installed_caskfile" do

--- a/Library/Homebrew/test/cask/caskroom_spec.rb
+++ b/Library/Homebrew/test/cask/caskroom_spec.rb
@@ -316,6 +316,32 @@ RSpec.describe Cask::Caskroom do
       })
     end
 
+    it "uses tap metadata instead of the API for a receipt-less third-party cask", :trust_store do
+      token = "third-party"
+      tap = Tap.fetch("thirdparty", "foo")
+      caskfile = write_installed_caskfile(token, "{}", extension: "json")
+      cask_path = tap.cask_dir/"#{token}.rb"
+      cask_path.dirname.mkpath
+      cask_path.write <<~RUBY
+        cask "#{token}" do
+          version "2.0"
+          app "Third Party.app"
+        end
+      RUBY
+      Homebrew::Trust.trust!(:tap, tap.name)
+      allow(Homebrew::EnvConfig).to receive(:no_install_from_api?).and_return(false)
+      allow(Homebrew::API).to receive_messages(cask_token?: false, cask_renames: {})
+      allow(Homebrew::API::Cask).to receive(:cask_json).and_raise("unexpected official API lookup")
+
+      described_class.migrate_caskfile_to_json(caskfile)
+
+      expect(JSON.parse(caskfile.read)).to eq({
+        "artifacts" => [{ "app" => ["Third Party.app"] }],
+      })
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+    end
+
     it "preserves artifacts when the install receipt is empty" do
       token = "empty-receipt"
       caskfile = write_installed_caskfile(token, <<~RUBY)


### PR DESCRIPTION
- Resolve legacy third-party artifacts from their installed tap.
- Avoid official API requests for receipt-less tap casks.

Fixes #23147 

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex Sol 5.6 max with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
