### PR TITLE
Count squash-merge commits into the contributions count

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -185,7 +185,7 @@ module Homebrew
 
         user_names.each_key do |username|
           grand_total = grand_totals.fetch(username)
-          greater_than_total = T.let(false, T::Boolean)
+          greater_than_total = T.let(grand_total.fetch(:merged_pr_author_hit_cap, 0).positive?, T::Boolean)
           contributions = CONTRIBUTION_TYPES.keys.filter_map do |type|
             type_count = grand_total[type]
             next if type_count.nil? || type_count.zero?

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -426,14 +426,20 @@ module Homebrew
 
         require "utils/github"
         github_users = users.keys.to_h { |user| [user, github_username_for(user, to:)] }
+        git_authored_pull_requests = users.keys.to_h { |user| [user, {}] }
+        git_merged_pull_requests = users.keys.to_h { |user| [user, {}] }
         repository_refs.each do |repository, (repository_path, ref)|
           require "utils/git"
           output = Utils.safe_popen_read(
             Utils::Git.git, "-C", repository_path, "log", ref, "--since=#{from}", "--before=#{to}",
             "--format=%H%x1f%P%x1f%an%x1f%ae%x1f%B%x1e"
           )
-          parse_git_log(output, users).each do |user, counts|
+          authored_pull_requests = users.keys.to_h { |user| [user, Set.new] }
+          merged_pull_requests = users.keys.to_h { |user| [user, Set.new] }
+          parse_git_log(output, users, authored_pull_requests:, merged_pull_requests:).each do |user, counts|
             results.fetch(user)[repository] = counts
+            git_authored_pull_requests.fetch(user)[repository] = authored_pull_requests.fetch(user)
+            git_merged_pull_requests.fetch(user)[repository] = merged_pull_requests.fetch(user)
           end
         end
 
@@ -452,10 +458,21 @@ module Homebrew
               []
             end
             counts = results.fetch(user).fetch(repository)
-            additional_authored_prs = [merged_pull_requests.length - counts.fetch(:merged_pr_author), 0].max
-            additional_authored_prs.times do
-              increment_contribution_count(counts, :merged_pr_author)
-              increment_contribution_count(counts, :merged_pr)
+            authored_pull_requests = git_authored_pull_requests.fetch(user).fetch(repository, Set.new)
+            merged_pull_request_ids = git_merged_pull_requests.fetch(user).fetch(repository, Set.new)
+            merged_pull_requests.each do |pull_request|
+              number = pull_request["number"]
+              next unless number.is_a?(Integer)
+
+              pull_request_id = number.to_s
+              authored_pull_requests << pull_request_id
+              merged_pull_request_ids << pull_request_id
+            end
+            unless authored_pull_requests.empty?
+              counts[:merged_pr_author] = [authored_pull_requests.length, MAX_CONTRIBUTIONS].min
+            end
+            unless merged_pull_request_ids.empty?
+              counts[:merged_pr] = [merged_pull_request_ids.length, MAX_CONTRIBUTIONS].min
             end
           end
         end
@@ -556,10 +573,15 @@ module Homebrew
       end
 
       sig {
-        params(output: String, users: T::Hash[String, String])
+        params(
+          output:                 String,
+          users:                  T::Hash[String, String],
+          authored_pull_requests: T.nilable(T::Hash[String, T::Set[String]]),
+          merged_pull_requests:   T.nilable(T::Hash[String, T::Set[String]]),
+        )
           .returns(T::Hash[String, T::Hash[Symbol, Integer]])
       }
-      def parse_git_log(output, users)
+      def parse_git_log(output, users, authored_pull_requests: nil, merged_pull_requests: nil)
         counts = users.to_h do |user, _|
           [user, CONTRIBUTION_TYPES.keys.to_h { |type| [type, 0] }]
         end
@@ -612,15 +634,23 @@ module Homebrew
           end
 
           parents = parents_string.split
-          source_owner = body[%r{\AMerge pull request #\d+ from ([^/\s]+)/}, 1]
-          next if parents.length < 2 || source_owner.nil?
+          pull_request = body.match(%r{\AMerge pull request #(\d+) from ([^/\s]+)/})
+          next if parents.length < 2 || pull_request.nil?
 
           merger = user_for_git_identity(author_name, author_email, identity_users)
+          pull_request_id = pull_request[1]
+          source_owner = pull_request[2]
+          next if pull_request_id.nil? || source_owner.nil?
+
           author = identity_users[source_owner.downcase] || commit_authors[parents.fetch(1)]
-          increment_contribution_count(counts.fetch(author), :merged_pr_author) if author
+          if author
+            increment_contribution_count(counts.fetch(author), :merged_pr_author)
+            authored_pull_requests&.fetch(author)&.add(pull_request_id)
+          end
           increment_contribution_count(counts.fetch(merger), :merged_pr_merger) if merger
           [author, merger].compact.uniq.each do |user|
             increment_contribution_count(counts.fetch(user), :merged_pr)
+            merged_pull_requests&.fetch(user)&.add(pull_request_id)
           end
         end
 

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -191,7 +191,8 @@ module Homebrew
             next if type_count.nil? || type_count.zero?
 
             count_prefix = ""
-            if (type == :approved_pr_review && type_count >= MAX_PR_SEARCH) || type_count >= MAX_CONTRIBUTIONS
+            if (type == :merged_pr_author && grand_total.fetch(:merged_pr_author_hit_cap, 0).positive?) ||
+               (type == :approved_pr_review && type_count >= MAX_PR_SEARCH) || type_count >= MAX_CONTRIBUTIONS
               greater_than_total ||= true
               count_prefix = ">="
             end
@@ -305,6 +306,15 @@ module Homebrew
             "None"
           end
 
+          capped = grand_total.fetch(:merged_pr_author_hit_cap, 0).positive? ||
+                   grand_total.fetch(:approved_pr_review_hit_cap, 0).positive?
+          capped ||= user_repositories.any? do |_, counts|
+            counts.fetch(:approved_pr_review) >= MAX_PR_SEARCH ||
+              counts.except(:approved_pr_review).values.any? do |count|
+                count >= MAX_CONTRIBUTIONS
+              end
+          end
+
           [
             user,
             user_names.fetch(user),
@@ -317,10 +327,7 @@ module Homebrew
             qualifying_total,
             maintainer_activity_met,
             lead_activity_met,
-            grand_total.fetch(:approved_pr_review_hit_cap, 0).positive? || user_repositories.any? do |_, counts|
-              counts.fetch(:approved_pr_review) >= MAX_PR_SEARCH ||
-                counts.except(:approved_pr_review).values.any? { |count| count >= MAX_CONTRIBUTIONS }
-            end,
+            capped,
             lead_maintainer ? "Lead Maintainer" : "Maintainer",
             new_role,
           ]
@@ -426,8 +433,12 @@ module Homebrew
 
         require "utils/github"
         github_users = users.keys.to_h { |user| [user, github_username_for(user, to:)] }
-        git_authored_pull_requests = users.keys.to_h { |user| [user, {}] }
-        git_merged_pull_requests = users.keys.to_h { |user| [user, {}] }
+        git_authored_pull_requests = users.keys.to_h do |user|
+          [user, repositories.to_h { |repository| [repository, Set.new] }]
+        end
+        git_merged_pull_requests = users.keys.to_h do |user|
+          [user, repositories.to_h { |repository| [repository, Set.new] }]
+        end
         repository_refs.each do |repository, (repository_path, ref)|
           require "utils/git"
           output = Utils.safe_popen_read(
@@ -448,32 +459,57 @@ module Homebrew
           github_user = github_users.fetch(user)
           next if github_user.nil?
 
-          repositories.each do |repository|
-            cache_key = ["merged-at", repository, github_user, merged_range].join("\0")
-            merged_pull_requests = github_search_with_rate_limit(cache_key, to:) do
-              GitHub.search_issues("", is: "merged", repo: repository, author: github_user, merged: merged_range)
-            rescue GitHub::API::ValidationFailedError
-              opoo "Couldn't search GitHub for PRs authored by #{github_user}. Their profile might be private. " \
-                   "Defaulting to 0."
-              []
-            end
-            counts = results.fetch(user).fetch(repository)
-            authored_pull_requests = git_authored_pull_requests.fetch(user).fetch(repository, Set.new)
-            merged_pull_request_ids = git_merged_pull_requests.fetch(user).fetch(repository, Set.new)
-            merged_pull_requests.each do |pull_request|
-              number = pull_request["number"]
-              next unless number.is_a?(Integer)
+          cache_key = ["merged-at", organisation, github_user, merged_range].join("\0")
+          merged_pull_requests = github_search_with_rate_limit(cache_key, to:) do
+            GitHub.search_issues("", is: "merged", user: organisation, author: github_user, merged: merged_range)
+          rescue GitHub::API::ValidationFailedError
+            opoo "Couldn't search GitHub for PRs authored by #{github_user}. Their profile might be private. " \
+                 "Defaulting to 0."
+            []
+          end
+          capped_merged_pull_requests = merged_pull_requests.length >= MAX_PR_SEARCH
+          if capped_merged_pull_requests
+            results.fetch(user).fetch(repositories.fetch(0))[:merged_pr_author_hit_cap] =
+              1
+          end
+          merged_pull_requests.each do |pull_request|
+            repository = pull_request.fetch("repository_url").delete_prefix("#{GitHub::API_URL}/repos/")
+            next unless repositories.include?(repository)
 
-              pull_request_id = number.to_s
-              authored_pull_requests << pull_request_id
-              merged_pull_request_ids << pull_request_id
+            authored_pull_requests = git_authored_pull_requests.fetch(user).fetch(repository)
+            merged_pull_request_ids = git_merged_pull_requests.fetch(user).fetch(repository)
+            add_merged_pull_request_id(pull_request, authored_pull_requests, merged_pull_request_ids)
+          end
+          repositories.each do |repository|
+            counts = results.fetch(user).fetch(repository)
+            authored_pull_requests = git_authored_pull_requests.fetch(user).fetch(repository)
+            merged_pull_request_ids = git_merged_pull_requests.fetch(user).fetch(repository)
+            update_merged_pull_request_counts(counts, authored_pull_requests, merged_pull_request_ids)
+          end
+          next unless skip_reviews_if_lead_met
+          next unless capped_merged_pull_requests
+          next if lead_activity_met?(results.fetch(user))
+
+          repositories.each do |repository|
+            break if lead_activity_met?(results.fetch(user))
+
+            repository_counts = results.fetch(user).fetch(repository)
+            repository_total = contribution_count(repository_counts.slice(*QUALIFYING_CONTRIBUTION_TYPES))
+            qualifying_total = contribution_count(total(results.fetch(user)).slice(*QUALIFYING_CONTRIBUTION_TYPES))
+            next if repository_total >= LEAD_REPOSITORY_ACTIVITY_THRESHOLD &&
+                    qualifying_total >= MAINTAINER_ACTIVITY_THRESHOLD
+
+            $stderr.puts "Querying merged-PR search for #{user} in #{repository}..." if progress
+            cache_key = ["merged-at", repository, github_user, merged_range].join("\0")
+            repository_pull_requests = github_search_with_rate_limit(cache_key, to:) do
+              GitHub.search_issues("", is: "merged", repo: repository, author: github_user, merged: merged_range)
             end
-            unless authored_pull_requests.empty?
-              counts[:merged_pr_author] = [authored_pull_requests.length, MAX_CONTRIBUTIONS].min
+            authored_pull_requests = git_authored_pull_requests.fetch(user).fetch(repository)
+            merged_pull_request_ids = git_merged_pull_requests.fetch(user).fetch(repository)
+            repository_pull_requests.each do |pull_request|
+              add_merged_pull_request_id(pull_request, authored_pull_requests, merged_pull_request_ids)
             end
-            unless merged_pull_request_ids.empty?
-              counts[:merged_pr] = [merged_pull_request_ids.length, MAX_CONTRIBUTIONS].min
-            end
+            update_merged_pull_request_counts(repository_counts, authored_pull_requests, merged_pull_request_ids)
           end
         end
 
@@ -519,6 +555,38 @@ module Homebrew
         end
 
         results
+      end
+
+      sig {
+        params(
+          pull_request:           T::Hash[String, T.untyped],
+          authored_pull_requests: T::Set[String],
+          merged_pull_requests:   T::Set[String],
+        ).void
+      }
+      def add_merged_pull_request_id(pull_request, authored_pull_requests, merged_pull_requests)
+        number = pull_request["number"]
+        return unless number.is_a?(Integer)
+
+        pull_request_id = number.to_s
+        authored_pull_requests << pull_request_id
+        merged_pull_requests << pull_request_id
+      end
+
+      sig {
+        params(
+          counts:                 T::Hash[Symbol, Integer],
+          authored_pull_requests: T::Set[String],
+          merged_pull_requests:   T::Set[String],
+        ).void
+      }
+      def update_merged_pull_request_counts(counts, authored_pull_requests, merged_pull_requests)
+        unless authored_pull_requests.empty?
+          counts[:merged_pr_author] = [authored_pull_requests.length, MAX_CONTRIBUTIONS].min
+        end
+        return if merged_pull_requests.empty?
+
+        counts[:merged_pr] = [merged_pull_requests.length, MAX_CONTRIBUTIONS].min
       end
 
       sig { params(user: String, to: String).returns(T.nilable(String)) }

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -191,7 +191,8 @@ module Homebrew
             next if type_count.nil? || type_count.zero?
 
             count_prefix = ""
-            if ((type == :merged_pr_author || type == :merged_pr) && grand_total.fetch(:merged_pr_author_hit_cap, 0).positive?) ||
+            if ([:merged_pr_author, :merged_pr].include?(type) && grand_total.fetch(:merged_pr_author_hit_cap,
+                                                                                    0).positive?) ||
                (type == :approved_pr_review && type_count >= MAX_PR_SEARCH) || type_count >= MAX_CONTRIBUTIONS
               greater_than_total ||= true
               count_prefix = ">="

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -593,6 +593,10 @@ module Homebrew
       sig { params(user: String, to: String).returns(T.nilable(String)) }
       def github_username_for(user, to:)
         return user unless user.include?("@")
+        if user.end_with?("@users.noreply.github.com")
+          return user.delete_suffix("@users.noreply.github.com").sub(/\A\d+\+/,
+                                                                     "")
+        end
 
         cache_key = ["public-email", user].join("\0")
         matches = github_search_with_rate_limit(cache_key, to:) do

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -435,25 +435,27 @@ module Homebrew
         end
 
         require "utils/github"
-        repositories.difference(repository_refs.keys).then do |remote_repositories|
-          unless remote_repositories.empty?
-            merged_range = "#{from}..#{Date.iso8601(to).prev_day.iso8601}"
-            users.each_key do |user|
-              cache_key = ["merged-at", organisation, user, merged_range].join("\0")
-              merged_pull_requests = github_search_with_rate_limit(cache_key, to:) do
-                GitHub.search_issues("", is: "merged", user: organisation, author: user, merged: merged_range)
-              rescue GitHub::API::ValidationFailedError
-                opoo "Couldn't search GitHub for PRs authored by #{user}. Their profile might be private. " \
-                     "Defaulting to 0."
-                []
-              end
-              merged_pull_requests.each do |pull_request|
-                repository = pull_request.fetch("repository_url").delete_prefix("#{GitHub::API_URL}/repos/")
-                next unless remote_repositories.include?(repository)
+        merged_range = "#{from}..#{Date.iso8601(to).prev_day.iso8601}"
+        users.each_key do |user|
+          cache_key = ["merged-at", organisation, user, merged_range].join("\0")
+          merged_pull_requests = github_search_with_rate_limit(cache_key, to:) do
+            GitHub.search_issues("", is: "merged", user: organisation, author: user, merged: merged_range)
+          rescue GitHub::API::ValidationFailedError
+            opoo "Couldn't search GitHub for PRs authored by #{user}. Their profile might be private. " \
+                 "Defaulting to 0."
+            []
+          end
+          pull_requests_by_repository = merged_pull_requests.group_by do |pull_request|
+            pull_request.fetch("repository_url").delete_prefix("#{GitHub::API_URL}/repos/")
+          end
+          pull_requests_by_repository.each do |repository, pull_requests|
+            next unless repositories.include?(repository)
 
-                increment_contribution_count(results.fetch(user).fetch(repository), :merged_pr_author)
-                increment_contribution_count(results.fetch(user).fetch(repository), :merged_pr)
-              end
+            counts = results.fetch(user).fetch(repository)
+            additional_authored_prs = [pull_requests.length - counts.fetch(:merged_pr_author), 0].max
+            additional_authored_prs.times do
+              increment_contribution_count(counts, :merged_pr_author)
+              increment_contribution_count(counts, :merged_pr)
             end
           end
         end

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -191,7 +191,7 @@ module Homebrew
             next if type_count.nil? || type_count.zero?
 
             count_prefix = ""
-            if (type == :merged_pr_author && grand_total.fetch(:merged_pr_author_hit_cap, 0).positive?) ||
+            if ((type == :merged_pr_author || type == :merged_pr) && grand_total.fetch(:merged_pr_author_hit_cap, 0).positive?) ||
                (type == :approved_pr_review && type_count >= MAX_PR_SEARCH) || type_count >= MAX_CONTRIBUTIONS
               greater_than_total ||= true
               count_prefix = ">="

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -423,6 +423,9 @@ module Homebrew
           end
           [user, user_results]
         end
+
+        require "utils/github"
+        github_users = users.keys.to_h { |user| [user, github_username_for(user, to:)] }
         repository_refs.each do |repository, (repository_path, ref)|
           require "utils/git"
           output = Utils.safe_popen_read(
@@ -434,25 +437,22 @@ module Homebrew
           end
         end
 
-        require "utils/github"
         merged_range = "#{from}..#{Date.iso8601(to).prev_day.iso8601}"
         users.each_key do |user|
-          cache_key = ["merged-at", organisation, user, merged_range].join("\0")
-          merged_pull_requests = github_search_with_rate_limit(cache_key, to:) do
-            GitHub.search_issues("", is: "merged", user: organisation, author: user, merged: merged_range)
-          rescue GitHub::API::ValidationFailedError
-            opoo "Couldn't search GitHub for PRs authored by #{user}. Their profile might be private. " \
-                 "Defaulting to 0."
-            []
-          end
-          pull_requests_by_repository = merged_pull_requests.group_by do |pull_request|
-            pull_request.fetch("repository_url").delete_prefix("#{GitHub::API_URL}/repos/")
-          end
-          pull_requests_by_repository.each do |repository, pull_requests|
-            next unless repositories.include?(repository)
+          github_user = github_users.fetch(user)
+          next if github_user.nil?
 
+          repositories.each do |repository|
+            cache_key = ["merged-at", repository, github_user, merged_range].join("\0")
+            merged_pull_requests = github_search_with_rate_limit(cache_key, to:) do
+              GitHub.search_issues("", is: "merged", repo: repository, author: github_user, merged: merged_range)
+            rescue GitHub::API::ValidationFailedError
+              opoo "Couldn't search GitHub for PRs authored by #{github_user}. Their profile might be private. " \
+                   "Defaulting to 0."
+              []
+            end
             counts = results.fetch(user).fetch(repository)
-            additional_authored_prs = [pull_requests.length - counts.fetch(:merged_pr_author), 0].max
+            additional_authored_prs = [merged_pull_requests.length - counts.fetch(:merged_pr_author), 0].max
             additional_authored_prs.times do
               increment_contribution_count(counts, :merged_pr_author)
               increment_contribution_count(counts, :merged_pr)
@@ -460,15 +460,15 @@ module Homebrew
           end
         end
 
-        review_users = users.keys
-        review_users.reject! { |user| lead_activity_met?(results.fetch(user)) } if skip_reviews_if_lead_met
-        review_users.each_with_index do |user, index|
+        review_users = github_users.filter_map { |user, github_user| [user, github_user] if github_user }
+        review_users.reject! { |user, _| lead_activity_met?(results.fetch(user)) } if skip_reviews_if_lead_met
+        review_users.each_with_index do |(user, github_user), index|
           if progress
             $stderr.puts "Querying approved-review search for #{user} (#{index + 1}/#{review_users.length})..."
           end
-          cache_key = ["approved", organisation, user, from, to].join("\0")
+          cache_key = ["approved", organisation, github_user, from, to].join("\0")
           approved_reviews = github_search_with_rate_limit(cache_key, to:) do
-            GitHub.search_approved_pull_requests_in_user_or_organisation(organisation, user, from:, to:)
+            GitHub.search_approved_pull_requests_in_user_or_organisation(organisation, github_user, from:, to:)
           end
           capped_reviews = approved_reviews.length >= MAX_PR_SEARCH
           results.fetch(user).fetch(repositories.fetch(0))[:approved_pr_review_hit_cap] = 1 if capped_reviews
@@ -492,15 +492,36 @@ module Homebrew
                     qualifying_total >= MAINTAINER_ACTIVITY_THRESHOLD
 
             $stderr.puts "Querying approved-review search for #{user} in #{repository}..." if progress
-            cache_key = ["approved", repository, user, from, to].join("\0")
+            cache_key = ["approved", repository, github_user, from, to].join("\0")
             repository_reviews = github_search_with_rate_limit(cache_key, to:) do
-              GitHub.search_issues("", is: "pr", review: "approved", repo: repository, reviewed_by: user, from:, to:)
+              GitHub.search_issues("", is: "pr", review: "approved", repo: repository, reviewed_by: github_user,
+                                   from:, to:)
             end
             repository_counts[:approved_pr_review] = repository_reviews.length
           end
         end
 
         results
+      end
+
+      sig { params(user: String, to: String).returns(T.nilable(String)) }
+      def github_username_for(user, to:)
+        return user unless user.include?("@")
+
+        cache_key = ["public-email", user].join("\0")
+        matches = github_search_with_rate_limit(cache_key, to:) do
+          GitHub.search("users", "\"#{user}\" in:email").fetch("items", [])
+        end
+        if matches.one?
+          login = matches.fetch(0)["login"]
+          return login if login.is_a?(String)
+        end
+
+        opoo "Could not find a unique public GitHub account for #{user}; skipping GitHub PR searches."
+        nil
+      rescue GitHub::API::ValidationFailedError
+        opoo "Could not search for a public GitHub account for #{user}; skipping GitHub PR searches."
+        nil
       end
 
       sig {

--- a/Library/Homebrew/test/dev-cmd/contributions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/contributions_spec.rb
@@ -298,6 +298,14 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     )
   end
 
+  it "uses the username embedded in a GitHub no-reply email address" do
+    command = described_class.new(["--user=39449589+krehel@users.noreply.github.com"])
+
+    expect(GitHub).not_to receive(:search)
+    expect(command.send(:github_username_for, "39449589+krehel@users.noreply.github.com", to: "2026-02-01"))
+      .to eq("krehel")
+  end
+
   it "counts authored squash-merged PRs in repositories with local Git history" do
     command = described_class.new(["--user=alice", "--repositories=Homebrew/homebrew-core"])
     repository = "Homebrew/homebrew-core"

--- a/Library/Homebrew/test/dev-cmd/contributions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/contributions_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     repository = "Homebrew/untapped"
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation).and_return([])
     expect(GitHub).to receive(:search_issues)
-      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2026-01-01..2026-01-31")
+      .with("", is: "merged", repo: repository, author: "alice", merged: "2026-01-01..2026-01-31")
       .and_return([{ "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" }])
 
     results = command.send(
@@ -185,6 +185,64 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     )
   end
 
+  it "searches merged PRs in each repository" do
+    command = described_class.new(["--user=alice", "--repositories=Homebrew/brew,Homebrew/homebrew-core"])
+    repositories = %w[Homebrew/brew Homebrew/homebrew-core]
+    allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation).and_return([])
+    expect(GitHub).to receive(:search_issues)
+      .with("", is: "merged", repo: "Homebrew/brew", author: "alice", merged: "2026-01-01..2026-01-31")
+      .and_return([])
+    expect(GitHub).to receive(:search_issues)
+      .with("", is: "merged", repo: "Homebrew/homebrew-core", author: "alice", merged: "2026-01-01..2026-01-31")
+      .and_return([{ "repository_url" => "#{GitHub::API_URL}/repos/Homebrew/homebrew-core" }])
+
+    results = command.send(
+      :scan_contributions,
+      "Homebrew",
+      repositories,
+      {},
+      { "alice" => "alice" },
+      from:                     "2026-01-01",
+      to:                       "2026-02-01",
+      skip_reviews_if_lead_met: false,
+      progress:                 false,
+    )
+
+    expect(results.fetch("alice").transform_values { |counts| counts.fetch(:merged_pr_author) }).to eq(
+      "Homebrew/brew" => 0, "Homebrew/homebrew-core" => 1,
+    )
+  end
+
+  it "uses a GitHub username resolved from a public email address" do
+    command = described_class.new(["--user=alice@example.com", "--repositories=Homebrew/untapped"])
+    repository = "Homebrew/untapped"
+    allow(GitHub).to receive(:search)
+      .with("users", "\"alice@example.com\" in:email")
+      .and_return({ "items" => [{ "login" => "alice" }] })
+    expect(GitHub).to receive(:search_issues)
+      .with("", is: "merged", repo: repository, author: "alice", merged: "2026-01-01..2026-01-31")
+      .and_return([{ "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" }])
+    expect(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation)
+      .with("Homebrew", "alice", from: "2026-01-01", to: "2026-02-01")
+      .and_return([])
+
+    results = command.send(
+      :scan_contributions,
+      "Homebrew",
+      [repository],
+      {},
+      { "alice@example.com" => "alice@example.com" },
+      from:                     "2026-01-01",
+      to:                       "2026-02-01",
+      skip_reviews_if_lead_met: false,
+      progress:                 false,
+    )
+
+    expect(results.fetch("alice@example.com").fetch(repository)).to eq(
+      merged_pr_author: 1, merged_pr_merger: 0, merged_pr: 1, approved_pr_review: 0, coauthor: 0,
+    )
+  end
+
   it "counts authored squash-merged PRs in repositories with local Git history" do
     command = described_class.new(["--user=alice", "--repositories=Homebrew/homebrew-core"])
     repository = "Homebrew/homebrew-core"
@@ -194,7 +252,7 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     allow(command).to receive(:parse_git_log).and_return("alice" => git_counts)
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation).and_return([])
     expect(GitHub).to receive(:search_issues)
-      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2026-01-01..2026-01-31")
+      .with("", is: "merged", repo: repository, author: "alice", merged: "2026-01-01..2026-01-31")
       .and_return(Array.new(2) { { "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" } })
 
     results = command.send(
@@ -259,7 +317,7 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     allow(Utils).to receive(:safe_popen_read).and_return("")
     allow(command).to receive(:parse_git_log).and_return("alice" => counts)
     allow(GitHub).to receive(:search_issues)
-      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2025-12-01..2026-02-28")
+      .with("", is: "merged", repo: a_kind_of(String), author: "alice", merged: "2025-12-01..2026-02-28")
       .and_return([])
     expect(GitHub).not_to receive(:search_approved_pull_requests_in_user_or_organisation)
 
@@ -289,7 +347,7 @@ RSpec.describe Homebrew::DevCmd::Contributions do
       { "alice" => (output == "cask") ? no_contributions.merge(coauthor: 500) : no_contributions.dup }
     end
     allow(GitHub).to receive(:search_issues)
-      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2025-12-01..2026-02-28")
+      .with("", is: "merged", repo: a_kind_of(String), author: "alice", merged: "2025-12-01..2026-02-28")
       .and_return([])
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation)
       .with("Homebrew", "alice", from: "2025-12-01", to: "2026-03-01")
@@ -331,7 +389,7 @@ RSpec.describe Homebrew::DevCmd::Contributions do
       { "alice" => counts.dup }
     end
     allow(GitHub).to receive(:search_issues)
-      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2025-12-01..2026-02-28")
+      .with("", is: "merged", repo: a_kind_of(String), author: "alice", merged: "2025-12-01..2026-02-28")
       .and_return([])
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation)
       .with("Homebrew", "alice", from: "2025-12-01", to: "2026-03-01")

--- a/Library/Homebrew/test/dev-cmd/contributions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/contributions_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation).and_return([])
     expect(GitHub).to receive(:search_issues)
       .with("", is: "merged", repo: repository, author: "alice", merged: "2026-01-01..2026-01-31")
-      .and_return([{ "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" }])
+      .and_return([{ "number" => 123, "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" }])
 
     results = command.send(
       :scan_contributions,
@@ -194,7 +194,7 @@ RSpec.describe Homebrew::DevCmd::Contributions do
       .and_return([])
     expect(GitHub).to receive(:search_issues)
       .with("", is: "merged", repo: "Homebrew/homebrew-core", author: "alice", merged: "2026-01-01..2026-01-31")
-      .and_return([{ "repository_url" => "#{GitHub::API_URL}/repos/Homebrew/homebrew-core" }])
+      .and_return([{ "number" => 123, "repository_url" => "#{GitHub::API_URL}/repos/Homebrew/homebrew-core" }])
 
     results = command.send(
       :scan_contributions,
@@ -221,7 +221,7 @@ RSpec.describe Homebrew::DevCmd::Contributions do
       .and_return({ "items" => [{ "login" => "alice" }] })
     expect(GitHub).to receive(:search_issues)
       .with("", is: "merged", repo: repository, author: "alice", merged: "2026-01-01..2026-01-31")
-      .and_return([{ "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" }])
+      .and_return([{ "number" => 123, "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" }])
     expect(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation)
       .with("Homebrew", "alice", from: "2026-01-01", to: "2026-02-01")
       .and_return([])
@@ -253,7 +253,10 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation).and_return([])
     expect(GitHub).to receive(:search_issues)
       .with("", is: "merged", repo: repository, author: "alice", merged: "2026-01-01..2026-01-31")
-      .and_return(Array.new(2) { { "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" } })
+      .and_return([
+        { "number" => 123, "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" },
+        { "number" => 124, "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" },
+      ])
 
     results = command.send(
       :scan_contributions,
@@ -269,6 +272,76 @@ RSpec.describe Homebrew::DevCmd::Contributions do
 
     expect(results.fetch("alice").fetch(repository)).to eq(
       merged_pr_author: 2, merged_pr_merger: 0, merged_pr: 2, approved_pr_review: 0, coauthor: 0,
+    )
+  end
+
+  it "counts a self-merged PR once" do
+    command = described_class.new(["--user=alice", "--repositories=Homebrew/homebrew-core"])
+    repository = "Homebrew/homebrew-core"
+    repository_refs = { repository => [Pathname("/Homebrew/homebrew-core"), "origin/HEAD"] }
+    separator = "\x1f"
+    record_separator = "\x1e"
+    merge = [
+      "merge", "base pull-request", "Alice", "alice@example.com",
+      "Merge pull request #123 from alice/topic"
+    ].join(separator)
+    pull_request = ["pull-request", "base", "Alice", "alice@example.com", "Change something"].join(separator)
+    git_log = "#{merge}#{record_separator}#{pull_request}#{record_separator}"
+    allow(Utils).to receive(:safe_popen_read).and_return(git_log)
+    allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation).and_return([])
+    expect(GitHub).to receive(:search_issues)
+      .with("", is: "merged", repo: repository, author: "alice", merged: "2026-01-01..2026-01-31")
+      .and_return([{ "number" => 123 }])
+
+    results = command.send(
+      :scan_contributions,
+      "Homebrew",
+      [repository],
+      repository_refs,
+      { "alice" => "Alice" },
+      from:                     "2026-01-01",
+      to:                       "2026-02-01",
+      skip_reviews_if_lead_met: false,
+      progress:                 false,
+    )
+
+    expect(results.fetch("alice").fetch(repository)).to eq(
+      merged_pr_author: 1, merged_pr_merger: 1, merged_pr: 1, approved_pr_review: 0, coauthor: 0,
+    )
+  end
+
+  it "counts a GitHub-authored PR once when Git only identifies its merger" do
+    command = described_class.new(["--user=alice", "--repositories=Homebrew/homebrew-core"])
+    repository = "Homebrew/homebrew-core"
+    repository_refs = { repository => [Pathname("/Homebrew/homebrew-core"), "origin/HEAD"] }
+    separator = "\x1f"
+    record_separator = "\x1e"
+    merge = [
+      "merge", "base pull-request", "Alice", "alice@example.com",
+      "Merge pull request #123 from Homebrew/topic"
+    ].join(separator)
+    pull_request = ["pull-request", "base", "BrewTestBot", "test-bot@example.com", "Change something"].join(separator)
+    git_log = "#{merge}#{record_separator}#{pull_request}#{record_separator}"
+    allow(Utils).to receive(:safe_popen_read).and_return(git_log)
+    allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation).and_return([])
+    expect(GitHub).to receive(:search_issues)
+      .with("", is: "merged", repo: repository, author: "alice", merged: "2026-01-01..2026-01-31")
+      .and_return([{ "number" => 123 }])
+
+    results = command.send(
+      :scan_contributions,
+      "Homebrew",
+      [repository],
+      repository_refs,
+      { "alice" => "Alice" },
+      from:                     "2026-01-01",
+      to:                       "2026-02-01",
+      skip_reviews_if_lead_met: false,
+      progress:                 false,
+    )
+
+    expect(results.fetch("alice").fetch(repository)).to eq(
+      merged_pr_author: 1, merged_pr_merger: 1, merged_pr: 1, approved_pr_review: 0, coauthor: 0,
     )
   end
 

--- a/Library/Homebrew/test/dev-cmd/contributions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/contributions_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     repository = "Homebrew/untapped"
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation).and_return([])
     expect(GitHub).to receive(:search_issues)
-      .with("", is: "merged", repo: repository, author: "alice", merged: "2026-01-01..2026-01-31")
+      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2026-01-01..2026-01-31")
       .and_return([{ "number" => 123, "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" }])
 
     results = command.send(
@@ -185,15 +185,12 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     )
   end
 
-  it "searches merged PRs in each repository" do
+  it "distributes organisation-wide merged PR searches by repository" do
     command = described_class.new(["--user=alice", "--repositories=Homebrew/brew,Homebrew/homebrew-core"])
     repositories = %w[Homebrew/brew Homebrew/homebrew-core]
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation).and_return([])
     expect(GitHub).to receive(:search_issues)
-      .with("", is: "merged", repo: "Homebrew/brew", author: "alice", merged: "2026-01-01..2026-01-31")
-      .and_return([])
-    expect(GitHub).to receive(:search_issues)
-      .with("", is: "merged", repo: "Homebrew/homebrew-core", author: "alice", merged: "2026-01-01..2026-01-31")
+      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2026-01-01..2026-01-31")
       .and_return([{ "number" => 123, "repository_url" => "#{GitHub::API_URL}/repos/Homebrew/homebrew-core" }])
 
     results = command.send(
@@ -213,6 +210,43 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     )
   end
 
+  it "scopes capped merged PR searches by repository until Lead activity is known" do
+    command = described_class.new(["--maintainer-report-csv=2026-1"])
+    repositories = Homebrew::DevCmd::Contributions::PRIMARY_REPOS.to_h do |repository|
+      [repository, [Pathname("/#{repository}"), "origin/HEAD"]]
+    end
+    no_contributions = {
+      merged_pr_author: 0, merged_pr_merger: 0, merged_pr: 0, approved_pr_review: 0, coauthor: 0
+    }
+    allow(Utils).to receive(:safe_popen_read).and_return("brew", "core", "cask")
+    allow(command).to receive(:parse_git_log) { { "alice" => no_contributions.dup } }
+    expect(GitHub).to receive(:search_issues)
+      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2025-12-01..2026-02-28")
+      .and_return(Array.new(100) do |index|
+        { "number" => index, "repository_url" => "#{GitHub::API_URL}/repos/Homebrew/homebrew-cask" }
+      end)
+    expect(GitHub).to receive(:search_issues)
+      .with("", is: "merged", repo: "Homebrew/brew", author: "alice", merged: "2025-12-01..2026-02-28")
+      .and_return(Array.new(25) { |index| { "number" => index + 100 } })
+    expect(GitHub).not_to receive(:search_approved_pull_requests_in_user_or_organisation)
+
+    results = command.send(
+      :scan_contributions,
+      "Homebrew",
+      repositories.keys,
+      repositories,
+      { "alice" => "Alice" },
+      from:                     "2025-12-01",
+      to:                       "2026-03-01",
+      skip_reviews_if_lead_met: true,
+      progress:                 true,
+    )
+
+    expect(results.fetch("alice").transform_values do |counts|
+      counts.fetch(:merged_pr_author)
+    end).to eq("Homebrew/brew" => 25, "Homebrew/homebrew-core" => 0, "Homebrew/homebrew-cask" => 100)
+  end
+
   it "uses a GitHub username resolved from a public email address" do
     command = described_class.new(["--user=alice@example.com", "--repositories=Homebrew/untapped"])
     repository = "Homebrew/untapped"
@@ -220,7 +254,7 @@ RSpec.describe Homebrew::DevCmd::Contributions do
       .with("users", "\"alice@example.com\" in:email")
       .and_return({ "items" => [{ "login" => "alice" }] })
     expect(GitHub).to receive(:search_issues)
-      .with("", is: "merged", repo: repository, author: "alice", merged: "2026-01-01..2026-01-31")
+      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2026-01-01..2026-01-31")
       .and_return([{ "number" => 123, "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" }])
     expect(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation)
       .with("Homebrew", "alice", from: "2026-01-01", to: "2026-02-01")
@@ -252,7 +286,7 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     allow(command).to receive(:parse_git_log).and_return("alice" => git_counts)
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation).and_return([])
     expect(GitHub).to receive(:search_issues)
-      .with("", is: "merged", repo: repository, author: "alice", merged: "2026-01-01..2026-01-31")
+      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2026-01-01..2026-01-31")
       .and_return([
         { "number" => 123, "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" },
         { "number" => 124, "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" },
@@ -290,8 +324,8 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     allow(Utils).to receive(:safe_popen_read).and_return(git_log)
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation).and_return([])
     expect(GitHub).to receive(:search_issues)
-      .with("", is: "merged", repo: repository, author: "alice", merged: "2026-01-01..2026-01-31")
-      .and_return([{ "number" => 123 }])
+      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2026-01-01..2026-01-31")
+      .and_return([{ "number" => 123, "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" }])
 
     results = command.send(
       :scan_contributions,
@@ -325,8 +359,8 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     allow(Utils).to receive(:safe_popen_read).and_return(git_log)
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation).and_return([])
     expect(GitHub).to receive(:search_issues)
-      .with("", is: "merged", repo: repository, author: "alice", merged: "2026-01-01..2026-01-31")
-      .and_return([{ "number" => 123 }])
+      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2026-01-01..2026-01-31")
+      .and_return([{ "number" => 123, "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" }])
 
     results = command.send(
       :scan_contributions,
@@ -390,7 +424,7 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     allow(Utils).to receive(:safe_popen_read).and_return("")
     allow(command).to receive(:parse_git_log).and_return("alice" => counts)
     allow(GitHub).to receive(:search_issues)
-      .with("", is: "merged", repo: a_kind_of(String), author: "alice", merged: "2025-12-01..2026-02-28")
+      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2025-12-01..2026-02-28")
       .and_return([])
     expect(GitHub).not_to receive(:search_approved_pull_requests_in_user_or_organisation)
 
@@ -420,7 +454,7 @@ RSpec.describe Homebrew::DevCmd::Contributions do
       { "alice" => (output == "cask") ? no_contributions.merge(coauthor: 500) : no_contributions.dup }
     end
     allow(GitHub).to receive(:search_issues)
-      .with("", is: "merged", repo: a_kind_of(String), author: "alice", merged: "2025-12-01..2026-02-28")
+      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2025-12-01..2026-02-28")
       .and_return([])
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation)
       .with("Homebrew", "alice", from: "2025-12-01", to: "2026-03-01")
@@ -462,7 +496,7 @@ RSpec.describe Homebrew::DevCmd::Contributions do
       { "alice" => counts.dup }
     end
     allow(GitHub).to receive(:search_issues)
-      .with("", is: "merged", repo: a_kind_of(String), author: "alice", merged: "2025-12-01..2026-02-28")
+      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2025-12-01..2026-02-28")
       .and_return([])
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation)
       .with("Homebrew", "alice", from: "2025-12-01", to: "2026-03-01")

--- a/Library/Homebrew/test/dev-cmd/contributions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/contributions_spec.rb
@@ -164,7 +164,6 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     command = described_class.new(["--user=alice", "--repositories=Homebrew/untapped"])
     repository = "Homebrew/untapped"
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation).and_return([])
-    expect(GitHub).not_to receive(:search_merged_pull_requests_in_user_or_organisation)
     expect(GitHub).to receive(:search_issues)
       .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2026-01-01..2026-01-31")
       .and_return([{ "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" }])
@@ -183,6 +182,35 @@ RSpec.describe Homebrew::DevCmd::Contributions do
 
     expect(results.fetch("alice").fetch(repository)).to eq(
       merged_pr_author: 1, merged_pr_merger: 0, merged_pr: 1, approved_pr_review: 0, coauthor: 0,
+    )
+  end
+
+  it "counts authored squash-merged PRs in repositories with local Git history" do
+    command = described_class.new(["--user=alice", "--repositories=Homebrew/homebrew-core"])
+    repository = "Homebrew/homebrew-core"
+    repository_refs = { repository => [Pathname("/Homebrew/homebrew-core"), "origin/HEAD"] }
+    git_counts = { merged_pr_author: 1, merged_pr_merger: 0, merged_pr: 1, approved_pr_review: 0, coauthor: 0 }
+    allow(Utils).to receive(:safe_popen_read).and_return("git log")
+    allow(command).to receive(:parse_git_log).and_return("alice" => git_counts)
+    allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation).and_return([])
+    expect(GitHub).to receive(:search_issues)
+      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2026-01-01..2026-01-31")
+      .and_return(Array.new(2) { { "repository_url" => "#{GitHub::API_URL}/repos/#{repository}" } })
+
+    results = command.send(
+      :scan_contributions,
+      "Homebrew",
+      [repository],
+      repository_refs,
+      { "alice" => "alice" },
+      from:                     "2026-01-01",
+      to:                       "2026-02-01",
+      skip_reviews_if_lead_met: false,
+      progress:                 false,
+    )
+
+    expect(results.fetch("alice").fetch(repository)).to eq(
+      merged_pr_author: 2, merged_pr_merger: 0, merged_pr: 2, approved_pr_review: 0, coauthor: 0,
     )
   end
 
@@ -230,6 +258,9 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     }
     allow(Utils).to receive(:safe_popen_read).and_return("")
     allow(command).to receive(:parse_git_log).and_return("alice" => counts)
+    allow(GitHub).to receive(:search_issues)
+      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2025-12-01..2026-02-28")
+      .and_return([])
     expect(GitHub).not_to receive(:search_approved_pull_requests_in_user_or_organisation)
 
     expect(command.send(
@@ -257,6 +288,9 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     allow(command).to receive(:parse_git_log) do |output, _|
       { "alice" => (output == "cask") ? no_contributions.merge(coauthor: 500) : no_contributions.dup }
     end
+    allow(GitHub).to receive(:search_issues)
+      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2025-12-01..2026-02-28")
+      .and_return([])
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation)
       .with("Homebrew", "alice", from: "2025-12-01", to: "2026-03-01")
       .and_return(Array.new(100) do
@@ -296,6 +330,9 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     allow(command).to receive(:parse_git_log) do
       { "alice" => counts.dup }
     end
+    allow(GitHub).to receive(:search_issues)
+      .with("", is: "merged", user: "Homebrew", author: "alice", merged: "2025-12-01..2026-02-28")
+      .and_return([])
     allow(GitHub).to receive(:search_approved_pull_requests_in_user_or_organisation)
       .with("Homebrew", "alice", from: "2025-12-01", to: "2026-03-01")
       .and_return([

--- a/Library/Homebrew/test/dev-cmd/contributions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/contributions_spec.rb
@@ -160,6 +160,27 @@ RSpec.describe Homebrew::DevCmd::Contributions do
     CSV
   end
 
+  it "marks capped merged-PR searches with no matching requested repositories as lower bounds" do
+    command = described_class.new([
+      "--user=alice", "--repositories=Homebrew/brew", "--from=2026-01-01", "--to=2026-02-01"
+    ])
+    repository_refs = { "Homebrew/brew" => [Pathname("/Homebrew/brew"), "origin/HEAD"] }
+    results = { "alice" => { "Homebrew/brew" => {
+      merged_pr_author: 0, merged_pr_merger: 0, merged_pr: 0, approved_pr_review: 0, coauthor: 0,
+      merged_pr_author_hit_cap: 1
+    } } }
+
+    allow(command).to receive(:prepare_contribution_repositories)
+      .with(["Homebrew/brew"], required: false)
+      .and_return(repository_refs)
+    allow(command).to receive(:scan_contributions)
+      .with("Homebrew", ["Homebrew/brew"], repository_refs, { "alice" => "alice" },
+            from: "2026-01-01", to: "2026-02-01", skip_reviews_if_lead_met: false, progress: false)
+      .and_return(results)
+
+    expect { command.run }.to output(/alice contributed >=0 times \(total\)/).to_stdout
+  end
+
   it "uses merge dates for repositories without local Git history" do
     command = described_class.new(["--user=alice", "--repositories=Homebrew/untapped"])
     repository = "Homebrew/untapped"


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

I used codex 5.6 to generate most of the change. I reviewed the code, ran the tests and checked the command output manually for my username.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

The contribution command was ignoring squash-merged PRs and normal merge commits whose head branch is under Homebrew/... rather than a contributor’s fork. (for example https://github.com/Homebrew/homebrew-core/pull/286711 )

A quick check I used: `brew contributions --user=moisan --from=2025-12-01 --to=2026-03-01`. It was showing no authored PRs previously and 37 with this change.