### PR TITLE
Align shared install step interfaces (18/24)

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4062,7 +4062,7 @@ class Formula
     #
     # ```ruby
     # post_install_steps do
-    #   mkdir "log/foo", base: :var
+    #   mkdir_p "log/foo", base: :var
     # end
     # ```
     #

--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -202,7 +202,7 @@ module Homebrew
           end
         when String, Pathname
           if %w[
-            path source target command matching_certificate fingerprint_of stdin_path stdout_path chdir
+            path source target command matching_certificate stdin_path stdout_path chdir
           ].include?(key)
             normalise_path_value(obj)
           else
@@ -247,20 +247,25 @@ module Homebrew
           target:      ::T.any(::String, ::Pathname),
           source_base: ::T.nilable(::T.any(::String, ::Symbol)),
           target_base: ::T.nilable(::T.any(::String, ::Symbol)),
+          # odeprecated
           force:       ::T::Boolean,
+          overwrite:   ::T::Boolean,
           source_glob: ::T::Boolean,
         ).void
       }
-      def move(source, target, source_base: nil, target_base: nil, force: false, source_glob: false)
+      def move(source, target, source_base: nil, target_base: nil, force: false, overwrite: true, source_glob: false)
         add_step("move",
                  "source"      => path_spec(source, base: source_base, default_base: @default_source_base),
                  "target"      => path_spec(target, base: target_base, default_base: @default_target_base),
                  "force"       => force,
+                 "overwrite"   => overwrite,
                  "source_glob" => source_glob)
       end
 
+      # odeprecated
       alias mv move
 
+      # odeprecated
       sig {
         params(
           source:      ::T.any(::String, ::Pathname),
@@ -353,31 +358,37 @@ module Homebrew
 
       sig {
         params(
-          source:         ::T.any(::String, ::Pathname),
-          target:         ::T.any(::String, ::Pathname),
-          source_base:    ::T.nilable(::T.any(::String, ::Symbol)),
-          target_base:    ::T.nilable(::T.any(::String, ::Symbol)),
-          source_formula: ::T.nilable(::String),
-          target_formula: ::T.nilable(::String),
-          force:          ::T::Boolean,
-          uninstall:      ::T::Boolean,
-          source_glob:    ::T::Boolean,
-          sudo:           ::T.any(::T::Boolean, ::Symbol),
+          source:              ::T.any(::String, ::Pathname),
+          target:              ::T.any(::String, ::Pathname),
+          source_base:         ::T.nilable(::T.any(::String, ::Symbol)),
+          target_base:         ::T.nilable(::T.any(::String, ::Symbol)),
+          source_formula:      ::T.nilable(::String),
+          target_formula:      ::T.nilable(::String),
+          # odeprecated
+          force:               ::T::Boolean,
+          # odeprecated
+          uninstall:           ::T::Boolean,
+          overwrite:           ::T::Boolean,
+          remove_on_uninstall: ::T::Boolean,
+          source_glob:         ::T::Boolean,
+          sudo:                ::T.any(::T::Boolean, ::Symbol),
         ).void
       }
       def symlink(source, target, source_base: nil, target_base: nil, source_formula: nil, target_formula: nil,
-                  force: false, uninstall: false, source_glob: false, sudo: false)
+                  force: false, uninstall: false, overwrite: false, remove_on_uninstall: false,
+                  source_glob: false, sudo: false)
         add_step("symlink",
                  "source"      => path_spec(source, base: source_base, formula: source_formula,
-                                           default_base: @default_source_base),
+                                    default_base: @default_source_base),
                  "target"      => path_spec(target, base: target_base, formula: target_formula,
-                                           default_base: @default_target_base),
-                 "force"       => force,
-                 "uninstall"   => uninstall,
+                                    default_base: @default_target_base),
+                 "force"       => force || overwrite,
+                 "uninstall"   => uninstall || remove_on_uninstall,
                  "source_glob" => source_glob,
                  "sudo"        => sudo.is_a?(::Symbol) ? sudo.to_s : sudo)
       end
 
+      # odeprecated
       sig {
         params(
           source:         ::T.any(::String, ::Pathname),
@@ -395,6 +406,7 @@ module Homebrew
         symlink(source, target, source_base:, target_base:, source_formula:, target_formula:, force:, uninstall:)
       end
 
+      # odeprecated
       sig {
         params(
           source:         ::T.any(::String, ::Pathname),
@@ -411,6 +423,7 @@ module Homebrew
         symlink(source, target, source_base:, target_base:, source_formula:, target_formula:, force: true, uninstall:)
       end
 
+      # odeprecated
       sig {
         params(
           source:      ::T.any(::String, ::Pathname),
@@ -425,6 +438,21 @@ module Homebrew
                  "target" => path_spec(target, base: target_base, default_base: @default_target_base))
       end
 
+      sig {
+        params(
+          source:      ::T.any(::String, ::Pathname),
+          target:      ::T.any(::String, ::Pathname),
+          source_base: ::T.nilable(::T.any(::String, ::Symbol)),
+          target_base: ::T.nilable(::T.any(::String, ::Symbol)),
+        ).void
+      }
+      def symlink_tree(source, target, source_base: nil, target_base: :homebrew_prefix)
+        add_step("link_dir",
+                 "source" => path_spec(source, base: source_base, default_base: @default_source_base),
+                 "target" => path_spec(target, base: target_base, default_base: @default_target_base))
+      end
+
+      # odeprecated
       sig {
         params(
           source:      ::T.any(::String, ::Pathname),
@@ -445,6 +473,26 @@ module Homebrew
 
       sig {
         params(
+          source:      ::T.any(::String, ::Pathname),
+          target:      ::T.nilable(::T.any(::String, ::Pathname)),
+          source_base: ::T.nilable(::T.any(::String, ::Symbol)),
+          target_base: ::T.nilable(::T.any(::String, ::Symbol)),
+          prefix:      ::String,
+          suffix:      ::String,
+        ).void
+      }
+      def symlink_children(source, target = nil, source_base: nil, target_base: :homebrew_prefix, prefix: "",
+                           suffix: "")
+        add_step("link_children",
+                 "source" => path_spec(source, base: source_base, default_base: @default_source_base),
+                 "target" => path_spec(target || source, base: target_base, default_base: @default_target_base),
+                 "prefix" => prefix,
+                 "suffix" => suffix)
+      end
+
+      # odeprecated
+      sig {
+        params(
           path:      ::T.any(::String, ::Pathname),
           content:   ::String,
           base:      ::T.nilable(::T.any(::String, ::Symbol)),
@@ -461,6 +509,20 @@ module Homebrew
 
       sig {
         params(
+          path:    ::T.any(::String, ::Pathname),
+          content: ::String,
+          base:    ::T.nilable(::T.any(::String, ::Symbol)),
+        ).void
+      }
+      def write_file(path, content, base: nil)
+        add_step("write",
+                 "path"      => path_spec(path, base:, default_base: @default_base),
+                 "content"   => content,
+                 "overwrite" => true)
+      end
+
+      sig {
+        params(
           path:   ::T.any(::String, ::Pathname),
           using:  ::T.any(::String, ::Symbol),
           base:   ::T.nilable(::T.any(::String, ::Symbol)),
@@ -468,9 +530,15 @@ module Homebrew
         ).void
       }
       def init_data_dir(path, using:, base: nil, locale: nil)
+        using = case using.to_s
+        when "postgresql" then "postgresql_initdb"
+        when "mysql" then "mysql_initialize"
+        when "mariadb" then "mariadb_install_db"
+        else using.to_s
+        end
         add_step("init_data_dir",
                  "path"   => path_spec(path, base:, default_base: @default_base),
-                 "using"  => using.to_s,
+                 "using"  => using,
                  "locale" => locale)
       end
 
@@ -485,13 +553,25 @@ module Homebrew
         add_rebuild_action("gio_querymodules", "lib/gio/modules")
       end
 
+      # odeprecated
       sig { void }
       def gdk_pixbuf_query_loaders
         add_step("gdk_pixbuf_query_loaders")
       end
 
       sig { void }
+      def update_gdk_pixbuf_loaders_cache
+        add_step("gdk_pixbuf_query_loaders")
+      end
+
+      # odeprecated
+      sig { void }
       def gtk_update_icon_cache
+        add_rebuild_action("gtk_update_icon_cache", "share/icons/hicolor")
+      end
+
+      sig { void }
+      def update_gtk_icon_cache
         add_rebuild_action("gtk_update_icon_cache", "share/icons/hicolor")
       end
 
@@ -505,6 +585,7 @@ module Homebrew
         add_rebuild_action("update_desktop_database", "share/applications")
       end
 
+      # odeprecated
       sig {
         params(
           name:                 ::String,
@@ -517,6 +598,19 @@ module Homebrew
                  "name"                 => name,
                  "matching_certificate" => (path_spec(matching_certificate, base:, default_base: nil) if
                    matching_certificate))
+      end
+
+      sig {
+        params(
+          name:           ::String,
+          fingerprint_of: ::T.nilable(::T.any(::String, ::Pathname)),
+          base:           ::T.nilable(::T.any(::String, ::Symbol)),
+        ).void
+      }
+      def delete_keychain_certificates(name, fingerprint_of: nil, base: nil)
+        add_step("delete_keychain_certificate",
+                 "name"                 => name,
+                 "matching_certificate" => (path_spec(fingerprint_of, base:, default_base: nil) if fingerprint_of))
       end
 
       sig {
@@ -805,7 +899,16 @@ module Homebrew
           source = resolve_step_source(step)
           target = resolve_path(step_path(step, "target"))
           target.dirname.mkpath
-          FileUtils.mv source, target, force: step["force"] == true
+          destination = step_destination(source, target)
+          if step.key?("overwrite")
+            overwrite = step["overwrite"] == true || step["force"] == true
+            raise Errno::EEXIST, destination.to_s if destination.exist? && !overwrite
+
+            FileUtils.rm_rf destination if overwrite && destination != source && (source.exist? || source.symlink?)
+            FileUtils.mv source, target
+          else
+            FileUtils.mv source, target, force: step["force"] == true
+          end
         when "move_children", "move_contents"
           source = resolve_path(step_path(step, "source"))
           target = resolve_path(step_path(step, "target"))
@@ -861,7 +964,7 @@ module Homebrew
           Utils::Inreplace.inreplace(path, before, after,
                                      audit_result: step["skip_audit"] != true,
                                      global:       step["first_only"] != true)
-        when "link_dir", "symlink_tree"
+        when "link_dir"
           source_dir = resolve_path(step_path(step, "source"))
           target_dir = resolve_path(step_path(step, "target"))
           source_dir.find do |source|
@@ -902,12 +1005,12 @@ module Homebrew
           end
         when "write"
           content = T.cast(step["content"], T.nilable(String))
-          raise ArgumentError, "install step write requires non-empty content" if content.blank?
+          raise ArgumentError, "install step write requires content" if content.nil?
 
           path = resolve_path(step_path(step, "path"))
           if step["overwrite"] == true || !path.exist?
             path.dirname.mkpath
-            path.write(expand_template_tokens(content))
+            path.atomic_write(expand_template_tokens(content))
           end
         when "run"
           run_serialised_command(step)
@@ -1249,7 +1352,10 @@ module Homebrew
 
       sig { params(spec: PathSpec).returns(T::Array[Pathname]) }
       def expand_path_glob(spec)
-        if spec["base"] == "path"
+        base = spec["base"]
+        # odeprecated
+        base = "search_path" if base == "path"
+        if base == "search_path"
           path = expand_template_tokens(spec.fetch("path"))
           return ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).flat_map do |directory|
             candidate = Pathname(directory)/path

--- a/Library/Homebrew/rubocops/cask/install_steps.rb
+++ b/Library/Homebrew/rubocops/cask/install_steps.rb
@@ -112,7 +112,7 @@ module RuboCop
           return fingerprint_keychain_step_lines(direct_nodes) if direct_nodes.length == 7
 
           if (name_node = keychain_delete_sequence_name(direct_nodes))&.str_type?
-            return ["delete_keychain_certificate #{T.cast(name_node, RuboCop::AST::StrNode).str_content.inspect}"]
+            return ["delete_keychain_certificates #{T.cast(name_node, RuboCop::AST::StrNode).str_content.inspect}"]
           end
 
           return if body_node.nil? || !body_node.block_type?
@@ -133,7 +133,7 @@ module RuboCop
           return if sequence_name_node.children != [:cert_name]
 
           name_nodes.map do |name|
-            "delete_keychain_certificate #{T.cast(name, RuboCop::AST::StrNode).str_content.inspect}"
+            "delete_keychain_certificates #{T.cast(name, RuboCop::AST::StrNode).str_content.inspect}"
           end
         end
 
@@ -169,8 +169,8 @@ module RuboCop
           name = T.cast(name_node, RuboCop::AST::StrNode).str_content.inspect
           path = T.cast(path_node, RuboCop::AST::StrNode).str_content.inspect
           source = <<~RUBY.chomp
-            delete_keychain_certificate #{name},
-                                        matching_certificate: #{path}
+            delete_keychain_certificates #{name},
+                                         fingerprint_of: #{path}
           RUBY
           [source]
         end

--- a/Library/Homebrew/rubocops/install_steps.rb
+++ b/Library/Homebrew/rubocops/install_steps.rb
@@ -194,7 +194,7 @@ module RuboCop
           step_nodes[log_node] = ["mkdir_p \"log\""]
           step_nodes[datadir_node] = []
           step_nodes[guard_node] = []
-          init_step_line = "init_data_dir name, using: :postgresql_initdb"
+          init_step_line = "init_data_dir formula_name, using: :postgresql"
           init_step_line += ', locale: "C"' if locale == "C"
           step_nodes[init_node] = [init_step_line]
           pg_version_calls = formula_body.each_descendant(:send).count do |node|
@@ -215,7 +215,7 @@ module RuboCop
           return if datadir_method.nil?
           return if normalised_install_step_source(datadir_method) != MYSQL_DATADIR_METHOD_SOURCE
 
-          add_mysql_data_step_nodes(direct_nodes, step_nodes, MYSQL_INITIALISE_SOURCE, :mysql_initialize)
+          add_mysql_data_step_nodes(direct_nodes, step_nodes, MYSQL_INITIALISE_SOURCE, :mysql)
         end
 
         sig {
@@ -225,7 +225,7 @@ module RuboCop
           ).void
         }
         def add_mariadb_step_nodes(direct_nodes, step_nodes)
-          add_mysql_data_step_nodes(direct_nodes, step_nodes, MARIADB_INITIALISE_SOURCE, :mariadb_install_db)
+          add_mysql_data_step_nodes(direct_nodes, step_nodes, MARIADB_INITIALISE_SOURCE, :mariadb)
         end
 
         sig {
@@ -263,12 +263,12 @@ module RuboCop
             case normalised_install_step_source(node)
             when POSTGRESQL_LINK_DIR_SOURCE
               step_nodes[node] = [
-                "link_dir \"include/postgresql\", \"include/{{name}}\"",
-                "link_dir \"lib/postgresql\", \"lib/{{name}}\"",
-                "link_dir \"share/postgresql\", \"share/{{name}}\"",
+                "symlink_tree \"include/postgresql\", \"include/{{formula_name}}\"",
+                "symlink_tree \"lib/postgresql\", \"lib/{{formula_name}}\"",
+                "symlink_tree \"share/postgresql\", \"share/{{formula_name}}\"",
               ]
             when POSTGRESQL_LINK_CHILDREN_SOURCE
-              step_nodes[node] = ["link_children \"bin\", suffix: \"-{{version.major}}\""]
+              step_nodes[node] = ["symlink_children \"bin\", suffix: \"-{{version.major}}\""]
             end
           end
         end

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -7,13 +7,14 @@ module RuboCop
       FILE_PREPARATION_STEP_METHODS =
         [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :move_contents, :copy, :remove, :inreplace, :symlink,
          :ln_s, :ln_sf].freeze
-      LINK_STEP_METHODS = [:link_dir, :link_children].freeze
-      CONFIG_WRITE_STEP_METHODS = [:write].freeze
+      LINK_STEP_METHODS = [:link_dir, :link_children, :symlink_tree, :symlink_children].freeze
+      CONFIG_WRITE_STEP_METHODS = [:write, :write_file].freeze
       SERVICE_DATA_STEP_METHODS = [:init_data_dir].freeze
       REBUILD_ACTION_STEP_METHODS =
-        [:compile_gsettings_schemas, :gio_querymodules, :gdk_pixbuf_query_loaders, :gtk_update_icon_cache,
+        [:compile_gsettings_schemas, :gio_querymodules, :gdk_pixbuf_query_loaders, :update_gdk_pixbuf_loaders_cache,
+         :gtk_update_icon_cache, :update_gtk_icon_cache,
          :update_mime_database, :update_desktop_database].freeze
-      KEYCHAIN_STEP_METHODS = [:delete_keychain_certificate].freeze
+      KEYCHAIN_STEP_METHODS = [:delete_keychain_certificate, :delete_keychain_certificates].freeze
       PERMISSION_STEP_METHODS = [:set_permissions, :set_ownership].freeze
       COMMAND_STEP_METHODS = [:run, :terminate_process].freeze
       MACHO_STEP_METHODS = [:change_dylib_id].freeze
@@ -55,12 +56,12 @@ module RuboCop
           [
             "system Formula[\"gdk-pixbuf\"].opt_bin/\"gdk-pixbuf-query-loaders\", " \
             "\"--update-cache\"",
-            "gdk_pixbuf_query_loaders",
+            "update_gdk_pixbuf_loaders_cache",
           ],
           [
             "system Formula[\"gtk+3\"].opt_bin/\"gtk3-update-icon-cache\", " \
             "\"-q\", \"-t\", \"-f\", HOMEBREW_PREFIX/\"share/icons/hicolor\"",
-            "gtk_update_icon_cache",
+            "update_gtk_icon_cache",
           ],
           [
             "system Formula[\"shared-mime-info\"].opt_bin/\"update-mime-database\", " \
@@ -371,7 +372,7 @@ module RuboCop
           install_step_path_keyword(source, base: default_source_base, keyword: :source_base),
           install_step_path_keyword(target, base: default_target_base, keyword: :target_base),
         ].compact
-        "mv #{install_step_path_source(source)}, #{install_step_path_source(target)}#{install_step_kwargs(kwargs)}"
+        "move #{install_step_path_source(source)}, #{install_step_path_source(target)}#{install_step_kwargs(kwargs)}"
       end
 
       sig {
@@ -395,8 +396,9 @@ module RuboCop
         kwargs = [
           source_keyword,
           install_step_path_keyword(target, base: default_target_base, keyword: :target_base),
+          ("overwrite: true" if method_name == :ln_sf),
         ].compact
-        "#{method_name} #{install_step_path_source(source)}, #{install_step_path_source(target)}" \
+        "symlink #{install_step_path_source(source)}, #{install_step_path_source(target)}" \
           "#{install_step_kwargs(kwargs)}"
       end
 
@@ -410,13 +412,10 @@ module RuboCop
       def write_step_line(path, content_node, default_base)
         return if path.nil? || relative_install_step_path?(path)
 
-        kwargs = [
-          install_step_path_keyword(path, base: default_base, keyword: :base),
-          "overwrite: true",
-        ].compact
+        kwargs = [install_step_path_keyword(path, base: default_base, keyword: :base)].compact
         return unless (content_source = write_content_source(content_node, kwargs))
 
-        "write #{install_step_path_source(path)}, #{content_source}"
+        "write_file #{install_step_path_source(path)}, #{content_source}"
       end
 
       sig { params(content_node: RuboCop::AST::Node, kwargs: T::Array[String]).returns(T.nilable(String)) }

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1195,9 +1195,9 @@ RSpec.describe Formula do
       post_install_steps do
         mkdir_p "log/foo"
         touch "foo/marker"
-        mv "move-source", "move-target"
-        move_children "children-source", "children-target"
-        ln_s "move-target", "linked-target", source_base: :relative, uninstall: true
+        move "move-source", "move-target"
+        move_contents "children-source", "children-target"
+        symlink "move-target", "linked-target", source_base: :relative, remove_on_uninstall: true
       end
     end
 
@@ -1205,12 +1205,13 @@ RSpec.describe Formula do
       { "type" => "mkdir_p", "path" => { "base" => "var", "path" => "log/foo" } },
       { "type" => "touch", "path" => { "base" => "var", "path" => "foo/marker" } },
       {
-        "type"   => "move",
-        "source" => { "base" => "prefix", "path" => "move-source" },
-        "target" => { "base" => "prefix", "path" => "move-target" },
+        "type"      => "move",
+        "source"    => { "base" => "prefix", "path" => "move-source" },
+        "target"    => { "base" => "prefix", "path" => "move-target" },
+        "overwrite" => true,
       },
       {
-        "type"   => "move_children",
+        "type"   => "move_contents",
         "source" => { "base" => "prefix", "path" => "children-source" },
         "target" => { "base" => "prefix", "path" => "children-target" },
       },
@@ -1265,7 +1266,7 @@ RSpec.describe Formula do
       url "foo-1.0"
 
       post_install_steps do
-        ln_s "source", "linked"
+        symlink "source", "linked"
       end
     end
 

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -48,13 +48,13 @@ RSpec.describe Homebrew::InstallSteps do
     expect(dylib.stat.mode & 0777).to eq(0444)
   end
 
-  specify "runs mkdir, touch, move and symlink steps", :aggregate_failures do
+  specify "runs directory, touch, move and symlink steps", :aggregate_failures do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var, default_source_base: :staged_path,
                                               default_target_base: :staged_path) do
       mkdir_p "log/example"
       touch "state/marker", base: :prefix
-      mv "move-source", "move-target"
-      ln_s "move-target", "linked-target", source_base: :relative
+      move "move-source", "move-target"
+      symlink "move-target", "linked-target", source_base: :relative
     end
 
     (root/"stage").mkpath
@@ -86,7 +86,7 @@ RSpec.describe Homebrew::InstallSteps do
   specify "links every source matched by a glob into a directory", :aggregate_failures do
     steps = Homebrew::InstallSteps::DSL.build(default_source_base: :prefix,
                                               default_target_base: :prefix) do
-      symlink "share/man/*.1", "share/man/man1", force: true, source_glob: true
+      symlink "share/man/*.1", "share/man/man1", source_glob: true, overwrite: true
     end
 
     (root/"prefix/share/man/man1").mkpath
@@ -191,17 +191,44 @@ RSpec.describe Homebrew::InstallSteps do
     )
   end
 
+  specify "keeps canonical DSL calls compatible with shipped API values", :aggregate_failures do
+    steps = Homebrew::InstallSteps::DSL.build do
+      symlink_tree "source", "target"
+      symlink_children "source", "target"
+      write_file "config", "content"
+      update_gdk_pixbuf_loaders_cache
+      update_gtk_icon_cache
+      delete_keychain_certificates "Example", fingerprint_of: "certificate"
+      symlink "source", "target", overwrite: true, remove_on_uninstall: true
+      init_data_dir "data", using: :postgresql
+    end
+
+    expect(steps.map { |step| step.fetch("type") }).to eq(
+      %w[link_dir link_children write gdk_pixbuf_query_loaders gtk_update_icon_cache
+         delete_keychain_certificate symlink init_data_dir],
+    )
+    expect(steps.fetch(2)).to include("content" => "content", "overwrite" => true)
+    expect(steps.fetch(5)).to include("matching_certificate" => { "path" => "certificate" })
+    expect(steps.fetch(6)).to include("force" => true, "uninstall" => true)
+    expect(steps.fetch(7)).to include("using" => "postgresql_initdb")
+  end
+
   specify "expands a scoped set of content tokens and leaves others verbatim", :aggregate_failures do
     root_path = root
     versioned_context = Class.new do
       define_method(:prefix) { root_path/"prefix" }
+      define_method(:name) { "example" }
+      define_method(:token) { "example-cask" }
       define_method(:version) { Version.new("1.2.3") }
     end.new
 
     steps = Homebrew::InstallSteps::DSL.build(default_base: :prefix) do
-      write "config.ini", <<~EOS
+      write_file "config.ini", <<~EOS
         prefix = {{prefix}}
         cellar = {{HOMEBREW_PREFIX}}
+        legacy = {{name}}
+        formula = {{formula_name}}
+        cask = {{token}}
         series = {{version.major_minor}} ({{version}})
         literal = {{unknown}} {single}
       EOS
@@ -212,6 +239,9 @@ RSpec.describe Homebrew::InstallSteps do
     written = (root/"prefix/config.ini").read
     expect(written).to include("prefix = #{root}/prefix")
     expect(written).to include("cellar = #{HOMEBREW_PREFIX}")
+    expect(written).to include("legacy = example")
+    expect(written).to include("formula = example")
+    expect(written).to include("cask = example-cask")
     expect(written).to include("series = 1.2 (1.2.3)")
     expect(written).to include("literal = {{unknown}} {single}")
   end
@@ -226,6 +256,38 @@ RSpec.describe Homebrew::InstallSteps do
     Homebrew::InstallSteps::Runner.new(context:).run(steps)
 
     expect((root/"var/identity").read).to eq("example-formula:example-cask\n")
+  end
+
+  specify "writes exact content and replaces existing files" do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      write_file "config/example.conf", "replacement"
+      write_file "empty", ""
+    end
+
+    (root/"var/config").mkpath
+    (root/"var/config/example.conf").write "old\n"
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect([(root/"var/config/example.conf").read, (root/"var/empty").read]).to eq(["replacement", ""])
+  end
+
+  specify "preserves meaningful blank values" do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      inreplace "remove.txt", "remove", ""
+      run "helper", args: [""], env: { "EMPTY" => "" }
+    end
+
+    (root/"var").mkpath
+    (root/"var/remove.txt").write "remove"
+    command = class_double(SystemCommand)
+    expect(command).to receive(:run!)
+      .with("helper", args: [""], sudo: false, env: { "EMPTY" => "" }, input: [], print_stdout: false,
+                      print_stderr: true, reset_uid: true, chdir: nil)
+
+    Homebrew::InstallSteps::Runner.new(context:, command:).run(steps)
+
+    expect((root/"var/remove.txt").read).to be_empty
   end
 
   specify "writes a default config file and preserves existing ones", :aggregate_failures do
@@ -347,7 +409,7 @@ RSpec.describe Homebrew::InstallSteps do
       .to eq([false, "replacement", "original"])
   end
 
-  specify "keeps the shipped move replacement default" do
+  specify "preserves the legacy move replacement behaviour" do
     steps = Homebrew::InstallSteps::DSL.build(default_source_base: :staged_path, default_target_base: :var) do
       move "source.txt", "target.txt"
     end
@@ -356,9 +418,23 @@ RSpec.describe Homebrew::InstallSteps do
     (root/"stage/source.txt").write "replacement"
     (root/"var/target.txt").write "existing"
 
+    steps.fetch(0).delete("overwrite")
     Homebrew::InstallSteps::Runner.new(context:).run(steps)
 
     expect((root/"var/target.txt").read).to eq("replacement")
+  end
+
+  specify "preserves a default move destination when repeated", :aggregate_failures do
+    steps = Homebrew::InstallSteps::DSL.build(default_source_base: :staged_path, default_target_base: :var) do
+      move "source", "target"
+    end
+    (root/"stage/source").mkpath
+    (root/"stage/source/file").write "content"
+    runner = Homebrew::InstallSteps::Runner.new(context:)
+
+    runner.run(steps)
+    expect { runner.run(steps) }.to raise_error(Errno::ENOENT)
+    expect((root/"var/target/file").read).to eq("content")
   end
 
   specify "requires one match for single-source globs" do
@@ -409,7 +485,7 @@ RSpec.describe Homebrew::InstallSteps do
     expect(root/"var/obsolete-dir").not_to exist
   end
 
-  specify "filters removals by symlink target and file content", :aggregate_failures do
+  specify "filters removals and accepts the legacy path base", :aggregate_failures do
     ENV["PATH"] = (root/"path-bin").to_s
     steps = Homebrew::InstallSteps::DSL.build do
       remove "links/*", base: :staged_path, symlink_target_contains: "wanted"
@@ -581,18 +657,18 @@ RSpec.describe Homebrew::InstallSteps do
     expect((root/"var/has-newline").read).to eq("value\n")
   end
 
-  specify "raises when a write step has missing or blank content" do
+  specify "raises when a write step has missing content" do
     expect do
       Homebrew::InstallSteps::Runner.new(context:).run([{ "type" => "write", "path" => "config/new.conf" }])
-    end.to raise_error(ArgumentError, /non-empty content/)
+    end.to raise_error(ArgumentError, /requires content/)
   end
 
   specify "runs service data directory initialisers", :aggregate_failures do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
-      init_data_dir "postgresql@16", using: :postgresql_initdb
-      init_data_dir "postgresql@12", using: :postgresql_initdb, locale: "C"
-      init_data_dir "mysql", using: :mysql_initialize
-      init_data_dir "mysql", using: :mariadb_install_db
+      init_data_dir "postgresql@16", using: :postgresql
+      init_data_dir "postgresql@12", using: :postgresql, locale: "C"
+      init_data_dir "mysql", using: :mysql
+      init_data_dir "mysql", using: :mariadb
     end
 
     runner = Homebrew::InstallSteps::Runner.new(context:)
@@ -644,11 +720,11 @@ RSpec.describe Homebrew::InstallSteps do
     FileUtils.chmod "+x", root/"prefix/bin/pg_config"
 
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var, default_source_base: :prefix) do
-      link_dir "include/postgresql", "include/#{name}"
-      link_dir "lib/postgresql", "lib/#{name}"
-      link_dir "share/postgresql", "share/#{name}"
-      link_children "bin", suffix: "-#{version.major}"
-      init_data_dir name, using: :postgresql_initdb
+      symlink_tree "include/postgresql", "include/#{formula_name}"
+      symlink_tree "lib/postgresql", "lib/#{formula_name}"
+      symlink_tree "share/postgresql", "share/#{formula_name}"
+      symlink_children "bin", suffix: "-#{version.major}"
+      init_data_dir formula_name, using: :postgresql
     end
 
     runner = Homebrew::InstallSteps::Runner.new(context: versioned_context)
@@ -676,7 +752,7 @@ RSpec.describe Homebrew::InstallSteps do
 
   specify "skips data directory initialisers in CI", :aggregate_failures do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
-      init_data_dir "postgresql@16", using: :postgresql_initdb
+      init_data_dir "postgresql@16", using: :postgresql
     end
 
     ENV["HOMEBREW_GITHUB_ACTIONS"] = "1"
@@ -691,7 +767,7 @@ RSpec.describe Homebrew::InstallSteps do
 
   specify "skips data directory initialisers when their marker exists", :aggregate_failures do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
-      init_data_dir "mysql", using: :mysql_initialize
+      init_data_dir "mysql", using: :mysql
     end
 
     (root/"var/mysql/mysql").mkpath
@@ -721,7 +797,7 @@ RSpec.describe Homebrew::InstallSteps do
     steps = Homebrew::InstallSteps::DSL.build do
       compile_gsettings_schemas
       gio_querymodules
-      gdk_pixbuf_query_loaders
+      update_gdk_pixbuf_loaders_cache
       update_mime_database
       update_desktop_database
     end
@@ -1138,11 +1214,11 @@ RSpec.describe Homebrew::InstallSteps do
     expect(directory.stat.mode & 0200).to be_zero
   end
 
-  describe "runs gtk_update_icon_cache rebuild action" do
+  describe "runs update_gtk_icon_cache rebuild action" do
     let(:formula) { instance_double(Formula, opt_bin: root/"opt/bin") }
     let(:steps) do
       Homebrew::InstallSteps::DSL.build do
-        gtk_update_icon_cache
+        update_gtk_icon_cache
       end
     end
 
@@ -1167,7 +1243,7 @@ RSpec.describe Homebrew::InstallSteps do
 
   specify "deletes matching keychain certificates by SHA-256 hash" do
     steps = Homebrew::InstallSteps::DSL.build do
-      delete_keychain_certificate "Charles"
+      delete_keychain_certificates "Charles"
     end
 
     runner = Homebrew::InstallSteps::Runner.new(context:)
@@ -1190,7 +1266,7 @@ RSpec.describe Homebrew::InstallSteps do
     certificate.dirname.mkpath
     certificate.write "certificate"
     steps = Homebrew::InstallSteps::DSL.build do
-      delete_keychain_certificate "NodeMITMProxyCA", matching_certificate: certificate
+      delete_keychain_certificates "NodeMITMProxyCA", fingerprint_of: certificate
     end
 
     runner = Homebrew::InstallSteps::Runner.new(context:)
@@ -1212,7 +1288,7 @@ RSpec.describe Homebrew::InstallSteps do
   specify "skips keychain certificate deletion when a local certificate is missing" do
     certificate = root/"missing.pem"
     steps = Homebrew::InstallSteps::DSL.build do
-      delete_keychain_certificate "NodeMITMProxyCA", matching_certificate: certificate
+      delete_keychain_certificates "NodeMITMProxyCA", fingerprint_of: certificate
     end
 
     runner = Homebrew::InstallSteps::Runner.new(context:)
@@ -1333,7 +1409,7 @@ RSpec.describe Homebrew::InstallSteps do
 
   specify "removes symlinks marked for uninstall" do
     steps = Homebrew::InstallSteps::DSL.build(default_target_base: :staged_path) do
-      ln_sf "target", "linked-target", source_base: :relative, uninstall: true
+      symlink "target", "linked-target", source_base: :relative, overwrite: true, remove_on_uninstall: true
     end
 
     (root/"stage").mkpath

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           system "true"
-          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `write_file`, `delete_keychain_certificate`, `delete_keychain_certificates`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     CASK
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           update_desktop_database
-          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `write_file`, `delete_keychain_certificate`, `delete_keychain_certificates`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     CASK
@@ -66,6 +66,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
           inreplace "foo.conf", /@PREFIX@/, "{{HOMEBREW_PREFIX}}"
           ln_sf "source", "target", source_base: :relative, uninstall: true
           write "foo.conf", "key = value\n"
+          write_file "foo.json", "{}\n"
           set_permissions "Foo.app", "0755"
           set_ownership "Foo.app", user: "root", group: "wheel"
           run "foo", args: ["--repair"]
@@ -73,6 +74,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
           change_dylib_id "Foo.app/Contents/Frameworks/libfoo.dylib", "@rpath/libfoo.dylib"
           delete_keychain_certificate "Charles"
           delete_keychain_certificate "NodeMITMProxyCA", matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"
+          delete_keychain_certificates "Charles"
           on_macos do
             if_path_exists "Foo.app" do
               touch "Foo.app/scoped-state"
@@ -96,7 +98,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           touch "#{appdir}/state"
-                 ^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+                 ^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `write_file`, `delete_keychain_certificate`, `delete_keychain_certificates`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     CASK
@@ -111,7 +113,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
         preflight_steps do
           on_macos do
             system "true"
-            ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+            ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `write_file`, `delete_keychain_certificate`, `delete_keychain_certificates`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
           end
         end
       end
@@ -142,8 +144,8 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
         postflight_steps do
           mkdir_p "Prepared"
           touch "Prepared/touched"
-          mv "source", "target"
-          ln_s "target", "Linked", source_base: :relative
+          move "source", "target"
+          symlink "target", "Linked", source_base: :relative
         end
       end
     CASK
@@ -168,7 +170,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
         sha256 :no_check
 
         postflight_steps do
-          write "Prepared/foo.conf", "key = value\n", overwrite: true
+          write_file "Prepared/foo.conf", "key = value\n"
         end
       end
     CASK
@@ -235,17 +237,17 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
         sha256 :no_check
 
         preflight_steps do
-          delete_keychain_certificate "Charles"
+          delete_keychain_certificates "Charles"
         end
 
         postflight_steps do
-          delete_keychain_certificate "AutoFirma ROOT"
-          delete_keychain_certificate "127.0.0.1"
+          delete_keychain_certificates "AutoFirma ROOT"
+          delete_keychain_certificates "127.0.0.1"
         end
 
         uninstall_postflight_steps do
-          delete_keychain_certificate "NodeMITMProxyCA",
-                                      matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"
+          delete_keychain_certificates "NodeMITMProxyCA",
+                                       fingerprint_of: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"
         end
       end
     CASK

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `bootstrap_cpython`, `bootstrap_pypy`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `symlink_tree`, `symlink_children`, `write`, `write_file`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `update_gdk_pixbuf_loaders_cache`, `gtk_update_icon_cache`, `update_gtk_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `bootstrap_cpython`, `bootstrap_pypy`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY
@@ -81,10 +81,14 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           init_data_dir name, using: :postgresql_initdb
           link_dir "source", "#{name}"
           link_children "source", suffix: "-#{version.major}"
+          symlink_tree "source", "#{name}"
+          symlink_children "source", suffix: "-#{version.major}"
           compile_gsettings_schemas
           gio_querymodules
           gdk_pixbuf_query_loaders
+          update_gdk_pixbuf_loaders_cache
           gtk_update_icon_cache
+          update_gtk_icon_cache
           update_mime_database
           update_desktop_database
           on_macos do
@@ -110,7 +114,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         post_install_steps do
           on_macos do
             system "true"
-            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `bootstrap_cpython`, `bootstrap_pypy`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `symlink_tree`, `symlink_children`, `write`, `write_file`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `update_gdk_pixbuf_loaders_cache`, `gtk_update_icon_cache`, `update_gtk_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `bootstrap_cpython`, `bootstrap_pypy`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
           end
         end
       end
@@ -124,7 +128,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           write "foo.conf", "prefix = #{prefix}"
-                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `bootstrap_cpython`, `bootstrap_pypy`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `symlink_tree`, `symlink_children`, `write`, `write_file`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `update_gdk_pixbuf_loaders_cache`, `gtk_update_icon_cache`, `update_gtk_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `bootstrap_cpython`, `bootstrap_pypy`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY
@@ -152,8 +156,8 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         post_install_steps do
           mkdir_p "log/foo"
           touch "foo/state"
-          mv "move-source", "move-target"
-          ln_sf "move-target", "linked-target", source_base: :relative
+          move "move-source", "move-target"
+          symlink "move-target", "linked-target", source_base: :relative, overwrite: true
         end
       end
     RUBY
@@ -179,8 +183,8 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         url "https://brew.sh/foo-1.0.tgz"
 
         post_install_steps do
-          write "foo/foo.conf", "key = value\n", base: :etc, overwrite: true
-          write "foo/banner", <<~TEXT, overwrite: true
+          write_file "foo/foo.conf", "key = value\n", base: :etc
+          write_file "foo/banner", <<~TEXT
             literal banner
           TEXT
         end
@@ -222,8 +226,8 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           compile_gsettings_schemas
-          gdk_pixbuf_query_loaders
-          gtk_update_icon_cache
+          update_gdk_pixbuf_loaders_cache
+          update_gtk_icon_cache
           update_mime_database
           update_desktop_database
         end
@@ -286,11 +290,11 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         post_install_steps do
           touch "postgresql/state"
           mkdir_p "log"
-          link_dir "include/postgresql", "include/{{name}}"
-          link_dir "lib/postgresql", "lib/{{name}}"
-          link_dir "share/postgresql", "share/{{name}}"
-          link_children "bin", suffix: "-{{version.major}}"
-          init_data_dir name, using: :postgresql_initdb
+          symlink_tree "include/postgresql", "include/{{formula_name}}"
+          symlink_tree "lib/postgresql", "lib/{{formula_name}}"
+          symlink_tree "share/postgresql", "share/{{formula_name}}"
+          symlink_children "bin", suffix: "-{{version.major}}"
+          init_data_dir formula_name, using: :postgresql
         end
 
         def post_install
@@ -337,7 +341,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         url "https://brew.sh/foo-1.0.tgz"
 
         post_install_steps do
-          init_data_dir "mysql", using: :mysql_initialize
+          init_data_dir "mysql", using: :mysql
         end
 
         def post_install
@@ -377,7 +381,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         url "https://brew.sh/foo-1.0.tgz"
 
         post_install_steps do
-          init_data_dir "mysql", using: :mariadb_install_db
+          init_data_dir "mysql", using: :mariadb
         end
       end
     RUBY


### PR DESCRIPTION
Formula and cask migrations need one predictable vocabulary while the
install-step surface already released from `main` remains compatible.

- use canonical file, link, cache, certificate and service names
- align overwrite, removal, token and blank-value semantics
- retain shipped methods and values as commented compatibility aliases
- keep compatibility-only names out of public documentation

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.