### PR TITLE
api/cask_download: preserve rename operations

### DIFF
--- a/Library/Homebrew/api/cask_download.rb
+++ b/Library/Homebrew/api/cask_download.rb
@@ -36,6 +36,11 @@ module Homebrew
           if cask_struct.container?
             container(nested: cask_struct.container_args[:nested], type: cask_struct.container_args[:type])
           end
+          # Staging (and the download queue's pre-staging) performs rename
+          # operations through this cask, so they must be preserved here.
+          cask_struct.renames.each do |from, to|
+            rename from, to
+          end
         end
 
         ::Cask::Download.new(cask, quarantine:, require_sha:)

--- a/Library/Homebrew/test/api/cask_download_spec.rb
+++ b/Library/Homebrew/test/api/cask_download_spec.rb
@@ -1,0 +1,22 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "api/cask_download"
+
+RSpec.describe Homebrew::API::CaskDownload do
+  describe "::download" do
+    it "preserves rename operations so staging can perform them" do
+      cask_struct = Homebrew::API::CaskStruct.from_hash({
+        "sha256"   => "abc123",
+        "version"  => "1.0.0",
+        "url_args" => ["https://example.com/file.zip"],
+        "renames"  => [["Test *.pkg", "Test.pkg"]],
+      })
+
+      download = described_class.download(token: "test-cask", cask_struct:)
+      renames = download&.cask&.rename
+
+      expect(renames&.map(&:pairs)).to eq([{ from: "Test *.pkg", to: "Test.pkg" }])
+    end
+  end
+end


### PR DESCRIPTION
[Changes](https://github.com/Homebrew/brew/pull/22670) to the download queue system were causing cask renames to not be applied when only the cask metadata is loaded.

Resolves https://github.com/Homebrew/homebrew-cask/issues/275937 & https://github.com/Homebrew/homebrew-cask/issues/275422

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`claude-code` with `Fable 5` was used to diagnose and fix the issue, I have verified the diff.