### PR TITLE
list: list only real cask directories

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -230,9 +230,14 @@ module Homebrew
             puts if $stdout.tty? && !args.formula?
           end
           unless args.formula?
-            if Cask::Caskroom.any_casks_installed?
+            # List only real cask directories, not alias symlinks from cask renames, so
+            # a renamed cask lists once under its real name. Keep in sync with the cask
+            # listing in `homebrew-list` in Library/Homebrew/list.sh.
+            cask_tokens = Cask::Caskroom.tokens
+            if cask_tokens.any?
               ohai "Casks" if $stdout.tty? && !args.cask?
-              system_command! "ls", args: [*ls_args, Cask::Caskroom.path], print_stdout: true
+              system_command! "ls", args: [*ls_args, "-d", *cask_tokens], print_stdout: true,
+                              chdir: Cask::Caskroom.path
             end
             warn_about_broken_caskroom_symlinks
           end

--- a/Library/Homebrew/list.sh
+++ b/Library/Homebrew/list.sh
@@ -246,27 +246,40 @@ homebrew-list() {
 
   if [[ -z "${formula}" && -d "${HOMEBREW_CASKROOM}" ]]
   then
-    local cask_output
-    cask_output="$(/usr/bin/env "${ls_env[@]}" ls "${ls_args[@]}" "${HOMEBREW_CASKROOM}")" || exit 1
-    if [[ -n "${cask_output}" ]]
-    then
-      if [[ -n "${tty}" && -z "${cask}" ]]
-      then
-        ohai "Casks"
-      fi
-
-      echo "${cask_output}"
-    fi
-
+    # List only real cask directories, not alias symlinks from cask renames, so a
+    # renamed cask lists once under its real name. Keep in sync with the cask
+    # listing in Homebrew::Cmd::List#run in Library/Homebrew/cmd/list.rb.
+    local cask_tokens=()
     # Keep in sync with Homebrew::Cmd::List#warn_about_broken_caskroom_symlinks
     # in Library/Homebrew/cmd/list.rb.
     local broken_cask_symlinks=()
     local cask_path
     for cask_path in "${HOMEBREW_CASKROOM}"/*
     do
-      [[ -L "${cask_path}" && ! -e "${cask_path}" ]] || continue
-      broken_cask_symlinks+=("${cask_path##*/}")
+      if [[ -L "${cask_path}" && ! -e "${cask_path}" ]]
+      then
+        broken_cask_symlinks+=("${cask_path##*/}")
+      elif [[ -d "${cask_path}" && ! -L "${cask_path}" ]]
+      then
+        cask_tokens+=("${cask_path##*/}")
+      fi
     done
+
+    if ((${#cask_tokens[@]} > 0))
+    then
+      local cask_output
+      cask_output="$(cd "${HOMEBREW_CASKROOM}" &&
+        /usr/bin/env "${ls_env[@]}" ls "${ls_args[@]}" -d "${cask_tokens[@]}")" || exit 1
+      if [[ -n "${cask_output}" ]]
+      then
+        if [[ -n "${tty}" && -z "${cask}" ]]
+        then
+          ohai "Casks"
+        fi
+
+        echo "${cask_output}"
+      fi
+    fi
     if ((${#broken_cask_symlinks[@]} > 0))
     then
       source "${HOMEBREW_LIBRARY}/Homebrew/utils.sh"

--- a/Library/Homebrew/test/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cmd/list_spec.rb
@@ -143,6 +143,7 @@ RSpec.describe Homebrew::Cmd::List do
     install_formula_version "testball", "0.1"
     install_cask "local-caffeine"
     FileUtils.ln_s "missing-cask", Cask::Caskroom.path/"dangling-alias"
+    FileUtils.ln_s "local-caffeine", Cask::Caskroom.path/"healthy-alias"
 
     variants = [[], ["-1"], ["--formula"], ["--cask"]]
     bash_results = variants.map do |argv|
@@ -218,6 +219,7 @@ RSpec.describe Homebrew::Cmd::List do
     FileUtils.ln_s Cask::Caskroom.path/"local-caffeine/1.2.3",
                    HOMEBREW_PREFIX/"var/homebrew/pinned_casks/local-caffeine"
     FileUtils.ln_s "missing-cask", Cask::Caskroom.path/"dangling-alias"
+    FileUtils.ln_s "local-caffeine", Cask::Caskroom.path/"healthy-alias"
 
     empty_cellar = mktmpdir
     empty_caskroom = mktmpdir
@@ -240,7 +242,7 @@ RSpec.describe Homebrew::Cmd::List do
                "EXPECTED_EMPTY_JSON"   => list_versions_json,
                "EXPECTED_FORMULA_JSON" => list_versions_json(formulae: formulae_json),
                "EXPECTED_JSON"         => list_versions_json(formulae: formulae_json, casks: casks_json),
-               "EXPECTED_PLAIN"        => "testball\ndangling-alias\nlocal-caffeine\n",
+               "EXPECTED_PLAIN"        => "testball\nlocal-caffeine\n",
                "EXPECTED_PLAIN_STDERR" => "Warning: Broken Caskroom symlinks " \
                                           "(`brew cleanup` removes them): dangling-alias\n",
                "NO_JQ_CASKROOM"        => no_jq_caskroom.to_s,
@@ -277,12 +279,15 @@ RSpec.describe Homebrew::Cmd::List do
     cask.unpin
   end
 
-  it "warns about broken Caskroom symlinks" do
-    Cask::Caskroom.path.mkpath
-    FileUtils.ln_s "missing-cask", Cask::Caskroom.path/"dangling-alias"
+  it "lists only real cask directories and warns about broken Caskroom symlinks" do
+    caskroom = Cask::Caskroom.path
+    (caskroom/"real-cask").mkpath
+    FileUtils.ln_s "real-cask", caskroom/"healthy-alias"
+    FileUtils.ln_s "missing-cask", caskroom/"dangling-alias"
 
     expect { described_class.new(["--cask"]).run }
-      .to output(/Broken Caskroom symlinks \(`brew cleanup` removes them\): dangling-alias/).to_stderr
+      .to output("real-cask\n").to_stdout
+      .and output(/Broken Caskroom symlinks \(`brew cleanup` removes them\): dangling-alias/).to_stderr
   end
 
   it "fails only for explicitly named missing pinned packages", :cask do


### PR DESCRIPTION
*@MikeMcQuaid, even though this is not a complex change, I would be nervous about it if merged, simply because it changes the behaviour of `brew list` for millions (or tens of millions?) of machines. I'm thinking in particular about all the automated scripts that might rely on current behaviour. However, with it being related to my last few PRs, it seemed worth waving in front of you at this juncture.*

A renamed cask lists under both its names in `brew list --cask`, because the bare listing is `ls`(1) of the Caskroom directory and cask renames leave an alias symlink beside the real directory. A user who installed a cask years ago that was later renamed can reasonably wonder why they have two TigerVNCs installed and how they differ — when there is actually just one, under two names. This PR lists only the real cask directories, in both the Bash fast path and the Ruby command.

Two things worth considering:

1. is pro the change. All other brew surfaces (`Caskroom.casks`, `brew outdated`, `brew upgrade`, the `--versions --json` listing) already behave this way: only real directories count as installed casks. The bare listing was the outlier.

2. is a caution. The real directory does not always carry a cask's current name. `Cask::Migrator` now points an old-name alias at a new-name directory, but earlier rename migrations did the reverse, and my TigerVNC install was one of those. On such machines this change lists the cask under its old name only. This concern is bounded though because `Cask::Migrator` fixes such cases on the cask's next install, upgrade or reinstall (or a manual `brew migrate`), ensuring the real directory corresponds to the current token.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Written with Claude in Claude Code under my direction and review. Red/green verified: with only the Ruby half of the change stashed, the #23247 parity test and the Ruby example both fail. `brew typecheck`, `brew style` (including shellcheck/shfmt) and changed tests clean locally.
