### PR TITLE
Add Python bootstrap action (17/24)

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -663,6 +663,16 @@ module Homebrew
         add_step("configure_php")
       end
 
+      sig { void }
+      def bootstrap_cpython
+        add_step("bootstrap_cpython")
+      end
+
+      sig { params(abi_version: ::String).void }
+      def bootstrap_pypy(abi_version:)
+        add_step("bootstrap_pypy", "abi_version" => abi_version)
+      end
+
       private
 
       sig { params(guard: PathSpec, block: ::T.proc.bind(DSL).void).void }
@@ -921,6 +931,10 @@ module Homebrew
           run_configure_clang_system
         when "configure_php"
           run_configure_php
+        when "bootstrap_cpython"
+          run_bootstrap_cpython
+        when "bootstrap_pypy"
+          run_bootstrap_pypy(step_string(step, "abi_version"))
         when "set_permissions"
           run_set_permissions(step)
         when "set_ownership"

--- a/Library/Homebrew/install_steps/formula_actions.rb
+++ b/Library/Homebrew/install_steps/formula_actions.rb
@@ -195,6 +195,133 @@ module Homebrew
           INI
         end
       end
+
+      sig { void }
+      def run_bootstrap_cpython
+        formula = @context
+        raise ArgumentError, "CPython bootstrap requires a formula" unless formula.is_a?(Formula)
+
+        ENV.delete("PYTHONPATH")
+        version_major_minor = context_version_major_minor
+        raise ArgumentError, "CPython bootstrap requires a version" if version_major_minor.nil?
+
+        site_packages = HOMEBREW_PREFIX/"lib/python#{version_major_minor}/site-packages"
+        lib_cellar = if Homebrew::SimulateSystem.simulating_or_running_on_macos?
+          context_path("frameworks")/"Python.framework/Versions/#{version_major_minor}/lib/python#{version_major_minor}"
+        else
+          context_path("lib")/"python#{version_major_minor}"
+        end
+        site_packages_cellar = lib_cellar/"site-packages"
+        site_packages.mkpath
+        FileUtils.rm_rf site_packages_cellar
+        site_packages_cellar.parent.install_symlink site_packages
+        FileUtils.rm_r Dir[site_packages/"sitecustomize.py[co]"], force: true
+        %w[setuptools distribute pip wheel].each do |package|
+          FileUtils.rm_r Dir[site_packages/"#{package}[-_.][0-9]*", site_packages/package], force: true
+        end
+
+        python = context_path("bin")/"python#{version_major_minor}"
+        run_command python, "-Im", "ensurepip"
+        bundled = lib_cellar/"ensurepip/_bundled"
+        setuptools = formula.resource("setuptools")
+        pip = formula.resource("pip")
+        wheel = formula.resource("wheel")
+        raise ArgumentError, "CPython bootstrap resources are missing" if setuptools.nil? || pip.nil? || wheel.nil?
+
+        run_command python, "-Im", "pip", "install", "-v", "--no-deps", "--no-index", "--upgrade", "--isolated",
+                    "--target=#{site_packages}",
+                    bundled/"setuptools-#{setuptools.version}-py3-none-any.whl",
+                    bundled/"pip-#{pip.version}-py3-none-any.whl",
+                    context_path("libexec")/"wheel-#{wheel.version}-py3-none-any.whl"
+        FileUtils.mv (site_packages/"bin").children, context_path("bin")
+        (site_packages/"bin").rmdir
+        FileUtils.rm_r context_path("bin").glob("pip{,3}"), force: true
+        FileUtils.mv context_path("bin")/"wheel", context_path("bin")/"wheel#{version_major_minor}"
+        {
+          "pip"    => "pip#{version_major_minor}",
+          "pip3"   => "pip#{version_major_minor}",
+          "wheel"  => "wheel#{version_major_minor}",
+          "wheel3" => "wheel#{version_major_minor}",
+        }.each do |short_name, long_name|
+          (context_path("libexec")/"bin").install_symlink (context_path("bin")/long_name).realpath => short_name
+        end
+        (HOMEBREW_PREFIX/"bin").install_symlink [context_path("bin")/"wheel#{version_major_minor}",
+                                                 context_path("bin")/"pip#{version_major_minor}"]
+        make_cpython_venv_activation_scripts_writable(lib_cellar)
+        return if version_major_minor != "3.9"
+
+        include_dirs = [HOMEBREW_PREFIX/"include", Utils::Path.formula_opt_include("openssl@3"),
+                        Utils::Path.formula_opt_include("sqlite")]
+        library_dirs = [HOMEBREW_PREFIX/"lib", Utils::Path.formula_opt_lib("openssl@3"),
+                        Utils::Path.formula_opt_lib("sqlite")]
+        (lib_cellar/"distutils/distutils.cfg").atomic_write <<~INI
+          [install]
+          prefix=#{HOMEBREW_PREFIX}
+          [build_ext]
+          include_dirs=#{include_dirs.join(":")}
+          library_dirs=#{library_dirs.join(":")}
+        INI
+        framework_compat = site_packages/"setuptools/_distutils/command/_framework_compat.py"
+        require "utils/inreplace"
+        Utils::Inreplace.inreplace(framework_compat, /^(\s+homebrew_prefix\s+=\s+).*/,
+                                   "\\1'#{HOMEBREW_PREFIX}'")
+      end
+
+      public
+
+      sig { params(lib_cellar: Pathname).void }
+      def make_cpython_venv_activation_scripts_writable(lib_cellar)
+        FileUtils.chmod "u+w", lib_cellar.glob("venv/scripts/**/*").select(&:file?)
+      end
+
+      private
+
+      sig { params(abi_version: String).void }
+      def run_bootstrap_pypy(abi_version)
+        formula = @context
+        raise ArgumentError, "PyPy bootstrap requires a formula" unless formula.is_a?(Formula)
+
+        pypy = context_path("bin")/"pypy#{abi_version}"
+        %w[_sqlite3 _curses syslog gdbm _tkinter].each do |module_name|
+          @command.run(pypy, args: ["-c", "import #{module_name}"], print_stdout: false, print_stderr: false)
+        end
+        site_packages = HOMEBREW_PREFIX/"lib/pypy#{abi_version}/site-packages"
+        libexec_site_packages = context_path("libexec")/"lib/pypy#{abi_version}/site-packages"
+        scripts_folder = HOMEBREW_PREFIX/"share/pypy#{abi_version}"
+        site_packages.mkpath
+        FileUtils.touch site_packages/".keepme"
+        FileUtils.rm_rf libexec_site_packages
+        libexec_site_packages.parent.install_symlink site_packages
+        if abi_version == "3.9"
+          if scripts_folder.symlink?
+            scripts_folder.unlink
+            scripts_folder.install_symlink context_path("pkgshare").children
+          end
+          unless (context_path("libexec")/"bin").exist?
+            context_path("libexec").install_symlink scripts_folder => "bin"
+          end
+        end
+        scripts_folder.mkpath
+        (libexec_site_packages.parent/"distutils/distutils.cfg").atomic_write <<~INI
+          [install]
+          install-scripts=#{scripts_folder}
+        INI
+        %w[setuptools pip].each do |package|
+          resource = formula.resource(package)
+          raise ArgumentError, "PyPy bootstrap resource #{package} is missing" if resource.nil?
+
+          resource.stage do
+            run_command pypy, "-s", "setup.py", "--no-user-cfg", "install", "--force", "--verbose"
+          end
+        end
+        context_path("bin").install_symlink scripts_folder/"pip#{abi_version}" => "pip_pypy#{abi_version}"
+        prefix_links = [context_path("bin")/"pip_pypy#{abi_version}"]
+        if formula == Formula["pypy3"]
+          context_path("bin").install_symlink "pip_pypy#{abi_version}" => "pip_pypy3"
+          prefix_links << (context_path("bin")/"pip_pypy3")
+        end
+        (HOMEBREW_PREFIX/"bin").install_symlink prefix_links
+      end
     end
   end
 end

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -20,7 +20,7 @@ module RuboCop
       NOTICE_STEP_METHODS = [:warn].freeze
       FORMULA_ACTION_STEP_METHODS =
         [:configure_gcc_runtime, :install_gzipped_executable, :configure_glibc_runtime,
-         :configure_clang_system, :configure_php].freeze
+         :configure_clang_system, :configure_php, :bootstrap_cpython, :bootstrap_pypy].freeze
       STEP_SCOPE_METHODS = [:if_path_exists, :unless_path_exists, :on_macos, :on_linux].freeze
       ALLOWED_STEP_METHODS = T.let(
         [*FILE_PREPARATION_STEP_METHODS, *LINK_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *SERVICE_DATA_STEP_METHODS,

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -1014,6 +1014,130 @@ RSpec.describe Homebrew::InstallSteps do
     end
   end
 
+  specify "dispatches CPython and PyPy bootstrap" do
+    steps = Homebrew::InstallSteps::DSL.build do
+      bootstrap_cpython
+      bootstrap_pypy abi_version: "3.10"
+    end
+
+    runner = Homebrew::InstallSteps::Runner.new(context:)
+    expect(runner).to receive(:run_bootstrap_cpython).ordered
+    expect(runner).to receive(:run_bootstrap_pypy).with("3.10").ordered
+
+    runner.run(steps)
+  end
+
+  specify "bootstraps CPython 3.9 configuration", :aggregate_failures do
+    python = formula do
+      T.bind(self, T.class_of(Formula))
+      url "foo-3.9.1"
+    end
+    allow(python).to receive(:prefix).and_return(root/"prefix")
+    stub_const("HOMEBREW_PREFIX", root/"homebrew")
+    allow(Homebrew::SimulateSystem).to receive(:simulating_or_running_on_macos?).and_return(false)
+    site_packages = root/"homebrew/lib/python3.9/site-packages"
+    resources = %w[setuptools pip wheel].to_h do |name|
+      [name, instance_double(Resource, version: Version.new("1.0"))]
+    end
+    allow(python).to receive(:resource) { |name| resources[name] }
+    site_packages_cellar = root/"prefix/lib/python3.9/site-packages"
+    (site_packages_cellar/"old.pth").tap do |path|
+      path.dirname.mkpath
+      path.write "old"
+    end
+    (site_packages/"bin").mkpath
+    (site_packages/"bin/pip3.9").write "pip"
+    (site_packages/"bin/wheel").write "wheel"
+    (root/"prefix/bin").mkpath
+    (root/"prefix/lib/python3.9/distutils").mkpath
+    (root/"homebrew/bin").mkpath
+    runner = Homebrew::InstallSteps::Runner.new(context: python)
+    allow(runner).to receive(:run_command) do |*args|
+      next unless args.include?("--target=#{site_packages}")
+
+      framework_compat = site_packages/"setuptools/_distutils/command/_framework_compat.py"
+      framework_compat.dirname.mkpath
+      framework_compat.write "    homebrew_prefix = None\n"
+    end
+    steps = Homebrew::InstallSteps::DSL.build do
+      bootstrap_cpython
+    end
+
+    runner.run(steps)
+
+    expect(site_packages_cellar).to be_a_symlink
+    expect(site_packages_cellar.realpath).to eq(site_packages.realpath)
+    expect(site_packages_cellar/"old.pth").not_to exist
+    expect((root/"prefix/lib/python3.9/distutils/distutils.cfg").read).to eq <<~INI
+      [install]
+      prefix=#{root}/homebrew
+      [build_ext]
+      include_dirs=#{root}/homebrew/include:#{root}/homebrew/opt/openssl@3/include:#{root}/homebrew/opt/sqlite/include
+      library_dirs=#{root}/homebrew/lib:#{root}/homebrew/opt/openssl@3/lib:#{root}/homebrew/opt/sqlite/lib
+    INI
+    expect((site_packages/"setuptools/_distutils/command/_framework_compat.py").read)
+      .to eq("    homebrew_prefix = '#{root}/homebrew'\n")
+  end
+
+  specify "bootstraps PyPy 3.10 configuration", :aggregate_failures do
+    pypy = formula do
+      T.bind(self, T.class_of(Formula))
+      url "foo-7.3.20"
+    end
+    allow(pypy).to receive_messages(
+      prefix:   root/"prefix",
+      libexec:  root/"prefix/libexec",
+      pkgshare: root/"prefix/share/pypy3",
+    )
+    stub_const("HOMEBREW_PREFIX", root/"homebrew")
+    resources = %w[setuptools pip].to_h do |name|
+      resource = instance_double(Resource)
+      allow(resource).to receive(:stage).and_yield
+      [name, resource]
+    end
+    allow(pypy).to receive(:resource) { |name| resources[name] }
+    allow(Formula).to receive(:[]).with("pypy3").and_return(instance_double(Formula))
+    scripts_folder = root/"homebrew/share/pypy3.10"
+    scripts_folder.mkpath
+    (scripts_folder/"pip3.10").write "pip"
+    (root/"prefix/libexec/lib/pypy3.10/distutils").mkpath
+    command = class_double(SystemCommand, run: nil)
+    runner = Homebrew::InstallSteps::Runner.new(context: pypy, command:)
+    allow(runner).to receive(:run_command)
+    steps = Homebrew::InstallSteps::DSL.build do
+      bootstrap_pypy abi_version: "3.10"
+    end
+
+    runner.run(steps)
+
+    site_packages = root/"homebrew/lib/pypy3.10/site-packages"
+    libexec_site_packages = root/"prefix/libexec/lib/pypy3.10/site-packages"
+    expect(site_packages/".keepme").to exist
+    expect(libexec_site_packages).to be_a_symlink
+    expect(libexec_site_packages.realpath).to eq(site_packages.realpath)
+    expect((root/"prefix/libexec/lib/pypy3.10/distutils/distutils.cfg").read).to eq <<~INI
+      [install]
+      install-scripts=#{scripts_folder}
+    INI
+    expect(root/"prefix/bin/pip_pypy3.10").to be_a_symlink
+    expect(root/"homebrew/bin/pip_pypy3.10").to be_a_symlink
+  end
+
+  specify "makes CPython venv activation script templates writable", :aggregate_failures do
+    script = root/"lib/venv/scripts/common/activate"
+    directory = root/"lib/venv/scripts/directory"
+    script.dirname.mkpath
+    directory.mkpath
+    script.write "activate"
+    FileUtils.chmod 0444, script
+    FileUtils.chmod 0555, directory
+
+    Homebrew::InstallSteps::Runner.new(context:).make_cpython_venv_activation_scripts_writable(root/"lib")
+
+    expect(script.stat.mode & 0200).to eq(0200)
+    expect(directory.stat.mode & 0200).to be_zero
+  end
+
   describe "runs gtk_update_icon_cache rebuild action" do
     let(:formula) { instance_double(Formula, opt_bin: root/"opt/bin") }
     let(:steps) do

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `bootstrap_cpython`, `bootstrap_pypy`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY
@@ -73,6 +73,8 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           configure_glibc_runtime
           configure_clang_system
           configure_php
+          bootstrap_cpython
+          bootstrap_pypy abi_version: "3.10"
           write "foo/banner", <<~TEXT
             literal banner
           TEXT
@@ -108,7 +110,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         post_install_steps do
           on_macos do
             system "true"
-            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `bootstrap_cpython`, `bootstrap_pypy`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
           end
         end
       end
@@ -122,7 +124,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           write "foo.conf", "prefix = #{prefix}"
-                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `bootstrap_cpython`, `bootstrap_pypy`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1156,6 +1156,8 @@ Use the named actions below for formula families that share post-install algorit
 * `configure_glibc_runtime`: generate requested glibc locales and timezone links.
 * `configure_clang_system`: generate macOS Clang system configuration files.
 * `configure_php`: configure shared PEAR and PECL state.
+* `bootstrap_cpython`: bootstrap CPython packaging state.
+* `bootstrap_pypy`: bootstrap PyPy packaging state with the required `abi_version:` argument.
 
 #### Service data directory steps
 


### PR DESCRIPTION
Five CPython and PyPy formulae share packaging bootstrap work that
depends on resources and implementation-specific install layouts.

- rebuild CPython site-packages, pip and wheel links from resources
- preserve the Python 3.9 compatibility configuration
- stage PyPy resources and links for the supported ABIs

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.