### PR TITLE
Disable ask mode in Codespaces prebuild

### DIFF
--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -13,6 +13,9 @@ then
   exit 0
 fi
 
+# disable interactive ask mode so non-interactive prebuilds don't hang
+export HOMEBREW_NO_ASK=1
+
 # install Homebrew's development gems
 brew install-bundler-gems --groups=all
 


### PR DESCRIPTION
Codespaces prebuilds have hung since ask mode became the default for `brew install` on June 8. The prebuild's `.devcontainer/on-create-command.sh` runs `brew install shellcheck shfmt gh gnu-tar` unattended, and default ask mode now stops at `Do you want to proceed with the installation? [y/n]` with nothing to answer it, so the job blocks until it times out ([example failing run](https://github.com/Homebrew/brew/actions/runs/29708807531/job/88257164388)).

This exports `HOMEBREW_NO_ASK=1` in the prebuild-only section so every `brew` call there stays non-interactive. Using the environment variable instead of `--yes` covers all `brew` invocations in the script, not just the single `brew install`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 4.8) did the work; I reviewed the diff, traced the hang to the June 8 ask-mode default, and ran `brew lgtm`.

-----
