### PR TITLE
dev-cmd/generate-zap: glob sfl files

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-zap.rb
+++ b/Library/Homebrew/dev-cmd/generate-zap.rb
@@ -88,6 +88,9 @@ module Homebrew
 
       UUID_PATTERN = /[0-9A-F]{8}(-[0-9A-F]{4}){3}-[0-9A-F]{12}/i
 
+      # Keep in sync with `RuboCop::Cop::Cask::SharedFilelistGlob`.
+      SHARED_FILELIST_PATTERN = /\.sfl\d+\z/
+
       sig { override.void }
       def run
         patterns = if args.name?
@@ -112,8 +115,8 @@ module Homebrew
           odie message
         end
 
-        trash_paths  = replace_uuids(collapse_to_wildcards(trash_paths))
-        delete_paths = replace_uuids(collapse_to_wildcards(delete_paths))
+        trash_paths  = glob_shared_filelists(replace_uuids(collapse_to_wildcards(trash_paths)))
+        delete_paths = glob_shared_filelists(replace_uuids(collapse_to_wildcards(delete_paths)))
 
         rmdir_paths = derive_rmdir_candidates(trash_paths + delete_paths)
 
@@ -267,6 +270,11 @@ module Homebrew
       sig { params(paths: T::Array[String]).returns(T::Array[String]) }
       def replace_uuids(paths)
         paths.map { |p| p.gsub(UUID_PATTERN, "*") }.uniq.sort
+      end
+
+      sig { params(paths: T::Array[String]).returns(T::Array[String]) }
+      def glob_shared_filelists(paths)
+        paths.map { |p| p.sub(SHARED_FILELIST_PATTERN, ".sfl*") }.uniq.sort
       end
 
       sig { params(paths: T::Array[String]).returns(T::Array[String]) }

--- a/Library/Homebrew/dev-cmd/generate-zap.rb
+++ b/Library/Homebrew/dev-cmd/generate-zap.rb
@@ -89,7 +89,7 @@ module Homebrew
       UUID_PATTERN = /[0-9A-F]{8}(-[0-9A-F]{4}){3}-[0-9A-F]{12}/i
 
       # Keep in sync with `RuboCop::Cop::Cask::SharedFilelistGlob`.
-      SHARED_FILELIST_PATTERN = /\.sfl\d+\z/
+      SHARED_FILELIST_PATTERN = /\.sfl\d\z/
 
       sig { override.void }
       def run

--- a/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
@@ -302,6 +302,28 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
     end
   end
 
+  describe "#glob_shared_filelists" do
+    it "replaces the Shared File List version with a glob" do
+      shared_file_list =
+        "~/Library/Application Support/com.apple.sharedfilelist/" \
+        "com.apple.LSSharedFileList.ApplicationRecentDocuments"
+      paths = [
+        "#{shared_file_list}/org.example.foo.sfl2",
+        "#{shared_file_list}/org.example.foo.sfl3",
+      ]
+      result = generate_zap.send(:glob_shared_filelists, paths)
+
+      expect(result).to eq(["#{shared_file_list}/org.example.foo.sfl*"])
+    end
+
+    it "leaves paths without a Shared File List version unchanged" do
+      paths = ["~/Library/Preferences/com.example.foo.plist"]
+      result = generate_zap.send(:glob_shared_filelists, paths)
+
+      expect(result).to eq(paths)
+    end
+  end
+
   describe "#derive_rmdir_candidates" do
     it "suggests Application Support parent directories" do
       paths = ["~/Library/Application Support/Foo/config.json"]


### PR DESCRIPTION
`brew style` enforces the use of a `glob` in zap files ending with `sfl(\d)` so let's do the same in `brew generate-zap`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

I used `claude-code` with Fable 5 to generate the fix and the tests.