### PR TITLE
docs: update FAQ and troubleshooting pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ First time contributing to Homebrew? Read our [Code of Conduct](https://github.c
 
 ### Report a bug
 
-* Run `brew update` (twice).
+* Run `brew update` twice.
 * Run and read `brew doctor`.
 * Read the [Troubleshooting checklist](https://docs.brew.sh/Troubleshooting).
 * Ideally, open a pull request to fix it, describing both your problem and your proposed solution.

--- a/docs/Common-Issues.md
+++ b/docs/Common-Issues.md
@@ -107,10 +107,10 @@ An Apple Silicon shell should normally report `arm64` and use `/opt/homebrew`.
 Before removing an old Intel installation, run its own executable to record its packages:
 
 ```sh
-arch -x86_64 /usr/local/bin/brew bundle dump
+arch -x86_64 /usr/local/bin/brew bundle dump --file=~/intel-Brewfile
 ```
 
-Review the resulting `Brewfile` and reproduce the installation under the correct prefix.
+Review the resulting `~/intel-Brewfile` and reproduce the installation under the correct prefix.
 Follow the [official uninstallation instructions](FAQ.md#how-do-i-uninstall-homebrew) only after confirming the replacement works.
 
 ## Casks

--- a/docs/Common-Issues.md
+++ b/docs/Common-Issues.md
@@ -1,246 +1,164 @@
 ---
-last_review_date: "1970-01-01"
+last_review_date: "2026-07-18"
 ---
 
 # Common Issues
 
-This is a list of commonly encountered problems, known issues, and their solutions.
+This page covers recurring Homebrew problems with current, non-destructive diagnostic steps.
+Start with the [Troubleshooting checklist](Troubleshooting.md) and read the full error before changing files or permissions.
 
 * Table of Contents
 {:toc}
 
 ## Running `brew`
 
-### `brew` complains about absence of "Command Line Tools"
+### Missing Command Line Tools
 
-You need the Xcode Command Line Utilities installed and updated for a supported Homebrew configuration and to build formulae from source: run `xcode-select --install` in the terminal. Casks and bottles can be installed without developer tools.
-
-### Ruby: `bad interpreter: /usr/bin/ruby^M: no such file or directory`
-
-You cloned with `git`, and your Git configuration is set to use Windows line endings. See this page on [configuring Git to handle line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings).
-
-### Ruby: `bad interpreter: /usr/bin/ruby`
-
-You don't have a `/usr/bin/ruby` or it is not executable. It's not recommended to let this persist; you'd be surprised how many `.app`s, tools and scripts expect your macOS-provided files and directories to be *unmodified* since macOS was installed.
-
-### `brew update` complains about untracked working tree files
-
-After running `brew update`, you receive a Git error warning about untracked files or local changes that would be overwritten by a checkout or merge, followed by a list of files inside your Homebrew installation.
-
-This is caused by an old bug in the `update` code that has long since been fixed. However, the nature of the bug requires that you do the following:
-
-```sh
-cd "$(brew --repository)"
-git reset --hard FETCH_HEAD
-```
-
-If `brew doctor` still complains about uncommitted modifications, also run this command:
-
-```sh
-cd "$(brew --repository)/Library"
-git clean -fd
-```
-
-### `launchctl` refuses to load `launchd` plist files
-
-When trying to load a plist file with `launchctl`, you receive an error that resembles either:
-
-    Bug: launchctl.c:2325 (23930):13: (dbfd = open(g_job_overrides_db_path, [...]
-    launch_msg(): Socket is not connected
-
-or:
-
-    Could not open job overrides database at: /private/var/db/launchd.db/com.apple.launchd/overrides.plist: 13: Permission denied
-    launch_msg(): Socket is not connected
-
-These are likely due to one of four issues:
-
-1. You are using iTerm. The solution is to use Terminal.app when interacting with `launchctl`.
-1. You are using a terminal multiplexer such as `tmux` or `screen`. You should interact with `launchctl` from a separate Terminal.app shell.
-1. You are attempting to run `launchctl` while logged in remotely. You should enable screen sharing on the remote machine and issue the command using Terminal.app running on that machine.
-1. You are `su`'ed as a different user.
-
-### `brew upgrade` errors out
-
-When running `brew upgrade`, you see something like this:
-
-    Error: undefined method `include?' for nil:NilClass
-    Please report this bug:
-        https://docs.brew.sh/Troubleshooting
-    /usr/local/Library/Homebrew/formula.rb:393:in `canonical_name'
-    /usr/local/Library/Homebrew/formula.rb:425:in `factory'
-    /usr/local/Library/Contributions/examples/brew-upgrade.rb:7
-    /usr/local/Library/Contributions/examples/brew-upgrade.rb:7:in `map'
-    /usr/local/Library/Contributions/examples/brew-upgrade.rb:7
-    /usr/local/bin/brew:46:in `require'
-    /usr/local/bin/brew:46:in `require?'
-    /usr/local/bin/brew:79
-
-This happens because an old version of the upgrade command is hanging around for some reason. The fix:
-
-```sh
-cd "$(brew --repository)/Library/Contributions/examples"
-git clean -n # if this doesn't list anything that you want to keep, then
-git clean -f # this will remove untracked files
-```
-
-## Installation fails with "unknown revision or path not in the working tree"
-
-When installing Homebrew, if the initial download fails with something like:
-
-    error: Not a valid ref: refs/remotes/origin/main
-    fatal: ambiguous argument 'refs/remotes/origin/main': unknown revision or path not in the working tree.
-    Use '--' to separate paths from revisions, like this:
-    'git <command> [<revision>...] -- [<file>...]'
-
-or:
-
-    fatal: the remote end hung up unexpectedly
-    fatal: early EOF
-    fatal: index-pack failed
-
-This is an issue in the connection between your machine and GitHub, rather than a bug in Homebrew itself. See this [discussion topic](https://github.com/orgs/Homebrew/discussions/666) for a number of solutions others have found, such as using a wired connection or a VPN, or disabling network monitoring tools.
-
-## Upgrading macOS
-
-Upgrading macOS can cause errors like the following:
-
-* `dyld: Library not loaded: /opt/homebrew/opt/icu4c/lib/libicui18n.76.dylib`
-* `configure: error: Cannot find libz`
-
-Following a macOS upgrade it may be necessary to reinstall the Xcode Command Line Tools and then `brew upgrade` all installed formulae:
+A supported Homebrew development environment on macOS requires the Xcode Command Line Tools to build formulae from source.
+Install them with:
 
 ```sh
 xcode-select --install
-brew upgrade
 ```
 
-## Unintentional dual Homebrew installations
+Casks and bottles can be installed without developer tools, but `brew doctor` may still report the unsupported configuration.
 
-When using tools such as Apple's *Migration Assistant* (MA), it's possible to have two Homebrew installations unintentionally.
-This most commonly results in MA copying `/usr/local` and `/Applications` from an Intel-based Mac to these same paths on an Apple Silicon-based Mac.
-This is problematic because `/Applications` may contain x86_64-only apps.
-Using an x86_64 terminal emulator will cause the shell to use the `/usr/local` installation of Homebrew
-instead of a new installation in `/opt/homebrew`, which is the correct path for an arm64 Homebrew installation on macOS.
+### `bad interpreter: /usr/bin/ruby^M`
 
-Continuing with this setup may eventually cause problems, so it's best to migrate your Homebrew installation.
-Follow these steps to do this.
+The Homebrew checkout has Windows line endings, usually because of a Git configuration setting.
+Review GitHub's guide to [configuring Git line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings), then restore the Homebrew repository with `brew update-reset` as described below.
 
-1. Run `arch -x86_64 /usr/local/bin/brew bundle dump --global` to dump your current installed formulae list to `~/.Brewfile`.
-1. Review the contents of `~/.Brewfile` to remove things you no longer want to have installed.
-1. Verify that your terminal emulator is running in arm64 mode by checking that the output of `arch` is `arm64`.
+### Missing or inaccessible `/usr/bin/ruby`
 
-   If it is not, use a different terminal emulator, such as Apple's Terminal.app, that will run in `arm64` mode.
+Files under `/usr/bin` are provided by macOS and should not be modified manually.
+Install current macOS updates or use Apple's supported recovery process to restore missing system files.
 
-1. Install Homebrew under the correct prefix (`/opt/homebrew`),
-   which will happen by default when the terminal is running in arm64 mode.
+### Local changes prevent `brew update`
 
-   **Follow the *Next Steps* instructions** listed at the end of the installation process;
-    failing to adjust your shell configuration accordingly could break your Homebrew installation.
-
-1. Run `/opt/homebrew/bin/brew bundle install --global` to replicate your original formulae installation using your new Homebrew installation in `/opt/homebrew`.
-
-Expect to spend some time [searching Homebrew's formulae and cask list](https://formulae.brew.sh/)
-for replacements for deprecated, disabled, or removed formulae.
-
-Once you are satisfied with the state of your new `/opt/homebrew` Homebrew installation,
-you can uninstall the old `/usr/local` installation.
-Download and run the [uninstaller script](https://github.com/Homebrew/install/#uninstall-homebrew):
+First inspect the repositories reported by `brew update`:
 
 ```sh
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)" -- --path=/usr/local
+git -C "$(brew --repository)" status --short
+git -C "$(brew --repository USER/REPOSITORY)" status --short
 ```
 
-For more information, see [this discussion](https://github.com/orgs/Homebrew/discussions/4397#discussioncomment-5567441).
+Repeat the second command for each tap named in the error, replacing `USER/REPOSITORY` with its tap name.
 
-## Homebrew Cask issues
+Preserve any work you intentionally made in Homebrew or a tap before continuing.
+Do not run arbitrary `git clean` or `git reset --hard` commands copied from old issue reports.
 
-### Cask - cURL error
+After preserving intentional changes, reset only the affected repositories:
 
-First, let's tackle a common problem: do you have a `.curlrc` file? Check with `ls -A ~ | grep .curlrc` (if you get a result, the file exists). Those are a frequent cause of issues of this nature. Before anything else, remove that file and try again. If it now works, do not open an issue. Incompatible `.curlrc` configurations must be fixed on your side.
+```sh
+brew update-reset "$(brew --repository)"
+brew update-reset "$(brew --repository USER/REPOSITORY)"
+```
 
-If, however, you do not have a `.curlrc` or removing it did not work, let’s see if the issue is upstream:
+Run only the commands that apply, replacing `USER/REPOSITORY` with the affected tap name.
+`brew update-reset` fetches and resets each specified repository to its upstream default branch.
+It destroys uncommitted and committed local changes in those repositories, so review its help and preserve your work first.
+Running `brew update-reset` without a repository resets Homebrew and every tap.
 
-1. Go to the vendor’s website (`brew home <cask_name>`).
-2. Find the download link for the app and click on it.
+## Installation and downloads
 
-#### If the download works
+### Git checkout or network failures
 
-The cask is outdated. Let’s fix it:
+Errors such as `early EOF`, `index-pack failed` or a failed connection to GitHub usually indicate a network, proxy, mirror or filtering problem.
 
-1. Look around the app’s website and find out what the latest version is. It may be expressed in the URL used to download it.
-2. Take a look at the cask’s version (`brew info <cask_name>`) and verify it is indeed outdated. If the app’s version is `:latest`, it means the `url` itself is outdated. It will need to be changed to the new one.
+1. Confirm that GitHub and the download host are reachable from the same shell.
+2. Check proxy environment variables, VPN software, firewalls and network-monitoring tools.
+3. Run `brew config` and review any configured Git or bottle mirrors.
+4. Retry from a stable network before reporting the problem.
 
-Help us by [submitting a fix](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md#updating-a-cask). If you get stumped, [open an issue](https://github.com/Homebrew/homebrew-cask/issues/new?template=01_bug_report.yml) explaining your steps so far and where you’re having trouble.
+If the failure is reproducible only with Homebrew, follow the [Troubleshooting checklist](Troubleshooting.md) and include the exact command and error output.
 
-#### If the download does not work
+### `curl` configuration
 
-The issue isn’t in any way related to Homebrew Cask, but with the vendor or your connection.
+A user `curl` configuration can change proxy, certificate, protocol or output behaviour.
+Inspect `~/.curlrc` and any `CURL_*` environment variables instead of deleting the configuration blindly.
+Temporarily test without custom settings, then correct the specific setting responsible for the failure.
 
-Start by diagnosing your connection (try to download other casks, or browse around the web). If the problem is with your connection, try a website like [Ask Different](https://apple.stackexchange.com/) to ask for advice.
+The [curl exit-code reference](https://everything.curl.dev/cmdline/exitcode.html) and [libcurl error reference](https://curl.se/libcurl/c/libcurl-errors.html) explain common transport errors.
 
-If you’re sure the issue is not with your connection, contact the app’s vendor and let them know their link is down, so they can fix it.
+## After a macOS upgrade
 
-**Do not open an issue.**
+A macOS upgrade may replace or invalidate the Command Line Tools and libraries used by installed formulae.
 
-### Cask - checksum does not match
+1. Install all available macOS updates.
+2. Reinstall or update the Xcode Command Line Tools when `brew doctor` reports a problem.
+3. Run `brew update`.
+4. Run `brew upgrade` to rebuild or reinstall outdated formulae.
 
-First, check if the problem was with your download. Delete the downloaded file (its location will be pointed out in the error message) and try again.
+Do not create symlinks for missing versioned libraries.
+Those links can hide an incomplete upgrade and cause incompatible software to load the wrong library.
 
-If the problem persists, the cask must be outdated. It’ll likely need a new version, but it’s possible the version has remained the same (this happens occasionally when the vendor updates the app in-place).
+## Multiple Homebrew installations
 
-1. Go to the vendor’s website (`brew home <cask_name>`).
-2. Find out what the latest version is. It may be expressed in the URL used to download it.
-3. Take a look at the cask’s version (`brew info <cask_name>`) and verify it is indeed outdated. If so, it will need to be updated.
+Migration Assistant or an x86_64 terminal on Apple Silicon can leave both `/usr/local` and `/opt/homebrew` installations active.
+Check the current process architecture and executable path:
 
-Help us by [submitting a fix](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md#updating-a-cask). If you get stumped, [open an issue](https://github.com/Homebrew/homebrew-cask/issues/new?template=01_bug_report.yml) explaining your steps so far and where you’re having trouble.
+```sh
+arch
+command -v brew
+brew --prefix
+```
 
-### Cask - permission denied
+An Apple Silicon shell should normally report `arm64` and use `/opt/homebrew`.
+Before removing an old Intel installation, run its own executable to record its packages:
 
-In this case, it’s likely your user account has no admin rights and therefore lacks permissions for writing to `/Applications`, which is the default install location. You can use [`--appdir`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/USAGE.md#options) to choose where to install your applications.
+```sh
+arch -x86_64 /usr/local/bin/brew bundle dump
+```
 
-If `--appdir` doesn’t fix the issue or you do have write permissions to `/Applications`, verify you’re the owner of the `Caskroom` directory by running `ls -dl "$(brew --caskroom)"` and checking the third field. If you are not the owner, fix it with `sudo chown -R "$(whoami)" "$(brew --caskroom)"`. If you are, the problem may lie in the app bundle itself.
+Review the resulting `Brewfile` and reproduce the installation under the correct prefix.
+Follow the [official uninstallation instructions](FAQ.md#how-do-i-uninstall-homebrew) only after confirming the replacement works.
 
-Some app bundles don’t have certain permissions that are necessary for us to move them to the appropriate location. You may check such permissions with `ls -ls '/path/to/application.app'`. If you see something like `dr-xr-xr-x` at the start of the output, that may be the cause. To fix it, we need to change the app bundle’s permission to allow us to move it, and then set it back to what it was (in case the developer set those permissions deliberately). See [litecoin.rb](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/l/litecoin.rb#L17-L27) for an example of such a cask.
+## Casks
 
-Help us by [submitting a fix](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md#updating-a-cask). If you get stumped, [open an issue](https://github.com/Homebrew/homebrew-cask/issues/new?template=01_bug_report.yml) explaining your steps so far and where you’re having trouble.
+### A cask download fails
 
-### Cask - source is not there
+Open the cask's homepage with `brew home <cask>` and test the vendor's download link.
 
-First, you need to identify which artifact is not being handled correctly anymore. It’s explicit in the error message: if it says `It seems the App source…'` then the problem is with the [`app`](Cask-Cookbook.md#stanza-app) stanza. This pattern is the same across [all artifacts](Cask-Cookbook.md#at-least-one-artifact-stanza-is-also-required).
+* If the vendor's download also fails, report the failure to the vendor or investigate the network connection.
+* If the vendor has published a different version or URL, [submit a cask update](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md#updating-a-cask).
 
-Fixing this error is typically easy, and requires only a bit of time on your part. Start by downloading the package for the cask: `brew fetch <cask_name>`. The last line of output will inform you of the location of the download. Navigate there and manually unpack it. As an example, let's say the structure inside the archive is as follows:
+### A cask checksum does not match
 
-    .
-    ├─ Files/SomeApp.app
-    ├─ Files/script.sh
-    └─ README.md
+Read the error to find the downloaded file, remove only that cached file and retry once.
+If the checksum still differs, compare `brew info <cask>` with the vendor's current release.
 
-Now, if we find this when looking at the cask with `brew cat <cask_name>`:
+A persistent mismatch usually means the cask is outdated or the vendor replaced an existing download.
+Do not bypass the checksum.
+Submit an update with evidence of the vendor's current version and download.
 
-    (…)
-    app "SomeApp.app"
-    (…)
+### Permission denied while installing a cask
 
-The cask expects `SomeApp.app` to be in the top directory of the archive (see how it says simply `SomeApp.app`) but the developer has since moved it to be inside a `Files` directory. All we have to do is update that line of the cask to follow the new structure: `app "Files/SomeApp.app"`.
+Confirm that your user can write to the selected application directory and that `brew doctor` does not report ownership problems.
+Use `--appdir` when you intentionally install applications somewhere other than `/Applications`.
 
-Note that occasionally the app’s name changes completely (from `SomeApp.app` to `OtherApp.app`, let's say). In these instances, the filename of the cask itself, as well as its token, must also change. Consult the [`token reference`](Cask-Cookbook.md#token-reference) for complete instructions on the new name.
+Do not recursively change ownership or permissions for the entire Caskroom or Homebrew prefix without first identifying the incorrect path and its expected owner.
+Include `ls -ld` output for the failing path when requesting help.
 
-Help us by [submitting a fix](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md#updating-a-cask). If you get stumped, [open an issue](https://github.com/Homebrew/homebrew-cask/issues/new?template=01_bug_report.yml) explaining your steps so far and where you’re having trouble.
+### The declared application or artifact is missing
 
-### Cask - wrong number of arguments
+The vendor may have renamed or moved files inside its archive.
+Fetch the cask, inspect the archive and compare its layout with `brew cat <cask>`:
 
-Make sure the issue really lies with your macOS version. To do so, try to install the software manually. If it is incompatible with your macOS version, it will tell you. In that case, there is nothing we can do to help you install the software, but we can add a [`depends_on macos:`](Cask-Cookbook.md#depends_on-macos) stanza to prevent the cask from being installed on incompatible macOS versions.
+```sh
+brew fetch CASK
+brew cat CASK
+```
 
-Help us by [submitting a fix](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md#updating-a-cask). If you get stumped, [open an issue](https://github.com/Homebrew/homebrew-cask/issues/new?template=01_bug_report.yml) explaining your steps so far and where you’re having trouble.
+Update the relevant artifact stanza to use the current path.
+See the [Cask Cookbook artifact reference](Cask-Cookbook.md#at-least-one-artifact-stanza-is-also-required) and [submit a cask update](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md#updating-a-cask).
 
-## Other local issues
+## Restoring an installation
 
-If your Homebrew installation gets messed up (and fixing the issues found by `brew doctor` doesn't solve the problem), reinstalling Homebrew may help to reset to a normal state. To easily reinstall Homebrew, use `brew bundle` to automatically restore your installed formulae and casks. To do so, run `brew bundle dump`, [uninstall](FAQ.md#how-do-i-uninstall-homebrew), [reinstall](Installation.md) and run `brew bundle install`.
+If `brew doctor` and the preceding checks do not identify the problem, create and review a package record before reinstalling:
 
-## Possible `curl` issues
+```sh
+brew bundle dump
+```
 
-Sometimes, the user's computer, configuration or network connection may cause issues downloading with `curl` which are outside Homebrew's control. Homebrew requires good internet connectivity and correct configuration to function correctly. Here some links that could help you identify cURL issues based on `curl`'s and `libcurl`'s exit codes:
-
-* <https://everything.curl.dev/cmdline/exitcode.html>
-* <https://curl.se/libcurl/c/libcurl-errors.html>
+Keep the generated `Brewfile` somewhere outside the Homebrew prefix.
+Follow the [uninstallation](FAQ.md#how-do-i-uninstall-homebrew) and [installation](Installation.md) documentation, then restore selected packages with `brew bundle install`.

--- a/docs/Common-Issues.md
+++ b/docs/Common-Issues.md
@@ -15,23 +15,19 @@ Start with the [Troubleshooting checklist](Troubleshooting.md) and read the full
 ### Missing Command Line Tools
 
 A supported Homebrew development environment on macOS requires the Xcode Command Line Tools to build formulae from source.
+Counterintuitively, installing Xcode alone is not enough: the Command Line Tools are a separate package.
 Install them with:
 
 ```sh
 xcode-select --install
 ```
 
-Casks and bottles can be installed without developer tools, but `brew doctor` may still report the unsupported configuration.
+Casks and bottles can be installed without developer tools, but `brew doctor` will still report the unsupported configuration.
 
 ### `bad interpreter: /usr/bin/ruby^M`
 
 The Homebrew checkout has Windows line endings, usually because of a Git configuration setting.
 Review GitHub's guide to [configuring Git line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings), then restore the Homebrew repository with `brew update-reset` as described below.
-
-### Missing or inaccessible `/usr/bin/ruby`
-
-Files under `/usr/bin` are provided by macOS and should not be modified manually.
-Install current macOS updates or use Apple's supported recovery process to restore missing system files.
 
 ### Local changes prevent `brew update`
 
@@ -44,6 +40,7 @@ git -C "$(brew --repository USER/REPOSITORY)" status --short
 
 Repeat the second command for each tap named in the error, replacing `USER/REPOSITORY` with its tap name.
 
+Unless you are a Homebrew or tap maintainer, any local changes are almost certainly unintentional and resetting is the right fix.
 Preserve any work you intentionally made in Homebrew or a tap before continuing.
 Do not run arbitrary `git clean` or `git reset --hard` commands copied from old issue reports.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,5 +1,5 @@
 ---
-last_review_date: "2026-06-10"
+last_review_date: "2026-07-18"
 ---
 
 # FAQ (Frequently Asked Questions)
@@ -90,7 +90,7 @@ Running a developer command (e.g. `brew edit`, `brew create`) enables Homebrew's
 * Homebrew may auto-run `brew update` before some commands every hour instead of every 24 hours.
 * Updates track the latest commit on `main` instead of the latest stable tag.
 
-To switch back to the default behavior, run `brew developer off`. If you only want to switch back to stable tags, set `HOMEBREW_UPDATE_TO_TAG=1` in your shell environment. To control auto-update frequency, use `HOMEBREW_AUTO_UPDATE_SECS`; to disable auto-updates entirely, set `HOMEBREW_NO_AUTO_UPDATE=1`.
+To switch back to the default behaviour, run `brew developer off`. If you only want to switch back to stable tags, set `HOMEBREW_UPDATE_TO_TAG=1` in your shell environment. To control auto-update frequency, use `HOMEBREW_AUTO_UPDATE_SECS`; to disable auto-updates entirely, set `HOMEBREW_NO_AUTO_UPDATE=1`.
 
 ## How do I contribute to Homebrew?
 
@@ -133,7 +133,10 @@ __tl;dr__ Sudo is dangerous, and you installed TextMate.app without sudo anyway.
 
 Homebrew refuses to work using sudo.
 
-You should only ever sudo a tool you trust. Of course, you can trust Homebrew 😉 — but do you trust the multi-megabyte Makefile that Homebrew runs? Developers often understand C++ far better than they understand `make` syntax. It’s too high a risk to sudo such stuff. It could modify (or upload) any files on your system. And indeed, we’ve seen some build scripts try to modify `/usr` even when the prefix was specified as something else entirely.
+Use `sudo` only with software that you trust.
+Even when you trust Homebrew itself, a source build can run large upstream build scripts that have not received a security review from Homebrew.
+Running those scripts as `root` would allow them to modify or upload files anywhere permitted by the operating system.
+Some build scripts have attempted to modify `/usr` even when configured with another installation prefix.
 
 We use the macOS sandbox to stop this but this doesn't work when run as the `root` user (which also has read and write access to almost everything on the system).
 The sandbox is part of Homebrew's wider [Software Supply Chain Security](Homebrew-Security-and-Supply-Chain.md) measures.
@@ -142,7 +145,7 @@ Did you `chown root /Applications/TextMate.app`? Probably not. So is it that imp
 
 Note: Homebrew is primarily designed for single-user use and does not work well in multi-user configurations.
 
-## What is the default ownership and permissions used by Homebrew?
+## What are the default ownership and permissions used by Homebrew?
 
 First, see previous question regarding sudo.
 
@@ -219,34 +222,29 @@ You can [modify a tool's build configuration](How-to-Build-Software-Outside-Home
 
 ## How does `brew upgrade` handle apps that update themselves?
 
-Many macOS apps can upgrade themselves:
+Many apps can update themselves without Homebrew:
 
 <img src="assets/img/docs/sparkle-test-app-software-update.png" width="600" alt="Sparkle update window">
 
-That could cause conflicts when used in tandem with Homebrew Cask’s `upgrade` mechanism.
+An app’s own updater can make Homebrew’s installation record older than the app that is actually installed.
+Blindly replacing the app based on that record could downgrade it.
 
-When software uses its built-in mechanisms to upgrade itself, it happens without Homebrew Cask’s knowledge, causing both versions to get out of sync. If you were to then upgrade through Homebrew Cask while we have a lower version of the software on record, you’d get a downgrade.
+Casks for self-updating apps declare `auto_updates true`.
+For a versioned cask that installs a single readable app bundle, Homebrew compares the bundle’s version metadata with the cask's current version.
+The default `brew upgrade` includes the cask when the installed app appears older and skips it when the installed app appears to be the same version or newer.
 
-There are a few ideas to fix this problem:
+This comparison is not available for every artifact or versioning scheme.
+When Homebrew cannot make a reliable comparison, it normally skips the self-updating cask instead of guessing.
+To persistently opt out of automatic upgrades for all `auto_updates true` casks, add `export HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS=1` to your shell configuration.
+This does not affect upgrades requested with `--greedy` or `--greedy-auto-updates`.
 
-* Try to prevent the software’s automated updates. `brew pin <cask>` can prevent Homebrew from upgrading a cask, but it does not disable an app’s own updater. Most software on Homebrew Cask is closed-source, so trying to control that for every app would be guesswork.
-* Try to extract the installed software’s version and compare it to the cask, deciding what to do at that time. It’d be a complicated solution that would break other parts of our methodology, such as using versions to interpolate `url` values (a definite win for maintainability). This solution also isn’t universal, as many software developers are inconsistent in their versioning schemes (and app bundles are meant to have two version strings) and it doesn’t work for all types of software we support.
+Casks that use [`version :latest`](Cask-Cookbook.md#special-value-latest) have no version number to compare and are excluded from an ordinary `brew upgrade`.
+When such a cask is named explicitly or included with `--greedy-latest`, Homebrew downloads the current artifact and, when possible, compares its SHA-256 checksum with the checksum recorded during installation.
+It skips reinstalling the cask when the artifact has not changed.
 
-So we let software be. Anything installed with Homebrew Cask should behave the same as if it were installed manually. But since we also want to support software that doesn’t self-upgrade, we add [`auto_updates true`](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/a/alfred.rb#L18) to casks for software that does. When Homebrew can detect that the version currently installed in the user’s `appdir` is older than the latest version in the tap, `brew upgrade` will try to upgrade these casks automatically.
-
-To persistently opt out of this default behaviour, add `export HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS=1` to your shell configuration. This does not affect upgrades requested with `--greedy` or `--greedy-auto-updates`.
-
-Casks which use [`version :latest`](Cask-Cookbook.md#special-value-latest) are also excluded, because we have no way to track their installed version. It helps to ask the developers of such software to provide versioned releases (i.e. include the version in the path of the download `url`).
-
-If you still want to force software to be upgraded via Homebrew Cask, you can reference it specifically in the `upgrade` command:
-
-    brew upgrade <cask>
-
-Or use the `--greedy` switch:
-
-    brew upgrade --greedy
-
-Refer to the `upgrade` section of the [`brew` manual page](Manpage.md) for more details.
+Naming a cask explicitly, using `--greedy-auto-updates` or using the broader `--greedy` option can include casks that the default checks skip.
+Set `HOMEBREW_UPGRADE_GREEDY=1` to apply `--greedy` persistently to all cask upgrades, or list selected casks in the space-separated `HOMEBREW_UPGRADE_GREEDY_CASKS` variable.
+Refer to the `upgrade` section of the [`brew` manual page](Manpage.md) for the full option details.
 
 ## Why don't you rewrite Homebrew in Rust to make it faster?
 

--- a/docs/Tips-and-Tricks.md
+++ b/docs/Tips-and-Tricks.md
@@ -1,5 +1,5 @@
 ---
-last_review_date: 2026-04-04
+last_review_date: 2026-07-18
 redirect_from:
   - /Tips-N'-Tricks
 ---
@@ -35,7 +35,7 @@ brew sh          # or: eval "$(brew --env)"
 gem install ronn # or c-programs
 ```
 
-This imports the `brew` environment into your existing shell; `gem` will pick up the environment variables and be able to build. As a bonus, `brew`'s automatically determined optimization flags are set.
+This imports the `brew` environment into your existing shell; `gem` will pick up the environment variables and be able to build. As a bonus, `brew`'s automatically determined optimisation flags are set.
 
 ## Install only a formula's dependencies (not the formula)
 
@@ -96,7 +96,7 @@ export HOMEBREW_INSTALL_BADGE="☕️ 🐸"
 
 Running `brew bundle dump` will record an installation to a `Brewfile` and `brew bundle install` will install from a `Brewfile`. See `brew bundle --help` for more details.
 
-## Appoint Homebrew Cask to manage a manually-installed app
+## Adopt a manually installed app as a cask
 
 Run `brew install --cask` with the `--adopt` switch:
 
@@ -196,7 +196,7 @@ $ brew alias --edit
 
 - [pcmpl-homebrew](https://github.com/hiddenlotus/pcmpl-homebrew) provides completion for emacs shell-mode and eshell-mode.
 
-## macOS Terminal.app: Enable the "Open man Page" contextual menu item
+## macOS Terminal.app: enable the "Open man Page" contextual menu item
 
 In the macOS Terminal, you can right-click on a command name (like `ls` or `tar`) and pop open its manpage in a new window by selecting "Open man Page".
 
@@ -250,7 +250,7 @@ export HOMEBREW_DOCKER_REGISTRY_BASIC_AUTH_TOKEN=none
 
 ## Load Homebrew from the same dotfiles on different operating systems
 
-Some users may want to use the same shell initialization files on macOS and Linux.
+Some users may want to use the same shell initialisation files on macOS and Linux.
 Use this to detect the likely Homebrew installation directory and load Homebrew when it's found.
 You may need to adapt this to your particular shell or other particulars of your environment.
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -27,7 +27,7 @@ Search the tracker responsible for the failing component:
 - The tap's own tracker for a formula, cask or command from a non-Homebrew tap
 
 Also search [Homebrew Discussions](https://github.com/orgs/Homebrew/discussions) for support and related reports.
-The [Discourse archive](https://discourse.brew.sh/) is read-only historical material and may contain outdated instructions.
+The [Discourse archive](https://discourse.brew.sh/) is read-only historical material and will contain outdated instructions.
 
 ## Collect diagnostic information
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,35 +1,61 @@
 ---
-last_review_date: "1970-01-01"
+last_review_date: "2026-07-18"
 ---
 
 # Troubleshooting
 
-**Run `brew update` twice and `brew doctor` (and fix all the warnings) *before* creating an issue!**
+Use this checklist before creating a Homebrew issue.
 
-This document will help you check for common issues and make sure your issue has not already been reported.
+## Update and diagnose
 
-## Check for common issues
+1. Run `brew update`.
+2. Run `brew update` again so the first update cannot leave the failing command on an older Homebrew version.
+3. Run `brew doctor` and read every warning.
+4. Correct warnings that apply to the failing command.
+5. Retry the original command and keep its complete output.
 
-* Read through the list of [Common Issues](Common-Issues.md).
+Do not apply destructive Git, ownership or permission changes from an old issue report without understanding which files they affect.
+See [Common Issues](Common-Issues.md) for current recovery guidance.
 
-## Check to see if the issue has been reported
+## Search existing reports
 
-* Search the appropriate issue tracker to see if someone else has already reported the same issue:
-  * [Homebrew/homebrew-core issue tracker](https://github.com/Homebrew/homebrew-core/issues) (formulae)
-  * [Homebrew/homebrew-cask issue tracker](https://github.com/Homebrew/homebrew-cask/issues) (casks)
-  * [Homebrew/brew issue tracker](https://github.com/Homebrew/brew/issues) (`brew` itself)
-* If the formula or cask that has failed to install is part of a non-Homebrew tap, then check that tap's issue tracker instead.
-* Search the [Homebrew discussion forum](https://github.com/orgs/Homebrew/discussions) or [Discourse archive](https://discourse.brew.sh/) to see if any discussions have started about the issue.
+Search the tracker responsible for the failing component:
+
+- [`Homebrew/homebrew-core` issues](https://github.com/Homebrew/homebrew-core/issues) for formulae
+- [`Homebrew/homebrew-cask` issues](https://github.com/Homebrew/homebrew-cask/issues) for casks
+- [`Homebrew/brew` issues](https://github.com/Homebrew/brew/issues) for the `brew` command
+- The tap's own tracker for a formula, cask or command from a non-Homebrew tap
+
+Also search [Homebrew Discussions](https://github.com/orgs/Homebrew/discussions) for support and related reports.
+The [Discourse archive](https://discourse.brew.sh/) is read-only historical material and may contain outdated instructions.
+
+## Collect diagnostic information
+
+For a formula installation or build failure, upload its logs:
+
+```sh
+brew gist-logs FORMULA
+```
+
+For other failures, collect:
+
+```sh
+brew config
+brew doctor
+```
+
+Remove credentials, private repository URLs and other secrets before publishing terminal output.
+Do not omit warnings merely because they appear unrelated.
 
 ## Create an issue
 
-If your problem hasn't been solved or reported, then create an issue:
+If the problem is neither resolved nor already reported, use the issue template in the appropriate repository:
 
-1. Collect debugging information:
-  * If you have a problem with installing a formula: run `brew gist-logs <formula>` (where `<formula>` is the name of the formula) to upload the logs to a new [Gist](https://gist.github.com/).
-  * If your have a non-formula problem: collect the output of `brew config` and `brew doctor`.
+- [`Homebrew/homebrew-core` issue chooser](https://github.com/Homebrew/homebrew-core/issues/new/choose)
+- [`Homebrew/homebrew-cask` issue chooser](https://github.com/Homebrew/homebrew-cask/issues/new/choose)
+- [`Homebrew/brew` issue chooser](https://github.com/Homebrew/brew/issues/new/choose)
 
-1. Create a new issue on the issue tracker for [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core/issues/new/choose), [Homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask/issues/new/choose) or [Homebrew/brew](https://github.com/Homebrew/brew/issues/new/choose) and follow the instructions:
-  * Give your issue a descriptive title which includes the formula name (if applicable) and the version of macOS or Linux you are using. For example, if a formula fails to build, title your issue "\<formula> failed to build on \<platform>", where *\<formula>* is the name of the formula that failed to build, and *\<platform>* is the name and version of macOS or Linux you are using.
-  * Include the URL provided by `brew gist-logs <formula>` (if applicable) plus links to any additional Gists you may have created.
-  * Include the output of `brew config` and `brew doctor`.
+Include the command, complete error, relevant `brew config` and `brew doctor` output and the `brew gist-logs` URL when available.
+Use a descriptive title that identifies the package, failure and operating system.
+
+See [Creating a Homebrew Issue](Creating-a-Homebrew-Issue.md) for reporting expectations.


### PR DESCRIPTION
Modernises the user troubleshooting pages. The FAQ's sudo answer is rewritten around the sandbox rationale, the self-updating cask answer documents the persistent `HOMEBREW_UPGRADE_GREEDY`/`HOMEBREW_UPGRADE_GREEDY_CASKS` opt-ins alongside the existing opt-out and its version-comparison wording now matches the implementation. Common Issues gains a working Intel-to-Apple Silicon migration snapshot (`arch -x86_64 /usr/local/bin/brew bundle dump`, since plain `brew` resolves to the new installation at that point) and drops long-stale material, while Troubleshooting explains why `brew update` must run twice before reporting a bug. CONTRIBUTING's matching wording is aligned.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5) prepared the changes and verified the upgrade and update behaviour against the implementation; I reviewed the diff and verified locally with Vale, Markdownlint and the docs Jekyll/HTMLProofer suite, whose only failures were transient HTTP 429 rate limits on pages this PR does not touch (addressed by #23169).

-----
