### PR TITLE
docs: update tap trust and supply-chain documentation

### DIFF
--- a/Library/Homebrew/cmd/trust.rb
+++ b/Library/Homebrew/cmd/trust.rb
@@ -12,8 +12,7 @@ module Homebrew
 
       cmd_args do
         description <<~EOS
-          Trust non-official tap formulae, casks or commands so Homebrew may load them when
-          `$HOMEBREW_REQUIRE_TAP_TRUST` is set.
+          Trust non-official tap formulae, casks or commands so Homebrew may load them.
           Trusted entries are stored in `${XDG_CONFIG_HOME}/homebrew/trust.json` if
           `$XDG_CONFIG_HOME` is set or `~/.homebrew/trust.json` otherwise.
         EOS

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -19,12 +19,12 @@ module Homebrew
           Generate the template files for a new tap.
         EOS
         switch "--no-git",
-               description: "Don't initialize a Git repository for the tap."
+               description: "Don't initialise a Git repository for the tap."
         flag   "--pull-label=",
                description: "Ignored; publishing pull requests is now manually dispatched.",
                odeprecated: true
         flag   "--branch=",
-               description: "Initialize Git repository and setup GitHub Actions workflows with the " \
+               description: "Initialise a Git repository and set up GitHub Actions workflows with the " \
                             "specified branch name (default: `main`)."
         switch "--github-packages",
                description: "Upload bottles to GitHub Packages."

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1875,11 +1875,11 @@ __fish_brew_complete_arg 'tap-info' -a '(__fish_brew_suggest_taps_installed)'
 
 
 __fish_brew_complete_cmd 'tap-new' 'Generate the template files for a new tap'
-__fish_brew_complete_arg 'tap-new' -l branch -d 'Initialize Git repository and setup GitHub Actions workflows with the specified branch name (default: `main`)'
+__fish_brew_complete_arg 'tap-new' -l branch -d 'Initialise a Git repository and set up GitHub Actions workflows with the specified branch name (default: `main`)'
 __fish_brew_complete_arg 'tap-new' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'tap-new' -l github-packages -d 'Upload bottles to GitHub Packages'
 __fish_brew_complete_arg 'tap-new' -l help -d 'Show this message'
-__fish_brew_complete_arg 'tap-new' -l no-git -d 'Don\'t initialize a Git repository for the tap'
+__fish_brew_complete_arg 'tap-new' -l no-git -d 'Don\'t initialise a Git repository for the tap'
 __fish_brew_complete_arg 'tap-new' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'tap-new' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'tap-new' -a '(__fish_brew_suggest_taps_installed)'
@@ -1962,7 +1962,7 @@ __fish_brew_complete_arg 'tests' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'tests' -l vernier -d 'Use `vernier` to profile tests'
 
 
-__fish_brew_complete_cmd 'trust' 'Trust non-official tap formulae, casks or commands so Homebrew may load them when `$HOMEBREW_REQUIRE_TAP_TRUST` is set'
+__fish_brew_complete_cmd 'trust' 'Trust non-official tap formulae, casks or commands so Homebrew may load them'
 __fish_brew_complete_arg 'trust' -l cask -d 'Trust the named cask'
 __fish_brew_complete_arg 'trust' -l command -d 'Trust the named external command'
 __fish_brew_complete_arg 'trust' -l debug -d 'Display any debugging information'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -246,7 +246,7 @@ __brew_internal_commands() {
     'test:Run the test method provided by an installed formula'
     'test-bot:Tests the full lifecycle of a Homebrew change to a tap (Git repository)'
     'tests:Run Homebrew'\''s unit and integration tests'
-    'trust:Trust non-official tap formulae, casks or commands so Homebrew may load them when `$HOMEBREW_REQUIRE_TAP_TRUST` is set'
+    'trust:Trust non-official tap formulae, casks or commands so Homebrew may load them'
     'typecheck:Check for typechecking errors using Sorbet'
     'unalias:Remove aliases'
     'unbottled:Show the unbottled dependents of formulae'
@@ -2422,11 +2422,11 @@ _brew_tap_info() {
 # brew tap-new
 _brew_tap_new() {
   _arguments \
-    '--branch[Initialize Git repository and setup GitHub Actions workflows with the specified branch name (default: `main`)]' \
+    '--branch[Initialise a Git repository and set up GitHub Actions workflows with the specified branch name (default: `main`)]' \
     '--debug[Display any debugging information]' \
     '--github-packages[Upload bottles to GitHub Packages]' \
     '--help[Show this message]' \
-    '--no-git[Don'\''t initialize a Git repository for the tap]' \
+    '--no-git[Don'\''t initialise a Git repository for the tap]' \
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - tap \

--- a/docs/Homebrew-Security-and-Supply-Chain.md
+++ b/docs/Homebrew-Security-and-Supply-Chain.md
@@ -10,14 +10,14 @@ last_review_date: "2026-06-15"
 
 Homebrew installs software from across the open source ecosystem.
 That makes the security of the software supply chain, the humans involved, repositories, build systems and download servers that turn source code into something you run, a core concern for us.
-This Homebrew security guide explains the recent supply-side security incidents affecting other package managers, how Homebrew's trust model differs and the steps we have taken to protect our users.
+This Homebrew security guide explains the recent supply-chain security incidents affecting other package managers, how Homebrew's trust model differs and the steps we have taken to protect our users.
 
 * Table of Contents
 {:toc}
 
 ## Recent incidents in other ecosystems
 
-The npm and PyPI ecosystems have been repeatedly targeted by supply-side attacks.
+The npm and PyPI ecosystems have been repeatedly targeted by supply-chain attacks.
 Recurring patterns include:
 
 * **Maintainer account takeover.**
@@ -38,9 +38,9 @@ A single compromised credential turns into immediate, automated, worldwide code 
 
 ## How Homebrew is different
 
-The Homebrew team is aware of the supply-side security issues with other package managers.
+The Homebrew team is aware of the supply-chain security issues with other package managers.
 Homebrew's design differs in several structural ways that limit the blast radius of an upstream compromise.
-Most of these protections long predate the recent wave of supply-side attacks and the current focus on them; they are core to how Homebrew has always packaged software rather than a reaction to any single incident.
+Most of these protections long predate the recent wave of supply-chain attacks and the current focus on them; they are core to how Homebrew has always packaged software rather than a reaction to any single incident.
 
 ### Human review on all changes
 
@@ -72,8 +72,8 @@ This makes the official Homebrew namespace structurally resistant to the typosqu
 Homebrew does not trust, recommend or automatically install from any third-party non-Homebrew repositories.
 Only official Homebrew taps and built-in commands are trusted by default.
 A non-official tap is executable code, not plain metadata, so loading it can run Ruby with your user's privileges.
-Homebrew is moving to require explicit trust for non-official taps, and `brew trust` lets you trust a single formula, cask or command rather than a whole tap.
-See [Tap Trust](Tap-Trust.md) for how to trust only what you need and the recently added `brew trust`, `brew untrust` and `Brewfile` `trusted: true` controls.
+Non-official taps require explicit trust by default, and `brew trust` lets you trust a single formula, cask or command rather than a whole tap.
+See [Tap Trust](Tap-Trust.md) for how to trust only what you need with `brew trust`, `brew untrust` and the `Brewfile` `trusted: true` option.
 
 Homebrew's [tap migrations](Migrating-A-Formula-To-A-Tap.md) stay within the Homebrew organisation: a formula or cask is only ever migrated into or within official Homebrew taps, never out to a third-party tap.
 A rename or move therefore cannot silently redirect users to a non-Homebrew repository.
@@ -199,7 +199,7 @@ At best, when a cask pins a `sha256`, Homebrew additionally guarantees the downl
 
 ### Cooldowns on riskier ecosystems
 
-For ecosystems with a track record of fast-moving supply-side attacks, Homebrew applies a download cooldown: a freshly-published upstream version is not adopted immediately, giving the wider community time to detect and report a malicious release before Homebrew users are exposed.
+For ecosystems with a track record of fast-moving supply-chain attacks, Homebrew applies a download cooldown: a freshly-published upstream version is not adopted immediately, giving the wider community time to detect and report a malicious release before Homebrew users are exposed.
 Cooldowns have been added for:
 
 * [Bundler](https://github.com/Homebrew/brew/pull/22555)
@@ -208,8 +208,8 @@ Cooldowns have been added for:
 * [PyPI resource resolution](https://github.com/Homebrew/brew/pull/21920)
 * [npm and PyPI in `bump`](https://github.com/Homebrew/brew/pull/21888)
 
-Homebrew applies these cooldowns narrowly, only to the language ecosystems that have actually suffered fast-moving supply-side attacks, rather than as a blanket delay on every package.
-A blanket cooldown would trade a small, speculative reduction in supply-side risk for a real, across-the-board delay in shipping critical fixes: when a zero-day in something like OpenSSL is being exploited in the wild, Homebrew works to get the fix to users as fast as possible, and Homebrew's design means upgrading one package can require upgrading others.
+Homebrew applies these cooldowns narrowly, only to the language ecosystems that have actually suffered fast-moving supply-chain attacks, rather than as a blanket delay on every package.
+A blanket cooldown would trade a small, speculative reduction in supply-chain risk for a real, across-the-board delay in shipping critical fixes: when a zero-day in something like OpenSSL is being exploited in the wild, Homebrew works to get the fix to users as fast as possible, and Homebrew's design means upgrading one package can require upgrading others.
 Across Homebrew's history far more users have been protected by shipping zero-day fixes quickly than have been exposed to npm-style token-theft or crypto-mining attacks, so a global cooldown would be a net negative for most users' security.
 The deeper reason Homebrew does not need a general cooldown is that, unlike language package managers, it already separates publishing from distribution: an upstream release does not reach users until it has passed human review, CI and checksum verification, which is the very review window that language-ecosystem cooldowns are trying to recreate.
 
@@ -220,7 +220,7 @@ Given our trust model, risk profile and the breadth of ecosystems we support, we
 
 When the two conflict, Homebrew prioritises security over backwards compatibility.
 Homebrew's [deprecation](Deprecating-Disabling-and-Removing.md) policy and regular major and minor releases let us deprecate, then disable, then entirely remove a risky behaviour or default across successive releases, often within roughly six to nine months.
-Being willing to break compatibility on that timescale is a large part of why Homebrew has been able to respond to new supply-side threats faster than ecosystems that must preserve old behaviour indefinitely.
+Being willing to break compatibility on that timescale is a large part of why Homebrew has been able to respond to new supply-chain threats faster than ecosystems that must preserve old behaviour indefinitely.
 
 ## Trust model comparison
 
@@ -239,4 +239,4 @@ Being willing to break compatibility on that timescale is a large part of why Ho
 
 This is not a solved problem and we do not claim Homebrew is immune.
 We have taken steps to mitigate these risks for our users, some long-standing (macOS sandboxing, human review on all changes, environment filtering, all package maintainers being Homebrew maintainers) and some newer (Linux sandboxing, sandboxing reads of sensitive locations, cooldowns on riskier ecosystems).
-We will continue to monitor the supply-side security landscape and take further steps as needed.
+We will continue to monitor the supply-chain security landscape and take further steps as needed.

--- a/docs/How-to-Create-and-Maintain-a-Tap.md
+++ b/docs/How-to-Create-and-Maintain-a-Tap.md
@@ -135,9 +135,15 @@ After tapping, users can install your formulae either with:
 - `brew install foo` if there's no core formula with the same name
 - `brew install user/repository/foo` to avoid conflicts with core formulae
 
-Users who install by short name will need to run `brew trust user/repository`
-first when Homebrew requires explicit trust for non-official taps, in
-Homebrew 6.0.0 or 5.2.0, whichever comes first.
+Non-official taps require explicit trust by default.
+Trust only the formula when whole-tap trust is unnecessary:
+
+```sh
+brew trust --formula user/repository/foo
+```
+
+Use `brew trust --tap user/repository` only when every formula, cask and external command in the tap should be trusted.
+See [Tap Trust](Tap-Trust.md) for the complete trust model.
 
 ## Maintaining a tap
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2208,10 +2208,9 @@ provided, display brief statistics for all installed taps.
 
 ### `trust` \[*`options`*\] \[*`target`* ...\]
 
-Trust non-official tap formulae, casks or commands so Homebrew may load them
-when `$HOMEBREW_REQUIRE_TAP_TRUST` is set. Trusted entries are stored in
-`${XDG_CONFIG_HOME}/homebrew/trust.json` if `$XDG_CONFIG_HOME` is set or
-`~/.homebrew/trust.json` otherwise.
+Trust non-official tap formulae, casks or commands so Homebrew may load them.
+Trusted entries are stored in `${XDG_CONFIG_HOME}/homebrew/trust.json` if
+`$XDG_CONFIG_HOME` is set or `~/.homebrew/trust.json` otherwise.
 
 `--tap`
 
@@ -3586,11 +3585,11 @@ Generate the template files for a new tap.
 
 `--no-git`
 
-: Don't initialize a Git repository for the tap.
+: Don't initialise a Git repository for the tap.
 
 `--branch`
 
-: Initialize Git repository and setup GitHub Actions workflows with the
+: Initialise a Git repository and set up GitHub Actions workflows with the
   specified branch name (default: `main`).
 
 `--github-packages`

--- a/docs/Tap-Trust.md
+++ b/docs/Tap-Trust.md
@@ -1,52 +1,43 @@
 ---
-last_review_date: "2026-06-10"
+last_review_date: "2026-07-18"
 ---
 
 # Tap Trust
 
-Homebrew taps can contain formulae, casks and external commands. Loading them
-can run Ruby code from the tap, so Homebrew distinguishes between official taps
-and non-official taps that you have explicitly trusted.
+Homebrew taps can contain formulae, casks and external commands.
+Loading them can run Ruby code from the tap, so Homebrew distinguishes between official taps and non-official taps that you have explicitly trusted.
 
 Official Homebrew taps and Homebrew's built-in commands are always trusted.
-Non-official taps require explicit trust [since Homebrew 6.0.0](
-https://brew.sh/2026/06/11/homebrew-6.0.0/).
+Non-official taps require explicit trust by default [since Homebrew 6.0.0](https://brew.sh/2026/06/11/homebrew-6.0.0/).
 
-`brew doctor` warns about non-official taps that are not trusted, and install
-commands will fail until the tap or the specific package is trusted.
+`brew doctor` warns about non-official taps for which neither the tap nor any individual item is trusted.
+Commands that need to load an untrusted tap or item will fail until the relevant trust is granted.
 
 ## Why tap trust exists
 
-Formulae, casks and external commands are executable package definitions, not
-plain metadata. Homebrew sometimes needs to evaluate Ruby code from a tap to
-resolve dependencies, discover available packages or run commands. Trusting a
-tap means you accept that code running with your user's privileges whenever
-Homebrew needs to load it.
+Formulae, casks and external commands are executable package definitions, not plain metadata.
+Homebrew sometimes needs to evaluate Ruby code from a tap to resolve dependencies, discover packages or run commands.
+Trusting a tap means accepting that its code may run with your user's privileges whenever Homebrew loads it.
 
-Tap trust reduces the amount of non-official code Homebrew evaluates by
-default. This limits the impact of compromised tap repositories, unexpected
-repository ownership changes, name collisions with packages from other taps and
-commands that are loaded just because their tap is present. It also makes
-automation clearer: scripts can trust exactly the tap, formula, cask or command
-they intend to use instead of relying on every tapped repository being loaded.
+Tap trust reduces the amount of non-official code Homebrew evaluates by default.
+This limits the impact of compromised tap repositories, unexpected repository ownership changes, package name collisions and commands loaded merely because their tap is present.
+It also makes automation explicit by allowing scripts to trust only the tap, formula, cask or command they intend to use.
 
-Tap trust is one part of Homebrew's wider approach to [Software Supply Chain Security](Homebrew-Security-and-Supply-Chain.md).
+Tap trust is one part of Homebrew's wider approach to [software supply chain security](Homebrew-Security-and-Supply-Chain.md).
 
-Prefer trusting the specific formula, cask or command you need. Trust a whole
-tap only when you are comfortable with all current and future formulae, casks
-and external commands from that tap being loaded by Homebrew.
+Prefer trusting the specific formula, cask or command you need.
+Trust a whole tap only when you accept all current and future formulae, casks and external commands from that tap.
 
 ## Installing from a tap
 
-Installing a fully-qualified formula or cask name trusts only that item:
+Installing a fully qualified formula or cask name trusts only that item:
 
 ```sh
 brew install user/repository/formula
 brew install --cask user/repository/cask
 ```
 
-To install by short name from a tapped repository, trust the specific item
-first:
+To install by short name from a tapped repository, trust the specific item first:
 
 ```sh
 brew tap user/repository
@@ -54,8 +45,7 @@ brew trust --formula user/repository/formula
 brew install formula
 ```
 
-Use `brew trust --cask user/repository/cask` for casks and
-`brew trust --command user/repository/command` for external commands.
+Use `brew trust --cask user/repository/cask` for casks and `brew trust --command user/repository/command` for external commands.
 
 You can also trust the whole tap:
 
@@ -65,16 +55,13 @@ brew trust user/repository
 brew install formula
 ```
 
-Whole-tap trust is broader. It allows Homebrew to load every current and future
-formula, cask and external command from that tap. This may be appropriate for a
-tap you administer or rely on heavily, but for one-off installs, automation or
-software from a vendor you do not fully control, prefer trusting only the item
-you need.
+Whole-tap trust allows Homebrew to load every current and future formula, cask and external command from that tap.
+This may be appropriate for a tap you administer or use frequently.
+For one-off installs, automation or software from a vendor you do not fully control, prefer trusting only the required item.
 
 ## Trusting in a `Brewfile`
 
-For `Brewfile` trust syntax and `brew bundle` dump and cleanup behaviour, see
-the [`trusted` section of the Homebrew Bundle documentation](Brew-Bundle-and-Brewfile.md#trusted).
+For `Brewfile` trust syntax and `brew bundle` dump and cleanup behaviour, see the [`trusted` section of the Homebrew Bundle documentation](Brew-Bundle-and-Brewfile.md#trusted).
 
 ## Managing trust
 
@@ -97,16 +84,16 @@ brew untrust user/repository
 brew untrust --formula user/repository/formula
 ```
 
-A trusted tap behaves as it did before tap trust checks were introduced. An
-untrusted tap is not loaded when tap trust is required, unless you explicitly
-install a fully-qualified formula or cask from that tap. If you trust only a
-specific formula, cask or command, Homebrew may load that item without trusting
-the rest of the tap.
+An untrusted tap is not loaded when tap trust is required unless you explicitly install a fully qualified formula or cask from that tap.
+If you trust only a specific formula, cask or command, Homebrew may load that item without trusting the rest of its tap.
 
 ## Environment variables
 
-Set `HOMEBREW_REQUIRE_TAP_TRUST=1` to require explicit trust now.
+Tap trust is required by default.
+The default trust configuration also enables commands that evaluate all formulae or casks.
+`HOMEBREW_REQUIRE_TAP_TRUST=1` explicitly retains that behaviour.
 
-`HOMEBREW_NO_REQUIRE_TAP_TRUST=1` keeps allowing non-official taps by default
-during the transition. This is not recommended and will be removed in a later
-release.
+`HOMEBREW_NO_REQUIRE_TAP_TRUST=1` disables the default trust requirement.
+Disabling tap trust allows Homebrew to load code from every tapped repository and is not recommended.
+Commands that evaluate all formulae or casks remain enabled when this opt-out is set.
+This temporary opt-out will be removed in a later release.

--- a/docs/Taps.md
+++ b/docs/Taps.md
@@ -24,12 +24,16 @@ petere/postgresql
 Homebrew updates the repository during `brew update`.
 
 Tapping a repository does not grant whole-tap trust.
-Install a fully qualified item to trust only that item, or use `brew trust` before accessing an item by its short name:
+Install a fully qualified item to trust only that item:
 
 ```sh
 brew tap user/repository
 brew install user/repository/formula
+```
 
+Alternatively, use `brew trust` first to access an item by its short name:
+
+```sh
 brew trust --formula user/repository/formula
 brew install formula
 ```

--- a/docs/Taps.md
+++ b/docs/Taps.md
@@ -1,80 +1,73 @@
 ---
-last_review_date: "1970-01-01"
+last_review_date: "2026-07-18"
 ---
 
 # Taps (Third-Party Repositories)
 
-The `brew tap` command adds more repositories to the list of formulae that Homebrew tracks, updates,
-and installs from. By default, `tap` assumes that the repositories come from GitHub,
-but the command isn't limited to any one location.
+The `brew tap` command adds repositories that Homebrew can use for formulae, casks and external commands.
+The one-argument form assumes a repository on GitHub, while the two-argument form accepts any URL supported by Git.
+
+Code in a tap can run with your user's privileges.
+Read [Tap Trust](Tap-Trust.md) before using a non-official tap.
 
 ## The `brew tap` command
 
-* `brew tap` without arguments lists all currently tapped repositories. For
-  example with one installed tap which is called `petere/postgresql`:
+`brew tap` without arguments lists the currently tapped repositories.
+It prints nothing when no taps are installed.
 
-  ```console
-  $ brew tap
-  petere/postgresql
-  ```
-
-* It should be noted: `brew tap` will not output anything if no taps were added yet. That is the case after a fresh install of Homebrew.
-
-* `brew tap <user>/<repo>` makes a clone of the repository at
-  `https://github.com/<user>/homebrew-<repo>` into `$(brew --repository)/Library/Taps`.
-  After that, `brew` will be able to work with those formulae as if they were in Homebrew's
-  [homebrew/core](https://github.com/Homebrew/homebrew-core) canonical repository.
-  You can install and uninstall them with `brew [un]install`, and the formulae are
-  automatically updated when you run `brew update`. (See below for details
-  about how `brew tap` handles the names of repositories.)
-
-* `brew tap <user>/<repo> <URL>` makes a clone of the repository at _URL_.
-  Unlike the one-argument version, _URL_ is not assumed to be GitHub, and it
-  doesn't have to be HTTP. Any location and any protocol that Git can handle is
-  fine.
-
-* `brew tap --repair` migrates tapped formulae from a symlink-based to
-  directory-based structure. (This should only need to be run once.)
-
-* `brew untap user/repo [user/repo user/repo ...]` removes the given taps. The
-  repositories are deleted and `brew` will no longer be aware of their formulae.
-  `brew untap` can handle multiple removals at once.
-
-## Repository naming conventions and assumptions
-
-On GitHub, your repository must be named `homebrew-something` to use
-the one-argument form of `brew tap`. The prefix "homebrew-" is not optional.
-(The two-argument form doesn't have this limitation, but it forces you to
-give the full URL explicitly.)
-
-When you use `brew tap` on the command line, however, you can leave out the
-"homebrew-" prefix in commands. That is, `brew tap username/foobar` can be used as a shortcut for the long
-version: `brew tap username/homebrew-foobar`. `brew` will automatically add
-back the "homebrew-" prefix whenever it's necessary.
-
-## Formula with duplicate names
-
-If your tap contains a formula that is also present in
-[homebrew/core](https://github.com/Homebrew/homebrew-core), that's fine,
-but you would need to specify its fully qualified name in the form
-`<user>/<repo>/<formula>` to install your version.
-
-Whenever a `brew install foo` command is issued, `brew` selects which formula
-to use by searching in the following order:
-
-* core formulae
-* other taps
-
-If you need a formula to be installed from a particular tap, you can use fully
-qualified names to refer to them.
-
-If you were to create a tap for an alternative `vim` formula, the behaviour would be:
-
-```sh
-brew install vim                     # installs from homebrew/core
-brew install username/repo/vim       # installs from your custom repository
+```console
+$ brew tap
+petere/postgresql
 ```
 
-As a result, we recommend you give new names to customized formulae if you want to make
-them easier to install. Note that there is (intentionally) no way of replacing
-dependencies of core formulae with those from other taps.
+`brew tap <user>/<repository>` clones `https://github.com/<user>/homebrew-<repository>` into Homebrew's tap directory.
+Homebrew updates the repository during `brew update`.
+
+Tapping a repository does not grant whole-tap trust.
+Install a fully qualified item to trust only that item, or use `brew trust` before accessing an item by its short name:
+
+```sh
+brew tap user/repository
+brew install user/repository/formula
+
+brew trust --formula user/repository/formula
+brew install formula
+```
+
+See [Tap Trust](Tap-Trust.md#installing-from-a-tap) for formula, cask, command and whole-tap trust options.
+
+`brew tap <user>/<repository> <URL>` clones a repository from the specified Git URL without assuming GitHub or a particular transport.
+
+`brew tap --repair` adds missing tap manpage and shell-completion symlinks.
+It also corrects remote references for taps whose upstream default branch has been renamed.
+
+`brew untap <user>/<repository> [...]` removes one or more taps.
+Homebrew deletes the local repositories and no longer loads their contents.
+
+## Repository naming conventions
+
+On GitHub, a repository must be named `homebrew-<repository>` to use the one-argument form of `brew tap`.
+The `homebrew-` prefix can be omitted from the command:
+
+```sh
+brew tap username/foobar
+```
+
+This command maps to `https://github.com/username/homebrew-foobar`.
+The two-argument form does not impose this naming convention because the full URL is explicit.
+
+## Duplicate names
+
+A tap may contain a formula with the same name as one in `homebrew/core`.
+Use the fully qualified name to select the formula from a particular tap:
+
+```sh
+brew install vim
+brew install username/repository/vim
+```
+
+The first command installs `vim` from `homebrew/core`.
+The second installs the formula from `username/repository` and trusts that individual formula.
+
+Give customised formulae distinct names when users should be able to select them without qualification.
+Dependencies of `homebrew/core` formulae cannot be replaced with formulae from other taps.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1398,7 +1398,7 @@ Print a JSON representation of \fItap\fP\&\. Currently the default and only acce
 .UR https://docs\.brew\.sh/Querying\-Brew
 .UE
 .SS "\fBtrust\fP \fR[\fIoptions\fP] \fR[\fItarget\fP \.\.\.]"
-Trust non\-official tap formulae, casks or commands so Homebrew may load them when \fB$HOMEBREW_REQUIRE_TAP_TRUST\fP is set\. Trusted entries are stored in \fB${XDG_CONFIG_HOME}/homebrew/trust\.json\fP if \fB$XDG_CONFIG_HOME\fP is set or \fB~/\.homebrew/trust\.json\fP otherwise\.
+Trust non\-official tap formulae, casks or commands so Homebrew may load them\. Trusted entries are stored in \fB${XDG_CONFIG_HOME}/homebrew/trust\.json\fP if \fB$XDG_CONFIG_HOME\fP is set or \fB~/\.homebrew/trust\.json\fP otherwise\.
 .TP
 \fB\-\-tap\fP
 Trust the named tap\.
@@ -2272,10 +2272,10 @@ Specify a comma\-separated \fIcops\fP list to skip checking for violations of th
 Generate the template files for a new tap\.
 .TP
 \fB\-\-no\-git\fP
-Don\[u2019]t initialize a Git repository for the tap\.
+Don\[u2019]t initialise a Git repository for the tap\.
 .TP
 \fB\-\-branch\fP
-Initialize Git repository and setup GitHub Actions workflows with the specified branch name (default: \fBmain\fP)\.
+Initialise a Git repository and set up GitHub Actions workflows with the specified branch name (default: \fBmain\fP)\.
 .TP
 \fB\-\-github\-packages\fP
 Upload bottles to GitHub Packages\.


### PR DESCRIPTION
Updates the tap trust and supply-chain documentation for the default-on trust model. Tap Trust now attributes eval-all command availability to the default configuration and describes `brew doctor`'s wholly-untrusted warning precisely, the security overview no longer describes required tap trust as upcoming, How to Create and Maintain a Tap replaces a stale future-tense trust paragraph with current `brew trust --formula`/`--tap` guidance and "supply-side attack" becomes the standard "supply-chain attack" throughout. The `trust` and `tap-new` help strings drop the stale `$HOMEBREW_REQUIRE_TAP_TRUST` framing and two US spellings, with the manpage and completions regenerated. All behavioural claims were verified against the implementation (`env_config.rb`, `cmd/trust.rb`, `tap.rb`).

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5) prepared the changes and verified every behavioural claim against the trust implementation; I reviewed the diff and verified locally with `brew lgtm --online`, Vale, `brew generate-man-completions` (no drift) and the docs Jekyll/HTMLProofer suite, whose only failures were transient HTTP 429 rate limits on pages this PR does not touch (addressed by #23169).

-----
