### PR TITLE
Handle missing bottle mirror metadata

### DIFF
--- a/Library/Homebrew/api/formula_bottle.rb
+++ b/Library/Homebrew/api/formula_bottle.rb
@@ -22,10 +22,10 @@ module Homebrew
 
         bottle_specification = BottleSpecification.new
         bottle_specification.root_url(
-          if Homebrew::EnvConfig.bottle_domain == HOMEBREW_BOTTLE_DEFAULT_DOMAIN
-            HOMEBREW_BOTTLE_DEFAULT_DOMAIN
-          else
+          if Homebrew::EnvConfig.bottle_domain_custom?
             Homebrew::EnvConfig.bottle_domain
+          else
+            HOMEBREW_BOTTLE_DEFAULT_DOMAIN
           end,
         )
         bottle_specification.rebuild(formula_struct.bottle_rebuild)

--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -223,9 +223,7 @@ module Homebrew
         # This was originally unintentional, but has a virtuous side effect of further
         # limiting domain separation on the backfilled signatures (by committing them to
         # their original bottle URLs).
-        url_sha256 = if EnvConfig.bottle_domain == HOMEBREW_BOTTLE_DEFAULT_DOMAIN
-          Digest::SHA256.hexdigest(bottle.url)
-        else
+        url_sha256 = if EnvConfig.bottle_domain_custom?
           # If our bottle is coming from a mirror, we need to recompute the expected
           # non-mirror URL to make the hash match.
           checksum = bottle.resource.checksum
@@ -235,6 +233,8 @@ module Homebrew
           url = "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}/#{path}"
 
           Digest::SHA256.hexdigest(url)
+        else
+          Digest::SHA256.hexdigest(bottle.url)
         end
         subject = "#{url_sha256}--#{bottle.filename}"
 

--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -191,11 +191,8 @@ class Bottle
     return unless (resource = github_packages_manifest_resource)
 
     begin
+      # `$HOMEBREW_BOTTLE_DOMAIN` fallback is configured on the resource below.
       resource.fetch(timeout:, quiet:)
-    rescue DownloadError
-      raise unless fallback_on_error?
-
-      retry
     rescue Resource::BottleManifest::Error
       raise if @fetch_tab_retried
 
@@ -300,7 +297,11 @@ class Bottle
 
   sig { returns(T.nilable(Resource::BottleManifest)) }
   def github_packages_manifest_resource
-    return if @resource.download_strategy != CurlGitHubPackagesDownloadStrategy
+    # `$HOMEBREW_BOTTLE_DOMAIN` may be a legacy flat-file mirror, so its
+    # bottle resource does not necessarily use the GitHub Packages strategy.
+    custom_bottle_domain = Homebrew::EnvConfig.bottle_domain_custom? &&
+                           root_url == Homebrew::EnvConfig.bottle_domain
+    return if @resource.download_strategy != CurlGitHubPackagesDownloadStrategy && !custom_bottle_domain
 
     @github_packages_manifest_resource ||= T.let(
       begin
@@ -314,11 +315,18 @@ class Bottle
 
         image_name = GitHubPackages.image_formula_name(@name)
         image_tag = GitHubPackages.image_version_rebuild(version_rebuild)
+        manifest_path = "#{image_name}/manifests/#{image_tag}"
         resource.url(
-          "#{root_url}/#{image_name}/manifests/#{image_tag}",
+          "#{root_url}/#{manifest_path}",
           using:   CurlGitHubPackagesDownloadStrategy,
           headers: ["Accept: application/vnd.oci.image.index.v1+json"],
         )
+        # Give a legacy mirror the first chance to serve the manifest. Many
+        # contain only bottle archives, so retain GHCR as a fallback. By
+        # contrast, `$HOMEBREW_ARTIFACT_DOMAIN` must provide an OCI registry
+        # proxy for bottle blobs and manifests; the strategy rewrites the GHCR
+        # URL for it.
+        resource.mirror("#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}/#{manifest_path}") if custom_bottle_domain
         T.cast(resource.downloader, CurlGitHubPackagesDownloadStrategy).resolved_basename =
           "#{name}-#{version_rebuild}.bottle_manifest.json"
         resource
@@ -347,7 +355,7 @@ class Bottle
   def fallback_on_error?
     # Use the default bottle domain as a fallback mirror
     if @resource.url&.start_with?(Homebrew::EnvConfig.bottle_domain) &&
-       Homebrew::EnvConfig.bottle_domain != HOMEBREW_BOTTLE_DEFAULT_DOMAIN
+       Homebrew::EnvConfig.bottle_domain_custom?
       opoo "Bottle missing, falling back to the default domain..."
       root_url(HOMEBREW_BOTTLE_DEFAULT_DOMAIN)
       @github_packages_manifest_resource = T.let(nil, T.nilable(Resource::BottleManifest))

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -124,13 +124,13 @@ module Homebrew
         default_text: "`$BAT_THEME`.",
       },
       HOMEBREW_BOTTLE_DOMAIN:                    {
-        description:  "Use this URL as the download mirror for bottles. " \
-                      "If bottles at that URL are temporarily unavailable, " \
-                      "the default bottle domain will be used as a fallback mirror. " \
+        description:  "Use this URL as the download mirror for bottles and their manifests. " \
+                      "If a bottle or manifest is unavailable at the mirror, " \
+                      "the default bottle domain will be used as a fallback. " \
+                      "Prefer `$HOMEBREW_ARTIFACT_DOMAIN` for a mirror that transparently proxies all " \
+                      "Homebrew downloads. " \
                       "For example, `export HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080` will cause all bottles " \
-                      "to download from the prefix `http://localhost:8080/`. " \
-                      "If bottles are not available at `$HOMEBREW_BOTTLE_DOMAIN` " \
-                      "they will be downloaded from the default bottle domain.",
+                      "to download from the prefix `http://localhost:8080/`.",
         default_text: "`https://ghcr.io/v2/homebrew/core`.",
         default:      HOMEBREW_BOTTLE_DEFAULT_DOMAIN,
       },
@@ -294,7 +294,7 @@ module Homebrew
       HOMEBREW_DOCKER_REGISTRY_BASIC_AUTH_TOKEN: {
         description: "Use this base64 encoded username and password for authenticating with a Docker registry " \
                      "proxying GitHub Packages. If set to `none`, no authentication header will be sent. " \
-                     "This can be used, if remote `$HOMEBREW_BOTTLE_DOMAIN` does not support any authentication. " \
+                     "This can be used, if remote `$HOMEBREW_ARTIFACT_DOMAIN` does not support any authentication. " \
                      "If `$HOMEBREW_DOCKER_REGISTRY_TOKEN` is set, it will be used instead.",
       },
       HOMEBREW_DOCKER_REGISTRY_TOKEN:            {
@@ -899,6 +899,11 @@ module Homebrew
       return false if subcommands.present? && subcommand.present? && subcommands.exclude?(subcommand)
 
       true
+    end
+
+    sig { returns(T::Boolean) }
+    def bottle_domain_custom?
+      Homebrew::EnvConfig.bottle_domain != HOMEBREW_BOTTLE_DEFAULT_DOMAIN
     end
 
     sig { returns(String) }

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -196,6 +196,14 @@ class FormulaInstaller
   sig { returns(T::Boolean) }
   def verbose? = @verbose
 
+  sig { returns(T::Boolean) }
+  def self.show_missing_bottle_metadata_warning?
+    return false if @missing_bottle_metadata_warning_shown
+
+    @missing_bottle_metadata_warning_shown = T.let(true, T.nilable(TrueClass))
+    true
+  end
+
   sig { returns(T::Set[Formula]) }
   def self.attempted
     @attempted ||= T.let(Set.new, T.nilable(T::Set[Formula]))
@@ -1626,6 +1634,17 @@ on_request: installed_on_request?, options:)
 
     keg = Keg.new(formula.prefix)
     skip_linkage = formula.bottle_specification.skip_relocation?(tab:)
+    if Homebrew::EnvConfig.bottle_domain_custom? && tab.changed_files.nil?
+      if self.class.show_missing_bottle_metadata_warning?
+        opoo <<~EOS
+          No bottle relocation metadata was found for this `HOMEBREW_BOTTLE_DOMAIN`.
+          Homebrew will perform full relocation. Ask the mirror operator to provide
+          an OCI registry proxy of `ghcr.io` that includes manifests and their
+          `sh.brew.tab` annotations, then use `HOMEBREW_ARTIFACT_DOMAIN` instead.
+        EOS
+      end
+      skip_linkage = false
+    end
     keg.replace_placeholders_with_locations(tab.changed_files, skip_linkage:)
 
     cellar = formula.bottle_specification.tag_to_cellar(Utils::Bottles.tag)

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -304,10 +304,10 @@ module Formulary
 
       if formula_struct.bottle?
         bottle do
-          if Homebrew::EnvConfig.bottle_domain == HOMEBREW_BOTTLE_DEFAULT_DOMAIN
-            root_url HOMEBREW_BOTTLE_DEFAULT_DOMAIN
-          else
+          if Homebrew::EnvConfig.bottle_domain_custom?
             root_url Homebrew::EnvConfig.bottle_domain
+          else
+            root_url HOMEBREW_BOTTLE_DEFAULT_DOMAIN
           end
           rebuild formula_struct.bottle_rebuild
           formula_struct.bottle_checksums.each do |args|

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -315,7 +315,7 @@ class Resource
         extra_urls << artifact_url
       end
 
-      if Homebrew::EnvConfig.bottle_domain != HOMEBREW_BOTTLE_DEFAULT_DOMAIN
+      if Homebrew::EnvConfig.bottle_domain_custom?
         tag, filename = url.split("/").last(2)
         extra_urls << "#{Homebrew::EnvConfig.bottle_domain}/glibc-bootstrap/#{tag}/#{filename}"
       end

--- a/Library/Homebrew/test/bottle_spec.rb
+++ b/Library/Homebrew/test/bottle_spec.rb
@@ -37,6 +37,57 @@ RSpec.describe Bottle do
     end
   end
 
+  describe "#github_packages_manifest_resource" do
+    sig { returns(String) }
+    def bottle_domain = "https://mirror.example.com/homebrew-bottles"
+
+    sig { params(root_url: String).returns(Bottle) }
+    def test_bottle(root_url = bottle_domain)
+      bottle_spec = BottleSpecification.new
+      bottle_spec.root_url(root_url)
+      bottle_spec.sha256(
+        cellar:            :any_skip_relocation,
+        Utils::Bottles.tag.to_sym => "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97",
+      )
+      described_class.new(nil, bottle_spec, Utils::Bottles.tag,
+                          name: "foo", pkg_version: PkgVersion.new(Version.new("1.2.3"), 0))
+    end
+
+    before do
+      ENV["HOMEBREW_BOTTLE_DOMAIN"] = bottle_domain
+    end
+
+    it "falls back to GHCR for a custom bottle domain" do
+      bottle = test_bottle
+      manifest_resource = bottle.github_packages_manifest_resource
+      downloader = manifest_resource&.downloader
+      raise "Expected a GitHub Packages download strategy" unless downloader.is_a?(CurlGitHubPackagesDownloadStrategy)
+
+      expect([manifest_resource&.url, downloader.mirrors]).to eq([
+        "#{bottle_domain}/foo/manifests/1.2.3",
+        ["#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}/foo/manifests/1.2.3"],
+      ])
+    end
+
+    it "keeps the bottle mirror when neither manifest URL is available", :aggregate_failures do
+      bottle = test_bottle
+      manifest_resource = bottle.github_packages_manifest_resource
+      raise "Expected a bottle manifest resource" if manifest_resource.nil?
+
+      allow(manifest_resource).to receive(:fetch)
+        .and_raise(DownloadError.new(manifest_resource, RuntimeError.new("manifest missing")))
+
+      expect { bottle.fetch_tab }.to raise_error(DownloadError)
+      expect(bottle.url).to start_with(bottle_domain)
+    end
+
+    it "does not create a manifest resource for an unrelated flat bottle domain" do
+      bottle = test_bottle("https://example.com/bottles")
+
+      expect(bottle.github_packages_manifest_resource).to be_nil
+    end
+  end
+
   describe "#sbom_supplement" do
     it "reads the supplement from a valid bottle manifest" do
       bottle_spec = BottleSpecification.new

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -124,6 +124,20 @@ RSpec.describe Homebrew::EnvConfig do
     end
   end
 
+  describe ".bottle_domain_custom?" do
+    it "returns true for a custom bottle domain" do
+      ENV["HOMEBREW_BOTTLE_DOMAIN"] = "https://mirror.example.com"
+
+      expect(env_config.bottle_domain_custom?).to be(true)
+    end
+
+    it "returns false for the default bottle domain" do
+      ENV["HOMEBREW_BOTTLE_DOMAIN"] = HOMEBREW_BOTTLE_DEFAULT_DOMAIN
+
+      expect(env_config.bottle_domain_custom?).to be(false)
+    end
+  end
+
   describe ".cleanup_periodic_full_days" do
     it "returns value if set" do
       ENV["HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS"] = "360"

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -145,6 +145,60 @@ RSpec.describe FormulaInstaller do
     end
   end
 
+  describe "#pour" do
+    let(:f) do
+      formula("missing-bottle-tab") do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/missing-bottle-tab-1.0.tar.gz"
+
+        bottle do
+          sha256 cellar: :any_skip_relocation,
+                 Utils::Bottles.tag.to_sym => "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97"
+        end
+      end
+    end
+    let(:installer) { Class.new(described_class).new(f) }
+    let(:downloader) { instance_double(AbstractDownloadStrategy, basename: "missing-bottle-tab", stage: nil) }
+    let(:downloadable) { instance_double(Resource, downloader:) }
+    let(:tab) do
+      instance_double(Tab, changed_files: nil, source: { "versions" => {} }, write: nil).as_null_object
+    end
+    let(:keg) { instance_double(Keg) }
+
+    before do
+      allow(installer).to receive(:downloadable).and_return(downloadable)
+      allow(Utils::Bottles).to receive(:load_tab).with(f).and_return(tab)
+      allow(Tab).to receive(:clear_cache)
+      allow(Keg).to receive(:new).with(f.prefix).and_return(keg)
+      allow(keg).to receive(:replace_placeholders_with_locations)
+      allow(f.bottle_specification).to receive(:skip_relocation?).with(tab:).and_return(true)
+    end
+
+    it "preserves the skip-linkage decision for the default bottle domain" do
+      expect(keg).to receive(:replace_placeholders_with_locations).with(nil, skip_linkage: true)
+
+      installer.pour
+    end
+
+    it "relocates dynamic linkage without metadata from a bottle mirror" do
+      ENV["HOMEBREW_BOTTLE_DOMAIN"] = "https://mirror.example.com"
+
+      expect(keg).to receive(:replace_placeholders_with_locations).with(nil, skip_linkage: false)
+
+      installer.pour
+    end
+
+    it "explains how a bottle mirror can provide metadata once per invocation" do
+      ENV["HOMEBREW_BOTTLE_DOMAIN"] = "https://mirror.example.com"
+
+      expect { 2.times { installer.pour } }
+        .to output(satisfy do |stderr|
+          stderr.scan("OCI registry proxy").one? &&
+            stderr.include?("sh.brew.tab") && stderr.include?("HOMEBREW_ARTIFACT_DOMAIN")
+        end).to_stderr
+    end
+  end
+
   describe "#build_bottle_postinstall" do
     let(:f) do
       formula "bottle-config" do

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -4353,12 +4353,12 @@ command execution (e.g. `$(cat file)`).
 
 `HOMEBREW_BOTTLE_DOMAIN`
 
-: Use this URL as the download mirror for bottles. If bottles at that URL are
-  temporarily unavailable, the default bottle domain will be used as a fallback
-  mirror. For example, `export HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080`
-  will cause all bottles to download from the prefix `http://localhost:8080/`.
-  If bottles are not available at `$HOMEBREW_BOTTLE_DOMAIN` they will be
-  downloaded from the default bottle domain.
+: Use this URL as the download mirror for bottles and their manifests. If a
+  bottle or manifest is unavailable at the mirror, the default bottle domain
+  will be used as a fallback. Prefer `$HOMEBREW_ARTIFACT_DOMAIN` for a mirror
+  that transparently proxies all Homebrew downloads. For example, `export
+  HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080` will cause all bottles to
+  download from the prefix `http://localhost:8080/`.
   
   *Default:* `https://ghcr.io/v2/homebrew/core`.
 
@@ -4600,7 +4600,7 @@ command execution (e.g. `$(cat file)`).
 
 : Use this base64 encoded username and password for authenticating with a Docker
   registry proxying GitHub Packages. If set to `none`, no authentication header
-  will be sent. This can be used, if remote `$HOMEBREW_BOTTLE_DOMAIN` does not
+  will be sent. This can be used, if remote `$HOMEBREW_ARTIFACT_DOMAIN` does not
   support any authentication. If `$HOMEBREW_DOCKER_REGISTRY_TOKEN` is set, it
   will be used instead.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2781,7 +2781,7 @@ Use this as the \fBbat\fP theme for syntax highlighting\.
 .RE
 .TP
 \fBHOMEBREW_BOTTLE_DOMAIN\fP
-Use this URL as the download mirror for bottles\. If bottles at that URL are temporarily unavailable, the default bottle domain will be used as a fallback mirror\. For example, \fBexport HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080\fP will cause all bottles to download from the prefix \fBhttp://localhost:8080/\fP\&\. If bottles are not available at \fB$HOMEBREW_BOTTLE_DOMAIN\fP they will be downloaded from the default bottle domain\.
+Use this URL as the download mirror for bottles and their manifests\. If a bottle or manifest is unavailable at the mirror, the default bottle domain will be used as a fallback\. Prefer \fB$HOMEBREW_ARTIFACT_DOMAIN\fP for a mirror that transparently proxies all Homebrew downloads\. For example, \fBexport HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080\fP will cause all bottles to download from the prefix \fBhttp://localhost:8080/\fP\&\.
 .RS
 .P
 \fIDefault:\fP \fBhttps://ghcr\.io/v2/homebrew/core\fP\&\.
@@ -2976,7 +2976,7 @@ Use this X11 display when opening a page in a browser, for example with \fBbrew 
 If set, print install times for each formula at the end of the run\.
 .TP
 \fBHOMEBREW_DOCKER_REGISTRY_BASIC_AUTH_TOKEN\fP
-Use this base64 encoded username and password for authenticating with a Docker registry proxying GitHub Packages\. If set to \fBnone\fP, no authentication header will be sent\. This can be used, if remote \fB$HOMEBREW_BOTTLE_DOMAIN\fP does not support any authentication\. If \fB$HOMEBREW_DOCKER_REGISTRY_TOKEN\fP is set, it will be used instead\.
+Use this base64 encoded username and password for authenticating with a Docker registry proxying GitHub Packages\. If set to \fBnone\fP, no authentication header will be sent\. This can be used, if remote \fB$HOMEBREW_ARTIFACT_DOMAIN\fP does not support any authentication\. If \fB$HOMEBREW_DOCKER_REGISTRY_TOKEN\fP is set, it will be used instead\.
 .TP
 \fBHOMEBREW_DOCKER_REGISTRY_TOKEN\fP
 Use this bearer token for authenticating with a Docker registry proxying GitHub Packages\. Preferred over \fB$HOMEBREW_DOCKER_REGISTRY_BASIC_AUTH_TOKEN\fP\&\.


### PR DESCRIPTION
- Fetch manifests from custom bottle domains before falling back to GHCR.
- Preserve full relocation and its once-per-invocation guidance when usable metadata is still unavailable.
- Keep `HOMEBREW_BOTTLE_DOMAIN` supported while documenting `HOMEBREW_ARTIFACT_DOMAIN` as the preferred transparent proxy.

Fixes #23218
Closes #23237

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 Sol max with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
