### PR TITLE
Add cask command wrappers (6/24)

### DIFF
--- a/Library/Homebrew/cask/artifact.rb
+++ b/Library/Homebrew/cask/artifact.rb
@@ -7,6 +7,7 @@ require "cask/artifact/artifact" # generic 'artifact' stanza
 require "cask/artifact/audio_unit_plugin"
 require "cask/artifact/binary"
 require "cask/artifact/colorpicker"
+require "cask/artifact/command_wrapper"
 require "cask/artifact/dictionary"
 require "cask/artifact/install_steps"
 require "cask/artifact/font"

--- a/Library/Homebrew/cask/artifact/abstract_artifact.rb
+++ b/Library/Homebrew/cask/artifact/abstract_artifact.rb
@@ -102,7 +102,10 @@ module Cask
               Vst3Plugin,
               ScreenSaver,
             ],
-            Binary,
+            [
+              Binary,
+              CommandWrapper,
+            ],
             Manpage,
             [
               BashCompletion,

--- a/Library/Homebrew/cask/artifact/command_wrapper.rb
+++ b/Library/Homebrew/cask/artifact/command_wrapper.rb
@@ -1,0 +1,64 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "cask/artifact/binary"
+
+module Cask
+  module Artifact
+    # Artifact corresponding to the `command_wrapper` stanza.
+    class CommandWrapper < Binary
+      sig { override.returns(Symbol) }
+      def self.dirmethod = :binarydir
+
+      sig {
+        override.params(
+          cask:    Cask,
+          source:  T.any(String, Pathname),
+          options: T.untyped,
+        ).returns(T.attached_class)
+      }
+      def self.from_args(cask, source, options = nil)
+        options ||= {}
+        options.assert_valid_keys(:target, :content)
+        raise CaskInvalidError.new(cask, "'command_wrapper' requires target") unless options.key?(:target)
+        raise CaskInvalidError.new(cask, "'command_wrapper' requires content") unless options.key?(:content)
+
+        new(cask, source, **options)
+      end
+
+      sig {
+        params(
+          cask:    Cask,
+          source:  T.any(String, Pathname),
+          target:  T.any(String, Pathname),
+          content: String,
+        ).void
+      }
+      def initialize(cask, source, target:, content:)
+        raise CaskInvalidError.new(cask, "'command_wrapper' requires content") if content.blank?
+
+        super(cask, source, target:)
+        @content = content
+      end
+
+      sig {
+        override.params(
+          force:   T::Boolean,
+          adopt:   T::Boolean,
+          command: T.class_of(SystemCommand),
+          options: T.anything,
+        ).void
+      }
+      def install_phase(force: false, adopt: false, command: SystemCommand, **options)
+        source.dirname.mkpath
+        source.write(@content)
+        super
+      end
+
+      sig { override.returns(T::Array[T.anything]) }
+      def to_args
+        [@source_string, { target: @target_string, content: @content }]
+      end
+    end
+  end
+end

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -43,6 +43,7 @@ module Cask
       Artifact::Artifact,
       Artifact::AudioUnitPlugin,
       Artifact::Binary,
+      Artifact::CommandWrapper,
       Artifact::Colorpicker,
       Artifact::Dictionary,
       Artifact::Font,

--- a/Library/Homebrew/test/cask/artifact/command_wrapper_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/command_wrapper_spec.rb
@@ -1,0 +1,59 @@
+# typed: false
+# frozen_string_literal: true
+
+RSpec.describe Cask::Artifact::CommandWrapper, :cask do
+  let(:cask) do
+    Cask::Cask.new("with-command-wrapper") do
+      version "1.2.3"
+      sha256 :no_check
+      url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
+
+      command_wrapper "example.wrapper.sh",
+                      target:  "example",
+                      content: <<~SH
+                        #!/bin/sh
+                        exec '/Applications/Example.app/Contents/MacOS/example' "$@"
+                      SH
+    end
+  end
+  let(:artifact) { cask.artifacts.find { |candidate| candidate.is_a?(described_class) } }
+  let(:target) { cask.config.binarydir/"example" }
+
+  around do |example|
+    cask.staged_path.mkpath
+    target.dirname.mkpath
+    example.run
+  ensure
+    FileUtils.rm_f target
+    FileUtils.rm_rf cask.staged_path
+  end
+
+  it "writes and links an executable command wrapper" do
+    artifact.install_phase(command: NeverSudoSystemCommand, force: false)
+
+    expect(target).to be_a_symlink.and have_attributes(read:        include("Contents/MacOS/example"),
+                                                       executable?: true)
+  end
+
+  it "serialises the wrapper definition" do
+    expect(artifact.to_args).to eq([
+      "example.wrapper.sh",
+      {
+        target:  "example",
+        content: "#!/bin/sh\nexec '/Applications/Example.app/Contents/MacOS/example' \"$@\"\n",
+      },
+    ])
+  end
+
+  it "rejects a missing target" do
+    expect do
+      described_class.from_args(cask, "other.wrapper.sh", content: "#!/bin/sh\n")
+    end.to raise_error(Cask::CaskInvalidError, /'command_wrapper' requires target/)
+  end
+
+  it "rejects missing content" do
+    expect do
+      described_class.from_args(cask, "other.wrapper.sh", target: "other")
+    end.to raise_error(Cask::CaskInvalidError, /'command_wrapper' requires content/)
+  end
+end

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -144,6 +144,7 @@ The `appimage` stanza is Linux-only, macOS integration stanzas such as `app` and
 | [`pkg`](#stanza-pkg)             | yes                           | Relative path to a `.pkg` file containing the distribution. |
 | [`installer`](#stanza-installer) | yes                           | Describes an executable which must be run to complete the installation. |
 | [`binary`](#stanza-binary)       | yes                           | Relative path to a Binary that should be linked into the `$(brew --prefix)/bin` folder on installation. |
+| [`command_wrapper`](#stanza-command_wrapper) | yes                  | Generates a command wrapper and links it into the `$(brew --prefix)/bin` folder. |
 | `manpage`                        | yes                           | Relative path to a Man Page that should be linked into the respective man page folder on installation, e.g. `/opt/homebrew/share/man/man3` for `my_app.3`. |
 | `bash_completion`                | yes                           | Relative path to a Bash completion file that should be linked into the `$(brew --prefix)/etc/bash_completion.d` folder on installation. |
 | `fish_completion`                | yes                           | Relative path to a fish completion file that should be linked into the `$(brew --prefix)/share/fish/vendor_completions.d` folder on installation. |
@@ -282,6 +283,19 @@ binary "#{appdir}/Atom.app/Contents/Resources/app/atom.sh", target: "atom"
 ```
 
 Behaviour and usage of `target:` is [the same as with `app`](#renaming-the-target). However, for `binary` the select cases don’t apply as rigidly. It’s fine to take extra liberties with `target:` to be consistent with other command-line tools, like [changing case](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/g/godot.rb#L19), [removing an extension](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/f/filebot.rb#L19), or [cleaning up the name](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/f/fig.rb#L21).
+
+### Stanza: `command_wrapper`
+
+`command_wrapper` writes literal wrapper content into the staged cask, makes it executable and links it like a [`binary`](#stanza-binary). Use it when a command needs to invoke an executable inside an application bundle with fixed arguments or environment setup.
+
+```ruby
+command_wrapper "example.wrapper.sh",
+                target:  "example",
+                content: <<~SH
+                  #!/bin/sh
+                  exec '#{appdir}/Example.app/Contents/MacOS/example' "$@"
+                SH
+```
 
 ### Stanza: `rename`
 


### PR DESCRIPTION
Many cask flight hooks only write a fixed launcher and link it into the
configured binary directory.

- generate executable wrapper content as a first-class cask artifact
- reuse binary linking, collision and uninstall behaviour
- serialise the stanza so cask JSON preserves its definition

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.