### PR TITLE
Validate serialised install steps (6/25)

### DIFF
--- a/Library/Homebrew/rubocops/shared/install_steps_helper.rb
+++ b/Library/Homebrew/rubocops/shared/install_steps_helper.rb
@@ -5,7 +5,7 @@ module RuboCop
   module Cop
     module InstallStepsHelper
       FILE_PREPARATION_STEP_METHODS =
-        [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :copy, :remove, :inreplace, :symlink,
+        [:mkdir, :mkdir_p, :touch, :move, :mv, :move_children, :move_contents, :copy, :remove, :inreplace, :symlink,
          :ln_s, :ln_sf].freeze
       LINK_STEP_METHODS = [:link_dir, :link_children].freeze
       CONFIG_WRITE_STEP_METHODS = [:write].freeze
@@ -15,14 +15,15 @@ module RuboCop
          :update_mime_database, :update_desktop_database].freeze
       KEYCHAIN_STEP_METHODS = [:delete_keychain_certificate].freeze
       PERMISSION_STEP_METHODS = [:set_permissions, :set_ownership].freeze
+      STEP_SCOPE_METHODS = [:if_path_exists, :unless_path_exists, :on_macos, :on_linux].freeze
       ALLOWED_STEP_METHODS = T.let(
         [*FILE_PREPARATION_STEP_METHODS, *LINK_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *SERVICE_DATA_STEP_METHODS,
-         *REBUILD_ACTION_STEP_METHODS].freeze,
+         *REBUILD_ACTION_STEP_METHODS, *STEP_SCOPE_METHODS].freeze,
         T::Array[Symbol],
       )
       CASK_ALLOWED_STEP_METHODS = T.let(
         [*FILE_PREPARATION_STEP_METHODS, *CONFIG_WRITE_STEP_METHODS, *KEYCHAIN_STEP_METHODS,
-         *PERMISSION_STEP_METHODS].freeze,
+         *PERMISSION_STEP_METHODS, *STEP_SCOPE_METHODS].freeze,
         T::Array[Symbol],
       )
 
@@ -96,15 +97,8 @@ module RuboCop
 
         direct_nodes = body.begin_type? ? body.child_nodes : [body]
         direct_nodes.each do |node|
-          return node unless node.send_type?
-
-          send_node = T.cast(node, RuboCop::AST::SendNode)
-          return node if send_node.receiver.present? || !allowed_methods.include?(send_node.method_name)
-
-          invalid_argument_node = send_node.each_descendant.find do |descendant|
-            !allowed_step_argument_node?(descendant)
-          end
-          return T.cast(invalid_argument_node, RuboCop::AST::Node) if invalid_argument_node
+          offense_node = install_step_offense_node(node, allowed_methods)
+          return offense_node if offense_node
         end
 
         nil
@@ -174,6 +168,45 @@ module RuboCop
 
       private
 
+      sig {
+        params(
+          node:            RuboCop::AST::Node,
+          allowed_methods: T::Array[Symbol],
+        ).returns(T.nilable(RuboCop::AST::Node))
+      }
+      def install_step_offense_node(node, allowed_methods)
+        if node.block_type?
+          block_node = T.cast(node, RuboCop::AST::BlockNode)
+          send_node = block_node.send_node
+          return node if send_node.receiver.present? || !STEP_SCOPE_METHODS.include?(send_node.method_name)
+          return node unless allowed_methods.include?(send_node.method_name)
+
+          invalid_argument = invalid_step_argument_node(send_node)
+          return invalid_argument if invalid_argument
+
+          direct_install_step_nodes(block_node.body).each do |child|
+            offense_node = install_step_offense_node(child, allowed_methods)
+            return offense_node if offense_node
+          end
+          return
+        end
+        return node unless node.send_type?
+
+        send_node = T.cast(node, RuboCop::AST::SendNode)
+        return node if send_node.receiver.present? || !allowed_methods.include?(send_node.method_name)
+        return node if STEP_SCOPE_METHODS.include?(send_node.method_name)
+
+        invalid_step_argument_node(send_node)
+      end
+
+      sig { params(send_node: RuboCop::AST::SendNode).returns(T.nilable(RuboCop::AST::Node)) }
+      def invalid_step_argument_node(send_node)
+        invalid_argument_node = send_node.each_descendant.find do |descendant|
+          !allowed_step_argument_node?(descendant)
+        end
+        T.cast(invalid_argument_node, T.nilable(RuboCop::AST::Node))
+      end
+
       sig { params(step_lines: T::Array[String], indent: Integer).returns(T::Array[String]) }
       def indented_install_step_lines(step_lines, indent)
         step_lines.flat_map do |step_line|
@@ -204,7 +237,7 @@ module RuboCop
 
         send_node = T.cast(node, RuboCop::AST::SendNode)
         return false if send_node.arguments.present?
-        return [:name, :version].include?(send_node.method_name) if send_node.receiver.nil?
+        return [:formula_name, :name, :token, :version].include?(send_node.method_name) if send_node.receiver.nil?
 
         return false unless (receiver = send_node.receiver)&.send_type?
 

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           system "true"
-          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
+          ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     CASK
@@ -44,14 +44,14 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
 
         preflight_steps do
           update_desktop_database
-          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`.
+          ^^^^^^^^^^^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     CASK
   end
 
   it "accepts install step DSL calls" do
-    expect_no_offenses <<~CASK
+    expect_no_offenses <<~'CASK'
       cask "foo" do
         version :latest
         sha256 :no_check
@@ -59,8 +59,10 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
         preflight_steps do
           mkdir_p "foo"
           touch "foo/state"
+          touch "#{token}/state"
           mv "source", "target"
           move_children "source", "target"
+          move_contents "source", "target"
           inreplace "foo.conf", /@PREFIX@/, "{{HOMEBREW_PREFIX}}"
           ln_sf "source", "target", source_base: :relative, uninstall: true
           write "foo.conf", "key = value\n"
@@ -68,6 +70,32 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
           set_ownership "Foo.app", user: "root", group: "wheel"
           delete_keychain_certificate "Charles"
           delete_keychain_certificate "NodeMITMProxyCA", matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"
+          on_macos do
+            if_path_exists "Foo.app" do
+              touch "Foo.app/scoped-state"
+            end
+          end
+          on_linux do
+            unless_path_exists "foo.conf" do
+              write "foo.conf", "key = value\n"
+            end
+          end
+        end
+      end
+    CASK
+  end
+
+  it "reports an offense when a scope contains Ruby code" do
+    expect_offense <<~CASK
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        preflight_steps do
+          on_macos do
+            system "true"
+            ^^^^^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          end
         end
       end
     CASK

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           system "true"
-          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
+          ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY
@@ -56,8 +56,10 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
         post_install_steps do
           mkdir_p "foo"
           touch "foo/state"
+          touch "foo/#{formula_name}"
           mv "source", "target"
           move_children "source", "target"
+          move_contents "source", "target"
           inreplace "foo.conf", /@PREFIX@/, "{{HOMEBREW_PREFIX}}"
           ln_sf "source", "target", source_base: :relative, uninstall: true
           write "foo.conf", "key = value\n", base: :etc
@@ -73,6 +75,31 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           gtk_update_icon_cache
           update_mime_database
           update_desktop_database
+          on_macos do
+            if_path_exists "foo" do
+              touch "foo/scoped-state"
+            end
+          end
+          on_linux do
+            unless_path_exists "foo.conf", base: :etc do
+              write "foo.conf", "key = value\n", base: :etc
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
+  it "reports an offense when a scope contains Ruby code" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        post_install_steps do
+          on_macos do
+            system "true"
+            ^^^^^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+          end
         end
       end
     RUBY
@@ -85,7 +112,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
 
         post_install_steps do
           write "foo.conf", "prefix = #{prefix}"
-                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`.
+                                      ^^^^^^^^^ FormulaAudit/InstallSteps: Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `link_dir`, `link_children`, `write`, `init_data_dir`, `compile_gsettings_schemas`, `gio_querymodules`, `gdk_pixbuf_query_loaders`, `gtk_update_icon_cache`, `update_mime_database`, `update_desktop_database`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
         end
       end
     RUBY


### PR DESCRIPTION
The runtime install-step DSL supports scoped guards, template identifiers and existing step aliases, but the RuboCop validation rejects these calls.

- validate nested path and platform guard blocks recursively
- allow formula and cask template identifiers
- accept existing serialised step aliases
- continue rejecting arbitrary Ruby within nested scopes

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.
