### PR TITLE
Fix uninstalling casks removed from the API

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -851,14 +851,21 @@ module Cask
         elsif tap_loader
           tap_loader.load(config: nil).artifacts_list(uninstall_only: true)
         end
-      rescue CaskError, MethodDeprecatedError, JSON::ParserError
+      rescue CaskError, MethodDeprecatedError, JSON::ParserError, ErrorDuringExecution, SystemExit
         nil
       end
 
-      # API fetch failures must not abort best-effort installed metadata recovery.
+      # API fetch failures must not abort best-effort installed metadata recovery. Skip the
+      # per-cask endpoint only when the token is definitively absent from the current API;
+      # a membership-check failure is treated as unknown so recovery still tries the endpoint.
       artifacts ||= begin
-        Homebrew::API::Cask.cask_json(token)["artifacts"]
-      rescue SystemExit
+        definitely_absent = begin
+          !Homebrew::API.cask_token?(token)
+        rescue ErrorDuringExecution, SystemExit
+          false
+        end
+        Homebrew::API::Cask.cask_json(token)["artifacts"] unless definitely_absent
+      rescue ErrorDuringExecution, SystemExit
         nil
       end
       artifacts ||= []

--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -115,6 +115,9 @@ module Cask
       # Preserve the original version and artifacts whenever the receipt cannot reproduce them.
       version = cask.version.to_s
       json_uninstall_artifacts = JSON.parse(JSON.generate(cask.artifacts_list(uninstall_only: true)))
+      # Keep missing artifacts distinguishable from an intentional empty artifact list.
+      return if source_artifacts.nil? && tab.uninstall_artifacts.blank? && json_uninstall_artifacts.empty?
+
       installed_json = cask.to_installed_json_hash
       installed_json["url_specs"] ||= source_url_specs if source_url_specs
       if tab.uninstall_artifacts.presence != json_uninstall_artifacts

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -66,6 +66,7 @@ module Cask
       @ran_prelude_fetch = T.let(false, T::Boolean)
       @ran_prelude = T.let(false, T::Boolean)
       @cask_and_formula_dependencies = T.let(nil, T.nilable(T::Array[T.any(Formula, ::Cask::Cask)]))
+      @installed_uninstall_artifacts_missing = T.let(false, T::Boolean)
     end
 
     sig { returns(T::Boolean) }
@@ -545,6 +546,12 @@ on_request: true)
     def uninstall(successor: nil)
       load_installed_caskfile!
       oh1 "Uninstalling Cask #{Formatter.identifier(@cask)}"
+      if !reinstall? && !upgrade? && @installed_uninstall_artifacts_missing && artifacts.empty?
+        opoo <<~EOS
+          No uninstall artifact metadata is available for Cask '#{@cask}'.
+          Homebrew will remove its records, but files installed by the Cask may remain.
+        EOS
+      end
       uninstall_artifacts(clear: true, successor:)
       if !reinstall? && !upgrade?
         remove_tabfile
@@ -956,6 +963,8 @@ on_request: true)
       Migrator.migrate_if_needed(@cask)
 
       installed_caskfile = @cask.installed_caskfile
+      @installed_uninstall_artifacts_missing = installed_caskfile.is_a?(Pathname) &&
+                                               installed_uninstall_artifacts_missing?(installed_caskfile)
 
       if installed_caskfile&.exist?
         tab = CaskLoader.load_installed_tab(@cask)
@@ -1016,6 +1025,16 @@ on_request: true)
     end
 
     private
+
+    sig { params(installed_caskfile: Pathname).returns(T::Boolean) }
+    def installed_uninstall_artifacts_missing?(installed_caskfile)
+      return false unless CaskLoader.installed_json_caskfile?(installed_caskfile)
+
+      installed_json = CaskLoader.load_installed_json(installed_caskfile)
+      return false if installed_json.nil? || installed_json.key?("artifacts")
+
+      CaskLoader.load_installed_tab(@cask).uninstall_artifacts.blank?
+    end
 
     sig { void }
     def check_prelude_requirements

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -183,6 +183,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
       token = "url-less-installed-cask"
       caskroom = mktmpdir
       allow(Cask::Caskroom).to receive(:path).and_return(caskroom)
+      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
       allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({ "artifacts" => [] })
       path = caskroom/token/".metadata/latest/20260713000000.000/Casks/#{token}.json"
       cask = described_class.new(token, from_json: {}, path:, from_installed_caskfile: true).load(config: nil)
@@ -197,6 +198,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
       token = "receipt-less-installed-cask"
       caskroom = mktmpdir
       allow(Cask::Caskroom).to receive(:path).and_return(caskroom)
+      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
       allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({
         "artifacts" => [
           { "app" => ["Receipt-less.app"] },

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -225,6 +225,7 @@ RSpec.describe Cask::CaskLoader, :cask do
     before { caskfile.write("{}") }
 
     it "falls back to the API for missing artifacts by default" do
+      allow(Homebrew::API).to receive(:cask_token?).with("stubbed").and_return(true)
       expect(Homebrew::API::Cask).to receive(:cask_json).with("stubbed").and_return(
         "artifacts" => [{ "app" => ["Stubbed.app"] }],
       )
@@ -566,7 +567,39 @@ RSpec.describe Cask::CaskLoader, :cask do
   end
 
   describe "::resolve_installed_artifacts" do
+    before { allow(Homebrew::API).to receive(:cask_token?).and_return(true) }
+
+    it "does not request API metadata for a removed cask" do
+      token = "removed-cask"
+      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(false)
+      expect(Homebrew::API::Cask).not_to receive(:cask_json)
+
+      expect(described_class.resolve_installed_artifacts(token, nil)).to eq([])
+    end
+
+    it "falls back to API artifacts when the membership check fails" do
+      token = "unavailable-membership"
+      api_artifacts = [{ "app" => ["API.app"] }]
+      allow(Homebrew::API).to receive(:cask_token?).with(token).and_raise(
+        ErrorDuringExecution.new(["curl"], status: 22),
+      )
+      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({ "artifacts" => api_artifacts })
+
+      expect(described_class.resolve_installed_artifacts(token, nil)).to eq(api_artifacts)
+    end
+
+    it "returns empty artifacts when the API download fails" do
+      token = "unavailable"
+      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
+      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_raise(
+        ErrorDuringExecution.new(["curl"], status: 22),
+      )
+
+      expect(described_class.resolve_installed_artifacts(token, nil)).to eq([])
+    end
+
     it "returns empty artifacts when the API cannot be loaded" do
+      allow(Homebrew::API).to receive(:cask_token?).with("unavailable").and_return(true)
       allow(Homebrew::API::Cask).to receive(:cask_json).with("unavailable").and_raise(SystemExit.new(1))
 
       expect(described_class.resolve_installed_artifacts("unavailable", nil)).to eq([])
@@ -575,6 +608,8 @@ RSpec.describe Cask::CaskLoader, :cask do
     it "falls back to API artifacts when tap lookup is ambiguous" do
       token = "ambiguous"
       api_artifacts = [{ "app" => ["API.app"] }]
+      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).with(token).and_return(nil)
       allow(Cask::CaskLoader::FromNameLoader).to receive(:try_new)
         .with(token, warn: false)
         .and_raise(Cask::TapCaskAmbiguityError.new(token, []))

--- a/Library/Homebrew/test/cask/caskroom_spec.rb
+++ b/Library/Homebrew/test/cask/caskroom_spec.rb
@@ -283,6 +283,7 @@ RSpec.describe Cask::Caskroom do
           app "Old.app"
         end
       RUBY
+      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
       allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({
         "artifacts" => [{ "app" => ["Current.app"] }],
       })
@@ -305,6 +306,7 @@ RSpec.describe Cask::Caskroom do
       allow(Cask::CaskLoader).to receive(:load)
         .with(caskfile, warn: false)
         .and_raise(MethodDeprecatedError.new)
+      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
       allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({
         "artifacts" => [{ "app" => ["Current.app"] }],
       })
@@ -362,6 +364,7 @@ RSpec.describe Cask::Caskroom do
     it "replaces malformed installed JSON using API metadata" do
       token = "malformed-json"
       caskfile = write_installed_caskfile(token, "{", extension: "json")
+      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
       allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({
         "artifacts" => [{ "app" => ["Current.app"] }],
       })
@@ -376,6 +379,7 @@ RSpec.describe Cask::Caskroom do
     it "replaces invalid artifact data in installed JSON using API metadata" do
       token = "invalid-artifacts"
       caskfile = write_installed_caskfile(token, JSON.generate({ "artifacts" => ["invalid"] }), extension: "json")
+      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
       allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({
         "artifacts" => [{ "app" => ["Current.app"] }],
       })
@@ -394,6 +398,19 @@ RSpec.describe Cask::Caskroom do
       described_class.migrate_caskfile_to_json(caskfile)
 
       expect(JSON.parse(caskfile.read)).to eq({ "artifacts" => [] })
+    end
+
+    it "does not mark unavailable artifacts as intentionally empty" do
+      token = "removed-cask"
+      caskfile = write_installed_caskfile(token, "{}", extension: "json")
+      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(false)
+      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_raise(
+        ErrorDuringExecution.new(["curl"], status: 22),
+      )
+
+      described_class.migrate_caskfile_to_json(caskfile)
+
+      expect(JSON.parse(caskfile.read)).to eq({})
     end
   end
 

--- a/Library/Homebrew/test/cask/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/uninstall_spec.rb
@@ -188,6 +188,37 @@ RSpec.describe Cask::Uninstall, :cask do
         expect(caskroom_path).not_to exist
       end
     end
+
+    context "when a removed Cask has incomplete installed metadata" do
+      let(:token) { "removed-cask" }
+      let(:caskroom_path) { Cask::Caskroom.path.join(token) }
+      let(:saved_caskfile) do
+        caskroom_path.join(".metadata", "1.0", "20250101000000.000", "Casks", "#{token}.json")
+      end
+
+      before do
+        saved_caskfile.dirname.mkpath
+        saved_caskfile.write("{}")
+        allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(false)
+        allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_raise(
+          ErrorDuringExecution.new(["curl"], status: 22),
+        )
+      end
+
+      it "removes Homebrew's records and warns that installed files may remain" do
+        expect do
+          described_class.uninstall_casks(Cask::Cask.new(token))
+        end.to output(/files installed by the Cask may remain/).to_stderr
+
+        expect(caskroom_path).not_to exist
+      end
+
+      it "does not warn when uninstalling as part of an upgrade" do
+        expect do
+          Cask::Installer.new(Cask::Cask.new(token), upgrade: true).uninstall(successor: Cask::Cask.new(token))
+        end.not_to output(/files installed by the Cask may remain/).to_stderr
+      end
+    end
   end
 
   describe ".check_dependent_casks" do

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -687,6 +687,7 @@ RSpec.describe Cask::Upgrade, :cask do
     it "uses the forced upgrade metadata for the next upgrade" do
       receipt_path = local_caffeine.metadata_main_container_path/AbstractTab::FILENAME
       receipt_path.unlink
+      allow(Homebrew::API).to receive(:cask_token?).with("local-caffeine").and_return(true)
       allow(Homebrew::API::Cask).to receive(:cask_json).with("local-caffeine").and_return({
         "artifacts" => [{ "app" => ["Caffeine.app"] }],
       })

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -329,6 +329,7 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
     allow(Cask::Caskroom).to receive(:path).and_return(caskroom)
     allow(Homebrew::EnvConfig).to receive_messages(developer?: false, disable_load_formula?: true,
                                                    no_install_from_api?: true)
+    allow(Homebrew::API).to receive(:cask_token?).with("stubbed").and_return(true)
     expect(Homebrew::API::Cask).to receive(:cask_json).once.with("stubbed").and_return({
       "artifacts" => [{ "app" => ["Stubbed.app"] }],
     })
@@ -354,6 +355,7 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
     migrated_internal_caskfile = internal_json_caskfile.dirname/"internal-json.json"
     uninstall_flight_caskfile =
       caskroom/"uninstall-flight-block/.metadata/1.0/20250101000000.000/Casks/uninstall-flight-block.rb"
+    allow(Homebrew::API).to receive(:cask_token?).with("pre-receipt-stubbed").and_return(true)
     expect(Homebrew::API::Cask).to receive(:cask_json).once.with("pre-receipt-stubbed").and_return({
       "artifacts" => [{ "app" => ["Pre Receipt Stubbed.app"] }],
     })


### PR DESCRIPTION
Casks that were deprecated and then removed from the API could no longer be uninstalled. Their installed compact JSON metadata has no uninstall artifacts, so Homebrew requested the now-removed per-cask API endpoint, hit a 404, and aborted before removing anything. Reported in https://github.com/orgs/Homebrew/discussions/6972.

This skips the per-cask API request when the token is not in the internal API (the removed-cask case) and rescues `ErrorDuringExecution` as well as `SystemExit`, so a genuine removal no longer 404s and transient API failures stay non-fatal. Migration no longer rewrites unknown artifacts into a durable empty list, keeping "metadata unavailable" distinct from "intentionally no artifacts". When artifact metadata is truly irrecoverable, uninstall removes Homebrew's records and prints a one-time warning that files installed by the cask may remain; that warning is limited to a direct uninstall so it never fires during upgrade or reinstall.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 4.8) drafted the implementation and tests; I reviewed the diff, verified the new upgrade-scoping test fails without the fix and passes with it, and ran `brew lgtm --online` plus targeted `brew tests` for cask_loader, caskroom, installer, uninstall, upgrade and update-report.

-----
