### PR TITLE
tap-new: lint generated workflows

### DIFF
--- a/.github/workflows/tap-new-publish.yml
+++ b/.github/workflows/tap-new-publish.yml
@@ -1,0 +1,54 @@
+name: tap-new publish template
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Pull request number
+        required: true
+      head_sha:
+        description: Expected pull request head commit SHA (optional)
+
+jobs:
+  pr-pull:
+    if: github.repository == ''
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+      issues: read
+      # tap-new-github-packages-start
+      packages: write
+      # tap-new-github-packages-end
+      pull-requests: write
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@18fcb8e3e06b4247c676c506750dc95ea7226479 # 2026.07.13.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up git
+        uses: Homebrew/actions/git-user-config@18fcb8e3e06b4247c676c506750dc95ea7226479 # 2026.07.13.1
+
+      - name: Pull bottles
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # tap-new-github-packages-start
+          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.repository_owner }}
+          # tap-new-github-packages-end
+          HEAD_SHA: ${{ inputs.head_sha }}
+          PULL_REQUEST: ${{ inputs.pull_request }}
+        run: |
+          if [[ -n "$HEAD_SHA" ]]
+          then
+            brew pr-pull --debug --tap="$GITHUB_REPOSITORY" --head-sha="$HEAD_SHA" "$PULL_REQUEST"
+          else
+            brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
+          fi
+
+      - name: Push commits
+        uses: Homebrew/actions/git-try-push@18fcb8e3e06b4247c676c506750dc95ea7226479 # 2026.07.13.1
+        with:
+          branch: TAP_NEW_BRANCH

--- a/.github/workflows/tap-new-tests.yml
+++ b/.github/workflows/tap-new-tests.yml
@@ -1,0 +1,69 @@
+name: tap-new tests template
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-bot:
+    if: github.repository == ''
+    strategy:
+      matrix:
+        os: [ macos-15-intel, macos-26 ]
+        include:
+          - os: ubuntu-latest
+            container:
+              image: ghcr.io/homebrew/brew:main
+              options: --privileged
+    runs-on: ${{ matrix.os }}
+    container: ${{ fromJSON(toJSON(matrix.container)) }} # zizmor: ignore[unpinned-images]
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      # tap-new-github-packages-start
+      packages: read
+      # tap-new-github-packages-end
+      pull-requests: read
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@18fcb8e3e06b4247c676c506750dc95ea7226479 # 2026.07.13.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Homebrew Bundler RubyGems
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ matrix.os }}-rubygems-
+
+      - run: brew test-bot --only-cleanup-before
+
+      - run: brew test-bot --only-setup
+
+      - run: brew test-bot --only-tap-syntax
+      # tap-new-github-packages-start
+      - name: Base64-encode GITHUB_TOKEN for HOMEBREW_DOCKER_REGISTRY_TOKEN
+        id: base64-encode
+        if: github.event_name == 'pull_request'
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          base64_token=$(echo -n "${TOKEN}" | base64 | tr -d "\n")
+          echo "::add-mask::${base64_token}"
+          echo "token=${base64_token}" >> "${GITHUB_OUTPUT}"
+      # tap-new-github-packages-end
+      - run: brew test-bot --only-formulaeTAP_NEW_ROOT_URL_ARGUMENT
+        if: github.event_name == 'pull_request'
+        # tap-new-github-packages-start
+        env:
+          HOMEBREW_DOCKER_REGISTRY_TOKEN: ${{ steps.base64-encode.outputs.token }}
+        # tap-new-github-packages-end
+
+      - name: Upload bottles as artifact
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bottles_${{ matrix.os }}
+          path: '*.bottle.*'

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "abstract_command"
-require "erb"
 require "fileutils"
 require "system_command"
 require "tap"
@@ -72,139 +71,29 @@ module Homebrew
         MARKDOWN
         write_path(tap, "README.md", readme)
 
-        tests_yml = <<~ERB
-          name: brew test-bot
+        dependabot_yml = <<~YAML
+          version: 2
+          updates:
+            - package-ecosystem: github-actions
+              directory: "/"
+              schedule:
+                interval: weekly
+              groups:
+                github-actions:
+                  patterns:
+                    - "*"
+        YAML
 
-          on:
-            push:
-              branches:
-                - <%= branch %>
-            pull_request:
-
-          jobs:
-            test-bot:
-              strategy:
-                matrix:
-                  os: [ macos-15-intel, macos-26 ]
-                  include:
-                    - os: ubuntu-latest
-                      container:
-                        image: ghcr.io/homebrew/brew:main
-                        options: --privileged
-              runs-on: ${{ matrix.os }}
-              container: ${{ matrix.container }}
-              permissions:
-                actions: read
-                checks: read
-                contents: read
-          <% if args.github_packages? -%>
-                packages: read
-          <% end -%>
-                pull-requests: read
-              steps:
-                - name: Set up Homebrew
-                  id: set-up-homebrew
-                  uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
-                  with:
-                    token: ${{ secrets.GITHUB_TOKEN }}
-
-                - name: Cache Homebrew Bundler RubyGems
-                  uses: actions/cache@v5
-                  with:
-                    path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-                    key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-                    restore-keys: ${{ matrix.os }}-rubygems-
-
-                - run: brew test-bot --only-cleanup-before
-
-                - run: brew test-bot --only-setup
-
-                - run: brew test-bot --only-tap-syntax
-          <% if args.github_packages? -%>
-                - name: Base64-encode GITHUB_TOKEN for HOMEBREW_DOCKER_REGISTRY_TOKEN
-                  id: base64-encode
-                  if: github.event_name == 'pull_request'
-                  env:
-                    TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  run: |
-                    base64_token=$(echo -n "${TOKEN}" | base64 | tr -d "\\n")
-                    echo "::add-mask::${base64_token}"
-                    echo "token=${base64_token}" >> "${GITHUB_OUTPUT}"
-          <% end -%>
-                - run: brew test-bot --only-formulae#{" --root-url=#{root_url}" if root_url}
-                  if: github.event_name == 'pull_request'
-          <% if args.github_packages? -%>
-                  env:
-                    HOMEBREW_DOCKER_REGISTRY_TOKEN: ${{ steps.base64-encode.outputs.token }}
-          <% end -%>
-
-                - name: Upload bottles as artifact
-                  if: always() && github.event_name == 'pull_request'
-                  uses: actions/upload-artifact@v7
-                  with:
-                    name: bottles_${{ matrix.os }}
-                    path: '*.bottle.*'
-        ERB
-
-        publish_yml = <<~ERB
-          name: brew pr-pull
-
-          on:
-            workflow_dispatch:
-              inputs:
-                pull_request:
-                  description: Pull request number
-                  required: true
-                head_sha:
-                  description: Expected pull request head commit SHA (optional)
-
-          jobs:
-            pr-pull:
-              runs-on: ubuntu-latest
-              permissions:
-                actions: read
-                checks: read
-                contents: write
-                issues: read
-          <% if args.github_packages? -%>
-                packages: write
-          <% end -%>
-                pull-requests: write
-              steps:
-                - name: Set up Homebrew
-                  uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
-                  with:
-                    token: ${{ secrets.GITHUB_TOKEN }}
-
-                - name: Set up git
-                  uses: Homebrew/actions/git-user-config@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
-
-                - name: Pull bottles
-                  env:
-                    HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          <% if args.github_packages? -%>
-                    HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                    HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.repository_owner }}
-          <% end -%>
-                    HEAD_SHA: ${{ inputs.head_sha }}
-                    PULL_REQUEST: ${{ inputs.pull_request }}
-                  run: |
-                    if [[ -n "$HEAD_SHA" ]]
-                    then
-                      brew pr-pull --debug --tap="$GITHUB_REPOSITORY" --head-sha="$HEAD_SHA" "$PULL_REQUEST"
-                    else
-                      brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
-                    fi
-
-                - name: Push commits
-                  uses: Homebrew/actions/git-try-push@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
-                  with:
-                    branch: <%= branch %>
-        ERB
-
+        tests_yml = render_workflow_template(
+          "tap-new-tests.yml", branch:, github_packages: args.github_packages?, root_url:
+        )
+        publish_yml = render_workflow_template(
+          "tap-new-publish.yml", branch:, github_packages: args.github_packages?
+        )
         (tap.path/".github/workflows").mkpath
-        write_path(tap, ".github/workflows/tests.yml", ERB.new(tests_yml, trim_mode: "-").result(binding))
-        write_path(tap, ".github/workflows/publish.yml", ERB.new(publish_yml, trim_mode: "-").result(binding))
+        write_path(tap, ".github/dependabot.yml", dependabot_yml)
+        write_path(tap, ".github/workflows/tests.yml", tests_yml)
+        write_path(tap, ".github/workflows/publish.yml", publish_yml)
 
         unless args.no_git?
           cd tap.path do |path|
@@ -248,6 +137,40 @@ module Homebrew
       end
 
       private
+
+      sig {
+        params(
+          filename:        String,
+          branch:          String,
+          github_packages: T::Boolean,
+          root_url:        T.nilable(String),
+        ).returns(String)
+      }
+      def render_workflow_template(filename, branch:, github_packages:, root_url: nil)
+        workflow = (HOMEBREW_LIBRARY_PATH.parent.parent/".github/workflows"/filename).read
+        workflow.sub!("name: tap-new tests template", "name: brew test-bot")
+        workflow.sub!("name: tap-new publish template", "name: brew pr-pull")
+        if filename == "tap-new-tests.yml"
+          workflow.sub!("on:\n  workflow_dispatch:\n", <<~YAML)
+            on:
+              push:
+                branches:
+                  - #{branch}
+              pull_request:
+          YAML
+        end
+        workflow.sub!("    if: github.repository == ''\n", "")
+        workflow.gsub!("TAP_NEW_BRANCH") { branch }
+        workflow.gsub!("TAP_NEW_ROOT_URL_ARGUMENT") { root_url ? " --root-url=#{root_url}" : "" }
+        unless github_packages
+          workflow.gsub!(
+            /^[ \t]*# tap-new-github-packages-start\n.*?^[ \t]*# tap-new-github-packages-end\n/m,
+            "",
+          )
+        end
+        workflow.gsub!(/^[ \t]*# tap-new-github-packages-(?:start|end)\n/, "")
+        workflow
+      end
 
       sig { params(tap: Tap, filename: T.any(String, Pathname), content: String).void }
       def write_path(tap, filename, content)

--- a/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
@@ -3,6 +3,7 @@
 
 require "cmd/shared_examples/args_parse"
 require "dev-cmd/tap-new"
+require "yaml"
 
 RSpec.describe Homebrew::DevCmd::TapNew do
   it_behaves_like "parseable arguments"
@@ -17,12 +18,12 @@ RSpec.describe Homebrew::DevCmd::TapNew do
       .and not_to_output.to_stderr
 
     expect(HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/README.md").to exist
-    expect(HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/tests.yml").to exist
-    expect((HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/tests.yml").read)
-      .not_to include("HOMEBREW_DEVELOPER")
-    expect((HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/tests.yml").read)
-      .to include("options: --privileged")
+    dependabot_yml = (HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/dependabot.yml").read
+    tests_yml = (HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/tests.yml").read
     publish_yml = (HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/publish.yml").read
+    [dependabot_yml, tests_yml, publish_yml].each { YAML.parse(it) }
+    expect(tests_yml).not_to include("HOMEBREW_DEVELOPER")
+    expect(tests_yml).to include("options: --privileged")
     expect(publish_yml).not_to include("HOMEBREW_DEVELOPER")
     expect(publish_yml).not_to include("pull_request_target")
     expect(publish_yml).not_to include("workflow_run")


### PR DESCRIPTION
- Move the tap-new workflows into `.github/workflows` so the existing actionlint and zizmor CI catches invalid changes before users do. This guards against regressions like those fixed in https://github.com/Homebrew/brew/pull/23154
- Keep the repository templates inert with an impossible repository condition, then remove it and configure events, branches and optional GitHub Packages settings when `tap-new` copies them. This means our Dependabot/Actionlint/Zizmor workflows will catch/update these too.
- Preserve the privileged Linux container in an actionlint-compatible matrix expression.
- Pin actions in the templates and generate grouped weekly Dependabot updates so immutable references remain current.
- Parse every generated YAML file in the existing integration spec.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 Sol high with local review, testing and lots of iteration.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
