### PR TITLE
tap-new: fix invalid job-level options in generated workflow

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -88,10 +88,11 @@ module Homebrew
                   os: [ macos-15-intel, macos-26 ]
                   include:
                     - os: ubuntu-latest
-                      container: ghcr.io/homebrew/brew:main
+                      container:
+                        image: ghcr.io/homebrew/brew:main
+                        options: --privileged
               runs-on: ${{ matrix.os }}
               container: ${{ matrix.container }}
-              options: ${{ matrix.container != '' && '--privileged' }}
               permissions:
                 actions: read
                 checks: read

--- a/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Homebrew::DevCmd::TapNew do
     expect((HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/tests.yml").read)
       .not_to include("HOMEBREW_DEVELOPER")
     expect((HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/tests.yml").read)
-      .to include("options: ${{ matrix.container != '' && '--privileged' }}")
+      .to include("options: --privileged")
     publish_yml = (HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/publish.yml").read
     expect(publish_yml).not_to include("HOMEBREW_DEVELOPER")
     expect(publish_yml).not_to include("pull_request_target")


### PR DESCRIPTION
Since f9a6801d19ba, brew tap-new generates a tests.yml that GitHub Actions refuses to parse:

    Invalid workflow file
    (Line: 19, Col: 5): Unexpected value 'options'

options is only valid nested under container, not at the job level. Move the privileged flag into a container object supplied by the ubuntu matrix entry, which the macOS legs leave empty as before.

Verified working in
https://github.com/EarthmanMuons/homebrew-tap/actions/runs/29614229149

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI disclosure: this fix was diagnosed and drafted with the help of Claude Code (Claude Fable 5); I reviewed the change and verified the generated workflow in my own tap's CI before filing.

-----
