### PR TITLE
Add glibc runtime action (14/24)

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -622,6 +622,11 @@ module Homebrew
                  "target" => path_spec(target, base: target_base, default_base: @default_target_base))
       end
 
+      sig { void }
+      def configure_glibc_runtime
+        add_step("configure_glibc_runtime")
+      end
+
       private
 
       sig { params(guard: PathSpec, block: ::T.proc.void).void }
@@ -868,6 +873,8 @@ module Homebrew
           run_configure_gcc_runtime
         when "install_gzipped_executable"
           run_install_gzipped_executable(step)
+        when "configure_glibc_runtime"
+          run_configure_glibc_runtime
         when "set_permissions"
           run_set_permissions(step)
         when "set_ownership"

--- a/Library/Homebrew/install_steps/formula_actions.rb
+++ b/Library/Homebrew/install_steps/formula_actions.rb
@@ -84,6 +84,36 @@ module Homebrew
         end
         target.chmod 0755
       end
+
+      sig { void }
+      def run_configure_glibc_runtime
+        (context_path("lib")/"locale").mkpath
+        legacy_formula = context_name != "glibc"
+        locales = ENV.filter_map do |key, value|
+          next unless key.match?(legacy_formula ? /^LANG$|^LC_/ : /^HOMEBREW_LANG$|^LANG$|^LC_/)
+          next if value == "C" || (legacy_formula && value.start_with?("C."))
+
+          value
+        end
+        locales = (locales + ["en_US.UTF-8"]).sort.uniq
+        ohai "Installing locale data for #{locales.join(" ")}"
+        locales.each do |locale|
+          lang, charmap = locale.split(".", 2)
+          next if lang.nil?
+
+          if charmap.present?
+            charmap = "UTF-8" if charmap == "utf8"
+            run_command context_path("bin")/"localedef", "-i", lang, "-f", charmap, locale
+          else
+            run_command context_path("bin")/"localedef", "-i", lang, locale
+          end
+        end
+
+        [[Pathname("/etc/localtime"), context_path("etc")/"localtime"],
+         [Pathname("/usr/share/zoneinfo"), context_path("share")/"zoneinfo"]].each do |source, target|
+          File.symlink source, target if source.exist? && !target.exist?
+        end
+      end
     end
   end
 end

--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -17,7 +17,8 @@ module RuboCop
       PERMISSION_STEP_METHODS = [:set_permissions, :set_ownership].freeze
       COMMAND_STEP_METHODS = [:run, :terminate_process].freeze
       NOTICE_STEP_METHODS = [:warn].freeze
-      FORMULA_ACTION_STEP_METHODS = [:configure_gcc_runtime, :install_gzipped_executable].freeze
+      FORMULA_ACTION_STEP_METHODS =
+        [:configure_gcc_runtime, :install_gzipped_executable, :configure_glibc_runtime].freeze
       STEP_SCOPE_METHODS = [:if_path_exists, :unless_path_exists, :on_macos, :on_linux].freeze
       ALLOWED_STEP_METHODS = T.let(
         [*FILE_PREPARATION_STEP_METHODS, *LINK_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *SERVICE_DATA_STEP_METHODS,

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -805,6 +805,56 @@ RSpec.describe Homebrew::InstallSteps do
     expect(stored_name.read).to eq("preserve")
   end
 
+  specify "dispatches glibc runtime configuration" do
+    steps = Homebrew::InstallSteps::DSL.build do
+      configure_glibc_runtime
+    end
+
+    runner = Homebrew::InstallSteps::Runner.new(context:)
+    expect(runner).to receive(:run_configure_glibc_runtime)
+
+    runner.run(steps)
+  end
+
+  specify "configures glibc locales and timezone links", :aggregate_failures do
+    steps = Homebrew::InstallSteps::DSL.build do
+      configure_glibc_runtime
+    end
+    glibc_context = context
+    root_path = root
+    glibc_context.define_singleton_method(:name) { "glibc" }
+    glibc_context.define_singleton_method(:lib) { root_path/"prefix/lib" }
+    glibc_context.define_singleton_method(:etc) { root_path/"prefix/etc" }
+    glibc_context.define_singleton_method(:share) { root_path/"prefix/share" }
+    (root/"prefix/etc").mkpath
+    (root/"prefix/share").mkpath
+    ENV.delete_if { |key,| key == "HOMEBREW_LANG" || key == "LANG" || key.start_with?("LC_") }
+    ENV["HOMEBREW_LANG"] = "de_DE.utf8"
+    ENV["LANG"] = "C"
+    ENV["LC_TIME"] = "en_GB"
+    timezone_sources = [Pathname("/etc/localtime"), Pathname("/usr/share/zoneinfo")]
+    allow_any_instance_of(Pathname).to receive(:exist?).and_wrap_original do |method, *args|
+      timezone_sources.include?(method.receiver) || method.call(*args)
+    end
+
+    runner = Homebrew::InstallSteps::Runner.new(context: glibc_context)
+    localedef = root/"prefix/bin/localedef"
+    expect(runner).to receive(:ohai).with("Installing locale data for de_DE.utf8 en_GB en_US.UTF-8")
+    expect(runner).to receive(:run_command)
+      .with(localedef, "-i", "de_DE", "-f", "UTF-8", "de_DE.utf8").ordered
+    expect(runner).to receive(:run_command).with(localedef, "-i", "en_GB", "en_GB").ordered
+    expect(runner).to receive(:run_command)
+      .with(localedef, "-i", "en_US", "-f", "UTF-8", "en_US.UTF-8").ordered
+
+    runner.run(steps)
+
+    expect(root/"prefix/lib/locale").to be_a_directory
+    expect(root/"prefix/etc/localtime").to be_a_symlink
+    expect((root/"prefix/etc/localtime").readlink).to eq(Pathname("/etc/localtime"))
+    expect(root/"prefix/share/zoneinfo").to be_a_symlink
+    expect((root/"prefix/share/zoneinfo").readlink).to eq(Pathname("/usr/share/zoneinfo"))
+  end
+
   describe "runs gtk_update_icon_cache rebuild action" do
     let(:formula) { instance_double(Formula, opt_bin: root/"opt/bin") }
     let(:steps) do

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `install_gzipped_executable`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY
@@ -69,6 +69,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           warn "foo exists"
           configure_gcc_runtime
           install_gzipped_executable "compressed.gz", "bin/executable"
+          configure_glibc_runtime
           write "foo/banner", <<~TEXT
             literal banner
           TEXT
@@ -104,7 +105,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         post_install_steps do
           on_macos do
             system "true"
-            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `install_gzipped_executable`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
           end
         end
       end
@@ -118,7 +119,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           write "foo.conf", "prefix = #{prefix}"
-                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `install_gzipped_executable`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `set_permissions`, `run`, `terminate_process`, `warn`, `configure_gcc_runtime`, `install_gzipped_executable`, `configure_glibc_runtime`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1119,6 +1119,7 @@ Use the named actions below for formula families that share post-install algorit
 
 * `configure_gcc_runtime`: generate the Linux GCC runtime links and specs.
 * `install_gzipped_executable`: unpack and install a gzipped executable.
+* `configure_glibc_runtime`: generate requested glibc locales and timezone links.
 
 #### Service data directory steps
 


### PR DESCRIPTION
Three glibc-family formulae share locale generation and timezone-link
setup with different rules for the legacy variants.

- derive requested locales while always providing the UTF-8 default
- invoke the installed `localedef` with normalised charmaps
- preserve host timezone links when their sources exist

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and
testing.