### PR TITLE
Add install step removals (4/24)

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -295,6 +295,26 @@ module Homebrew
 
       sig {
         params(
+          paths:                   Paths,
+          base:                    ::T.nilable(::T.any(::String, ::Symbol)),
+          recursive:               ::T::Boolean,
+          sudo:                    ::T.any(::T::Boolean, ::Symbol),
+          symlink_target_contains: ::T.nilable(::String),
+          content_contains:        ::T.nilable(::String),
+        ).void
+      }
+      def remove(paths, base: nil, recursive: false, sudo: false, symlink_target_contains: nil,
+                 content_contains: nil)
+        add_step("remove",
+                 "paths"                   => path_specs(paths, base:, default_base: @default_base),
+                 "recursive"               => recursive,
+                 "sudo"                    => sudo.is_a?(::Symbol) ? sudo.to_s : sudo,
+                 "symlink_target_contains" => symlink_target_contains,
+                 "content_contains"        => content_contains)
+      end
+
+      sig {
+        params(
           source:         ::T.any(::String, ::Pathname),
           target:         ::T.any(::String, ::Pathname),
           source_base:    ::T.nilable(::T.any(::String, ::Symbol)),
@@ -646,6 +666,28 @@ module Homebrew
           else
             FileUtils.rm_f destination if overwrite && destination.symlink?
             FileUtils.cp source, target
+          end
+        when "remove"
+          paths = step_paths(step, "paths").flat_map { |path| expand_path_glob(path) }
+          if step.key?("symlink_target_contains")
+            paths.select! do |path|
+              path.symlink? && path.readlink.to_s.include?(step_string(step, "symlink_target_contains"))
+            end
+          end
+          if step.key?("content_contains")
+            paths.select! do |path|
+              path.file? && path.readable? && path.read.include?(step_string(step, "content_contains"))
+            end
+          end
+          paths.each do |path|
+            if step["sudo"] == true || (step["sudo"] == "if_needed" && !path.dirname.writable?)
+              require "cask/utils"
+              ::Cask::Utils.gain_permissions_remove(path, command: @command)
+            elsif step["recursive"] == true
+              FileUtils.rm_rf path
+            else
+              FileUtils.rm_f path
+            end
           end
         when "link_dir"
           source_dir = resolve_path(step_path(step, "source"))

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -5,7 +5,7 @@ module RuboCop
   module Cop
     module InstallStepsHelper
       FILE_PREPARATION_STEP_METHODS =
-        [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :copy, :symlink, :ln_s, :ln_sf].freeze
+        [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :copy, :remove, :symlink, :ln_s, :ln_sf].freeze
       LINK_STEP_METHODS = [:link_dir, :link_children].freeze
       CONFIG_WRITE_STEP_METHODS = [:write].freeze
       SERVICE_DATA_STEP_METHODS = [:init_data_dir].freeze

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -341,6 +341,54 @@ RSpec.describe Homebrew::InstallSteps do
       .to raise_error(ArgumentError, /exactly one path/)
   end
 
+  specify "removes paths and expands globs", :aggregate_failures do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      remove ["obsolete.txt", "obsolete-*"], recursive: true
+    end
+
+    (root/"var/obsolete-dir").mkpath
+    (root/"var/obsolete.txt").write "obsolete"
+    (root/"var/obsolete-dir/child").write "obsolete"
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect(root/"var/obsolete.txt").not_to exist
+    expect(root/"var/obsolete-dir").not_to exist
+  end
+
+  specify "filters removals by symlink target and file content", :aggregate_failures do
+    ENV["PATH"] = (root/"path-bin").to_s
+    steps = Homebrew::InstallSteps::DSL.build do
+      remove "links/*", base: :staged_path, symlink_target_contains: "wanted"
+      remove "launcher", base: :path, content_contains: "owned marker"
+    end
+
+    (root/"stage/links").mkpath
+    (root/"stage/links/wanted").make_symlink("/tmp/wanted-target")
+    (root/"stage/links/kept").make_symlink("/tmp/other-target")
+    (root/"path-bin").mkpath
+    (root/"path-bin/launcher").write "owned marker"
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect(root/"stage/links/wanted").not_to exist
+    expect(root/"stage/links/kept").to be_a_symlink
+    expect(root/"path-bin/launcher").not_to exist
+  end
+
+  specify "uses elevated cask removal when requested" do
+    require "cask/utils"
+
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      remove "protected", sudo: true
+    end
+    (root/"var/protected").mkpath
+    command = class_double(SystemCommand)
+    expect(Cask::Utils).to receive(:gain_permissions_remove).with(root/"var/protected", command:)
+
+    Homebrew::InstallSteps::Runner.new(context:, command:).run(steps)
+  end
+
   specify "appends a trailing newline unless already present", :aggregate_failures do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
       write "missing-newline", "value"

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           system "true"
-          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
+          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
         end
       end
     CASK
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           update_desktop_database
-          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
+          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
         end
       end
     CASK

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
         end
       end
     RUBY
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           write "foo.conf", "prefix = #{prefix}"
-                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
+                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
         end
       end
     RUBY

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -599,6 +599,7 @@ Relative paths default to `staged_path` for `base:`, `source_base:` and `target_
 * `mv`: alias for `move`; example: `mv "payload", "Shared/payload"`.
 * `move_children`: move the contents of one directory into another; example: `move_children "payload", "Shared/payload"`.
 * `copy`: copy a file or, with `recursive: true`, a directory; example: `copy "payload", "Shared/payload"`.
+* `remove`: remove one or more paths; example: `remove ["Shared/old", "Shared/*.bak"], recursive: true`.
 * `symlink`: create a symlink; example: `symlink "Shared/payload", "Payload", source_base: :relative`.
 * `ln_s`: alias for `symlink`; example: `ln_s "Shared/payload", "Payload", source_base: :relative`.
 * `ln_sf`: create or replace a symlink; example: `ln_sf "Shared/payload", "Payload", source_base: :relative, uninstall: true`.
@@ -607,6 +608,8 @@ Relative paths default to `staged_path` for `base:`, `source_base:` and `target_
   `delete_keychain_certificate "NodeMITMProxyCA", matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"`.
 * `set_permissions`: recursively change existing path permissions with `chmod`; example: `set_permissions "Shared/payload", "0755"`.
 * `set_ownership`: recursively change existing path ownership with `sudo chown`; example: `set_ownership "Shared/payload", user: "root", group: "wheel"`. Missing paths are ignored. When `user:` is omitted, the current user is used. When `group:` is omitted, `staff` is used.
+
+Path collections passed to `remove` expand globs automatically. Removals may be restricted with `symlink_target_contains:` or `content_contains:`.
 
 {% endraw %}
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1199,9 +1199,12 @@ represented by structured steps.
 * `mv`: alias for `move`; example: `mv "default.conf", "foo/default.conf"`.
 * `move_children`: move the contents of one directory into another; example: `move_children "defaults", "foo/defaults"`.
 * `copy`: copy a file or, with `recursive: true`, a directory; example: `copy "default.conf", "foo/default.conf"`.
+* `remove`: remove one or more paths; example: `remove ["old.conf", "foo/*.bak"]`. Use `recursive: true` for directories.
 * `symlink`: create a symlink; example: `symlink "cert.pem", "foo/cert.pem", source_base: :relative`.
 * `ln_s`: alias for `symlink`; example: `ln_s "cert.pem", "foo/cert.pem", source_base: :relative`.
 * `ln_sf`: create or replace a symlink; example: `ln_sf "cert.pem", "foo/cert.pem", source_base: :relative`.
+
+Path collections passed to `remove` expand globs automatically. Removals may be restricted with `symlink_target_contains:` or `content_contains:`.
 
 #### Default config and template steps
 


### PR DESCRIPTION
Tap migrations need declarative removal without giving JSON consumers an
arbitrary shell escape.

- serialise guarded path arrays with automatic glob expansion
- restrict removals by symlink target or owned file content
- route elevated cask removals through the existing permission helper

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and
testing.