### PR TITLE
Add Linux Landlock sandbox

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -334,7 +334,6 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     container:
       image: ${{ matrix.container }}
-      options: ${{ matrix.container != '' && '--privileged' }}
     strategy:
       fail-fast: false
       matrix:
@@ -359,6 +358,7 @@ jobs:
           - name: test-bot (macOS arm64)
             runs-on: macos-26
     env:
+      HOMEBREW_SANDBOX_LINUX_LANDLOCK: 1
       HOMEBREW_TEST_BOT_ANALYTICS: 1
     steps:
       - name: Install Homebrew and Homebrew's dependencies

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -439,6 +439,13 @@ then
   export HOMEBREW_COLOR="1"
 fi
 
+# This is set by Homebrew's self-hosted runner environment.
+# shellcheck disable=SC2154
+if [[ -n "${HOMEBREW_LINUX}" && -n "${GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED}" ]]
+then
+  export HOMEBREW_SANDBOX_LINUX_LANDLOCK="1"
+fi
+
 # Force UTF-8 to avoid encoding issues for users with broken locale settings.
 if [[ -n "${HOMEBREW_MACOS}" ]]
 then

--- a/Library/Homebrew/extend/os/linux/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/linux/dependency_collector.rb
@@ -85,6 +85,7 @@ module OS
       def bubblewrap_dependency_needed?
         return false unless ::Homebrew::EnvConfig.sandbox_linux?
         return false if ENV["HOMEBREW_TESTS"]
+        return false if OS::Linux::Sandbox.landlock?
 
         ::Sandbox.executable.blank?
       end

--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -173,9 +173,10 @@ module OS
           return if inside_docker && !GitHub::Actions.env_set?
 
           state = ::Sandbox.state
-          return if [:disabled, :available].include?(state)
+          return if state == :available
 
           reason = ::Sandbox.failure_reason || "The Linux sandbox is not available."
+          state = :landlock if OS::Linux::Sandbox.landlock?
           lines = case state
           when :missing
             missing_lines = [

--- a/Library/Homebrew/extend/os/linux/sandbox.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox.rb
@@ -1,11 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "fileutils"
-require "env_config"
-require "system_command"
-require "utils/popen"
-require "utils/github/actions"
+require "extend/os/linux/sandbox/bubblewrap"
 
 module OS
   module Linux
@@ -14,88 +10,23 @@ module OS
 
       requires_ancestor { ::Sandbox }
 
-      BUBBLEWRAP = "bwrap"
-      BUBBLEWRAP_TEST_ARGS = [
-        "--unshare-user",
-        "--unshare-ipc",
-        "--unshare-pid",
-        "--unshare-uts",
-        "--unshare-cgroup-try",
-        "--ro-bind", "/", "/",
-        "--proc", "/proc",
-        "--dev", "/dev",
-        "true"
-      ].freeze
-      SYSTEM_BUBBLEWRAP_PATHS = %w[
-        /usr/bin
-        /bin
-      ].freeze
-      HOMEBREW_BUBBLEWRAP_PATHS = [
-        "#{HOMEBREW_PREFIX}/bin",
-      ].freeze
-      NESTED_BUBBLEWRAP_ERROR = "Creating new namespace failed: nesting depth or /proc/sys/user/max_*_namespaces " \
-                                "exceeded"
-      class SysctlSetting < T::Struct
-        const :assignment, String
-        const :description, T::Array[String]
-        const :optional, T::Boolean, default: false
-      end
-      # These settings mirror the `sysctl` assignments in
-      # Library/Homebrew/cmd/setup-sandbox.sh; keep both in sync.
-      SANDBOX_SYSCTL_SETTINGS = T.let([
-        SysctlSetting.new(
-          assignment:  "kernel.unprivileged_userns_clone=1",
-          description: [
-            "Allows unprivileged processes to create user namespaces. Rootless",
-            "Bubblewrap needs this to isolate builds without elevated privileges.",
-          ],
-        ),
-        SysctlSetting.new(
-          assignment:  "user.max_user_namespaces=28633",
-          description: [
-            "Allows each user to allocate enough user namespaces. A zero or low",
-            "limit can prevent Bubblewrap from creating its sandbox.",
-          ],
-        ),
-        SysctlSetting.new(
-          assignment:  "kernel.apparmor_restrict_unprivileged_userns=0",
-          description: [
-            "Allows unprivileged user namespaces on AppArmor-enabled systems",
-            "that restrict them by default. Older kernels may not provide this",
-            "setting.",
-          ],
-          optional:    true,
-        ),
-      ].freeze, T::Array[SysctlSetting])
       # `TIOCSCTTY` from `<asm-generic/ioctls.h>`; Ruby does not expose it.
       TIOCSCTTY = 0x540E
-      # Per-distro Bubblewrap install commands, detected by package manager and
-      # checked in priority order. Mirrors the build tools instructions in
-      # `Homebrew/install`'s `install.sh`.
-      BUBBLEWRAP_INSTALL_COMMANDS = T.let({
-        "apt-get" => "sudo apt-get install bubblewrap",
-        "dnf"     => "sudo dnf install bubblewrap",
-        "yum"     => "sudo yum install bubblewrap",
-        "pacman"  => "sudo pacman -S bubblewrap",
-        "apk"     => "sudo apk add bubblewrap",
-      }.freeze, T::Hash[String, String])
-      private_constant :BUBBLEWRAP, :BUBBLEWRAP_TEST_ARGS, :SYSTEM_BUBBLEWRAP_PATHS, :HOMEBREW_BUBBLEWRAP_PATHS,
-                       :NESTED_BUBBLEWRAP_ERROR, :SysctlSetting, :SANDBOX_SYSCTL_SETTINGS, :TIOCSCTTY,
-                       :BUBBLEWRAP_INSTALL_COMMANDS
+      private_constant :TIOCSCTTY
 
       sig { returns(::PATH) }
       def self.bubblewrap_candidate_paths
-        ::Sandbox.executable_candidate_paths
+        ::Sandbox::Bubblewrap.executable_candidate_paths
       end
 
       sig { returns(T.nilable(::Pathname)) }
       def self.bubblewrap_executable
-        ::Sandbox.executable
+        ::Sandbox::Bubblewrap.executable
       end
 
       sig { returns(::Pathname) }
       def self.bubblewrap_executable!
-        bubblewrap_executable || raise("Bubblewrap is required to use the Linux sandbox.")
+        ::Sandbox::Bubblewrap.executable!
       end
 
       sig { void }
@@ -122,29 +53,27 @@ module OS
 
       module ClassMethods
         extend T::Helpers
-        include SystemCommand::Mixin
-        include Utils::Output::Mixin
 
         requires_ancestor { T.class_of(::Sandbox) }
 
         sig { returns(String) }
         def executable_name
-          BUBBLEWRAP
+          ::Sandbox::Bubblewrap.executable_name
         end
 
         sig { params(candidate: ::Pathname).returns(T::Boolean) }
         def executable_usable?(candidate)
-          !File.stat(candidate).setuid?
+          ::Sandbox::Bubblewrap.executable_usable?(candidate)
         end
 
         sig { returns(T::Array[String]) }
         def system_bubblewrap_paths
-          SYSTEM_BUBBLEWRAP_PATHS
+          ::Sandbox::Bubblewrap.system_paths
         end
 
         sig { returns(::PATH) }
         def executable_candidate_paths
-          PATH.new(HOMEBREW_BUBBLEWRAP_PATHS, system_bubblewrap_paths, super)
+          ::Sandbox::Bubblewrap.executable_candidate_paths
         end
 
         sig { returns(::PATH) }
@@ -154,47 +83,22 @@ module OS
 
         sig { returns(T.nilable(::Pathname)) }
         def bubblewrap_executable
-          executable
+          ::Sandbox::Bubblewrap.executable
         end
 
         sig { returns(::Pathname) }
         def bubblewrap_executable!
-          bubblewrap_executable || raise("Bubblewrap is required to use the Linux sandbox.")
+          ::Sandbox::Bubblewrap.executable!
         end
 
         sig { params(install_from_tests: T::Boolean).void }
         def ensure_sandbox_installed!(install_from_tests: false)
-          return unless Homebrew::EnvConfig.sandbox_linux?
-          return if ENV["HOMEBREW_TESTS"] && !install_from_tests
-          return if ENV["HOMEBREW_INSTALLING_BUBBLEWRAP"]
-          return if bubblewrap_executable
-
-          begin
-            require "exceptions"
-            require "formula"
-            with_env(HOMEBREW_INSTALLING_BUBBLEWRAP: "1") do
-              ::Formula["bubblewrap"].ensure_installed!(reason: "Linux sandboxing")
-            end
-            reset_state!
-            return if bubblewrap_executable
-          rescue ::FormulaUnavailableError
-            nil
-          end
-
-          return unless GitHub::Actions.env_set?
-          return unless ENV.fetch("HOMEBREW_GITHUB_HOSTED_RUNNER", nil)
-          return unless which("apt-get")
-
-          ohai "Installing Bubblewrap..."
-          command = ["apt-get", "install", "--yes", "bubblewrap"]
-          command.unshift("sudo") unless Process.euid.zero?
-          system(*command)
-          reset_state!
+          ::Sandbox::Bubblewrap.ensure_installed!(install_from_tests:)
         end
 
         sig { returns(T::Boolean) }
         def available?
-          state == :available
+          ::Sandbox::Bubblewrap.available?
         end
 
         # Bubblewrap reports this specific namespace error when an outer
@@ -203,84 +107,42 @@ module OS
         # `$HOMEBREW_AVOID_NESTED_SANDBOXING` opt-in is set.
         sig { returns(T::Boolean) }
         def nested_sandbox?
-          return false unless Homebrew::EnvConfig.sandbox_linux?
-
-          bubblewrap = bubblewrap_executable
-          return false unless bubblewrap
-
-          Utils.popen_read(bubblewrap.to_s, *BUBBLEWRAP_TEST_ARGS, err: :out).include?(NESTED_BUBBLEWRAP_ERROR)
+          ::Sandbox::Bubblewrap.nested_sandbox?
         end
 
         sig { returns(Symbol) }
         def state
-          return :disabled unless Homebrew::EnvConfig.sandbox_linux?
-
-          @state ||= T.let(compute_state, T.nilable(Symbol))
+          ::Sandbox::Bubblewrap.state
         end
 
         sig { void }
         def reset_state!
-          @state = T.let(nil, T.nilable(Symbol))
+          ::Sandbox::Bubblewrap.reset_state!
         end
 
         sig { returns(T::Array[String]) }
         def configuration_commands
-          SANDBOX_SYSCTL_SETTINGS.map do |setting|
-            command = "sudo sysctl -w #{setting.assignment}"
-            command += " || true" if setting.optional
-            command
-          end
+          ::Sandbox::Bubblewrap.configuration_commands
         end
 
         sig { returns(T::Array[String]) }
         def configuration_command_messages
-          commands = configuration_commands
-          SANDBOX_SYSCTL_SETTINGS.each_with_index.flat_map do |setting, index|
-            [
-              "  #{commands.fetch(index)}",
-              *setting.description.map { |line| "    #{line}" },
-            ]
-          end
+          ::Sandbox::Bubblewrap.configuration_command_messages
         end
 
         sig { void }
         def configure!
-          unless bubblewrap_executable
-            ensure_sandbox_installed!(install_from_tests: true)
-            unless bubblewrap_executable
-              reset_state!
-              return
-            end
-          end
-
-          ohai "Configuring Bubblewrap..."
-          command = [HOMEBREW_BREW_FILE.to_s, "setup-sandbox"]
-          command.unshift("sudo") unless Process.euid.zero?
-          raise ErrorDuringExecution.new(command, status: $CHILD_STATUS || 1) unless system(*command)
-
-          reset_state!
+          ::Sandbox::Bubblewrap.configure!
         end
 
         sig { returns(T.nilable(String)) }
         def failure_reason
-          case state
-          when :disabled, :available
-            nil
-          when :missing
-            "Bubblewrap is required to use the Linux sandbox but was not found."
-          when :setuid
-            "A rootless Bubblewrap executable is required to use the Linux sandbox, " \
-            "but all found `bwrap` executables are setuid."
-          when :unavailable
-            "Bubblewrap is installed but cannot create a rootless sandbox."
-          else
-            "The Linux sandbox is not available."
-          end
+          ::Sandbox::Bubblewrap.failure_reason
         end
 
         sig { returns(T.nilable(String)) }
         def sandbox_install_command
-          BUBBLEWRAP_INSTALL_COMMANDS.find { |package_manager, _| which(package_manager) }&.last
+          ::Sandbox::Bubblewrap.install_command
         end
 
         # `ioctl` request used to attach the sandboxed child to a controlling TTY.
@@ -288,181 +150,33 @@ module OS
         def terminal_ioctl_request
           TIOCSCTTY
         end
-
-        private
-
-        sig { returns(Symbol) }
-        def compute_state
-          bubblewraps = bubblewrap_executables
-          return :missing if bubblewraps.empty?
-
-          bubblewraps = bubblewraps.select { |candidate| executable_usable?(candidate) }
-          return :setuid if bubblewraps.empty?
-
-          return :available if bubblewraps.any? { |candidate| bubblewrap_sandbox_available?(candidate) }
-
-          :unavailable
-        end
-
-        sig { returns(T::Array[::Pathname]) }
-        def bubblewrap_executables
-          executable_candidate_paths.filter_map do |path|
-            begin
-              candidate = ::Pathname.new(File.expand_path(executable_name, path))
-            rescue ArgumentError
-              next
-            end
-
-            candidate if candidate.file? && candidate.executable?
-          end
-        end
-
-        sig { params(bubblewrap: ::Pathname).returns(T::Boolean) }
-        def bubblewrap_sandbox_available?(bubblewrap)
-          result = system_command(
-            bubblewrap,
-            args:         BUBBLEWRAP_TEST_ARGS,
-            print_stderr: false,
-          )
-          return true if result.success?
-
-          opoo "bubblewrap test probe failed"
-          $stderr.print result.merged_output
-          false
-        end
       end
 
       sig { params(args: T.any(String, ::Pathname)).void }
       def run(*args)
-        @prepared_writable_paths = T.let([], T.nilable(T::Array[::Pathname]))
-        @masked_read_paths = T.let([], T.nilable(T::Array[::Pathname]))
-        old_report_on_exception = T.let(Thread.report_on_exception, T.nilable(T::Boolean))
-        Thread.report_on_exception = false
-        super
-      ensure
-        Thread.report_on_exception = old_report_on_exception unless old_report_on_exception.nil?
-        @prepared_writable_paths&.reverse_each do |path|
-          path.rmdir if path.directory?
-        rescue Errno::ENOENT, Errno::ENOTEMPTY
-          nil
-        end
-        @prepared_writable_paths = nil
-        @masked_read_paths&.reverse_each { |path| FileUtils.rm_rf(path) }
-        @masked_read_paths = nil
+        bubblewrap.run { super }
       end
 
       private
 
       sig { params(args: T::Array[T.any(String, ::Pathname)], tmpdir: String).returns(T::Array[T.any(String, ::Pathname)]) }
       def sandbox_command(args, tmpdir)
-        [::Sandbox.executable!, *bubblewrap_args(tmpdir), "--", *args]
+        bubblewrap.command(args, tmpdir)
       end
 
       sig { params(tmpdir: String).returns(T::Array[String]) }
       def bubblewrap_args(tmpdir)
-        args = T.let([
-          "--unshare-user",
-          "--unshare-ipc",
-          "--unshare-pid",
-          "--unshare-uts",
-          "--unshare-cgroup-try",
-          "--die-with-parent",
-          "--new-session",
-          "--ro-bind", "/", "/",
-          "--dev", "/dev",
-          "--proc", "/proc"
-        ], T::Array[String])
-        args << "--unshare-net" if deny_all_network?
-
-        writable_paths.each do |path, type|
-          prepare_writable_path(path, type)
-          args += ["--bind", path, path]
-        end
-
-        denied_write_paths.each do |path|
-          next unless File.exist?(path)
-
-          args += ["--ro-bind", path, path]
-        end
-
-        denied_read_paths.each do |path|
-          next unless File.exist?(path)
-
-          args += if File.directory?(path)
-            ["--bind", masked_read_path, path]
-          else
-            ["--ro-bind", File::NULL, path]
-          end
-        end
-
-        args += ["--bind", tmpdir, tmpdir, "--chdir", tmpdir]
-
-        args
-      end
-
-      sig { returns(T::Boolean) }
-      def deny_all_network?
-        profile.rules.any? do |rule|
-          !rule.allow && rule.operation == "network*" && rule.filter.nil?
-        end
+        bubblewrap.arguments(tmpdir)
       end
 
       sig { returns(T::Hash[String, Symbol]) }
       def writable_paths
-        profile.rules.each_with_object({}) do |rule, paths|
-          next if !rule.allow || !rule.operation.start_with?("file-write")
-          next unless (filter = rule.filter)
-
-          case filter.type
-          when :literal, :subpath
-            paths[filter.path] ||= filter.type
-          when :regex
-            raise ArgumentError, "Linux sandbox does not support regex path filters: #{filter.path}"
-          else
-            raise ArgumentError, "Invalid path filter type: #{filter.type}"
-          end
-        end
+        bubblewrap.writable_paths
       end
 
-      sig { returns(T::Array[String]) }
-      def denied_write_paths
-        profile.rules.filter_map do |rule|
-          next if rule.allow || !rule.operation.start_with?("file-write")
-
-          filter = rule.filter
-          filter.path if filter && [:literal, :subpath].include?(filter.type)
-        end.uniq
-      end
-
-      sig { returns(T::Array[String]) }
-      def denied_read_paths
-        profile.rules.filter_map do |rule|
-          next if rule.allow || !rule.operation.start_with?("file-read")
-
-          filter = rule.filter
-          filter.path if filter && [:literal, :subpath].include?(filter.type)
-        end.uniq
-      end
-
-      sig { returns(String) }
-      def masked_read_path
-        path = ::Pathname.new(Dir.mktmpdir("homebrew-sandbox-deny-read", HOMEBREW_TEMP))
-        @masked_read_paths&.<< path
-        path.to_s
-      end
-
-      sig { params(path: String, type: Symbol).void }
-      def prepare_writable_path(path, type)
-        pathname = ::Pathname.new(path)
-        return if pathname.exist?
-
-        if type == :literal
-          FileUtils.mkdir_p(pathname.dirname)
-          FileUtils.touch(pathname)
-        else
-          FileUtils.mkdir_p(pathname)
-          @prepared_writable_paths&.<< pathname
-        end
+      sig { returns(::Sandbox::Bubblewrap) }
+      def bubblewrap
+        @bubblewrap ||= T.let(::Sandbox::Bubblewrap.new(profile), T.nilable(::Sandbox::Bubblewrap))
       end
     end
   end

--- a/Library/Homebrew/extend/os/linux/sandbox.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "extend/os/linux/sandbox/bubblewrap"
+require "extend/os/linux/sandbox/landlock"
 
 module OS
   module Linux
@@ -27,6 +28,16 @@ module OS
       sig { returns(::Pathname) }
       def self.bubblewrap_executable!
         ::Sandbox::Bubblewrap.executable!
+      end
+
+      sig { returns(T::Boolean) }
+      def self.landlock?
+        ENV.fetch("HOMEBREW_SANDBOX_LINUX_LANDLOCK", nil) == "1"
+      end
+
+      sig { returns(T.any(T.class_of(::Sandbox::Bubblewrap), T.class_of(::Sandbox::Landlock))) }
+      def self.sandbox_implementation
+        landlock? ? ::Sandbox::Landlock : ::Sandbox::Bubblewrap
       end
 
       sig { void }
@@ -93,12 +104,17 @@ module OS
 
         sig { params(install_from_tests: T::Boolean).void }
         def ensure_sandbox_installed!(install_from_tests: false)
-          ::Sandbox::Bubblewrap.ensure_installed!(install_from_tests:)
+          OS::Linux::Sandbox.sandbox_implementation.ensure_installed!(install_from_tests:)
         end
 
         sig { returns(T::Boolean) }
         def available?
-          ::Sandbox::Bubblewrap.available?
+          OS::Linux::Sandbox.sandbox_implementation.available?
+        end
+
+        sig { returns(T::Boolean) }
+        def full_write_isolation?
+          OS::Linux::Sandbox.sandbox_implementation.full_write_isolation?
         end
 
         # Bubblewrap reports this specific namespace error when an outer
@@ -107,42 +123,45 @@ module OS
         # `$HOMEBREW_AVOID_NESTED_SANDBOXING` opt-in is set.
         sig { returns(T::Boolean) }
         def nested_sandbox?
-          ::Sandbox::Bubblewrap.nested_sandbox?
+          OS::Linux::Sandbox.sandbox_implementation.nested_sandbox?
         end
 
         sig { returns(Symbol) }
         def state
-          ::Sandbox::Bubblewrap.state
+          OS::Linux::Sandbox.sandbox_implementation.state
         end
 
         sig { void }
         def reset_state!
           ::Sandbox::Bubblewrap.reset_state!
+          ::Sandbox::Landlock.reset_state!
         end
 
         sig { returns(T::Array[String]) }
         def configuration_commands
-          ::Sandbox::Bubblewrap.configuration_commands
+          OS::Linux::Sandbox.sandbox_implementation.configuration_commands
         end
 
         sig { returns(T::Array[String]) }
         def configuration_command_messages
-          ::Sandbox::Bubblewrap.configuration_command_messages
+          OS::Linux::Sandbox.sandbox_implementation.configuration_command_messages
         end
 
         sig { void }
         def configure!
-          ::Sandbox::Bubblewrap.configure!
+          OS::Linux::Sandbox.sandbox_implementation.configure!
         end
 
         sig { returns(T.nilable(String)) }
         def failure_reason
-          ::Sandbox::Bubblewrap.failure_reason
+          return super if self != ::Sandbox
+
+          OS::Linux::Sandbox.sandbox_implementation.failure_reason
         end
 
         sig { returns(T.nilable(String)) }
         def sandbox_install_command
-          ::Sandbox::Bubblewrap.install_command
+          OS::Linux::Sandbox.sandbox_implementation.install_command
         end
 
         # `ioctl` request used to attach the sandboxed child to a controlling TTY.
@@ -154,14 +173,14 @@ module OS
 
       sig { params(args: T.any(String, ::Pathname)).void }
       def run(*args)
-        bubblewrap.run { super }
+        implementation.run { super }
       end
 
       private
 
       sig { params(args: T::Array[T.any(String, ::Pathname)], tmpdir: String).returns(T::Array[T.any(String, ::Pathname)]) }
       def sandbox_command(args, tmpdir)
-        bubblewrap.command(args, tmpdir)
+        implementation.command(args, tmpdir)
       end
 
       sig { params(tmpdir: String).returns(T::Array[String]) }
@@ -172,6 +191,20 @@ module OS
       sig { returns(T::Hash[String, Symbol]) }
       def writable_paths
         bubblewrap.writable_paths
+      end
+
+      sig { void }
+      def apply_sandbox
+        sandbox = implementation
+        sandbox.apply! if sandbox.is_a?(::Sandbox::Landlock)
+      end
+
+      sig { returns(T.any(::Sandbox::Bubblewrap, ::Sandbox::Landlock)) }
+      def implementation
+        @implementation ||= T.let(
+          OS::Linux::Sandbox.sandbox_implementation.new(profile),
+          T.nilable(T.any(::Sandbox::Bubblewrap, ::Sandbox::Landlock)),
+        )
       end
 
       sig { returns(::Sandbox::Bubblewrap) }

--- a/Library/Homebrew/extend/os/linux/sandbox/backend.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox/backend.rb
@@ -1,0 +1,88 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "fileutils"
+
+class Sandbox
+  class LinuxBackend
+    class << self
+      sig { returns(T::Boolean) }
+      def full_write_isolation? = true
+    end
+
+    sig { params(profile: SandboxProfile).void }
+    def initialize(profile)
+      @profile = profile
+      @prepared_writable_paths = T.let([], T::Array[::Pathname])
+    end
+
+    sig { params(block: T.proc.void).void }
+    def run(&block)
+      yield
+    ensure
+      @prepared_writable_paths.reverse_each do |path|
+        path.rmdir if path.directory?
+      rescue Errno::ENOENT, Errno::ENOTEMPTY
+        nil
+      end
+      @prepared_writable_paths.clear
+    end
+
+    private
+
+    sig { returns(SandboxProfile) }
+    attr_reader :profile
+
+    public
+
+    sig { returns(T::Hash[String, Symbol]) }
+    def writable_paths
+      profile.rules.each_with_object({}) do |rule, paths|
+        next if !rule.allow || !rule.operation.start_with?("file-write")
+        next unless (filter = rule.filter)
+
+        case filter.type
+        when :literal, :subpath
+          paths[filter.path] ||= filter.type
+        when :regex
+          raise ArgumentError, "Linux sandbox does not support regex path filters: #{filter.path}"
+        else
+          raise ArgumentError, "Invalid path filter type: #{filter.type}"
+        end
+      end
+    end
+
+    private
+
+    sig { params(allow: T::Boolean, operation: String).returns(T::Array[String]) }
+    def profile_paths(allow:, operation:)
+      profile.rules.filter_map do |rule|
+        next if rule.allow != allow || !rule.operation.start_with?(operation)
+
+        filter = rule.filter
+        filter.path if filter && [:literal, :subpath].include?(filter.type)
+      end.uniq
+    end
+
+    sig { returns(T::Boolean) }
+    def deny_all_network?
+      profile.rules.any? do |rule|
+        !rule.allow && rule.operation == "network*" && rule.filter.nil?
+      end
+    end
+
+    sig { params(path: String, type: Symbol).void }
+    def prepare_writable_path(path, type)
+      pathname = ::Pathname.new(path)
+      return if pathname.exist?
+
+      if type == :literal
+        FileUtils.mkdir_p(pathname.dirname)
+        FileUtils.touch(pathname)
+      else
+        FileUtils.mkdir_p(pathname)
+        @prepared_writable_paths << pathname
+      end
+    end
+  end
+end

--- a/Library/Homebrew/extend/os/linux/sandbox/bubblewrap.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox/bubblewrap.rb
@@ -1,0 +1,372 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "fileutils"
+require "env_config"
+require "system_command"
+require "utils/popen"
+require "utils/github/actions"
+require "extend/os/linux/sandbox/backend"
+
+class Sandbox
+  class Bubblewrap < LinuxBackend
+    extend SystemCommand::Mixin
+    extend Utils::Output::Mixin
+
+    EXECUTABLE = "bwrap"
+    TEST_ARGS = [
+      "--unshare-user",
+      "--unshare-ipc",
+      "--unshare-pid",
+      "--unshare-uts",
+      "--unshare-cgroup-try",
+      "--ro-bind", "/", "/",
+      "--proc", "/proc",
+      "--dev", "/dev",
+      "true"
+    ].freeze
+    SYSTEM_PATHS = %w[
+      /usr/bin
+      /bin
+    ].freeze
+    HOMEBREW_PATHS = [
+      "#{HOMEBREW_PREFIX}/bin",
+    ].freeze
+    NESTED_ERROR = "Creating new namespace failed: nesting depth or /proc/sys/user/max_*_namespaces exceeded"
+    class SysctlSetting < T::Struct
+      const :assignment, String
+      const :description, T::Array[String]
+      const :optional, T::Boolean, default: false
+    end
+    # These settings mirror the `sysctl` assignments in
+    # Library/Homebrew/cmd/setup-sandbox.sh; keep both in sync.
+    SYSCTL_SETTINGS = T.let([
+      SysctlSetting.new(
+        assignment:  "kernel.unprivileged_userns_clone=1",
+        description: [
+          "Allows unprivileged processes to create user namespaces. Rootless",
+          "Bubblewrap needs this to isolate builds without elevated privileges.",
+        ],
+      ),
+      SysctlSetting.new(
+        assignment:  "user.max_user_namespaces=28633",
+        description: [
+          "Allows each user to allocate enough user namespaces. A zero or low",
+          "limit can prevent Bubblewrap from creating its sandbox.",
+        ],
+      ),
+      SysctlSetting.new(
+        assignment:  "kernel.apparmor_restrict_unprivileged_userns=0",
+        description: [
+          "Allows unprivileged user namespaces on AppArmor-enabled systems",
+          "that restrict them by default. Older kernels may not provide this",
+          "setting.",
+        ],
+        optional:    true,
+      ),
+    ].freeze, T::Array[SysctlSetting])
+    # Per-distro Bubblewrap install commands, detected by package manager and
+    # checked in priority order. Mirrors the build tools instructions in
+    # `Homebrew/install`'s `install.sh`.
+    INSTALL_COMMANDS = T.let({
+      "apt-get" => "sudo apt-get install bubblewrap",
+      "dnf"     => "sudo dnf install bubblewrap",
+      "yum"     => "sudo yum install bubblewrap",
+      "pacman"  => "sudo pacman -S bubblewrap",
+      "apk"     => "sudo apk add bubblewrap",
+    }.freeze, T::Hash[String, String])
+    private_constant :EXECUTABLE, :TEST_ARGS, :SYSTEM_PATHS, :HOMEBREW_PATHS, :NESTED_ERROR, :SysctlSetting,
+                     :SYSCTL_SETTINGS, :INSTALL_COMMANDS
+
+    class << self
+      sig { returns(String) }
+      def executable_name
+        EXECUTABLE
+      end
+
+      sig { params(candidate: ::Pathname).returns(T::Boolean) }
+      def executable_usable?(candidate)
+        !File.stat(candidate).setuid?
+      end
+
+      sig { returns(T::Array[String]) }
+      def system_paths
+        SYSTEM_PATHS
+      end
+
+      sig { returns(::PATH) }
+      def executable_candidate_paths
+        PATH.new(HOMEBREW_PATHS, system_paths, ORIGINAL_PATHS, ENV.fetch("PATH"), HOMEBREW_ORIGINAL_BREW_FILE.dirname)
+      end
+
+      sig { returns(T.nilable(::Pathname)) }
+      def executable
+        executable_candidate_paths.each do |path|
+          begin
+            candidate = ::Pathname.new(File.expand_path(executable_name, path))
+          rescue ArgumentError
+            next
+          end
+
+          next if !candidate.file? || !candidate.executable?
+          next unless executable_usable?(candidate)
+
+          return candidate
+        end
+
+        nil
+      end
+
+      sig { returns(::Pathname) }
+      def executable!
+        executable || raise("Bubblewrap is required to use the Linux sandbox.")
+      end
+
+      sig { params(install_from_tests: T::Boolean).void }
+      def ensure_installed!(install_from_tests: false)
+        return unless Homebrew::EnvConfig.sandbox_linux?
+        return if ENV["HOMEBREW_TESTS"] && !install_from_tests
+        return if ENV["HOMEBREW_INSTALLING_BUBBLEWRAP"]
+        return if executable
+
+        begin
+          require "exceptions"
+          require "formula"
+          with_env(HOMEBREW_INSTALLING_BUBBLEWRAP: "1") do
+            ::Formula["bubblewrap"].ensure_installed!(reason: "Linux sandboxing")
+          end
+          reset_state!
+          return if executable
+        rescue ::FormulaUnavailableError
+          nil
+        end
+
+        return unless GitHub::Actions.env_set?
+        return unless ENV.fetch("HOMEBREW_GITHUB_HOSTED_RUNNER", nil)
+        return unless which("apt-get")
+
+        ohai "Installing Bubblewrap..."
+        command = ["apt-get", "install", "--yes", "bubblewrap"]
+        command.unshift("sudo") unless Process.euid.zero?
+        system(*command)
+        reset_state!
+      end
+
+      sig { returns(T::Boolean) }
+      def available?
+        state == :available
+      end
+
+      # Bubblewrap reports this specific namespace error when an outer
+      # Bubblewrap sandbox prevents Homebrew from creating another rootless
+      # sandbox. The shared `avoid_nested_sandboxing?` only calls this once the
+      # `$HOMEBREW_AVOID_NESTED_SANDBOXING` opt-in is set.
+      sig { returns(T::Boolean) }
+      def nested_sandbox?
+        return false unless Homebrew::EnvConfig.sandbox_linux?
+
+        bubblewrap = executable
+        return false unless bubblewrap
+
+        Utils.popen_read(bubblewrap.to_s, *TEST_ARGS, err: :out).include?(NESTED_ERROR)
+      end
+
+      sig { returns(Symbol) }
+      def state
+        return :config_disabled unless Homebrew::EnvConfig.sandbox_linux?
+
+        @state ||= T.let(compute_state, T.nilable(Symbol))
+      end
+
+      sig { void }
+      def reset_state!
+        @state = T.let(nil, T.nilable(Symbol))
+      end
+
+      sig { returns(T::Array[String]) }
+      def configuration_commands
+        SYSCTL_SETTINGS.map do |setting|
+          command = "sudo sysctl -w #{setting.assignment}"
+          command += " || true" if setting.optional
+          command
+        end
+      end
+
+      sig { returns(T::Array[String]) }
+      def configuration_command_messages
+        commands = configuration_commands
+        SYSCTL_SETTINGS.each_with_index.flat_map do |setting, index|
+          [
+            "  #{commands.fetch(index)}",
+            *setting.description.map { |line| "    #{line}" },
+          ]
+        end
+      end
+
+      sig { void }
+      def configure!
+        unless executable
+          ensure_installed!(install_from_tests: true)
+          unless executable
+            reset_state!
+            return
+          end
+        end
+
+        ohai "Configuring Bubblewrap..."
+        command = [HOMEBREW_BREW_FILE.to_s, "setup-sandbox"]
+        command.unshift("sudo") unless Process.euid.zero?
+        raise ErrorDuringExecution.new(command, status: $CHILD_STATUS || 1) unless system(*command)
+
+        reset_state!
+      end
+
+      sig { returns(T.nilable(String)) }
+      def failure_reason
+        case state
+        when :config_disabled, :available
+          nil
+        when :missing
+          "Bubblewrap is required to use the Linux sandbox but was not found."
+        when :setuid
+          "A rootless Bubblewrap executable is required to use the Linux sandbox, " \
+          "but all found `bwrap` executables are setuid."
+        when :unavailable
+          "Bubblewrap is installed but cannot create a rootless sandbox."
+        else
+          "The Linux sandbox is not available."
+        end
+      end
+
+      sig { returns(T.nilable(String)) }
+      def install_command
+        INSTALL_COMMANDS.find { |package_manager, _| which(package_manager) }&.last
+      end
+
+      private
+
+      sig { returns(Symbol) }
+      def compute_state
+        bubblewraps = executables
+        return :missing if bubblewraps.empty?
+
+        bubblewraps = bubblewraps.select { |candidate| executable_usable?(candidate) }
+        return :setuid if bubblewraps.empty?
+
+        return :available if bubblewraps.any? { |candidate| sandbox_available?(candidate) }
+
+        :unavailable
+      end
+
+      sig { returns(T::Array[::Pathname]) }
+      def executables
+        executable_candidate_paths.filter_map do |path|
+          begin
+            candidate = ::Pathname.new(File.expand_path(executable_name, path))
+          rescue ArgumentError
+            next
+          end
+
+          candidate if candidate.file? && candidate.executable?
+        end
+      end
+
+      sig { params(bubblewrap: ::Pathname).returns(T::Boolean) }
+      def sandbox_available?(bubblewrap)
+        result = system_command(
+          bubblewrap,
+          args:         TEST_ARGS,
+          print_stderr: false,
+        )
+        return true if result.success?
+
+        opoo "bubblewrap test probe failed"
+        $stderr.print result.merged_output
+        false
+      end
+    end
+
+    sig { params(profile: SandboxProfile).void }
+    def initialize(profile)
+      super
+      @masked_read_paths = T.let([], T::Array[::Pathname])
+    end
+
+    sig { params(block: T.proc.void).void }
+    def run(&block)
+      old_report_on_exception = T.let(Thread.report_on_exception, T.nilable(T::Boolean))
+      Thread.report_on_exception = false
+      super
+    ensure
+      Thread.report_on_exception = old_report_on_exception unless old_report_on_exception.nil?
+      @masked_read_paths.reverse_each { |path| FileUtils.rm_rf(path) }
+      @masked_read_paths.clear
+    end
+
+    sig { params(args: T::Array[T.any(String, ::Pathname)], tmpdir: String).returns(T::Array[T.any(String, ::Pathname)]) }
+    def command(args, tmpdir)
+      [self.class.executable!, *arguments(tmpdir), "--", *args]
+    end
+
+    sig { params(tmpdir: String).returns(T::Array[String]) }
+    def arguments(tmpdir)
+      args = T.let([
+        "--unshare-user",
+        "--unshare-ipc",
+        "--unshare-pid",
+        "--unshare-uts",
+        "--unshare-cgroup-try",
+        "--die-with-parent",
+        "--new-session",
+        "--ro-bind", "/", "/",
+        "--dev", "/dev",
+        "--proc", "/proc"
+      ], T::Array[String])
+      args << "--unshare-net" if deny_all_network?
+
+      writable_paths.each do |path, type|
+        prepare_writable_path(path, type)
+        args += ["--bind", path, path]
+      end
+
+      denied_write_paths.each do |path|
+        next unless File.exist?(path)
+
+        args += ["--ro-bind", path, path]
+      end
+
+      denied_read_paths.each do |path|
+        next unless File.exist?(path)
+
+        args += if File.directory?(path)
+          ["--bind", masked_read_path, path]
+        else
+          ["--ro-bind", File::NULL, path]
+        end
+      end
+
+      args += ["--bind", tmpdir, tmpdir, "--chdir", tmpdir]
+
+      args
+    end
+
+    private
+
+    sig { returns(T::Array[String]) }
+    def denied_write_paths
+      profile_paths(allow: false, operation: "file-write")
+    end
+
+    sig { returns(T::Array[String]) }
+    def denied_read_paths
+      profile_paths(allow: false, operation: "file-read")
+    end
+
+    sig { returns(String) }
+    def masked_read_path
+      path = ::Pathname.new(Dir.mktmpdir("homebrew-sandbox-deny-read", HOMEBREW_TEMP))
+      @masked_read_paths << path
+      path.to_s
+    end
+  end
+end

--- a/Library/Homebrew/extend/os/linux/sandbox/landlock.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox/landlock.rb
@@ -1,0 +1,445 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "fileutils"
+require "utils/output"
+require "extend/os/linux/sandbox/backend"
+
+class Sandbox
+  class Landlock < LinuxBackend
+    include Utils::Output::Mixin
+
+    # Keep these constants and structure layouts in sync with Linux's Landlock UAPI:
+    # https://github.com/torvalds/linux/blob/master/include/uapi/linux/landlock.h
+    CREATE_RULESET_VERSION = 1
+    RULE_PATH_BENEATH = 1
+
+    # Linux's `prctl(2)` operation and `open(2)` flags come from these UAPI headers:
+    # https://github.com/torvalds/linux/blob/master/include/uapi/linux/prctl.h
+    # https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/fcntl.h
+    PR_SET_NO_NEW_PRIVS = 38
+    O_PATH = 010000000
+    O_CLOEXEC = 02000000
+
+    # Landlock has no dedicated libc wrappers, so call `syscall(2)` as documented:
+    # https://man7.org/linux/man-pages/man2/landlock_create_ruleset.2.html
+    # Homebrew's x86_64 and arm64 Linux architectures both use these numbers:
+    # https://github.com/torvalds/linux/blob/master/arch/x86/entry/syscalls/syscall_64.tbl
+    # https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/unistd.h
+    CREATE_RULESET_SYSCALL = 444
+    ADD_RULE_SYSCALL = 445
+    RESTRICT_SELF_SYSCALL = 446
+
+    ACCESS_FS_EXECUTE = 0x0001
+    ACCESS_FS_WRITE_FILE = 0x0002
+    ACCESS_FS_READ_FILE = 0x0004
+    ACCESS_FS_READ_DIR = 0x0008
+    ACCESS_FS_REMOVE_DIR = 0x0010
+    ACCESS_FS_REMOVE_FILE = 0x0020
+    ACCESS_FS_MAKE_CHAR = 0x0040
+    ACCESS_FS_MAKE_DIR = 0x0080
+    ACCESS_FS_MAKE_REG = 0x0100
+    ACCESS_FS_MAKE_SOCK = 0x0200
+    ACCESS_FS_MAKE_FIFO = 0x0400
+    ACCESS_FS_MAKE_BLOCK = 0x0800
+    ACCESS_FS_MAKE_SYM = 0x1000
+    ACCESS_FS_REFER = 0x2000
+    ACCESS_FS_TRUNCATE = 0x4000
+    ACCESS_FS_IOCTL_DEV = 0x8000
+    ACCESS_FS_RESOLVE_UNIX = 0x10000
+
+    ACCESS_NET_BIND_TCP = 0x01
+    ACCESS_NET_CONNECT_TCP = 0x02
+    ACCESS_NET_BIND_UDP = 0x04
+    ACCESS_NET_CONNECT_SEND_UDP = 0x08
+    SCOPE_ABSTRACT_UNIX_SOCKET = 0x01
+    # ABI 3 is the first version that can restrict both cross-directory
+    # renames and truncation:
+    # https://www.kernel.org/doc/html/latest/userspace-api/landlock.html#previous-limitations
+    MINIMUM_ABI = 3
+    # UDP controls required to block all network access were added in ABI 10:
+    # https://www.kernel.org/doc/html/latest/userspace-api/landlock.html#network-flags
+    MINIMUM_FULL_NETWORK_ABI = 10
+
+    WRITE_ACCESS_FS = T.let(
+      (ACCESS_FS_WRITE_FILE | ACCESS_FS_REMOVE_DIR | ACCESS_FS_REMOVE_FILE | ACCESS_FS_MAKE_CHAR |
+      ACCESS_FS_MAKE_DIR | ACCESS_FS_MAKE_REG | ACCESS_FS_MAKE_SOCK | ACCESS_FS_MAKE_FIFO |
+      ACCESS_FS_MAKE_BLOCK | ACCESS_FS_MAKE_SYM).freeze,
+      Integer,
+    )
+    FILE_WRITE_ACCESS_FS = T.let((ACCESS_FS_WRITE_FILE | ACCESS_FS_TRUNCATE).freeze, Integer)
+    FILE_READ_ACCESS_FS = T.let((ACCESS_FS_EXECUTE | ACCESS_FS_READ_FILE).freeze, Integer)
+    READ_ACCESS_FS = T.let((ACCESS_FS_EXECUTE | ACCESS_FS_READ_FILE | ACCESS_FS_READ_DIR).freeze, Integer)
+    private_constant :CREATE_RULESET_VERSION, :RULE_PATH_BENEATH, :PR_SET_NO_NEW_PRIVS, :O_PATH, :O_CLOEXEC,
+                     :CREATE_RULESET_SYSCALL, :ADD_RULE_SYSCALL, :RESTRICT_SELF_SYSCALL,
+                     :ACCESS_FS_EXECUTE, :ACCESS_FS_WRITE_FILE, :ACCESS_FS_READ_FILE, :ACCESS_FS_READ_DIR,
+                     :ACCESS_FS_REMOVE_DIR, :ACCESS_FS_REMOVE_FILE, :ACCESS_FS_MAKE_CHAR, :ACCESS_FS_MAKE_DIR,
+                     :ACCESS_FS_MAKE_REG, :ACCESS_FS_MAKE_SOCK, :ACCESS_FS_MAKE_FIFO, :ACCESS_FS_MAKE_BLOCK,
+                     :ACCESS_FS_MAKE_SYM, :ACCESS_FS_REFER, :ACCESS_FS_TRUNCATE, :ACCESS_FS_RESOLVE_UNIX,
+                     :ACCESS_FS_IOCTL_DEV,
+                     :ACCESS_NET_BIND_TCP, :ACCESS_NET_CONNECT_TCP, :ACCESS_NET_BIND_UDP,
+                     :ACCESS_NET_CONNECT_SEND_UDP, :SCOPE_ABSTRACT_UNIX_SOCKET, :MINIMUM_ABI,
+                     :MINIMUM_FULL_NETWORK_ABI, :WRITE_ACCESS_FS, :FILE_WRITE_ACCESS_FS, :FILE_READ_ACCESS_FS,
+                     :READ_ACCESS_FS
+
+    class << self
+      # Landlock cannot restrict chmod, chown, extended attributes or timestamp
+      # changes. Callers requiring Bubblewrap-equivalent write isolation must
+      # compensate for these limitations:
+      # https://www.kernel.org/doc/html/latest/userspace-api/landlock.html#filesystem-flags
+      sig { returns(T::Boolean) }
+      def full_write_isolation? = false
+
+      sig { returns(T::Boolean) }
+      def available?
+        state == :available
+      end
+
+      sig { returns(Symbol) }
+      def state
+        @state ||= T.let(compute_state, T.nilable(Symbol))
+      end
+
+      sig { returns(T.nilable(Integer)) }
+      def abi_version
+        state
+        @abi_version
+      end
+
+      sig { returns(T.nilable(String)) }
+      def failure_reason
+        case state
+        when :available
+          nil
+        when :missing_fiddle
+          "Landlock requires Ruby's bundled Fiddle library."
+        when :unsupported
+          "Landlock is not supported by this Linux kernel."
+        when :disabled
+          "Landlock is disabled by this Linux kernel."
+        when :unsupported_abi
+          abi = @abi_version
+          if abi
+            "Landlock ABI #{MINIMUM_ABI} or later is required; found ABI #{abi}."
+          else
+            "Landlock ABI #{MINIMUM_ABI} or later is required."
+          end
+        else
+          "Landlock is not available."
+        end
+      end
+
+      sig { void }
+      def reset_state!
+        @state = T.let(nil, T.nilable(Symbol))
+        @abi_version = T.let(nil, T.nilable(Integer))
+      end
+
+      sig { params(install_from_tests: T::Boolean).void }
+      def ensure_installed!(install_from_tests: false); end
+
+      sig { void }
+      def configure!
+        ensure_available!
+      end
+
+      sig { returns(T::Array[String]) }
+      def configuration_commands = []
+
+      sig { returns(T::Array[String]) }
+      def configuration_command_messages = []
+
+      sig { returns(T.nilable(String)) }
+      def install_command = nil
+
+      sig { returns(T::Boolean) }
+      def nested_sandbox? = false
+
+      sig { params(attributes: T.nilable(String), size: Integer, flags: Integer).returns(Integer) }
+      def landlock_create_ruleset(attributes, size, flags)
+        @landlock_create_ruleset ||= T.let(
+          Fiddle::Function.new(
+            Fiddle.dlopen(nil)["syscall"],
+            [Fiddle::TYPE_LONG, Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T, Fiddle::TYPE_UINT],
+            Fiddle::TYPE_LONG,
+          ),
+          T.nilable(Fiddle::Function),
+        )
+        @landlock_create_ruleset.call(CREATE_RULESET_SYSCALL, attributes, size, flags)
+      end
+
+      sig { params(ruleset_fd: Integer, type: Integer, attributes: String, flags: Integer).returns(Integer) }
+      def landlock_add_rule(ruleset_fd, type, attributes, flags)
+        @landlock_add_rule ||= T.let(
+          Fiddle::Function.new(
+            Fiddle.dlopen(nil)["syscall"],
+            [Fiddle::TYPE_LONG, Fiddle::TYPE_INT, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_UINT],
+            Fiddle::TYPE_LONG,
+          ),
+          T.nilable(Fiddle::Function),
+        )
+        @landlock_add_rule.call(ADD_RULE_SYSCALL, ruleset_fd, type, attributes, flags)
+      end
+
+      sig { params(ruleset_fd: Integer, flags: Integer).returns(Integer) }
+      def landlock_restrict_self(ruleset_fd, flags)
+        @landlock_restrict_self ||= T.let(
+          Fiddle::Function.new(
+            Fiddle.dlopen(nil)["syscall"],
+            [Fiddle::TYPE_LONG, Fiddle::TYPE_INT, Fiddle::TYPE_UINT],
+            Fiddle::TYPE_LONG,
+          ),
+          T.nilable(Fiddle::Function),
+        )
+        @landlock_restrict_self.call(RESTRICT_SELF_SYSCALL, ruleset_fd, flags)
+      end
+
+      sig { returns(Integer) }
+      def set_no_new_privileges
+        @prctl ||= T.let(
+          Fiddle::Function.new(
+            Fiddle.dlopen(nil)["prctl"],
+            [Fiddle::TYPE_INT, Fiddle::TYPE_ULONG, Fiddle::TYPE_ULONG, Fiddle::TYPE_ULONG, Fiddle::TYPE_ULONG],
+            Fiddle::TYPE_INT,
+          ),
+          T.nilable(Fiddle::Function),
+        )
+        @prctl.call(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)
+      end
+
+      sig { params(path: String).returns(Integer) }
+      def open_path(path)
+        @open ||= T.let(
+          Fiddle::Function.new(
+            Fiddle.dlopen(nil)["open"],
+            [Fiddle::TYPE_CONST_STRING, Fiddle::TYPE_INT],
+            Fiddle::TYPE_INT,
+          ),
+          T.nilable(Fiddle::Function),
+        )
+        @open.call(path, O_PATH | O_CLOEXEC)
+      end
+
+      sig { params(file_descriptor: Integer).returns(Integer) }
+      def close_file_descriptor(file_descriptor)
+        @close ||= T.let(
+          Fiddle::Function.new(
+            Fiddle.dlopen(nil)["close"],
+            [Fiddle::TYPE_INT],
+            Fiddle::TYPE_INT,
+          ),
+          T.nilable(Fiddle::Function),
+        )
+        @close.call(file_descriptor)
+      end
+
+      sig { returns(Integer) }
+      def last_error
+        Fiddle.last_error
+      end
+
+      private
+
+      sig { void }
+      def ensure_available!
+        return if available?
+
+        raise failure_reason || "Landlock is not available."
+      end
+
+      sig { returns(Symbol) }
+      def compute_state
+        begin
+          require "fiddle"
+        rescue LoadError
+          return :missing_fiddle
+        end
+
+        version = landlock_create_ruleset(nil, 0, CREATE_RULESET_VERSION)
+        if version.positive?
+          @abi_version = T.let(version, T.nilable(Integer))
+          if version >= MINIMUM_ABI
+            :available
+          else
+            :unsupported_abi
+          end
+        else
+          case last_error
+          when Errno::ENOSYS::Errno then :unsupported
+          when Errno::EOPNOTSUPP::Errno then :disabled
+          else                               :unavailable
+          end
+        end
+      end
+    end
+
+    sig { params(profile: SandboxProfile).void }
+    def initialize(profile)
+      super
+      @writable_paths = T.let([], T::Array[String])
+      @readable_paths = T.let([], T::Array[String])
+      @error_pipe_path = T.let(nil, T.nilable(String))
+      @deny_all_network = T.let(false, T::Boolean)
+      @deny_read = T.let(false, T::Boolean)
+    end
+
+    sig { params(args: T::Array[T.any(String, ::Pathname)], tmpdir: String).returns(T::Array[T.any(String, ::Pathname)]) }
+    def command(args, tmpdir)
+      paths = writable_paths
+      @writable_paths = paths.keys | [File::NULL, tmpdir]
+      @writable_paths.each { |path| prepare_writable_path(path, paths.fetch(path, :subpath)) }
+      denied_read_paths = self.denied_read_paths
+      @readable_paths = readable_paths(denied_read_paths)
+      @deny_read = denied_read_paths.any?
+      @deny_all_network = deny_all_network?
+      @error_pipe_path = File.join(tmpdir, "socket")
+      args
+    end
+
+    sig { void }
+    def apply!
+      abi = self.class.abi_version
+      if !abi || abi < MINIMUM_ABI
+        raise self.class.failure_reason || "Landlock ABI #{MINIMUM_ABI} or later is required."
+      end
+
+      if @deny_all_network && abi < MINIMUM_FULL_NETWORK_ABI
+        opoo "Landlock ABI #{MINIMUM_FULL_NETWORK_ABI} or later is required to deny all network access; " \
+             "found ABI #{abi}. Applying the network restrictions supported by this kernel."
+      end
+
+      attributes, handled_access_fs, allowed_write_access_fs = ruleset_attributes(abi)
+      ruleset_fd = self.class.landlock_create_ruleset(attributes, attributes.bytesize, 0)
+      raise_system_call_error("landlock_create_ruleset") if ruleset_fd.negative?
+
+      begin
+        error_pipe_path = @error_pipe_path
+        if @deny_all_network && abi >= 9 && error_pipe_path
+          add_path_rule(ruleset_fd, error_pipe_path, ACCESS_FS_RESOLVE_UNIX)
+        end
+        @readable_paths.each do |path|
+          allowed_access = File.directory?(path) ? READ_ACCESS_FS : FILE_READ_ACCESS_FS
+          add_path_rule(ruleset_fd, path, allowed_access)
+        end
+        @writable_paths.each do |path|
+          allowed_access = if File.directory?(path)
+            allowed_write_access_fs
+          else
+            allowed_write_access_fs & FILE_WRITE_ACCESS_FS
+          end
+          add_path_rule(ruleset_fd, path, allowed_access & handled_access_fs)
+        end
+
+        raise_system_call_error("prctl") if self.class.set_no_new_privileges.negative?
+        if self.class.landlock_restrict_self(ruleset_fd, 0).negative?
+          raise_system_call_error("landlock_restrict_self")
+        end
+      ensure
+        close_file_descriptor(ruleset_fd)
+      end
+    end
+
+    private
+
+    sig { params(abi: Integer).returns([String, Integer, Integer]) }
+    def ruleset_attributes(abi)
+      allowed_access_fs = WRITE_ACCESS_FS
+      allowed_access_fs |= ACCESS_FS_REFER if abi >= 2
+      allowed_access_fs |= ACCESS_FS_TRUNCATE if abi >= 3
+      handled_access_fs = allowed_access_fs
+      # IOCTL_DEV is available from ABI 5 and deliberately remains absent from
+      # allowed path rules, denying device ioctls opened inside the sandbox:
+      # https://www.kernel.org/doc/html/latest/userspace-api/landlock.html#ioctl-support
+      handled_access_fs |= ACCESS_FS_IOCTL_DEV if abi >= 5
+      handled_access_fs |= READ_ACCESS_FS if @deny_read
+      handled_access_fs |= ACCESS_FS_RESOLVE_UNIX if @deny_all_network && abi >= 9
+
+      # Optional ruleset fields are appended as `__u64` members, so only pass
+      # the prefix needed for features supported by the running kernel.
+      attributes = [handled_access_fs]
+      if @deny_all_network && abi >= 4
+        handled_access_net = ACCESS_NET_BIND_TCP | ACCESS_NET_CONNECT_TCP
+        handled_access_net |= ACCESS_NET_BIND_UDP | ACCESS_NET_CONNECT_SEND_UDP if abi >= MINIMUM_FULL_NETWORK_ABI
+        attributes << handled_access_net
+        attributes << SCOPE_ABSTRACT_UNIX_SOCKET if abi >= 6
+      end
+
+      [attributes.pack("Q*"), handled_access_fs, allowed_access_fs]
+    end
+
+    sig { params(ruleset_fd: Integer, path: String, allowed_access: Integer).void }
+    def add_path_rule(ruleset_fd, path, allowed_access)
+      path_fd = open_path(path)
+      result = self.class.landlock_add_rule(
+        ruleset_fd,
+        RULE_PATH_BENEATH,
+        # The packed UAPI struct has no padding or reserved field: one `__u64`
+        # access mask followed by one `__s32` file descriptor.
+        [allowed_access, path_fd].pack("Ql"),
+        0,
+      )
+      raise_system_call_error("landlock_add_rule") if result.negative?
+    ensure
+      close_file_descriptor(path_fd) if path_fd
+    end
+
+    sig { returns(T::Array[::Pathname]) }
+    def denied_read_paths
+      profile_paths(allow: false, operation: "file-read").filter_map do |path|
+        pathname = ::Pathname.new(path)
+        pathname.lstat
+        pathname
+      rescue Errno::ENOENT
+        nil
+      end
+    end
+
+    sig { params(denied_paths: T::Array[::Pathname]).returns(T::Array[String]) }
+    def readable_paths(denied_paths)
+      return [] if denied_paths.empty? || denied_paths.include?(root_path)
+
+      root_path.children.sort.each_with_object([]) do |path, paths|
+        add_readable_path(path, denied_paths, paths)
+      end
+    end
+
+    sig { params(path: ::Pathname, denied_paths: T::Array[::Pathname], paths: T::Array[String]).void }
+    def add_readable_path(path, denied_paths, paths)
+      return if denied_paths.include?(path)
+
+      path_stat = path.lstat
+      return if path_stat.symlink?
+
+      if path_stat.directory? && denied_paths.any? { |denied_path| denied_path.ascend.include?(path) }
+        path.children.sort.each { |child| add_readable_path(child, denied_paths, paths) }
+      else
+        paths << path.to_s
+      end
+    rescue Errno::EACCES, Errno::ENOENT
+      nil
+    end
+
+    sig { returns(::Pathname) }
+    def root_path
+      ::Pathname.new("/")
+    end
+
+    sig { params(path: String).returns(Integer) }
+    def open_path(path)
+      file_descriptor = self.class.open_path(path)
+      raise_system_call_error("open") if file_descriptor.negative?
+
+      file_descriptor
+    end
+
+    sig { params(file_descriptor: Integer).void }
+    def close_file_descriptor(file_descriptor)
+      raise_system_call_error("close") if self.class.close_file_descriptor(file_descriptor).negative?
+    end
+
+    sig { params(operation: String).void }
+    def raise_system_call_error(operation)
+      raise SystemCallError.new(operation, self.class.last_error)
+    end
+  end
+end

--- a/Library/Homebrew/extend/os/linux/sandbox/landlock.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox/landlock.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "fileutils"
+require "env_config"
 require "utils/output"
 require "extend/os/linux/sandbox/backend"
 
@@ -111,6 +112,8 @@ class Sandbox
         case state
         when :available
           nil
+        when :config_disabled
+          "Landlock cannot be used because Linux sandboxing is disabled."
         when :missing_fiddle
           "Landlock requires Ruby's bundled Fiddle library."
         when :unsupported
@@ -249,6 +252,8 @@ class Sandbox
 
       sig { returns(Symbol) }
       def compute_state
+        return :config_disabled unless Homebrew::EnvConfig.sandbox_linux?
+
         begin
           require "fiddle"
         rescue LoadError

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1418,24 +1418,26 @@ on_request: installed_on_request?, options:)
 
     args << post_install_formula_path
 
-    if use_sandbox?("running post-install")
-      sandbox = Sandbox.new
-      formula.logs.mkpath
-      sandbox.record_log(formula.logs/"postinstall.sandbox.log")
-      sandbox.allow_write_temp_and_cache
-      sandbox.allow_write_log(formula)
-      sandbox.allow_write_xcode
-      sandbox.deny_write_homebrew_repository
-      sandbox.deny_read_home
-      sandbox.allow_write_cellar(formula)
-      sandbox.deny_all_network unless formula.network_access_allowed?(:postinstall)
-      Keg.keg_link_directories.each do |dir|
-        sandbox.allow_write_path "#{HOMEBREW_PREFIX}/#{dir}"
-      end
-      sandbox.run(*args)
-    else
-      Utils.safe_fork do
-        exec(*args)
+    with_preserved_brew_file do
+      if use_sandbox?("running post-install")
+        sandbox = Sandbox.new
+        formula.logs.mkpath
+        sandbox.record_log(formula.logs/"postinstall.sandbox.log")
+        sandbox.allow_write_temp_and_cache
+        sandbox.allow_write_log(formula)
+        sandbox.allow_write_xcode
+        sandbox.deny_write_homebrew_repository
+        sandbox.deny_read_home
+        sandbox.allow_write_cellar(formula)
+        sandbox.deny_all_network unless formula.network_access_allowed?(:postinstall)
+        Keg.keg_link_directories.each do |dir|
+          sandbox.allow_write_path "#{HOMEBREW_PREFIX}/#{dir}"
+        end
+        sandbox.run(*args)
+      else
+        Utils.safe_fork do
+          exec(*args)
+        end
       end
     end
   # Handle all possible exceptions when postinstall does not complete.
@@ -1835,6 +1837,42 @@ on_request: installed_on_request?, options:)
   end
 
   private
+
+  # Landlock cannot protect `bin/brew` while allowing post-install writes to
+  # `bin`, so a malicious post-install could replace `brew` to persist into
+  # later invocations. Snapshot and restore the entry, using a pre-opened `bin`
+  # descriptor to restore its mode before repairing the entry if needed.
+  sig { params(block: T.proc.void).void }
+  def with_preserved_brew_file(&block)
+    return yield if Sandbox.full_write_isolation?
+
+    brew_file = HOMEBREW_PREFIX/"bin/brew"
+    File.open(brew_file.dirname) do |brew_directory|
+      brew_directory_mode = brew_directory.stat.mode & 07777
+      symlink = brew_file.symlink?
+      contents = if symlink
+        brew_file.readlink.to_s
+      else
+        brew_file.binread
+      end
+      brew_file_mode = brew_file.lstat.mode & 07777
+
+      begin
+        yield
+      ensure
+        brew_directory.chmod brew_directory_mode
+        if symlink && (!brew_file.symlink? || brew_file.readlink.to_s != contents)
+          FileUtils.rm_rf brew_file
+          brew_file.make_symlink contents
+        elsif !symlink && (brew_file.symlink? || !brew_file.file? || brew_file.binread != contents ||
+                           (brew_file.lstat.mode & 07777) != brew_file_mode)
+          FileUtils.rm_rf brew_file
+          brew_file.atomic_write contents
+          brew_file.chmod brew_file_mode
+        end
+      end
+    end
+  end
 
   # Whether to run the given install `step` (e.g. `"building"`) inside
   # Homebrew's sandbox. Warns when it will not: noting reliance on the outer

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -125,11 +125,9 @@ class GitHubRunnerMatrix
     end
 
     unless self_hosted
-      options = %w[--user linuxbrew]
-      options << "--privileged" if Homebrew::EnvConfig.sandbox_linux?
       container = {
         image:   "ghcr.io/homebrew/brew:main",
-        options: options.join(" "),
+        options: "--user linuxbrew --env HOMEBREW_SANDBOX_LINUX_LANDLOCK=1",
       }
       workdir = "/github/home"
     end

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -80,6 +80,9 @@ class Sandbox
     false
   end
 
+  sig { returns(T::Boolean) }
+  def self.full_write_isolation? = true
+
   # Whether Homebrew is itself running inside another sandbox, which would make
   # its own nested sandbox hang (macOS) or fail to start (Linux). Overridden
   # per-OS.
@@ -516,7 +519,7 @@ class Sandbox
             end
 
             stdout_thread = Thread.new do
-              controller.each_char { |c| print(c) }
+              copy_pty_output(controller)
             end
 
             Utils.safe_fork(directory: tmpdir, yield_parent: true) do |error_pipe|
@@ -534,6 +537,7 @@ class Sandbox
                 Dir.chdir(tmpdir)
 
                 worker.close_on_exec = true
+                apply_sandbox
                 exec(*command, in: worker, out: worker, err: worker) # And map everything to the PTY.
               else
                 # Parent side
@@ -622,6 +626,17 @@ class Sandbox
 
   sig { void }
   def ensure_child_tty_available; end
+
+  sig { void }
+  def apply_sandbox; end
+
+  sig { params(controller: IO).void }
+  def copy_pty_output(controller)
+    controller.each_char { |c| print(c) }
+  rescue Errno::EIO
+    # Linux marks a PTY as an I/O error when its peer closes, so treat this as EOF:
+    # https://github.com/torvalds/linux/blob/master/drivers/tty/pty.c
+  end
 
   sig { void }
   def record_sandbox_log; end

--- a/Library/Homebrew/test/bash_spec.rb
+++ b/Library/Homebrew/test/bash_spec.rb
@@ -19,9 +19,24 @@ RSpec.describe "Bash" do
   end
 
   describe "brew" do
-    subject { HOMEBREW_LIBRARY_PATH.parent.parent/"bin/brew" }
+    subject(:brew) { HOMEBREW_LIBRARY_PATH.parent.parent/"bin/brew" }
 
     it { is_expected.to have_valid_bash_syntax }
+
+    it "selects Landlock on self-hosted Linux GitHub Actions runners", :needs_linux do
+      stdout, stderr, status = Open3.capture3(
+        {
+          "CI"                                  => "1",
+          "GITHUB_ACTIONS"                      => "true",
+          "GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED" => "1",
+          "HOMEBREW_DEV_CMD_RUN"                => "1",
+          "HOMEBREW_SANDBOX_LINUX_LANDLOCK"     => nil,
+        },
+        brew.to_s, "ruby", "--", "-e", "print OS::Linux::Sandbox.sandbox_implementation"
+      )
+
+      expect([stdout, stderr, status.success?]).to eq(["Sandbox::Landlock", "", true])
+    end
   end
 
   describe "every `.sh` file" do

--- a/Library/Homebrew/test/dev-cmd/test_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/test_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Homebrew::DevCmd::Test do
     (HOMEBREW_LINKED_KEGS/formula_name).make_relative_symlink(Formula[formula_name].prefix)
 
     expect { brew "test", "--verbose", formula_name, "HOMEBREW_NO_INSTALL_FROM_API" => "1" }
-      .to output(/curl: \(6\) Could not resolve host: example\.org/).to_stdout
+      .to output(/curl: \((?:6\) Could not resolve host:|7\) Failed to connect to) example\.org/).to_stdout
       .and be_a_failure
   end
 end

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -145,6 +145,42 @@ RSpec.describe FormulaInstaller do
     end
   end
 
+  describe "#post_install" do
+    it "restores bin/brew after a Landlock-sandboxed post-install replaces it" do
+      prefix = mktmpdir
+      stub_const("HOMEBREW_PREFIX", prefix)
+      brew_file = prefix/"bin/brew"
+      original_brew_file = prefix/"Homebrew/bin/brew"
+      original_brew_file.dirname.mkpath
+      original_brew_file.write "#!/bin/sh\n"
+      brew_file.dirname.mkpath
+      brew_file.make_relative_symlink original_brew_file
+      original_target = brew_file.readlink
+      original_directory_mode = brew_file.dirname.stat.mode & 07777
+      formula = formula("replace-brew-postinstall") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      installer = described_class.new(formula)
+      sandbox = instance_double(Sandbox).as_null_object
+
+      allow(installer).to receive_messages(post_install_formula_path: formula.path, use_sandbox?: true)
+      allow(formula).to receive_messages(logs: mktmpdir, network_access_allowed?: true)
+      allow(Sandbox).to receive_messages(full_write_isolation?: false, new: sandbox)
+      allow(sandbox).to receive(:run) do
+        FileUtils.rm_f brew_file
+        brew_file.write "malicious\n"
+        brew_file.dirname.chmod 0500
+      end
+
+      installer.post_install
+
+      expect(brew_file).to be_a_symlink
+      expect(brew_file.readlink).to eq(original_target)
+      expect(brew_file.dirname.stat.mode & 07777).to eq(original_directory_mode)
+    end
+  end
+
   describe "#pour" do
     let(:f) do
       formula("missing-bottle-tab") do

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -49,6 +49,19 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
                        .respond_to?(:to_json),
       ).to be(true)
     end
+
+    it "uses Landlock in unprivileged Linux containers" do
+      linux_containers = described_class.new([], ["deleted"], all_supported: false, dependent_matrix: false)
+                                        .active_runner_specs_hash
+                                        .filter_map { |runner| runner[:container] }
+
+      expect(linux_containers).to eq(Array.new(2) do
+        {
+          image:   "ghcr.io/homebrew/brew:main",
+          options: "--user linuxbrew --env HOMEBREW_SANDBOX_LINUX_LANDLOCK=1",
+        }
+      end)
+    end
   end
 
   describe "#generate_runners!" do

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe DependencyCollector do
     end
 
     around do |example|
-      with_env(HOMEBREW_TESTS: nil) { example.run }
+      with_env(HOMEBREW_SANDBOX_LINUX_LANDLOCK: nil, HOMEBREW_TESTS: nil) { example.run }
     end
 
     before do
@@ -87,6 +87,12 @@ RSpec.describe DependencyCollector do
       allow(Sandbox).to receive(:executable).and_return(Pathname("/usr/bin/bwrap"))
 
       expect(collector.bubblewrap_dep_if_needed(Set.new)).to be_nil
+    end
+
+    it "returns nil when using Landlock" do
+      with_env(HOMEBREW_SANDBOX_LINUX_LANDLOCK: "1") do
+        expect(collector.bubblewrap_dep_if_needed(Set.new)).to be_nil
+      end
     end
 
     it "returns nil for Bubblewrap and its dependencies" do

--- a/Library/Homebrew/test/os/linux/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/linux/diagnostic_spec.rb
@@ -7,6 +7,10 @@ require "sandbox"
 RSpec.describe Homebrew::Diagnostic::Checks do
   subject(:checks) { described_class.new }
 
+  around do |example|
+    with_env(HOMEBREW_SANDBOX_LINUX_LANDLOCK: nil) { example.run }
+  end
+
   before do
     allow(OS::Linux).to receive(:inside_docker?).and_return(false)
   end
@@ -154,6 +158,21 @@ RSpec.describe Homebrew::Diagnostic::Checks do
           "export HOMEBREW_NO_SANDBOX_LINUX=1",
         )
       expect(message).to end_with("  export HOMEBREW_NO_SANDBOX_LINUX=1\n")
+    end
+  end
+
+  specify "#check_linux_sandbox describes unavailable Landlock" do
+    allow(OS::Linux).to receive(:inside_docker?).and_return(true)
+    allow(Sandbox).to receive_messages(
+      state:          :unsupported,
+      failure_reason: "Landlock is not supported by this Linux kernel.",
+    )
+
+    with_env(GITHUB_ACTIONS: "true", HOMEBREW_NO_SANDBOX_LINUX: nil, HOMEBREW_SANDBOX_LINUX_LANDLOCK: "1") do
+      message = checks.check_linux_sandbox
+
+      expect(message).to include("Landlock is not supported by this Linux kernel.")
+      expect(message).not_to include("Bubblewrap", "--privileged")
     end
   end
 

--- a/Library/Homebrew/test/sandbox_landlock_spec.rb
+++ b/Library/Homebrew/test/sandbox_landlock_spec.rb
@@ -1,0 +1,257 @@
+# typed: true
+# frozen_string_literal: true
+
+require "sandbox"
+require "extend/os/linux/sandbox/landlock"
+
+RSpec.describe Sandbox::Landlock do
+  subject(:landlock) { described_class.new(sandbox.send(:profile)) }
+
+  let(:sandbox) { Sandbox.new }
+
+  around do |example|
+    described_class.reset_state!
+    example.run
+  ensure
+    described_class.reset_state!
+  end
+
+  describe "::available?" do
+    it "declares its weaker write-isolation contract" do
+      expect(described_class.full_write_isolation?).to be(false)
+    end
+
+    it "reports the supported Landlock ABI" do
+      allow(described_class).to receive(:landlock_create_ruleset).with(nil, 0, 1).and_return(4)
+
+      expect(described_class).to be_available
+      expect(described_class.state).to eq(:available)
+      expect(described_class.abi_version).to eq(4)
+      expect(described_class.failure_reason).to be_nil
+    end
+
+    it "returns false for a kernel without Landlock support" do
+      allow(described_class).to receive(:landlock_create_ruleset).with(nil, 0, 1).and_return(-1)
+      allow(described_class).to receive(:last_error).and_return(Errno::ENOSYS::Errno)
+
+      expect(described_class).not_to be_available
+      expect(described_class.state).to eq(:unsupported)
+      expect(described_class.failure_reason).to include("not supported by this Linux kernel")
+    end
+
+    it "returns false when Landlock is disabled by the kernel configuration" do
+      allow(described_class).to receive(:landlock_create_ruleset).with(nil, 0, 1).and_return(-1)
+      allow(described_class).to receive(:last_error).and_return(Errno::EOPNOTSUPP::Errno)
+
+      expect(described_class).not_to be_available
+      expect(described_class.state).to eq(:disabled)
+      expect(described_class.failure_reason).to include("disabled by this Linux kernel")
+    end
+
+    it "returns false when Fiddle is unavailable" do
+      allow(described_class).to receive(:require).with("fiddle").and_raise(LoadError)
+
+      expect(described_class).not_to be_available
+      expect(described_class.state).to eq(:missing_fiddle)
+      expect(described_class.failure_reason).to include("Fiddle")
+    end
+
+    it "returns false for an ABI without truncate restrictions" do
+      allow(described_class).to receive(:landlock_create_ruleset).with(nil, 0, 1).and_return(2)
+
+      expect(described_class).not_to be_available
+      expect(described_class.state).to eq(:unsupported_abi)
+      expect(described_class.abi_version).to eq(2)
+      expect(described_class.failure_reason).to eq("Landlock ABI 3 or later is required; found ABI 2.")
+    end
+
+    it "only raises when explicitly configuring unavailable Landlock" do
+      allow(described_class).to receive_messages(available?: false, failure_reason: "Landlock is not available.")
+
+      expect { described_class.ensure_installed! }.not_to raise_error
+      expect { described_class.configure! }.to raise_error(RuntimeError, "Landlock is not available.")
+    end
+  end
+
+  describe "#apply!" do
+    let(:writable_dir) { mktmpdir }
+    let(:tmpdir) { mktmpdir }
+
+    it "rejects an ABI without complete write restrictions" do
+      allow(described_class).to receive_messages(abi_version:    2,
+                                                 failure_reason: "Landlock ABI 3 or later is required; found ABI 2.")
+      expect(described_class).not_to receive(:landlock_create_ruleset)
+
+      expect { landlock.apply! }
+        .to raise_error(RuntimeError, "Landlock ABI 3 or later is required; found ABI 2.")
+    end
+
+    it "restricts writes and network access using the supported ABI" do
+      sandbox.allow_write_path writable_dir
+      sandbox.deny_all_network
+      landlock.command(["true"], tmpdir.to_s)
+
+      allow(described_class).to receive(:abi_version).and_return(10)
+      expect(described_class).to receive(:landlock_create_ruleset) do |attributes, size, flags|
+        expect(attributes.unpack("Q3")).to eq([131_058, 15, 1])
+        expect(size).to eq(24)
+        expect(flags).to eq(0)
+        17
+      end
+      allow(landlock).to receive(:open_path).with(writable_dir.to_s).and_return(18)
+      expect(landlock).to receive(:open_path).with(File::NULL).and_return(19)
+      allow(landlock).to receive(:open_path).with(tmpdir.to_s).and_return(20)
+      expect(landlock).to receive(:open_path).with("#{tmpdir}/socket").and_return(21)
+      path_rules = []
+      expect(described_class).to receive(:landlock_add_rule).exactly(4).times do |ruleset_fd, type, attributes, flags|
+        expect(ruleset_fd).to eq(17)
+        expect(type).to eq(1)
+        expect(attributes.bytesize).to eq(12)
+        path_rules << attributes.unpack("Ql")
+        expect(flags).to eq(0)
+        0
+      end
+      expect(described_class).to receive(:set_no_new_privileges).and_return(0)
+      expect(described_class).to receive(:landlock_restrict_self).with(17, 0).and_return(0)
+      expect(landlock).to receive(:close_file_descriptor).with(21).ordered
+      expect(landlock).to receive(:close_file_descriptor).with(18).ordered
+      expect(landlock).to receive(:close_file_descriptor).with(19).ordered
+      expect(landlock).to receive(:close_file_descriptor).with(20).ordered
+      expect(landlock).to receive(:close_file_descriptor).with(17).ordered
+
+      landlock.apply!
+
+      expect(path_rules).to eq([[65_536, 21], [32_754, 18], [16_386, 19], [32_754, 20]])
+    end
+
+    it "handles reads, directory listings, and execution outside denied hierarchies" do
+      readable_dir = mktmpdir
+      readable_file = readable_dir/"file"
+      readable_file.write("content")
+      denied_dir = mktmpdir
+      sandbox.deny_read_path denied_dir
+      allow(landlock).to receive(:readable_paths).with([denied_dir])
+                                                 .and_return([readable_dir.to_s, readable_file.to_s])
+      landlock.command(["true"], tmpdir.to_s)
+
+      allow(described_class).to receive(:abi_version).and_return(10)
+      expect(described_class).to receive(:landlock_create_ruleset) do |attributes, size, flags|
+        expect(attributes.unpack("Q")).to eq([65_535])
+        expect(size).to eq(8)
+        expect(flags).to eq(0)
+        17
+      end
+      expect(landlock).to receive(:open_path).with(readable_dir.to_s).and_return(18)
+      expect(landlock).to receive(:open_path).with(readable_file.to_s).and_return(19)
+      expect(landlock).to receive(:open_path).with(File::NULL).and_return(20)
+      expect(landlock).to receive(:open_path).with(tmpdir.to_s).and_return(21)
+      path_rules = []
+      expect(described_class).to receive(:landlock_add_rule).exactly(4).times do |ruleset_fd, type, attributes, flags|
+        expect(ruleset_fd).to eq(17)
+        expect(type).to eq(1)
+        path_rules << attributes.unpack("Ql")
+        expect(flags).to eq(0)
+        0
+      end
+      expect(described_class).to receive(:set_no_new_privileges).and_return(0)
+      expect(described_class).to receive(:landlock_restrict_self).with(17, 0).and_return(0)
+      allow(landlock).to receive(:close_file_descriptor)
+
+      landlock.apply!
+
+      expect(path_rules).to eq([[13, 18], [5, 19], [16_386, 20], [32_754, 21]])
+    end
+
+    context "with an older ABI" do
+      before do
+        allow(landlock).to receive(:open_path).and_return(18)
+        allow(described_class).to receive_messages(abi_version: 7, landlock_create_ruleset: 17, landlock_add_rule: 0,
+                                                   set_no_new_privileges: 0, landlock_restrict_self: 0)
+        allow(landlock).to receive(:close_file_descriptor)
+      end
+
+      it "warns when applying incomplete network denial" do
+        sandbox.deny_all_network
+        landlock.command(["true"], tmpdir.to_s)
+
+        expect { landlock.apply! }
+          .to output(/Landlock ABI 10 or later is required to deny all network access; found ABI 7/).to_stderr
+      end
+
+      it "does not warn before applying network denial" do
+        sandbox.deny_all_network
+
+        expect { landlock.command(["true"], tmpdir.to_s) }.not_to output.to_stderr
+      end
+
+      it "does not warn without network denial" do
+        landlock.command(["true"], tmpdir.to_s)
+
+        expect { landlock.apply! }.not_to output.to_stderr
+      end
+
+      it "uses the supported network access rights" do
+        sandbox.deny_all_network
+        landlock.command(["true"], tmpdir.to_s)
+
+        attributes, = landlock.send(:ruleset_attributes, 7)
+
+        expect(attributes.unpack("Q3")).to eq([65_522, 3, 1])
+      end
+    end
+  end
+
+  describe "#command" do
+    it "prepares missing writable directories and removes them after running" do
+      writable_dir = mktmpdir/"created"
+      sandbox.allow_write_path writable_dir
+
+      expect(landlock.command(["true"], mktmpdir.to_s)).to eq(["true"])
+      expect(writable_dir).to be_a_directory
+
+      landlock.run { nil }
+
+      expect(writable_dir).not_to exist
+    end
+
+    it "rejects regex path filters" do
+      sandbox.allow_write path: "^/tmp/homebrew-[^/]+$", type: :regex
+
+      expect { landlock.command(["true"], mktmpdir.to_s) }
+        .to raise_error(ArgumentError, /Linux sandbox does not support regex path filters/)
+    end
+
+    it "allows reading paths outside denied hierarchies" do
+      root = mktmpdir
+      readable_dir = root/"readable"
+      denied_dir = root/"denied"
+      readable_dir.mkpath
+      denied_dir.mkpath
+      allow(landlock).to receive(:root_path).and_return(root)
+
+      expect(landlock.send(:readable_paths, [denied_dir])).to eq([readable_dir.to_s])
+    end
+
+    it "does not allow a symlink alias into a denied hierarchy" do
+      root = mktmpdir
+      denied_dir = root/"denied"
+      denied_dir.mkpath
+      alias_path = root/"alias"
+      alias_path.make_symlink(denied_dir)
+      allow(landlock).to receive(:root_path).and_return(root)
+
+      expect(landlock.send(:readable_paths, [denied_dir])).to be_empty
+    end
+
+    it "skips dangling symlinks" do
+      root = mktmpdir
+      denied_dir = root/"denied"
+      denied_dir.mkpath
+      dangling_path = root/"dangling"
+      dangling_path.make_symlink(root/"missing")
+      allow(landlock).to receive(:root_path).and_return(root)
+
+      expect(landlock.send(:readable_paths, [denied_dir])).to be_empty
+    end
+  end
+end

--- a/Library/Homebrew/test/sandbox_landlock_spec.rb
+++ b/Library/Homebrew/test/sandbox_landlock_spec.rb
@@ -48,6 +48,13 @@ RSpec.describe Sandbox::Landlock do
       expect(described_class.failure_reason).to include("disabled by this Linux kernel")
     end
 
+    it "returns false when Linux sandboxing is disabled" do
+      allow(Homebrew::EnvConfig).to receive(:sandbox_linux?).and_return(false)
+
+      expect(described_class).not_to be_available
+      expect(described_class.state).to eq(:config_disabled)
+    end
+
     it "returns false when Fiddle is unavailable" do
       allow(described_class).to receive(:require).with("fiddle").and_raise(LoadError)
 

--- a/Library/Homebrew/test/sandbox_linux_spec.rb
+++ b/Library/Homebrew/test/sandbox_linux_spec.rb
@@ -7,6 +7,20 @@ require "extend/os/linux/sandbox" if OS.linux?
 RSpec.describe Sandbox, :needs_linux do
   subject(:sandbox) { described_class.new }
 
+  describe "::sandbox_implementation" do
+    it "uses Bubblewrap by default" do
+      with_env(HOMEBREW_SANDBOX_LINUX_LANDLOCK: nil) do
+        expect(OS::Linux::Sandbox.sandbox_implementation).to eq(Sandbox::Bubblewrap)
+      end
+    end
+
+    it "uses Landlock when requested" do
+      with_env(HOMEBREW_SANDBOX_LINUX_LANDLOCK: "1") do
+        expect(OS::Linux::Sandbox.sandbox_implementation).to eq(Sandbox::Landlock)
+      end
+    end
+  end
+
   describe "::bubblewrap_executable" do
     let(:sandbox_class) do
       Class.new(Sandbox::Bubblewrap) do

--- a/Library/Homebrew/test/sandbox_linux_spec.rb
+++ b/Library/Homebrew/test/sandbox_linux_spec.rb
@@ -463,5 +463,25 @@ RSpec.describe Sandbox, :needs_linux do
     it "returns the command exit status" do
       expect { sandbox.run "false" }.to raise_error(ErrorDuringExecution)
     end
+
+    it "prevents listing a denied read hierarchy" do
+      denied_dir = mktmpdir
+      FileUtils.touch denied_dir/"secret"
+      sandbox.deny_read_path denied_dir
+
+      expect { sandbox.run "/bin/sh", "-c", 'ls "$1" | grep -q secret', "brew-test", denied_dir }
+        .to raise_error(ErrorDuringExecution)
+    end
+
+    it "prevents executing from a denied read hierarchy" do
+      denied_dir = mktmpdir
+      executable = denied_dir/"secret"
+      executable.write "#!/bin/sh\nexit 0\n"
+      executable.chmod 0755
+      sandbox.deny_read_path denied_dir
+
+      expect { sandbox.run "/bin/sh", "-c", 'exec "$1"', "brew-test", executable }
+        .to raise_error(ErrorDuringExecution)
+    end
   end
 end

--- a/Library/Homebrew/test/sandbox_linux_spec.rb
+++ b/Library/Homebrew/test/sandbox_linux_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Sandbox, :needs_linux do
 
   describe "::bubblewrap_executable" do
     let(:sandbox_class) do
-      Class.new(Sandbox) do
+      Class.new(Sandbox::Bubblewrap) do
         class << self
           attr_accessor :test_executable_candidate_paths
 
@@ -33,22 +33,22 @@ RSpec.describe Sandbox, :needs_linux do
     end
 
     it "searches Homebrew Bubblewrap before system Bubblewrap and skips setuid candidates" do
-      expect(described_class.executable_candidate_paths.to_a).to start_with("#{HOMEBREW_PREFIX}/bin", "/usr/bin",
-                                                                            "/bin")
-      expect(sandbox_class.bubblewrap_executable).to eq(usable_bubblewrap)
+      expect(Sandbox::Bubblewrap.executable_candidate_paths.to_a).to start_with("#{HOMEBREW_PREFIX}/bin", "/usr/bin",
+                                                                                "/bin")
+      expect(sandbox_class.executable).to eq(usable_bubblewrap)
     end
 
     it "raises when no suitable bubblewrap candidate exists" do
       sandbox_class.test_executable_candidate_paths = PATH.new(mktmpdir)
 
-      expect { sandbox_class.bubblewrap_executable! }
+      expect { sandbox_class.executable! }
         .to raise_error(RuntimeError, "Bubblewrap is required to use the Linux sandbox.")
     end
   end
 
   describe "::available?" do
     let(:sandbox_class) do
-      Class.new(Sandbox) do
+      Class.new(Sandbox::Bubblewrap) do
         class << self
           attr_accessor :test_executable_candidate_paths
 
@@ -94,6 +94,7 @@ RSpec.describe Sandbox, :needs_linux do
       allow(Homebrew::EnvConfig).to receive(:sandbox_linux?).and_return(false)
 
       expect(sandbox_class.available?).to be(false)
+      expect(sandbox_class.state).to eq(:config_disabled)
     end
 
     it "returns false when bubblewrap is unavailable" do
@@ -184,7 +185,7 @@ RSpec.describe Sandbox, :needs_linux do
   end
 
   describe "::configuration_commands" do
-    let(:sandbox_class) { Class.new(described_class) }
+    let(:sandbox_class) { Class.new(Sandbox::Bubblewrap) }
 
     around do |example|
       with_env(GITHUB_ACTIONS: nil, HOMEBREW_GITHUB_HOSTED_RUNNER: nil) { example.run }
@@ -199,9 +200,9 @@ RSpec.describe Sandbox, :needs_linux do
     end
 
     it "uses system Bubblewrap when configuring Linux sandbox sysctls" do
-      allow(sandbox_class).to receive(:bubblewrap_executable).and_return(Pathname("/usr/bin/bwrap"))
+      allow(sandbox_class).to receive(:executable).and_return(Pathname("/usr/bin/bwrap"))
       allow(Process).to receive(:euid).and_return(1000)
-      expect(sandbox_class).not_to receive(:ensure_sandbox_installed!)
+      expect(sandbox_class).not_to receive(:ensure_installed!)
       expect(sandbox_class).to receive(:ohai).with("Configuring Bubblewrap...").ordered
       expect(sandbox_class).to receive(:system)
         .with("sudo", HOMEBREW_BREW_FILE.to_s, "setup-sandbox").and_return(true).ordered
@@ -210,8 +211,8 @@ RSpec.describe Sandbox, :needs_linux do
     end
 
     it "does not configure Linux sandbox sysctls when Bubblewrap remains unavailable" do
-      expect(sandbox_class).to receive(:bubblewrap_executable).twice.and_return(nil)
-      expect(sandbox_class).to receive(:ensure_sandbox_installed!)
+      expect(sandbox_class).to receive(:executable).twice.and_return(nil)
+      expect(sandbox_class).to receive(:ensure_installed!)
         .with(install_from_tests: true)
       expect(sandbox_class).not_to receive(:system)
 
@@ -219,11 +220,11 @@ RSpec.describe Sandbox, :needs_linux do
     end
 
     it "installs Bubblewrap and configures Linux sandbox sysctls as root" do
-      expect(sandbox_class).to receive(:bubblewrap_executable)
+      expect(sandbox_class).to receive(:executable)
         .twice
         .and_return(nil, Pathname(HOMEBREW_PREFIX/"bin/bwrap"))
       allow(Process).to receive(:euid).and_return(0)
-      expect(sandbox_class).to receive(:ensure_sandbox_installed!)
+      expect(sandbox_class).to receive(:ensure_installed!)
         .with(install_from_tests: true)
       expect(sandbox_class).to receive(:ohai).with("Configuring Bubblewrap...").ordered
       expect(sandbox_class).to receive(:system)
@@ -233,7 +234,7 @@ RSpec.describe Sandbox, :needs_linux do
     end
 
     it "raises when configuring Linux sandbox sysctls fails" do
-      allow(sandbox_class).to receive(:bubblewrap_executable).and_return(Pathname("/usr/bin/bwrap"))
+      allow(sandbox_class).to receive(:executable).and_return(Pathname("/usr/bin/bwrap"))
       allow(Process).to receive(:euid).and_return(0)
       allow(sandbox_class).to receive(:ohai)
       expect(sandbox_class).to receive(:system)
@@ -244,22 +245,22 @@ RSpec.describe Sandbox, :needs_linux do
   end
 
   describe "::sandbox_install_command" do
-    let(:sandbox_class) { Class.new(described_class) }
+    let(:sandbox_class) { Class.new(Sandbox::Bubblewrap) }
 
     it "returns the distro-specific install command for the detected package manager" do
       allow(sandbox_class).to receive(:which).with("apt-get").and_return(nil)
       allow(sandbox_class).to receive(:which).with("dnf").and_return(Pathname("/usr/bin/dnf"))
-      expect(sandbox_class.sandbox_install_command).to eq("sudo dnf install bubblewrap")
+      expect(sandbox_class.install_command).to eq("sudo dnf install bubblewrap")
     end
 
     it "returns nil when no known package manager is found" do
       allow(sandbox_class).to receive(:which).and_return(nil)
-      expect(sandbox_class.sandbox_install_command).to be_nil
+      expect(sandbox_class.install_command).to be_nil
     end
   end
 
   describe "::ensure_sandbox_installed!" do
-    let(:sandbox_class) { Class.new(described_class) }
+    let(:sandbox_class) { Class.new(Sandbox::Bubblewrap) }
 
     around do |example|
       with_env(GITHUB_ACTIONS: nil, HOMEBREW_GITHUB_HOSTED_RUNNER: nil,
@@ -271,29 +272,29 @@ RSpec.describe Sandbox, :needs_linux do
     end
 
     it "does nothing when Homebrew Bubblewrap is already available" do
-      expect(sandbox_class).to receive(:bubblewrap_executable)
+      expect(sandbox_class).to receive(:executable)
         .once
         .and_return(Pathname(HOMEBREW_PREFIX/"bin/bwrap"))
       expect(Formula).not_to receive(:[])
       expect(sandbox_class).not_to receive(:which)
       expect(sandbox_class).not_to receive(:system)
 
-      sandbox_class.ensure_sandbox_installed!
+      sandbox_class.ensure_installed!
     end
 
     it "does nothing when system Bubblewrap is already available" do
-      expect(sandbox_class).to receive(:bubblewrap_executable)
+      expect(sandbox_class).to receive(:executable)
         .once
         .and_return(Pathname("/usr/bin/bwrap"))
       expect(Formula).not_to receive(:[])
       expect(sandbox_class).not_to receive(:which)
       expect(sandbox_class).not_to receive(:system)
 
-      sandbox_class.ensure_sandbox_installed!
+      sandbox_class.ensure_installed!
     end
 
     it "installs Bubblewrap with Homebrew before trying apt-get on GitHub Actions" do
-      expect(sandbox_class).to receive(:bubblewrap_executable)
+      expect(sandbox_class).to receive(:executable)
         .twice
         .and_return(nil, Pathname(HOMEBREW_PREFIX/"bin/bwrap"))
       expect(Formula).to receive(:[]).with("bubblewrap")
@@ -302,12 +303,12 @@ RSpec.describe Sandbox, :needs_linux do
       expect(sandbox_class).not_to receive(:system)
 
       with_env(GITHUB_ACTIONS: "true", HOMEBREW_GITHUB_HOSTED_RUNNER: "1") do
-        sandbox_class.ensure_sandbox_installed!
+        sandbox_class.ensure_installed!
       end
     end
 
     it "falls back to sudo apt-get on GitHub Actions Ubuntu when Homebrew Bubblewrap is unavailable" do
-      expect(sandbox_class).to receive(:bubblewrap_executable)
+      expect(sandbox_class).to receive(:executable)
         .twice
         .and_return(nil)
       expect(Formula).to receive(:[]).with("bubblewrap")
@@ -320,12 +321,12 @@ RSpec.describe Sandbox, :needs_linux do
         .and_return(true)
 
       with_env(GITHUB_ACTIONS: "true", HOMEBREW_GITHUB_HOSTED_RUNNER: "1") do
-        sandbox_class.ensure_sandbox_installed!
+        sandbox_class.ensure_installed!
       end
     end
 
     it "falls back to apt-get as root on GitHub Actions Ubuntu when Homebrew Bubblewrap is unavailable" do
-      expect(sandbox_class).to receive(:bubblewrap_executable)
+      expect(sandbox_class).to receive(:executable)
         .twice
         .and_return(nil)
       expect(Formula).to receive(:[]).with("bubblewrap")
@@ -338,12 +339,12 @@ RSpec.describe Sandbox, :needs_linux do
         .and_return(true)
 
       with_env(GITHUB_ACTIONS: "true", HOMEBREW_GITHUB_HOSTED_RUNNER: "1") do
-        sandbox_class.ensure_sandbox_installed!
+        sandbox_class.ensure_installed!
       end
     end
 
     it "does not fall back to apt-get outside GitHub Actions Ubuntu" do
-      expect(sandbox_class).to receive(:bubblewrap_executable)
+      expect(sandbox_class).to receive(:executable)
         .twice
         .and_return(nil, nil)
       expect(Formula).to receive(:[]).with("bubblewrap")
@@ -352,12 +353,12 @@ RSpec.describe Sandbox, :needs_linux do
       expect(sandbox_class).not_to receive(:system)
 
       with_env(GITHUB_ACTIONS: "true") do
-        sandbox_class.ensure_sandbox_installed!
+        sandbox_class.ensure_installed!
       end
     end
 
     it "does not fall back to apt-get outside GitHub Actions" do
-      expect(sandbox_class).to receive(:bubblewrap_executable)
+      expect(sandbox_class).to receive(:executable)
         .twice
         .and_return(nil, nil)
       expect(Formula).to receive(:[]).with("bubblewrap")
@@ -365,7 +366,7 @@ RSpec.describe Sandbox, :needs_linux do
       expect(sandbox_class).not_to receive(:which)
       expect(sandbox_class).not_to receive(:system)
 
-      sandbox_class.ensure_sandbox_installed!
+      sandbox_class.ensure_installed!
     end
   end
 

--- a/Library/Homebrew/test/sandbox_shared_spec.rb
+++ b/Library/Homebrew/test/sandbox_shared_spec.rb
@@ -75,6 +75,15 @@ RSpec.describe Sandbox do
     end
   end
 
+  describe "#copy_pty_output" do
+    it "treats a PTY EIO as EOF" do
+      controller = instance_double(IO)
+      allow(controller).to receive(:each_char).and_raise(Errno::EIO)
+
+      expect { sandbox.send(:copy_pty_output, controller) }.not_to raise_error
+    end
+  end
+
   describe "::failure_reason" do
     let(:sandbox_class) { Class.new(described_class) }
 


### PR DESCRIPTION
This may be a suitable substitute for Bubblewrap that'd be easier to use in e.g. CI environments.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex GPT 5.6 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
