### PR TITLE
Allow reordered Cask migration artifacts

### DIFF
--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -117,7 +117,8 @@ module Cask
       json_uninstall_artifacts = JSON.parse(JSON.generate(cask.artifacts_list(uninstall_only: true)))
       installed_json = cask.to_installed_json_hash
       installed_json["url_specs"] ||= source_url_specs if source_url_specs
-      if tab.uninstall_artifacts.presence != json_uninstall_artifacts
+      receipt_artifacts = tab.uninstall_artifacts.presence
+      if receipt_artifacts.nil? || !artifacts_equivalent?(receipt_artifacts, json_uninstall_artifacts)
         installed_json["artifacts"] = json_uninstall_artifacts
       end
       installed_json["version"] = version if caskfile.dirname.dirname.dirname.basename.to_s != version
@@ -130,8 +131,9 @@ module Cask
         # Only durable on-disk data may satisfy this check: the API fallback would mask a
         # migrated caskfile that lost its artifacts for as long as the API definition matches.
         migrated_cask = CaskLoader.load_from_installed_caskfile(json_caskfile, api_fallback: false)
+        migrated_artifacts = JSON.parse(JSON.generate(migrated_cask.artifacts_list(uninstall_only: true)))
         if migrated_cask.version.to_s != version ||
-           JSON.parse(JSON.generate(migrated_cask.artifacts_list(uninstall_only: true))) != json_uninstall_artifacts
+           !artifacts_equivalent?(migrated_artifacts, json_uninstall_artifacts)
           raise "migrated Cask metadata differs from the original after preserving version and artifacts"
         end
       rescue
@@ -144,6 +146,12 @@ module Cask
       end
       caskfile.unlink if caskfile != json_caskfile
     end
+
+    sig { params(first: T::Array[T.anything], second: T::Array[T.anything]).returns(T::Boolean) }
+    def self.artifacts_equivalent?(first, second)
+      first.tally == second.tally
+    end
+    private_class_method :artifacts_equivalent?
 
     # Return tokens for Caskroom directories missing expected installed metadata.
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/test/cask/caskroom_spec.rb
+++ b/Library/Homebrew/test/cask/caskroom_spec.rb
@@ -274,6 +274,64 @@ RSpec.describe Cask::Caskroom do
       ])
     end
 
+    it "treats reordered receipt artifacts as equivalent" do
+      token = "reordered-artifacts"
+      caskfile = write_installed_caskfile(token, <<~RUBY)
+        cask "#{token}" do
+          version "1.0"
+          font "Font0.ttf"
+          font "Font1.ttf"
+          font "Font2.ttf"
+          font "Font3.ttf"
+          font "Font4.ttf"
+          font "Font5.ttf"
+          font "Font6.ttf"
+          font "Font7.ttf"
+        end
+      RUBY
+      artifacts = Array.new(8) { |i| { "font" => ["Font#{i}.ttf"] } }
+      write_receipt(token, artifacts)
+
+      described_class.migrate_caskfile_to_json(caskfile)
+
+      json_caskfile = caskfile.sub_ext(".json")
+      expect([caskfile.exist?, JSON.parse(json_caskfile.read)]).to eq([false, {}])
+    end
+
+    it "restores original metadata when migrated artifact multiplicity differs" do
+      token = "changed-artifacts"
+      caskfile = write_installed_caskfile(token, <<~RUBY)
+        cask "#{token}" do
+          version "1.0"
+          font "Duplicate.ttf"
+          font "Duplicate.ttf"
+        end
+      RUBY
+      original_contents = caskfile.read
+      json_caskfile = caskfile.sub_ext(".json")
+      migrated_cask = instance_double(
+        Cask::Cask,
+        version:        "1.0",
+        artifacts_list: [{ font: ["Duplicate.ttf"] }],
+      )
+      allow(Cask::CaskLoader).to receive(:load_from_installed_caskfile)
+        .with(json_caskfile, api_fallback: false)
+        .and_return(migrated_cask)
+
+      error = T.let(nil, T.nilable(RuntimeError))
+      begin
+        described_class.migrate_caskfile_to_json(caskfile)
+      rescue RuntimeError => e
+        error = e
+      end
+
+      expect([error&.message, caskfile.read, json_caskfile.exist?]).to eq([
+        "migrated Cask metadata differs from the original after preserving version and artifacts",
+        original_contents,
+        false,
+      ])
+    end
+
     it "uses API metadata when a Ruby caskfile contains a removed method" do
       token = "removed-method"
       caskfile = write_installed_caskfile(token, <<~RUBY)


### PR DESCRIPTION
## Summary

- compare uninstall artifact lists as multisets during installed Cask metadata migration
- keep strict version checks, duplicate counts, and per-artifact argument ordering
- add regression coverage for reordered same-type artifacts and changed multiplicity

## Root cause

`Cask::ArtifactSet` sorts artifacts by class, while artifacts of the same class compare equally. Ruby's sort can therefore reorder same-type entries when the legacy metadata and the compact installed JSON are loaded through different paths.

The migration compared the resulting arrays with strict positional equality. A legacy JetBrains Mono Nerd Font installation reproduced this with 96 font artifacts: the artifact multisets were identical and all expected files existed, but entries 0 and 95 exchanged positions. `brew update` then warned and restored the original metadata on every run.

This change treats only the outer uninstall artifact list as unordered. `Array#tally` preserves multiplicity, and nested arrays inside each artifact remain order-sensitive. The existing strict version check, on-disk-only verification, and rollback on actual data loss are unchanged.

This follows the installed metadata design: the compact JSON relies on `INSTALL_RECEIPT.json` for version and uninstall artifacts, and migration must preserve those artifacts without requiring a non-semantic outer order.

## Reproduction

With the affected legacy Caskroom metadata installed:

```console
$ brew update
Warning: Failed to migrate .../font-jetbrains-mono-nerd-font.json to JSON metadata: migrated Cask metadata differs from the original after preserving version and artifacts
$ brew update
Warning: Failed to migrate .../font-jetbrains-mono-nerd-font.json to JSON metadata: migrated Cask metadata differs from the original after preserving version and artifacts
```

The first regression example added here fails on the parent commit with the same exception:

```console
$ ./bin/brew tests --only=cask/caskroom:277
1 example, 1 failure
RuntimeError: migrated Cask metadata differs from the original after preserving version and artifacts
```

## Validation

```console
./bin/brew tests --only=cask/caskroom
./bin/brew lgtm --online
```

Both pass on macOS x86_64. The multiplicity regression was also red/green checked against an intentionally set-like comparison.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex was used to diagnose the field failure, implement the change, and draft tests and prose. Codex inspected the final diff, reproduced both regression tests red/green, and ran `./bin/brew lgtm --online` successfully. This remains a draft pending the contributor's final human review.

-----
