### PR TITLE
list: test the Bash fast path against the Ruby command

### DIFF
--- a/Library/Homebrew/test/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cmd/list_spec.rb
@@ -33,14 +33,18 @@ RSpec.describe Homebrew::Cmd::List do
     Cask::CaskLoader.load(token).tap { |cask| InstallHelper.stub_cask_installation(cask) }
   end
 
+  def bash_list_env
+    {
+      "HOMEBREW_CASKROOM" => Cask::Caskroom.path.to_s,
+      "HOMEBREW_CELLAR"   => HOMEBREW_CELLAR.to_s,
+      "HOMEBREW_LIBRARY"  => HOMEBREW_LIBRARY_PATH.parent.to_s,
+      "HOMEBREW_PREFIX"   => HOMEBREW_PREFIX.to_s,
+    }
+  end
+
   def run_list_bash(env = {})
     stdout, stderr, status = Open3.capture3(
-      {
-        "HOMEBREW_CASKROOM" => Cask::Caskroom.path.to_s,
-        "HOMEBREW_CELLAR"   => HOMEBREW_CELLAR.to_s,
-        "HOMEBREW_LIBRARY"  => HOMEBREW_LIBRARY_PATH.parent.to_s,
-        "HOMEBREW_PREFIX"   => HOMEBREW_PREFIX.to_s,
-      }.merge(env),
+      bash_list_env.merge(env),
       "/bin/bash", "-c", <<~SH,
         source "$1"
 
@@ -110,7 +114,48 @@ RSpec.describe Homebrew::Cmd::List do
     status
   end
 
+  def bash_list_output(argv)
+    Open3.capture3(
+      bash_list_env,
+      "/bin/bash", "-c", 'source "$1" && shift && homebrew-list list "$@"',
+      "bash", (HOMEBREW_LIBRARY_PATH/"list.sh").to_s, *argv
+    )
+  end
+
+  def ruby_list_output(argv)
+    old_stdout = $stdout
+    old_stderr = $stderr
+    $stdout = StringIO.new
+    $stderr = StringIO.new
+    described_class.new(argv).run
+    [$stdout.string, $stderr.string]
+  ensure
+    $stdout = old_stdout
+    $stderr = old_stderr
+  end
+
   it_behaves_like "parseable arguments"
+
+  # The Bash fast path serves bare listings in production while tests usually enter
+  # at the Ruby command, so drift between the two ships silently unless they are
+  # tested against each other.
+  it "matches the Bash fast path against the Ruby command", :cask do
+    install_formula_version "testball", "0.1"
+    install_cask "local-caffeine"
+    FileUtils.ln_s "missing-cask", Cask::Caskroom.path/"dangling-alias"
+
+    variants = [[], ["-1"], ["--formula"], ["--cask"]]
+    bash_results = variants.map do |argv|
+      stdout, stderr, status = bash_list_output(argv)
+      [argv, status.success?, stdout, stderr]
+    end
+    ruby_results = variants.map do |argv|
+      stdout, stderr = ruby_list_output(argv)
+      [argv, true, stdout, stderr]
+    end
+
+    expect(bash_results).to eq(ruby_results)
+  end
 
   it "prints all installed formulae" do
     formulae.each do |f|


### PR DESCRIPTION
The follow-up promised on #23235: bare `brew list` invocations are served by the Bash fast path in production, while the test suite's examples enter at the Ruby command — so a feature added to one implementation can pass its own tests while production serves the other. That is exactly how #23235's warning shipped inert on its main path.

This adds a parity test: both implementations run against the same installed state (a formula, a cask, and a broken Caskroom symlink) across the flag variants both serve — bare, `-1`, `--formula`, `--cask` — and their stdout, stderr and exit status are diffed against each other, not against hand-written expectations. Drift now fails in CI whichever side changed. (`--versions --json` is excluded: the Ruby command intentionally defers that to the Bash path.)

Red/green: disabling the Bash-side warning from #23245 — recreating the drift that actually shipped — fails the test.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Written with Claude in Claude Code under my direction and review. Red/green verified as described above. `brew typecheck`, `brew style` and changed tests clean locally.
