### PR TITLE
docs/Rakefile: ignore generated rubydoc files and HTTP 429 responses

### DIFF
--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -40,7 +40,7 @@ task test: :build do
       },
     },
     favicon:             true,
-    ignore_status_codes: [0, 403],
+    ignore_status_codes: [0, 403, 429],
     check_favicon:       true,
     check_opengraph:     true,
     check_html:          true,
@@ -48,6 +48,7 @@ task test: :build do
     enforce_https:       true,
     ignore_files:        [
       /Kickstarter-Supporters/,
+      %r{/rubydoc/},
     ],
     ignore_urls:         [
       "/",


### PR DESCRIPTION
HTMLProofer currently scans generated rubydoc output and intermittently fails on transient HTTP 429 rate limiting while checking external links. This treats 429 responses as inconclusive and skips files under `/rubydoc/`, so documentation test runs are less flaky ahead of an upcoming series of documentation PRs.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5) made this change; I reviewed the diff and verified locally with `brew style docs`, a Jekyll build, `rake lint` and `rake test` (HTMLProofer including external links).

-----
