### PR TITLE
Align install step autocorrections (20/24)

### DIFF
--- a/Library/Homebrew/rubocops/cask/install_steps.rb
+++ b/Library/Homebrew/rubocops/cask/install_steps.rb
@@ -60,13 +60,7 @@ module RuboCop
             next unless (flight_stanza = stanzas.find { |stanza| stanza.stanza_name == flight_block })
 
             steps_stanza = stanzas.find { |stanza| stanza.stanza_name == steps_block }
-
-            if steps_stanza
-              add_offense(steps_stanza.source_range,
-                          message: "`#{flight_stanza.stanza_name}` and `#{steps_block}` cannot both be used.")
-            else
-              audit_flight_block(flight_stanza, steps_block)
-            end
+            audit_flight_block(flight_stanza, steps_block) if steps_stanza.nil?
           end
 
           stanzas.each do |stanza|

--- a/Library/Homebrew/rubocops/install_steps.rb
+++ b/Library/Homebrew/rubocops/install_steps.rb
@@ -292,7 +292,7 @@ module RuboCop
                       source_formula: "ca-certificates",
                       source_base: :formula_pkgetc,
                       target_base: :pkgetc,
-                      force: true
+                      overwrite: true
             RUBY
           end
         end

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -5,7 +5,8 @@ module RuboCop
   module Cop
     module InstallStepsHelper
       FILE_PREPARATION_STEP_METHODS =
-        [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :move_contents, :copy, :remove, :inreplace, :symlink,
+        [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :move_contents, :copy, :remove, :inreplace,
+         :symlink,
          :ln_s, :ln_sf].freeze
       LINK_STEP_METHODS = [:link_dir, :link_children, :symlink_tree, :symlink_children].freeze
       CONFIG_WRITE_STEP_METHODS = [:write, :write_file].freeze
@@ -23,6 +24,10 @@ module RuboCop
         [:configure_gcc_runtime, :install_gzipped_executable, :configure_glibc_runtime,
          :configure_clang_system, :configure_php, :bootstrap_cpython, :bootstrap_pypy].freeze
       STEP_SCOPE_METHODS = [:if_path_exists, :unless_path_exists, :on_macos, :on_linux].freeze
+      # odeprecated
+      COMPATIBILITY_STEP_METHODS =
+        [:mkdir, :mv, :move_children, :ln_s, :ln_sf, :link_dir, :link_children, :write, :gio_querymodules,
+         :gdk_pixbuf_query_loaders, :gtk_update_icon_cache, :delete_keychain_certificate].freeze
       ALLOWED_STEP_METHODS = T.let(
         [*FILE_PREPARATION_STEP_METHODS, *LINK_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *SERVICE_DATA_STEP_METHODS,
          *REBUILD_ACTION_STEP_METHODS, :set_permissions, *COMMAND_STEP_METHODS, *NOTICE_STEP_METHODS,
@@ -41,8 +46,8 @@ module RuboCop
                                           :sym].freeze
 
       STEP_BLOCK_MSG = T.let(
-        "Steps blocks may only contain install step DSL calls: " \
-        "#{ALLOWED_STEP_METHODS.map { |method| "`#{method}`" }.join(", ")}.".freeze,
+        "Steps blocks may only contain install step DSL calls. Prefer canonical calls: " \
+        "#{(ALLOWED_STEP_METHODS - COMPATIBILITY_STEP_METHODS).map { |method| "`#{method}`" }.join(", ")}.".freeze,
         String,
       )
       SIMPLE_STEP_CONVERSION_MSG = "Use `%<steps_block>s` for simple file preparation."
@@ -79,8 +84,8 @@ module RuboCop
 
       sig { params(allowed_methods: T::Array[Symbol]).returns(String) }
       def step_block_msg(allowed_methods)
-        "Steps blocks may only contain install step DSL calls: " \
-          "#{allowed_methods.map { |method| "`#{method}`" }.join(", ")}."
+        "Steps blocks may only contain install step DSL calls. Prefer canonical calls: " \
+          "#{(allowed_methods - COMPATIBILITY_STEP_METHODS).map { |method| "`#{method}`" }.join(", ")}."
       end
 
       class InstallStepPath < T::Struct
@@ -274,7 +279,7 @@ module RuboCop
 
         if send_node.method_name == :mkpath && send_node.arguments.empty? && send_node.receiver
           path = install_step_path(send_node.receiver)
-          return mkdir_step_line(:mkdir_p, path, default_base)
+          return mkdir_step_line(path, default_base)
         end
 
         if [:write, :atomic_write].include?(send_node.method_name)
@@ -308,7 +313,7 @@ module RuboCop
         when :mkdir, :mkdir_p
           return if send_node.arguments.length != 1
 
-          mkdir_step_line(send_node.method_name, install_step_path(send_node.arguments.first), default_base)
+          mkdir_step_line(install_step_path(send_node.arguments.first), default_base)
         when :touch
           return if send_node.arguments.length != 1
 
@@ -322,7 +327,7 @@ module RuboCop
         when :ln_s, :ln_sf
           return if send_node.arguments.length != 2
 
-          symlink_step_line(send_node.method_name,
+          symlink_step_line(send_node.method_name == :ln_sf,
                             install_step_path(send_node.arguments.fetch(0)),
                             install_step_path(send_node.arguments.fetch(1)),
                             default_source_base, default_target_base)
@@ -331,15 +336,14 @@ module RuboCop
 
       sig {
         params(
-          method_name:  Symbol,
           path:         T.nilable(InstallStepPath),
           default_base: Symbol,
         ).returns(T.nilable(String))
       }
-      def mkdir_step_line(method_name, path, default_base)
+      def mkdir_step_line(path, default_base)
         return if path.nil? || relative_install_step_path?(path)
 
-        "mkdir#{"_p" if method_name == :mkdir_p} #{install_step_path_source(path)}" \
+        "mkdir_p #{install_step_path_source(path)}" \
           "#{install_step_path_keywords(path, base: default_base, keyword: :base)}"
       end
 
@@ -377,14 +381,14 @@ module RuboCop
 
       sig {
         params(
-          method_name:         Symbol,
+          overwrite:           T::Boolean,
           source:              T.nilable(InstallStepPath),
           target:              T.nilable(InstallStepPath),
           default_source_base: Symbol,
           default_target_base: Symbol,
         ).returns(T.nilable(String))
       }
-      def symlink_step_line(method_name, source, target, default_source_base, default_target_base)
+      def symlink_step_line(overwrite, source, target, default_source_base, default_target_base)
         return if source.nil? || target.nil?
         return if relative_install_step_path?(target)
 
@@ -396,7 +400,7 @@ module RuboCop
         kwargs = [
           source_keyword,
           install_step_path_keyword(target, base: default_target_base, keyword: :target_base),
-          ("overwrite: true" if method_name == :ln_sf),
+          ("overwrite: true" if overwrite),
         ].compact
         "symlink #{install_step_path_source(source)}, #{install_step_path_source(target)}" \
           "#{install_step_kwargs(kwargs)}"
@@ -412,7 +416,9 @@ module RuboCop
       def write_step_line(path, content_node, default_base)
         return if path.nil? || relative_install_step_path?(path)
 
-        kwargs = [install_step_path_keyword(path, base: default_base, keyword: :base)].compact
+        kwargs = [
+          install_step_path_keyword(path, base: default_base, keyword: :base),
+        ].compact
         return unless (content_source = write_content_source(content_node, kwargs))
 
         "write_file #{install_step_path_source(path)}, #{content_source}"
@@ -421,8 +427,6 @@ module RuboCop
       sig { params(content_node: RuboCop::AST::Node, kwargs: T::Array[String]).returns(T.nilable(String)) }
       def write_content_source(content_node, kwargs)
         return unless content_node.str_type?
-        return unless T.cast(content_node, RuboCop::AST::StrNode).str_content.end_with?("\n")
-
         unless content_node.loc.respond_to?(:heredoc_end)
           return "#{content_node.source}#{install_step_kwargs(kwargs)}"
         end

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -213,6 +213,27 @@ RSpec.describe Homebrew::InstallSteps do
     expect(steps.fetch(7)).to include("using" => "postgresql_initdb")
   end
 
+  specify "keeps shipped step names serialisable for compatibility" do
+    steps = Homebrew::InstallSteps::DSL.build do
+      mkdir "directory"
+      mv "source", "target"
+      move_children "source", "target"
+      ln_sf "source", "target"
+      link_dir "source", "target"
+      link_children "source", "target"
+      write "config", "content"
+      gio_querymodules
+      gdk_pixbuf_query_loaders
+      gtk_update_icon_cache
+      delete_keychain_certificate "Example"
+    end
+
+    expect(steps.map { |step| step.fetch("type") }).to eq(%w[
+      mkdir move move_children symlink link_dir link_children write gio_querymodules
+      gdk_pixbuf_query_loaders gtk_update_icon_cache delete_keychain_certificate
+    ])
+  end
+
   specify "expands a scoped set of content tokens and leaves others verbatim", :aggregate_failures do
     root_path = root
     versioned_context = Class.new do

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -4,18 +4,17 @@
 require "rubocops/rubocop-cask"
 
 RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
-  it "reports an offense when a flight block and matching steps are both present" do
-    expect_offense <<~CASK
+  it "allows a flight block after matching steps during migration" do
+    expect_no_offenses <<~CASK
       cask "foo" do
         version :latest
         sha256 :no_check
 
-        postflight do
+        postflight_steps do
           touch "foo"
         end
 
-        postflight_steps do
-        ^^^^^^^^^^^^^^^^^^^ `postflight` and `postflight_steps` cannot both be used.
+        postflight do
           touch "foo"
         end
       end
@@ -30,7 +29,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           system "true"
-          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `write_file`, `delete_keychain_certificate`, `delete_keychain_certificates`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls. Prefer canonical calls: `mkdir_p`, `touch`, `move`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `write_file`, `delete_keychain_certificates`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     CASK
@@ -44,7 +43,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           update_desktop_database
-          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `write_file`, `delete_keychain_certificate`, `delete_keychain_certificates`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls. Prefer canonical calls: `mkdir_p`, `touch`, `move`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `write_file`, `delete_keychain_certificates`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     CASK
@@ -60,29 +59,28 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
           mkdir_p "foo"
           touch "foo/state"
           touch "#{token}/state"
+          move "source", "target"
           mv "source", "target"
           move_children "source", "target"
           move_contents "source", "target"
-          inreplace "foo.conf", /@PREFIX@/, "{{HOMEBREW_PREFIX}}"
-          ln_sf "source", "target", source_base: :relative, uninstall: true
-          write "foo.conf", "key = value\n"
-          write_file "foo.json", "{}\n"
+          inreplace "foo.conf", "@PREFIX@", "{{HOMEBREW_PREFIX}}"
+          symlink "source", "target", source_base: :relative, overwrite: true, remove_on_uninstall: true
+          write_file "foo.conf", "key = value\n"
           set_permissions "Foo.app", "0755"
           set_ownership "Foo.app", user: "root", group: "wheel"
           run "foo", args: ["--repair"]
           terminate_process "foo", attempts: 3
           change_dylib_id "Foo.app/Contents/Frameworks/libfoo.dylib", "@rpath/libfoo.dylib"
-          delete_keychain_certificate "Charles"
-          delete_keychain_certificate "NodeMITMProxyCA", matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"
           delete_keychain_certificates "Charles"
+          delete_keychain_certificates "NodeMITMProxyCA", fingerprint_of: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"
           on_macos do
             if_path_exists "Foo.app" do
-              touch "Foo.app/scoped-state"
+              touch "Foo.app/marker"
             end
           end
           on_linux do
             unless_path_exists "foo.conf" do
-              write "foo.conf", "key = value\n"
+              write_file "foo.conf", "key = value\n"
             end
           end
         end
@@ -98,7 +96,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           touch "#{appdir}/state"
-                 ^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `write_file`, `delete_keychain_certificate`, `delete_keychain_certificates`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+                 ^^^^^^^^^ Steps blocks may only contain install step DSL calls. Prefer canonical calls: `mkdir_p`, `touch`, `move`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `write_file`, `delete_keychain_certificates`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     CASK
@@ -113,7 +111,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
         preflight_steps do
           on_macos do
             system "true"
-            ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `write_file`, `delete_keychain_certificate`, `delete_keychain_certificates`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+            ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls. Prefer canonical calls: `mkdir_p`, `touch`, `move`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `write_file`, `delete_keychain_certificates`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `change_dylib_id`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
           end
         end
       end
@@ -320,7 +318,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
         sha256 :no_check
 
         uninstall_postflight_steps do
-          delete_keychain_certificate "Charles"
+          delete_keychain_certificates "Charles"
           set_permissions "Foo.app", "0755"
           set_ownership "Foo.app", user: "root", group: "wheel"
         end
@@ -429,14 +427,26 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
     CASK
   end
 
-  it "does not autocorrect config writes without trailing newlines" do
-    expect_no_offenses <<~CASK
+  it "autocorrects config writes without trailing newlines" do
+    expect_offense <<~CASK
       cask "foo" do
         version :latest
         sha256 :no_check
 
         postflight do
+        ^^^^^^^^^^^^^ Use `postflight_steps` for simple file preparation.
           File.write staged_path/"Prepared/foo.conf", "key = value"
+        end
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        postflight_steps do
+          write_file "Prepared/foo.conf", "key = value"
         end
       end
     CASK

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `symlink_tree`, `symlink_children`, `write`, `write_file`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `update_gdk_pixbuf_loaders_cache`, `gtk_update_icon_cache`, `update_gtk_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `bootstrap_cpython`, `bootstrap_pypy`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls. Prefer canonical calls: `mkdir_p`, `touch`, `move`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `symlink_tree`, `symlink_children`, `write_file`, `init_data_dir`, `compile_gsettings_schemas`, `update_gdk_pixbuf_loaders_cache`, `update_gtk_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `bootstrap_cpython`, `bootstrap_pypy`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY
@@ -56,18 +56,19 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           mkdir_p "foo"
           touch "foo/state"
           touch "foo/#{formula_name}"
-          mv "source", "target"
-          move_children "source", "target"
+          move "source", "target"
           move_contents "source", "target"
-          inreplace "foo.conf", /@PREFIX@/, "{{HOMEBREW_PREFIX}}"
-          ln_sf "source", "target", source_base: :relative, uninstall: true
-          write "foo.conf", "key = value\n", base: :etc
-          write "foo/adjacent", "first" "second"
+          inreplace "foo.conf", %r{{{HOMEBREW_CELLAR}}/foo/[^/]+}, "{{opt_prefix}}", audit_result: false
+          symlink "source", "target", source_base: :relative, overwrite: true, remove_on_uninstall: true
+          write_file "foo.conf", "key = value\n", base: :etc
+          write_file "foo/adjacent", "first" "second"
           set_permissions "foo", "0755"
           run "foo", args: ["--repair"]
           terminate_process "foo", attempts: 3
           change_dylib_id "lib/libfoo.dylib", "{{opt_prefix}}/lib/libfoo.1.dylib", resolve_source: true
-          warn "foo exists"
+          if_path_exists "foo" do
+            warn "foo exists"
+          end
           configure_gcc_runtime
           install_gzipped_executable "compressed.gz", "bin/executable"
           configure_glibc_runtime
@@ -75,19 +76,16 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           configure_php
           bootstrap_cpython
           bootstrap_pypy abi_version: "3.10"
-          write "foo/banner", <<~TEXT
+          write_file "foo/banner", <<~TEXT
             literal banner
           TEXT
-          init_data_dir name, using: :postgresql_initdb
-          link_dir "source", "#{name}"
-          link_children "source", suffix: "-#{version.major}"
-          symlink_tree "source", "#{name}"
+          init_data_dir formula_name, using: :postgresql
+          symlink_tree "source", "#{formula_name}"
           symlink_children "source", suffix: "-#{version.major}"
           compile_gsettings_schemas
           gio_querymodules
           gdk_pixbuf_query_loaders
           update_gdk_pixbuf_loaders_cache
-          gtk_update_icon_cache
           update_gtk_icon_cache
           update_mime_database
           update_desktop_database
@@ -98,7 +96,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           end
           on_linux do
             unless_path_exists "foo.conf", base: :etc do
-              write "foo.conf", "key = value\n", base: :etc
+              write_file "foo.conf", "key = value\n", base: :etc
             end
           end
         end
@@ -114,21 +112,21 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         post_install_steps do
           on_macos do
             system "true"
-            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `symlink_tree`, `symlink_children`, `write`, `write_file`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `update_gdk_pixbuf_loaders_cache`, `gtk_update_icon_cache`, `update_gtk_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `bootstrap_cpython`, `bootstrap_pypy`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls. Prefer canonical calls: `mkdir_p`, `touch`, `move`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `symlink_tree`, `symlink_children`, `write_file`, `init_data_dir`, `compile_gsettings_schemas`, `update_gdk_pixbuf_loaders_cache`, `update_gtk_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `bootstrap_cpython`, `bootstrap_pypy`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
           end
         end
       end
     RUBY
   end
 
-  it "reports an offense when write content is interpolated" do
+  it "reports an offense when write_file content is interpolated" do
     expect_offense(<<~'RUBY')
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
 
         post_install_steps do
-          write "foo.conf", "prefix = #{prefix}"
-                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `symlink_tree`, `symlink_children`, `write`, `write_file`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `update_gdk_pixbuf_loaders_cache`, `gtk_update_icon_cache`, `update_gtk_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `bootstrap_cpython`, `bootstrap_pypy`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          write_file "foo.conf", "prefix = #{prefix}"
+                                           ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls. Prefer canonical calls: `mkdir_p`, `touch`, `move`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `symlink_tree`, `symlink_children`, `write_file`, `init_data_dir`, `compile_gsettings_schemas`, `update_gdk_pixbuf_loaders_cache`, `update_gtk_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `change_dylib_id`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `configure_clang_system`, `configure_php`, `bootstrap_cpython`, `bootstrap_pypy`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY
@@ -192,13 +190,24 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
     RUBY
   end
 
-  it "does not autocorrect config writes without trailing newlines" do
-    expect_no_offenses(<<~RUBY)
+  it "autocorrects config writes without trailing newlines" do
+    expect_offense(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
 
         def post_install
+        ^^^^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Use `post_install_steps` for simple file preparation.
           (var/"foo.conf").write "key = value"
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        post_install_steps do
+          write_file "foo.conf", "key = value"
         end
       end
     RUBY
@@ -449,14 +458,14 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         url "https://brew.sh/foo-1.0.tgz"
 
         post_install_steps do
-          link_dir "include/postgresql", "include/{{name}}"
-          link_children "bin", suffix: "-{{version.major}}"
-          init_data_dir name, using: :postgresql_initdb
+          symlink_tree "include/postgresql", "include/{{formula_name}}"
+          symlink_children "bin", suffix: "-{{version.major}}"
+          init_data_dir formula_name, using: :postgresql
           symlink "cert.pem", "cert.pem",
                   source_formula: "ca-certificates",
                   source_base:    :formula_pkgetc,
                   target_base:    :pkgetc,
-                  force:          true
+                  overwrite:      true
         end
       end
     RUBY
@@ -485,7 +494,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
                   source_formula: "ca-certificates",
                   source_base: :formula_pkgetc,
                   target_base: :pkgetc,
-                  force: true
+                  overwrite: true
         end
 
         def post_install

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-install-steps.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-install-steps.rb
@@ -19,17 +19,17 @@ cask "with-install-steps" do
   end
 
   postflight_steps do
-    mv "move-source", "Prepared/moved"
-    ln_s "Prepared/moved", "PreparedLink", source_base: :relative, uninstall: true
+    move "move-source", "Prepared/moved"
+    symlink "Prepared/moved", "PreparedLink", source_base: :relative, remove_on_uninstall: true
   end
 
   uninstall_preflight_steps do
-    mkdir "UninstallPrepared"
+    mkdir_p "UninstallPrepared"
     set_ownership "UninstallPrepared", user: "root", group: "wheel"
     touch "UninstallPrepared/touched"
   end
 
   uninstall_postflight_steps do
-    move_children "UninstallPrepared", "UninstallMoved"
+    move_contents "UninstallPrepared", "UninstallMoved"
   end
 end

--- a/Library/Homebrew/test/support/fixtures/formulae/install-steps.rb
+++ b/Library/Homebrew/test/support/fixtures/formulae/install-steps.rb
@@ -11,9 +11,9 @@ class InstallSteps < Formula
   post_install_steps do
     mkdir_p "log/install-steps"
     touch "install-steps/state"
-    mv "move-source", "move-target"
-    move_children "move-children-source", "move-children-target"
-    ln_sf "move-target", "linked-target", source_base: :relative, uninstall: true
-    init_data_dir "lib/install-steps", using: :postgresql_initdb
+    move "move-source", "move-target"
+    move_contents "move-children-source", "move-children-target"
+    symlink "move-target", "linked-target", source_base: :relative, overwrite: true, remove_on_uninstall: true
+    init_data_dir "lib/install-steps", using: :postgresql
   end
 end


### PR DESCRIPTION
Mechanical migrations should emit the canonical shared interface without
rejecting released compatibility names.

- emit canonical file, link, cache and service step names
- validate nested guards and regular-expression option nodes
- retain compatibility aliases during literal-block validation
- permit matching cask flight blocks during the migration bridge

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.