### PR TITLE
docs: simplify the Expense and Reimbursement Policy

### DIFF
--- a/docs/Expense-and-Reimbursement-Policy.md
+++ b/docs/Expense-and-Reimbursement-Policy.md
@@ -53,7 +53,7 @@ Use a reimbursement for a project purchase that you have already paid.
 Use an invoice for completed work or services.
 If an expense contains multiple receipts, enter them as separate line items.
 
-Open Source Collective may request payment, identity or tax information before it can pay an expense.
+Open Source Collective will request payment, identity or tax information before it can pay an expense.
 
 ## Receipts policy
 
@@ -66,8 +66,8 @@ Attach a legible vendor receipt showing:
 * The purchaser or project when the receipt provides that information.
 
 Add a short explanation when the connection to Homebrew is not obvious.
-A card statement is not normally a substitute for a receipt.
-Ask the Lead Maintainers before relying on alternative proof for a purchase where the vendor does not issue receipts.
+A card statement is not a substitute for a receipt.
+Open Source Collective decides whether alternative proof is acceptable and may decline an expense when a vendor does not issue receipts.
 
 ## Travel policy
 
@@ -87,14 +87,14 @@ An approved travel budget may include:
 * Necessary baggage, parking or visa costs.
 * A taxi, rideshare or rental vehicle when it is the practical option.
 
-Upgrades, luxury accommodation, companion travel and personal entertainment are not reimbursable unless an explicit accessibility or medical exception was approved.
+Upgrades, luxury accommodation, companion travel and personal entertainment are not reimbursable.
 
 ### Meals and entertainment
 
 Homebrew normally covers pre-approved group meals attended primarily by Homebrew maintainers as part of an event or project gathering.
 The reimbursement should identify the attendees and the Homebrew purpose.
 
-Individual meals and entertainment are not normally reimbursable unless they were explicitly included in the approved event budget.
+Individual meals and entertainment are not reimbursable unless they were explicitly included in the approved event budget.
 
 ### Personal travel
 
@@ -105,12 +105,13 @@ The maintainer is responsible for every personal portion of the trip.
 ### Accessibility and medical needs
 
 Reasonable accessibility or medical needs may justify an exception or a more expensive option.
-Request approval in advance when possible and disclose only the information needed to evaluate the expense.
+Request approval in advance and disclose as much useful information as possible to evaluate the expense.
+It will be kept private.
 
 ## Services and project property
 
 The Lead Maintainers must approve a new or recurring paid service.
-Where practical, the service should use a Homebrew-controlled account and payment method instead of depending on an individual maintainer.
+The service must use a Homebrew-controlled account and payment method instead of depending on an individual maintainer.
 
 An item purchased for Homebrew should have a named custodian and a recorded location while Homebrew owns it.
 
@@ -118,4 +119,4 @@ An item purchased for Homebrew should have a named custodian and a recorded loca
 
 Ask for new approval before materially exceeding an approved amount or changing the purpose of an expense.
 If an emergency makes advance approval impossible, contact the Lead Maintainers as soon as practical.
-Reimbursement is not guaranteed when approval was not obtained first.
+Reimbursement is much less likely when approval was not obtained first.

--- a/docs/Expense-and-Reimbursement-Policy.md
+++ b/docs/Expense-and-Reimbursement-Policy.md
@@ -1,252 +1,121 @@
+---
+last_review_date: "2026-07-18"
+---
+
 # Expense and Reimbursement Policy
 
-This document presents _guidelines_ for spending money on behalf of Homebrew and seeking reimbursement for expenses incurred while doing work to benefit Homebrew, such as paying for goods or services or traveling to conferences or the Annual General Meeting.
+Homebrew only occasionally reimburses costs paid by individual maintainers.
+Whenever practical, a vendor should invoice Homebrew directly or the purchase should use a Homebrew-controlled payment method.
 
-In all cases, **assume no expense is reimbursable without pre-approval** from the Project Leader or Lead Maintainers.
-_Pre_-approval comes _before_ the expense is incurred, not before the bill is paid.
+Do not spend money expecting reimbursement unless the Lead Maintainers approve the expense before it is incurred.
+The approval should record what Homebrew is paying for and the maximum amount or budget.
 
-Pre-approval does not guarantee reimbursement; Homebrew is constrained within [Open Source Collective's Policies](https://docs.oscollective.org/how-it-works/basics) for its primary 501(c)6 business league accounts.
+Homebrew uses Open Source Collective as its fiscal host.
+Its [expense policies](https://docs.oscollective.org/for-hosted-member-projects/spending-money-and-getting-paid/expense-policies-and-limitations) also apply and take precedence when they are more restrictive.
 
-## Read This Section If You Read Nothing Else
+## Expenses Homebrew may cover
 
-* Seek pre-approval from the Lead Maintainers before committing to spend money, with no exceptions.
-* Seek consensus on the reasonability of pricing before seeking pre-approval, comparing pricing from multiple vendors if possible and including that comparison in your pre-approval request.
-* Seek discounts or free accounts for non-profits, open-source projects, or other traits that enable us to save money because of the nature of our organization.
+An expense must directly support Homebrew and be reasonable for the expected project benefit.
+Typical examples include:
 
-* Read [Ways to Mess Up](#ways-to-mess-up) if you want some concrete examples of what not to do.
+* Project infrastructure and services.
+* Approved hardware, equipment and shipping.
+* Travel to an approved Homebrew event or another event where a maintainer is representing Homebrew.
+* Group meals or event costs approved as part of a Homebrew gathering.
 
-## Purpose
+Homebrew does not reimburse personal purchases, unrelated travel, companion costs, donations to unrelated organisations, fines or other costs without a clear project purpose.
 
-Homebrew is required by our fiscal sponsor to spend money donated to the project for the reasonable benefit and continuance of the project.
+Stipends, hardware grants, conference travel and Annual General Meeting travel assistance have additional requirements in [Maintainer Stipends and Grants](Maintainer-Stipends-and-Grants.md).
 
-We are accountable to our donors to spend our limited funds wisely and impactfully.
+## Requesting approval
 
-## Seeking pre-approval
+Send the Lead Maintainers a short request before booking, ordering or otherwise committing to an expense.
+Include:
 
-Assemble a document that includes:
+* What is being purchased and how it benefits Homebrew.
+* The expected total and currency.
+* When the purchase or travel will occur.
+* For travel, the event, dates and categories of costs requested.
 
-* The purpose of the expense, such as the need for the trip or item
-* The timeline for the purchase or dates of travel
-* A budget demonstrating a comparison among different options, e.g.
-  * Different airlines or hotel chains and locations
-  * Different reasonable travel times, departures, and arrivals
-  * Different stores
-  * Different vendors for a service
-* For non-consumable goods, who will store the item(s)
-* For depreciable goods, when the good will need to be replaced
+No formal procurement document is required for an ordinary expense.
+The requester should still be able to explain why the proposed cost is reasonable.
+The Lead Maintainers may set a spending limit or other conditions when approving the request.
 
-Submit this document to any Lead Maintainer, who will discuss it with at least a majority of Lead Maintainers and approve or return it with adjusted expectations.
-The more work put into this, the more likely the Lead Maintainers will approve it as written!
+For a large expense that would be difficult to pay personally, arrange for the vendor to invoice Homebrew through Open Collective.
+Maintainers are not expected to advance significant personal funds.
 
-## Getting Reimbursed
+## Getting reimbursed
 
-All reimbursement requests must be filed through Open Collective
-within 14 days of incurring the expense, except for airfare, which can be submitted with other travel reimbursement requests if the flight(s) are more than 14 days in advance.
+Submit an approved expense through [Homebrew on Open Collective](https://opencollective.com/homebrew/expenses/new) promptly after paying it.
+Follow Open Source Collective's current [invoice and reimbursement guidance](https://docs.oscollective.org/for-hosted-member-projects/spending-money-and-getting-paid/invoice-and-reimbursement-examples).
 
-* [501(c)6 business league @ `opencollective.com/homebrew`](https://opencollective.com/homebrew/expenses/new)
+Use a reimbursement for a project purchase that you have already paid.
+Use an invoice for completed work or services.
+If an expense contains multiple receipts, enter them as separate line items.
 
-In the absence of this Open Collective system, submit an invoice to the Lead Maintainers containing the following:
+Open Source Collective may request payment, identity or tax information before it can pay an expense.
 
-* Your legal banking name
-* Your mailing address
-* Payment transfer information suitable for sending via a method supported by [Wise](https://wise.com) or wire transfer
-* Line items for each expense include the amount paid and the currency of the payment, the date of expense, who was paid, and the purpose of the payment
-* Scans or photographs of receipts for each expense, receipts complying with the [Receipts Policy](#receipts-policy)
+## Receipts policy
 
-## Receipts Policy
+Attach a legible vendor receipt showing:
 
-A receipt must have the following:
+* The vendor.
+* What was purchased.
+* The transaction date.
+* The amount and currency.
+* The purchaser or project when the receipt provides that information.
 
-* Date of transaction
-* Total amount of transaction
-* Taxes itemized, if any taxes were applied— this enables us to request a refund of sales or VAT tax for most purchases
-* The payment method, including the last four digits and cardholder if a credit card or debit card was used
+Add a short explanation when the connection to Homebrew is not obvious.
+A card statement is not normally a substitute for a receipt.
+Ask the Lead Maintainers before relying on alternative proof for a purchase where the vendor does not issue receipts.
 
-Note that OpenCollective cannot reimburse with only credit card statements or transactions.
-A receipt from the vendor is required in all but (rare) exceptional circumstances.
-One known exception is tap-to-pay public transit where no receipt is issued.
+## Travel policy
 
-## Travel Policy
+Homebrew reimburses travel only for an approved event with a clear project benefit.
+Approval should establish the approximate budget and the categories of travel that Homebrew will cover.
 
-Since Homebrew operates as a non-profit and has limited funds available, Homebrew limits travel on its behalf to carefully selected events with clear benefits to the project.
+Choose reasonable travel and lodging rather than treating either the absolute cheapest option or a fixed government rate as mandatory.
+Cost, journey time, safety, accessibility and proximity to the event may all affect what is reasonable.
 
-### Lodging
+### Transportation and lodging
 
-You are expected to choose the lowest logical lodging costs.
-This may warrant choosing lodging closer to a venue or travel hub if the cost to travel to and from a farther hotel may exceed the cost of the closer hotel or jeopardize the timeliness of travel during rush hours, etc.
+An approved travel budget may include:
 
-Homebrew follows US Government guidelines on reimbursement rates for lodging.
-Although Homebrew provides actual expense reimbursement for lodging and does not pay a per-diem,
-we treat US Department of State (DOS) and US General Services Administration (GSA) per-diem rates as the maximum reasonable reimbursement.
-See these links for details and the current rates:
+* Economy-class airfare, rail or bus travel.
+* Reasonable lodging for the event.
+* Local public transport.
+* Necessary baggage, parking or visa costs.
+* A taxi, rideshare or rental vehicle when it is the practical option.
 
-* US [international travel rates](https://allowances.state.gov/web920/per_diem.asp?) are governed by DOS
-* US [domestic travel rates](https://www.gsa.gov/perdiem) are governed by the GSA
+Upgrades, luxury accommodation, companion travel and personal entertainment are not reimbursable unless an explicit accessibility or medical exception was approved.
 
-| Accommodation Type     | Reimbursable by default? |
-|------------------------|--------------------------|
-| Hotel, including taxes | Yes                      |
-| Hotel breakfast        | Yes                      |
-| AirBnB/VRBO            | No                       |
-| Hostel                 | No, do not use           |
+### Meals and entertainment
 
-### Meals and Entertainment
+Homebrew normally covers pre-approved group meals attended primarily by Homebrew maintainers as part of an event or project gathering.
+The reimbursement should identify the attendees and the Homebrew purpose.
 
-Homebrew does not cover individual M&E expenses during travel other than hotel breakfast.
+Individual meals and entertainment are not normally reimbursable unless they were explicitly included in the approved event budget.
 
-Homebrew will reimburse for group meals with participants consisting primarily of Homebrew maintainers.
-Some guests are permitted; use discretion for who is appropriate for Homebrew to cover.
-The person responsible for paying and seeking reimbursement for this is the first of the PL, the most senior member of the Lead Maintainers, or the most senior member present.
-Any person unable to float the expense until reimbursed may pass.
+### Personal travel
 
-You must list the participants in the group meal and their affiliation with Homebrew or whose guests they are.
+A maintainer may extend or combine an approved Homebrew trip with personal or other business travel when doing so does not increase Homebrew's cost.
+Homebrew will reimburse no more than the lower of the actual project-related cost and a reasonable equivalent itinerary covering only the Homebrew event.
+The maintainer is responsible for every personal portion of the trip.
 
-| Meal      | Reimbursable by default?          |
-|-----------|-----------------------------------|
-| Breakfast | Yes, if taken at the hotel        |
-| Lunch     | No                                |
-| Dinner    | No if individual, Yes if HB group |
+### Accessibility and medical needs
 
-### Transportation
+Reasonable accessibility or medical needs may justify an exception or a more expensive option.
+Request approval in advance when possible and disclose only the information needed to evaluate the expense.
 
-Homebrew will cover city-to-city transportation from the city of residence to the city of venue,
-between the hotel and the venue, and
-any co-located events where Homebrew has a presence, according to this table.
+## Services and project property
 
-| Transport Type   | Reimbursable by default?                                 |
-|------------------|----------------------------------------------------------|
-| Airplane         | Yes (cheapest class, reasonable cost/comfort/time ratio) |
-| Train            | Yes (cheapest class)                                     |
-| Long-haul bus    | Yes (cheapest class)                                     |
-| Light rail       | Yes                                                      |
-| Metro            | Yes                                                      |
-| Bus              | Yes                                                      |
-| Taxi             | No                                                       |
-| Rideshare        | No                                                       |
-| Personal vehicle | Yes, for home to transit hub only                        |
-| Rental vehicle   | No                                                       |
+The Lead Maintainers must approve a new or recurring paid service.
+Where practical, the service should use a Homebrew-controlled account and payment method instead of depending on an individual maintainer.
 
-#### Airplanes
+An item purchased for Homebrew should have a named custodian and a recorded location while Homebrew owns it.
 
-All air travel must be pre-approved by the Lead Maintainers before purchasing.
+## Changes and emergencies
 
-Coach or economy class airfare must be bought at least four weeks in advance of travel unless the Lead Maintainers grant an exception.
-Purchase non-refundable tickets _and_ single trip travel insurance, which is also reimbursable.
-Check if your credit card may provide an adequate level of travel insurance automatically.
-
-You must choose the lowest logical and reasonable airfare.
-Reasonability takes into account
-departure and arrival times,
-time in transit,
-and
-number of stops.
-
-Higher-level seating is permissible, but you are responsible for the difference between covered expenses and actual expenses.
-The Lead Maintainers may grant exceptions to this in extenuating circumstances.
-
-A single checked bag fee will be covered if the airline does not include it.
-
-#### Ground Transportation
-
-##### Mass Transit (Bus, Train, etc.)
-
-Use mass transit when available and reasonable.
-Plan travel ahead of time and be early for scheduled departure.
-
-##### Rideshare and taxi services
-
-Avoid using rideshare or taxi services when reasonable mass transit options exist.
-Use rideshare only when a large option, such as a van or SUV, will be full or nearly full of Homebrew maintainers.
-
-##### Personally-owned Vehicles
-
-With pre-approval, Homebrew may reimburse maintainers for using a personal vehicle to travel to and from Homebrew events,
-primarily for transit between one's home and an airport or mass transit station
-when that distance does not exceed 250 miles or 400 kilometers.
-
-Homebrew will only cover mileage at the current United States IRS non-taxable expense rate.
-This rate may change, but US Congress sets it statutorily and rarely changes despite changes in fuel prices.
-Homebrew is constrained because our fiscal sponsor is a US entity.
-
-<!-- https://www.convertunits.com/from/U.S.+cent/mile/to/U.S.+cents/kilometer -->
-The 2024 rate is 14¢/mile or 8.7¢/kilometer, per [IR-2023-239](https://www.irs.gov/newsroom/irs-issues-standard-mileage-rates-for-2024-mileage-rate-increases-to-67-cents-a-mile-up-1-point-5-cents-from-2023).
-
-Airport long-term or extended parking fees will be reimbursed if cheaper than rideshare or taxi to or from the airport.
-
-##### Rental Vehicles
-
-Avoid if at all possible.
-Use only as a last resort.
-
-### Travel Extensions
-
-Homebrew permits scheduling Homebrew-related travel before, during, or after other personal or business travel as long as it does not increase the costs for Homebrew.
-If any cost is reduced as a result of personal travel, the member must bill for the lower cost.
-
-The pre-approval submission must budget for only the maximum amount necessary for the Homebrew portion of travel.
-The pre-approval submission must also indicate that personal or business travel may increase the amount shown on receipts but reflect an explicit acceptance that only the Homebrew-relevant travel portions will be reimbursed.
-
-For example, consider a Homebrew member flying to Brussels for AGM and then staying in Europe for several days afterward.
-Homebrew would cover the flight and hotel as if the member was flying in the day before the event and departing the day after.
-The member is responsible for all other costs, including additional flight costs.
-If the flight is cheaper, the member must bill for the lower cost and not what the cost could have been had they traveled the minimum.
-
-### Visa expenses
-
-Homebrew will reimburse visa application expenses and other related expenses for travel reimbursable under the aforementioned policies.
-
-### Expenses that are never reimbursable
-
-* Partner, spouse, and/or companion travel
-* First class, business class, economy-plus travel
-
-* Upgrades to air travel, car rentals, or hotel rooms
-
-* Purchase of clothing, luggage, toiletries and other miscellaneous personal items
-* Supplemental car rental insurance
-* Fines, penalties, or legal fees
-* Personal entertainment or recreational expenses beyond any allotted per diem
-
-The Lead Maintainers will consider exceptions to these if an exception is medically necessary to enable travel.
-Such exceptions must be included in the pre-approval request, and the request should be submitted further in advance so the Lead Maintainers can discuss it.
-
-## Maintainer Grant Reimbursement Policy
-
-See [Maintainer Stipends and Grants](Maintainer-Stipends-and-Grants.md) for all policies and procedures related to maintainer grants for hardware, non-AGM-related conference travel, etc.
-
-## Services Policy
-
-The Lead Maintainers must approve all expenses for one-time or ongoing services.
-A Homebrew-owned payment instrument (virtual payment card, etc.) must be used, except in an emergency, in which case it should be transferred back to a Homebrew card ASAP.
-
-## Homebrew Assets Policy
-
-All goods purchased and intended to be owned by Homebrew, such as promotional marketing materials, must be tracked in the Physical Inventory list.
-This list enables Homebrew to track who has what, esp. things that may need to be shipped to Homebrew maintainers representing the project at conferences, etc.
-
-## Ways to Mess Up
-
-These are examples of expenses or circumstances that will certainly result in rejecting a reimbursement request.
-
-1. Paying for first-class airfare when another reasonable option exists, such as staying an additional night, seeking an alternative route, or using an alternative mode of transportation.
-
-1. Buying any computer for Homebrew development expecting that Homebrew will reimburse you without pre-approval from the Lead Maintainers.
-
-1. Paying a sponsorship fee to exhibit on behalf of Homebrew at a conference without pre-approval from the Lead Maintainers.
-
-Any money transferred from Homebrew to you may come with tax implications.
-You, and not OpenCollective or Homebrew, are responsible for any required interactions with your government.
-You must retain evidence that all reimbursed expenses are strictly for Homebrew benefit and are not personal in nature and,
-therefore, are not considered taxable income.
-**Receipts are required for all expenses, no matter the amount.**
-
-<!--
-Add more examples as we think of them!
-The more realistic or stranger than fiction, the better.
--->
-
-## References
-
-Policies that we read while constructing this policy.
-If we encounter ambiguity in this policy, the Lead Maintainers may consult these
-source documents for clarity.
+Ask for new approval before materially exceeding an approved amount or changing the purpose of an expense.
+If an emergency makes advance approval impossible, contact the Lead Maintainers as soon as practical.
+Reimbursement is not guaranteed when approval was not obtained first.


### PR DESCRIPTION
Simplifies the Expense and Reimbursement Policy. The rewrite removes the DOS/GSA per-diem ceilings, the accommodation and transport type tables, the 14-day filing deadline and the mileage schedule in favour of reasonable-cost judgement anchored on pre-approval, de-legalises the prose and resolves the old contradiction with the stipends page over hackathon meals. These are intentional substantive policy changes, not editorial ones: per [Homebrew Governance section 3](https://docs.brew.sh/Homebrew-Governance#3-decision-making), changes to documented financial processes are made by vote of the Lead Maintainers, so this PR must not merge until that approval is recorded here.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5) prepared the rewrite and enumerated every removed or weakened rule during review so the Lead Maintainers can approve the policy change knowingly; I reviewed the diff and verified locally with Vale, Markdownlint and the docs Jekyll/HTMLProofer suite, whose only failures were transient HTTP 429 rate limits on pages this PR does not touch (addressed by #23169).

-----
