### PR TITLE
docs: correct the Cask Cookbook and cask terminology

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -162,7 +162,7 @@ module Cask
 
       return if cask.artifacts.none? { |k| k.is_a?(Artifact::Pkg) && k.stanza_options.key?(:allow_untrusted) }
 
-      add_error "allow_untrusted is not permitted in official Homebrew Cask taps"
+      add_error "allow_untrusted is not permitted in the official homebrew/cask tap"
     end
 
     sig { void }

--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -135,7 +135,7 @@ module Cask
         <<~EOS
           Cask #{cask} installs files under /usr/local. The presence of such
           files can cause warnings when running `brew doctor`, which is considered
-          to be a bug in Homebrew Cask.
+          to be a bug in Homebrew's cask handling.
         EOS
       end
 

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -720,7 +720,7 @@ on_request: true)
       # versioned staged distribution
       gain_permissions_remove(T.must(backup_path)) if backup_path&.exist?
 
-      # Homebrew Cask metadata
+      # Cask metadata
       bmp = backup_metadata_path
       return unless bmp&.directory?
 
@@ -737,7 +737,7 @@ on_request: true)
       # versioned staged distribution
       gain_permissions_remove(@cask.staged_path) if @cask.staged_path&.exist?
 
-      # Homebrew Cask metadata
+      # Cask metadata
       if @cask.metadata_versioned_path.directory?
         @cask.metadata_versioned_path.children.each do |subdir|
           gain_permissions_remove(subdir)

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1174,7 +1174,7 @@ module Homebrew
 
         path = Cask::Caskroom.path
 
-        add_info "Homebrew Cask Staging Location", user_tilde(path.to_s)
+        add_info "Cask Staging Location", user_tilde(path.to_s)
 
         return if !path.exist? || path.writable?
 
@@ -1216,7 +1216,7 @@ module Homebrew
 
           "#{tap.path} (#{Utils.pluralize("cask", cask_count, include_count: true)})"
         end
-        add_info "Homebrew Cask Taps:", taps_info
+        add_info "Cask Taps:", taps_info
 
         taps_string = Utils.pluralize("tap", error_tap_paths.count)
         "Unable to read from cask #{taps_string}: #{error_tap_paths.to_sentence}" if error_tap_paths.present?

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -154,7 +154,7 @@ can take several different forms:
 
 ## SPECIFYING CASKS
 
-Many Homebrew Cask commands accept one or more <cask> arguments. These can be
+Many commands that work with casks accept one or more <cask> arguments. These can be
 specified the same way as the <formula> arguments described in
 `SPECIFYING FORMULAE` above.
 

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -428,7 +428,7 @@ RSpec.describe Cask::Audit, :cask do
 
     describe "pkg allow_untrusted checks" do
       let(:only) { ["untrusted_pkg"] }
-      let(:message) { "allow_untrusted is not permitted in official Homebrew Cask taps" }
+      let(:message) { "allow_untrusted is not permitted in the official homebrew/cask tap" }
 
       context "when the Cask has no pkg stanza" do
         let(:cask_token) { "basic-cask" }

--- a/Library/Homebrew/test/cask/dsl/caveats_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/caveats_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Cask::DSL::Caveats, :cask do
       expected_caveats_str = <<~EOS
         Cask #{cask} installs files under /usr/local. The presence of such
         files can cause warnings when running `brew doctor`, which is considered
-        to be a bug in Homebrew Cask.
+        to be a bug in Homebrew's cask handling.
       EOS
 
       caveats.eval_caveats do

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -1,5 +1,5 @@
 ---
-last_review_date: "2025-05-18"
+last_review_date: "2026-07-18"
 ---
 
 # Cask Cookbook
@@ -25,7 +25,7 @@ end
 
 ## The cask language is declarative
 
-Each cask contains a series of stanzas (or “fields”) which *declare* how the software is to be obtained and installed. In a declarative language, the author does not need to worry about **order**. As long as all the needed fields are present, Homebrew Cask will figure out what needs to be done at install time.
+Each cask contains a series of stanzas (or “fields”) which *declare* how the software is to be obtained and installed. In a declarative language, the author does not need to worry about **order**. As long as all the needed fields are present, Homebrew determines what needs to be done at install time.
 
 To make maintenance easier, the most-frequently-updated stanzas are usually placed at the top. But that’s a convention, not a rule.
 
@@ -35,7 +35,7 @@ Exception: `do` blocks such as `postflight` may enclose a block of pure Ruby cod
 
 The cask name ([`<cask-token>`](#token-reference)) on the header line `cask <cask-token> do` should match the cask filename, without the `.rb` extension, enclosed in double quotes.
 
-There are currently some arbitrary limitations on cask tokens which are in the process of being removed. GitHub Actions will catch any errors during the transition.
+The [token reference](#token-reference) describes the current naming rules and exceptions.
 
 ## Stanza order
 
@@ -84,6 +84,7 @@ Having a common order for stanzas makes casks easier to update and parse. Below 
     internet_plugin
     keyboard_layout
     prefpane
+    qlplugin
     mdimporter
     screen_saver
     service
@@ -93,17 +94,17 @@ Having a common order for stanzas makes casks easier to update and parse. Below 
     artifact, target: # target: shown here as is required with `artifact`
     stage_only
 
-    preflight
     preflight_steps
+    preflight
 
-    postflight
     postflight_steps
+    postflight
 
-    uninstall_preflight
     uninstall_preflight_steps
+    uninstall_preflight
 
-    uninstall_postflight
     uninstall_postflight_steps
+    uninstall_postflight
 
     uninstall
 
@@ -117,7 +118,8 @@ Note that every stanza that has additional parameters (`:symbols` after a `,`) s
 
 ### Required stanzas
 
-Each of the following stanzas is required for every cask.
+Each cask requires the identity and download stanzas below.
+Submissions to `homebrew/cask` may require additional stanzas such as `livecheck`, `depends_on`, `uninstall` or `zap` when the package needs them.
 
 | name                               | multiple occurrences allowed? | value |
 | ---------------------------------- | :---------------------------: | ----- |
@@ -127,17 +129,17 @@ Each of the following stanzas is required for every cask.
 | [`name`](#stanza-name)             | yes                           | String providing the full and proper name defined by the vendor. |
 | [`desc`](#stanza-desc)             | no                            | One-line description of the cask. Shown when running `brew info`. |
 | `homepage`                         | no                            | Application homepage; used for the `brew home` command. |
-| [`livecheck`](#stanza-livecheck)   | no                            | Ruby block describing how to find updates for this cask. Supersedes `appcast`. |
-| [`depends_on`](#stanza-depends_on) | yes                           | List of dependencies and requirements for this cask. |
-| [`zap`](#stanza-zap)               | yes                           | Additional procedures for a more complete uninstall, including user files and shared resources. |
 
 ### At least one artifact stanza is also required
 
 Each cask must declare one or more [artifacts](/rubydoc/Cask/Artifact.html) (i.e. something to install).
+Not every artifact type is supported on every operating system and a cask does not need to support both macOS and Linux.
+The `appimage` stanza is Linux-only, macOS integration stanzas such as `app` and `pkg` are macOS-only and portable stanzas such as `binary` can be used on either operating system.
 
 | name                             | multiple occurrences allowed? | value |
 | -------------------------------- | :---------------------------: | ----- |
 | [`app`](#stanza-app)             | yes                           | Relative path to an `.app` that should be moved into the `/Applications` folder on installation. |
+| `appimage`                       | yes                           | Relative path to an AppImage that should be linked into the configured AppImage directory on installation. |
 | [`suite`](#stanza-suite)         | yes                           | Relative path to a containing directory that should be moved into the `/Applications` folder on installation. |
 | [`pkg`](#stanza-pkg)             | yes                           | Relative path to a `.pkg` file containing the distribution. |
 | [`installer`](#stanza-installer) | yes                           | Describes an executable which must be run to complete the installation. |
@@ -154,12 +156,13 @@ Each cask must declare one or more [artifacts](/rubydoc/Cask/Artifact.html) (i.e
 | `internet_plugin`                | yes                           | Relative path to an Internet Plugin that should be moved into the `~/Library/Internet Plug-Ins` folder on installation. |
 | `keyboard_layout`                | yes                           | Relative path to a Keyboard Layout that should be moved into the `/Library/Keyboard Layouts` folder on installation. |
 | `prefpane`                       | yes                           | Relative path to a Preference Pane that should be moved into the `~/Library/PreferencePanes` folder on installation. |
+| `qlplugin`                       | yes                           | Relative path to a Quick Look plugin that should be moved into the `~/Library/QuickLook` folder on installation. |
 | `mdimporter`                     | yes                           | Relative path to a Spotlight Metadata Importer that should be moved into the `~/Library/Spotlight` folder on installation. |
 | `screen_saver`                   | yes                           | Relative path to a Screen Saver that should be moved into the `~/Library/Screen Savers` folder on installation. |
 | `service`                        | yes                           | Relative path to a Service that should be moved into the `~/Library/Services` folder on installation. |
-| `audio_unit_plugin`              | yes                           | Relative path to an Audio Unit Plugin that should be moved into the `~/Library/Audio/Components` folder on installation. |
-| `vst_plugin`                     | yes                           | Relative path to a VST Plugin that should be moved into the `~/Library/Audio/VST` folder on installation. |
-| `vst3_plugin`                    | yes                           | Relative path to a VST3 Plugin that should be moved into the `~/Library/Audio/VST3` folder on installation. |
+| `audio_unit_plugin`              | yes                           | Relative path to an Audio Unit Plugin that should be moved into the `~/Library/Audio/Plug-Ins/Components` folder on installation. |
+| `vst_plugin`                     | yes                           | Relative path to a VST Plugin that should be moved into the `~/Library/Audio/Plug-Ins/VST` folder on installation. |
+| `vst3_plugin`                    | yes                           | Relative path to a VST3 Plugin that should be moved into the `~/Library/Audio/Plug-Ins/VST3` folder on installation. |
 | `artifact`                       | yes                           | Relative path to an arbitrary path that should be moved on installation. Must provide an absolute path as a `target`. (Example: [free-gpgmail.rb](https://github.com/Homebrew/homebrew-cask/blob/b3c438d608d9702380edf10d5495e0727cf17108/Casks/f/free-gpgmail.rb#L44)) This is only for unusual cases; the `app` stanza is strongly preferred when moving `.app` bundles. |
 | `stage_only`                     | no                            | `true`. Asserts that the cask contains no activatable artifacts. |
 
@@ -180,19 +183,22 @@ Generated completion artifacts are different: `generate_completions_from_executa
 | [`uninstall`](#stanza-uninstall)           | yes                           | Procedures to uninstall a cask. Optional unless a `pkg` or `installer` artifact stanza is used. |
 | [`conflicts_with`](#stanza-conflicts_with) | yes                           | List of conflicts with this cask. |
 | [`caveats`](#stanza-caveats)               | yes                           | String or Ruby block providing the user with cask-specific information at install time. |
+| [`livecheck`](#stanza-livecheck)           | no                            | Ruby block describing how to find updates when automatic detection is insufficient. It is not used with `version :latest` unless the block uses `skip`. |
+| [`depends_on`](#stanza-depends_on)         | yes                           | Dependencies and operating-system or architecture requirements for this cask. |
+| [`zap`](#stanza-zap)                       | no                            | Additional procedures for a more complete uninstall, including user files and shared resources. |
 | [`deprecate!`](#stanza-deprecate--disable) | no                            | Date as a string in `YYYY-MM-DD` format and a string or symbol providing a reason. |
 | [`disable!`](#stanza-deprecate--disable)   | no                            | Date as a string in `YYYY-MM-DD` format and a string or symbol providing a reason. |
-| `preflight`                                | yes                           | Ruby block containing preflight install operations (needed only in very rare cases). |
+| `preflight`                                | no                            | Ruby block containing preflight install operations (needed only in very rare cases). |
 | `preflight_steps`                          | yes                           | Declarative file preparation steps run before artifact installation. |
-| [`postflight`](#stanza-flight)             | yes                           | Ruby block containing postflight install operations. |
+| [`postflight`](#stanza-flight)             | no                            | Ruby block containing postflight install operations. |
 | `postflight_steps`                         | yes                           | Declarative file preparation steps run after artifact installation. |
-| `uninstall_preflight`                      | yes                           | Ruby block containing preflight uninstall operations (needed only in very rare cases). |
+| `uninstall_preflight`                      | no                            | Ruby block containing preflight uninstall operations (needed only in very rare cases). |
 | `uninstall_preflight_steps`                | yes                           | Declarative file preparation steps run before artifact uninstallation. |
-| `uninstall_postflight`                     | yes                           | Ruby block containing postflight uninstall operations. |
+| `uninstall_postflight`                     | no                            | Ruby block containing postflight uninstall operations. |
 | `uninstall_postflight_steps`               | yes                           | Declarative file preparation steps run after artifact uninstallation. |
-| [`language`](#stanza-language)             | required                      | Ruby block, called with language code parameters, containing other stanzas and/or a return value. |
+| [`language`](#stanza-language)             | yes                           | Ruby block, called with language code parameters, containing other stanzas and/or a return value. |
 | `container nested:`                        | no                            | Relative path to an inner container that must be extracted before moving on with the installation. This allows for support of `.dmg` inside `.tar`, `.zip` inside `.dmg`, etc. (Example: [blocs.rb](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/b/blocs.rb#L17-L19)) |
-| `container type:`                          | no                            | Symbol to override container-type autodetect. May be one of: `:air`, `:bz2`, `:cab`, `:dmg`, `:generic_unar`, `:gzip`, `:otf`, `:pkg`, `:rar`, `:seven_zip`, `:sit`, `:tar`, `:ttf`, `:xar`, `:zip`, `:naked`. (Example: [parse.rb](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/p/parse.rb#L10)) |
+| `container type:`                          | no                            | Symbol to override container-type autodetect. May be one of: `:air`, `:bzip2`, `:cab`, `:dmg`, `:generic_unar`, `:gzip`, `:otf`, `:pkg`, `:rar`, `:seven_zip`, `:sit`, `:tar`, `:ttf`, `:xar`, `:zip`, `:naked`. (Example: [parse.rb](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/p/parse.rb#L10)) |
 | `auto_updates`                             | no                            | `true`. Asserts that the cask artifacts auto-update. Use if `Check for Updates…` or similar is present in an app menu, but not if it only opens a webpage and does not do the download and installation for you. |
 | [`no_autobump!`](#stanza-no_autobump)      | no                            | Allowed symbol or a string. Excludes cask from autobumping if set. |
 | [`rename`](#stanza-rename)      | yes                            | A pair of strings. |
@@ -211,6 +217,12 @@ by default moves the source to:
 
 ```bash
 /Applications/Alfred 2.app
+```
+
+When an archive expands into a subdirectory, include that subdirectory in the path to the app bundle:
+
+```ruby
+app "Simple Floating Clock/SimpleFloatingClock.app"
 ```
 
 #### Renaming the target
@@ -286,7 +298,7 @@ rename "foobar-*.pkg", "foobar.pkg"
 
 ### Stanza: `caveats`
 
-Sometimes there are particularities with the installation of a piece of software that cannot or should not be handled programmatically by Homebrew Cask. In those instances, `caveats` is the way to inform the user. Information in `caveats` is displayed when a cask is invoked with either `install` or `info`.
+Sometimes there are particularities with the installation of a piece of software that cannot or should not be handled programmatically by Homebrew’s cask installer. In those instances, `caveats` is the way to inform the user. Information in `caveats` is displayed when a cask is invoked with either `install` or `info`.
 
 To avoid flooding users with too many messages (thus desensitising them to the important ones), `caveats` should be used sparingly and exclusively for installation-related matters. If you’re not sure whether a `caveat` you find pertinent is installation-related or not, ask a maintainer. As a general rule, if your case isn’t already covered in our comprehensive [`caveats mini-DSL`](#caveats-mini-dsl), it’s unlikely to be accepted.
 
@@ -299,8 +311,8 @@ When `caveats` is a string, it is evaluated at compile time. The following metho
 | `token`            | the cask token |
 | `version`          | the cask version |
 | `homepage`         | the cask homepage |
-| `caskroom_path`    | the containing directory for this cask: `$(brew --caskroom)/<token>` (only available with block form) |
-| `staged_path`      | the staged location for this cask, including version number: `$(brew --caskroom)/<token>/<version>` (only available with block form) |
+| `caskroom_path`    | the containing directory for this cask: `$(brew --caskroom)/<token>` |
+| `staged_path`      | the staged location for this cask, including version number: `$(brew --caskroom)/<token>/<version>` |
 
 Example:
 
@@ -327,10 +339,10 @@ The following methods may be called to generate standard warning messages:
 | `logout`                           | Users should log out and log back in to complete installation. |
 | `reboot`                           | Users should reboot to complete installation. |
 | `files_in_usr_local`               | The cask installs files to `/usr/local`, which may confuse Homebrew. |
-| `kext`                             | Users may need to enable their kexts in *System Settings → Privacy & Security* (or *System Preferences → Security & Privacy → General* in earlier macOS versions). |
+| `kext`                             | Users may need to enable their kexts in *System Settings → Privacy & Security*. |
 | `unsigned_accessibility`           | Users will need to re-enable the app on each update in *System Settings → Privacy & Security* (or *System Preferences → Security & Privacy → Privacy* in earlier macOS versions) as it is unsigned. |
-| `license "web_page"`               | Users may find the software's usage license at `web_page`. |
-| `free_license "web_page"`          | Users may obtain an official license to use the software at `web_page`. |
+| `license "web_page"`               | Users may find the software's usage licence at `web_page`. |
+| `free_license "web_page"`          | Users may obtain an official licence to use the software at `web_page`. |
 
 Example:
 
@@ -358,13 +370,14 @@ conflicts_with cask: "macfuse-dev"
 
 `depends_on` is used to declare dependencies and requirements for a cask. `depends_on` is not consulted until `install` is attempted.
 
-| key        | description |
-| ---------- | ----------- |
-| `cask:`    | required Homebrew cask tokens as string or array |
-| `formula:` | required Homebrew formula names as string or array |
-| `macos:`   | macOS release requirements as symbol, array or string comparison expression |
-| `arch:`    | hardware requirements as symbol or array  |
-| `java:`    | *stub - not yet functional* |
+| key              | description |
+| ---------------- | ----------- |
+| `cask:`          | required Homebrew cask tokens as string or array |
+| `formula:`       | required Homebrew formula names as string or array |
+| `macos:`         | minimum macOS release as a symbol, or an array of exact acceptable releases; the older string comparison form is deprecated |
+| `maximum_macos:` | maximum macOS release requirement using a `<=` comparison |
+| `linux:`         | Linux requirement, expressed as `depends_on :linux` |
+| `arch:`          | hardware requirements as symbol or array |
 
 #### `depends_on` *cask*
 
@@ -501,7 +514,7 @@ Refer to [Deprecating, Disabling and Removing](Deprecating-Disabling-and-Removin
 
 `desc` is not for app slogans! Vendors’ descriptions tend to be filled with generic adjectives such as “modern” and “lightweight”. Those are meaningless marketing fluff (do you ever see apps proudly describing themselves as outdated and bulky?) which must be deleted. It’s fine to use the information on the software’s website as a starting point, but it will require editing in almost all cases.
 
-#### Dos and Don'ts
+#### Dos and don'ts
 
 * **Do** start with an uppercase letter.
 
@@ -524,7 +537,7 @@ Refer to [Deprecating, Disabling and Removing](Deprecating-Disabling-and-Removin
   + desc "Sound and music editor"
   ```
 
-* **Do not** include the platform. Casks always work on macOS, so this is redundant information.
+* **Do not** include the platform. Platform compatibility belongs in the cask's requirements rather than its description.
 
   ```diff
   - desc "Sound and music editor for macOS"
@@ -792,9 +805,9 @@ Refer to the [Autobump](Autobump.md) page for more information about the autobum
 
 ### Stanza: `name`
 
-`name` accepts a UTF-8 string defining the name of the software, including capitalization and punctuation. It is used to help with searchability and disambiguation.
+`name` accepts a UTF-8 string defining the name of the software, including capitalisation and punctuation. It is used to help with searchability and disambiguation.
 
-Unlike the [token](#token-reference), which is simplified and reduced to a limited set of characters, the `name` stanza can include the proper capitalization, spacing and punctuation to match the official name of the software. For disambiguation purposes, it is recommended to spell out the name of the application, including the vendor name if necessary. A good example is the [`pycharm-ce`](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/p/pycharm-ce.rb#L9-L10) cask, whose name is spelled out as `Jetbrains PyCharm Community Edition`, even though it is likely never referenced as such anywhere.
+Unlike the [token](#token-reference), which is simplified and reduced to a limited set of characters, the `name` stanza can include the proper capitalisation, spacing and punctuation to match the official name of the software. For disambiguation purposes, it is recommended to spell out the name of the application, including the vendor name if necessary. A good example is the [`pycharm-ce`](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/p/pycharm-ce.rb#L9-L10) cask, whose name is spelled out as `Jetbrains PyCharm Community Edition`, even though it is likely never referenced as such anywhere.
 
 Additional details about the software can be provided in the [`desc`](#stanza-desc) stanza.
 
@@ -814,7 +827,7 @@ Subsequent arguments to `pkg` are key-value pairs which modify the install proce
 
 #### `pkg` *choices*
 
-`pkg choices:` can be used to override a `.pkg`’s default install options via `-applyChoiceChangesXML`. It uses a deserialized version of the `choiceChanges` property list (refer to the `CHOICE CHANGES FILE` section of the `installer` manual page by running `man -P 'less --pattern "^CHOICE CHANGES FILE"' installer`).
+`pkg choices:` can be used to override a `.pkg`’s default install options via `-applyChoiceChangesXML`. It uses a deserialised version of the `choiceChanges` property list (refer to the `CHOICE CHANGES FILE` section of the `installer` manual page by running `man -P 'less --pattern "^CHOICE CHANGES FILE"' installer`).
 
 Running this macOS `installer` command:
 
@@ -916,15 +929,15 @@ The easiest and most useful `uninstall` directive is [`pkgutil:`](#uninstall-pkg
 * **`on_upgrade:`** (symbol or array) - set to `:signal` (or `[:signal]`) to also run the `signal:` directive during `brew upgrade` and `brew reinstall`
 * [`login_item:`](#uninstall-login_item) (string or array) - names of login items to remove
 * [`kext:`](#uninstall-kext) (string or array) - bundle IDs of kexts to unload from the system
-* [`script:`](#uninstall-script) (string or hash) - relative path to an uninstall script to be run via *sudo*; use hash if args are needed
+* [`script:`](#uninstall-script) (string or hash) - relative path to an uninstall script; use a hash to provide arguments or request `sudo: true`
 * [`pkgutil:`](#uninstall-pkgutil) (string, regexp or array of strings and regexps) - strings or regexps matching bundle IDs of packages to uninstall using `pkgutil`
 * [`delete:`](#uninstall-delete) (string or array) - double-quoted, absolute paths of files or directory trees to remove. Should only be used as a last resort; `pkgutil:` is strongly preferred.
-* **`rmdir:`** (string or array) - double-quoted, absolute paths of directories to remove if empty; works recursively
 * [`trash:`](#uninstall-trash) (string or array) - double-quoted, absolute paths of files or directory trees to move to Trash
+* **`rmdir:`** (string or array) - double-quoted, absolute paths of directories to remove if empty; works recursively
 
 Each `uninstall` technique is applied according to the order above. The order in which `uninstall` keys appear in the cask file is ignored.
 
-For assistance filling in the right values for `uninstall` keys, there are several helper [commands found under `cmd`](https://github.com/Homebrew/homebrew-cask/tree/HEAD/cmd) and [scripts found under `developer/bin`](https://github.com/Homebrew/homebrew-cask/tree/HEAD/developer/bin) in the Homebrew Cask repository. Many support `--help` (or otherwise print usage) with additional documentation.
+For assistance filling in the right values for `uninstall` keys, there are several helper [commands found under `cmd`](https://github.com/Homebrew/homebrew-cask/tree/HEAD/cmd) and [scripts found under `developer/bin`](https://github.com/Homebrew/homebrew-cask/tree/HEAD/developer/bin) in the `homebrew/cask` repository. Many support `--help` (or otherwise print usage) with additional documentation.
 
 Working out an `uninstall` stanza is easiest when done on a system where the package is currently installed and operational. To operate on an uninstalled `.pkg` file, see [Working with a `.pkg` file manually](#working-with-a-pkg-file-manually), below.
 
@@ -1008,7 +1021,7 @@ uninstall signal: [
 ]
 ```
 
-Note that when multiple running processes match the given bundle ID, all matching processes will be signaled.
+Note that when multiple running processes match the given bundle ID, all matching processes will be signalled.
 
 Unlike `quit:` directives, Unix signals originate from the current user, not from the superuser. This is construed as a safety feature, since the superuser is capable of bringing down the system via signals. However, this inconsistency could also be considered a bug, and may be addressed in some fashion in a future version.
 
@@ -1149,13 +1162,16 @@ When a plain URL string is insufficient to fetch a file, additional information 
 
 When the domains of `url` and `homepage` differ, the discrepancy should be documented with the `verified:` parameter, repeating the smallest possible portion of the URL that uniquely identifies the app or vendor, excluding the protocol. (Example: [1password-cli.rb](https://github.com/Homebrew/homebrew-cask/blob/ec2476459ead02e80391f44d42a2b48a18bf373d/Casks/1/1password-cli.rb#L8-L9))
 
-This must be added so a user auditing the cask knows the URL was verified by the Homebrew Cask team as the one provided by the vendor, even though it may look unofficial. It is our responsibility as Homebrew Cask maintainers to verify both the `url` and `homepage` information when first added (or subsequently modified, apart from versioning).
+This must be added so a user auditing the cask knows the URL was verified by cask maintainers as the one provided by the vendor, even though it may look unofficial. Cask maintainers are responsible for verifying both the `url` and `homepage` information when first added (or subsequently modified, apart from versioning).
 
-The parameter doesn’t mean you should trust the source blindly, but we only approve casks in which users can easily verify its authenticity with basic means, such as checking the official homepage or public repository. Occasionally, slightly more elaborate techniques may be used, such as inspecting a [`livecheck`](#stanza-livecheck) URL we established as official. Cases where such quick verifications aren’t possible (e.g. when the download URL is behind a registration wall) are [treated in a stricter manner](Acceptable-Casks.md#verifiable-upstream-distribution).
+The parameter doesn’t mean you should trust the source blindly.
+We approve only casks whose authenticity users can verify through an official homepage, public repository or similarly authoritative source.
+Occasionally, verification may require inspecting a [`livecheck`](#stanza-livecheck) URL already established as official.
+Cases where such verification is not possible, such as a download hidden behind a registration wall, are [treated in a stricter manner](Acceptable-Casks.md#verifiable-upstream-distribution).
 
 #### Difficulty finding a URL
 
-Web browsers may obscure the direct `url` of a download for a variety of reasons. Homebrew Cask supplies a [`brew list-url-attributes-on-file`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/cmd/list-url-attributes-on-file.rb) command which can read extended file attributes to extract the actual source URL of most files downloaded by a browser on macOS. The command usually emits multiple candidate URLs; you may have to test each of them:
+Web browsers may obscure the direct `url` of a download for a variety of reasons. The `homebrew/cask` repository provides a [`brew list-url-attributes-on-file`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/cmd/list-url-attributes-on-file.rb) command which can read extended file attributes to extract the actual source URL of most files downloaded by a browser on macOS. The command usually emits multiple candidate URLs; you may have to test each of them:
 
 ```bash
 brew list-url-attributes-on-file <file>
@@ -1356,7 +1372,7 @@ cask "inkscape" do
 end
 ```
 
-To adjust the installed version depending on the current macOS release, use a series of `on_<system>` blocks that cover the range of supported releases. Each block can contain stanzas that set which version to download and customize installation/uninstallation and livecheck behaviour for one or more releases. Example (from [calibre.rb](https://github.com/Homebrew/homebrew-cask/blob/482c34e950da8d649705f4aaea7b760dcb4b5402/Casks/c/calibre.rb#L1-L34)):
+To adjust the installed version depending on the current macOS release, use a series of `on_<system>` blocks that cover the range of supported releases. Each block can contain stanzas that set which version to download and customise installation/uninstallation and livecheck behaviour for one or more releases. Example (from [calibre.rb](https://github.com/Homebrew/homebrew-cask/blob/482c34e950da8d649705f4aaea7b760dcb4b5402/Casks/c/calibre.rb#L1-L34)):
 
 ```ruby
 cask "calibre" do
@@ -1413,11 +1429,17 @@ end
 
 This should be used sparingly: any method which is needed by two or more casks should instead be rolled into Homebrew/brew. Care must also be taken that such methods be very efficient.
 
-Variables and methods should not be defined outside the `Utils` namespace, as they may collide with Homebrew Cask internals.
+Variables and methods should not be defined outside the `Utils` namespace, as they may collide with Homebrew’s cask internals.
 
 ## Token reference
 
-This section describes the algorithm implemented in the `generate_cask_token` script, and covers detailed rules and exceptions which are not needed in most cases.
+This section describes the algorithm implemented in the `generate_cask_token` script and covers detailed rules and exceptions that are not needed in most cases.
+Generate a token from the installed app bundle or the software's full name with:
+
+```sh
+"$(brew --repository homebrew/cask)/developer/bin/generate_cask_token" "/full/path/to/Software.app"
+"$(brew --repository homebrew/cask)/developer/bin/generate_cask_token" "Software Name"
+```
 
 * [Purpose](#purpose)
 * [Finding the simplified name of the vendor’s distribution](#finding-the-simplified-name-of-the-vendors-distribution)
@@ -1432,7 +1454,7 @@ This section describes the algorithm implemented in the `generate_cask_token` sc
 Software vendors are often inconsistent with their naming. By enforcing strict naming conventions we aim to:
 
 * Prevent duplicate submissions
-* Minimize renaming events
+* Minimise renaming events
 * Unambiguously boil down the name of the software into a unique identifier
 * Avoid conflicts with Homebrew/homebrew-core formulae
 
@@ -1493,7 +1515,7 @@ Details of software names and brands will inevitably be lost in the conversion t
   * `CFBundleDisplayName` in `InfoPlist.strings` of an `English.lproj` localization directory
   * `CFBundleName` in `InfoPlist.strings` of an `English.lproj` localization directory
 
-* When there is no vendor localization string, romanize the name by transliteration or decomposition.
+* When there is no vendor localisation string, romanise the name by transliteration or decomposition.
 
 * As a last resort, translate the name of the app bundle into English.
 
@@ -1501,11 +1523,11 @@ Details of software names and brands will inevitably be lost in the conversion t
 
 * The simplified name of a `pkg` may be more tricky to determine than that of an App. If a `pkg` installs an App, then use that App name with the rules above. If not, just create the best name you can, based on the vendor’s web page.
 
-#### Simplified names of non-App software
+#### Simplified names of non-app software
 
-* Currently, rules for generating a token are not well-defined for Preference Panes, Quick Look plugins, and several other types of software installable by Homebrew Cask. Just create the best name you can, based on the filename on disk or the vendor’s web page. Watch out for duplicates.
+* Currently, rules for generating a token are not well-defined for Preference Panes, Quick Look plugins and several other types of software installable as casks. Just create the best name you can, based on the filename on disk or the vendor’s web page. Watch out for duplicates.
 
-  Non-app tokens should become more standardized in the future.
+  Non-app tokens should become more standardised in the future.
 
 ### Converting the simplified name to a token
 
@@ -1527,11 +1549,17 @@ To convert the App’s simplified name (above) to a token:
 
 #### Casks pinned to specific versions
 
-Casks pinned to a specific version of the application (e.g. [`carbon-copy-cloner@5`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/c/carbon-copy-cloner%405.rb)) should use the same token as the standard cask with a suffix of `@<version-number>`. For Carbon Copy Cloner (`carbon-copy-cloner`), pinned to version 6, the token is `carbon-copy-cloner@6`.
+Only create a versioned cask for a release line that meets the [acceptance requirements for versioned releases](Acceptable-Casks.md#default-and-alternative-release-channels).
+Casks pinned to a specific version of the application (e.g. [`carbon-copy-cloner@5`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/c/carbon-copy-cloner%405.rb)) should use the same token as the standard cask with a suffix of `@<version-number>`.
+For Carbon Copy Cloner (`carbon-copy-cloner`), pinned to version 6, the token is `carbon-copy-cloner@6`.
 
-#### Casks pinned to development channels
+#### Casks for alternative release channels
 
-Casks that use a development "channel", such as betas, should use the same token as the standard cask with a suffix of `@<channel>`. For Google Chrome (`google-chrome`), using the "beta" channel, the token should be `google-chrome@beta`.
+Casks that track an alternative upstream release channel should use the same token as the standard cask with an `@<channel>` suffix.
+For Google Chrome (`google-chrome`), the beta-channel token is `google-chrome@beta`.
+
+A suffix such as `@latest` names an upstream release channel and is unrelated to the [`version :latest`](#special-value-latest) special value.
+Use a concrete version and checksum when the channel provides versioned artifacts.
 
 ### Cask filenames
 

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -25,7 +25,7 @@ end
 
 ## The cask language is declarative
 
-Each cask contains a series of stanzas (or “fields”) which *declare* how the software is to be obtained and installed. In a declarative language, the author does not need to worry about **order**. As long as all the needed fields are present, Homebrew determines what needs to be done at install time.
+Each cask contains a series of stanzas (or “fields”) which *declare* how the software is to be obtained and installed. In a declarative language, the author does not need to worry about **order**. As long as all the needed fields are present, Homebrew determines what to do at install time.
 
 To make maintenance easier, the most-frequently-updated stanzas are usually placed at the top. But that’s a convention, not a rule.
 
@@ -84,7 +84,6 @@ Having a common order for stanzas makes casks easier to update and parse. Below 
     internet_plugin
     keyboard_layout
     prefpane
-    qlplugin
     mdimporter
     screen_saver
     service
@@ -156,7 +155,6 @@ The `appimage` stanza is Linux-only, macOS integration stanzas such as `app` and
 | `internet_plugin`                | yes                           | Relative path to an Internet Plugin that should be moved into the `~/Library/Internet Plug-Ins` folder on installation. |
 | `keyboard_layout`                | yes                           | Relative path to a Keyboard Layout that should be moved into the `/Library/Keyboard Layouts` folder on installation. |
 | `prefpane`                       | yes                           | Relative path to a Preference Pane that should be moved into the `~/Library/PreferencePanes` folder on installation. |
-| `qlplugin`                       | yes                           | Relative path to a Quick Look plugin that should be moved into the `~/Library/QuickLook` folder on installation. |
 | `mdimporter`                     | yes                           | Relative path to a Spotlight Metadata Importer that should be moved into the `~/Library/Spotlight` folder on installation. |
 | `screen_saver`                   | yes                           | Relative path to a Screen Saver that should be moved into the `~/Library/Screen Savers` folder on installation. |
 | `service`                        | yes                           | Relative path to a Service that should be moved into the `~/Library/Services` folder on installation. |
@@ -1549,9 +1547,9 @@ To convert the App’s simplified name (above) to a token:
 
 #### Casks pinned to specific versions
 
-Only create a versioned cask for a release line that meets the [acceptance requirements for versioned releases](Acceptable-Casks.md#default-and-alternative-release-channels).
-Casks pinned to a specific version of the application (e.g. [`carbon-copy-cloner@5`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/c/carbon-copy-cloner%405.rb)) should use the same token as the standard cask with a suffix of `@<version-number>`.
-For Carbon Copy Cloner (`carbon-copy-cloner`), pinned to version 6, the token is `carbon-copy-cloner@6`.
+A versioned cask may only be created for a release line that meets the [acceptance requirements for versioned releases](Acceptable-Casks.md#default-and-alternative-release-channels).
+Casks pinned to a specific version of the application (e.g. [`corretto@11`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/c/corretto%4011.rb)) should use the same token as the standard cask with a suffix of `@<version-number>`.
+For Corretto (`corretto`), pinned to version 11, the token is `corretto@11`, while the most recent version does not have a suffix.
 
 #### Casks for alternative release channels
 
@@ -1587,7 +1585,7 @@ For versioned/development channel casks:
 | -------------------- | ------------------- | ---------------------- | -------- |
 | `google-chrome`      | Beta channel        | `google-chrome@beta`   | `google-chrome@beta.rb` |
 | `vlc`                | Nightly channel     | `vlc@nightly`          | `vlc@nightly.rb` |
-| `carbon-copy-cloner` | Pinned to version 5 | `carbon-copy-cloner@5` | `carbon-copy-cloner@5.rb` |
+| `corretto`           | Pinned to version 11 | `corretto@11`         | `corretto@11.rb` |
 
 ### Special affixes
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -4223,9 +4223,9 @@ can take several different forms:
 
 ## SPECIFYING CASKS
 
-Many Homebrew Cask commands accept one or more *`cask`* arguments. These can be
-specified the same way as the *`formula`* arguments described in `SPECIFYING
-FORMULAE` above.
+Many commands that work with casks accept one or more *`cask`* arguments. These
+can be specified the same way as the *`formula`* arguments described in
+`SPECIFYING FORMULAE` above.
 
 ## ENVIRONMENT
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2701,7 +2701,7 @@ The name of a formula: e\.g\. \fBgit\fP, \fBnode\fP, \fBwget\fP\&\.
 .IP \(bu 4
 The fully\-qualified name of a tapped formula: Sometimes a formula from a tapped repository may conflict with one in \fBhomebrew/core\fP\&\. You can still access these formulae by using a special syntax, e\.g\. \fBhomebrew/dupes/vim\fP or \fBhomebrew/versions/node4\fP\&\.
 .SH "SPECIFYING CASKS"
-Many Homebrew Cask commands accept one or more \fIcask\fP arguments\. These can be specified the same way as the \fIformula\fP arguments described in \fBSPECIFYING FORMULAE\fP above\.
+Many commands that work with casks accept one or more \fIcask\fP arguments\. These can be specified the same way as the \fIformula\fP arguments described in \fBSPECIFYING FORMULAE\fP above\.
 .SH "ENVIRONMENT"
 Note that environment variables must have a value set to be detected\. For example, run \fBexport HOMEBREW_NO_INSECURE_REDIRECT=1\fP rather than just \fBexport HOMEBREW_NO_INSECURE_REDIRECT\fP\&\.
 .P


### PR DESCRIPTION
Corrects the Cask Cookbook against the current DSL, fixing reference drift verified against the implementation: the `depends_on` table drops the `java:` stub the DSL rejects and gains the missing `maximum_macos:` and `linux:` rows, the required-stanzas table now matches the audit (`livecheck`, `depends_on` and `zap` are not required for every cask and flight blocks are single-occurrence), the `uninstall` keys are listed in their real execution order, `container type: :bz2` becomes `:bzip2`, the audio plug-in targets gain their `Plug-Ins` directory, `qlplugin` is documented, caveats string-form interpolation is corrected and the token reference shows how to run `generate_cask_token`. An archive-subfolder `app` example is added and UK spellings are applied. The remaining "Homebrew Cask" product naming in source strings is removed (doctor labels, cask caveats and audit wording, the manpage `SPECIFYING CASKS` section) with the manpage regenerated. The write-step token documentation is deliberately left untouched because the in-flight install-steps series is changing those semantics and should own their docs.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5) prepared the corrections with each claim verified against the cask DSL and audit implementation, several empirically via `brew ruby`; I reviewed the diff and verified locally with `brew lgtm --online`, the targeted cask specs, Vale, `brew generate-man-completions` (no drift) and the docs Jekyll/HTMLProofer suite.

-----
