### PR TITLE
Add scoped install step guards (1/24)

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -47,6 +47,15 @@ module Homebrew
       TEMPLATE_VERSION = TemplateVersion.new.freeze
       private_constant :TEMPLATE_VERSION
 
+      ABSOLUTE_TEMPLATE_TOKENS = %w[
+        HOMEBREW_PREFIX HOMEBREW_CELLAR prefix opt_prefix bin sbin lib libexec share pkgshare var etc pkgetc
+        staged_path appdir caskroom_path temp rack bash_completion zsh_completion fish_completion pwsh_completion
+      ].freeze
+      private_constant :ABSOLUTE_TEMPLATE_TOKENS
+
+      PRESERVED_STEP_VALUE_KEYS = %w[after args before content env overwrite].freeze
+      private_constant :PRESERVED_STEP_VALUE_KEYS
+
       sig {
         params(
           default_base:        ::T.nilable(::T.any(::String, ::Symbol)),
@@ -66,9 +75,20 @@ module Homebrew
       sig { returns(Steps) }
       attr_reader :steps
 
+      # odeprecated
       sig { returns(String) }
       def name
         "{{name}}"
+      end
+
+      sig { returns(String) }
+      def formula_name
+        "{{formula_name}}"
+      end
+
+      sig { returns(String) }
+      def token
+        "{{token}}"
       end
 
       sig { returns(TemplateVersion) }
@@ -129,9 +149,26 @@ module Homebrew
             key = key.to_s
             [key, normalise_step_value(key, value)]
           end
-          ::T.cast(::Utils.deep_compact_blank(step), Step)
+          compact_step(step)
         end
       end
+
+      sig { params(step: ::T::Hash[String, ::T.nilable(StepValue)]).returns(Step) }
+      def self.compact_step(step)
+        compacted_step = ::T.cast(
+          ::Utils.deep_compact_blank(step.except(*PRESERVED_STEP_VALUE_KEYS)) || {},
+          Step,
+        )
+        PRESERVED_STEP_VALUE_KEYS.each do |key|
+          value = step[key]
+          next if value.nil?
+          next if %w[args env].include?(key) && [[], {}].include?(value)
+
+          compacted_step[key] = value
+        end
+        compacted_step
+      end
+      private_class_method :compact_step
 
       sig { params(key: String, obj: RawStepValue).returns(::T.nilable(StepValue)) }
       def self.normalise_step_value(key, obj)
@@ -141,9 +178,19 @@ module Homebrew
         when Array
           obj.map { |value| normalise_path_value(value) } if %w[guards paths].include?(key)
         when Hash
-          normalise_path_value(obj)
+          if key == "env"
+            ::T.cast(obj.to_h { |env_key, value| [env_key.to_s, value&.to_s] }.compact, PathSpec)
+          else
+            normalise_path_value(obj)
+          end
         when String, Pathname
-          %w[path source target matching_certificate].include?(key) ? normalise_path_value(obj) : obj.to_s
+          if %w[
+            path source target command matching_certificate fingerprint_of stdin_path stdout_path chdir
+          ].include?(key)
+            normalise_path_value(obj)
+          else
+            obj.to_s
+          end
         else
           obj
         end
@@ -161,6 +208,7 @@ module Homebrew
       end
       private_class_method :normalise_path_value
 
+      # odeprecated
       sig { params(path: ::T.any(::String, ::Pathname), base: ::T.nilable(::T.any(::String, ::Symbol))).void }
       def mkdir(path, base: nil)
         add_step("mkdir", "path" => path_spec(path, base:, default_base: @default_base))
@@ -183,13 +231,15 @@ module Homebrew
           source_base: ::T.nilable(::T.any(::String, ::Symbol)),
           target_base: ::T.nilable(::T.any(::String, ::Symbol)),
           force:       ::T::Boolean,
+          source_glob: ::T::Boolean,
         ).void
       }
-      def move(source, target, source_base: nil, target_base: nil, force: false)
+      def move(source, target, source_base: nil, target_base: nil, force: false, source_glob: false)
         add_step("move",
-                 "source" => path_spec(source, base: source_base, default_base: @default_source_base),
-                 "target" => path_spec(target, base: target_base, default_base: @default_target_base),
-                 "force"  => force)
+                 "source"      => path_spec(source, base: source_base, default_base: @default_source_base),
+                 "target"      => path_spec(target, base: target_base, default_base: @default_target_base),
+                 "force"       => force,
+                 "source_glob" => source_glob)
       end
 
       alias mv move
@@ -218,17 +268,21 @@ module Homebrew
           target_formula: ::T.nilable(::String),
           force:          ::T::Boolean,
           uninstall:      ::T::Boolean,
+          source_glob:    ::T::Boolean,
+          sudo:           ::T.any(::T::Boolean, ::Symbol),
         ).void
       }
       def symlink(source, target, source_base: nil, target_base: nil, source_formula: nil, target_formula: nil,
-                  force: false, uninstall: false)
+                  force: false, uninstall: false, source_glob: false, sudo: false)
         add_step("symlink",
-                 "source"    => path_spec(source, base: source_base, formula: source_formula,
+                 "source"      => path_spec(source, base: source_base, formula: source_formula,
                                            default_base: @default_source_base),
-                 "target"    => path_spec(target, base: target_base, formula: target_formula,
+                 "target"      => path_spec(target, base: target_base, formula: target_formula,
                                            default_base: @default_target_base),
-                 "force"     => force,
-                 "uninstall" => uninstall)
+                 "force"       => force,
+                 "uninstall"   => uninstall,
+                 "source_glob" => source_glob,
+                 "sudo"        => sudo.is_a?(::Symbol) ? sudo.to_s : sudo)
       end
 
       sig {
@@ -376,27 +430,31 @@ module Homebrew
           paths:       Paths,
           permissions: ::String,
           base:        ::T.nilable(::T.any(::String, ::Symbol)),
+          recursive:   ::T::Boolean,
         ).void
       }
-      def set_permissions(paths, permissions, base: nil)
+      def set_permissions(paths, permissions, base: nil, recursive: true)
         add_step("set_permissions",
-                 "paths"       => path_specs(paths, base:, default_base: @default_base),
-                 "permissions" => permissions)
+                 "paths"         => path_specs(paths, base:, default_base: @default_base),
+                 "permissions"   => permissions,
+                 "non_recursive" => !recursive)
       end
 
       sig {
         params(
-          paths: Paths,
-          user:  ::T.nilable(::String),
-          group: ::String,
-          base:  ::T.nilable(::T.any(::String, ::Symbol)),
+          paths:     Paths,
+          user:      ::T.nilable(::String),
+          group:     ::String,
+          base:      ::T.nilable(::T.any(::String, ::Symbol)),
+          recursive: ::T::Boolean,
         ).void
       }
-      def set_ownership(paths, user: nil, group: "staff", base: nil)
+      def set_ownership(paths, user: nil, group: "staff", base: nil, recursive: true)
         add_step("set_ownership",
-                 "paths" => path_specs(paths, base:, default_base: @default_base),
-                 "user"  => user,
-                 "group" => group)
+                 "paths"         => path_specs(paths, base:, default_base: @default_base),
+                 "user"          => user,
+                 "group"         => group,
+                 "non_recursive" => !recursive)
       end
 
       private
@@ -417,7 +475,7 @@ module Homebrew
         step = fields.transform_keys(&:to_s)
         step["guards"] = @guards unless @guards.empty?
         step["type"] = type
-        @steps << ::T.cast(::Utils.deep_compact_blank(step), Step)
+        @steps.concat(::Homebrew::InstallSteps::DSL.normalise_steps([step]))
       end
 
       sig { params(type: ::String, path: ::String).void }
@@ -455,6 +513,16 @@ module Homebrew
 
       sig {
         params(
+          path:         ::T.nilable(::T.any(::String, ::Pathname)),
+          default_base: ::T.nilable(::T.any(::String, ::Symbol)),
+        ).returns(::T.nilable(PathSpec))
+      }
+      def optional_path_spec(path, default_base:)
+        path_spec(path, base: nil, default_base:) if path
+      end
+
+      sig {
+        params(
           path:         ::T.any(::String, ::Pathname),
           default_base: ::T.nilable(::T.any(::String, ::Symbol)),
         ).returns(::T.nilable(::T.any(::String, ::Symbol)))
@@ -462,6 +530,7 @@ module Homebrew
       def default_base_for(path, default_base)
         path = path.to_s
         return if path.start_with?("/", "~")
+        return if ABSOLUTE_TEMPLATE_TOKENS.any? { |token| path.start_with?("{{#{token}}}") }
 
         default_base
       end
@@ -474,7 +543,11 @@ module Homebrew
       # Path tokens reuse the step base resolution; formula metadata tokens are
       # resolved separately. Anything else is left verbatim so literal braces in
       # templates are never rewritten.
-      CONTENT_PATH_TOKENS = %w[prefix opt_prefix bin var etc pkgetc staged_path appdir].freeze
+      CONTENT_PATH_TOKENS = %w[
+        prefix opt_prefix bin sbin lib libexec share pkgshare var etc pkgetc staged_path appdir caskroom_path
+        temp rack
+        bash_completion zsh_completion fish_completion pwsh_completion
+      ].freeze
 
       sig { params(context: Object, command: T.class_of(SystemCommand)).void }
       def initialize(context:, command: SystemCommand)
@@ -513,7 +586,9 @@ module Homebrew
           path.dirname.mkpath
           FileUtils.touch path
         when "move"
-          source = resolve_path(step_path(step, "source"))
+          source = resolve_step_source(step)
+          return unless source
+
           target = resolve_path(step_path(step, "target"))
           target.dirname.mkpath
           FileUtils.mv source, target, force: step["force"] == true
@@ -550,9 +625,20 @@ module Homebrew
           end
         when "symlink"
           target = resolve_path(step_path(step, "target"))
-          target.dirname.mkpath
-          FileUtils.rm_f target if step["force"] == true
-          File.symlink link_source(step_path(step, "source")), target
+          if step["source_glob"] == true
+            sources = expand_path_glob(step_path(step, "source"))
+            return if sources.empty?
+
+            if sources.length > 1 || target.directory?
+              target.mkpath
+              sources.each { |source| create_symlink(source, target/source.basename, step) }
+            else
+              source = sources.first
+              create_symlink(source, target, step) if source
+            end
+          else
+            create_symlink(link_source(step_path(step, "source")), target, step)
+          end
         when "write"
           content = T.cast(step["content"], T.nilable(String))
           raise ArgumentError, "install step write requires non-empty content" if content.blank?
@@ -651,7 +737,7 @@ module Homebrew
       sig { params(source: SystemCommandArg, target: Pathname, step: Step).void }
       def create_symlink(source, target, step)
         target.dirname.mkpath
-        if step["sudo"] == true || (step["sudo_if_needed"] == true && !target.dirname.writable?)
+        if step["sudo"] == true || (step["sudo"] == "if_needed" && !target.dirname.writable?)
           args = ["-s"]
           args << "-f" if step["force"] == true
           @command.run!("/bin/ln", args: [*args, source, target], sudo: true)
@@ -666,7 +752,9 @@ module Homebrew
         paths = existing_step_paths(step)
         return if paths.empty?
 
-        @command.run!("chmod", args: ["-R", "--", step_string(step, "permissions"), *paths], sudo: false)
+        args = []
+        args << "-R" if step["non_recursive"] != true
+        @command.run!("chmod", args: [*args, "--", step_string(step, "permissions"), *paths], sudo: false)
       end
 
       sig { params(step: Step).void }
@@ -690,7 +778,9 @@ module Homebrew
         end
 
         ohai "Changing ownership of paths required by #{@context} with `sudo` (which may request your password)..."
-        @command.run!("chown", args: ["-R", "--", "#{step["user"] || ::User.current}:#{step["group"] || "staff"}",
+        args = []
+        args << "-R" if step["non_recursive"] != true
+        @command.run!("chown", args: [*args, "--", "#{step["user"] || ::User.current}:#{step["group"] || "staff"}",
                                       *paths],
                                sudo: true)
       end
@@ -701,7 +791,15 @@ module Homebrew
         return if step["uninstall"] != true
 
         target = resolve_path(step_path(step, "target"))
-        FileUtils.rm_f target if target.symlink?
+        return unless target.symlink?
+        return if target.readlink != Pathname(link_source(step_path(step, "source")))
+
+        if step["sudo"] == true || (step["sudo"] == "if_needed" && !target.dirname.writable?)
+          require "cask/utils"
+          ::Cask::Utils.gain_permissions_remove(target, command: @command)
+        else
+          FileUtils.rm_f target
+        end
       end
 
       sig { params(step: Step).void }
@@ -752,10 +850,20 @@ module Homebrew
       sig { params(token: String).returns(T.nilable(TemplateTokenValue)) }
       def template_token_value(token)
         case token
+        when "HOMEBREW_BREW_FILE"
+          HOMEBREW_BREW_FILE
+        when "HOMEBREW_CELLAR"
+          HOMEBREW_CELLAR
         when "HOMEBREW_PREFIX"
           HOMEBREW_PREFIX
+        when "formula_name"
+          context_value(:name)&.to_s
         when "name"
           context_name
+        when "token"
+          context_value(:token)&.to_s
+        when "user"
+          ENV.fetch("USER")
         when "version"
           context_version
         when "version.major"
@@ -874,6 +982,8 @@ module Homebrew
         case base
         when "home"
           Pathname(Dir.home)
+        when "temp"
+          HOMEBREW_TEMP
         when "homebrew_prefix"
           HOMEBREW_PREFIX
         when "formula_pkgetc"

--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -295,6 +295,26 @@ module Homebrew
 
       sig {
         params(
+          paths:                   Paths,
+          base:                    ::T.nilable(::T.any(::String, ::Symbol)),
+          recursive:               ::T::Boolean,
+          sudo:                    ::T.any(::T::Boolean, ::Symbol),
+          symlink_target_contains: ::T.nilable(::String),
+          content_contains:        ::T.nilable(::String),
+        ).void
+      }
+      def remove(paths, base: nil, recursive: false, sudo: false, symlink_target_contains: nil,
+                 content_contains: nil)
+        add_step("remove",
+                 "paths"                   => path_specs(paths, base:, default_base: @default_base),
+                 "recursive"               => recursive,
+                 "sudo"                    => sudo.is_a?(::Symbol) ? sudo.to_s : sudo,
+                 "symlink_target_contains" => symlink_target_contains,
+                 "content_contains"        => content_contains)
+      end
+
+      sig {
+        params(
           source:         ::T.any(::String, ::Pathname),
           target:         ::T.any(::String, ::Pathname),
           source_base:    ::T.nilable(::T.any(::String, ::Symbol)),
@@ -646,6 +666,28 @@ module Homebrew
           else
             FileUtils.rm_f destination if overwrite && destination.symlink?
             FileUtils.cp source, target
+          end
+        when "remove"
+          paths = step_paths(step, "paths").flat_map { |path| expand_path_glob(path) }
+          if step.key?("symlink_target_contains")
+            paths.select! do |path|
+              path.symlink? && path.readlink.to_s.include?(step_string(step, "symlink_target_contains"))
+            end
+          end
+          if step.key?("content_contains")
+            paths.select! do |path|
+              path.file? && path.readable? && path.read.include?(step_string(step, "content_contains"))
+            end
+          end
+          paths.each do |path|
+            if step["sudo"] == true || (step["sudo"] == "if_needed" && !path.dirname.writable?)
+              require "cask/utils"
+              ::Cask::Utils.gain_permissions_remove(path, command: @command)
+            elsif step["recursive"] == true
+              FileUtils.rm_rf path
+            else
+              FileUtils.rm_f path
+            end
           end
         when "link_dir"
           source_dir = resolve_path(step_path(step, "source"))

--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -260,6 +260,41 @@ module Homebrew
 
       sig {
         params(
+          source:      ::T.any(::String, ::Pathname),
+          target:      ::T.any(::String, ::Pathname),
+          source_base: ::T.nilable(::T.any(::String, ::Symbol)),
+          target_base: ::T.nilable(::T.any(::String, ::Symbol)),
+        ).void
+      }
+      def move_contents(source, target, source_base: nil, target_base: nil)
+        add_step("move_contents",
+                 "source" => path_spec(source, base: source_base, default_base: @default_source_base),
+                 "target" => path_spec(target, base: target_base, default_base: @default_target_base))
+      end
+
+      sig {
+        params(
+          source:      ::T.any(::String, ::Pathname),
+          target:      ::T.any(::String, ::Pathname),
+          source_base: ::T.nilable(::T.any(::String, ::Symbol)),
+          target_base: ::T.nilable(::T.any(::String, ::Symbol)),
+          recursive:   ::T::Boolean,
+          overwrite:   ::T::Boolean,
+          source_glob: ::T::Boolean,
+        ).void
+      }
+      def copy(source, target, source_base: nil, target_base: nil, recursive: false, overwrite: true,
+               source_glob: false)
+        add_step("copy",
+                 "source"      => path_spec(source, base: source_base, default_base: @default_source_base),
+                 "target"      => path_spec(target, base: target_base, default_base: @default_target_base),
+                 "recursive"   => recursive,
+                 "overwrite"   => overwrite,
+                 "source_glob" => source_glob)
+      end
+
+      sig {
+        params(
           source:         ::T.any(::String, ::Pathname),
           target:         ::T.any(::String, ::Pathname),
           source_base:    ::T.nilable(::T.any(::String, ::Symbol)),
@@ -587,12 +622,10 @@ module Homebrew
           FileUtils.touch path
         when "move"
           source = resolve_step_source(step)
-          return unless source
-
           target = resolve_path(step_path(step, "target"))
           target.dirname.mkpath
           FileUtils.mv source, target, force: step["force"] == true
-        when "move_children"
+        when "move_children", "move_contents"
           source = resolve_path(step_path(step, "source"))
           target = resolve_path(step_path(step, "target"))
           target.mkpath
@@ -600,6 +633,20 @@ module Homebrew
           return if children.empty?
 
           FileUtils.mv children, target
+        when "copy"
+          source = resolve_step_source(step)
+          target = resolve_path(step_path(step, "target"))
+          target.dirname.mkpath
+          destination = step_destination(source, target)
+          overwrite = step["overwrite"] != false
+          raise Errno::EEXIST, destination.to_s if destination.exist? && !overwrite
+
+          if step["recursive"] == true
+            FileUtils.cp_r source, target, remove_destination: overwrite
+          else
+            FileUtils.rm_f destination if overwrite && destination.symlink?
+            FileUtils.cp source, target
+          end
         when "link_dir"
           source_dir = resolve_path(step_path(step, "source"))
           target_dir = resolve_path(step_path(step, "target"))
@@ -890,12 +937,20 @@ module Homebrew
         step_paths(step, "paths").flat_map { |spec| expand_path_glob(spec) }.select(&:exist?)
       end
 
-      sig { params(step: Step).returns(T.nilable(Pathname)) }
+      sig { params(step: Step).returns(Pathname) }
       def resolve_step_source(step)
         source = resolve_path(step_path(step, "source"))
         return source if step["source_glob"] != true
 
-        Pathname.glob(source.to_s).first
+        sources = Pathname.glob(source.to_s)
+        raise ArgumentError, "install step source glob must match exactly one path: #{source}" if sources.length != 1
+
+        sources.fetch(0)
+      end
+
+      sig { params(source: Pathname, target: Pathname).returns(Pathname) }
+      def step_destination(source, target)
+        target.directory? ? target/source.basename : target
       end
 
       sig { params(spec: PathSpec).returns(T::Array[Pathname]) }

--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "simulate_system"
 require "system_command"
 require "utils/output"
 
@@ -58,6 +59,8 @@ module Homebrew
         @default_source_base = default_source_base
         @default_target_base = default_target_base
         @steps = ::T.let([], Steps)
+        @guards = ::T.let([], PathSpecs)
+        @next_guard_id = ::T.let(0, ::Integer)
       end
 
       sig { returns(Steps) }
@@ -87,6 +90,38 @@ module Homebrew
         dsl.steps
       end
 
+      sig {
+        params(
+          path:  ::T.any(::String, ::Pathname),
+          base:  ::T.nilable(::T.any(::String, ::Symbol)),
+          block: ::T.proc.void,
+        ).void
+      }
+      def if_path_exists(path, base: nil, &block)
+        with_guard(path_spec(path, base:, default_base: @default_base).merge("condition" => "if_exists"), &block)
+      end
+
+      sig {
+        params(
+          path:  ::T.any(::String, ::Pathname),
+          base:  ::T.nilable(::T.any(::String, ::Symbol)),
+          block: ::T.proc.void,
+        ).void
+      }
+      def unless_path_exists(path, base: nil, &block)
+        with_guard(path_spec(path, base:, default_base: @default_base).merge("condition" => "unless_exists"), &block)
+      end
+
+      sig { params(block: ::T.proc.void).void }
+      def on_macos(&block)
+        with_guard({ "condition" => "on", "value" => "macos" }, &block)
+      end
+
+      sig { params(block: ::T.proc.void).void }
+      def on_linux(&block)
+        with_guard({ "condition" => "on", "value" => "linux" }, &block)
+      end
+
       sig { params(steps: ::T::Array[RawStep]).returns(Steps) }
       def self.normalise_steps(steps)
         steps.map do |step|
@@ -104,7 +139,7 @@ module Homebrew
         when Symbol
           obj.to_s
         when Array
-          obj.map { |value| normalise_path_value(value) } if key == "paths"
+          obj.map { |value| normalise_path_value(value) } if %w[guards paths].include?(key)
         when Hash
           normalise_path_value(obj)
         when String, Pathname
@@ -366,9 +401,21 @@ module Homebrew
 
       private
 
+      sig { params(guard: PathSpec, block: ::T.proc.void).void }
+      def with_guard(guard, &block)
+        previous_guards = ::T.let(nil, ::T.nilable(PathSpecs))
+        previous_guards = @guards
+        @next_guard_id += 1
+        @guards = [*@guards, guard.merge("id" => @next_guard_id.to_s)]
+        instance_eval(&block)
+      ensure
+        @guards = previous_guards if previous_guards
+      end
+
       sig { params(type: ::String, fields: ::T.nilable(StepValue)).void }
       def add_step(type, **fields)
         step = fields.transform_keys(&:to_s)
+        step["guards"] = @guards unless @guards.empty?
         step["type"] = type
         @steps << ::T.cast(::Utils.deep_compact_blank(step), Step)
       end
@@ -433,10 +480,12 @@ module Homebrew
       def initialize(context:, command: SystemCommand)
         @context = context
         @command = command
+        @guard_results = T.let({}, T::Hash[PathSpec, T::Boolean])
       end
 
       sig { params(steps: Steps, phase: Symbol).void }
       def run(steps, phase: :install)
+        @guard_results.clear
         DSL.normalise_steps(steps).each do |step|
           if phase == :uninstall
             run_uninstall_step(step)
@@ -450,6 +499,8 @@ module Homebrew
 
       sig { params(step: Step).void }
       def run_install_step(step)
+        return unless step_guards_match?(step)
+
         case step.fetch("type")
         when "mkdir"
           resolve_path(step_path(step, "path")).mkdir
@@ -571,6 +622,45 @@ module Homebrew
         end
       end
 
+      sig { params(step: Step).returns(T::Boolean) }
+      def step_guards_match?(step)
+        guards = T.cast(step["guards"], T.nilable(PathSpecs))
+        guards.nil? || guards.all? { |guard| guard_matches?(guard) }
+      end
+
+      sig { params(guard: PathSpec).returns(T::Boolean) }
+      def guard_matches?(guard)
+        return @guard_results.fetch(guard) if @guard_results.key?(guard)
+
+        matches = case guard.fetch("condition")
+        when "if_exists"
+          path_spec_exists?(guard)
+        when "unless_exists"
+          !path_spec_exists?(guard)
+        when "on"
+          case guard.fetch("value")
+          when "macos" then Homebrew::SimulateSystem.simulating_or_running_on_macos?
+          when "linux" then Homebrew::SimulateSystem.simulating_or_running_on_linux?
+          else false
+          end
+        else
+          false
+        end
+        @guard_results[guard] = matches
+      end
+      sig { params(source: SystemCommandArg, target: Pathname, step: Step).void }
+      def create_symlink(source, target, step)
+        target.dirname.mkpath
+        if step["sudo"] == true || (step["sudo_if_needed"] == true && !target.dirname.writable?)
+          args = ["-s"]
+          args << "-f" if step["force"] == true
+          @command.run!("/bin/ln", args: [*args, source, target], sudo: true)
+        else
+          FileUtils.rm_f target if step["force"] == true
+          File.symlink source, target
+        end
+      end
+
       sig { params(step: Step).void }
       def run_set_permissions(step)
         paths = existing_step_paths(step)
@@ -689,10 +779,36 @@ module Homebrew
 
       sig { params(step: Step).returns(T::Array[Pathname]) }
       def existing_step_paths(step)
-        step_paths(step, "paths").filter_map do |spec|
-          path = resolve_path(spec).expand_path
-          path if path.exist?
+        step_paths(step, "paths").flat_map { |spec| expand_path_glob(spec) }.select(&:exist?)
+      end
+
+      sig { params(step: Step).returns(T.nilable(Pathname)) }
+      def resolve_step_source(step)
+        source = resolve_path(step_path(step, "source"))
+        return source if step["source_glob"] != true
+
+        Pathname.glob(source.to_s).first
+      end
+
+      sig { params(spec: PathSpec).returns(T::Array[Pathname]) }
+      def expand_path_glob(spec)
+        if spec["base"] == "path"
+          path = expand_template_tokens(spec.fetch("path"))
+          return ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).flat_map do |directory|
+            candidate = Pathname(directory)/path
+            candidate.to_s.match?(/[?*\[{]/) ? Pathname.glob(candidate.to_s) : [candidate]
+          end
         end
+
+        path = resolve_path(spec).expand_path
+        return [path] unless path.to_s.match?(/[?*\[{]/)
+
+        Pathname.glob(path.to_s)
+      end
+
+      sig { params(spec: PathSpec).returns(T::Boolean) }
+      def path_spec_exists?(spec)
+        expand_path_glob(spec).any?(&:exist?)
       end
 
       sig { params(step: Step, key: String).returns(String) }

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -5,7 +5,7 @@ module RuboCop
   module Cop
     module InstallStepsHelper
       FILE_PREPARATION_STEP_METHODS =
-        [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :copy, :symlink, :ln_s, :ln_sf].freeze
+        [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :copy, :remove, :symlink, :ln_s, :ln_sf].freeze
       LINK_STEP_METHODS = [:link_dir, :link_children].freeze
       CONFIG_WRITE_STEP_METHODS = [:write].freeze
       SERVICE_DATA_STEP_METHODS = [:init_data_dir].freeze

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -5,7 +5,7 @@ module RuboCop
   module Cop
     module InstallStepsHelper
       FILE_PREPARATION_STEP_METHODS =
-        [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :symlink, :ln_s, :ln_sf].freeze
+        [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :copy, :symlink, :ln_s, :ln_sf].freeze
       LINK_STEP_METHODS = [:link_dir, :link_children].freeze
       CONFIG_WRITE_STEP_METHODS = [:write].freeze
       SERVICE_DATA_STEP_METHODS = [:init_data_dir].freeze

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -341,6 +341,54 @@ RSpec.describe Homebrew::InstallSteps do
       .to raise_error(ArgumentError, /exactly one path/)
   end
 
+  specify "removes paths and expands globs", :aggregate_failures do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      remove ["obsolete.txt", "obsolete-*"], recursive: true
+    end
+
+    (root/"var/obsolete-dir").mkpath
+    (root/"var/obsolete.txt").write "obsolete"
+    (root/"var/obsolete-dir/child").write "obsolete"
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect(root/"var/obsolete.txt").not_to exist
+    expect(root/"var/obsolete-dir").not_to exist
+  end
+
+  specify "filters removals by symlink target and file content", :aggregate_failures do
+    ENV["PATH"] = (root/"path-bin").to_s
+    steps = Homebrew::InstallSteps::DSL.build do
+      remove "links/*", base: :staged_path, symlink_target_contains: "wanted"
+      remove "launcher", base: :path, content_contains: "owned marker"
+    end
+
+    (root/"stage/links").mkpath
+    (root/"stage/links/wanted").make_symlink("/tmp/wanted-target")
+    (root/"stage/links/kept").make_symlink("/tmp/other-target")
+    (root/"path-bin").mkpath
+    (root/"path-bin/launcher").write "owned marker"
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect(root/"stage/links/wanted").not_to exist
+    expect(root/"stage/links/kept").to be_a_symlink
+    expect(root/"path-bin/launcher").not_to exist
+  end
+
+  specify "uses elevated cask removal when requested" do
+    require "cask/utils"
+
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      remove "protected", sudo: true
+    end
+    (root/"var/protected").mkpath
+    command = class_double(SystemCommand)
+    expect(Cask::Utils).to receive(:gain_permissions_remove).with(root/"var/protected", command:)
+
+    Homebrew::InstallSteps::Runner.new(context:, command:).run(steps)
+  end
+
   specify "appends a trailing newline unless already present", :aggregate_failures do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
       write "missing-newline", "value"

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -51,6 +51,22 @@ RSpec.describe Homebrew::InstallSteps do
     expect((root/"stage/linked-target").readlink).to eq(Pathname("move-target"))
   end
 
+  specify "links every source matched by a glob into a directory", :aggregate_failures do
+    steps = Homebrew::InstallSteps::DSL.build(default_source_base: :prefix,
+                                              default_target_base: :prefix) do
+      symlink "share/man/*.1", "share/man/man1", force: true, source_glob: true
+    end
+
+    (root/"prefix/share/man/man1").mkpath
+    (root/"prefix/share/man/tool.1").write "tool"
+    (root/"prefix/share/man/other.1").write "other"
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect(root/"prefix/share/man/man1/tool.1").to be_a_symlink
+    expect(root/"prefix/share/man/man1/other.1").to be_a_symlink
+  end
+
   specify "runs mkdir without creating parent directories" do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
       mkdir "missing-parent/example"
@@ -166,6 +182,18 @@ RSpec.describe Homebrew::InstallSteps do
     expect(written).to include("cellar = #{HOMEBREW_PREFIX}")
     expect(written).to include("series = 1.2 (1.2.3)")
     expect(written).to include("literal = {{unknown}} {single}")
+  end
+
+  specify "expands formula and cask identity tokens" do
+    context.define_singleton_method(:name) { "example-formula" }
+    context.define_singleton_method(:token) { "example-cask" }
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      write "identity", "#{formula_name}:#{token}"
+    end
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect((root/"var/identity").read).to eq("example-formula:example-cask\n")
   end
 
   specify "writes a default config file and preserves existing ones", :aggregate_failures do
@@ -502,20 +530,31 @@ RSpec.describe Homebrew::InstallSteps do
   specify "sets permissions and ownership for existing cask step paths" do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :staged_path) do
       set_permissions ["Prepared.app", "Missing.app"], "0755"
+      set_permissions "Prepared.file", "0644", recursive: false
       set_ownership "Owned.app", user: "root", group: "wheel"
+      set_ownership "Owned.file", user: "root", group: "wheel", recursive: false
     end
 
     command = class_double(SystemCommand)
     (root/"stage/Prepared.app").mkpath
+    (root/"stage/Prepared.file").write ""
     (root/"stage/Owned.app").mkpath
+    (root/"stage/Owned.file").write ""
 
     allow(Cask::Quarantine).to receive(:app_management_permissions_granted?)
       .with(app: root/"stage/Owned.app", command:)
       .and_return(true)
+    allow(Cask::Quarantine).to receive(:app_management_permissions_granted?)
+      .with(app: root/"stage/Owned.file", command:)
+      .and_return(true)
     expect(command).to receive(:run!)
       .with("chmod", args: ["-R", "--", "0755", root/"stage/Prepared.app"], sudo: false).ordered
     expect(command).to receive(:run!)
+      .with("chmod", args: ["--", "0644", root/"stage/Prepared.file"], sudo: false).ordered
+    expect(command).to receive(:run!)
       .with("chown", args: ["-R", "--", "root:wheel", root/"stage/Owned.app"], sudo: true).ordered
+    expect(command).to receive(:run!)
+      .with("chown", args: ["--", "root:wheel", root/"stage/Owned.file"], sudo: true).ordered
 
     Homebrew::InstallSteps::Runner.new(context:, command:).run(steps)
   end
@@ -563,6 +602,28 @@ RSpec.describe Homebrew::InstallSteps do
     expect(root/"stage/Nested/source-file").to exist
   end
 
+  specify "uses sudo only when an if-needed symlink target is not writable" do
+    steps = Homebrew::InstallSteps::DSL.build(default_target_base: :staged_path) do
+      symlink "target", "writable/linked-target", source_base: :relative, sudo: :if_needed
+      symlink "target", "protected/linked-target", source_base: :relative, sudo: :if_needed
+    end
+    protected_dir = root/"stage/protected"
+    (root/"stage/writable").mkpath
+    protected_dir.mkpath
+    FileUtils.chmod "-w", protected_dir
+    command = class_double(SystemCommand)
+    expect(command).to receive(:run!)
+      .with("/bin/ln", args: ["-s", "target", protected_dir/"linked-target"], sudo: true)
+
+    begin
+      Homebrew::InstallSteps::Runner.new(context:, command:).run(steps)
+    ensure
+      FileUtils.chmod "+w", protected_dir
+    end
+
+    expect(root/"stage/writable/linked-target").to be_a_symlink
+  end
+
   specify "removes symlinks marked for uninstall" do
     steps = Homebrew::InstallSteps::DSL.build(default_target_base: :staged_path) do
       ln_sf "target", "linked-target", source_base: :relative, uninstall: true
@@ -574,6 +635,37 @@ RSpec.describe Homebrew::InstallSteps do
     Homebrew::InstallSteps::Runner.new(context:).run(steps, phase: :uninstall)
 
     expect(root/"stage/linked-target").not_to be_a_symlink
+  end
+
+  specify "preserves symlinks with unexpected targets on uninstall" do
+    steps = Homebrew::InstallSteps::DSL.build(default_target_base: :staged_path) do
+      symlink "target", "linked-target", source_base: :relative, uninstall: true
+    end
+    (root/"stage").mkpath
+    File.symlink "different-target", root/"stage/linked-target"
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps, phase: :uninstall)
+
+    expect(root/"stage/linked-target").to be_a_symlink
+  end
+
+  specify "uses elevated removal for matching symlinks when needed" do
+    steps = Homebrew::InstallSteps::DSL.build(default_target_base: :staged_path) do
+      symlink "target", "protected/linked-target", source_base: :relative, uninstall: true, sudo: :if_needed
+    end
+    protected_dir = root/"stage/protected"
+    protected_dir.mkpath
+    target = protected_dir/"linked-target"
+    File.symlink "target", target
+    FileUtils.chmod "-w", protected_dir
+    command = class_double(SystemCommand)
+    expect(Cask::Utils).to receive(:gain_permissions_remove).with(target, command:)
+
+    begin
+      Homebrew::InstallSteps::Runner.new(context:, command:).run(steps, phase: :uninstall)
+    ensure
+      FileUtils.chmod "+w", protected_dir
+    end
   end
 
   specify "does not expose the surrounding formula or cask DSL" do

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -186,6 +186,58 @@ RSpec.describe Homebrew::InstallSteps do
     expect((root/"var/config/replaced.conf").read).to eq("default\n")
   end
 
+  specify "snapshots conditions shared by a scope" do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      unless_path_exists "initialised" do
+        mkdir_p "initialised"
+        touch "initialised/marker"
+      end
+    end
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect(root/"var/initialised/marker").to exist
+  end
+
+  specify "keeps guard snapshots separate between concatenated step lists" do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      if_path_exists "missing" do
+        touch "unexpected"
+      end
+    end
+    steps.concat(
+      Homebrew::InstallSteps::DSL.build(default_base: :var) do
+        if_path_exists "existing" do
+          touch "matched"
+        end
+      end,
+    )
+    (root/"var/existing").mkpath
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect(root/"var/matched").to exist
+  end
+
+  specify "runs only steps matching the simulated platform" do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      on_macos do
+        touch "macos"
+      end
+      on_linux do
+        touch "linux"
+      end
+    end
+
+    expect([:macos, :linux].to_h do |os|
+      FileUtils.rm_rf root/"var"
+      Homebrew::SimulateSystem.with(os:) do
+        Homebrew::InstallSteps::Runner.new(context:).run(steps)
+      end
+      [os, [(root/"var/macos").exist?, (root/"var/linux").exist?]]
+    end).to eq(macos: [true, false], linux: [false, true])
+  end
+
   specify "appends a trailing newline unless already present", :aggregate_failures do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
       write "missing-newline", "value"

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -266,6 +266,81 @@ RSpec.describe Homebrew::InstallSteps do
     end).to eq(macos: [true, false], linux: [false, true])
   end
 
+  specify "copies paths" do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var, default_source_base: :staged_path,
+                                              default_target_base: :var) do
+      copy "source.txt", "copied.txt"
+    end
+
+    (root/"stage").mkpath
+    (root/"stage/source.txt").write "copied"
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect((root/"var/copied.txt").read).to eq("copied")
+  end
+
+  specify "replaces copied paths by default and can reject replacement" do
+    rejecting_steps = Homebrew::InstallSteps::DSL.build(default_source_base: :staged_path,
+                                                        default_target_base: :var) do
+      copy "source.txt", "copied.txt", overwrite: false
+    end
+    steps = Homebrew::InstallSteps::DSL.build(default_source_base: :staged_path, default_target_base: :var) do
+      copy "source.txt", "copied.txt"
+    end
+    (root/"stage").mkpath
+    (root/"var").mkpath
+    (root/"stage/source.txt").write "replacement"
+    (root/"var/copied.txt").write "existing"
+
+    expect { Homebrew::InstallSteps::Runner.new(context:).run(rejecting_steps) }.to raise_error(Errno::EEXIST)
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+    expect((root/"var/copied.txt").read).to eq("replacement")
+  end
+
+  specify "replaces symlink destinations when copying files" do
+    steps = Homebrew::InstallSteps::DSL.build(default_source_base: :staged_path, default_target_base: :var) do
+      copy "source.txt", "copied.txt"
+    end
+    (root/"stage").mkpath
+    (root/"var").mkpath
+    (root/"stage/source.txt").write "replacement"
+    (root/"var/linked.txt").write "original"
+    File.symlink "linked.txt", root/"var/copied.txt"
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect([(root/"var/copied.txt").symlink?, (root/"var/copied.txt").read, (root/"var/linked.txt").read])
+      .to eq([false, "replacement", "original"])
+  end
+
+  specify "keeps the shipped move replacement default" do
+    steps = Homebrew::InstallSteps::DSL.build(default_source_base: :staged_path, default_target_base: :var) do
+      move "source.txt", "target.txt"
+    end
+    (root/"stage").mkpath
+    (root/"var").mkpath
+    (root/"stage/source.txt").write "replacement"
+    (root/"var/target.txt").write "existing"
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect((root/"var/target.txt").read).to eq("replacement")
+  end
+
+  specify "requires one match for single-source globs" do
+    steps = Homebrew::InstallSteps::DSL.build(default_source_base: :staged_path, default_target_base: :var) do
+      copy "*.txt", "copied.txt", source_glob: true
+    end
+    (root/"stage").mkpath
+    (root/"stage/first.txt").write "first"
+    (root/"stage/second.txt").write "second"
+
+    expect { Homebrew::InstallSteps::Runner.new(context:).run(steps) }
+      .to raise_error(ArgumentError, /exactly one path/)
+  end
+
   specify "appends a trailing newline unless already present", :aggregate_failures do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
       write "missing-newline", "value"
@@ -594,6 +669,18 @@ RSpec.describe Homebrew::InstallSteps do
       move_children ".", "Nested"
     end
 
+    (root/"stage").mkpath
+    (root/"stage/source-file").write "source"
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect(root/"stage/Nested/source-file").to exist
+  end
+
+  specify "moves a directory's contents" do
+    steps = Homebrew::InstallSteps::DSL.build(default_source_base: :staged_path, default_target_base: :staged_path) do
+      move_contents ".", "Nested"
+    end
     (root/"stage").mkpath
     (root/"stage/source-file").write "source"
 

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           system "true"
-          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
+          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
         end
       end
     CASK
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           update_desktop_database
-          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
+          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
         end
       end
     CASK

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           system "true"
-          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
+          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
         end
       end
     CASK
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           update_desktop_database
-          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
+          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
         end
       end
     CASK

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
         end
       end
     RUBY
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           write "foo.conf", "prefix = #{prefix}"
-                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
+                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
         end
       end
     RUBY

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
         end
       end
     RUBY
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           write "foo.conf", "prefix = #{prefix}"
-                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
+                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
         end
       end
     RUBY

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -598,6 +598,7 @@ Relative paths default to `staged_path` for `base:`, `source_base:` and `target_
 * `move`: move one file or directory; example: `move "payload", "Shared/payload"`.
 * `mv`: alias for `move`; example: `mv "payload", "Shared/payload"`.
 * `move_children`: move the contents of one directory into another; example: `move_children "payload", "Shared/payload"`.
+* `copy`: copy a file or, with `recursive: true`, a directory; example: `copy "payload", "Shared/payload"`.
 * `symlink`: create a symlink; example: `symlink "Shared/payload", "Payload", source_base: :relative`.
 * `ln_s`: alias for `symlink`; example: `ln_s "Shared/payload", "Payload", source_base: :relative`.
 * `ln_sf`: create or replace a symlink; example: `ln_sf "Shared/payload", "Payload", source_base: :relative, uninstall: true`.

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -599,6 +599,7 @@ Relative paths default to `staged_path` for `base:`, `source_base:` and `target_
 * `mv`: alias for `move`; example: `mv "payload", "Shared/payload"`.
 * `move_children`: move the contents of one directory into another; example: `move_children "payload", "Shared/payload"`.
 * `copy`: copy a file or, with `recursive: true`, a directory; example: `copy "payload", "Shared/payload"`.
+* `remove`: remove one or more paths; example: `remove ["Shared/old", "Shared/*.bak"], recursive: true`.
 * `symlink`: create a symlink; example: `symlink "Shared/payload", "Payload", source_base: :relative`.
 * `ln_s`: alias for `symlink`; example: `ln_s "Shared/payload", "Payload", source_base: :relative`.
 * `ln_sf`: create or replace a symlink; example: `ln_sf "Shared/payload", "Payload", source_base: :relative, uninstall: true`.
@@ -607,6 +608,8 @@ Relative paths default to `staged_path` for `base:`, `source_base:` and `target_
   `delete_keychain_certificate "NodeMITMProxyCA", matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"`.
 * `set_permissions`: recursively change existing path permissions with `chmod`; example: `set_permissions "Shared/payload", "0755"`.
 * `set_ownership`: recursively change existing path ownership with `sudo chown`; example: `set_ownership "Shared/payload", user: "root", group: "wheel"`. Missing paths are ignored. When `user:` is omitted, the current user is used. When `group:` is omitted, `staff` is used.
+
+Path collections passed to `remove` expand globs automatically. Removals may be restricted with `symlink_target_contains:` or `content_contains:`.
 
 {% endraw %}
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1199,9 +1199,12 @@ represented by structured steps.
 * `mv`: alias for `move`; example: `mv "default.conf", "foo/default.conf"`.
 * `move_children`: move the contents of one directory into another; example: `move_children "defaults", "foo/defaults"`.
 * `copy`: copy a file or, with `recursive: true`, a directory; example: `copy "default.conf", "foo/default.conf"`.
+* `remove`: remove one or more paths; example: `remove ["old.conf", "foo/*.bak"]`. Use `recursive: true` for directories.
 * `symlink`: create a symlink; example: `symlink "cert.pem", "foo/cert.pem", source_base: :relative`.
 * `ln_s`: alias for `symlink`; example: `ln_s "cert.pem", "foo/cert.pem", source_base: :relative`.
 * `ln_sf`: create or replace a symlink; example: `ln_sf "cert.pem", "foo/cert.pem", source_base: :relative`.
+
+Path collections passed to `remove` expand globs automatically. Removals may be restricted with `symlink_target_contains:` or `content_contains:`.
 
 #### Default config and template steps
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1190,7 +1190,7 @@ represented by structured steps.
 
 #### File preparation steps
 
-`mkdir`, `mkdir_p` and `touch` default to paths relative to `var`. `move`, `mv`, `move_children`, `symlink`, `ln_s` and `ln_sf` default their source and target paths to `prefix`. Use `base:`, `source_base:` or `target_base:` when a step needs another formula path such as `pkgetc`; use `source_base: :relative` for relative symlink sources.
+`mkdir`, `mkdir_p` and `touch` default to paths relative to `var`. Other file steps default their source and target paths to `prefix`. Use `base:`, `source_base:` or `target_base:` when a step needs another formula path such as `pkgetc`; use `source_base: :relative` for relative symlink sources.
 
 * `mkdir`: create one directory; example: `mkdir "log/foo"`.
 * `mkdir_p`: create a directory and any missing parents; example: `mkdir_p "log/foo"`.
@@ -1198,6 +1198,7 @@ represented by structured steps.
 * `move`: move one file or directory; example: `move "default.conf", "foo/default.conf"`.
 * `mv`: alias for `move`; example: `mv "default.conf", "foo/default.conf"`.
 * `move_children`: move the contents of one directory into another; example: `move_children "defaults", "foo/defaults"`.
+* `copy`: copy a file or, with `recursive: true`, a directory; example: `copy "default.conf", "foo/default.conf"`.
 * `symlink`: create a symlink; example: `symlink "cert.pem", "foo/cert.pem", source_base: :relative`.
 * `ln_s`: alias for `symlink`; example: `ln_s "cert.pem", "foo/cert.pem", source_base: :relative`.
 * `ln_sf`: create or replace a symlink; example: `ln_sf "cert.pem", "foo/cert.pem", source_base: :relative`.


### PR DESCRIPTION
Formula and cask migrations need serialisable conditions that make one consistent decision for every step in a guarded group.

- add path-existence and platform scopes to the shared step DSL
- snapshot nested guard results while one install phase runs
- expand guarded path globs without evaluating tap Ruby

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.
