### PR TITLE
`brew search --desc`: show casks without descriptions

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -77,7 +77,7 @@ module Homebrew
                   "`HOMEBREW_NO_REQUIRE_TAP_TRUST=1` set!"
           end
 
-          Search.search_descriptions(string_or_regex, args)
+          Search.search_descriptions(string_or_regex, args, show_missing: true)
         elsif args.pull_request?
           search_pull_requests(query)
         else

--- a/Library/Homebrew/descriptions.rb
+++ b/Library/Homebrew/descriptions.rb
@@ -63,8 +63,8 @@ class Descriptions
 
   # Take search results -- a hash mapping formula names to descriptions -- and
   # print them.
-  sig { void }
-  def print
+  sig { params(show_missing: T::Boolean).void }
+  def print(show_missing: false)
     @descriptions.keys.sort.each do |full_name|
       description = @descriptions[full_name]
       next if description.nil?
@@ -78,9 +78,10 @@ class Descriptions
       display_name = decorate_name(full_name, display_name, description)
       if description.is_a?(Array)
         names = description[0]
-        next if description[1].nil?
+        description = description.fetch(1, nil)
+        next if description.nil? && !show_missing
 
-        description = description.fetch(1)
+        description ||= Formatter.warning("[no description]")
         puts names.present? ? "#{display_name}: (#{names}) #{description}" : "#{display_name}: #{description}"
       else
         puts "#{display_name}: #{description}"

--- a/Library/Homebrew/search.rb
+++ b/Library/Homebrew/search.rb
@@ -56,9 +56,10 @@ module Homebrew
         # Since only one command is typically loaded at a time, this alias is not expected to be available at runtime.
         args:            T.any(Homebrew::Cmd::Desc::Args, Homebrew::Cmd::SearchCmd::Args),
         search_type:     T.nilable(Descriptions::SearchField),
+        show_missing:    T::Boolean,
       ).void
     }
-    def self.search_descriptions(string_or_regex, args, search_type: nil)
+    def self.search_descriptions(string_or_regex, args, search_type: nil, show_missing: false)
       require "descriptions"
 
       search_type ||= Descriptions::SearchField::Description
@@ -95,7 +96,7 @@ module Homebrew
       if eval_all
         CacheStoreDatabase.use(:cask_descriptions) do |db|
           cache_store = CaskDescriptionCacheStore.new(T.cast(db, CacheStoreDatabase[String, T.anything]))
-          Descriptions.search(string_or_regex, search_type, cache_store, eval_all:).print
+          Descriptions.search(string_or_regex, search_type, cache_store, eval_all:).print(show_missing:)
         end
       else
         unofficial = Tap.all.sum { |tap| tap.official? ? 0 : tap.cask_files.size }
@@ -109,7 +110,7 @@ module Homebrew
         status_data = casks.transform_values do |cask|
           { deprecated: cask["deprecate_present"].present?, disabled: cask["disable_present"].present? }
         end
-        Descriptions.search(string_or_regex, search_type, descriptions, status_data:, eval_all:).print
+        Descriptions.search(string_or_regex, search_type, descriptions, status_data:, eval_all:).print(show_missing:)
       end
     end
 

--- a/Library/Homebrew/test/cmd/search_spec.rb
+++ b/Library/Homebrew/test/cmd/search_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe Homebrew::Cmd::SearchCmd do
       .and be_a_success
   end
 
+  it "shows missing cask descriptions in description searches" do
+    expect(Homebrew::Search).to receive(:search_descriptions)
+      .with("testball", anything, show_missing: true)
+
+    described_class.new(["--desc", "testball"]).run
+  end
+
   describe "::print_missing_formula_help" do
     let(:search_cmd) { described_class.new([""]) }
 

--- a/Library/Homebrew/test/descriptions_spec.rb
+++ b/Library/Homebrew/test/descriptions_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe Descriptions do
     expect { descriptions.print }.not_to output.to_stdout
   end
 
+  it "prints casks without a description when requested" do
+    descriptions_hash["homebrew/cask/foo"] = ["Foo", nil]
+
+    expect { descriptions.print(show_missing: true) }.to output("foo: (Foo) [no description]\n").to_stdout
+  end
+
+  it "prints casks with an incomplete description" do
+    descriptions_hash["homebrew/cask/foo"] = ["Foo"]
+
+    expect { descriptions.print(show_missing: true) }.to output("foo: (Foo) [no description]\n").to_stdout
+  end
+
   it "prints trailing status for interactive formula descriptions" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
     descriptions_hash["homebrew/core/foo"] = "Core foo"

--- a/Library/Homebrew/test/search_spec.rb
+++ b/Library/Homebrew/test/search_spec.rb
@@ -208,6 +208,15 @@ RSpec.describe Homebrew::Search do
           .to output(/testball: \(Test Ball\) Some test/).to_stdout
           .and not_to_output(/testball: Some test/).to_stdout
       end
+
+      it "searches cask names without descriptions", :needs_macos do
+        api_casks["testball"]["desc"] = nil
+
+        expect do
+          described_class.search_descriptions(described_class.query_regexp("ball"), args, show_missing: true)
+        end
+          .to output(/testball: \(Test Ball\) \[no description\]/).to_stdout
+      end
     end
   end
 end


### PR DESCRIPTION
- Keep cask name matches visible with the existing placeholder
- Preserve direct `brew desc` output for missing descriptions
- Handle incomplete cached cask description pairs safely
- 
Fixes #23227

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex GPT 5.6 Sol xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
