### PR TITLE
list: warn about broken Caskroom symlinks from the Bash fast path

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -254,6 +254,8 @@ module Homebrew
 
       # A broken symlink in the Caskroom (e.g. a dangling cask rename alias) lists
       # like an installed cask but cannot load or uninstall, so flag it.
+      # Keep in sync with the broken-symlink warning in `homebrew-list` in
+      # Library/Homebrew/list.sh.
       sig { void }
       def warn_about_broken_caskroom_symlinks
         broken_symlinks = Cask::Caskroom.path.glob("*").select { |child| child.symlink? && !child.exist? }

--- a/Library/Homebrew/list.sh
+++ b/Library/Homebrew/list.sh
@@ -258,6 +258,23 @@ homebrew-list() {
       echo "${cask_output}"
     fi
 
+    # Keep in sync with Homebrew::Cmd::List#warn_about_broken_caskroom_symlinks
+    # in Library/Homebrew/cmd/list.rb.
+    local broken_cask_symlinks=()
+    local cask_path
+    for cask_path in "${HOMEBREW_CASKROOM}"/*
+    do
+      [[ -L "${cask_path}" && ! -e "${cask_path}" ]] || continue
+      broken_cask_symlinks+=("${cask_path##*/}")
+    done
+    if ((${#broken_cask_symlinks[@]} > 0))
+    then
+      source "${HOMEBREW_LIBRARY}/Homebrew/utils.sh"
+      local joined_broken_cask_symlinks
+      printf -v joined_broken_cask_symlinks '%s, ' "${broken_cask_symlinks[@]}"
+      opoo "Broken Caskroom symlinks (\`brew cleanup\` removes them): ${joined_broken_cask_symlinks%, }"
+    fi
+
     return 0
   fi
 }

--- a/Library/Homebrew/test/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cmd/list_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Homebrew::Cmd::List do
       {
         "HOMEBREW_CASKROOM" => Cask::Caskroom.path.to_s,
         "HOMEBREW_CELLAR"   => HOMEBREW_CELLAR.to_s,
-        "HOMEBREW_LIBRARY"  => HOMEBREW_LIBRARY_PATH.to_s,
+        "HOMEBREW_LIBRARY"  => HOMEBREW_LIBRARY_PATH.parent.to_s,
         "HOMEBREW_PREFIX"   => HOMEBREW_PREFIX.to_s,
       }.merge(env),
       "/bin/bash", "-c", <<~SH,
@@ -85,7 +85,7 @@ RSpec.describe Homebrew::Cmd::List do
             homebrew-list list --versions --json
         }
 
-        check "formulae and casks" 0 "${EXPECTED_PLAIN}" "" homebrew-list list
+        check "formulae and casks" 0 "${EXPECTED_PLAIN}" "${EXPECTED_PLAIN_STDERR}" homebrew-list list
         check "formula and cask versions JSON" 0 "${EXPECTED_JSON}" "" homebrew-list list --versions --json
         check "formula versions JSON" 0 "${EXPECTED_FORMULA_JSON}" "" \\
           homebrew-list list --versions --json --formula
@@ -172,6 +172,7 @@ RSpec.describe Homebrew::Cmd::List do
     (HOMEBREW_PREFIX/"var/homebrew/pinned_casks").mkpath
     FileUtils.ln_s Cask::Caskroom.path/"local-caffeine/1.2.3",
                    HOMEBREW_PREFIX/"var/homebrew/pinned_casks/local-caffeine"
+    FileUtils.ln_s "missing-cask", Cask::Caskroom.path/"dangling-alias"
 
     empty_cellar = mktmpdir
     empty_caskroom = mktmpdir
@@ -194,7 +195,9 @@ RSpec.describe Homebrew::Cmd::List do
                "EXPECTED_EMPTY_JSON"   => list_versions_json,
                "EXPECTED_FORMULA_JSON" => list_versions_json(formulae: formulae_json),
                "EXPECTED_JSON"         => list_versions_json(formulae: formulae_json, casks: casks_json),
-               "EXPECTED_PLAIN"        => "testball\nlocal-caffeine\n",
+               "EXPECTED_PLAIN"        => "testball\ndangling-alias\nlocal-caffeine\n",
+               "EXPECTED_PLAIN_STDERR" => "Warning: Broken Caskroom symlinks " \
+                                          "(`brew cleanup` removes them): dangling-alias\n",
                "NO_JQ_CASKROOM"        => no_jq_caskroom.to_s,
                "NO_JQ_CELLAR"          => no_jq_cellar.to_s,
                "NO_JQ_PATH"            => no_jq_root.to_s,


### PR DESCRIPTION
 Oops, when adding the broken-Caskroom-symlink warning in #23235 just hours ago I didn't realise that bare `brew list` invocations are served by the Bash fast path, which must be kept in sync with the Ruby command — so the warning never fired for the plain `brew list --cask` case it was written for.

<details>
<summary>Details</summary>

The warning added in #23235 lives in the Ruby `list` command, but the Bash fast path (`list.sh`) returns before the Ruby command ever loads for bare listings — the "keep Bash and Ruby in sync" rule in this repo's agent instructions exists for exactly this situation, and I missed it.

The Bash-side warning matches the Ruby one exactly: stderr only, stdout untouched, fires only when a broken symlink exists. The Bash list test needed its `HOMEBREW_LIBRARY` pointed at the production-shaped `Library` directory so the fast path can source `utils.sh` for `opoo` as a real brew does; the test now asserts the exact warning line on stderr alongside the unchanged stdout.

A follow-up will propose making the listing skip alias symlinks entirely, so a renamed cask lists once — that changes `brew list` stdout, so it comes separately.

</details>

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Written with Claude in Claude Code under my direction and review. Red/green verified: the Bash list example fails with the `list.sh` change stashed. `brew typecheck`, `brew style` (including shellcheck/shfmt) and changed tests clean locally.
