### PR TITLE
List formulae from untrusted taps

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -105,8 +105,20 @@ module Homebrew
            !(args.installed_on_request? || installed_as_dependency ||
              args.poured_from_bottle? || args.built_from_source?)
           unless args.cask?
-            formula_names = args.no_named? ? Formula.installed : args.named.to_resolved_formulae
-            full_formula_names = formula_names.map(&:full_name).sort(&Cask::List::TAP_AND_NAME_COMPARISON)
+            full_formula_names = if args.no_named?
+              Formula.racks.map do |rack|
+                name = rack.basename.to_s
+                tap = begin
+                  Keg.from_rack(rack)&.tab&.tap
+                rescue JSON::ParserError, SystemCallError, Tap::InvalidNameError
+                  opoo "Could not identify the tap for #{name} from its installation receipt."
+                  nil
+                end
+                (tap.nil? || tap.core_tap?) ? name : "#{tap}/#{name}"
+              end
+            else
+              args.named.to_resolved_formulae.map(&:full_name)
+            end.sort(&Cask::List::TAP_AND_NAME_COMPARISON)
             full_formula_names = Formatter.columns(full_formula_names) unless args.public_send(:"1?")
             puts full_formula_names if full_formula_names.present?
           end

--- a/Library/Homebrew/test/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cmd/list_spec.rb
@@ -122,6 +122,40 @@ RSpec.describe Homebrew::Cmd::List do
       .and not_to_output.to_stderr
   end
 
+  it "prints full names for formulae installed from untrusted taps", :trust_store do
+    tap = Tap.fetch("thirdparty", "foo")
+    formula_path = tap.formula_dir/"untrusted.rb"
+    formula_path.dirname.mkpath
+    formula_path.write <<~RUBY
+      raise "untrusted tap formula evaluated"
+    RUBY
+    keg = HOMEBREW_CELLAR/"untrusted/1.0"
+    (keg/".brew").mkpath
+    (keg/".brew/untrusted.rb").write <<~RUBY
+      raise "installed untrusted formula evaluated"
+    RUBY
+    (keg/AbstractTab::FILENAME).write JSON.generate(source: { tap: tap.name })
+
+    with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+      expect { described_class.new(["--formula", "--full-name", "-1"]).run }
+        .to output("thirdparty/foo/untrusted\n").to_stdout
+        .and not_to_output.to_stderr
+    end
+  ensure
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
+  it "continues when an installation receipt is invalid" do
+    install_formula_version "working", "1.0"
+    keg = HOMEBREW_CELLAR/"broken/1.0"
+    keg.mkpath
+    (keg/AbstractTab::FILENAME).write "{"
+
+    expect { described_class.new(["--formula", "--full-name", "-1"]).run }
+      .to output("broken\nworking\n").to_stdout
+      .and output(/Could not identify the tap for broken from its installation receipt/).to_stderr
+  end
+
   describe "filtering by install-on-request status" do
     let(:on_request) do
       formula("on-request") do


### PR DESCRIPTION
- Read tap names from install receipts without evaluating untrusted code.
- Add regression coverage for tap and installed formula files.

Fixes #23238
Closes #23239

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 Sol xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
