### PR TITLE
rubocops/urls: Ignore GitHub username and repo in binary URL check

### DIFF
--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -38,14 +38,14 @@ module RuboCop
 
           # Check for binary URLs
           audit_urls(urls, /(darwin|macos|osx)/i) do |match, url|
-            path = URI.parse(url).path || ""
-            filename = File.basename(path)
-            extname = File.extname(filename)
-            next if filename.present? && !filename.include?(match.to_s)
             next if T.must(@formula_name).include?(match.to_s.downcase)
-            next if %w[patch diff].include?(extname)
             next if tap_style_exception? :not_a_binary_url_prefix_allowlist
             next if tap_style_exception? :binary_bootstrap_formula_urls_allowlist
+
+            path = URI.parse(url).path || ""
+            filename = File.basename(path)
+            next if filename.present? && !filename.include?(match.to_s)
+            next if %w[.patch .diff].include?(File.extname(filename))
 
             problem "#{url} looks like a binary package, not a source archive; " \
                     "homebrew/core is source-only."

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -37,9 +37,11 @@ module RuboCop
           return if formula_tap != "homebrew-core"
 
           # Check for binary URLs
-          audit_urls(urls, /(darwin|macos|osx)/i) do |match, url|
+          filenames = urls.map { |url| File.basename(URI.parse(url).path) }
+          audit_urls(filenames, /(darwin|macos|osx)/i) do |match, filename|
+            extname = File.extname(filename)
             next if T.must(@formula_name).include?(match.to_s.downcase)
-            next if url.match?(/.(patch|diff)(\?full_index=1)?$/)
+            next if %w(patch diff).include?(extname)
             next if tap_style_exception? :not_a_binary_url_prefix_allowlist
             next if tap_style_exception? :binary_bootstrap_formula_urls_allowlist
 

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -37,9 +37,11 @@ module RuboCop
           return if formula_tap != "homebrew-core"
 
           # Check for binary URLs
-          filenames = urls.map { |url| File.basename(URI.parse(url).path) }
-          audit_urls(filenames, /(darwin|macos|osx)/i) do |match, filename|
+          audit_urls(urls, /(darwin|macos|osx)/i) do |match, url|
+            path = URI.parse(url).path || ""
+            filename = File.basename(path)
             extname = File.extname(filename)
+            next if !filename.blank? && !filename.include?(match.to_s)
             next if T.must(@formula_name).include?(match.to_s.downcase)
             next if %w[patch diff].include?(extname)
             next if tap_style_exception? :not_a_binary_url_prefix_allowlist

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -36,16 +36,14 @@ module RuboCop
 
           return if formula_tap != "homebrew-core"
 
+          github_pattern = %r{^https://github\.com/[\w-]+/[\w.-]+/(.*)$}
           # Check for binary URLs
           audit_urls(urls, /(darwin|macos|osx)/i) do |match, url|
             next if T.must(@formula_name).include?(match.to_s.downcase)
+            next if url.match?(/.(patch|diff)(\?full_index=1)?$/)
+            next if url.match(github_pattern)&.[](1)&.then { !it.include?(match.to_s) }
             next if tap_style_exception? :not_a_binary_url_prefix_allowlist
             next if tap_style_exception? :binary_bootstrap_formula_urls_allowlist
-
-            path = URI.parse(url).path || ""
-            filename = File.basename(path)
-            next if filename.present? && !filename.include?(match.to_s)
-            next if %w[.patch .diff].include?(File.extname(filename))
 
             problem "#{url} looks like a binary package, not a source archive; " \
                     "homebrew/core is source-only."

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -41,7 +41,7 @@ module RuboCop
             path = URI.parse(url).path || ""
             filename = File.basename(path)
             extname = File.extname(filename)
-            next if !filename.blank? && !filename.include?(match.to_s)
+            next if filename.present? && !filename.include?(match.to_s)
             next if T.must(@formula_name).include?(match.to_s.downcase)
             next if %w[patch diff].include?(extname)
             next if tap_style_exception? :not_a_binary_url_prefix_allowlist

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -41,7 +41,7 @@ module RuboCop
           audit_urls(filenames, /(darwin|macos|osx)/i) do |match, filename|
             extname = File.extname(filename)
             next if T.must(@formula_name).include?(match.to_s.downcase)
-            next if %w(patch diff).include?(extname)
+            next if %w[patch diff].include?(extname)
             next if tap_style_exception? :not_a_binary_url_prefix_allowlist
             next if tap_style_exception? :binary_bootstrap_formula_urls_allowlist
 

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -36,12 +36,19 @@ module RuboCop
 
           return if formula_tap != "homebrew-core"
 
-          github_pattern = %r{^https://github\.com/[\w-]+/[\w.-]+/(.*)$}
           # Check for binary URLs
-          audit_urls(urls, /(darwin|macos|osx)/i) do |match, url|
+          binary_package_pattern = /(darwin|macos|osx)/i
+          github_pattern = %r{^https://github\.com/[\w-]+/[\w.-]+/(.*)$}i
+          audit_urls(urls, binary_package_pattern) do |match, url|
             next if T.must(@formula_name).include?(match.to_s.downcase)
             next if url.match?(/.(patch|diff)(\?full_index=1)?$/)
-            next if url.match(github_pattern)&.[](1)&.then { !it.include?(match.to_s) }
+            next if url.match(github_pattern)&.then do |match_data|
+              # For GitHub URLs, the username and repository name have no
+              # bearing on whether a file is a binary package. We'll extract the
+              # remainder of the URL and match against the binary pattern.
+              # See: https://github.com/Homebrew/brew/pull/23236
+              !match_data[1].match?(binary_package_pattern)
+            end
             next if tap_style_exception? :not_a_binary_url_prefix_allowlist
             next if tap_style_exception? :binary_bootstrap_formula_urls_allowlist
 

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -160,6 +160,12 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
       "col"         => 2,
       "formula_tap" => "homebrew-core",
     }, {
+      "url"         => "https://github.com/username/repo/archive/refs/tags/example-darwin.amd64.tar.gz",
+      "msg"         => "https://github.com/username/repo/archive/refs/tags/example-darwin.amd64.tar.gz looks like a binary package, " \
+                       "not a source archive; homebrew/core is source-only.",
+      "col"         => 2,
+      "formula_tap" => "homebrew-core",
+    }, {
       "url" => "cvs://brew.sh/foo/bar",
       "msg" => "Use of the \"cvs://\" scheme is deprecated, pass `using: :cvs` instead",
       "col" => 2,
@@ -297,6 +303,17 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
               url
             end
           end
+        end
+      RUBY
+
+      expect(inspect_source(source)).to eq([])
+    end
+
+    it "does not report an offense based on the username or repo name of a GitHub URL" do
+      source = <<~RUBY
+        class Foo < Formula
+          desc "foo"
+          url "https://github.com/scriptingosx/cool-darwin-app/archive/refs/tags/v0.1.1.tar.gz"
         end
       RUBY
 

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -160,8 +160,8 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
       "col"         => 2,
       "formula_tap" => "homebrew-core",
     }, {
-      "url"         => "https://github.com/username/repo/archive/refs/tags/example-darwin.amd64.tar.gz",
-      "msg"         => "https://github.com/username/repo/archive/refs/tags/example-darwin.amd64.tar.gz looks like a binary package, " \
+      "url"         => "https://github.com/foo/bar/archive/refs/tags/darwin.tar.gz",
+      "msg"         => "https://github.com/foo/bar/archive/refs/tags/darwin.tar.gz looks like a binary package, " \
                        "not a source archive; homebrew/core is source-only.",
       "col"         => 2,
       "formula_tap" => "homebrew-core",


### PR DESCRIPTION
This is a requested change from https://github.com/Homebrew/homebrew-core/pull/293667#issuecomment-5001837846 . We want to prevent binary files from being linked to but the current check is broad. It checks for suspicious strings anywhere in the URL when really, all we care about is the filename. Specifically from that PR, the current audit flags `https://github.com/scriptingosx/utiluti/archive/refs/tags/v1.5.tar.gz` as being a binary file because the username contains `osx`.

This PR fixes this issue by parsing the URL and only running the regex check against the filename part. Potentially, we could also possibly allow extensions like `.gz` and `.zip` as those are usually not used for binaries, but I don't think it's necessary.

#### Reproducing the bug
If you remove `utiluti` from `not_a_binary_url_prefix_allowlist.json` and run `brew audit --strict utiluti` you'll see the following error:
```
utiluti
  * line 4, col 3: https://github.com/scriptingosx/utiluti/archive/refs/tags/v1.5.tar.gz looks like a binary package, not a source archive; homebrew/core is source-only.
Error: 1 problem in 1 formula detected.
```

#### Testing
I haven't written a test yet. If we like the approach it looks like the correct location would be [Library/Homebrew/test/rubocops/urls/http_spec.rb](https://github.com/Homebrew/brew/blob/main/Library/Homebrew/test/rubocops/urls/http_spec.rb) ?

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
