### PR TITLE
formula: enable PIE for Haskell on Linux

### DIFF
--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -49,6 +49,13 @@ module OS
       def valid_platform?
         supports_linux?
       end
+
+      sig { returns(T::Array[String]) }
+      def std_cabal_v2_args
+        args = super
+        args << "--ghc-option=-pie" if ::Hardware::CPU.arm?
+        args
+      end
     end
   end
 end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -3214,6 +3214,27 @@ RSpec.describe Formula do
     end
   end
 
+  describe "#std_cabal_v2_args" do
+    let(:f) do
+      formula do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+    end
+
+    context "when running on Linux", :needs_linux do
+      it "includes flag for PIE on arm" do
+        allow(Hardware::CPU).to receive(:arm?).and_return(true)
+        expect(f.std_cabal_v2_args).to include("--ghc-option=-pie")
+      end
+
+      it "excludes flag for PIE on non-arm" do
+        allow(Hardware::CPU).to receive(:arm?).and_return(false)
+        expect(f.std_cabal_v2_args).not_to include("--ghc-option=-pie")
+      end
+    end
+  end
+
   describe "#std_pip_args" do
     let(:f) do
       formula do


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Based on Arch Linux hardening recommendation:
- https://wiki.archlinux.org/title/Arch_package_guidelines/Security#Haskell_2

We already build most C/C++ projects as PIE due to Ubuntu & brew GCC using `--enable-default-pie`.

Was able to verify this worked with:
* `pandoc` - pretty standard Haskell build
* `koka` - a custom build that uses a Haskell build script to create final binary

---

Other refs:
* https://ghc.gitlab.haskell.org/ghc/doc/users_guide/phases.html#ghc-flag-pie
  - NOTE: I think our GHC has static libs built with `-fPIC` so we can build a statically linked executable. `-dynamic` doesn't really work for us due to the GHC not having a stable ABI.
* https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html#build-as-position-independent-code 