### PR TITLE
Document canonical install steps (21/24)

### DIFF
--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -157,7 +157,7 @@ The `appimage` stanza is Linux-only, macOS integration stanzas such as `app` and
 | [`app`](#stanza-app)                                                                   |              yes              | Relative path to an `.app` that should be moved into the `/Applications` folder on installation.                                                                                                                                                                                                                                                                           |
 | `appimage`                                                                             |              yes              | Relative path to an AppImage that should be linked into the configured AppImage directory on installation.                                                                                                                                                                                                                                                                 |
 | [`pkg`](#stanza-pkg)                                                                   |              yes              | Relative path to a `.pkg` file containing the distribution.                                                                                                                                                                                                                                                                                                                |
-| [`generated_script`](#stanza-generated_script)                                         |              yes              | Generates an executable for another artifact or install step to use.                                                                                                                                                                                                                                                                                                       |
+| [`generated_script`](#stanza-generated_script)                                         |              yes              | Generates a script for another artifact or install step to use.                                                                                                                                                                                                                                                                                                       |
 | [`installer`](#stanza-installer)                                                       |              yes              | Describes an executable which must be run to complete the installation.                                                                                                                                                                                                                                                                                                    |
 | [`binary`](#stanza-binary)                                                             |              yes              | Relative path to a Binary that should be linked into the `$(brew --prefix)/bin` folder on installation.                                                                                                                                                                                                                                                                    |
 | [`command_wrapper`](#stanza-command_wrapper)                                           |              yes              | Generates a command wrapper and links it into the `$(brew --prefix)/bin` folder.                                                                                                                                                                                                                                                                                           |
@@ -315,7 +315,7 @@ Use `content:` instead of `executable:` for wrappers which need custom shell log
 
 ### Stanza: `generated_script`
 
-`generated_script` writes literal content to an executable path in the staged cask. It does not link or run the file. Use it when a later `installer`, `uninstall` or install step needs a generated script.
+`generated_script` writes literal content to a script in the staged cask and makes it executable. It does not link or run the file. Use it when a later `installer`, `uninstall` or install step needs a generated script.
 
 ```ruby
 generated_script "installer.sh", content: <<~SH
@@ -626,50 +626,48 @@ preflight_steps do
 end
 
 postflight_steps do
-  mv "payload", "Shared/payload"
-  ln_s "Shared/payload", "Payload", source_base: :relative
+  move "payload", "Shared/payload"
+  symlink "Shared/payload", "Payload", source_base: :relative
   set_permissions "Shared/payload", "0755"
 end
 
 uninstall_postflight_steps do
-  delete_keychain_certificate "Charles"
-  delete_keychain_certificate "NodeMITMProxyCA",
-                              matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"
+  delete_keychain_certificates "Charles"
+  delete_keychain_certificates "NodeMITMProxyCA",
+                               fingerprint_of: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"
 end
 ```
 
-A steps block may only contain supported step calls with literal arguments; it cannot call the wider cask DSL or arbitrary Ruby code. Each phase may define either its Ruby flight block or its matching steps block, not both.
+A steps block may only contain supported step calls with literal arguments; it cannot call the wider cask DSL or arbitrary Ruby code. During migration, a phase may define both forms. Its structured steps run before the matching Ruby flight block. Remove the Ruby block once all of its behaviour is represented by structured steps.
 
 #### File preparation steps
 
-Relative paths default to `staged_path` for `base:`, `source_base:` and `target_base:`. Symlink steps can use `uninstall: true` to remove the symlink during uninstall.
+Relative paths default to `staged_path` for `base:`, `source_base:` and `target_base:`. Symlink steps can use `remove_on_uninstall: true` to remove the symlink during uninstall.
 
 {% raw %}
 
-* `mkdir`: create one directory; example: `mkdir "Shared"`.
 * `mkdir_p`: create a directory and any missing parents; example: `mkdir_p "Shared"`.
 * `touch`: create or update a file timestamp; example: `touch "Shared/state"`.
 * `move`: move one file or directory; example: `move "payload", "Shared/payload"`.
-* `mv`: alias for `move`; example: `mv "payload", "Shared/payload"`.
-* `move_children`: move the contents of one directory into another; example: `move_children "payload", "Shared/payload"`.
+* `move_contents`: move the contents of one directory into another; example: `move_contents "payload", "Shared/payload"`.
 * `copy`: copy a file or, with `recursive: true`, a directory; example: `copy "payload", "Shared/payload"`.
 * `remove`: remove one or more paths; example: `remove ["Shared/old", "Shared/*.bak"], recursive: true`.
-* `inreplace`: replace text in a file; example: `inreplace "Shared/foo.conf", "@PREFIX@", "{{HOMEBREW_PREFIX}}"`. Pass a regular expression as `before` for pattern matching.
+* `inreplace`: replace a string or regular expression in a file; example: `inreplace "Shared/foo.conf", "@PREFIX@", "{{HOMEBREW_PREFIX}}"`.
 * `symlink`: create a symlink; example: `symlink "Shared/payload", "Payload", source_base: :relative`.
-* `ln_s`: alias for `symlink`; example: `ln_s "Shared/payload", "Payload", source_base: :relative`.
-* `ln_sf`: create or replace a symlink; example: `ln_sf "Shared/payload", "Payload", source_base: :relative, uninstall: true`.
-* `write`: write literal content to a file unless it already exists; example: `write "Shared/foo.conf", "key = value"`. Pass `overwrite: true` to always replace the file. A trailing newline is appended unless the content already ends with one.
-* `delete_keychain_certificate`: delete macOS keychain certificates whose common name matches the argument; example: `delete_keychain_certificate "Charles"`. Pass `matching_certificate:` with a local certificate path to delete only the matching SHA-256 fingerprint; example:
-  `delete_keychain_certificate "NodeMITMProxyCA", matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"`.
+* `write_file`: atomically write exact literal content, replacing an existing file; example: `write_file "Shared/foo.conf", "key = value\n"`.
+* `delete_keychain_certificates`: delete macOS keychain certificates whose common name matches the argument; example: `delete_keychain_certificates "Charles"`. Pass `fingerprint_of:` with a local certificate path to delete only the matching SHA-256 fingerprint; example:
+  `delete_keychain_certificates "NodeMITMProxyCA", fingerprint_of: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"`.
 * `set_permissions`: recursively change existing path permissions with `chmod`; example: `set_permissions "Shared/payload", "0755"`.
 * `set_ownership`: recursively change existing path ownership with `sudo chown`; example: `set_ownership "Shared/payload", user: "root", group: "wheel"`. Missing paths are ignored. When `user:` is omitted, the current user is used. When `group:` is omitted, `staff` is used.
 * `run`: run one executable with literal arguments; example: `run "Example.app/Contents/MacOS/helper", args: ["--repair"], base: :appdir`.
-* `terminate_process`: terminate a process by name; example: `terminate_process "Example", attempts: 3, must_succeed: false`. `attempts:` sets the total number of attempts and defaults to one. The step also supports `match: :full`, `notices:` shown before the first attempt and a `failure_message:` warning.
+* `terminate_process`: terminate a process by name; example: `terminate_process "Example"`. It supports `match: :full`, a total `attempts:` count, `notices:` shown before the first attempt and a `failure_message:` warning. Failure is ignored by default; pass `must_succeed: true` when it should abort.
 * `change_dylib_id`: change one Mach-O dynamic library ID; pass the complete source and new ID, use `resolve_source: true` for a source symlink and wrap the step in `on_macos`.
 
-Use `if_path_exists` and `unless_path_exists` blocks to guard one or more steps by a path, and `on_macos` and `on_linux` blocks for platform-specific steps. Each guard is evaluated once for its whole block. `copy`, `move` and symlink steps accept `source_glob: true`; path collections used by `remove`, `set_permissions` and `set_ownership` expand globs automatically. Symlink removal can additionally match the serialised source during uninstall, while `remove` can restrict removal with `symlink_target_contains:` or `content_contains:`.
+`move` and `copy` replace an existing target by default, matching the corresponding file helpers; pass `overwrite: false` to reject replacement. `symlink` preserves an existing target by default, so pass `overwrite: true` when replacement is intentional. `copy`, `move` and symlink steps accept `source_glob: true`; path collections used by `remove`, `set_permissions` and `set_ownership` expand globs automatically. Symlink removal matches the serialised source during uninstall, while `remove` can restrict removal with `symlink_target_contains:` or `content_contains:` and accepts `sudo: true` or `sudo: :if_needed`.
 
-`run` does not evaluate a shell command string. It supports a literal `env:`, `stdin_path:`, `stdout_path:`, `chdir:`, `sudo:`, `print_stdout:` and `print_stderr:`. Wrap it in one of the guard blocks described above when it should be conditional.
+Use `if_path_exists`, `unless_path_exists`, `on_macos` and `on_linux` blocks to guard one or more steps. A condition is evaluated once when its scope begins, so related steps make the same decision. Use `unless_path_exists` around `write_file` when an existing file must be preserved.
+
+`run` does not evaluate a shell command string. It supports a literal `env:`, `stdin_path:`, `stdout_path:`, `chdir:` and `sudo:`. Standard output is hidden by default and standard error is printed; use `print_stdout: true` or `print_stderr: false` to change that behaviour.
 
 #### Interpolation in steps blocks
 
@@ -679,7 +677,7 @@ Ruby `#{...}` interpolation is normally evaluated before structured steps are se
 
 The runtime steps DSL retains compatibility helpers for `token`, `name`, `version`, `version.major` and `version.major_minor`. Interpolating these helpers is safe and permitted by RuboCop because they return the corresponding `{{...}}` token text rather than a concrete value. Other Ruby interpolation is rejected. Prefer explicit `{{...}}` tokens in new steps so it is clear that expansion is deferred until installation.
 
-Content, replacements, command arguments and command environments may use fixed install-time tokens. These include `{{HOMEBREW_BREW_FILE}}`, `{{HOMEBREW_CELLAR}}`, `{{HOMEBREW_PREFIX}}`, `{{name}}`, `{{user}}`, `{{staged_path}}`, `{{appdir}}`, `{{caskroom_path}}`, `{{temp}}`, `{{version}}`, `{{version.major}}` and `{{version.major_minor}}`. Any other `{{...}}` is left verbatim. For example: `write "settings.conf", "application = {{appdir}}/Example.app"`.
+Content, replacements, command arguments and command environments may use fixed install-time tokens. These include `{{HOMEBREW_BREW_FILE}}`, `{{HOMEBREW_CELLAR}}`, `{{HOMEBREW_PREFIX}}`, `{{token}}`, `{{name}}`, `{{user}}`, `{{staged_path}}`, `{{appdir}}`, `{{caskroom_path}}`, `{{temp}}`, `{{version}}`, `{{version.major}}` and `{{version.major_minor}}`. `{{name}}` is retained for compatibility; prefer `{{token}}`. Any other `{{...}}` is left verbatim. For example: `write_file "settings.conf", "application = {{appdir}}/Example.app"`.
 
 {% endraw %}
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1077,8 +1077,8 @@ class Foo < Formula
   post_install_steps do
     mkdir_p "log/foo"
     touch "foo/state"
-    mv "default.conf", "foo/default.conf"
-    ln_s "cert.pem", "foo/cert.pem", source_base: :relative
+    move "default.conf", "foo/default.conf"
+    symlink "cert.pem", "foo/cert.pem", source_base: :relative
   end
   # ...
 end
@@ -1091,33 +1091,41 @@ represented by structured steps.
 
 #### File preparation steps
 
-`mkdir`, `mkdir_p` and `touch` default to paths relative to `var`. Other file steps default their source and target paths to `prefix`. Use `base:`, `source_base:` or `target_base:` when a step needs another formula path such as `pkgetc`; use `source_base: :relative` for relative symlink sources.
+`mkdir_p`, `touch`, `remove`, `inreplace`, `write_file`, `set_permissions` and guard paths default to paths relative to `var`. File steps with separate sources and targets default both to `prefix`. Use `base:`, `source_base:` or `target_base:` when a step needs another formula path such as `pkgetc`; use `source_base: :relative` for relative symlink sources.
 
-* `mkdir`: create one directory; example: `mkdir "log/foo"`.
 * `mkdir_p`: create a directory and any missing parents; example: `mkdir_p "log/foo"`.
 * `touch`: create or update a file timestamp; example: `touch "foo/state"`.
 * `move`: move one file or directory; example: `move "default.conf", "foo/default.conf"`.
-* `mv`: alias for `move`; example: `mv "default.conf", "foo/default.conf"`.
-* `move_children`: move the contents of one directory into another; example: `move_children "defaults", "foo/defaults"`.
+* `move_contents`: move the contents of one directory into another; example: `move_contents "defaults", "foo/defaults"`.
 * `copy`: copy a file or, with `recursive: true`, a directory; example: `copy "default.conf", "foo/default.conf"`.
 * `remove`: remove one or more paths; example: `remove ["old.conf", "foo/*.bak"]`. Use `recursive: true` for directories.
-* `inreplace`: replace text in a file; example: `inreplace "foo.conf", "@PREFIX@", "{{HOMEBREW_PREFIX}}"`. Pass a regular expression as `before` for pattern matching.
+* `inreplace`: replace a string or regular expression in a file; example: `inreplace "foo.conf", "@PREFIX@", "{{HOMEBREW_PREFIX}}"`. Its `audit_result:` and `global:` options match the formula `inreplace` helper.
 * `symlink`: create a symlink; example: `symlink "cert.pem", "foo/cert.pem", source_base: :relative`.
-* `ln_s`: alias for `symlink`; example: `ln_s "cert.pem", "foo/cert.pem", source_base: :relative`.
-* `ln_sf`: create or replace a symlink; example: `ln_sf "cert.pem", "foo/cert.pem", source_base: :relative`.
+* `symlink_tree`: recursively symlink a directory's contents while preserving real target directories.
+* `symlink_children`: symlink each direct child of a directory, optionally adding a `prefix:` or `suffix:`.
 * `set_permissions`: change existing path permissions; example: `set_permissions "foo", "0755"`.
 * `change_dylib_id`: change one Mach-O dynamic library ID; pass the complete source and new ID, use `resolve_source: true` for a source symlink and wrap the step in `on_macos`.
 
-Use `if_path_exists` and `unless_path_exists` blocks to guard one or more steps by a path, and `on_macos` and `on_linux` blocks for platform-specific steps. Each guard is evaluated once for its whole block. `copy`, `move` and symlink steps accept `source_glob: true`; path collections used by `remove` and `set_permissions` expand globs automatically. Removals may additionally be restricted with `symlink_target_contains:` or `content_contains:`.
+`move` and `copy` replace an existing target by default, matching the corresponding file helpers; pass `overwrite: false` to reject replacement. `symlink` preserves an existing target by default, so pass `overwrite: true` when replacement is intentional. `move` and `copy` accept `source_glob: true` when the glob must resolve to exactly one source; `symlink` accepts one or more matching sources. Path collections used by `remove` and `set_permissions` expand globs automatically. `remove` ignores missing paths and may additionally be restricted with `symlink_target_contains:` or `content_contains:`. It accepts `sudo: true` or `sudo: :if_needed` for paths requiring elevated permissions.
+
+Use `if_path_exists`, `unless_path_exists`, `on_macos` and `on_linux` blocks to guard one or more steps. A condition is evaluated once when its scope begins, so related steps make the same decision:
+
+```ruby
+unless_path_exists "foo/default.conf" do
+  mkdir_p "foo"
+  copy "default.conf", "foo/default.conf"
+end
+```
 
 #### Default config and template steps
 
-`write` creates a default configuration or data file from literal content. It defaults to the same base as the other file preparation steps; pass `base:` (such as `base: :etc`) to target another formula path. By default `write` does not overwrite an existing file, so user edits are preserved across upgrades; pass `overwrite: true` to always replace the file.
+`write_file` atomically writes its exact literal content, replacing an existing file. It defaults to the same base as the other file preparation steps; pass `base:` (such as `base: :etc`) to target another formula path. Use `unless_path_exists` when a default file should preserve user edits across upgrades:
 
-* `write`: write literal content to a file unless it already exists; example: `write "foo.conf", "key = value", base: :etc`.
-* `write` with `overwrite: true`: always replace the file; example: `write "foo/version", "1.0", overwrite: true`.
-
-A trailing newline is appended unless the content already ends with one, so written files end in a newline as POSIX expects.
+```ruby
+unless_path_exists "foo.conf", base: :etc do
+  write_file "foo.conf", "key = value\n", base: :etc
+end
+```
 
 {% raw %}
 
@@ -1129,22 +1137,22 @@ Ruby `#{...}` interpolation is normally evaluated before structured steps are se
 
 The runtime steps DSL retains compatibility helpers for `formula_name`, `name`, `version`, `version.major` and `version.major_minor`. Interpolating these helpers is safe and permitted by RuboCop because they return the corresponding `{{...}}` token text rather than a concrete value. Other Ruby interpolation is rejected. Prefer explicit `{{...}}` tokens in new steps so it is clear that expansion is deferred until installation.
 
-Content, replacements, command arguments and command environments may use a fixed set of `{{...}}` tokens: `{{HOMEBREW_BREW_FILE}}`, `{{HOMEBREW_CELLAR}}`, `{{HOMEBREW_PREFIX}}`, `{{name}}`, `{{user}}`, `{{prefix}}`, `{{opt_prefix}}`, `{{bin}}`, `{{sbin}}`, `{{lib}}`, `{{libexec}}`, `{{share}}`, `{{pkgshare}}`, `{{rack}}`, `{{var}}`, `{{etc}}`, `{{pkgetc}}`, `{{version}}`, `{{version.major}}` and `{{version.major_minor}}`. Completion directory tokens are also available. Any other `{{...}}` is left verbatim, so literal braces are never rewritten. For example: `write "foo.conf", "prefix = {{HOMEBREW_PREFIX}}", base: :etc`.
+Content, replacements, command arguments and command environments may use a fixed set of `{{...}}` tokens: `{{HOMEBREW_BREW_FILE}}`, `{{HOMEBREW_CELLAR}}`, `{{HOMEBREW_PREFIX}}`, `{{formula_name}}`, `{{name}}`, `{{user}}`, `{{prefix}}`, `{{opt_prefix}}`, `{{bin}}`, `{{sbin}}`, `{{lib}}`, `{{libexec}}`, `{{share}}`, `{{pkgshare}}`, `{{rack}}`, `{{var}}`, `{{etc}}`, `{{pkgetc}}`, `{{version}}`, `{{version.major}}` and `{{version.major_minor}}`. `{{name}}` is retained for compatibility; prefer `{{formula_name}}`. Completion directory tokens are also available. Any other `{{...}}` is left verbatim, so literal braces are never rewritten. For example: `write_file "foo.conf", "prefix = {{HOMEBREW_PREFIX}}\n", base: :etc`.
 {% endraw %}
 
 #### Command and lifecycle steps
 
-`run` executes one command with a literal argument array; it does not evaluate a shell command string. Select the executable with `base:`, such as `:bin`, `:libexec` or `:homebrew_prefix`, or pass an absolute system executable. The step also supports a literal `env:`, `stdin_path:`, `stdout_path:`, `chdir:`, `sudo:`, `print_stdout:` and `print_stderr:`. Wrap it in one of the guard blocks described above when it should be conditional.
+`run` executes one command with a literal argument array; it does not evaluate a shell command string. Select the executable with `base:`, such as `:bin`, `:libexec` or `:homebrew_prefix`, or pass an absolute system executable. The step also supports a literal `env:`, `stdin_path:`, `stdout_path:`, `chdir:` and `sudo:`. Standard output is hidden by default and standard error is printed, matching `SystemCommand`; use `print_stdout: true` or `print_stderr: false` to change that behaviour.
 
 ```ruby
 run "foo-helper", args: ["--prefix", "{{HOMEBREW_PREFIX}}"], base: :libexec
-terminate_process "foo", must_succeed: false
+terminate_process "foo", match: :full, attempts: 3
 if_path_exists "foo.conf", base: :etc do
   warn "Remove the old foo.conf before continuing"
 end
 ```
 
-`terminate_process` terminates a process by name or, with `match: :full`, by its full command line. `attempts:` sets the total number of attempts and defaults to one. It also supports `notices:` shown before the first attempt and a `failure_message:` warning.
+`terminate_process` terminates a process by name or, with `match: :full`, by its full command line. `attempts:` is the total number of attempts and defaults to one. Failure is ignored by default; pass `must_succeed: true` when it should abort. The step also supports `notices:` shown before the first attempt and a `failure_message:` warning.
 `warn` emits a literal warning. Wrap it in `if_path_exists` when the warning only applies while a path exists.
 
 #### Repeated formula actions
@@ -1166,25 +1174,25 @@ bootstrap command unless the directory already contains the default marker
 file. It defaults to paths relative to `var` and skips the bootstrap command in
 Homebrew's GitHub Actions jobs. It does not change permissions or ownership.
 
-* `init_data_dir` with `using: :postgresql_initdb`: initialise PostgreSQL with
-  `initdb`; example: `init_data_dir "postgresql@16", using: :postgresql_initdb`.
+* `init_data_dir` with `using: :postgresql`: initialise PostgreSQL with
+  `initdb`; example: `init_data_dir "postgresql@16", using: :postgresql`.
   PostgreSQL defaults to `locale: "en_US.UTF-8"` and can set another locale,
-  for example `init_data_dir "postgresql@12", using: :postgresql_initdb, locale: "C"`.
-* `init_data_dir` with `using: :mysql_initialize`: initialise MySQL with
+  for example `init_data_dir "postgresql@12", using: :postgresql, locale: "C"`.
+* `init_data_dir` with `using: :mysql`: initialise MySQL with
   `mysqld --initialize-insecure`; example:
-  `init_data_dir "mysql", using: :mysql_initialize`.
-* `init_data_dir` with `using: :mariadb_install_db`: initialise MariaDB with
-  `mysql_install_db`; example: `init_data_dir "mysql", using: :mariadb_install_db`.
+  `init_data_dir "mysql", using: :mysql`.
+* `init_data_dir` with `using: :mariadb`: initialise MariaDB with
+  `mysql_install_db`; example: `init_data_dir "mysql", using: :mariadb`.
 
-`link_dir` recursively links a source directory's contents into a target
+`symlink_tree` recursively links a source directory's contents into a target
 directory, preserving existing real directories and skipping `.DS_Store` files.
-`link_children` links each direct child of a source directory into a target
+`symlink_children` links each direct child of a source directory into a target
 directory, defaulting the target to the same path as the source, and can add a
 `prefix` or `suffix` to each linked name. For example:
 
 ```ruby
-link_dir "share/postgresql", "share/{{name}}"
-link_children "bin", suffix: "-{{version.major}}"
+symlink_tree "share/postgresql", "share/{{formula_name}}"
+symlink_children "bin", suffix: "-{{version.major}}"
 ```
 
 #### Desktop and cache rebuild steps
@@ -1192,8 +1200,8 @@ link_children "bin", suffix: "-{{version.major}}"
 These steps rebuild shared desktop and cache state using Homebrew-owned tools.
 
 * `compile_gsettings_schemas`: compile GSettings schemas in `share/glib-2.0/schemas`.
-* `gdk_pixbuf_query_loaders`: update the GDK Pixbuf loader cache.
-* `gtk_update_icon_cache`: refresh the `hicolor` GTK icon cache.
+* `update_gdk_pixbuf_loaders_cache`: update the GDK Pixbuf loader cache.
+* `update_gtk_icon_cache`: refresh the `hicolor` GTK icon cache.
 * `update_mime_database`: rebuild the shared MIME database in `share/mime`.
 * `update_desktop_database`: rebuild the desktop entry database in `share/applications`.
 
@@ -1203,10 +1211,11 @@ class Foo < Formula
   url "https://example.com/foo-1.0.tar.gz"
 
   post_install_steps do
-    ln_sf "cert.pem", "cert.pem",
-          source_formula: "ca-certificates",
-          source_base:    :formula_pkgetc,
-          target_base:    :pkgetc
+    symlink "cert.pem", "cert.pem",
+            source_formula: "ca-certificates",
+            source_base:    :formula_pkgetc,
+            target_base:    :pkgetc,
+            overwrite:      true
   end
   # ...
 end


### PR DESCRIPTION
Formula and cask authors need one current reference while released
aliases remain an implementation-only compatibility bridge.

- document shared names, defaults, guards, tokens and command behaviour
- remove compatibility-only methods and values from the cookbooks
- explain ordered coexistence with legacy hooks during tap migration

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.