### PR TITLE
docs: update formula authoring and toolchain references

### DIFF
--- a/docs/Bottles.md
+++ b/docs/Bottles.md
@@ -1,5 +1,5 @@
 ---
-last_review_date: "1970-01-01"
+last_review_date: "2026-07-18"
 ---
 
 # Bottles (Binary Packages)
@@ -10,25 +10,32 @@ Bottles are produced by installing a formula with `brew install --build-bottle <
 
 When the formula being installed defines a bottle matching your system, it will be downloaded and installed automatically when you run `brew install <formula>`.
 
-Bottles will not be used if:
+Bottles are not used when:
 
 - the user requests it (by specifying `--build-from-source`),
 - the formula requests it (with `pour_bottle?`),
 - any options are specified during installation (bottles are all compiled with default options),
 - the bottle is not up to date (e.g. missing or mismatched checksum),
-- or the bottle's `cellar` is neither `:any` (it requires being installed to a specific Cellar path) nor equal to the current `HOMEBREW_CELLAR` (the required Cellar path does not match that of the current Homebrew installation).
+- the bottle's `cellar` is neither relocatable nor equal to the current `HOMEBREW_CELLAR`.
 
 ## Creation
 
 Bottles for `homebrew/core` formulae are created by [BrewTestBot](BrewTestBot.md) when a pull request is submitted. If the formula builds successfully on each supported platform and a maintainer approves the change, BrewTestBot updates its `bottle do` block and uploads each bottle to [GitHub Packages](https://github.com/orgs/Homebrew/packages).
 
-By default, bottles will be built for the oldest CPU supported by the OS/architecture you're building for (Core 2 for 64-bit x86 operating systems). This ensures that bottles are compatible with all computers you might distribute them to. If you *really* want your bottles to be optimised for something else, you can pass the `--bottle-arch=` option to build for another architecture; for example, `brew install foo --build-bottle --bottle-arch=penryn`. Just remember that if you build for a newer architecture, some of your users might get binaries they can't run and that would be sad!
+By default, Homebrew targets the oldest CPU generation supported for the operating system and architecture being bottled.
+For 64-bit x86 builds, the baseline is Core 2 unless the platform definition specifies a newer minimum.
+This makes the bottle usable across the supported hardware range.
+
+Use `--bottle-arch=` only when the formula intentionally requires another architecture and its compatibility has been reviewed.
+A bottle built for a newer CPU can fail with an illegal-instruction error on older supported hardware.
 
 ## Format
 
-Bottles are simple gzipped tarballs of compiled binaries. The formula name, version, target operating system and rebuild version is stored in the filename, any other metadata is in the formula's bottle DSL, and the formula definition is located within the bottle at `<formula>/<version>/.brew/<formula>.rb`.
+Bottles are simple gzipped tarballs of compiled binaries.
+The formula name, version, target operating system and rebuild version are stored in the filename.
+Other metadata is in the formula's bottle DSL, and the formula definition is located within the bottle at `<formula>/<version>/.brew/<formula>.rb`.
 
-## Bottle DSL (Domain Specific Language)
+## Bottle DSL (domain specific language)
 
 Bottles are specified in formula definitions by a DSL contained within a `bottle do ... end` block.
 
@@ -54,6 +61,8 @@ bottle do
 end
 ```
 
+Use the `all:` tag for a platform-independent bottle whose contents are identical and usable on every supported operating system and architecture.
+
 ### Root URL (`root_url`)
 
 Optionally contains the URL root used to determine bottle URLs.
@@ -70,7 +79,8 @@ Most compiled software contains references to its compiled location, preventing 
 
 Optionally contains the rebuild version of the bottle.
 
-Sometimes bottles may need be updated without bumping the version or revision of the formula, e.g. if a new patch was applied. In such cases `rebuild` will have a value of `1` or more.
+Sometimes a bottle must be updated without changing the formula version or revision, such as after a bottle-only packaging correction.
+In that case `rebuild` has a value of `1` or greater.
 
 ### Checksum (`sha256`)
 

--- a/docs/Brew-Livecheck.md
+++ b/docs/Brew-Livecheck.md
@@ -56,7 +56,7 @@ The `livecheck` block regex restricts matches to a subset of the fetched content
 
 * **Anchor the start/end of the regex to restrict its scope**. For example, on HTML pages we often match file names or version directories in `href` attribute URLs (e.g. `/href=.*?example[._-]v?(\d+(?:\.\d+)+)\.zip/i`). The general idea is that limiting scope will help exclude unwanted matches.
 
-* **Avoid generic catchalls like `.*` or `.+`** in favor of something non-greedy and/or contextually appropriate. For example, to match characters within the bounds of an HTML attribute, use `[^"' >]+?`.
+* **Avoid generic catchalls like `.*` or `.+`** in favour of something non-greedy and/or contextually appropriate. For example, to match characters within the bounds of an HTML attribute, use `[^"' >]+?`.
 
 * **Use `[._-]` in place of a period/underscore/hyphen between the software name and version in a file name**. For a file named `example-1.2.3.tar.gz`, `example[._-]v?(\d+(?:\.\d+)+)\.t` will continue matching if the upstream file name format changes to `example_1.2.3.tar.gz` or `example.1.2.3.tar.gz`.
 

--- a/docs/Building-Against-Non-Homebrew-Dependencies.md
+++ b/docs/Building-Against-Non-Homebrew-Dependencies.md
@@ -1,15 +1,29 @@
 ---
-last_review_date: "1970-01-01"
+last_review_date: "2026-07-18"
 ---
 
 # Building Against Non-Homebrew Dependencies
 
-## History
+Homebrew formulae normally build in `superenv`, which filters the user's environment and exposes declared dependencies.
+This makes builds reproducible and prevents an undeclared program or library on one contributor's machine from silently changing the result.
 
-Originally Homebrew was a build-from-source package manager and all user environment variables and non-Homebrew-installed software were available to builds. Since then Homebrew added `Requirement`s to specify dependencies on non-Homebrew software (such as those provided by `brew cask` like X11/XQuartz), the `superenv` build system to strip out unspecified dependencies, environment filtering to stop the user environment leaking into Homebrew builds and `default_formula` to specify that a `Requirement` can be satisfied by a particular formula.
+## `homebrew/core`
 
-As Homebrew became primarily a binary package manager, most users were fulfilling `Requirement`s with the `default_formula`, not with arbitrary alternatives. To improve quality and reduce variation, Homebrew now exclusively supports using the default formula, as an ordinary dependency, and no longer supports using arbitrary alternatives.
+Formulae in `homebrew/core` must use declared Homebrew dependencies or supported platform facilities.
+They cannot depend on an arbitrary executable, library or language runtime from the user's `PATH` when a Homebrew dependency is the supported alternative.
 
-## Today
+Declare ordinary dependencies with `depends_on` and use the default formula for requirements that provide one.
+Do not use `env :std` in `homebrew/core` to expose undeclared user software.
 
-If you wish to build against custom non-Homebrew dependencies that are provided by Homebrew (e.g. a non-Homebrew, non-macOS `ruby`) then you must [create and maintain your own tap](How-to-Create-and-Maintain-a-Tap.md) as these formulae will not be accepted in Homebrew/homebrew-core. Once you have done that you can specify `env :std` in the formula which will allow e.g. `which ruby` to access your existing `PATH` variable and allow compilation to link against this Ruby. You can also [include a custom Requirement](https://github.com/Homebrew/brew/tree/HEAD/Library/Homebrew/requirements) in your formula that more accurately describes the non-Homebrew software you build against.
+## Third-party taps
+
+If software must build against a private, locally managed or otherwise non-Homebrew dependency, [maintain the formula in your own tap](How-to-Create-and-Maintain-a-Tap.md).
+Document the external dependency, supported versions and setup required by users of that tap.
+
+An external tap may use `env :std` when exposing the user's normal environment is an intentional part of the formula's contract.
+This reduces reproducibility and can make bottles unsuitable, so prefer a declared dependency whenever possible.
+
+A tap can also define a [custom `Requirement`](https://github.com/Homebrew/brew/tree/HEAD/Library/Homebrew/requirements) when it can validate the external software precisely.
+The requirement should explain how to satisfy it and should not accept versions or installations that the formula has not tested.
+
+Run the tap's formula audit and tests in a clean environment to ensure that undeclared software does not accidentally become mandatory.

--- a/docs/C++-Standard-Libraries.md
+++ b/docs/C++-Standard-Libraries.md
@@ -1,32 +1,31 @@
 ---
-last_review_date: "1970-01-01"
+last_review_date: "2026-07-18"
 ---
 
 # C++ Standard Libraries
 
-There are two C++ standard libraries supported by Apple compilers.
+C++ libraries must use a compatible compiler, C++ standard library and application binary interface across their dependency graph.
+Mixing incompatible C++ runtimes can cause link failures, missing symbols or crashes that are not resolved by changing header or library search paths.
 
-The default for 10.9 and later is **libc++**, which is also the default for `clang` on older
-platforms when building C++11 code.
+## macOS
 
-The default for 10.8 and earlier was **libstdc++**, supported by Apple GCC
-compilers, GNU GCC compilers, and `clang`. This was marked deprecated with a
-warning during compilation as of Xcode 8.
+Apple Clang and Homebrew bottles on supported macOS versions use `libc++`.
+Formulae should use the compiler and standard library selected by Homebrew unless upstream has a documented requirement that cannot be met by the default toolchain.
 
-There are subtle incompatibilities between several of the C++ standard libraries,
-so Homebrew will refuse to install software if a dependency was built with an
-incompatible C++ library. It's recommended that you install the dependency tree
-using a compatible compiler.
+GNU GCC normally uses its own `libstdc++`.
+A formula built with GNU GCC must not pass C++ objects across a dependency boundary that was built with an incompatible runtime unless upstream explicitly supports that combination.
 
-**If you've upgraded to 10.9 or later from an earlier version:** Because the default C++
-standard library is now libc++, you may not be able to build software using
-dependencies that you built on 10.8 or earlier. If you're reading this page because
-you were directed here by a build error, you can most likely fix the issue if
-you reinstall all the dependencies of the package you're trying to build.
+## Linux
 
-Example install using GCC 9:
+Homebrew's Linux toolchain normally uses `libstdc++`.
+The same compatibility rule applies: a formula and the C++ libraries whose interfaces it consumes must agree on their runtime and ABI.
 
-```sh
-brew install gcc@9
-brew install --cc=gcc-9 <formula>
-```
+## Resolving compatibility errors
+
+After an operating system, compiler or C++ runtime upgrade, reinstall the affected formula and its C++ dependencies with the current Homebrew toolchain.
+Do not create replacement symlinks for missing versioned C++ libraries because doing so can load an ABI-incompatible library.
+
+Formula authors should inspect the complete compiler and linker commands before overriding Homebrew's compiler selection.
+If upstream requires a specific compiler, declare it as a dependency and test the complete dependency graph on every supported platform.
+
+See the [Formula Cookbook](Formula-Cookbook.md) for build and dependency guidance.

--- a/docs/Custom-GCC-and-cross-compilers.md
+++ b/docs/Custom-GCC-and-cross-compilers.md
@@ -1,15 +1,23 @@
 ---
-last_review_date: "1970-01-01"
+last_review_date: "2026-07-18"
 ---
 
-# Custom GCC and Cross Compilers
+# Custom GCC and Cross-Compilers
 
-Homebrew depends on having an up-to-date version of Xcode because it comes with specific versions of build tools, e.g. `clang`. Installing a custom version of GCC or Autotools into your `PATH` has the potential to break lots of compiles so we prefer the Apple- or Homebrew-provided compilers. Cross compilers based on GCC will typically be "keg-only" and therefore not linked into your `PATH` by default, or be prefixed with the target architecture, again to avoid conflicting with Apple or Homebrew compilers.
+Homebrew uses the supported platform compiler by default.
+Changing `PATH` so an unrelated compiler, linker or build tool shadows the platform toolchain can make builds fail in ways that are difficult to reproduce.
 
-Rather than merging formulae for either of these cases at this time, we're listing them on this page. If you come up with a formula for a new version of GCC or cross-compiler suite, please link to it here.
+Homebrew provides current GNU GCC through the `gcc` formula and LLVM through the `llvm` formula.
+Versioned formulae may exist for software that still requires an older compiler, but they can have narrower platform support and shorter remaining support periods.
+Check `brew info <formula>` rather than relying on a compiler list in this document.
 
-- Homebrew provides a `gcc` formula for use with Xcode 4.2+.
-- Homebrew provides older GCC formulae, e.g. `gcc@9`.
-- Homebrew provides some cross-compilers and toolchains, but these are named to avoid clashing with the default tools, e.g. `i686-elf-gcc`, `x86_64-elf-gcc`.
-- Homebrew provides LLVM's Clang, which is bundled with the `llvm` formula.
-- [RISC-V](https://github.com/riscv/homebrew-riscv) provides the RISC-V toolchain including binutils and GCC.
+On macOS, the unversioned `cc`, `gcc` and `c++` commands are Apple Clang entry points.
+Homebrew's GNU compiler executables use versioned names to avoid replacing the platform compiler.
+Formulae and build scripts should identify the required compiler explicitly instead of assuming that `gcc` means GNU GCC on every platform.
+
+Cross-compiler formulae use target-prefixed names such as `x86_64-elf-gcc` and are not intended to replace the host compiler.
+Other toolchains may be available from third-party taps.
+Review the tap's ownership and [trust only the required item](Tap-Trust.md#installing-from-a-tap) before installation.
+
+Formula authors should declare compiler and toolchain dependencies in the formula, keep them isolated from the host toolchain and test generated binaries for the intended target.
+Use a third-party tap for a specialised or experimental toolchain that does not meet the criteria for `homebrew/core`.

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -65,7 +65,8 @@ brew create https://example.com/foo-0.1.tar.gz
 
 This creates `$(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/f/foo.rb` and opens it in your `EDITOR`.
 
-Passing in `--ruby` or `--python` will populate various defaults commonly useful for projects written in those languages.
+`brew create --help` lists templates for supported languages and build systems.
+Pass the appropriate option to populate useful defaults for the project.
 
 If `brew` said `Warning: Version cannot be determined from URL` when doing the `create` step, you’ll need to explicitly add the correct [`version`](/rubydoc/Formula.html#version-class_method) to the formula and then save the formula.
 
@@ -119,13 +120,10 @@ We generally try not to duplicate system libraries and complicated tools in core
 
 Special exceptions are OpenSSL and LibreSSL. Things that use either *should* be built using Homebrew’s shipped equivalent and our BrewTestBot's post-install `audit` will warn if it detects you haven't done this.
 
-For `Homebrew/homebrew-core`, keep dependencies minimal and context-dependent.
-Prefer dependencies needed to build, test or satisfy current core dependents,
-and avoid adding optional upstream features that bring in large recursive
-dependency trees. When a formula needs both a light default build and a maximal
-build, maintainers may prefer a separate `*-full` formula instead. See the
-[dependency policy in the `Homebrew/homebrew-core` Maintainer
-Guide]({% link Homebrew-homebrew-core-Maintainer-Guide.md %}#dependencies-and-full-variants).
+For `homebrew/core`, keep dependencies minimal and context-dependent.
+Prefer dependencies needed to build, test or satisfy current core dependents and avoid optional upstream features that bring in large recursive dependency trees.
+When a formula needs both a light default build and a maximal build, Homebrew may accept a separate `*-full` formula.
+See the [`homebrew/core` dependency policy](Acceptable-Formulae.md#dependencies-and-full-variants).
 
 **Important:** `$(brew --prefix)/bin` is NOT in the `PATH` during formula installation. If you have dependencies at build time, you must specify them and `brew` will add them to the `PATH` or create a [`Requirement`](/rubydoc/Requirement.html).
 
@@ -255,58 +253,11 @@ To require the `curl` formula on Linux and pre-macOS 12:
 uses_from_macos "curl", since: :monterey
 ```
 
-### Specifying gems, Python modules, Go projects, etc. as dependencies
+### Language-specific dependencies
 
-Homebrew doesn’t package already-packaged language-specific libraries. These should be installed directly from `gem`/`cpan`/`pip` etc.
-
-### Ruby Gem Dependencies
-
-The preferred mechanism for installing gem dependencies is to use `bundler` with the upstream's `Gemfile.lock`. This requires the upstream checks in their `Gemfile.lock`, so if they don't, it's a good idea to file an issue and ask them to do so. Assuming they have one, this is as simple as:
-
-```ruby
-ENV["GEM_HOME"] = libexec
-system "bundle", "install", "--without", "development"
-```
-
-From there, you can build and install the project itself:
-
-```ruby
-system "gem", "build", "<project>.gemspec"
-system "gem", "install", "--ignore-dependencies", "<project>-#{version}.gem"
-```
-
-And install any bins, and munge their shebang lines, with:
-
-```ruby
-bin.install libexec/"bin/<bin>"
-bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV.fetch("GEM_HOME", nil))
-```
-
-### Python dependencies
-
-For python we use [`resource`](/rubydoc/Formula.html#resource-class_method)s for dependencies and there's automation to generate these for you. Running `brew update-python-resources <formula>` will automatically add the necessary [`resource`](/rubydoc/Formula.html#resource-class_method) stanzas for the dependencies of your Python application to the formula. Note that `brew update-python-resources` is run automatically by `brew create` if you pass the `--python` switch. If `brew update-python-resources` is unable to determine the correct `resource` stanzas, [homebrew-pypi-poet](https://github.com/tdsmith/homebrew-pypi-poet) is a good third-party alternative that may help.
-
-### All other cases
-
-If all else fails, you'll want to use [`resource`](/rubydoc/Formula.html#resource-class_method)s for all other language-specific dependencies. This requires you to specify both a specific URL for a version and the sha256 checksum for security. Here's an example:
-
-```ruby
-class Foo < Formula
-  # ...
-  url "https://example.com/foo-1.0.tar.gz"
-
-  resource "pycrypto" do
-    url "https://files.pythonhosted.org/packages/60/db/645aa9af249f059cc3a368b118de33889219e0362141e75d4eaf6f80f163/pycrypto-2.6.1.tar.gz"
-    sha256 "f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c"
-  end
-
-  def install
-    resource("pycrypto").stage { system "python", "-m", "pip", "install", *std_pip_args, "." }
-  end
-end
-```
-
-[`jrnl`](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/j/jrnl.rb) is an example of a formula that does this well. The end result means the user doesn't have to use `pip` or Python and can just run `jrnl`.
+Use [Language-Specific Formulae](Language-Specific-Formulae.md) for Python, Node.js, Java and Ruby dependency and installation patterns.
+Use [`resource`](/rubydoc/Formula.html#resource-class_method) blocks when dependencies need separate immutable URLs and SHA-256 checksums.
+Do not rely on packages installed in the contributor's global language environment.
 
 ### Install the formula
 
@@ -389,7 +340,7 @@ In case there are specific issues with the Homebrew packaging (compared to how t
 
 Name the formula like the project markets the product. So it’s `pkgconf`, not `pkgconfig`; `sdl_mixer`, not `sdl-mixer` or `sdlmixer`.
 
-The only exception is stuff like “Apache Ant”. Apache sticks “Apache” in front of everything, but we use the formula name `ant`. We only include the prefix in cases like `gnuplot` (because it’s part of the name) and `gnu-go` (because everyone calls it “GNU Go”—nobody just calls it “Go”). The word “Go” is too common and there are too many implementations of it.
+The only exception is software such as “Apache Ant”. Apache puts “Apache” in front of everything, but we use the formula name `ant`. We only include the prefix in cases such as `gnuplot`, where it is part of the name, and `gnu-go`, because everyone calls it “GNU Go” and not just “Go”. The word “Go” is too common and there are too many implementations of it.
 
 If you’re not sure about the name, check its homepage, Wikipedia page and [what Debian calls it](https://www.debian.org/distrib/packages).
 
@@ -485,105 +436,20 @@ end
 
 For any formula using certain well-known build systems, there will be arguments that should be passed during compilation so that the build conforms to Homebrew standards. These have been collected into a set of `std_*_args` methods. Detailed information about each of those methods can be found in the [`Formula` class API](/rubydoc/Formula.html) documentation.
 
-Most of these methods accept parameters to customize their output. For example, to set the install prefix to [**`libexec`**](#variables-for-directory-locations) for `configure` or `cmake`:
+Most of these methods accept parameters to customise their output. For example, to set the install prefix to [**`libexec`**](#variables-for-directory-locations) for `configure` or `cmake`:
 
 ```ruby
 system "./configure", *std_configure_args(prefix: libexec)
 system "cmake", "-S", ".", "-B", "build", *std_cmake_args(install_prefix: libexec)
 ```
 
-The `std_*_args` methods, as well as the arguments they pass, are:
+Homebrew provides helpers for Cabal, Cargo, CMake, Autoconf, Go, Meson, npm, pip and Zig builds.
+Pass the helper directly to the build command rather than copying its expanded argument list, because defaults change with Homebrew's build and security policy.
+Use the [`Formula` class API](/rubydoc/Formula.html) for each helper's current signature, supported overrides and generated arguments.
 
-#### `std_cabal_v2_args`
-
-```ruby
-"--jobs=#{ENV.make_jobs}"
-"--max-backjumps=100000"
-"--install-method=copy"
-"--installdir=#{bin}"
-```
-
-#### `std_cargo_args`
-
-```ruby
-"--locked"
-"--root=#{root}"
-"--path=#{path}"
-```
-
-#### `std_cmake_args`
-
-```ruby
-"-DCMAKE_INSTALL_PREFIX=#{install_prefix}"
-"-DCMAKE_INSTALL_LIBDIR=#{install_libdir}"
-"-DCMAKE_BUILD_TYPE=Release"
-"-DCMAKE_FIND_FRAMEWORK=#{find_framework}"
-"-DCMAKE_VERBOSE_MAKEFILE=ON"
-"-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=#{HOMEBREW_LIBRARY_PATH}/cmake/trap_fetchcontent_provider.cmake"
-"-Wno-dev"
-"-DBUILD_TESTING=OFF"
-```
-
-#### `std_configure_args`
-
-```ruby
-"--disable-debug"
-"--disable-dependency-tracking"
-"--prefix=#{prefix}"
-"--libdir=#{libdir}"
-```
-
-#### `std_go_args`
-
-```ruby
-"-trimpath"
-"-o=#{output}"
-```
-
-It also provides a convenient way to set `-ldflags`, `-gcflags`, and `-tags`, see examples: [`babelfish`](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/b/babelfish.rb) and [`wazero`](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/w/wazero.rb) formulae.
-
-#### `std_meson_args`
-
-```ruby
-"--prefix=#{prefix}"
-"--libdir=lib"
-"--buildtype=release"
-"--wrap-mode=nofallback"
-```
-
-#### `std_npm_args`
-
-```ruby
-"-ddd"
-"--global"
-"--build-from-source"
-"--cache=$(brew --cache)/npm_cache"
-"--prefix=#{libexec}"
-```
-
-#### `std_pip_args`
-
-```ruby
-"--verbose"
-"--no-deps"
-"--no-binary=:all:"
-"--ignore-installed"
-"--no-compile"
-```
-
-#### `std_zig_args`
-
-```ruby
-"--prefix"
-prefix
-"--release=#{release_mode}"
-"-Doptimize=Release#{release_mode}"
-"--summary"
-"all"
-"-Dcpu=#{Hardware.zig_cpu(ENV.effective_arch)}"
-```
-
-`release_mode` is a symbol that accepts only `:fast`, `:safe`, and `:small` values (with `:fast` being default).
+Use `std_npm_args` for npm installations as described in [Language-Specific Formulae](Language-Specific-Formulae.md#standard-npm-installation).
+Use `std_pip_args` for direct pip installations as described in [Language-Specific Formulae](Language-Specific-Formulae.md#installing-python-bindings).
+`std_go_args` also provides supported ways to set `-ldflags`, `-gcflags` and `-tags`; see the [`babelfish`](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/b/babelfish.rb) and [`wazero`](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/w/wazero.rb) formulae for current examples.
 
 ### `bin.install "foo"`
 
@@ -821,7 +687,7 @@ See the [`icoutils`](https://github.com/Homebrew/homebrew-core/blob/442f9cc511ce
 
 ### `livecheck` blocks
 
-When `brew livecheck` is unable to identify versions for a formula, we can control its behavior using a `livecheck` block. Here is a simple example to check a page for links containing a filename like `example-1.2.tar.gz`:
+When `brew livecheck` is unable to identify versions for a formula, we can control its behaviour using a `livecheck` block. Here is a simple example to check a page for links containing a filename like `example-1.2.tar.gz`:
 
 ```ruby
 livecheck do
@@ -832,7 +698,7 @@ end
 
 For `url`/`regex` guidelines and additional `livecheck` block examples, refer to the [`brew livecheck`](Brew-Livecheck.md) documentation. For more technical information on the methods used in a `livecheck` block, please refer to the [`Livecheck` class](/rubydoc/Livecheck.html) documentation.
 
-### Excluding formula from autobumping
+### Excluding formulae from autobumping
 
 By default, all new formulae in the `Homebrew/homebrew-core` repository are autobumped. This means that future updates are handled automatically by Homebrew CI jobs, and contributors do not have to submit pull requests.
 
@@ -929,8 +795,8 @@ Formulae can specify an alternate download for the upstream project's developmen
 
 * Git repositories **must always** specify `branch:`. If the repository is very large, specify `only_path` to [limit the checkout to one path](Cask-Cookbook.md#git-urls).
 
-```sh
-head "<https://github.com/some/package.git>", branch: "main"
+```ruby
+head "https://github.com/some/package.git", branch: "main"
 ```
 
 * Mercurial repositories need `branch:` specified to fetch a branch other than "default".
@@ -961,7 +827,7 @@ You can test whether the [`head`](/rubydoc/Formula.html#head-class_method) is be
 
 ### Compiler selection
 
-Sometimes a package fails to build when using a certain compiler. Since recent [Xcode versions](Xcode.md) no longer include a GCC compiler we cannot simply force the use of GCC. Instead, the correct way to declare this is with the [`fails_with`](/rubydoc/Formula.html#fails_with-class_method) DSL method. A properly constructed [`fails_with`](/rubydoc/Formula.html#fails_with-class_method) block documents the latest compiler build version known to cause compilation to fail, and the cause of the failure. For example:
+Sometimes a package fails to build when using a certain compiler. Since the [supported Xcode and Command Line Tools versions](Installation.md#macos-requirements) no longer include a GCC compiler we cannot simply force the use of GCC. Instead, the correct way to declare this is with the [`fails_with`](/rubydoc/Formula.html#fails_with-class_method) DSL method. A properly constructed [`fails_with`](/rubydoc/Formula.html#fails_with-class_method) block documents the latest compiler build version known to cause compilation to fail, and the cause of the failure. For example:
 
 ```ruby
 fails_with :clang do
@@ -1164,7 +1030,7 @@ end
 
 ### Running commands after installation
 
-Any initialization steps that aren't necessarily part of the install process can be located in a `post_install` block, such as setup commands or data directory creation. This block can be re-run separately with `brew postinstall <formula>`.
+Any initialisation steps that aren't necessarily part of the install process can be located in a `post_install` block, such as setup commands or data directory creation. This block can be re-run separately with `brew postinstall <formula>`.
 
 For simple file preparation, prefer [`post_install_steps`](/rubydoc/Formula.html#post_install_steps-class_method). These steps are stored in the JSON API and do not require evaluating formula Ruby. A `post_install_steps` block may only contain the supported step calls with literal arguments. It cannot call the wider formula DSL or arbitrary Ruby code. Homebrew executes the steps with the same sandbox policy as `post_install`.
 
@@ -1333,6 +1199,7 @@ This table lists the options you can set within a `service` block. The `run` or 
 | `cron`                  | -            |  yes  |  yes  | controls the trigger times, required for the `:cron` type |
 | `keep_alive`            | `false`      |  yes  |  yes  | [sets contexts](#keep_alive-options) in which the service will keep the process running |
 | `launch_only_once`      | `false`      |  yes  |  yes  | whether the command should only run once |
+| `run_at_load`           | `true`       |  yes  | no-op | whether the command should run when the service is loaded |
 | `require_root`          | `false`      |  yes  |  yes  | whether the service requires root access. If true, Homebrew hints at using `sudo` on various occasions, but does not enforce it |
 | `environment_variables` | -            |  yes  |  yes  | hash of variables to set |
 | `working_dir`           | -            |  yes  |  yes  | directory to operate from |
@@ -1468,7 +1335,7 @@ Homebrew has multiple levels of environment variable filtering which affects whi
 
 Firstly, the overall [environment in which Homebrew runs is filtered](https://github.com/Homebrew/brew/issues/932) to avoid environment contamination breaking from-source builds. In particular, this process filters all but a select list of variables, plus allowing any prefixed with `HOMEBREW_`. The specific implementation is found in [`bin/brew`](https://github.com/Homebrew/brew/blob/HEAD/bin/brew).
 
-The second level of filtering [removes sensitive environment variables](https://github.com/Homebrew/brew/pull/2524) (such as credentials like keys, passwords or tokens) to prevent malicious subprocesses from obtaining them. This has the effect of preventing any such variables from reaching a formula's Ruby code since they are filtered before it is called. The specific implementation is found in the [`ENV.clear_sensitive_environment!` method](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/extend/ENV.rb).
+The second level of filtering [removes sensitive environment variables](https://github.com/Homebrew/brew/pull/2524) (such as credentials like keys, passwords or tokens) to prevent malicious subprocesses from obtaining them. This has the effect of preventing any such variables from reaching a formula's Ruby code since they are filtered before it is called. The specific implementation is found in the [`ENV.clear_sensitive_environment!` method](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/extend/ENV/sensitive.rb).
 
 In summary, any environment variables intended for use by a formula need to conform to these filtering rules in order to be available.
 
@@ -1482,7 +1349,7 @@ There are also `ENV` helper methods available for many common environment variab
 
 * `ENV.cxx11` - compile with C++11 features enabled
 * `ENV.deparallelize` - compile with only one job at a time; pass a block to have it only influence specific install steps
-* `ENV.O0`, `ENV.O1`, `ENV.O3` - set a specific compiler optimization level (*default:* macOS: `-Os`, Linux: `-O2`)
+* `ENV.O0`, `ENV.O1`, `ENV.O3` - set a specific compiler optimisation level (*default:* Clang: `-Os`, GCC: `-O2`)
 * `ENV.runtime_cpu_detection` - account for formulae that detect CPU features at runtime
 * `ENV.append_to_cflags` - add a value to `CFLAGS` `CXXFLAGS` `OBJCFLAGS` `OBJCXXFLAGS` all at once
 * `ENV.prepend_create_path` - create and prepend a path to an existing list of paths

--- a/docs/How-to-Build-Software-Outside-Homebrew-with-Homebrew-keg-only-Dependencies.md
+++ b/docs/How-to-Build-Software-Outside-Homebrew-with-Homebrew-keg-only-Dependencies.md
@@ -1,79 +1,73 @@
 ---
-last_review_date: "1970-01-01"
+last_review_date: "2026-07-18"
 ---
 
-# How to Build Software Outside Homebrew with Homebrew `keg_only` Dependencies
+# Building Software with Homebrew Keg-Only Dependencies
 
-## What does "keg-only" mean?
+A keg-only formula is installed in its own prefix but is not linked into Homebrew's common `bin`, `lib` and `include` directories.
+This prevents a Homebrew package from shadowing software provided by macOS or conflicting with another formula.
+See the [FAQ explanation of keg-only formulae](FAQ.md#what-does-keg-only-mean).
 
-The [FAQ](FAQ.md#what-does-keg-only-mean) briefly explains this.
+Do not replace macOS tools or libraries with manual symlinks.
+Avoid `brew link --force` because it makes unrelated builds and system commands resolve a different dependency globally.
+Pass the required location only to the build that needs it.
 
-As an example:
+## Discover the prefix
 
-*OpenSSL isn’t symlinked into my `PATH` and non-Homebrew builds can’t find it!*
-
-This is because Homebrew isolates it within its individual prefix, rather than symlinking to the publicly available location.
-
-## Advice on potential workarounds
-
-A number of people in this situation are either forcefully linking keg-only tools with `brew link --force` or moving default system utilities out of the `PATH` and replacing them with manually created symlinks to the Homebrew-provided tool.
-
-*Please* do not remove macOS native tools and forcefully replace them with symlinks back to the Homebrew-provided tool. Doing so can and likely will cause significant breakage when attempting to build software.
-
-`brew link --force` creates a warning in `brew doctor` to let both you and maintainers know that a link exists that could be causing issues. If you’ve linked something and there’s no problems at all? Feel free to ignore the `brew doctor` error.
-
-## How do I use those tools outside of Homebrew?
-
-Useful, reliable alternatives exist should you wish to use keg-only tools outside of Homebrew.
-
-### Build flags
-
-You can set flags to give configure scripts or Makefiles a nudge in the right direction. An example of flag setting:
+Use `brew --prefix <formula>` rather than embedding `/opt/homebrew`, `/usr/local` or a Cellar version:
 
 ```sh
-./configure --prefix=/Users/Dave/Downloads CFLAGS="-I$(brew --prefix openssl)/include" LDFLAGS="-L$(brew --prefix openssl)/lib"
+brew --prefix openssl@3
 ```
 
-An example using `pip`:
+The returned `opt` path remains stable when the formula is upgraded.
+
+## Compiler and linker flags
+
+For a build system that accepts compiler and linker flags:
 
 ```sh
-CFLAGS="-I$(brew --prefix icu4c)/include" LDFLAGS="-L$(brew --prefix icu4c)/lib" pip install pyicu
+CPPFLAGS="-I$(brew --prefix openssl@3)/include" \
+  LDFLAGS="-L$(brew --prefix openssl@3)/lib" \
+  ./configure
 ```
 
-### `PATH` modification
+Use `CPPFLAGS` for C or C++ preprocessor include paths unless upstream explicitly documents `CFLAGS` or `CXXFLAGS`.
+These flags affect only that command.
 
-You can temporarily prepend your `PATH` with the tool’s `bin` directory, such as:
+## Executable lookup
+
+Temporarily prepend a keg-only formula's executable directory when a build requires its tools:
 
 ```sh
-export PATH="$(brew --prefix openssl)/bin:${PATH}"
+PATH="$(brew --prefix FORMULA)/bin:$PATH" make
 ```
 
-This will prepend the directory to your `PATH`, ensuring any build script that searches the `PATH` will find it first.
+Do not add a keg-only dependency to a global shell `PATH` unless you want it to override the platform command in every future shell.
 
-Changing your `PATH` using this command ensures the change only exists for the duration of the shell session. Once the current session ends, the `PATH` reverts to its prior state.
+## `pkg-config`
 
-### `pkg-config` detection
-
-If the tool you are attempting to build is [pkg-config](https://en.wikipedia.org/wiki/Pkg-config) aware, you can amend your `PKG_CONFIG_PATH` to find a keg-only utility’s `.pc` files, if it has any. Not all formulae ship with these files.
-
-An example of this is:
+When the dependency installs `.pc` metadata, point `pkg-config` to it for one command:
 
 ```sh
-export PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig"
+PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig" pkg-config --cflags --libs openssl
 ```
 
-If you’re curious about the `PKG_CONFIG_PATH` variable, `man pkg-config` goes into more detail.
+Some formulae use `lib/pkgconfig`, some use `share/pkgconfig` and some provide no `pkg-config` metadata.
+Inspect the formula prefix rather than assuming a file exists.
 
-You can get `pkg-config` to print the default search path with:
+## CMake
+
+Add the formula prefix to `CMAKE_PREFIX_PATH` when a CMake project uses package configuration or Common Package Specification files:
 
 ```sh
-pkg-config --variable pc_path pkg-config
+CMAKE_PREFIX_PATH="$(brew --prefix openssl@3)" cmake -S . -B build
 ```
 
-### Common Package Specification detection
+If more than one prefix is required, separate them with the platform's normal path separator and preserve any intentional existing value.
 
-CMake 4.3 and newer can read [Common Package Specification](https://cps-org.github.io/cps/) `.cps` files from package prefixes. If the tool you are attempting to build uses CMake and a keg-only dependency ships `.cps` files, prepend that dependency's prefix to `CMAKE_PREFIX_PATH`:
+## Language packages
 
-```sh
-export CMAKE_PREFIX_PATH="$(brew --prefix openssl):${CMAKE_PREFIX_PATH}"
-```
+Build Python and other language extensions inside an isolated project environment.
+Pass the same include, library or package-discovery settings to that environment's build command.
+Do not change ownership of Homebrew or macOS directories to make a language package install succeed.

--- a/docs/Rename-A-Formula.md
+++ b/docs/Rename-A-Formula.md
@@ -1,18 +1,22 @@
 ---
-last_review_date: "1970-01-01"
+last_review_date: "2026-07-18"
 ---
 
 # Renaming a Formula or Cask
 
-## Renaming a Formula
+A rename must preserve upgrades from the old package name and avoid leaving chained or conflicting rename records.
+Complete the file change and rename metadata in the same pull request.
 
-Sometimes software and formulae need to be renamed. To rename a formula you need to:
+## Formulae
 
-1. Rename the formula file and its class to a new formula name. The new name must meet all the usual rules of formula naming. Fix any test failures that may occur due to the stricter requirements for new formulae compared to existing formulae (e.g. `brew audit --strict` must pass for that formula).
+1. Choose a new name that meets the [formula naming rules](Formula-Cookbook.md#a-quick-word-on-naming).
+2. Rename the formula file and class together.
+3. Update aliases, dependencies, service names, caveats, tests and documentation that refer to the old name.
+4. Add an old-to-new mapping to the tap's `formula_renames.json` using canonical names without a tap prefix.
+5. Collapse an existing rename chain so every historical name maps directly to the current formula.
+6. Run the strict audit, formula test and changed-package checks.
 
-2. Create a pull request on the corresponding tap deleting the old formula file, adding the new formula file, and adding it to `formula_renames.json` with a commit message like `newack: renamed from ack`. Use the canonical name (e.g. `ack` instead of `user/repo/ack`).
-
-A `formula_renames.json` example for a formula rename:
+Example:
 
 ```json
 {
@@ -20,17 +24,25 @@ A `formula_renames.json` example for a formula rename:
 }
 ```
 
-## Renaming a Cask
+Use a commit summary such as `newack: renamed from ack`.
+Do not leave a formula under both names unless they are intentionally separate packages that can be maintained independently.
 
-To rename a cask, follow a similar process:
+## Casks
 
-1. Rename the cask file and update the cask stanza to use the new cask token. The new token must meet all the usual rules of cask naming.
-2. Create a pull request on the corresponding tap deleting the old cask file, adding the new cask file, and adding it to `cask_renames.json` with a commit message like `new-token: renamed from old-token`.
+1. Choose a token that meets the [cask token rules](Cask-Cookbook.md#token-reference).
+2. Rename the cask file and update the token in the `cask` block.
+3. Update references to the old token, including dependencies, conflicts and documentation.
+4. Add an old-to-new mapping to `cask_renames.json`.
+5. Collapse existing rename chains and ensure the old token does not conflict with a current cask.
+6. Test installation, migration and uninstall behaviour and run the cask audit.
 
-A `cask_renames.json` example:
+Example:
 
 ```json
 {
   "old-token": "new-token"
 }
 ```
+
+Use a commit summary such as `new-token: renamed from old-token`.
+Homebrew uses the rename mapping during updates and `brew migrate`, so the target must exist in the same tap.

--- a/docs/Reproducible-Builds.md
+++ b/docs/Reproducible-Builds.md
@@ -1,5 +1,5 @@
 ---
-last_review_date: "1970-01-01"
+last_review_date: "2026-07-18"
 ---
 
 # Reproducible Builds
@@ -10,7 +10,8 @@ The Homebrew build environment is designed with [reproducible builds](https://re
 
 Some build tools embed or record the time at which the build occurs. This can cause build artifacts to differ between repeated builds of the same sources. To avoid this issue, the Homebrew build environment sets the [`SOURCE_DATE_EPOCH` environment variable](https://reproducible-builds.org/docs/source-date-epoch/) to the modification time of the source code for tools that consume it.
 
-In cases where a build time must be manually set, `time` is a Ruby `DateTime` object containing the same timestamp as the `SOURCE_DATE_EPOCH` environment variable. Methods provided by Ruby on `DateTime` objects can then be used to format this time into the desired format.
+In cases where a build time must be manually set, `time` is a Ruby `Time` object containing the same timestamp as the `SOURCE_DATE_EPOCH` environment variable.
+Methods provided by Ruby on `Time` objects can then be used to format this time into the desired format.
 
 ```ruby
 def install
@@ -21,7 +22,7 @@ def install
 end
 ```
 
-See the [`kustomize`](https://github.com/Homebrew/homebrew-core/blob/442f9cc511ce6dfe75b96b2c83749d90dde914d2/Formula/k/kustomize.rb#L32) formula for an example of using `time.iso8601` or the [`git-town`](https://github.com/Homebrew/homebrew-core/blob/442f9cc511ce6dfe75b96b2c83749d90dde914d2/Formula/g/git-town.rb#L25) formula for an example of using `time.strftime` with custom format specifiers.
+Use `time.iso8601` or `time.strftime` when upstream's build interface requires a formatted timestamp.
 
 ## Reproducible gzip compression
 
@@ -43,7 +44,7 @@ def install
 end
 ```
 
-See the [`par` formula](https://github.com/Homebrew/homebrew-core/blob/442f9cc511ce6dfe75b96b2c83749d90dde914d2/Formula/p/par.rb#L30) for an example with a single file or the [`pari-elldata` formula](https://github.com/Homebrew/homebrew-core/blob/442f9cc511ce6dfe75b96b2c83749d90dde914d2/Formula/p/pari-elldata.rb#L28) for an example with multiple files.
+Pass one path or multiple paths to the same helper rather than invoking the host's `gzip` directly.
 
 ## Relocatability
 

--- a/docs/Xcode.md
+++ b/docs/Xcode.md
@@ -1,18 +1,38 @@
 ---
-last_review_date: "1970-01-01"
+last_review_date: "2026-07-18"
 ---
 
-# Xcode
+# Xcode and Command Line Tools Maintenance
 
-## Supported Xcode versions
+This page is a maintainer runbook for updating Homebrew when Apple releases Xcode or the Command Line Tools.
+Users looking for installation requirements should read [Installation](Installation.md#macos-requirements).
 
-Homebrew supports and recommends the latest Xcode and/or Command Line Tools available for your platform (see `OS::Mac::Xcode.latest_version` and `OS::Mac::CLT.latest_clang_version` in [`Library/Homebrew/os/mac/xcode.rb`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/os/mac/xcode.rb)).
+## Supported versions
 
-## Updating for new Xcode releases
+Homebrew supports the current Xcode and Command Line Tools versions appropriate for each supported macOS release.
+The authoritative version mappings and diagnostic messages are implemented in [`Library/Homebrew/os/mac/xcode.rb`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/os/mac/xcode.rb).
 
-When a new Xcode release is made, the following things need to be updated:
+Do not copy a current Xcode version into other documentation.
+Link to the implementation or supported-platform documentation so the value has one maintained source.
 
-* In [`Library/Homebrew/os/mac/xcode.rb`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/os/mac/xcode.rb)
-  * `OS::Mac::Xcode.latest_version`
-  * `OS::Mac::CLT.latest_clang_version`
-  * `OS::Mac::Xcode.detect_version_from_clang_version`
+## Updating for a release
+
+When Apple publishes a new Xcode or Command Line Tools release:
+
+1. Confirm the version, build number, bundled Apple Clang version and supported macOS versions from Apple's release information.
+2. Update `OS::Mac::Xcode.latest_version` when the latest Xcode mapping changes.
+3. Update `OS::Mac::CLT.latest_clang_version` when the Command Line Tools compiler mapping changes.
+4. Update `OS::Mac::Xcode.detect_version_from_clang_version` when Homebrew must infer a new Xcode version from Apple Clang.
+5. Review minimum-version checks and diagnostic text in the same file for assumptions affected by the release.
+6. Add or update automated coverage for every changed mapping or inference.
+7. Verify `brew config` and the relevant `brew doctor` output on an affected macOS runner when one is available.
+
+Run the repository checks from the Homebrew/brew checkout:
+
+```sh
+./bin/brew typecheck
+./bin/brew style --fix Library/Homebrew/os/mac/xcode.rb
+./bin/brew tests --changed
+```
+
+Use `./bin/brew lgtm --online` before committing the complete change.

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,11 +34,10 @@ Documentation is grouped below by audience: users, contributors, maintainers and
 
 - [Querying `brew`](Querying-Brew.md)
 - [C++ Standard Libraries](C%2B%2B-Standard-Libraries.md)
-- [Custom GCC and Cross Compilers](Custom-GCC-and-cross-compilers.md)
+- [Custom GCC and Cross-Compilers](Custom-GCC-and-cross-compilers.md)
 - [External Commands](External-Commands.md)
 - [Language Runtimes and Packages](Language-Runtimes-and-Packages.md)
-- [How to Build Software Outside Homebrew with Homebrew `keg_only` Dependencies](How-to-Build-Software-Outside-Homebrew-with-Homebrew-keg-only-Dependencies.md)
-- [Xcode](Xcode.md)
+- [Building Software with Homebrew Keg-Only Dependencies](How-to-Build-Software-Outside-Homebrew-with-Homebrew-keg-only-Dependencies.md)
 
 - [Creating a Homebrew Issue](Creating-a-Homebrew-Issue.md)
 - [Updating Software in Homebrew](Updating-Software-in-Homebrew.md)
@@ -87,6 +86,7 @@ Documentation is grouped below by audience: users, contributors, maintainers and
 - [Releases](Releases.md)
 
 - [Linux CI](Linux-CI.md)
+- [Xcode](Xcode.md)
 
 ## Governance
 


### PR DESCRIPTION
Updates the formula authoring and toolchain references. The Formula Cookbook stops hand-expanding the `std_*_args` helper argument lists, which had drifted from the implementation (`std_cargo_args` was missing `--jobs`, `std_cmake_args` was missing `-DCCACHE_FOUND=OFF`), and points at the Formula API documentation that stays current instead; it also gains the missing `run_at_load` service row, fixes the `head` example URL, retargets the `ENV.clear_sensitive_environment!` link to the file that holds the implementation and defers dependency policy to Acceptable Formulae. Bottles documents the `all:` platform-independent tag, Reproducible Builds calls `time` a `Time` rather than a `DateTime`, the C++/GCC/keg-only pages drop long-stale content and Xcode becomes the maintainer runbook it now is, moving to the maintainer section of the index. The write-step token list is deliberately left untouched for the in-flight install-steps series to own.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5) prepared the changes with the DSL and helper claims verified against `formula.rb`, `service.rb` and the livecheck strategies; I reviewed the diff and verified locally with Vale, Markdownlint and the docs Jekyll/HTMLProofer suite, which passed fully.

-----
