### PR TITLE
Add phase timings to `brew prof`

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -1,6 +1,12 @@
 # typed: strict
 # frozen_string_literal: true
 
+phase_timings_output = ENV.delete("HOMEBREW_PHASE_TIMINGS")
+if phase_timings_output
+  phase_timings_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC).to_f
+  phase_timings_command = ARGV.dup
+end
+
 # `HOMEBREW_STACKPROF` should be set via `brew prof --stackprof`, not manually.
 if ENV["HOMEBREW_STACKPROF"]
   require "rubygems"
@@ -17,6 +23,15 @@ std_trap = trap("INT") { exit! 130 } # no backtrace thanks
 
 require_relative "global"
 require "utils/output"
+
+if phase_timings_output
+  require "utils/phase_timings"
+  Homebrew::PhaseTimings.start!(
+    output_path: phase_timings_output,
+    started_at:  phase_timings_started_at,
+    command:     phase_timings_command,
+  )
+end
 
 begin
   trap("INT", std_trap) # restore default CTRL-C handler
@@ -109,10 +124,10 @@ begin
     end
     Homebrew.running_command = cmd
     if cmd_class
-      unless Homebrew::EnvConfig.no_install_from_api?
-        require "api"
-        Homebrew::API.fetch_api_files!
-      end
+      install_from_api = !Homebrew::EnvConfig.no_install_from_api?
+      require "api" if install_from_api
+      Homebrew::PhaseTimings.install! if phase_timings_output
+      Homebrew::API.fetch_api_files! if install_from_api
 
       command_instance = cmd_class.new
 
@@ -232,4 +247,5 @@ ensure
     StackProf.stop
     StackProf.results("prof/stackprof.dump")
   end
+  Homebrew::PhaseTimings.write! if phase_timings_output
 end

--- a/Library/Homebrew/dev-cmd/prof.rb
+++ b/Library/Homebrew/dev-cmd/prof.rb
@@ -15,13 +15,17 @@ module Homebrew
                description: "Use `stackprof` instead of `ruby-prof` (the default)."
         switch "--vernier",
                description: "Use `vernier` instead of `ruby-prof` (the default)."
+        switch "--timings",
+               description: "Record machine-readable timings for Homebrew command phases."
+        conflicts "--timings", "--stackprof"
+        conflicts "--timings", "--vernier"
 
         named_args :command, min: 1
       end
 
       sig { override.void }
       def run
-        Homebrew.install_bundler_gems!(groups: ["prof"], setup_path: false)
+        Homebrew.install_bundler_gems!(groups: ["prof"], setup_path: false) unless args.timings?
 
         brew_rb = (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path
         FileUtils.mkdir_p "prof"
@@ -37,6 +41,14 @@ module Homebrew
           EOS
         else
           raise UsageError, "`#{cmd}` is an unknown command!"
+        end
+
+        if args.timings?
+          output_filename = "prof/timings.json"
+          safe_system({ "HOMEBREW_PHASE_TIMINGS" => output_filename },
+                      *HOMEBREW_RUBY_EXEC_ARGS, brew_rb, *args.named)
+          ohai "Phase timings written to #{output_filename}"
+          return
         end
 
         Homebrew.setup_gem_environment!

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/prof.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/prof.rbi
@@ -15,5 +15,8 @@ class Homebrew::DevCmd::Prof::Args < Homebrew::CLI::Args
   def stackprof?; end
 
   sig { returns(T::Boolean) }
+  def timings?; end
+
+  sig { returns(T::Boolean) }
   def vernier?; end
 end

--- a/Library/Homebrew/test/dev-cmd/prof_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/prof_spec.rb
@@ -47,6 +47,23 @@ RSpec.describe Homebrew::DevCmd::Prof do
 
       prof.run
     end
+
+    it "records phase timings without loading a sampling profiler" do
+      prof = described_class.new(["--timings", "help"])
+
+      expect(Homebrew).not_to receive(:install_bundler_gems!)
+      expect(Homebrew).not_to receive(:setup_gem_environment!)
+      expect(prof).to receive(:safe_system)
+        .with(
+          { "HOMEBREW_PHASE_TIMINGS" => "prof/timings.json" },
+          *HOMEBREW_RUBY_EXEC_ARGS,
+          (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path,
+          "help",
+        )
+      allow(prof).to receive(:ohai)
+
+      prof.run
+    end
   end
 
   describe "integration tests", :integration_test, :needs_network do
@@ -55,6 +72,7 @@ RSpec.describe Homebrew::DevCmd::Prof do
         HOMEBREW_LIBRARY_PATH/"prof/call_stack.html",
         HOMEBREW_LIBRARY_PATH/"prof/d3-flamegraph.html",
         HOMEBREW_LIBRARY_PATH/"prof/stackprof.dump",
+        HOMEBREW_LIBRARY_PATH/"prof/timings.json",
         HOMEBREW_LIBRARY_PATH/"prof/vernier.json",
       ]
     end
@@ -77,6 +95,21 @@ RSpec.describe Homebrew::DevCmd::Prof do
       expect { brew "prof", "--vernier", "config" }
         .to output(/^HOMEBREW_VERSION:/).to_stdout
         .and be_a_success
+    end
+
+    it "records fetch phases" do
+      setup_test_formula "testball"
+
+      expect do
+        brew "prof", "--timings", "--", "fetch", "--force", "testball",
+             "HOMEBREW_NO_INSTALL_FROM_API" => "1"
+      end.to be_a_success
+
+      timings = JSON.parse((HOMEBREW_LIBRARY_PATH/"prof/timings.json").read)
+      phases = timings.fetch("events").map { |event| event.fetch("phase") }
+      expect(phases).to include(
+        "startup", "formula_resolution", "formula_inflation", "download_enqueue", "curl_body", "checksum", "symlink"
+      )
     end
   end
 end

--- a/Library/Homebrew/test/utils/phase_timings_spec.rb
+++ b/Library/Homebrew/test/utils/phase_timings_spec.rb
@@ -1,0 +1,37 @@
+# typed: true
+# frozen_string_literal: true
+
+require "utils/phase_timings"
+
+RSpec.describe Homebrew::PhaseTimings do
+  let(:output_path) { HOMEBREW_TEMP/"phase-timings.json" }
+
+  after { output_path.unlink if output_path.exist? }
+
+  it "writes machine-readable phase events" do
+    described_class.start!(
+      output_path:,
+      started_at:  Process.clock_gettime(Process::CLOCK_MONOTONIC).to_f,
+      command:     ["install", "foo"],
+    )
+
+    expect(described_class.measure("checksum", detail: "foo") { :result }).to eq(:result)
+    described_class.write!
+
+    timings = JSON.parse(output_path.read)
+    expect(timings).to include(
+      "schema_version" => 1,
+      "time_unit"      => "microseconds",
+      "command"        => ["install", "foo"],
+    )
+    expect(timings.fetch("events")).to include(
+      hash_including(
+        "phase"     => "checksum",
+        "detail"    => "foo",
+        "start"     => be_a(Integer),
+        "duration"  => be_a(Integer),
+        "thread_id" => be_a(Integer),
+      ),
+    )
+  end
+end

--- a/Library/Homebrew/utils/phase_timings.rb
+++ b/Library/Homebrew/utils/phase_timings.rb
@@ -1,0 +1,168 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "json"
+
+module Homebrew
+  module PhaseTimings
+    Event = T.type_alias { T::Hash[String, T.any(Integer, String)] }
+
+    @command = T.let([], T::Array[String])
+    @events = T.let([], T::Array[Event])
+    @mutex = T.let(Thread::Mutex.new, Thread::Mutex)
+    @output_path = T.let(nil, T.nilable(Pathname))
+    @started_at = T.let(0.0, Float)
+
+    sig {
+      params(
+        output_path: T.any(Pathname, String),
+        started_at:  Float,
+        command:     T::Array[String],
+      ).void
+    }
+    def self.start!(output_path:, started_at:, command:)
+      @output_path = Pathname(output_path)
+      @started_at = started_at
+      @command = command
+      @mutex.synchronize { @events = [] }
+      record("startup", started_at, monotonic_time)
+    end
+
+    sig {
+      type_parameters(:U)
+        .params(
+          phase:  String,
+          detail: T.nilable(String),
+          _block: T.proc.returns(T.type_parameter(:U)),
+        )
+        .returns(T.type_parameter(:U))
+    }
+    def self.measure(phase, detail: nil, &_block)
+      started_at = monotonic_time
+      begin
+        yield
+      ensure
+        record(phase, started_at, monotonic_time, detail:)
+      end
+    end
+
+    sig { void }
+    def self.install!
+      instrument(Homebrew::CLI::NamedArgs, :to_formulae_and_casks, "formula_resolution") if defined?(Homebrew::CLI)
+      instrument(Formulary.singleton_class, :factory, "formula_inflation") if defined?(Formulary)
+      instrument(Homebrew::API.singleton_class, :fetch_api_files!, "api_metadata_load") if defined?(Homebrew::API)
+      if defined?(Homebrew::API::Internal)
+        instrument(Homebrew::API::Internal.singleton_class, :formula_struct, "api_metadata_load")
+      end
+      instrument(Homebrew::Install.singleton_class, :formula_installers, "planning") if defined?(Homebrew::Install)
+      if defined?(FormulaInstaller)
+        instrument(FormulaInstaller, :prelude, "planning")
+        instrument(FormulaInstaller, :compute_dependencies, "dependency_resolution")
+        instrument(FormulaInstaller, :pour, "pour")
+        instrument(FormulaInstaller, :link, "link")
+        instrument(FormulaInstaller, :clean, "cleanup")
+        instrument(FormulaInstaller, :post_install, "postinstall")
+      end
+      instrument(Homebrew::DownloadQueue, :enqueue, "download_enqueue") if defined?(Homebrew::DownloadQueue)
+      if defined?(Utils::Curl)
+        instrument(Utils::Curl, :curl_headers, "curl_headers")
+        instrument(Utils::Curl.singleton_class, :curl_headers, "curl_headers")
+        instrument(Utils::Curl, :curl_download, "curl_body")
+        instrument(Utils::Curl.singleton_class, :curl_download, "curl_body")
+      end
+      instrument(Downloadable::VerificationCache, :verify, "checksum") if defined?(Downloadable::VerificationCache)
+      if defined?(AbstractFileDownloadStrategy)
+        instrument(AbstractFileDownloadStrategy, :create_symlink_to_cached_download, "symlink")
+      end
+      instrument(AbstractDownloadStrategy, :stage, "extraction") if defined?(AbstractDownloadStrategy)
+      instrument(Bottle, :stage_from_download_queue, "extraction") if defined?(Bottle)
+      instrument(Cask::Download, :stage_from_download_queue, "extraction") if defined?(Cask::Download)
+      instrument(Tab, :write, "tab_write") if defined?(Tab)
+      return unless defined?(Cleanup)
+
+      instrument(Cleanup.singleton_class, :install_formula_clean!, "cleanup")
+    end
+
+    sig { void }
+    def self.write!
+      output_path = @output_path
+      return if output_path.nil?
+
+      events = @mutex.synchronize { @events.sort_by { |event| event.fetch("start") } }
+      output_path.dirname.mkpath
+      output_path.write("#{JSON.pretty_generate({
+        "schema_version" => 1,
+        "time_unit"      => "microseconds",
+        "command"        => @command,
+        "events"         => events,
+      })}\n")
+    end
+
+    sig { params(receiver: Object, args: T::Array[T.anything]).returns(T.nilable(String)) }
+    def self.detail_for(receiver, args)
+      object = if receiver.respond_to?(:formula)
+        receiver.public_method(:formula).call
+      elsif receiver.respond_to?(:url)
+        receiver.public_method(:url).call
+      else
+        args.first
+      end
+
+      if object.respond_to?(:full_name)
+        object.full_name.to_s
+      elsif object.respond_to?(:download_queue_name)
+        object.download_queue_name.to_s
+      elsif object.is_a?(String) || object.is_a?(Symbol) || object.is_a?(Pathname)
+        object.to_s
+      end
+    end
+
+    sig { params(klass: T::Module[T.anything], method_name: Symbol, phase: String).void }
+    private_class_method def self.instrument(klass, method_name, phase)
+      visibility = if klass.private_method_defined?(method_name)
+        :private
+      elsif klass.protected_method_defined?(method_name)
+        :protected
+      elsif klass.method_defined?(method_name)
+        :public
+      end
+      return if visibility.nil?
+
+      wrapper = Module.new do
+        define_method(method_name) do |*args, **kwargs, &block|
+          Homebrew::PhaseTimings.measure(
+            phase,
+            detail: Homebrew::PhaseTimings.detail_for(self, args),
+          ) { super(*args, **kwargs, &block) }
+        end
+      end
+      wrapper.module_eval { private method_name } if visibility == :private
+      wrapper.module_eval { protected method_name } if visibility == :protected
+      klass.prepend(wrapper)
+    end
+
+    sig {
+      params(
+        phase:        String,
+        started_at:   Float,
+        completed_at: Float,
+        detail:       T.nilable(String),
+      ).void
+    }
+    private_class_method def self.record(phase, started_at, completed_at, detail: nil)
+      event = T.let({
+        "phase"     => phase,
+        "start"     => ((started_at - @started_at) * 1_000_000).round,
+        "duration"  => ((completed_at - started_at) * 1_000_000).round,
+        "thread_id" => Thread.current.object_id,
+      }, Event)
+      event["detail"] = detail if detail
+      @mutex.synchronize { @events << event }
+    end
+
+    sig { returns(Float) }
+    private_class_method def self.monotonic_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC).to_f
+    end
+  end
+end


### PR DESCRIPTION
- Record install and fetch work as machine-readable phase events.
- Keep instrumentation opt-in and isolated from child `brew` calls.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 Sol xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
