### PR TITLE
cask/quarantine: skip xattr on Linux binaries

### DIFF
--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -62,7 +62,8 @@ module Cask
     sig { params(file: T.any(String, Pathname)).returns(String) }
     def self.status(file)
       xattr = self.xattr
-      raise "unexpected nil xattr" if xattr.nil?
+      # No `xattr` executable (e.g. on Linux) means nothing can be quarantined.
+      return "" if xattr.nil?
 
       system_command(xattr,
                      args:         ["-p", QUARANTINE_ATTRIBUTE, file],


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Fable 5, manual review/testing and `brew lgtm --online`

-----

We made some fixes so audits now run against Linux, but Linux does not have an xattr executable, causing checks against binaries to error due to the missing xattr.

-----

`Cask::Quarantine.status` raises "unexpected nil xattr" when no `xattr` executable can be located. That doesn't occur on macOS, but on Linux `xattr` does not exist and causes failure.

#23122 enabled cask audits on Linux, the audit fails for Linux casks with a `binary` artifact (example below):

```
    Error: audit for sonarqube-cli: failed
     - exception while auditing sonarqube-cli: unexpected nil xattr

```

Casks whose only Linux artifact is an `app_image` are unaffected because `extract_artifacts` filters on Pkg/App/Binary/Installer and bails out before the quarantine call.