### PR TITLE
Return the alias name from tap_formula_name_type

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -713,20 +713,16 @@ module Formulary
 
       return unless (name_tap_type = Formulary.tap_formula_name_type(ref, warn:))
 
-      loader_from_name_tap_type(ref, name_tap_type)
+      loader_from_name_tap_type(name_tap_type)
     end
 
     sig {
-      params(ref: String, name_tap_type: [String, Tap, T.nilable(Symbol)]).returns(T.nilable(T.attached_class))
+      params(name_tap_type: [String, Tap, T.nilable(Symbol), T.nilable(String)])
+        .returns(T.nilable(T.attached_class))
     }
-    def self.loader_from_name_tap_type(ref, name_tap_type)
-      name, tap, type = name_tap_type
+    def self.loader_from_name_tap_type(name_tap_type)
+      name, tap, type, alias_name = name_tap_type
       path = Formulary.find_formula_in_tap(name, tap)
-
-      if type == :alias
-        # TODO: Simplify this by making `tap_formula_name_type` return the alias name.
-        alias_name = T.must(ref[HOMEBREW_TAP_FORMULA_REGEX, :name]).downcase
-      end
 
       if type == :migration && tap.core_tap? && (loader = FromAPILoader.try_new(name))
         T.cast(loader, T.attached_class)
@@ -797,7 +793,7 @@ module Formulary
                "#{migrated_tap.core_tap? ? migrated_name : "#{migrated_tap}/#{migrated_name}"}."
         end
 
-        if (core_loader = loader_from_name_tap_type("#{core_tap}/#{name}", name_tap_type))&.path&.exist?
+        if (core_loader = loader_from_name_tap_type(name_tap_type))&.path&.exist?
           return core_loader
         end
       end
@@ -919,15 +915,11 @@ module Formulary
         return
       end
 
-      alias_name = name
-
       ref = "#{CoreTap.instance}/#{name}"
 
       return unless (name_tap_type = Formulary.tap_formula_name_type(ref, warn:))
 
-      name, tap, type = name_tap_type
-
-      alias_name = (type == :alias) ? alias_name.downcase : nil
+      name, tap, _type, alias_name = name_tap_type
 
       new(name, tap:, alias_name:)
     end
@@ -1171,18 +1163,23 @@ module Formulary
     loader_for(ref).path
   end
 
-  sig { params(tapped_name: String, warn: T::Boolean).returns(T.nilable([String, Tap, T.nilable(Symbol)])) }
+  sig {
+    params(tapped_name: String, warn: T::Boolean)
+      .returns(T.nilable([String, Tap, T.nilable(Symbol), T.nilable(String)]))
+  }
   def self.tap_formula_name_type(tapped_name, warn:)
     return unless (tap_with_name = Tap.with_formula_name(tapped_name))
 
     tap, name = tap_with_name
 
     type = nil
+    alias_name = nil
 
     # FIXME: Remove the need to do this here.
     alias_table_key = tap.core_tap? ? name : "#{tap}/#{name}"
 
     if (possible_alias = tap.alias_table[alias_table_key].presence)
+      alias_name = name
       # FIXME: Remove the need to split the name and instead make
       #        the alias table only contain short names.
       name = Utils.name_from_full_name(possible_alias)
@@ -1223,7 +1220,7 @@ module Formulary
       opoo "Formula #{old_name} was renamed to #{new_name}." if destination_exists
     end
 
-    [name, tap, type]
+    [name, tap, type, alias_name]
   end
 
   sig { params(ref: T.any(String, Pathname), from: T.nilable(Symbol), warn: T::Boolean).returns(FormulaLoader) }

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -356,12 +356,9 @@ RSpec.describe Formulary do
           expect(described_class.factory(formula_name)).to be_a(Formula)
         end
 
-        it "returns a Formula from an Alias path" do
-          expect(described_class.factory(alias_name)).to be_a(Formula)
-        end
-
-        it "returns a Formula from a fully qualified Alias path" do
-          expect(described_class.factory("#{tap.name}/#{alias_name}")).to be_a(Formula)
+        it "returns a Formula with the correct alias path from a bare or fully qualified Alias name" do
+          expect(described_class.factory(alias_name).alias_path).to eq(alias_path)
+          expect(described_class.factory("#{tap.name}/#{alias_name}").alias_path).to eq(alias_path)
         end
 
         it "raises an error when the Formula cannot be found" do


### PR DESCRIPTION
`tap_formula_name_type` already knows the alias name when it resolves an
alias, but it drops it and returns only the real name. So two callers
(`FromTapLoader` and `FromAPILoader`) had to rebuild the alias name from
the reference string, one of them with a regexp and `T.must`. There was
already a `TODO` asking to fix this.

Now `tap_formula_name_type` returns the alias name as a fourth tuple value
(`nil` when it is not an alias), and the callers just read it. This removes
the duplicated logic, a `T.must`, and an unused `ref` argument.

No behavior change: the returned alias name is the same lower-cased short
name as before. I made the existing tap alias tests stricter (they now
check `alias_path`) to confirm this. This is a refactor, not a bug fix.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
AI (Claude Code) assisted in writing the code and tests.
I reviewed the change and ran brew lgtm locally