### PR TITLE
Remove Caskroom symlinks broken by cask uninstall, and warn when they exist

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -757,17 +757,14 @@ on_request: true)
       # toplevel staged distribution
       @cask.caskroom_path.rmdir_if_possible unless upgrade?
 
-      # Remove symlinks for renamed casks if they are now broken.
-      @cask.old_tokens.each do |old_token|
-        old_caskroom_path = Caskroom.path/old_token
-        FileUtils.rm old_caskroom_path if old_caskroom_path.symlink? && !old_caskroom_path.exist?
-      end
+      remove_broken_caskroom_symlinks
     end
 
     sig { void }
     def purge_caskroom_path
       odebug "Purging all staged versions of Cask #{@cask}"
       gain_permissions_remove(@cask.caskroom_path)
+      remove_broken_caskroom_symlinks
     end
 
     sig { params(cask_only: T::Boolean).void }
@@ -1025,6 +1022,20 @@ on_request: true)
     end
 
     private
+
+    # Remove Caskroom symlinks (e.g. from cask renames) that removing this cask's
+    # directory has broken, whatever the symlink is named.
+    sig { void }
+    def remove_broken_caskroom_symlinks
+      return unless Caskroom.path.directory?
+
+      Caskroom.path.children.each do |link|
+        next if !link.symlink? || link.exist?
+        next if link.readlink.basename != @cask.caskroom_path.basename
+
+        FileUtils.rm link
+      end
+    end
 
     sig { params(installed_caskfile: Pathname).returns(T::Boolean) }
     def installed_uninstall_artifacts_missing?(installed_caskfile)

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -229,9 +229,12 @@ module Homebrew
             system_command! "ls", args: [*ls_args, HOMEBREW_CELLAR], print_stdout: true
             puts if $stdout.tty? && !args.formula?
           end
-          if !args.formula? && Cask::Caskroom.any_casks_installed?
-            ohai "Casks" if $stdout.tty? && !args.cask?
-            system_command! "ls", args: [*ls_args, Cask::Caskroom.path], print_stdout: true
+          unless args.formula?
+            if Cask::Caskroom.any_casks_installed?
+              ohai "Casks" if $stdout.tty? && !args.cask?
+              system_command! "ls", args: [*ls_args, Cask::Caskroom.path], print_stdout: true
+            end
+            warn_about_broken_caskroom_symlinks
           end
         else
           kegs, casks = args.named.to_kegs_to_casks
@@ -248,6 +251,17 @@ module Homebrew
       end
 
       private
+
+      # A broken symlink in the Caskroom (e.g. a dangling cask rename alias) lists
+      # like an installed cask but cannot load or uninstall, so flag it.
+      sig { void }
+      def warn_about_broken_caskroom_symlinks
+        broken_symlinks = Cask::Caskroom.path.glob("*").select { |child| child.symlink? && !child.exist? }
+        return if broken_symlinks.empty?
+
+        opoo "Broken Caskroom symlinks (`brew cleanup` removes them): " \
+             "#{broken_symlinks.map(&:basename).sort.join(", ")}"
+      end
 
       sig { params(name: String).returns(T.nilable(String)) }
       def pinned_formula_entry(name)

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -462,6 +462,21 @@ RSpec.describe Cask::Installer, :cask do
       expect(Cask::Caskroom.path.join("local-caffeine")).not_to be_a_directory
     end
 
+    it "removes Caskroom symlinks the uninstall broke, whatever name they carry" do
+      caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
+      alias_link = Cask::Caskroom.path.join("local-caffeine-renamed")
+      unrelated_link = Cask::Caskroom.path.join("alias-of-another-cask")
+      installer = described_class.new(caffeine)
+      installer.install
+      FileUtils.ln_s "local-caffeine", alias_link
+      FileUtils.ln_s "another-cask", unrelated_link
+
+      installer.uninstall
+
+      expect([alias_link.symlink?, unrelated_link.symlink?, Cask::Caskroom.path.join("local-caffeine").exist?])
+        .to eq([false, true, false])
+    end
+
     it "uninstalls all versions if force is set" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
       mutated_version = "#{caffeine.version}.1"

--- a/Library/Homebrew/test/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cmd/list_spec.rb
@@ -229,6 +229,14 @@ RSpec.describe Homebrew::Cmd::List do
     cask.unpin
   end
 
+  it "warns about broken Caskroom symlinks" do
+    Cask::Caskroom.path.mkpath
+    FileUtils.ln_s "missing-cask", Cask::Caskroom.path/"dangling-alias"
+
+    expect { described_class.new(["--cask"]).run }
+      .to output(/Broken Caskroom symlinks \(`brew cleanup` removes them\): dangling-alias/).to_stderr
+  end
+
   it "fails only for explicitly named missing pinned packages", :cask do
     install_formula_version "testball", "0.1"
     (HOMEBREW_PREFIX/"var/homebrew/pinned").mkpath


### PR DESCRIPTION
When a cask is renamed, both names keep working because the Caskroom holds one real directory and, beside it, a symlink under the other name pointing at the first.

Uninstalling the cask deletes the real directory and then, as part of the same uninstall, runs `purge_versioned_files` to remove symlinks broken by that deletion. However, it looks for them by name, checking only the cask's former names as computed from the tap's current rename tables (`old_tokens`), so a symlink under any other name survives. That happened to me this morning: a January-era rename migration had linked the names the other way round from how `Cask::Migrator` does it today (`tigervnc-viewer -> tigervnc`, new name pointing at old directory), and uninstalling left it dangling, on current brew 6.0.12:

```
$ brew uninstall tigervnc        # removed the real directory
$ brew uninstall tigervnc-viewer
Error: Cask 'tigervnc' is not installed.
```

Until the leftover symlink is removed it behaves like a phantom cask: `brew list --cask` still shows the name (the bare listing is `ls`(1) of the Caskroom directory), while loading or uninstalling that name follows the symlink to a cask that no longer exists and errors. `brew cleanup` has swept broken Caskroom symlinks since 2024 (3ddc196f11), so the state does eventually heal — but nothing prevents it, and nothing tells the user what is wrong or that `brew cleanup` is the cure in the meantime.

Two commits, independently droppable:

**cask/installer: remove Caskroom symlinks broken by uninstall.** The `old_tokens` check only solves part of the problem, so stop consulting it entirely: after removing a cask's directory, scan the Caskroom's entries and delete any broken symlink that pointed at the directory just removed, whatever the symlink is called. Broken symlinks pointing at other casks' directories are left alone. `brew uninstall --force` removes the cask directory through a separate routine (`purge_caskroom_path`) that previously had no symlink cleanup at all, so it gets the same scan. The test installs a cask, adds an alias symlink under a name the old check would never match plus an unrelated broken symlink, uninstalls, and asserts only the cask's own alias is removed.

**list: warn about broken Caskroom symlinks.** For symlinks that still break by other means, the bare cask listing now warns on stderr, naming them and pointing at `brew cleanup` — stdout is untouched, so scripts parsing `brew list` output see no change. This also covers the oddest corner: when broken symlinks are the only Caskroom entries, the listing currently prints nothing at all (its `any_casks_installed?` gate skips symlinks while the `ls` it gates counts them) even though `brew uninstall` of the listed name errors.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Written with Claude in Claude Code under my direction and review, from a failure hit live on my machine. Both behaviours red/green verified (each new example fails with its code change removed). `brew typecheck`, `brew style` and changed tests clean locally; searched existing issues/PRs for prior reports first and found none.
