### PR TITLE
Remove unused services subcommand TRIGGERS constants

### DIFF
--- a/Library/Homebrew/services/subcommand/cleanup.rb
+++ b/Library/Homebrew/services/subcommand/cleanup.rb
@@ -32,8 +32,6 @@ module Homebrew
           end
           puts "All #{service_type} services OK, nothing cleaned..."
         end
-
-        TRIGGERS = %w[cleanup clean cl rm].freeze
       end
     end
   end

--- a/Library/Homebrew/services/subcommand/info.rb
+++ b/Library/Homebrew/services/subcommand/info.rb
@@ -36,8 +36,6 @@ module Homebrew
           end
         end
 
-        TRIGGERS = %w[info i].freeze
-
         sig { params(bool: T.nilable(T.any(String, T::Boolean))).returns(String) }
         def self.pretty_bool(bool)
           return bool.to_s if !$stdout.tty? || Homebrew::EnvConfig.no_emoji?

--- a/Library/Homebrew/services/subcommand/kill.rb
+++ b/Library/Homebrew/services/subcommand/kill.rb
@@ -23,8 +23,6 @@ module Homebrew
           Homebrew::Services::Cli.check!(targets)
           Homebrew::Services::Cli.kill(targets, verbose: args.verbose?)
         end
-
-        TRIGGERS = %w[kill k].freeze
       end
     end
   end

--- a/Library/Homebrew/services/subcommand/list.rb
+++ b/Library/Homebrew/services/subcommand/list.rb
@@ -39,8 +39,6 @@ module Homebrew
 
         extend Utils::Output::Mixin
 
-        TRIGGERS = [nil, "list", "ls"].freeze
-
         JSON_FIELDS = [:name, :status, :user, :file, :exit_code].freeze
 
         # Print the JSON representation in the CLI

--- a/Library/Homebrew/services/subcommand/restart.rb
+++ b/Library/Homebrew/services/subcommand/restart.rb
@@ -44,8 +44,6 @@ module Homebrew
         # after a package gets updated through `brew upgrade`.
         # This works by removing the old file with `brew services stop`
         # and installing the new one with `brew services start|run`.
-
-        TRIGGERS = %w[restart relaunch reload r].freeze
       end
     end
   end

--- a/Library/Homebrew/services/subcommand/run.rb
+++ b/Library/Homebrew/services/subcommand/run.rb
@@ -25,8 +25,6 @@ module Homebrew
           Homebrew::Services::Cli.check!(targets)
           Homebrew::Services::Cli.run(targets, args.file, verbose: args.verbose?)
         end
-
-        TRIGGERS = ["run"].freeze
       end
     end
   end

--- a/Library/Homebrew/services/subcommand/start.rb
+++ b/Library/Homebrew/services/subcommand/start.rb
@@ -25,8 +25,6 @@ module Homebrew
           Homebrew::Services::Cli.check!(targets)
           Homebrew::Services::Cli.start(targets, args.file, verbose: args.verbose?)
         end
-
-        TRIGGERS = %w[start launch load s l].freeze
       end
     end
   end

--- a/Library/Homebrew/services/subcommand/stop.rb
+++ b/Library/Homebrew/services/subcommand/stop.rb
@@ -38,8 +38,6 @@ module Homebrew
             keep:     args.keep?,
           )
         end
-
-        TRIGGERS = %w[stop unload terminate term t u].freeze
       end
     end
   end

--- a/Library/Homebrew/test/cmd/services/cleanup_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/services/cleanup_subcommand_spec.rb
@@ -6,12 +6,6 @@ require "services/system"
 require "services/cli"
 
 RSpec.describe Homebrew::Cmd::Services::CleanupSubcommand do
-  describe "#TRIGGERS" do
-    it "contains all restart triggers" do
-      expect(Homebrew::Cmd::Services::CleanupSubcommand::TRIGGERS).to eq(%w[cleanup clean cl rm])
-    end
-  end
-
   describe "#run" do
     it "root - prints on empty cleanup" do
       expect(Homebrew::Services::System).to receive(:root?).once.and_return(true)

--- a/Library/Homebrew/test/cmd/services/info_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/services/info_subcommand_spec.rb
@@ -8,12 +8,6 @@ RSpec.describe Homebrew::Cmd::Services::InfoSubcommand do
     allow_any_instance_of(IO).to receive(:tty?).and_return(false)
   end
 
-  describe "#TRIGGERS" do
-    it "contains all restart triggers" do
-      expect(Homebrew::Cmd::Services::InfoSubcommand::TRIGGERS).to eq(%w[info i])
-    end
-  end
-
   describe "#run" do
     it "fails with empty list" do
       expect do

--- a/Library/Homebrew/test/cmd/services/list_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/services/list_subcommand_spec.rb
@@ -4,12 +4,6 @@
 require "cmd/services"
 
 RSpec.describe Homebrew::Cmd::Services::ListSubcommand do
-  describe "#TRIGGERS" do
-    it "contains all restart triggers" do
-      expect(Homebrew::Cmd::Services::ListSubcommand::TRIGGERS).to eq([nil, "list", "ls"])
-    end
-  end
-
   describe "#run" do
     it "fails with empty list" do
       expect(Homebrew::Services::Formulae).to receive(:services_list).and_return([])

--- a/Library/Homebrew/test/cmd/services/restart_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/services/restart_subcommand_spec.rb
@@ -4,12 +4,6 @@
 require "cmd/services"
 
 RSpec.describe Homebrew::Cmd::Services::RestartSubcommand do
-  describe "#TRIGGERS" do
-    it "contains all restart triggers" do
-      expect(Homebrew::Cmd::Services::RestartSubcommand::TRIGGERS).to eq(%w[restart relaunch reload r])
-    end
-  end
-
   describe "#run" do
     it "fails with empty list" do
       expect do


### PR DESCRIPTION
Each `Homebrew::Cmd::Services::*Subcommand` class defined a `TRIGGERS` constant listing the subcommand name and its aliases, but nothing reads it. The values used to dispatch `brew services <subcommand>` come from `AbstractCommand`: `subcommand_name` (derived from the class name) and the `subcommand_args aliases:` declaration in each subcommand. A repo-wide search finds no reference to `TRIGGERS` outside its own definitions and four specs that assert its contents.

This removes the eight dead `TRIGGERS` constants and the four `describe "#TRIGGERS"` spec blocks, so the aliases have a single source of truth (`subcommand_args aliases:`) and there is no unused, drift-prone duplication to maintain.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code identified the `TRIGGERS` constants as dead code while working on `brew deadcode`, confirmed via `git grep` that they have no readers (the aliases are sourced from `subcommand_args aliases:`), and made the removals. Verified by running `brew lgtm` locally: `brew typecheck` and `brew style --changed` are clean and the changed `test/cmd/services/*_subcommand_spec.rb` suites pass.

-----

https://claude.ai/code/session_011BgWRBydtdkvt8ocqH4nj9
