### PR TITLE
Warn when sandbox paths stay readable

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -265,7 +265,7 @@ class Sandbox
     require "trust"
 
     home = Pathname(Dir.home(ENV.fetch("USER"))).realpath
-    if [
+    readable_paths = [
       HOMEBREW_PREFIX,
       HOMEBREW_REPOSITORY,
       HOMEBREW_CACHE,
@@ -276,10 +276,11 @@ class Sandbox
       ENV.fetch("RUNNER_TEMP", nil),
       Homebrew::Trust.trust_file,
       *home_write_paths.select { |path| File.exist?(path) },
-    ].compact.any? do |path|
+    ].compact.flat_map do |path|
       path = Pathname(path)
-      [path.expand_path, (path.realpath if path.exist?)].compact.any? { |pathname| pathname.ascend.include?(home) }
+      [path.expand_path, (path.realpath if path.exist?)].compact
     end
+    if readable_paths.any? { |path| path.ascend.include?(home) }
       # When Homebrew or CI needs some `$HOME` paths to stay readable, deny only
       # well-known credential and personal-data paths instead of enumerating all
       # of `$HOME`.
@@ -363,7 +364,20 @@ class Sandbox
         next unless path.exist?
 
         path = path.realpath
-        deny_read_path path if path.ascend.include?(home)
+        next unless path.ascend.include?(home)
+
+        if (readable_path = readable_paths.find { |required_path| required_path.ascend.include?(path) })
+          opoo <<~EOS
+            The sandbox cannot prevent formulae from reading:
+              #{path}
+            because this required path is inside it:
+              #{readable_path}
+            Formulae may access personal data in this directory.
+          EOS
+          next
+        end
+
+        deny_read_path path
       rescue Errno::ENOENT
         nil
       end

--- a/Library/Homebrew/test/sandbox_shared_spec.rb
+++ b/Library/Homebrew/test/sandbox_shared_spec.rb
@@ -363,6 +363,31 @@ RSpec.describe Sandbox do
       expect(denied).not_to include(*allowed_dirs.map { |path| path.realpath.to_s })
     end
 
+    it "keeps Homebrew readable inside a sensitive home path" do
+      stub_const("HOMEBREW_PREFIX", home/"Documents/homebrew")
+      [HOMEBREW_PREFIX, home/".ssh"].each(&:mkpath)
+
+      sandbox.deny_read_home
+
+      denied = sandbox.send(:profile).rules.map { |rule| rule.filter&.path }
+      expect(denied).to contain_exactly((home/".ssh").realpath.to_s)
+    end
+
+    it "warns when Homebrew is inside a sensitive home path" do
+      stub_const("HOMEBREW_PREFIX", home/"Documents/homebrew")
+      HOMEBREW_PREFIX.mkpath
+
+      expect(sandbox).to receive(:opoo).with(<<~EOS)
+        The sandbox cannot prevent formulae from reading:
+          #{(home/"Documents").realpath}
+        because this required path is inside it:
+          #{HOMEBREW_PREFIX.realpath}
+        Formulae may access personal data in this directory.
+      EOS
+
+      sandbox.deny_read_home
+    end
+
     it "does not deny arbitrary home entries whose names contain parentheses or backslashes" do
       stub_const("HOMEBREW_LOGS", home/"Library/Logs/Homebrew")
       teams_log = home/"Library/Logs/Microsoft Teams Helper (Renderer)"


### PR DESCRIPTION
- Preserve required Homebrew paths inside protected home directories.
- Warn that formulae may access personal data in those directories.

See https://github.com/orgs/Homebrew/discussions/6976

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 Sol xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
