### PR TITLE
Use --end-of-options for Git arguments

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -637,6 +637,9 @@ HOMEBREW_MACOS_NEWEST_SUPPORTED="26"
 HOMEBREW_MACOS_OLDEST_SUPPORTED="14"
 HOMEBREW_MACOS_OLDEST_ALLOWED="10.15"
 
+# Some Git versions are too old for some Homebrew functionality we rely on.
+HOMEBREW_MINIMUM_GIT_VERSION="2.30.0"
+
 if [[ -n "${HOMEBREW_MACOS}" ]]
 then
   HOMEBREW_PRODUCT="Homebrew"
@@ -685,9 +688,6 @@ then
     HOMEBREW_SYSTEM_CA_CERTIFICATES_TOO_OLD="1"
     HOMEBREW_FORCE_BREWED_CA_CERTIFICATES="1"
   fi
-
-  # Some Git versions are too old for some Homebrew functionality we rely on.
-  HOMEBREW_MINIMUM_GIT_VERSION="2.14.3"
 else
   if [[ -r "/proc/cpuinfo" ]] &&
      [[ "${HOMEBREW_PROCESSOR}" == "x86_64" ]]
@@ -732,8 +732,6 @@ Minimum required version: ${HOMEBREW_MINIMUM_CURL_VERSION}
   fi
 
   # Ensure the system Git is at or newer than the minimum required version.
-  # Git 2.7.4 is the version of git on Ubuntu 16.04 LTS (Xenial Xerus).
-  HOMEBREW_MINIMUM_GIT_VERSION="2.7.0"
   git_version_output="$(${HOMEBREW_GIT} --version 2>/dev/null)"
   # $extra is intentionally discarded.
   # shellcheck disable=SC2034

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -688,6 +688,11 @@ then
     HOMEBREW_SYSTEM_CA_CERTIFICATES_TOO_OLD="1"
     HOMEBREW_FORCE_BREWED_CA_CERTIFICATES="1"
   fi
+
+  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "110000" ]]
+  then
+    HOMEBREW_FORCE_BREWED_GIT="1"
+  fi
 else
   if [[ -r "/proc/cpuinfo" ]] &&
      [[ "${HOMEBREW_PROCESSOR}" == "x86_64" ]]

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -665,7 +665,7 @@ EOS
   then
     safe_cd "${HOMEBREW_REPOSITORY}"
     echo "HOMEBREW_BREW_GIT_REMOTE set: using ${HOMEBREW_BREW_GIT_REMOTE} as the Homebrew/brew Git remote."
-    git remote set-url origin "${HOMEBREW_BREW_GIT_REMOTE}"
+    git remote set-url origin --end-of-options "${HOMEBREW_BREW_GIT_REMOTE}"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     git fetch --force --tags origin
     SKIP_FETCH_BREW_REPOSITORY=1
@@ -676,7 +676,7 @@ EOS
   then
     safe_cd "${HOMEBREW_CORE_REPOSITORY}"
     echo "HOMEBREW_CORE_GIT_REMOTE set: using ${HOMEBREW_CORE_GIT_REMOTE} as the Homebrew/homebrew-core Git remote."
-    git remote set-url origin "${HOMEBREW_CORE_GIT_REMOTE}"
+    git remote set-url origin --end-of-options "${HOMEBREW_CORE_GIT_REMOTE}"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     git config fetch.prune true
     git fetch --force origin

--- a/Library/Homebrew/download_strategy/git_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/git_download_strategy.rb
@@ -104,7 +104,8 @@ class GitDownloadStrategy < VCSDownloadStrategy
   sig { returns(T::Boolean) }
   def ref?
     silent_command("git",
-                   args: ["--git-dir", git_dir, "rev-parse", "-q", "--verify", "#{@ref}^{commit}"])
+                   args: ["--git-dir", git_dir, "rev-parse", "-q", "--verify", "--end-of-options",
+                          "#{@ref}^{commit}"])
       .success?
   end
 
@@ -145,7 +146,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
 
     args << "--config" << "advice.detachedHead=false" # Silences “detached head” warning.
     args << "--config" << "core.fsmonitor=false" # Prevent `fsmonitor` from watching this repository.
-    args << @url << cached_location.to_s
+    args << "--end-of-options" << @url << cached_location.to_s
   end
 
   sig { returns(String) }

--- a/Library/Homebrew/livecheck/strategy/git.rb
+++ b/Library/Homebrew/livecheck/strategy/git.rb
@@ -124,7 +124,7 @@ module Homebrew
         def self.ls_remote_tags(url)
           stdout, stderr, _status = system_command(
             "git",
-            args:         ["ls-remote", "--tags", url],
+            args:         ["ls-remote", "--tags", "--end-of-options", url],
             env:          { "GIT_TERMINAL_PROMPT" => "0" },
             print_stdout: false,
             print_stderr: false,

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -281,7 +281,7 @@ module Homebrew
       return unless url.to_s.end_with?(".git")
       return unless Utils::Git.remote_exists?(url.to_s)
 
-      detected_branch = Utils.popen_read("git", "ls-remote", "--symref", url.to_s, "HEAD")
+      detected_branch = Utils.popen_read("git", "ls-remote", "--symref", "--end-of-options", url.to_s, "HEAD")
                              .match(%r{ref: refs/heads/(.*?)\s+HEAD})&.to_a&.second
 
       if specs[:branch].blank?

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -588,8 +588,7 @@ class Tap
       clear_cache
     end
 
-    # `--` guards against a redirect value that begins with `-` being treated as a `git` option.
-    safe_system "git", "-C", path, "remote", "set-url", "origin", "--", redirected_remote
+    safe_system "git", "-C", path, "remote", "set-url", "origin", "--end-of-options", redirected_remote
     clear_cache
     Tap.clear_cache
 
@@ -703,7 +702,7 @@ class Tap
     Tap.clear_cache
 
     $stderr.ohai "Tapping #{name}" unless quiet
-    args = %W[clone #{requested_remote} #{path}]
+    args = %w[clone]
 
     # Override possible user configs like:
     #   git config --global clone.defaultRemoteName notorigin
@@ -714,6 +713,7 @@ class Tap
     args << "--template="
     # Prevent `fsmonitor` from watching this repository.
     args << "--config" << "core.fsmonitor=false"
+    args << "--end-of-options" << requested_remote << path.to_s
 
     begin
       if worktree_source_tap_path
@@ -808,7 +808,7 @@ class Tap
   def fix_remote_configuration(requested_remote: nil, quiet: false)
     if requested_remote.present?
       path.cd do
-        safe_system "git", "remote", "set-url", "origin", requested_remote
+        safe_system "git", "remote", "set-url", "origin", "--end-of-options", requested_remote
         safe_system "git", "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"
       end
       $stderr.ohai "#{name}: changed remote from #{remote} to #{requested_remote}" unless quiet

--- a/Library/Homebrew/test/download_strategies/git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/git_spec.rb
@@ -16,6 +16,26 @@ RSpec.describe GitDownloadStrategy do
     FileUtils.mkpath cached_location
   end
 
+  describe "#clone_args" do
+    it "terminates options before the URL" do
+      expect(strategy.send(:clone_args)).to end_with("--end-of-options", url, cached_location.to_s)
+    end
+  end
+
+  describe "#ref?" do
+    it "terminates options before the ref" do
+      expect(strategy).to receive(:silent_command)
+        .with(
+          "git",
+          args: ["--git-dir", cached_location/".git", "rev-parse", "-q", "--verify", "--end-of-options",
+                 "master^{commit}"],
+        )
+        .and_return(instance_double(SystemCommand::Result, success?: true))
+
+      strategy.send(:ref?)
+    end
+  end
+
   def git_commit_all
     system "git", "add", "--all"
     # Allow instance variables here to have nice commit messages.

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -891,13 +891,19 @@ RSpec.describe Homebrew::FormulaAuditor do
     end
 
     it "requires `branch:` to be specified for Git head URLs" do
+      head_url = "https://github.com/Homebrew/homebrew-test-bot.git"
       fa = formula_auditor "foo", <<~RUBY, online: true
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
           sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
-          head "https://github.com/Homebrew/homebrew-test-bot.git"
+          head "#{head_url}"
         end
       RUBY
+      allow(Utils::Git).to receive(:remote_exists?).and_return(true)
+      allow(Utils).to receive(:popen_read).and_call_original
+      expect(Utils).to receive(:popen_read)
+        .with("git", "ls-remote", "--symref", "--end-of-options", head_url, "HEAD")
+        .and_return("ref: refs/heads/main\tHEAD\n")
 
       fa.audit_specs
       # This is `.last` because the first problem is the unreachable stable URL.

--- a/Library/Homebrew/test/livecheck/strategy/git_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/git_spec.rb
@@ -183,6 +183,22 @@ RSpec.describe Homebrew::Livecheck::Strategy::Git do
   end
 
   describe "::ls_remote_tags" do
+    it "terminates options before the URL" do
+      expect(git).to receive(:system_command)
+        .with(
+          "git",
+          args:         ["ls-remote", "--tags", "--end-of-options", "-u:evil"],
+          env:          { "GIT_TERMINAL_PROMPT" => "0" },
+          print_stdout: false,
+          print_stderr: false,
+          debug:        false,
+          verbose:      false,
+        )
+        .and_return([nil, nil, nil])
+
+      git.ls_remote_tags("-u:evil")
+    end
+
     it "returns the Git tags for the provided remote URL", :needs_network do
       expect(git.ls_remote_tags(git_url)).not_to be_empty
     end

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -699,6 +699,21 @@ RSpec.describe Tap do
     end
   end
 
+  describe "#fix_remote_configuration" do
+    it "terminates options before the requested remote" do
+      tap = described_class.fetch("dashy", "foo")
+      tap.path.mkpath
+      allow(tap).to receive(:remote)
+      allow(tap).to receive(:safe_system)
+      expect(tap).to receive(:safe_system)
+        .with("git", "remote", "set-url", "origin", "--end-of-options", "-u:evil")
+
+      tap.fix_remote_configuration(requested_remote: "-u:evil")
+    ensure
+      FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"dashy"
+    end
+  end
+
   specify "Git variant" do
     touch path/"README"
     setup_git_repo
@@ -867,8 +882,8 @@ RSpec.describe Tap do
       allow(tap).to receive_messages(command_files: [], formula_files: [], cask_files: [],
                                      formula_names: [], cask_tokens: [], link_completions_and_manpages: nil)
       expect(tap).to receive(:git_command!)
-        .with(["clone", requested_remote, tap.path.to_s, "--origin=origin", "--template=",
-               "--config", "core.fsmonitor=false"])
+        .with(["clone", "--origin=origin", "--template=", "--config", "core.fsmonitor=false",
+               "--end-of-options", requested_remote, tap.path.to_s])
         .and_wrap_original do
           tap.path.mkpath
           (tap.path/".git").mkpath

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -228,6 +228,14 @@ RSpec.describe Utils::Git do
     end
 
     context "when git is available" do
+      it "terminates options before the URL" do
+        expect(described_class).to receive(:quiet_system)
+          .with("git", "ls-remote", "--end-of-options", "-u:evil")
+          .and_return(false)
+
+        described_class.remote_exists?("-u:evil")
+      end
+
       it "returns true when git remote exists", :needs_network do
         git = HOMEBREW_SHIMS_PATH/"shared/git"
         url = "https://github.com/Homebrew/homebrew.github.io"

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -53,7 +53,7 @@ module Utils
     def self.remote_exists?(url)
       return true unless available?
 
-      quiet_system "git", "ls-remote", url
+      quiet_system "git", "ls-remote", "--end-of-options", url
     end
 
     sig { void }


### PR DESCRIPTION
Git 2.24.0 added `--end-of-options` to its shared parser, and Git 2.30.0 added support to `rev-parse`. This hoists a shared minimum Git version of 2.30.0 for macOS and Linux and uses the flag before URLs passed to `git clone`, `git remote set-url`, and `git ls-remote`, as well as the ref passed to `git rev-parse`. The covered paths include Git download strategies, tap installation and redirects, `brew update` custom remotes, livecheck tag queries, and resource audits. The tap clone arguments are reordered so all options remain before the terminator.

This hardens Git subprocess calls that can receive custom tap URLs, redirect targets, third-party VCS URLs, user-configured Homebrew remotes, or formula refs. It is defensive hardening rather than a fix for a known Homebrew exploit, so there are no bug reproduction steps.

The `checkout` and `reset` ref-bearing calls are intentionally unchanged because their parsing issue was fixed in Git 2.43.1. Their existing trailing `--` remains the revision/pathspec separator rather than an option terminator.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex (GPT-5) assisted with surveying the call sites, implementing the changes, and writing tests. I reviewed the resulting diff, verified the relevant behavior against upstream Git history, ran focused red/green tests, and successfully ran `./bin/brew lgtm` locally.
