### PR TITLE
Add process termination steps (10/24)

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -16,8 +16,9 @@ module Homebrew
     Paths = T.type_alias { T.any(String, Pathname, T::Array[T.any(String, Pathname)]) }
     RawPathSpec = T.type_alias { T::Hash[T.any(String, Symbol), T.nilable(T.any(String, Symbol, Pathname))] }
     RawPathSpecs = T.type_alias { T::Array[T.any(String, Symbol, Pathname, RawPathSpec)] }
-    RawStepValue =
-      T.type_alias { T.nilable(T.any(String, Symbol, Integer, T::Boolean, Pathname, RawPathSpec, RawPathSpecs)) }
+    RawStepValue = T.type_alias do
+      T.nilable(T.any(String, Symbol, Integer, T::Boolean, Pathname, RawPathSpec, RawPathSpecs))
+    end
     RawStep = T.type_alias { T::Hash[T.any(String, Symbol), RawStepValue] }
     SystemCommandArg = T.type_alias { T.any(String, Pathname) }
     TemplateTokenValue = T.type_alias { T.any(String, Pathname) }
@@ -567,6 +568,36 @@ module Homebrew
                  "chdir"           => optional_path_spec(chdir, default_base: @default_base))
       end
 
+      sig {
+        params(
+          name:            ::String,
+          match:           ::T.any(::String, ::Symbol),
+          sudo:            ::T::Boolean,
+          attempts:        ::Integer,
+          must_succeed:    ::T::Boolean,
+          notices:         ::T::Array[::String],
+          failure_message: ::T.nilable(::String),
+        ).void
+      }
+      def terminate_process(name, match: :name, sudo: false, attempts: 1, must_succeed: false,
+                            notices: [], failure_message: nil)
+        ::Kernel.raise ::ArgumentError, "terminate_process attempts must be positive" if attempts < 1
+
+        match = match.to_s
+        unless %w[name full].include?(match)
+          ::Kernel.raise ::ArgumentError, "terminate_process match must be :name or :full"
+        end
+
+        add_step("terminate_process",
+                 "name"            => name,
+                 "match"           => match,
+                 "sudo"            => sudo,
+                 "attempts"        => attempts,
+                 "must_succeed"    => must_succeed,
+                 "notices"         => notices,
+                 "failure_message" => failure_message)
+      end
+
       private
 
       sig { params(guard: PathSpec, block: ::T.proc.void).void }
@@ -805,6 +836,8 @@ module Homebrew
           end
         when "run"
           run_serialised_command(step)
+        when "terminate_process"
+          run_terminate_process(step)
         when "set_permissions"
           run_set_permissions(step)
         when "set_ownership"
@@ -910,6 +943,38 @@ module Homebrew
         output_path = resolve_path(step_path(step, "stdout_path"))
         output_path.dirname.mkpath
         output_path.write(result.stdout)
+      end
+
+      sig { params(step: Step).void }
+      def run_terminate_process(step)
+        T.cast(step["notices"], T.nilable(T::Array[String]))&.each do |notice|
+          ohai expand_template_tokens(notice)
+        end
+        name = expand_template_tokens(step_string(step, "name"))
+        if step_string(step, "match") == "full"
+          command = "/usr/bin/pkill"
+          args = ["-f", name]
+        else
+          command = "/usr/bin/killall"
+          args = [name]
+        end
+        attempts = T.cast(step["attempts"] || 1, Integer)
+
+        begin
+          run_command command, *args, sudo: step["sudo"] == true
+        rescue ErrorDuringExecution
+          attempts -= 1
+          if attempts <= 0
+            failure_message = T.cast(step["failure_message"], T.nilable(String))
+            opoo expand_template_tokens(failure_message) if failure_message
+            raise if step["must_succeed"] == true
+
+            return
+          end
+
+          sleep 1
+          retry
+        end
       end
 
       sig { params(source: SystemCommandArg, target: Pathname, step: Step).void }

--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -598,6 +598,11 @@ module Homebrew
                  "failure_message" => failure_message)
       end
 
+      sig { params(message: ::String).void }
+      def warn(message)
+        add_step("warn", "message" => message)
+      end
+
       private
 
       sig { params(guard: PathSpec, block: ::T.proc.void).void }
@@ -838,6 +843,8 @@ module Homebrew
           run_serialised_command(step)
         when "terminate_process"
           run_terminate_process(step)
+        when "warn"
+          opoo expand_template_tokens(step_string(step, "message"))
         when "set_permissions"
           run_set_permissions(step)
         when "set_ownership"

--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -603,6 +603,11 @@ module Homebrew
         add_step("warn", "message" => message)
       end
 
+      sig { void }
+      def configure_gcc_runtime
+        add_step("configure_gcc_runtime")
+      end
+
       private
 
       sig { params(guard: PathSpec, block: ::T.proc.void).void }
@@ -845,6 +850,8 @@ module Homebrew
           run_terminate_process(step)
         when "warn"
           opoo expand_template_tokens(step_string(step, "message"))
+        when "configure_gcc_runtime"
+          run_configure_gcc_runtime
         when "set_permissions"
           run_set_permissions(step)
         when "set_ownership"
@@ -1307,3 +1314,5 @@ module Homebrew
     end
   end
 end
+
+require "install_steps/formula_actions"

--- a/Library/Homebrew/install_steps/formula_actions.rb
+++ b/Library/Homebrew/install_steps/formula_actions.rb
@@ -1,0 +1,65 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Homebrew
+  module InstallSteps
+    class Runner
+      private
+
+      sig { void }
+      def run_configure_gcc_runtime
+        return unless Homebrew::SimulateSystem.simulating_or_running_on_linux?
+
+        version_major = context_version_major
+        raise ArgumentError, "GCC runtime configuration requires a version" if version_major.nil?
+
+        gcc = context_path("bin")/"gcc-#{version_major}"
+        libgcc = Pathname(run_command_output(gcc, "-print-libgcc-file-name").strip).dirname
+        require "utils/path"
+
+        glibc_installed = Utils::Path.formula_any_version_installed?("glibc")
+        glibc_lib = Utils::Path.formula_opt_lib("glibc")
+        crtdir = if glibc_installed
+          glibc_lib
+        else
+          Pathname(run_command_output("/usr/bin/cc", "-print-file-name=crti.o").strip).dirname
+        end
+        FileUtils.ln_sf Dir[crtdir/"*crt?.o"], libgcc
+
+        specs = libgcc/"specs"
+        ohai "Creating the GCC specs file: #{specs}"
+        FileUtils.rm_f ["#{specs}.orig", specs]
+        system_header_dirs = [HOMEBREW_PREFIX/"include"]
+        if glibc_installed
+          system_header_dirs << Utils::Path.formula_opt_include("glibc")
+        else
+          target = run_command_output(gcc, "-print-multiarch").strip
+          system_header_dirs += [Pathname("/usr/include")/target, Pathname("/usr/include")]
+        end
+
+        specs_string = run_command_output(gcc, "-dumpspecs")
+        Pathname("#{specs}.orig").write specs_string
+        libdir = if context_name == "gcc"
+          HOMEBREW_PREFIX/"lib/gcc/current"
+        else
+          HOMEBREW_PREFIX/"lib/gcc"/version_major
+        end
+        link_libgcc = glibc_installed ? "-nostdlib -L#{libgcc} -L#{glibc_lib}" : "+"
+        homebrew_rpath = version_major.to_i >= 11
+        specs.write specs_string + <<~EOS
+          *cpp_unique_options:
+          + -isysroot #{HOMEBREW_PREFIX}/nonexistent #{system_header_dirs.map { |p| "-idirafter #{p}" }.join(" ")}
+
+          *link_libgcc:
+          #{link_libgcc} -L#{libdir} -L#{HOMEBREW_PREFIX}/lib
+
+          *link:
+          + --dynamic-linker #{HOMEBREW_PREFIX}/lib/ld.so -rpath #{libdir}#{" -rpath #{HOMEBREW_PREFIX}/lib" unless homebrew_rpath}
+
+          #{"*homebrew_rpath:\n-rpath #{HOMEBREW_PREFIX}/lib\n" if homebrew_rpath}
+        EOS
+        specs.write(specs.read.gsub(" %o ", "\\0%(homebrew_rpath) ")) if homebrew_rpath
+      end
+    end
+  end
+end

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -17,11 +17,12 @@ module RuboCop
       PERMISSION_STEP_METHODS = [:set_permissions, :set_ownership].freeze
       COMMAND_STEP_METHODS = [:run, :terminate_process].freeze
       NOTICE_STEP_METHODS = [:warn].freeze
+      FORMULA_ACTION_STEP_METHODS = [:configure_gcc_runtime].freeze
       STEP_SCOPE_METHODS = [:if_path_exists, :unless_path_exists, :on_macos, :on_linux].freeze
       ALLOWED_STEP_METHODS = T.let(
         [*FILE_PREPARATION_STEP_METHODS, *LINK_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *SERVICE_DATA_STEP_METHODS,
          *REBUILD_ACTION_STEP_METHODS, :set_permissions, *COMMAND_STEP_METHODS, *NOTICE_STEP_METHODS,
-         *STEP_SCOPE_METHODS].freeze,
+         *FORMULA_ACTION_STEP_METHODS, *STEP_SCOPE_METHODS].freeze,
         T::Array[Symbol],
       )
       CASK_ALLOWED_STEP_METHODS = T.let(

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -16,10 +16,12 @@ module RuboCop
       KEYCHAIN_STEP_METHODS = [:delete_keychain_certificate].freeze
       PERMISSION_STEP_METHODS = [:set_permissions, :set_ownership].freeze
       COMMAND_STEP_METHODS = [:run, :terminate_process].freeze
+      NOTICE_STEP_METHODS = [:warn].freeze
       STEP_SCOPE_METHODS = [:if_path_exists, :unless_path_exists, :on_macos, :on_linux].freeze
       ALLOWED_STEP_METHODS = T.let(
         [*FILE_PREPARATION_STEP_METHODS, *LINK_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *SERVICE_DATA_STEP_METHODS,
-         *REBUILD_ACTION_STEP_METHODS, :set_permissions, *COMMAND_STEP_METHODS, *STEP_SCOPE_METHODS].freeze,
+         *REBUILD_ACTION_STEP_METHODS, :set_permissions, *COMMAND_STEP_METHODS, *NOTICE_STEP_METHODS,
+         *STEP_SCOPE_METHODS].freeze,
         T::Array[Symbol],
       )
       CASK_ALLOWED_STEP_METHODS = T.let(

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -15,7 +15,7 @@ module RuboCop
          :update_mime_database, :update_desktop_database].freeze
       KEYCHAIN_STEP_METHODS = [:delete_keychain_certificate].freeze
       PERMISSION_STEP_METHODS = [:set_permissions, :set_ownership].freeze
-      COMMAND_STEP_METHODS = [:run].freeze
+      COMMAND_STEP_METHODS = [:run, :terminate_process].freeze
       STEP_SCOPE_METHODS = [:if_path_exists, :unless_path_exists, :on_macos, :on_linux].freeze
       ALLOWED_STEP_METHODS = T.let(
         [*FILE_PREPARATION_STEP_METHODS, *LINK_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *SERVICE_DATA_STEP_METHODS,
@@ -30,7 +30,8 @@ module RuboCop
 
       # `dstr` covers heredocs such as `write` content; interpolation is limited
       # to known template values below.
-      ALLOWED_STEP_ARGUMENT_NODE_TYPES = [:array, :dstr, :hash, :nil, :pair, :regexp, :regopt, :str, :sym].freeze
+      ALLOWED_STEP_ARGUMENT_NODE_TYPES = [:array, :dstr, :hash, :int, :nil, :pair, :regexp, :regopt, :str,
+                                          :sym].freeze
 
       STEP_BLOCK_MSG = T.let(
         "Steps blocks may only contain install step DSL calls: " \

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -427,6 +427,22 @@ RSpec.describe Homebrew::InstallSteps do
     expect((root/"var/pattern.txt").read).to eq("replaced")
   end
 
+  specify "warns inside a matching path scope" do
+    steps = Homebrew::InstallSteps::DSL.build do
+      if_path_exists "{{var}}/{missing,conflict}" do
+        warn "{{token}} conflict"
+      end
+    end
+    named_context = context
+    named_context.define_singleton_method(:name) { ["Example"] }
+    named_context.define_singleton_method(:token) { "example" }
+    (root/"var/conflict").mkpath
+    runner = Homebrew::InstallSteps::Runner.new(context: named_context)
+    expect(runner).to receive(:opoo).with("example conflict")
+
+    runner.run(steps)
+  end
+
   specify "runs serialised commands" do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
       run "helper", args: ["--path={{var}}"], base: :libexec, env: { "EXAMPLE" => "{{var}}/value" }

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -715,6 +715,61 @@ RSpec.describe Homebrew::InstallSteps do
     runner.run(steps)
   end
 
+  specify "dispatches GCC runtime configuration" do
+    steps = Homebrew::InstallSteps::DSL.build do
+      configure_gcc_runtime
+    end
+
+    runner = Homebrew::InstallSteps::Runner.new(context:)
+    expect(runner).to receive(:run_configure_gcc_runtime)
+
+    runner.run(steps)
+  end
+
+  specify "configures GCC runtime files on Linux", :aggregate_failures do
+    steps = Homebrew::InstallSteps::DSL.build do
+      configure_gcc_runtime
+    end
+    gcc_context = context
+    gcc_context.define_singleton_method(:name) { "gcc" }
+    libgcc = root/"gcc/lib/gcc/15"
+    crtdir = root/"system/lib"
+    libgcc.mkpath
+    crtdir.mkpath
+    crti = crtdir/"crti.o"
+    crti.write "crt"
+    specs = libgcc/"specs"
+    specs.write "old specs"
+    Pathname("#{specs}.orig").write "old original specs"
+    gcc = root/"prefix/bin/gcc-15"
+    original_specs = "*link:\n+ %o \n"
+
+    allow(Homebrew::SimulateSystem).to receive(:simulating_or_running_on_linux?).and_return(true)
+    allow(Utils::Path).to receive(:formula_any_version_installed?).with("glibc").and_return(false)
+    allow(Utils::Path).to receive(:formula_opt_lib).with("glibc").and_return(root/"glibc/lib")
+    runner = Homebrew::InstallSteps::Runner.new(context: gcc_context)
+    expect(runner).to receive(:context_version_major).and_return("15")
+    expect(runner).to receive(:run_command_output)
+      .with(gcc, "-print-libgcc-file-name").ordered
+      .and_return("#{libgcc}/libgcc_s.so\n")
+    expect(runner).to receive(:run_command_output)
+      .with("/usr/bin/cc", "-print-file-name=crti.o").ordered
+      .and_return("#{crti}\n")
+    expect(runner).to receive(:run_command_output)
+      .with(gcc, "-print-multiarch").ordered
+      .and_return("x86_64-linux-gnu\n")
+    expect(runner).to receive(:run_command_output).with(gcc, "-dumpspecs").ordered.and_return(original_specs)
+    expect(FileUtils).to receive(:ln_sf).with([crti.to_s], libgcc).and_call_original
+    expect(FileUtils).to receive(:rm_f).with(["#{specs}.orig", specs]).and_call_original
+
+    runner.run(steps)
+
+    expect(libgcc/"crti.o").to be_a_symlink
+    expect((libgcc/"crti.o").readlink).to eq(crti)
+    expect(Pathname("#{specs}.orig").read).to eq(original_specs)
+    expect(specs.read).to include("%(homebrew_rpath)", "-idirafter /usr/include/x86_64-linux-gnu")
+  end
+
   describe "runs gtk_update_icon_cache rebuild action" do
     let(:formula) { instance_double(Formula, opt_bin: root/"opt/bin") }
     let(:steps) do

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -470,6 +470,58 @@ RSpec.describe Homebrew::InstallSteps do
     expect((root/"var/output.txt").read).to eq("output")
   end
 
+  specify "can ignore process termination failure after retries" do
+    steps = Homebrew::InstallSteps::DSL.build do
+      terminate_process "/Applications/Example.app", match: :full, attempts: 3,
+                                                       notices: ["Closing {{name}}"],
+                                                       failure_message: "Unable to close {{name}}"
+    end
+
+    named_context = context
+    named_context.define_singleton_method(:name) { "Example" }
+    command = class_double(SystemCommand)
+    runner = Homebrew::InstallSteps::Runner.new(context: named_context, command:)
+    allow(runner).to receive(:sleep)
+    expect(runner).to receive(:ohai).with("Closing Example")
+    expect(runner).to receive(:opoo).with("Unable to close Example")
+    expect(command).to receive(:run!)
+      .with("/usr/bin/pkill", args: ["-f", "/Applications/Example.app"], sudo: false,
+                              print_stdout: true, print_stderr: true, reset_uid: true)
+      .exactly(3).times
+      .and_raise(ErrorDuringExecution.new([], status: 1))
+
+    expect { runner.run(steps) }.not_to raise_error
+  end
+
+  specify "rejects unknown process match modes" do
+    expect do
+      Homebrew::InstallSteps::DSL.build do
+        terminate_process "Example", match: :prefix
+      end
+    end.to raise_error(ArgumentError, "terminate_process match must be :name or :full")
+  end
+
+  specify "rejects non-positive process termination attempts" do
+    expect do
+      Homebrew::InstallSteps::DSL.build do
+        terminate_process "Example", attempts: 0
+      end
+    end.to raise_error(ArgumentError, "terminate_process attempts must be positive")
+  end
+
+  specify "uses killall for exact process names" do
+    steps = Homebrew::InstallSteps::DSL.build do
+      terminate_process "Example", must_succeed: true
+    end
+
+    command = class_double(SystemCommand)
+    expect(command).to receive(:run!)
+      .with("/usr/bin/killall", args: ["Example"], sudo: false,
+                                print_stdout: true, print_stderr: true, reset_uid: true)
+
+    Homebrew::InstallSteps::Runner.new(context:, command:).run(steps)
+  end
+
   specify "appends a trailing newline unless already present", :aggregate_failures do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
       write "missing-newline", "value"

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           system "true"
-          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`, `run`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     CASK
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           update_desktop_database
-          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`, `run`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     CASK
@@ -69,6 +69,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
           set_permissions "Foo.app", "0755"
           set_ownership "Foo.app", user: "root", group: "wheel"
           run "foo", args: ["--repair"]
+          terminate_process "foo", attempts: 3
           delete_keychain_certificate "Charles"
           delete_keychain_certificate "NodeMITMProxyCA", matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"
           on_macos do
@@ -95,7 +96,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
         preflight_steps do
           on_macos do
             system "true"
-            ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`, `run`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+            ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
           end
         end
       end

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY
@@ -67,6 +67,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           run "foo", args: ["--repair"]
           terminate_process "foo", attempts: 3
           warn "foo exists"
+          configure_gcc_runtime
           write "foo/banner", <<~TEXT
             literal banner
           TEXT
@@ -102,7 +103,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         post_install_steps do
           on_macos do
             system "true"
-            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
           end
         end
       end
@@ -116,7 +117,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           write "foo.conf", "prefix = #{prefix}"
-                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY
@@ -65,6 +65,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           write "foo.conf", "key = value\n", base: :etc
           set_permissions "foo", "0755"
           run "foo", args: ["--repair"]
+          terminate_process "foo", attempts: 3
           write "foo/banner", <<~TEXT
             literal banner
           TEXT
@@ -100,7 +101,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         post_install_steps do
           on_macos do
             system "true"
-            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
           end
         end
       end
@@ -114,7 +115,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           write "foo.conf", "prefix = #{prefix}"
-                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY
@@ -66,6 +66,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           set_permissions "foo", "0755"
           run "foo", args: ["--repair"]
           terminate_process "foo", attempts: 3
+          warn "foo exists"
           write "foo/banner", <<~TEXT
             literal banner
           TEXT
@@ -101,7 +102,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         post_install_steps do
           on_macos do
             system "true"
-            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
           end
         end
       end
@@ -115,7 +116,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           write "foo.conf", "prefix = #{prefix}"
-                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -649,6 +649,7 @@ Relative paths default to `staged_path` for `base:`, `source_base:` and `target_
 * `set_permissions`: recursively change existing path permissions with `chmod`; example: `set_permissions "Shared/payload", "0755"`.
 * `set_ownership`: recursively change existing path ownership with `sudo chown`; example: `set_ownership "Shared/payload", user: "root", group: "wheel"`. Missing paths are ignored. When `user:` is omitted, the current user is used. When `group:` is omitted, `staff` is used.
 * `run`: run one executable with literal arguments; example: `run "Example.app/Contents/MacOS/helper", args: ["--repair"], base: :appdir`.
+* `terminate_process`: terminate a process by name; example: `terminate_process "Example", attempts: 3, must_succeed: false`. `attempts:` sets the total number of attempts and defaults to one. The step also supports `match: :full`, `notices:` shown before the first attempt and a `failure_message:` warning.
 
 Use `if_path_exists` and `unless_path_exists` blocks to guard one or more steps by a path, and `on_macos` and `on_linux` blocks for platform-specific steps. Each guard is evaluated once for its whole block. `copy`, `move` and symlink steps accept `source_glob: true`; path collections used by `remove`, `set_permissions` and `set_ownership` expand globs automatically. Symlink removal can additionally match the serialised source during uninstall, while `remove` can restrict removal with `symlink_target_contains:` or `content_contains:`.
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1113,6 +1113,12 @@ end
 `terminate_process` terminates a process by name or, with `match: :full`, by its full command line. `attempts:` sets the total number of attempts and defaults to one. It also supports `notices:` shown before the first attempt and a `failure_message:` warning.
 `warn` emits a literal warning. Wrap it in `if_path_exists` when the warning only applies while a path exists.
 
+#### Repeated formula actions
+
+Use the named actions below for formula families that share post-install algorithms. Unique complex logic should be installed as a packaged helper and invoked with `run` instead of adding a formula-specific action.
+
+* `configure_gcc_runtime`: generate the Linux GCC runtime links and specs.
+
 #### Service data directory steps
 
 `init_data_dir` creates a database service data directory and runs a supported

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1105,9 +1105,13 @@ Content, replacements, command arguments and command environments may use a fixe
 ```ruby
 run "foo-helper", args: ["--prefix", "{{HOMEBREW_PREFIX}}"], base: :libexec
 terminate_process "foo", must_succeed: false
+if_path_exists "foo.conf", base: :etc do
+  warn "Remove the old foo.conf before continuing"
+end
 ```
 
 `terminate_process` terminates a process by name or, with `match: :full`, by its full command line. `attempts:` sets the total number of attempts and defaults to one. It also supports `notices:` shown before the first attempt and a `failure_message:` warning.
+`warn` emits a literal warning. Wrap it in `if_path_exists` when the warning only applies while a path exists.
 
 #### Service data directory steps
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1098,13 +1098,16 @@ A trailing newline is appended unless the content already ends with one, so writ
 Content, replacements, command arguments and command environments may use a fixed set of `{{...}}` tokens that are expanded at install time so values are not hardcoded into the JSON API: `{{HOMEBREW_BREW_FILE}}`, `{{HOMEBREW_CELLAR}}`, `{{HOMEBREW_PREFIX}}`, `{{name}}`, `{{user}}`, `{{prefix}}`, `{{opt_prefix}}`, `{{bin}}`, `{{sbin}}`, `{{lib}}`, `{{libexec}}`, `{{share}}`, `{{pkgshare}}`, `{{rack}}`, `{{var}}`, `{{etc}}`, `{{pkgetc}}`, `{{version}}`, `{{version.major}}` and `{{version.major_minor}}`. Completion directory tokens are also available. Any other `{{...}}` is left verbatim, so literal braces are never rewritten. Use tokens instead of Ruby interpolation, for example `write "foo.conf", "prefix = {{HOMEBREW_PREFIX}}", base: :etc`.
 {% endraw %}
 
-#### Command steps
+#### Command and lifecycle steps
 
 `run` executes one command with a literal argument array; it does not evaluate a shell command string. Select the executable with `base:`, such as `:bin`, `:libexec` or `:homebrew_prefix`, or pass an absolute system executable. The step also supports a literal `env:`, `stdin_path:`, `stdout_path:`, `chdir:`, `sudo:`, `print_stdout:` and `print_stderr:`. Wrap it in one of the guard blocks described above when it should be conditional.
 
 ```ruby
 run "foo-helper", args: ["--prefix", "{{HOMEBREW_PREFIX}}"], base: :libexec
+terminate_process "foo", must_succeed: false
 ```
+
+`terminate_process` terminates a process by name or, with `match: :full`, by its full command line. `attempts:` sets the total number of attempts and defaults to one. It also supports `notices:` shown before the first attempt and a `failure_message:` warning.
 
 #### Service data directory steps
 


### PR DESCRIPTION
Flight hooks repeatedly stop applications or helpers before mutating
their installed state.

- select processes by exact name or full command line
- serialise attempts, privilege and required-success policies
- preserve fixed user notices and final failure warnings

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and
testing.