### PR TITLE
fetch: exclude arches without downloads

### DIFF
--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -312,7 +312,7 @@ module Homebrew
             rescue Cask::CaskInvalidError, Cask::CaskUnreadableError
               raise unless cask.on_system_blocks_exist?
             end
-            if loaded_cask.nil?
+            if loaded_cask.nil? || loaded_cask.depends_on.arch&.none? { |dep_arch| dep_arch[:type] == arch }
               opoo "Cask #{cask} is not supported on os #{os} and arch #{arch}"
               next
             end

--- a/Library/Homebrew/test/cmd/fetch_spec.rb
+++ b/Library/Homebrew/test/cmd/fetch_spec.rb
@@ -95,6 +95,11 @@ RSpec.describe Homebrew::Cmd::FetchCmd do
                                            "caffeine-arm-linux.zip", "caffeine-intel-linux.zip")
     end
 
+    it "skips arches the cask's depends_on arch excludes" do
+      cmd = described_class.new(["--cask", "--os=macos", "--arch=intel", "depends-on-arch-arm64"])
+      expect(cmd.send(:cask_downloads, Cask::CaskLoader.load("depends-on-arch-arm64"))).to be_empty
+    end
+
     it "collapses to a single download for a cask without on_system blocks" do
       cmd = described_class.new(["--cask", "--all-platforms", "local-caffeine"])
       expect(cmd.send(:cask_downloads, Cask::CaskLoader.load("local-caffeine")).length).to eq(1)

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/depends-on-arch-arm64.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/depends-on-arch-arm64.rb
@@ -1,0 +1,15 @@
+# typed: false
+
+cask "depends-on-arch-arm64" do
+  arch arm: "arm", intel: "intel"
+
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine-#{arch}-darwin.zip"
+  homepage "https://brew.sh/"
+
+  depends_on arch: :arm64
+
+  app "Caffeine.app"
+end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Opus 4.8 High + Fable review, manual review and testing, and `brew lgtm --online` for validation.

-----

`brew fetch sonarqube-cli --arch=intel` fails with a `curl: (22) ... 403` because the cask builds its URL from the `arch` stanza and has a single `sha256` inside `on_macos`, so under an arch the cask doesn't support it still resolves and attempts to fetch a URL that doesn't exist upstream as the cask wasn't resolving the `depends_on arch` with `fetch`.

This will skip an os/arch combination when the loaded cask's `depends_on arch` excludes that architecture, reusing the existing "not supported" warning:

    $ brew fetch --cask sonarqube-cli --arch=intel
    Warning: Cask sonarqube-cli is not supported on os golden_gate and arch intel

Adds a `depends-on-arch-arm64` test cask replicating the behavior and a `#cask_downloads` spec covering the skip.