### PR TITLE
Add Clang system config action (15/24)

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -627,6 +627,11 @@ module Homebrew
         add_step("configure_glibc_runtime")
       end
 
+      sig { void }
+      def configure_clang_system
+        add_step("configure_clang_system")
+      end
+
       private
 
       sig { params(guard: PathSpec, block: ::T.proc.void).void }
@@ -875,6 +880,8 @@ module Homebrew
           run_install_gzipped_executable(step)
         when "configure_glibc_runtime"
           run_configure_glibc_runtime
+        when "configure_clang_system"
+          run_configure_clang_system
         when "set_permissions"
           run_set_permissions(step)
         when "set_ownership"

--- a/Library/Homebrew/install_steps/formula_actions.rb
+++ b/Library/Homebrew/install_steps/formula_actions.rb
@@ -114,6 +114,27 @@ module Homebrew
           File.symlink source, target if source.exist? && !target.exist?
         end
       end
+
+      sig { void }
+      def run_configure_clang_system
+        return unless Homebrew::SimulateSystem.simulating_or_running_on_macos?
+
+        macos_version = MacOS.version
+        kernel_version = OS.kernel_version.major
+        raise ArgumentError, "Clang system configuration requires a kernel version" if kernel_version.nil?
+
+        kernel_version = kernel_version.to_s
+        arch = Hardware::CPU.arch
+        config_dir = context_path("etc")/"clang"
+        return if [:arm64, :x86_64, :aarch64, arch].uniq.product(
+          ["darwin#{kernel_version}", "macosx#{macos_version}"],
+        ).all? do |target_arch, system|
+          (config_dir/"#{target_arch}-apple-#{system}.cfg").exist?
+        end
+
+        require "utils/clang"
+        Utils::Clang.write_system_config_files(config_dir:, macos_version:, kernel_version:, arch:)
+      end
     end
   end
 end

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -18,7 +18,8 @@ module RuboCop
       COMMAND_STEP_METHODS = [:run, :terminate_process].freeze
       NOTICE_STEP_METHODS = [:warn].freeze
       FORMULA_ACTION_STEP_METHODS =
-        [:configure_gcc_runtime, :install_gzipped_executable, :configure_glibc_runtime].freeze
+        [:configure_gcc_runtime, :install_gzipped_executable, :configure_glibc_runtime,
+         :configure_clang_system].freeze
       STEP_SCOPE_METHODS = [:if_path_exists, :unless_path_exists, :on_macos, :on_linux].freeze
       ALLOWED_STEP_METHODS = T.let(
         [*FILE_PREPARATION_STEP_METHODS, *LINK_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *SERVICE_DATA_STEP_METHODS,

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -855,6 +855,47 @@ RSpec.describe Homebrew::InstallSteps do
     expect((root/"prefix/share/zoneinfo").readlink).to eq(Pathname("/usr/share/zoneinfo"))
   end
 
+  specify "dispatches Clang system configuration" do
+    steps = Homebrew::InstallSteps::DSL.build do
+      configure_clang_system
+    end
+
+    runner = Homebrew::InstallSteps::Runner.new(context:)
+    expect(runner).to receive(:run_configure_clang_system)
+
+    runner.run(steps)
+  end
+
+  specify "repairs incomplete Clang system configuration" do
+    require "utils/clang"
+
+    steps = Homebrew::InstallSteps::DSL.build do
+      configure_clang_system
+    end
+    clang_context = context
+    root_path = root
+    clang_context.define_singleton_method(:etc) { root_path/"prefix/etc" }
+    config_dir = root/"prefix/etc/clang"
+    config_dir.mkpath
+    (config_dir/"arm64-apple-darwin23.cfg").write ""
+    (config_dir/"arm64-apple-macosx14.cfg").write ""
+    macos_version = MacOSVersion.new("14")
+    stub_const("MacOS", Module.new do
+      define_singleton_method(:version) { macos_version }
+    end)
+    allow(Homebrew::SimulateSystem).to receive(:simulating_or_running_on_macos?).and_return(true)
+    allow(OS).to receive(:kernel_version).and_return(Version.new("23"))
+    allow(Hardware::CPU).to receive(:arch).and_return(:arm64)
+    expect(Utils::Clang).to receive(:write_system_config_files).with(
+      config_dir:,
+      macos_version:,
+      kernel_version: "23",
+      arch:           :arm64,
+    )
+
+    Homebrew::InstallSteps::Runner.new(context: clang_context).run(steps)
+  end
+
   describe "runs gtk_update_icon_cache rebuild action" do
     let(:formula) { instance_double(Formula, opt_bin: root/"opt/bin") }
     let(:steps) do

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY
@@ -70,6 +70,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           configure_gcc_runtime
           install_gzipped_executable "compressed.gz", "bin/executable"
           configure_glibc_runtime
+          configure_clang_system
           write "foo/banner", <<~TEXT
             literal banner
           TEXT
@@ -105,7 +106,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         post_install_steps do
           on_macos do
             system "true"
-            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
           end
         end
       end
@@ -119,7 +120,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           write "foo.conf", "prefix = #{prefix}"
-                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY

--- a/Library/Homebrew/test/utils/clang_spec.rb
+++ b/Library/Homebrew/test/utils/clang_spec.rb
@@ -1,0 +1,34 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "utils/clang"
+
+RSpec.describe Utils::Clang, :needs_macos do
+  sig { returns(Pathname) }
+  let(:config_dir) { Pathname(TEST_TMPDIR)/"clang-config" }
+
+  after { FileUtils.rm_rf config_dir }
+
+  specify "writes Clang system configuration files" do
+    macos_version = MacOSVersion.new("14")
+    allow(MacOS).to receive(:version).and_return(macos_version)
+
+    described_class.write_system_config_files(
+      config_dir:,
+      macos_version:,
+      kernel_version: 23,
+      arch:           :arm64,
+    )
+
+    expect(config_dir.children.map { |path| path.basename.to_s }).to contain_exactly(
+      "aarch64-apple-darwin23.cfg",
+      "aarch64-apple-macosx14.cfg",
+      "arm64-apple-darwin23.cfg",
+      "arm64-apple-macosx14.cfg",
+      "x86_64-apple-darwin23.cfg",
+      "x86_64-apple-macosx14.cfg",
+    )
+    expect((config_dir/"arm64-apple-macosx14.cfg").read)
+      .to eq("-isysroot #{MacOS::CLT::PKG_PATH}/SDKs/MacOSX14.sdk\n")
+  end
+end

--- a/Library/Homebrew/utils/clang.rb
+++ b/Library/Homebrew/utils/clang.rb
@@ -1,0 +1,32 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Utils
+  module Clang
+    sig {
+      params(
+        config_dir:     Pathname,
+        macos_version:  T.any(String, MacOSVersion),
+        kernel_version: T.any(String, Integer),
+        arch:           Symbol,
+      ).void
+    }
+    def self.write_system_config_files(config_dir:, macos_version:, kernel_version:, arch:)
+      config_dir.mkpath
+      arches = Set.new([:arm64, :x86_64, :aarch64, arch])
+      sysroot = if macos_version.blank? || MacOS.version > macos_version
+        "#{MacOS::CLT::PKG_PATH}/SDKs/MacOSX.sdk"
+      else
+        "#{MacOS::CLT::PKG_PATH}/SDKs/MacOSX#{macos_version}.sdk"
+      end
+
+      { darwin: kernel_version, macosx: macos_version }.each do |system, version|
+        arches.each do |target_arch|
+          (config_dir/"#{target_arch}-apple-#{system}#{version}.cfg").atomic_write <<~CONFIG
+            -isysroot #{sysroot}
+          CONFIG
+        end
+      end
+    end
+  end
+end

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1120,6 +1120,7 @@ Use the named actions below for formula families that share post-install algorit
 * `configure_gcc_runtime`: generate the Linux GCC runtime links and specs.
 * `install_gzipped_executable`: unpack and install a gzipped executable.
 * `configure_glibc_runtime`: generate requested glibc locales and timezone links.
+* `configure_clang_system`: generate macOS Clang system configuration files.
 
 #### Service data directory steps
 


### PR DESCRIPTION
Four LLVM and Clang formulae share macOS target configuration generation
for the active SDK and kernel versions.

- skip non-macOS installs and generated native configurations
- select the current or versioned Command Line Tools SDK
- emit compatible arm64, aarch64 and x86_64 target files

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and
testing.