### PR TITLE
Add GCC runtime install action (12/24)

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -603,6 +603,11 @@ module Homebrew
         add_step("warn", "message" => message)
       end
 
+      sig { void }
+      def configure_gcc_runtime
+        add_step("configure_gcc_runtime")
+      end
+
       private
 
       sig { params(guard: PathSpec, block: ::T.proc.void).void }
@@ -845,6 +850,8 @@ module Homebrew
           run_terminate_process(step)
         when "warn"
           opoo expand_template_tokens(step_string(step, "message"))
+        when "configure_gcc_runtime"
+          run_configure_gcc_runtime
         when "set_permissions"
           run_set_permissions(step)
         when "set_ownership"
@@ -1307,3 +1314,5 @@ module Homebrew
     end
   end
 end
+
+require "install_steps/formula_actions"

--- a/Library/Homebrew/install_steps/formula_actions.rb
+++ b/Library/Homebrew/install_steps/formula_actions.rb
@@ -1,0 +1,65 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Homebrew
+  module InstallSteps
+    class Runner
+      private
+
+      sig { void }
+      def run_configure_gcc_runtime
+        return unless Homebrew::SimulateSystem.simulating_or_running_on_linux?
+
+        version_major = context_version_major
+        raise ArgumentError, "GCC runtime configuration requires a version" if version_major.nil?
+
+        gcc = context_path("bin")/"gcc-#{version_major}"
+        libgcc = Pathname(run_command_output(gcc, "-print-libgcc-file-name").strip).dirname
+        require "utils/path"
+
+        glibc_installed = Utils::Path.formula_any_version_installed?("glibc")
+        glibc_lib = Utils::Path.formula_opt_lib("glibc")
+        crtdir = if glibc_installed
+          glibc_lib
+        else
+          Pathname(run_command_output("/usr/bin/cc", "-print-file-name=crti.o").strip).dirname
+        end
+        FileUtils.ln_sf Dir[crtdir/"*crt?.o"], libgcc
+
+        specs = libgcc/"specs"
+        ohai "Creating the GCC specs file: #{specs}"
+        FileUtils.rm_f ["#{specs}.orig", specs]
+        system_header_dirs = [HOMEBREW_PREFIX/"include"]
+        if glibc_installed
+          system_header_dirs << Utils::Path.formula_opt_include("glibc")
+        else
+          target = run_command_output(gcc, "-print-multiarch").strip
+          system_header_dirs += [Pathname("/usr/include")/target, Pathname("/usr/include")]
+        end
+
+        specs_string = run_command_output(gcc, "-dumpspecs")
+        Pathname("#{specs}.orig").write specs_string
+        libdir = if context_name == "gcc"
+          HOMEBREW_PREFIX/"lib/gcc/current"
+        else
+          HOMEBREW_PREFIX/"lib/gcc"/version_major
+        end
+        link_libgcc = glibc_installed ? "-nostdlib -L#{libgcc} -L#{glibc_lib}" : "+"
+        homebrew_rpath = version_major.to_i >= 11
+        specs.write specs_string + <<~EOS
+          *cpp_unique_options:
+          + -isysroot #{HOMEBREW_PREFIX}/nonexistent #{system_header_dirs.map { |p| "-idirafter #{p}" }.join(" ")}
+
+          *link_libgcc:
+          #{link_libgcc} -L#{libdir} -L#{HOMEBREW_PREFIX}/lib
+
+          *link:
+          + --dynamic-linker #{HOMEBREW_PREFIX}/lib/ld.so -rpath #{libdir}#{" -rpath #{HOMEBREW_PREFIX}/lib" unless homebrew_rpath}
+
+          #{"*homebrew_rpath:\n-rpath #{HOMEBREW_PREFIX}/lib\n" if homebrew_rpath}
+        EOS
+        specs.write(specs.read.gsub(" %o ", "\\0%(homebrew_rpath) ")) if homebrew_rpath
+      end
+    end
+  end
+end

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -17,11 +17,12 @@ module RuboCop
       PERMISSION_STEP_METHODS = [:set_permissions, :set_ownership].freeze
       COMMAND_STEP_METHODS = [:run, :terminate_process].freeze
       NOTICE_STEP_METHODS = [:warn].freeze
+      FORMULA_ACTION_STEP_METHODS = [:configure_gcc_runtime].freeze
       STEP_SCOPE_METHODS = [:if_path_exists, :unless_path_exists, :on_macos, :on_linux].freeze
       ALLOWED_STEP_METHODS = T.let(
         [*FILE_PREPARATION_STEP_METHODS, *LINK_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *SERVICE_DATA_STEP_METHODS,
          *REBUILD_ACTION_STEP_METHODS, :set_permissions, *COMMAND_STEP_METHODS, *NOTICE_STEP_METHODS,
-         *STEP_SCOPE_METHODS].freeze,
+         *FORMULA_ACTION_STEP_METHODS, *STEP_SCOPE_METHODS].freeze,
         T::Array[Symbol],
       )
       CASK_ALLOWED_STEP_METHODS = T.let(

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -715,6 +715,61 @@ RSpec.describe Homebrew::InstallSteps do
     runner.run(steps)
   end
 
+  specify "dispatches GCC runtime configuration" do
+    steps = Homebrew::InstallSteps::DSL.build do
+      configure_gcc_runtime
+    end
+
+    runner = Homebrew::InstallSteps::Runner.new(context:)
+    expect(runner).to receive(:run_configure_gcc_runtime)
+
+    runner.run(steps)
+  end
+
+  specify "configures GCC runtime files on Linux", :aggregate_failures do
+    steps = Homebrew::InstallSteps::DSL.build do
+      configure_gcc_runtime
+    end
+    gcc_context = context
+    gcc_context.define_singleton_method(:name) { "gcc" }
+    libgcc = root/"gcc/lib/gcc/15"
+    crtdir = root/"system/lib"
+    libgcc.mkpath
+    crtdir.mkpath
+    crti = crtdir/"crti.o"
+    crti.write "crt"
+    specs = libgcc/"specs"
+    specs.write "old specs"
+    Pathname("#{specs}.orig").write "old original specs"
+    gcc = root/"prefix/bin/gcc-15"
+    original_specs = "*link:\n+ %o \n"
+
+    allow(Homebrew::SimulateSystem).to receive(:simulating_or_running_on_linux?).and_return(true)
+    allow(Utils::Path).to receive(:formula_any_version_installed?).with("glibc").and_return(false)
+    allow(Utils::Path).to receive(:formula_opt_lib).with("glibc").and_return(root/"glibc/lib")
+    runner = Homebrew::InstallSteps::Runner.new(context: gcc_context)
+    expect(runner).to receive(:context_version_major).and_return("15")
+    expect(runner).to receive(:run_command_output)
+      .with(gcc, "-print-libgcc-file-name").ordered
+      .and_return("#{libgcc}/libgcc_s.so\n")
+    expect(runner).to receive(:run_command_output)
+      .with("/usr/bin/cc", "-print-file-name=crti.o").ordered
+      .and_return("#{crti}\n")
+    expect(runner).to receive(:run_command_output)
+      .with(gcc, "-print-multiarch").ordered
+      .and_return("x86_64-linux-gnu\n")
+    expect(runner).to receive(:run_command_output).with(gcc, "-dumpspecs").ordered.and_return(original_specs)
+    expect(FileUtils).to receive(:ln_sf).with([crti.to_s], libgcc).and_call_original
+    expect(FileUtils).to receive(:rm_f).with(["#{specs}.orig", specs]).and_call_original
+
+    runner.run(steps)
+
+    expect(libgcc/"crti.o").to be_a_symlink
+    expect((libgcc/"crti.o").readlink).to eq(crti)
+    expect(Pathname("#{specs}.orig").read).to eq(original_specs)
+    expect(specs.read).to include("%(homebrew_rpath)", "-idirafter /usr/include/x86_64-linux-gnu")
+  end
+
   describe "runs gtk_update_icon_cache rebuild action" do
     let(:formula) { instance_double(Formula, opt_bin: root/"opt/bin") }
     let(:steps) do

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY
@@ -67,6 +67,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           run "foo", args: ["--repair"]
           terminate_process "foo", attempts: 3
           warn "foo exists"
+          configure_gcc_runtime
           write "foo/banner", <<~TEXT
             literal banner
           TEXT
@@ -102,7 +103,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         post_install_steps do
           on_macos do
             system "true"
-            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
           end
         end
       end
@@ -116,7 +117,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           write "foo.conf", "prefix = #{prefix}"
-                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1113,6 +1113,12 @@ end
 `terminate_process` terminates a process by name or, with `match: :full`, by its full command line. `attempts:` sets the total number of attempts and defaults to one. It also supports `notices:` shown before the first attempt and a `failure_message:` warning.
 `warn` emits a literal warning. Wrap it in `if_path_exists` when the warning only applies while a path exists.
 
+#### Repeated formula actions
+
+Use the named actions below for formula families that share post-install algorithms. Unique complex logic should be installed as a packaged helper and invoked with `run` instead of adding a formula-specific action.
+
+* `configure_gcc_runtime`: generate the Linux GCC runtime links and specs.
+
 #### Service data directory steps
 
 `init_data_dir` creates a database service data directory and runs a supported


### PR DESCRIPTION
Eight GCC formulae share the same Linux runtime-link and specs
generation algorithm after installation.

- probe the active GCC and glibc runtime locations
- generate family-appropriate library, linker and header search paths
- keep the repeated algorithm behind one literal formula step

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and
testing.