### PR TITLE
docs: update installation, platform support and shell completion pages

### DIFF
--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -5,20 +5,20 @@ redirect_from:
   - /linux
   - /Linux
   - /Linuxbrew
-last_review_date: "2026-07-02"
+last_review_date: "2026-07-18"
 ---
 
 # Homebrew on Linux
 
 The Homebrew package manager may be used on Linux and [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/about) 2. Homebrew was formerly referred to as Linuxbrew when running on Linux or WSL. Homebrew does not use any libraries provided by your host system, except *glibc* and *gcc* if they are new enough. Homebrew can install its own current versions of *glibc* and *gcc* for older distributions of Linux.
 
-[Features](#features), [installation instructions](#install) and [requirements](#requirements) are described below. Terminology (e.g. the difference between a Cellar, Tap, Cask and so forth) is [explained in the documentation](Formula-Cookbook.md#homebrew-terminology).
+[Features](#features), [installation instructions](#install) and [requirements](#requirements) are described below. Terminology (e.g. the difference between the Cellar, a tap and a cask) is [explained in the documentation](Formula-Cookbook.md#homebrew-terminology).
 
 ## Features
 
 - Install software not packaged by your host distribution
 - Install up-to-date versions of software when your host distribution is old
-- Use the same package manager to manage your macOS, Linux, and Windows systems
+- Use the same package manager to manage your macOS, Linux and Windows systems
 
 ## Install
 
@@ -28,13 +28,15 @@ The installation script installs Homebrew to `/home/linuxbrew/.linuxbrew` using 
 
 The prefix `/home/linuxbrew/.linuxbrew` was chosen to avoid writing to system-owned directories after installation while still allowing most precompiled binaries (bottles) to be used. Homebrew is designed for single-user installations rather than shared role accounts.
 
-Follow the *Next steps* instructions to add Homebrew to your `PATH` and to your bash shell rcfile, either `~/.bashrc` for `bash` or `~/.zshrc` for `zsh`.
+Follow the installer's *Next steps* instructions to add Homebrew to your `PATH` and shell configuration.
+For a supported installation using Bash, run:
 
 ```sh
-test -d ~/.linuxbrew && eval "$(~/.linuxbrew/bin/brew shellenv)"
-test -d /home/linuxbrew/.linuxbrew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.bashrc
+eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> ~/.bashrc
 ```
+
+Use `~/.zshrc` instead of `~/.bashrc` when zsh is your login shell.
 
 You're done! Try installing a package:
 
@@ -80,11 +82,11 @@ To install build tools, paste at a terminal prompt:
 
 ### ARM32 (Tier 3 Support)
 
-Homebrew can run on 32-bit ARM systems (e.g. Raspberry Pi and others), but as they lack bottles (binary packages) they are a [Tier 3 supported platform](Support-Tiers.md#tier-3).
+Homebrew can run on 32-bit ARM systems such as Raspberry Pi devices, but because they lack bottles they are a [Tier 3 platform](Support-Tiers.md#tier-3).
 
-You may need to install your own Ruby using your system package manager, a PPA, or `rbenv/ruby-build` as we don't distribute a Homebrew Portable Ruby for ARM32.
+You may need to install your own Ruby using your system package manager, a PPA or `rbenv/ruby-build` because Homebrew does not distribute Portable Ruby for ARM32.
 
-### 32-bit x86 (Unsupported)
+### 32-bit x86 (unsupported)
 
 Homebrew does not run at all on 32-bit x86 platforms.
 
@@ -92,7 +94,7 @@ Homebrew does not run at all on 32-bit x86 platforms.
 
 Due to [known issues](https://github.com/microsoft/WSL/issues/8219) with WSL 1, you may experience issues running various executables installed by Homebrew. We recommend you switch to WSL 2 instead.
 
-## Homebrew on Linux Community
+## Homebrew on Linux community
 
 - [@HomebrewOnLinux on Twitter](https://twitter.com/HomebrewOnLinux)
 - [Homebrew/discussions (forum)](https://github.com/orgs/Homebrew/discussions/categories/linux)

--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -96,5 +96,4 @@ Due to [known issues](https://github.com/microsoft/WSL/issues/8219) with WSL 1, 
 
 ## Homebrew on Linux community
 
-- [@HomebrewOnLinux on Twitter](https://twitter.com/HomebrewOnLinux)
 - [Homebrew/discussions (forum)](https://github.com/orgs/Homebrew/discussions/categories/linux)

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -8,9 +8,22 @@ Instructions for a supported install of Homebrew are on the [homepage](https://b
 
 The script installs Homebrew to its default, supported, best prefix (`/opt/homebrew` for Apple Silicon, `/usr/local` for macOS Intel and `/home/linuxbrew/.linuxbrew` for Linux) so that [you don’t need *sudo* after Homebrew's initial installation](FAQ.md#why-does-homebrew-say-sudo-is-bad) when you `brew install`. This prefix is required for most bottles (binary packages) to be used. It is a careful script; it can be run even if you have stuff installed in the preferred prefix already. It tells you exactly what it will do before it does it too. You have to confirm everything it will do before it starts.
 
-The macOS `.pkg` installer also installs Homebrew to its default prefix (`/opt/homebrew` for Apple Silicon and `/usr/local` for macOS Intel) for the same reasons as above. It's available on [Homebrew/brew's latest GitHub release](https://github.com/Homebrew/brew/releases/latest). To specify an alternate install user, like in situations where the package is installed at the login window before a user has logged in, write a property list file to `/var/tmp/.homebrew_pkg_user.plist` with the value `HOMEBREW_PKG_USER`. For example, `defaults write /var/tmp/.homebrew_pkg_user HOMEBREW_PKG_USER penny`. The file and user must exist prior to install.
+The macOS `.pkg` installer also installs Homebrew to its default prefix (`/opt/homebrew` for Apple Silicon and `/usr/local` for macOS Intel) for the same reasons as above.
+It is available on [Homebrew/brew's latest GitHub release](https://github.com/Homebrew/brew/releases/latest).
+To specify an alternate install user, such as when the package is installed at the login window before a user has logged in, create `/var/tmp/.homebrew_pkg_user.plist` with a `HOMEBREW_PKG_USER` value before installation:
 
-## macOS Requirements
+```sh
+sudo defaults write /var/tmp/.homebrew_pkg_user HOMEBREW_PKG_USER penny
+sudo chown root:wheel /var/tmp/.homebrew_pkg_user.plist
+sudo chmod 600 /var/tmp/.homebrew_pkg_user.plist
+sudo chmod -N /var/tmp/.homebrew_pkg_user.plist
+```
+
+The file must be a regular non-symlink file owned by `root`, have mode `0600` and have no access control list.
+The named user must also exist before installation.
+The installer ignores an override that does not meet these requirements and falls back to the active console user.
+
+## macOS requirements
 
 * An Apple Silicon CPU or 64-bit Intel CPU <sup>[1](#1)</sup>
 * macOS Sonoma (14) (or higher) installed on officially supported hardware<sup>[2](#2)</sup>
@@ -19,11 +32,11 @@ The macOS `.pkg` installer also installs Homebrew to its default prefix (`/opt/h
   [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) <sup>[3](#3)</sup>
 * The Bourne-again shell for installation (i.e. `bash`) <sup>[4](#4)</sup>
 
-## Advanced Configuration
+## Advanced configuration
 
 The Homebrew installer offers various advanced configuration settings. **Most users can skip this section and instead follow the instructions on the [homepage](https://brew.sh/)!**
 
-### Git Remote Mirroring
+### Git remote mirroring
 
 If you have issues connecting to GitHub.com, you can use Git mirrors for Homebrew's installation and `brew update` by setting `HOMEBREW_BREW_GIT_REMOTE` and/or `HOMEBREW_CORE_GIT_REMOTE` in your shell environment with this script:
 
@@ -37,7 +50,7 @@ The default Git remote will be used if the corresponding environment variable is
 
 **Note:** if you set these variables you are granting these repositories the same level of trust you currently grant to Homebrew itself. You should be extremely confident that these repositories will not be compromised.
 
-### Default Tap Cloning
+### Default tap cloning
 
 You can instruct Homebrew to return to pre-4.0.0 behaviour by cloning the Homebrew/homebrew-core tap during installation by setting the `HOMEBREW_NO_INSTALL_FROM_API` environment variable with the following:
 
@@ -52,7 +65,7 @@ This will make Homebrew install formulae and casks from the `homebrew/core` and 
 
 If you want a non-interactive run of the Homebrew installer that doesn't prompt for passwords (e.g. in automation scripts), prepend [`NONINTERACTIVE=1`](https://github.com/Homebrew/install/#install-homebrew-on-macos-or-linux) to the installation command.
 
-## Alternative Installs
+## Alternative installs
 
 ### Linux or Windows 10 Subsystem for Linux
 

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -1,20 +1,25 @@
 ---
-last_review_date: "1970-01-01"
+last_review_date: "2026-07-18"
 ---
 
 # `brew` Shell Completion
 
-Homebrew comes with completion definitions for the `brew` command. Some packages also provide completion definitions for their own programs.
+Homebrew provides completion definitions for `brew` in Bash, fish and zsh.
+Some formulae and external commands provide completions for their own commands.
 
-`zsh`, `bash` and `fish` are currently supported.
+Homebrew stores completions under `HOMEBREW_PREFIX`, which a system shell may not search automatically.
+The installer does not modify every shell's completion configuration because startup files and plugin managers vary.
 
-You must manually configure your shell to enable its completion support. This is because the Homebrew-managed completions are stored under `HOMEBREW_PREFIX` which your system shell may not be aware of, and since it is difficult to automatically configure `bash` and `zsh` completions in a robust manner, the Homebrew installer does not do it for you.
+Completions supplied by external Homebrew commands are not linked automatically.
+Enable them with:
 
-Shell completions for external Homebrew commands are not automatically installed. To opt-in to using completions for external commands (if provided), they need to be linked to `HOMEBREW_PREFIX` by running `brew completions link`.
+```sh
+brew completions link
+```
 
-## Configuring Completions in `bash`
+## Bash
 
-To make Homebrew's completions available in `bash`, you must source the definitions as part of your shell's startup. Add the following to your `~/.bash_profile` (or, if it doesn't exist, `~/.profile`):
+Add the following to `~/.bash_profile`, or to `~/.profile` when `~/.bash_profile` does not exist:
 
 ```sh
 if type brew &>/dev/null
@@ -32,40 +37,35 @@ then
 fi
 ```
 
-If you install the `bash-completion` formula, this will automatically source the completions' initialisation script (so you do not need to follow the instructions in the formula's caveats).
+The `bash-completion` formula supports the system Bash shipped by macOS.
+Use `bash-completion@2` with Homebrew's Bash 4 or newer.
+Install only one of these formulae.
+The snippet above loads the installed version, so do not also source it elsewhere in the same shell configuration.
 
-If you are using Homebrew's `bash` as your shell (i.e. `bash` >= v4) you should use the `bash-completion@2` formula instead.
+## zsh
 
-## Configuring Completions in `zsh`
-
-To make Homebrew's completions available in `zsh`, the Homebrew-managed `zsh/site-functions` path needs to be inserted into `FPATH` before initialising `zsh`'s completion facility. This is done by `brew shellenv`, so if you followed the post-Homebrew installation steps, `eval "$(brew shellenv)"` should be in your `~/.zprofile` (on macOS) or `~/.zshrc` (on Linux). All you need is add the following to your `~/.zshrc` if it's not already there, and, if you're on Linux, make sure it's placed after `eval "$(brew shellenv)"`:
+`brew shellenv` adds Homebrew's zsh completion directory to `FPATH`.
+Ensure that `eval "$(brew shellenv)"` runs before zsh initialises completion, then add the following to `~/.zshrc` if your configuration or framework does not already call `compinit`:
 
 ```sh
 autoload -Uz compinit
 compinit
 ```
 
-Note that if you are using Oh My Zsh, it will call `compinit` for you when you source `oh-my-zsh.sh`. In this case, make sure `eval "$(brew shellenv)"` is called before sourcing `oh-my-zsh.sh` if you're on Linux, and you should be all set without any additional configuration.
+Oh My Zsh calls `compinit` when it loads.
+Make sure `brew shellenv` is evaluated first, particularly on Linux.
 
-You may also need to forcibly rebuild `zcompdump`:
+If zsh reports insecure completion directories, run `compaudit` to list the affected paths.
+Inspect their ownership and remove group or world write access only from the directories reported by `compaudit`.
+Do not recursively change permissions across the entire Homebrew prefix.
 
-```sh
-rm -f ~/.zcompdump; compinit
-```
+## fish
 
-Additionally, if you receive "zsh compinit: insecure directories" warnings when attempting to load these completions, you may need to run this:
+Homebrew's `fish` formula discovers Homebrew-managed completions automatically.
 
-```sh
-chmod -R go-w "$(brew --prefix)/share"
-```
+For a fish installation from another source, add the following to `~/.config/fish/config.fish`:
 
-## Configuring Completions in `fish`
-
-No configuration is needed if you're using Homebrew's `fish`. Friendly!
-
-If your `fish` is from somewhere else, add the following to your `~/.config/fish/config.fish`:
-
-```sh
+```fish
 if test -d (brew --prefix)"/share/fish/completions"
     set -p fish_complete_path (brew --prefix)/share/fish/completions
 end
@@ -75,9 +75,12 @@ if test -d (brew --prefix)"/share/fish/vendor_completions.d"
 end
 ```
 
-## Configuring Completions in `pwsh`
+## PowerShell
 
-To make Homebrew's completions available in `pwsh` (PowerShell), you must source the definitions as part of your shell's startup. Add the following to your `PROFILE`, for example: `~/.config/powershell/Microsoft.PowerShell_profile.ps1`:
+Some formulae install PowerShell completions for their own commands under Homebrew's PowerShell completion directory.
+Homebrew does not currently provide a PowerShell completion definition for `brew` itself.
+
+Add the following to your PowerShell profile, such as `~/.config/powershell/Microsoft.PowerShell_profile.ps1`:
 
 ```pwsh
 if ((Get-Command brew) -and (Test-Path ($completions = "$(brew --prefix)/share/pwsh/completions"))) {

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -83,7 +83,7 @@ Homebrew does not currently provide a PowerShell completion definition for `brew
 Add the following to your PowerShell profile, such as `~/.config/powershell/Microsoft.PowerShell_profile.ps1`:
 
 ```pwsh
-if ((Get-Command brew) -and (Test-Path ($completions = "$(brew --prefix)/share/pwsh/completions"))) {
+if ((Get-Command brew -ErrorAction SilentlyContinue) -and (Test-Path ($completions = "$(brew --prefix)/share/pwsh/completions"))) {
   foreach ($f in Get-ChildItem -Path $completions -File) {
     . $f
   }

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -39,7 +39,7 @@ fi
 
 The `bash-completion` formula supports the system Bash shipped by macOS.
 Use `bash-completion@2` with Homebrew's Bash 4 or newer.
-Install only one of these formulae.
+The two formulae conflict with each other, so install only one.
 The snippet above loads the installed version, so do not also source it elsewhere in the same shell configuration.
 
 ## zsh

--- a/docs/Support-Tiers.md
+++ b/docs/Support-Tiers.md
@@ -6,13 +6,13 @@ last_review_date: "2026-04-03"
 
 Homebrew defines three support tiers to help users understand how well Homebrew is expected to work on different systems.
 
-These tiers describe the level of compatibility, automation coverage, and community support that the project actively maintains. They also set expectations for how we handle issues, pull requests, and regressions.
+These tiers describe the level of compatibility, automation coverage and community support that the project actively maintains. They also set expectations for how we handle issues, pull requests and regressions.
 
-These tiers describe Homebrew support for the host system itself, not a guarantee that every third-party formula or cask will remain runnable on that system forever. Package-specific policies, such as the phaseout for Rosetta-dependent casks on Apple Silicon, are documented separately in [Acceptable Casks](Acceptable-Casks.md).
+These tiers describe Homebrew support for the host system itself, not a guarantee that every third-party formula or cask will remain runnable on that system forever. Package-specific policies, such as the phase-out for Rosetta-dependent casks on Apple Silicon, are documented separately in [Acceptable Casks](Acceptable-Casks.md).
 
 ## Tier 1
 
-A Tier 1 configuration is considered fully supported. These configurations receive the highest level of CI coverage and are prioritized during issue review and formula development.
+A Tier 1 configuration is considered fully supported. These configurations receive the highest level of CI coverage and are prioritised during issue review and formula development.
 
 Users can expect:
 
@@ -70,7 +70,7 @@ Tier 2 configurations include:
 - macOS prerelease versions before they are promoted to Tier 1
 - macOS systems with outdated versions of Xcode Command Line Tools
 - Linux systems with `glibc` versions between 2.13 and 2.38 (Homebrew’s own `glibc` formula will be installed automatically)
-- Homebrew installed outside the default prefix, requiring source builds for official packages (i.e. installing outside `/opt/homebrew`, `/usr/local`, or `/home/linuxbrew/.linuxbrew`)
+- Homebrew installed outside the default prefix, requiring source builds for official packages (i.e. installing outside `/opt/homebrew`, `/usr/local` or `/home/linuxbrew/.linuxbrew`)
 - Architectures not yet officially supported by Homebrew
 - Macs using OpenCore Legacy Patcher with a Westmere or newer Intel CPU
 
@@ -81,7 +81,7 @@ A Tier 3 configuration is not supported. These configurations fall far outside H
 The following conditions typically apply:
 
 - Homebrew may work, but with a poor and unstable experience
-- Migration to a Tier 1 or 2 configuration, or to a non-Homebrew tool, is strongly recommended
+- Migration to a Tier 1 or 2 configuration or to a non-Homebrew tool is strongly recommended
 - Pull requests must meet a very high bar: they must resolve an issue (not merely work around it) and must not introduce high ongoing maintenance cost (e.g. patches must already be merged upstream)
 - Homebrew maintainers do not commit to fixing bugs affecting these systems
 - Functionality may regress intentionally if it benefits supported configurations
@@ -94,7 +94,7 @@ Tier 3 configurations include:
 
 - macOS versions no longer covered by CI and no longer receiving regular Apple security updates
 - Systems that build official packages from source despite available bottles
-- Homebrew installed outside the default prefix (e.g. `/opt/homebrew`, `/usr/local`, or `/home/linuxbrew/.linuxbrew` used on mismatched architectures)
+- Homebrew installed outside the default prefix (e.g. `/opt/homebrew`, `/usr/local` or `/home/linuxbrew/.linuxbrew` used on mismatched architectures)
 - Homebrew installations managed by Nix (e.g. nix-darwin or nix-homebrew)
 - Installing formulae using `--HEAD`
 - Installing deprecated or disabled formulae
@@ -105,7 +105,7 @@ Tier 3 configurations include:
 An unsupported configuration is one in which:
 
 - Homebrew will not run without third-party patches or modifications
-- Migration to another tool is required (e.g. [MacPorts](https://www.macports.org), [Tigerbrew](https://github.com/mistydemeo/tigerbrew), or a native Linux package manager)
+- Migration to another tool is required (e.g. [MacPorts](https://www.macports.org), [Tigerbrew](https://github.com/mistydemeo/tigerbrew) or a native Linux package manager)
 
 Unsupported configurations include:
 
@@ -117,17 +117,17 @@ Unsupported configurations include:
 - CPUs built inside of Minecraft
 - Toasters
 
-## Unsupported Software
+## Unsupported software
 
 Packages installed from third-party taps outside the Homebrew GitHub organization are unsupported by default.
 
-While Homebrew may assist third-party maintainers in resolving issues related to the formula, cask, or tap system itself, it does not provide support for the behavior or operation of third-party software.
+While Homebrew may assist third-party maintainers in resolving issues related to the formula, cask or tap system itself, it does not provide support for the behaviour or operation of third-party software.
 
 Bugs that occur only when using third-party formulae or casks may be closed without investigation.
 
 If you are using a Homebrew wrapper, get support from and file issues with that wrapper instead of Homebrew unless the same problem is reproducible when running Homebrew directly.
 
-## Future macOS Support
+## Future macOS support
 
 Apple has announced that macOS Tahoe 26 will be the final version of macOS to support Intel x86_64 hardware. In alignment with this change, Homebrew plans to remove support for macOS on Intel in a future release after that point.
 
@@ -168,4 +168,4 @@ The following timeline outlines expected Tier classifications based on Apple’s
 
 [Apple has also announced](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment) that Rosetta 2 will remain available as a general-purpose compatibility tool through macOS 27, with only a narrower legacy-games-focused subset planned beyond that.
 
-This does not change the support tier of an otherwise supported Apple Silicon Mac, but it does shorten the expected support window for x86_64-only casks that rely on [`requires_rosetta`](Cask-Cookbook.md#caveats-mini-dsl). See [Acceptable Casks](Acceptable-Casks.md) for the expected acceptance, deprecation, and removal timeline for those casks.
+This does not change the support tier of an otherwise supported Apple Silicon Mac, but it does shorten the expected support window for x86_64-only casks that rely on [`requires_rosetta`](Cask-Cookbook.md#caveats-mini-dsl). See [Acceptable Casks](Acceptable-Casks.md) for the expected acceptance, deprecation and removal timeline for those casks.


### PR DESCRIPTION
Updates the installation and platform documentation. Installation now documents the `.pkg` install-user override requirements the installer actually enforces (a regular file owned by `root`, mode `0600`, no ACLs, with working example commands; the previous `defaults write` example produced a file the installer silently ignores). Shell Completion no longer claims Homebrew ships PowerShell completions for `brew` itself (they are bash, fish and zsh only, with PowerShell scoped to formula-provided completions) and the bash-completion guidance no longer double-sources. Homebrew on Linux gets a working shell setup snippet with a zsh note and Support Tiers loses its remaining US spellings and serial commas.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5) prepared the changes and verified the installer and completions behaviour against `utils/macos_user.sh` and `completions.rb`; I reviewed the diff and verified locally with Vale, Markdownlint and the docs Jekyll/HTMLProofer suite, whose only failures were transient HTTP 429 rate limits on pages this PR does not touch (addressed by #23169).

-----
