### PR TITLE
docs: convert Adding Software to Homebrew into a package-type router

### DIFF
--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -124,7 +124,6 @@ module Homebrew
 
         cask_path.atomic_write <<~RUBY
           # Documentation: https://docs.brew.sh/Cask-Cookbook
-          #                https://docs.brew.sh/Adding-Software-to-Homebrew#cask-stanzas
           # PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
           cask "#{token}" do
             version "#{version}"

--- a/docs/Acceptable-Casks.md
+++ b/docs/Acceptable-Casks.md
@@ -56,7 +56,7 @@ Casks distribute applications and other pre-built files published by the upstrea
 Open-source command-line-only software normally belongs in [`homebrew/core`](https://github.com/Homebrew/homebrew-core) as a formula built from source.
 Open-source graphical software without a current compiled distribution also normally belongs in `homebrew/core`.
 A rejection from `homebrew/core` does not by itself make the software eligible for `homebrew/cask`.
-The [Adding Software to Homebrew](Adding-Software-to-Homebrew.md) guide describes the distinction between formulae and casks.
+The [Adding Software to Homebrew](Adding-Software-to-Homebrew.md#choose-a-package-type) guide describes the distinction between formulae and casks.
 
 ### Verifiable upstream distribution
 

--- a/docs/Adding-Software-to-Homebrew.md
+++ b/docs/Adding-Software-to-Homebrew.md
@@ -68,7 +68,7 @@ The normal validation is:
 HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source FORMULA
 brew test FORMULA
 brew audit --strict --new --online FORMULA
-brew style --fix FORMULA
+brew style --fix --formula FORMULA
 ```
 
 For a cask:
@@ -79,7 +79,7 @@ For a cask:
 HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask CASK
 brew uninstall --cask CASK
 brew audit --new --cask CASK
-brew style --fix CASK
+brew style --fix --cask CASK
 ```
 
 Inspect the installed files and user-facing output, not only the exit status.

--- a/docs/Adding-Software-to-Homebrew.md
+++ b/docs/Adding-Software-to-Homebrew.md
@@ -1,376 +1,93 @@
 ---
-last_review_date: "1970-01-01"
+last_review_date: "2026-07-18"
 ---
 
 # Adding Software to Homebrew
 
-Is your favourite software missing from Homebrew? Then you're the perfect person to resolve this problem.
+Homebrew accepts new software as either a formula or a cask.
+This page helps choose the correct package type and routes each step to the maintained reference instead of duplicating complete formula and cask examples.
 
-If you want to add software that is either closed source or a GUI-only program, you will want to follow the guide for [Casks](#casks). Otherwise follow the guide for [Formulae](#formulae) (see also: [Homebrew terminology](Formula-Cookbook.md#homebrew-terminology)).
+## Choose a package type
 
-Before you start, please check the open pull requests for [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core/pulls) or [Homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask/pulls) to make sure no one else beat you to the punch.
+<a data-proofer-ignore name="casks"></a>
 
-Next, you will want to go through the [Acceptable Formulae](Acceptable-Formulae.md) or [Acceptable Casks](Acceptable-Casks.md) documentation to determine if the software is an appropriate addition to Homebrew. If you are creating a formula for an alternative version of software already in Homebrew (e.g. a major/minor version that differs significantly from the existing version), be sure to read the [Versions](Versions.md) documentation to understand versioned formulae requirements.
+Use a formula for open source command-line software and libraries that Homebrew can build from source.
+Use a cask for native macOS applications and for proprietary or supported binary-only software.
+Casks may target macOS, Linux or both, but only supported artifact types are available on each operating system.
 
-If everything checks out, you're ready to get started on a new formula!
+Read the acceptance policy before writing the package:
 
-## Formulae
+- [Acceptable Formulae](Acceptable-Formulae.md)
+- [Acceptable Casks](Acceptable-Casks.md)
+- [Package Acceptance Policy](Package-Acceptance-Policy.md)
+- [Versioned Formulae](Versions.md) when packaging a non-current major or minor release
 
-### Writing the formula
+Search open and closed pull requests in [`homebrew/core`](https://github.com/Homebrew/homebrew-core/pulls) or [`homebrew/cask`](https://github.com/Homebrew/homebrew-cask/pulls) before starting.
+A previous rejection may identify an unresolved licensing, security, maintenance or distribution problem.
 
-1. It's a good idea to find existing formulae in Homebrew that have similarities to the software you want to add. This will help you to understand how specific languages, build methods, etc. are typically handled. Start by tapping `homebrew/core`: first set `HOMEBREW_NO_INSTALL_FROM_API=1` in your shell environment, then run `brew tap --force homebrew/core` to clone the `homebrew/core` tap to the path returned by `brew --repository homebrew/core`.
+## Prepare a contribution checkout
 
-1. If you're starting from scratch, you can use the [`brew create` command](Manpage.md#create-options-url) to produce a basic version of your formula. This command accepts a number of options and you may be able to save yourself some work by using an appropriate template option like `--python`.
+Follow [How to Open a Homebrew Pull Request](How-To-Open-a-Homebrew-Pull-Request.md) to fork the correct repository, tap its local checkout and create a branch from the latest `origin/HEAD`.
 
-1. You will now have to develop the boilerplate code from `brew create` into a full-fledged formula. Your main references will be the [Formula Cookbook](Formula-Cookbook.md), similar formulae in Homebrew, and the upstream documentation for your chosen software. Be sure to also take note of the Homebrew documentation for writing [language-specific formulae](Language-Specific-Formulae.md), if applicable.
+Use `brew create` to generate a starting point from the release download URL:
 
-1. Make sure you write a good test as part of your formula. Refer to the [Add a test to the formula](Formula-Cookbook.md#add-a-test-to-the-formula) section of the Cookbook for help with this.
-
-1. Try installing your formula using `brew install --build-from-source <formula>`, where *\<formula>* is the name of your formula. If any errors occur, correct your formula and attempt to install it again. The formula installation should finish without errors by the end of this step.
-
-If you're stuck, ask for help on GitHub or the [Homebrew discussion forum](https://github.com/orgs/Homebrew/discussions). The maintainers are very happy to help but we also like to see that you've put effort into trying to find a solution first.
-
-### Testing and auditing the formula
-
-1. Run `brew audit --strict --new --online <formula>` with your formula. If any errors occur, correct your formula and run the audit again. The audit should finish without any errors by the end of this step.
-
-1. Run your formula's test using `brew test <formula>`. The test should finish without any errors.
-
-### Submitting the formula
-
-You're finally ready to submit your formula to the [homebrew-core](https://github.com/Homebrew/homebrew-core) repository. If you haven't done this before, you can refer to the [How to Open a Homebrew Pull Request](How-To-Open-a-Homebrew-Pull-Request.md#formulae-related-pull-request) documentation for help. Maintainers will review the pull request and provide feedback about any areas that need to be addressed before the formula can be added to Homebrew.
-
-If you've made it this far, congratulations on submitting a Homebrew formula! We appreciate the hard work you put into this and you can take satisfaction in knowing that your work may benefit other Homebrew users as well.
-
-## Casks
-
-**Note:** Before taking the time to craft a new cask:
-
-* make sure it can be accepted by checking [Acceptable Casks](Acceptable-Casks.md), and
-* check that the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
-
-### Writing the cask
-
-Making a new cask is easy. Follow the directions in [How to Open a Homebrew Pull Request](How-To-Open-a-Homebrew-Pull-Request.md#cask-related-pull-request) to begin.
-
-#### Examples
-
-Here’s a cask for `dixa` as an example. Note the `verified` parameter below the `url`, which is needed when [the URL and homepage hostnames differ](Cask-Cookbook.md#when-url-and-homepage-domains-differ-add-verified).
-
-```ruby
-cask "dixa" do
-  version "4.0.12"
-  sha256 "a4e1a30d074e724ba24e9e2674a72bc4050f00161fb7dc23295a2c189ecda5bb"
-
-  url "https://github.com/dixahq/dixa-desktop-app-release/releases/download/v#{version}/dixa-#{version}.dmg",
-      verified: "github.com/dixahq/dixa-desktop-app-release/"
-  name "Dixa"
-  desc "Customer service platform"
-  homepage "https://dixa.com/"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
-  app "Dixa.app"
-
-  zap trash: [
-    "~/Library/Application Support/Dixa",
-    "~/Library/Logs/Dixa",
-    "~/Library/Preferences/dixa.plist",
-    "~/Library/Saved Application State/dixa.savedState",
-  ]
-end
+```sh
+brew create URL
+brew create --cask URL
 ```
 
-And here is one for `pomello`. Note that it has an unversioned download (the download `url` does not contain the version number, unlike the example above). It also suppresses the checksum with `sha256 :no_check`, which is necessary because since the download `url` does not contain the version number, its checksum will change when a new version is made available.
+`brew create --help` lists language and build-system templates such as `--python`, `--node`, `--cmake` and `--rust`.
+Use `--tap homebrew/core` or `--tap homebrew/cask` when Homebrew cannot infer the intended repository.
 
-```ruby
-cask "pomello" do
-  version "0.10.17"
-  sha256 :no_check
+Generated files are templates, not completed packages.
+Review every field, remove unused boilerplate and compare the result with current packages that use the same build or artifact type.
 
-  url "https://pomelloapp.com/download/mac/latest"
-  name "Pomello"
-  desc "Turns your Trello cards into Pomodoro tasks"
-  homepage "https://pomelloapp.com/"
+## Write the package
 
-  livecheck do
-    url :url
-    strategy :header_match
-  end
+For a formula, use the [Formula Cookbook](Formula-Cookbook.md) as the authoritative DSL and testing reference.
+The [language-specific formula guide](Language-Specific-Formulae.md) covers Python, Node.js, Java and Ruby helpers.
 
-  app "Pomello.app"
+For a cask, use the [Cask Cookbook](Cask-Cookbook.md) for token rules, required stanzas, artifact selection, uninstall behaviour and `zap` guidance.
+Do not copy a complete cask from a general documentation page because versions, checksums, URLs and vendor packaging change frequently.
 
-  zap trash: [
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.tinynudge.pomello.*",
-    "~/Library/Application Support/Pomello",
-    "~/Library/Caches/com.tinynudge.pomello",
-    "~/Library/Caches/com.tinynudge.pomello.ShipIt",
-    "~/Library/HTTPStorages/com.tinynudge.pomello",
-    "~/Library/Preferences/com.tinynudge.pomello.plist",
-    "~/Library/Saved Application State/com.tinynudge.pomello.savedState",
-  ]
-end
+In both cases:
+
+- use the vendor's canonical homepage and immutable release source
+- verify downloads with SHA-256 when the URL is versioned
+- declare only required dependencies
+- add a meaningful test for formulae
+- include complete uninstall behaviour for casks that run an installer
+- avoid scripts or permissions broader than the installation requires
+
+## Test locally
+
+Use the current commands from the pull-request guide.
+The normal validation is:
+
+```sh
+HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source FORMULA
+brew test FORMULA
+brew audit --strict --new --online FORMULA
+brew style --fix FORMULA
 ```
 
-Here is a last example for `fabfilter-one`, which uses a `pkg` installer to install the application instead of a stand-alone application bundle (`.app`). Note the [`uninstall pkgutil:`](Cask-Cookbook.md#uninstall-pkgutil) stanza, which is needed to uninstall all files that were installed using the installer.
+For a cask:
 
-You will also see how to adapt `version` to the download `url`. Use [our custom `version` methods](Cask-Cookbook.md#version-methods) to do so, resorting to the standard [Ruby `String` methods](https://ruby-doc.org/core/String.html) when they don’t suffice.
+<a data-proofer-ignore name="testing-and-auditing-the-cask"></a>
 
-```ruby
-cask "fabfilter-one" do
-  version "3.37"
-  sha256 "4059594580e365237ded16a213d8d549cbb01c4b8bad80895c61f44bcff7eb68"
-
-  url "https://download.fabfilter.com/ffone#{version.no_dots}.dmg"
-  name "FabFilter One"
-  desc "Synthesizer plug-in"
-  homepage "https://www.fabfilter.com/products/volcano-2-powerful-filter-plug-in"
-
-  livecheck do
-    url "https://www.fabfilter.com/download"
-    strategy :page_match do |page|
-      match = page.match(/ffone(\d)(\d+)\.dmg/i)
-      next if match.blank?
-
-      "#{match[1]}.#{match[2]}"
-    end
-  end
-
-  depends_on macos: :sonoma
-
-  pkg "FabFilter One #{version} Installer.pkg"
-
-  uninstall pkgutil: "com.fabfilter.One.#{version.major}"
-
-  # No zap stanza required
-end
+```sh
+HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask CASK
+brew uninstall --cask CASK
+brew audit --new --cask CASK
+brew style --fix CASK
 ```
 
-#### Generating a token for the cask
+Inspect the installed files and user-facing output, not only the exit status.
+Run `brew lgtm --online` from the contribution checkout before submitting the pull request.
 
-The cask **token** is the mnemonic string people will use to interact with the cask via `brew install`, etc. The name of the cask **file** is simply the token with the extension `.rb` appended.
+## Submit the pull request
 
-The easiest way to generate a token for a cask is to run `generate_cask_token`:
+Return to [How to Open a Homebrew Pull Request](How-To-Open-a-Homebrew-Pull-Request.md#create-your-pull-request-from-a-new-branch) for commit, push and submission instructions.
+Complete the pull-request template, disclose AI assistance when applicable and respond to review feedback with tested changes.
 
-```bash
-$(brew --repository homebrew/cask)/developer/bin/generate_cask_token "/full/path/to/new/software.app"
-```
-
-If the software you wish to create a cask for is not installed, or does not have an associated App bundle, just give the full proper name of the software instead of a pathname:
-
-```bash
-$(brew --repository homebrew/cask)/developer/bin/generate_cask_token "Google Chrome"
-```
-
-If the `generate_cask_token` script does not work for you, see [Cask Token Details](#cask-token-details).
-
-#### Creating the cask file
-
-Once you know the token, create your cask with the `brew create --cask` command:
-
-```bash
-brew create --cask download-url --set-name my-new-cask
-```
-
-This will open `EDITOR` with a template for your new cask, to be stored in the file `my-new-cask.rb`.
-
-#### Cask stanzas
-
-Fill in the following stanzas for your cask:
-
-| name               | value       |
-| ------------------ | ----------- |
-| `version`          | application version |
-| `sha256`           | SHA-256 checksum of the file downloaded from `url`, calculated by the command `shasum -a 256 <file>`. Can be suppressed by using the special value `:no_check`. (see [`sha256` Stanza Details](Cask-Cookbook.md#stanza-sha256)) |
-| `url`              | URL to the `.dmg`/`.zip`/`.tgz` file (or other common archive formats) that contains the application.<br />A [`verified` parameter](Cask-Cookbook.md#when-url-and-homepage-domains-differ-add-verified) must be added if the hostnames in the `url` and `homepage` stanzas differ. |
-| `name`             | the full and proper name defined by the vendor, and any useful alternate names (see [`name` Stanza Details](Cask-Cookbook.md#stanza-name)) |
-| `desc`             | one-line description of the software (see [`desc` Stanza Details](Cask-Cookbook.md#stanza-desc)) |
-| `homepage`         | application homepage; used for the `brew home` command |
-| `livecheck`        | Ruby block describing how to find updates for this cask (see [`livecheck` Stanza Details](Cask-Cookbook.md#stanza-livecheck)) |
-| `app`              | relative path to an `.app` bundle that should be moved into the `/Applications` folder on installation (see [`app` Stanza Details](Cask-Cookbook.md#stanza-app)) |
-| `zap`              | additional procedures for a more complete uninstall, including configuration files and shared resources (see [`zap` Stanza Details](Cask-Cookbook.md#stanza-zap)) |
-
-Other commonly used stanzas are:
-
-| name               | value       |
-| ------------------ | ----------- |
-| `pkg`              | relative path to a `.pkg` file containing the distribution (see [`pkg` Stanza Details](Cask-Cookbook.md#stanza-pkg)) |
-| `caveats`          | string or Ruby block providing the user with cask-specific information at install time (see [`caveats` Stanza Details](Cask-Cookbook.md#stanza-caveats)) |
-| `uninstall`        | procedures to uninstall a cask; optional unless the `pkg` stanza is used (see [`uninstall` Stanza Details](Cask-Cookbook.md#stanza-uninstall)) |
-
-Additional [artifact stanzas](Cask-Cookbook.md#at-least-one-artifact-stanza-is-also-required) may be needed for special use cases. Even more special-use stanzas are listed at [Optional stanzas](Cask-Cookbook.md#optional-stanzas).
-
-#### Cask token details
-
-If a token conflicts with an already-existing cask, authors should manually make the new token unique by prepending the vendor name. Example: [unison.rb](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/u/unison.rb) and [panic-unison.rb](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/p/panic-unison.rb).
-
-If possible, avoid creating tokens that differ only by the placement of hyphens.
-
-To generate a token manually, or to learn about exceptions for unusual cases, see the [Token reference](Cask-Cookbook.md#token-reference).
-
-#### Archives with subfolders
-
-When a downloaded archive expands to a subfolder, the subfolder name must be included in the `app` value.
-
-Example:
-
-1. Simple Floating Clock is downloaded to the file `sfc.zip`.
-1. `sfc.zip` unzips to a folder called `Simple Floating Clock`.
-1. The folder `Simple Floating Clock` contains the application `SimpleFloatingClock.app`.
-1. So, the `app` stanza should include the subfolder as a relative path:
-
-```ruby
-app "Simple Floating Clock/SimpleFloatingClock.app"
-```
-
-### Testing and auditing the cask
-
-Give it a shot with:
-
-```bash
-export HOMEBREW_NO_AUTO_UPDATE=1
-export HOMEBREW_NO_INSTALL_FROM_API=1
-brew install my-new-cask
-```
-
-Did it install? If something went wrong, edit your cask with `brew edit my-new-cask` to fix it.
-
-Test also if the uninstall works successfully:
-
-```bash
-brew uninstall my-new-cask
-```
-
-If everything looks good, you’ll also want to make sure your cask passes audit with:
-
-```bash
-brew audit --new --cask my-new-cask
-```
-
-You should also check stylistic details with `brew style`:
-
-```bash
-brew style --fix my-new-cask
-```
-
-Keep in mind that all these checks will be made when you submit your PR, so by doing them in advance you’re saving everyone a lot of time and trouble.
-
-If your application and Homebrew Cask do not work well together, feel free to [file an issue](https://github.com/Homebrew/homebrew-cask#reporting-bugs) after checking out open issues.
-
-### Submitting the cask
-
-#### Finding a home for your cask
-
-See the [Acceptable Casks](Acceptable-Casks.md) documentation.
-
-Hop into your tap and check to make sure your new cask is there:
-
-```console
-$ cd "$(brew --repository)"/Library/Taps/homebrew/homebrew-cask
-$ git status
-On branch main
-Untracked files:
-  (use "git add <file>..." to include in what will be committed)
-        Casks/m/my-new-cask.rb
-```
-
-So far, so good. Now make a feature branch `my-new-cask-branch` that you’ll use in your pull request:
-
-```console
-$ git checkout -b my-new-cask-branch
-Switched to a new branch 'my-new-cask-branch'
-```
-
-Stage your cask with:
-
-```bash
-git add Casks/m/my-new-cask.rb
-```
-
-You can view the changes that are to be committed with:
-
-```bash
-git diff --cached
-```
-
-Commit your changes with:
-
-```bash
-git commit -v
-```
-
-#### Commit messages
-
-For any Git project, some good rules for commit messages are:
-
-* The first line is the commit summary, 50 characters or less,
-* Followed by an empty line,
-* Followed by an explanation of the commit, wrapped to 72 characters.
-
-See [A Note About Git Commit Messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) for more.
-
-The first line of a commit message becomes the **title** of a pull request on GitHub, like the subject line of an email. Including the key info in the first line will help us respond faster to your pull request.
-
-For cask commits in the Homebrew Cask project, we like to include the application name, version number, and purpose of the commit in the first line.
-
-Examples of good, clear commit summaries:
-
-* `transmission 1.0 (new cask)`
-* `transmission 2.82`
-* `transmission: fix checksum`
-* `codebox latest (new cask)`
-
-Examples of difficult, unclear commit summaries:
-
-* `Upgrade to v2.82`
-* `Checksum was bad`
-
-#### Pushing
-
-Push your changes on the branch `my-new-cask-branch` to your GitHub account:
-
-```bash
-git push $YOUR_GITHUB_USERNAME my-new-cask-branch
-```
-
-If you are using [GitHub two-factor authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa) and have set your remote repository as HTTPS you will need to [set up a personal access token](https://docs.github.com/en/repositories/creating-and-managing-repositories/troubleshooting-cloning-errors#provide-an-access-token) and use that instead of your password.
-
-#### Filing a pull request on GitHub
-
-##### a) use suggestion from `git push`
-
-The `git push` command prints a suggestion for how to create a pull request:
-
-    remote: Create a pull request for 'new-cask-cask' on GitHub by visiting:
-    remote:      https://github.com/$YOUR_GITHUB_USERNAME/homebrew-cask/pull/new/my-new-cask-branch
-
-##### b) use suggestion from GitHub's website
-
-Now go to the [`homebrew-cask` GitHub repository](https://github.com/Homebrew/homebrew-cask). GitHub will often show your `my-new-cask-branch` branch with a handy button to `Compare & pull request`.
-
-##### c) manually create a pull request on GitHub
-
-Otherwise, click the `Contribute > Open pull request` button and choose to `compare across forks`. The base fork should be `Homebrew/homebrew-cask @ main`, and the head fork should be `$YOUR_GITHUB_USERNAME/homebrew-cask @ my-new-cask-branch`. You can also add any further comments to your pull request at this stage.
-
-#### Congratulations
-
-You are done now, and your cask should be pulled in or otherwise noticed in a while. If a maintainer suggests some changes, just make them on the `my-new-cask-branch` branch locally and [push](#pushing).
-
-### Cleaning up
-
-After your pull request is submitted, you should get yourself back onto `main`, so that `brew update` will pull down new casks properly:
-
-```bash
-cd "$(brew --repository)"/Library/Taps/homebrew/homebrew-cask
-git checkout main
-```
-
-If earlier you set the variable `HOMEBREW_NO_AUTO_UPDATE` and `HOMEBREW_NO_INSTALL_FROM_API` then clean it up with:
-
-```bash
-unset HOMEBREW_NO_AUTO_UPDATE
-unset HOMEBREW_NO_INSTALL_FROM_API
-```
+Use [Homebrew Discussions](https://github.com/orgs/Homebrew/discussions) when the package type, policy or build approach remains unclear after reading the relevant guide.

--- a/docs/How-To-Open-a-Homebrew-Pull-Request.md
+++ b/docs/How-To-Open-a-Homebrew-Pull-Request.md
@@ -7,7 +7,7 @@ last_review_date: "2026-07-18"
 The following commands are used by Homebrew contributors to set up a fork of Homebrew's Git repository on GitHub, create a new branch and create a GitHub pull request ("PR") for the changes in that branch.
 
 The type of change you want to make determines which of Homebrew's main repositories should receive the pull request.
-Submit changes to Homebrew's core code, including the `brew` implementation, to [Homebrew/brew](https://github.com/Homebrew/brew).
+Submit changes to Homebrew's `brew` implementation to [Homebrew/brew](https://github.com/Homebrew/brew).
 Submit formula changes to the [homebrew/core](https://github.com/Homebrew/homebrew-core) tap and cask changes to the [homebrew/cask](https://github.com/Homebrew/homebrew-cask) tap.
 
 ## Submit a new version of an existing formula

--- a/docs/How-To-Open-a-Homebrew-Pull-Request.md
+++ b/docs/How-To-Open-a-Homebrew-Pull-Request.md
@@ -1,12 +1,14 @@
 ---
-last_review_date: "2026-01-06"
+last_review_date: "2026-07-18"
 ---
 
 # How to Open a Homebrew Pull Request
 
 The following commands are used by Homebrew contributors to set up a fork of Homebrew's Git repository on GitHub, create a new branch and create a GitHub pull request ("PR") for the changes in that branch.
 
-The type of change you want to make influences which of Homebrew's main repositories you'll need to send your pull request to. If you want to submit a change to Homebrew's core code (the `brew` implementation), you should open a pull request on [Homebrew/brew](https://github.com/Homebrew/brew). If you want to submit a change for a formula, you should open a pull request on the [homebrew/core](https://github.com/Homebrew/homebrew-core) tap, while for casks you should open the pull request on the [homebrew/cask](https://github.com/Homebrew/homebrew-cask) tap or another [official tap](https://github.com/Homebrew), depending on the formula type.
+The type of change you want to make determines which of Homebrew's main repositories should receive the pull request.
+Submit changes to Homebrew's core code, including the `brew` implementation, to [Homebrew/brew](https://github.com/Homebrew/brew).
+Submit formula changes to the [homebrew/core](https://github.com/Homebrew/homebrew-core) tap and cask changes to the [homebrew/cask](https://github.com/Homebrew/homebrew-cask) tap.
 
 ## Submit a new version of an existing formula
 
@@ -68,13 +70,13 @@ Before creating a new cask, please read [Acceptable Casks](Acceptable-Casks.md).
 
 1. [Fork the Homebrew/homebrew-cask repository on GitHub](https://github.com/Homebrew/homebrew-cask/fork).
    * This creates a personal remote repository that you can push to. This is needed because only Homebrew maintainers have push access to the main repositories.
-2. Tap (download a local clone of) the repository of core Homebrew casks:
+2. Tap (download a local clone of) the `homebrew/cask` repository:
 
    ```sh
    brew tap --force homebrew/cask
    ```
 
-3. Change to the directory containing Homebrew casks:
+3. Change to the directory containing `homebrew/cask`:
 
    ```sh
    cd "$(brew --repository homebrew/cask)"
@@ -129,8 +131,9 @@ To make changes on a new branch and submit it for review, create a GitHub pull r
    brew lgtm --online
    ```
 
-6. [Make a separate commit](Formula-Cookbook.md#commit) for each changed formula with `git add` and `git commit`. Each formula's commits must be squashed.
-   * Please note that our required commit message format for simple version updates is "`<FORMULA_NAME> <NEW_VERSION>`", e.g. "`source-highlight 3.1.8`".
+6. [Make a separate commit](Formula-Cookbook.md#commit) for each changed formula or cask with `git add` and `git commit`. Each package's commits must be squashed.
+   * Use "`<NAME> <VERSION>`" for a simple version update, such as "`source-highlight 3.1.8`".
+   * Use "`<NAME> <VERSION> (new formula)`" or "`<NAME> <VERSION> (new cask)`" for a new package.
 7. Upload your branch of new commits to your fork:
 
    ```sh
@@ -142,7 +145,7 @@ To make changes on a new branch and submit it for review, create a GitHub pull r
 
 Thank you!
 
-### "Artificial Intelligence"/Large Language Model (AI/LLM) usage
+### "Artificial intelligence"/large language model (AI/LLM) usage
 
 We allow you to create issues and pull requests with AI/LLM with the following requirements (see [Responsible AI Usage](Responsible-AI-Usage.md) for the principles behind them):
 


### PR DESCRIPTION
Converts Adding Software to Homebrew into a package-type router: choose formula or cask, read the acceptance policy, then follow the maintained references instead of duplicating complete examples that drift (the removed inline casks referenced versions and URLs from years ago). Compatibility anchors preserve the old `#casks` and `#testing-and-auditing-the-cask` deep links used by the homebrew-cask repository. The pull-request guide documents the new-package commit-message forms alongside version updates and covers casks in the commit step, the interim Acceptable Casks link gains its section anchor now that the heading exists and `brew create`'s cask template drops a link to a section that no longer does.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5) prepared the rewrite with every routed command verified against the current implementations; I reviewed the diff and verified locally with `brew lgtm --online`, `brew generate-man-completions` (no drift), Vale, Markdownlint and the docs Jekyll/HTMLProofer suite.

-----
