### PR TITLE
Add install step inreplace (5/24)

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -10,13 +10,14 @@ module Homebrew
   module InstallSteps
     PathSpec = T.type_alias { T::Hash[String, String] }
     PathSpecs = T.type_alias { T::Array[PathSpec] }
-    StepValue = T.type_alias { T.any(String, T::Boolean, PathSpec, PathSpecs) }
+    StepValue = T.type_alias { T.any(String, Integer, T::Boolean, PathSpec, PathSpecs) }
     Step = T.type_alias { T::Hash[String, StepValue] }
     Steps = T.type_alias { T::Array[Step] }
     Paths = T.type_alias { T.any(String, Pathname, T::Array[T.any(String, Pathname)]) }
     RawPathSpec = T.type_alias { T::Hash[T.any(String, Symbol), T.nilable(T.any(String, Symbol, Pathname))] }
     RawPathSpecs = T.type_alias { T::Array[T.any(String, Symbol, Pathname, RawPathSpec)] }
-    RawStepValue = T.type_alias { T.nilable(T.any(String, Symbol, T::Boolean, Pathname, RawPathSpec, RawPathSpecs)) }
+    RawStepValue =
+      T.type_alias { T.nilable(T.any(String, Symbol, Integer, T::Boolean, Pathname, RawPathSpec, RawPathSpecs)) }
     RawStep = T.type_alias { T::Hash[T.any(String, Symbol), RawStepValue] }
     SystemCommandArg = T.type_alias { T.any(String, Pathname) }
     TemplateTokenValue = T.type_alias { T.any(String, Pathname) }
@@ -311,6 +312,27 @@ module Homebrew
                  "sudo"                    => sudo.is_a?(::Symbol) ? sudo.to_s : sudo,
                  "symlink_target_contains" => symlink_target_contains,
                  "content_contains"        => content_contains)
+      end
+
+      sig {
+        params(
+          path:         ::T.any(::String, ::Pathname),
+          before:       ::T.any(::String, ::Regexp),
+          after:        ::String,
+          base:         ::T.nilable(::T.any(::String, ::Symbol)),
+          audit_result: ::T::Boolean,
+          global:       ::T::Boolean,
+        ).void
+      }
+      def inreplace(path, before, after, base: nil, audit_result: true, global: true)
+        add_step("inreplace",
+                 "path"           => path_spec(path, base:, default_base: @default_base),
+                 "before"         => before.is_a?(::Regexp) ? before.source : before,
+                 "after"          => after,
+                 "regexp"         => before.is_a?(::Regexp),
+                 "regexp_options" => (before.options if before.is_a?(::Regexp)),
+                 "skip_audit"     => !audit_result,
+                 "first_only"     => !global)
       end
 
       sig {
@@ -689,7 +711,18 @@ module Homebrew
               FileUtils.rm_f path
             end
           end
-        when "link_dir"
+        when "inreplace"
+          require "utils/inreplace"
+
+          path = resolve_path(step_path(step, "path"))
+          before = expand_template_tokens(step_string(step, "before"))
+          after = expand_template_tokens(step_string(step, "after"))
+          regexp_options = T.cast(step["regexp_options"], T.nilable(Integer))
+          before = Regexp.new(before, regexp_options || 0) if step["regexp"] == true
+          Utils::Inreplace.inreplace(path, before, after,
+                                     audit_result: step["skip_audit"] != true,
+                                     global:       step["first_only"] != true)
+        when "link_dir", "symlink_tree"
           source_dir = resolve_path(step_path(step, "source"))
           target_dir = resolve_path(step_path(step, "target"))
           source_dir.find do |source|

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -5,7 +5,8 @@ module RuboCop
   module Cop
     module InstallStepsHelper
       FILE_PREPARATION_STEP_METHODS =
-        [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :copy, :remove, :symlink, :ln_s, :ln_sf].freeze
+        [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :copy, :remove, :inreplace, :symlink,
+         :ln_s, :ln_sf].freeze
       LINK_STEP_METHODS = [:link_dir, :link_children].freeze
       CONFIG_WRITE_STEP_METHODS = [:write].freeze
       SERVICE_DATA_STEP_METHODS = [:init_data_dir].freeze
@@ -27,7 +28,7 @@ module RuboCop
 
       # `dstr` covers heredocs such as `write` content; interpolation is limited
       # to known template values below.
-      ALLOWED_STEP_ARGUMENT_NODE_TYPES = [:array, :dstr, :hash, :nil, :pair, :str, :sym].freeze
+      ALLOWED_STEP_ARGUMENT_NODE_TYPES = [:array, :dstr, :hash, :nil, :pair, :regexp, :regopt, :str, :sym].freeze
 
       STEP_BLOCK_MSG = T.let(
         "Steps blocks may only contain install step DSL calls: " \

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -389,6 +389,22 @@ RSpec.describe Homebrew::InstallSteps do
     Homebrew::InstallSteps::Runner.new(context:, command:).run(steps)
   end
 
+  specify "replaces literal and regular expression matches", :aggregate_failures do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      inreplace "literal.txt", "before", "after"
+      inreplace "pattern.txt", /before.+after/i, "replaced"
+    end
+
+    (root/"var").mkpath
+    (root/"var/literal.txt").write "before"
+    (root/"var/pattern.txt").write "BEFORE and AFTER"
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect((root/"var/literal.txt").read).to eq("after")
+    expect((root/"var/pattern.txt").read).to eq("replaced")
+  end
+
   specify "appends a trailing newline unless already present", :aggregate_failures do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
       write "missing-newline", "value"

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           system "true"
-          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
+          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
         end
       end
     CASK
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           update_desktop_database
-          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
+          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
         end
       end
     CASK
@@ -61,6 +61,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
           touch "foo/state"
           mv "source", "target"
           move_children "source", "target"
+          inreplace "foo.conf", /@PREFIX@/, "{{HOMEBREW_PREFIX}}"
           ln_sf "source", "target", source_base: :relative, uninstall: true
           write "foo.conf", "key = value\n"
           set_permissions "Foo.app", "0755"

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
         end
       end
     RUBY
@@ -58,6 +58,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           touch "foo/state"
           mv "source", "target"
           move_children "source", "target"
+          inreplace "foo.conf", /@PREFIX@/, "{{HOMEBREW_PREFIX}}"
           ln_sf "source", "target", source_base: :relative, uninstall: true
           write "foo.conf", "key = value\n", base: :etc
           write "foo/banner", <<~TEXT
@@ -84,7 +85,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           write "foo.conf", "prefix = #{prefix}"
-                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
+                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
         end
       end
     RUBY

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -611,6 +611,7 @@ Relative paths default to `staged_path` for `base:`, `source_base:` and `target_
 * `move_children`: move the contents of one directory into another; example: `move_children "payload", "Shared/payload"`.
 * `copy`: copy a file or, with `recursive: true`, a directory; example: `copy "payload", "Shared/payload"`.
 * `remove`: remove one or more paths; example: `remove ["Shared/old", "Shared/*.bak"], recursive: true`.
+* `inreplace`: replace text in a file; example: `inreplace "Shared/foo.conf", "@PREFIX@", "{{HOMEBREW_PREFIX}}"`. Pass a regular expression as `before` for pattern matching.
 * `symlink`: create a symlink; example: `symlink "Shared/payload", "Payload", source_base: :relative`.
 * `ln_s`: alias for `symlink`; example: `ln_s "Shared/payload", "Payload", source_base: :relative`.
 * `ln_sf`: create or replace a symlink; example: `ln_sf "Shared/payload", "Payload", source_base: :relative, uninstall: true`.

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1200,6 +1200,7 @@ represented by structured steps.
 * `move_children`: move the contents of one directory into another; example: `move_children "defaults", "foo/defaults"`.
 * `copy`: copy a file or, with `recursive: true`, a directory; example: `copy "default.conf", "foo/default.conf"`.
 * `remove`: remove one or more paths; example: `remove ["old.conf", "foo/*.bak"]`. Use `recursive: true` for directories.
+* `inreplace`: replace text in a file; example: `inreplace "foo.conf", "@PREFIX@", "{{HOMEBREW_PREFIX}}"`. Pass a regular expression as `before` for pattern matching.
 * `symlink`: create a symlink; example: `symlink "cert.pem", "foo/cert.pem", source_base: :relative`.
 * `ln_s`: alias for `symlink`; example: `ln_s "cert.pem", "foo/cert.pem", source_base: :relative`.
 * `ln_sf`: create or replace a symlink; example: `ln_sf "cert.pem", "foo/cert.pem", source_base: :relative`.


### PR DESCRIPTION
Several tap hooks only substitute install-time paths in generated files
and do not need arbitrary Ruby execution.

- expose the familiar `inreplace` name and option defaults
- serialise literal substitutions, regular expressions and their flags
- expand only fixed install-time template tokens
- share validation and execution between formulae and casks

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.