### PR TITLE
Generate stable cask syntax jobs

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
@@ -87,12 +87,14 @@ module Homebrew
 
         runner = random_runner[:name]
         syntax_job = {
-          name:   "syntax",
+          name:   "tap_syntax",
           tap:    tap.name,
           runner:,
+          stable: false,
         }
+        stable_syntax_job = syntax_job.merge(name: "tap_syntax (stable)", stable: true, skip_audit: true)
 
-        matrix = [syntax_job]
+        matrix = [syntax_job, stable_syntax_job]
 
         if !syntax_only && !labels&.include?("ci-syntax-only")
           cask_jobs = if casks&.any?
@@ -114,7 +116,12 @@ module Homebrew
           matrix += cask_jobs
         end
 
-        syntax_job[:name] += " (#{syntax_job[:runner]})"
+        jobs = matrix.count
+        odie "Maximum job matrix size exceeded: #{jobs}/#{MAX_JOBS}" if jobs > MAX_JOBS
+
+        [syntax_job, stable_syntax_job].each do |job|
+          job[:name] += " (#{job[:runner]})"
+        end
 
         puts JSON.pretty_generate(matrix)
         github_output = ENV.fetch("GITHUB_OUTPUT", nil)

--- a/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
@@ -232,6 +232,49 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
 
   it_behaves_like "parseable arguments"
 
+  it "generates current and stable tap syntax jobs" do
+    ENV["GITHUB_REPOSITORY"] = "Homebrew/homebrew-cask"
+    ENV.delete("GITHUB_OUTPUT")
+    command = described_class.new(["--syntax-only"])
+    allow(command).to receive(:random_runner).and_return({ name: "macos-26" })
+    stdout = StringIO.new
+    allow(command).to receive(:puts) { |output| stdout.puts(output) }
+
+    command.run
+
+    expect(JSON.parse(stdout.string)).to eq(
+      [
+        {
+          "name"   => "tap_syntax (macos-26)",
+          "tap"    => "homebrew/cask",
+          "runner" => "macos-26",
+          "stable" => false,
+        },
+        {
+          "name"       => "tap_syntax (stable) (macos-26)",
+          "tap"        => "homebrew/cask",
+          "runner"     => "macos-26",
+          "stable"     => true,
+          "skip_audit" => true,
+        },
+      ],
+    )
+  end
+
+  it "rejects a matrix exceeding GitHub's job limit" do
+    ENV["GITHUB_REPOSITORY"] = "Homebrew/homebrew-cask"
+    ENV.delete("GITHUB_OUTPUT")
+    command = described_class.new(["--cask", "test"])
+    allow(command).to receive_messages(random_runner:   { name: "macos-26" },
+                                       generate_matrix: Array.new(
+                                         described_class::MAX_JOBS - 1, {}
+                                       ))
+
+    expect { command.run }
+      .to output("Error: Maximum job matrix size exceeded: 257/256\n").to_stderr
+      .and raise_error(SystemExit)
+  end
+
   describe "::filter_runners" do
     let(:arm_linux_runner) { OS::LINUX_CI_ARM_RUNNER }
     # We simulate a macOS version older than the newest, as the method will use


### PR DESCRIPTION
Cask syntax needs the same current and stable Homebrew coverage as core without duplicating matrix construction in the tap workflow.

- rename generated syntax jobs to `tap_syntax`
- add a stable row using the same selected runner
- retain both rows for `ci-syntax-only` pull requests
- skip redundant tap audit work in the stable row

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 Sol xhigh with local review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
