### PR TITLE
formula-analytics: compress Armbian versions

### DIFF
--- a/Library/Homebrew/dev-cmd/formula-analytics.rb
+++ b/Library/Homebrew/dev-cmd/formula-analytics.rb
@@ -428,6 +428,8 @@ module Homebrew
         when /Fedora Linux (\d+)[.\d]*/ then "Fedora Linux #{Regexp.last_match(1)}"
         when /KDE neon .*?([\d.]+)/ then "KDE neon #{Regexp.last_match(1)}"
         when /Amazon Linux (\d+)\.[.\d]*/ then "Amazon Linux #{Regexp.last_match(1)}"
+        when /^Armbian\S*(?: OS)? (\d+)\.0?(\d+)\S*(?: (\w+))?/
+          "Armbian #{Regexp.last_match(1)}.#{Regexp.last_match(2)} #{Regexp.last_match(3)&.downcase}".strip
         when /Fedora Linux Rawhide[.\dn]*/ then "Fedora Linux Rawhide"
         when /Red Hat Enterprise Linux CoreOS (\d+\.\d+)[-.\d]*/
           "Red Hat Enterprise Linux CoreOS #{Regexp.last_match(1)}"


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Used Claude Opus 4.8, though I had a version of this written by hand sitting around.  I tested manually and verified.

Armbian publishes nightly `-trunk.N` images, so a new `os_version` row appears in analytics roughly every day which can be collapsed into singular versions by the operating system version.

This performs 4 normalisations -

- the nightly build number is dropped
- the `_community` / `-unofficial` / `OS` name variants fold into `Armbian`
- inconsistent zero padding (`26.05` vs `26.5`) is unified
- the codename is lowercased

---

- Over the last 90 days this cuts Armbian from 78 rows to 28
- Over the last 365 days, 231 to 47. 48 of the 78 input rows were nightly builds.

```
    Armbian 26.8.0-trunk.61 trixie        ┐
    Armbian 26.8.0-trunk.157 trixie       ├─→  Armbian 26.8 trixie
    Armbian_community 26.8.0-trunk.170 …  ┘

    Armbian-unofficial 26.2.1 trixie      ──→  Armbian 26.2 trixie
    Armbian OS 26.05.0 resolute           ──→  Armbian 26.5 resolute
    Armbian 22.05.0-trunk Buster          ──→  Armbian 22.5 buster
```