### PR TITLE
Add `appimage` to cask stanza order

### DIFF
--- a/Library/Homebrew/rubocops/cask/constants/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/constants/stanza.rb
@@ -40,6 +40,7 @@ module RuboCop
           [
             :suite,
             :app,
+            :appimage,
             :pkg,
             :installer,
             :binary,

--- a/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
@@ -42,6 +42,24 @@ RSpec.describe RuboCop::Cop::Cask::StanzaOrder, :config do
     CASK
   end
 
+  it "orders `appimage` after `app`" do
+    expect_offense <<~CASK
+      cask 'foo' do
+        appimage 'Foo.AppImage'
+        ^^^^^^^^^^^^^^^^^^^^^^^ `appimage` stanza out of order
+        app 'Foo.app'
+        ^^^^^^^^^^^^^ `app` stanza out of order
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask 'foo' do
+        app 'Foo.app'
+        appimage 'Foo.AppImage'
+      end
+    CASK
+  end
+
   it "orders legacy flight blocks after matching install step blocks" do
     expect_offense <<~CASK
       cask 'foo' do

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -70,6 +70,7 @@ Having a common order for stanzas makes casks easier to update and parse. Below 
 
     suite
     app
+    appimage
     pkg
     installer
     binary


### PR DESCRIPTION
The `appimage` cask artifact (Linux-only) is already documented in the Cask Cookbook's artifact table but was missing from the `STANZA_ORDER` constant the stanza-ordering cop uses, so the cop could not place it.

This adds `:appimage` immediately after `:app`, matching `Artifact::AppImage`'s position after `Artifact::App` in `ORDINARY_ARTIFACT_CLASSES` (`cask/dsl.rb`) and reflecting that it is the Linux counterpart to the macOS `app` artifact (`LINUX_ONLY_ARTIFACTS` in `cask/artifact.rb`). The Cask Cookbook's complete-order block, which intentionally mirrors `STANZA_ORDER`, is updated to match, and a new rubocop spec covers the ordering and autocorrection.

Follow-up to the review discussion on #23207.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code (Opus 4.8) drafted the implementation and tests; I reviewed the diff, verified the new spec fails without the change and passes with it, and ran `brew lgtm` plus the stanza-order spec.

-----
