### PR TITLE
Handle cask mount failures and interrupts

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -33,7 +33,7 @@ module Homebrew
       @symlink_targets = T.let({}, T::Hash[Pathname, T::Set[Downloadable]])
       @downloads_by_location = T.let({}, T::Hash[Pathname, Concurrent::Promises::Future])
       @cancelled = T.let(Concurrent::AtomicBoolean.new(false), Concurrent::AtomicBoolean)
-      @download_threads = T.let(Concurrent::Set.new, Concurrent::Set)
+      @active_threads = T.let(Concurrent::Set.new, Concurrent::Set)
       @fetch_failed = T.let(false, T::Boolean)
     end
 
@@ -56,10 +56,9 @@ module Homebrew
         pool, RetryableDownload.new(downloadable, tries:),
         @cancelled, force, quiet, check_attestation
       ) do |download, cancelled, force, quiet, check_attestation|
-        raise CancelledDownloadError if cancelled.true?
+        with_active_thread do
+          raise CancelledDownloadError if cancelled.true?
 
-        @download_threads.add(Thread.current)
-        begin
           download.clear_cache if force
           if !force && downloadable.downloaded_and_valid?
             check_bottle_attestation(downloadable, check_attestation:)
@@ -73,23 +72,23 @@ module Homebrew
           check_bottle_attestation(downloadable, check_attestation:)
           create_symlinks_for_shared_download(cached_location)
           cached_location
-        rescue Interrupt
-          raise CancelledDownloadError
-        ensure
-          @download_threads.delete(Thread.current)
         end
       end
 
       downloads[downloadable] = if stage
         download.then_on(
-          pool, downloadable, pour
-        ) do |downloaded_path, queued_downloadable, queue_pour|
-          if queued_downloadable.stage_from_download_queue?(downloaded_path, pour: queue_pour)
-            queued_downloadable.extracting!
-            queued_downloadable.stage_from_download_queue(downloaded_path, pour: queue_pour)
-            queued_downloadable.downloaded!
+          pool, downloadable, pour, @cancelled
+        ) do |downloaded_path, queued_downloadable, queue_pour, cancelled|
+          with_active_thread do
+            raise CancelledDownloadError if cancelled.true?
+
+            if queued_downloadable.stage_from_download_queue?(downloaded_path, pour: queue_pour)
+              queued_downloadable.extracting!
+              queued_downloadable.stage_from_download_queue(downloaded_path, pour: queue_pour)
+              queued_downloadable.downloaded!
+            end
+            downloaded_path
           end
-          downloaded_path
         end
       else
         download
@@ -298,13 +297,23 @@ module Homebrew
       downloadable.is_a?(Resource::BottleManifest) || exception.is_a?(Resource::BottleManifest::Error)
     end
 
+    sig { type_parameters(:U).params(_block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
+    def with_active_thread(&_block)
+      @active_threads.add(Thread.current)
+      yield
+    rescue Interrupt
+      raise CancelledDownloadError
+    ensure
+      @active_threads.delete(Thread.current)
+    end
+
     sig { void }
     def cancel
-      # Signal cooperative cancellation and interrupt any active download threads.
+      # Signal cooperative cancellation and interrupt any active worker threads.
       # Raising Interrupt on the thread triggers the existing rescue Interrupt in
       # system_command.rb which sends SIGINT to the curl subprocess directly.
       @cancelled.make_true
-      @download_threads.each { |thread| thread.raise(Interrupt) }
+      @active_threads.each { |thread| thread.raise(Interrupt) }
     end
 
     sig { returns(Concurrent::FixedThreadPool) }

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -97,6 +97,36 @@ RSpec.describe Homebrew::DownloadQueue do
     download_queue.fetch
   end
 
+  it "interrupts queued staging when the fetch is interrupted", timeout: 5 do
+    allow(retryable_download).to receive(:fetch).and_return(cached_download)
+    allow(downloadable).to receive(:stage_from_download_queue?).and_return(true)
+    allow(downloadable).to receive_messages(extracting!: nil, downloaded!: nil)
+    staging_started = Queue.new
+    staging_interrupted = Queue.new
+    release_staging = Queue.new
+    allow(downloadable).to receive(:stage_from_download_queue) do
+      staging_started << true
+      release_staging.pop
+    rescue Interrupt
+      staging_interrupted << true
+      raise
+    end
+
+    download_queue.enqueue(downloadable, stage: true)
+    fetch_thread = Thread.current
+    interrupter = Thread.new do
+      next unless staging_started.pop(timeout: 1)
+
+      fetch_thread.raise(Interrupt)
+    end
+
+    expect { download_queue.fetch }.to raise_error(Interrupt)
+    expect(staging_interrupted.pop(timeout: 1)).to be(true)
+  ensure
+    release_staging&.push(true)
+    interrupter.kill if interrupter && !interrupter.join(1)
+  end
+
   it "promotes an in-flight download to queued staging" do
     expect(retryable_download).to receive(:fetch).once.and_return(cached_download)
     expect(downloadable).to receive(:stage_from_download_queue?).with(cached_download, pour: false).and_return(true)

--- a/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
@@ -27,5 +27,17 @@ RSpec.describe UnpackStrategy::Dmg, :needs_macos do
         expect(unpack_dir.children(false).map(&:to_s)).to contain_exactly("container")
       end
     end
+
+    it "does not treat an unrelated attach failure as a license agreement" do
+      unpack_strategy = described_class.new(path)
+      attach_result = instance_double(SystemCommand::Result, success?: false, stdout: "")
+      attach_error = ErrorDuringExecution.new(["hdiutil", "attach"], status: 1)
+
+      allow(unpack_strategy).to receive(:system_command).and_return(attach_result)
+      expect(attach_result).to receive(:assert_success!).and_raise(attach_error)
+      expect(unpack_strategy).not_to receive(:system_command!)
+
+      expect { unpack_strategy.send(:mount) { nil } }.to raise_error(attach_error)
+    end
   end
 end

--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -216,6 +216,8 @@ module UnpackStrategy
         plist = if without_eula.success?
           without_eula.plist
         else
+          without_eula.assert_success! if without_eula.stdout.empty?
+
           cdr_path = mount_dir/path.basename.sub_ext(".cdr")
 
           quiet_flag = "-quiet" unless verbose


### PR DESCRIPTION
- Preserve real `hdiutil attach` failures instead of treating them as EULAs
- Include queued staging in cancellation so Ctrl-C stops worker processes

Fixes https://github.com/Homebrew/brew/issues/23251

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 sol xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
