### PR TITLE
write_env_script: add permission change

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -350,6 +350,7 @@ class Pathname
       #!/bin/bash
       #{env_export}exec "#{target}" #{args} "$@"
     SH
+    chmod 0555
   end
 
   # Writes a wrapper env script and moves all files to the dst.

--- a/Library/Homebrew/test/extend/pathname_spec.rb
+++ b/Library/Homebrew/test/extend/pathname_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe Pathname do
         BASH
       end
     end
+
+    it "makes scripts read-only executable" do
+      mktmpdir do |tmpdir|
+        script = tmpdir/"wrapper_script"
+        script.write_env_script "test", TEST: "bar"
+
+        expect(script.stat.mode & 0777).to eq(0555)
+      end
+    end
   end
 
   describe ".env_script_all_files" do


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Cleaner normally changes executable files to 0555 only after a formula’s install block completes. If a formula needs to run an environment wrapper created with write_env_script during that block (for example, [homebrew-core#294303](https://github.com/Homebrew/homebrew-core/pull/294303)), the newly written script still has non-executable default permissions.
Set environment wrappers to 0555 when writing them, so they can be executed during installation and already match Homebrew’s normal post-install mode.