### PR TITLE
cask/migrator: do not copy a cask into itself through a rename alias

### DIFF
--- a/Library/Homebrew/cask/migrator.rb
+++ b/Library/Homebrew/cask/migrator.rb
@@ -149,6 +149,7 @@ module Cask
       if dry_run
         oh1 "Would migrate cask #{Formatter.identifier(old_token)} to #{Formatter.identifier(new_token)}"
 
+        puts "rm #{new_caskroom_path}" if new_caskroom_path.symlink?
         puts "cp -r #{old_caskroom_path} #{new_caskroom_path}"
         puts "mv #{new_caskroom_path}/#{old_installed_caskfile} #{new_caskroom_path}/#{new_installed_caskfile}"
         puts "rm -r #{old_caskroom_path}"
@@ -160,6 +161,11 @@ module Cask
         end
       else
         oh1 "Migrating cask #{Formatter.identifier(old_token)} to #{Formatter.identifier(new_token)}"
+
+        # An earlier rename migration era could leave the new token as an alias symlink
+        # pointing at the old directory; remove it so the copy below cannot recurse
+        # into its own source.
+        FileUtils.rm new_caskroom_path if new_caskroom_path.symlink?
 
         begin
           FileUtils.cp_r old_caskroom_path, new_caskroom_path

--- a/Library/Homebrew/test/cask/migrator_spec.rb
+++ b/Library/Homebrew/test/cask/migrator_spec.rb
@@ -78,6 +78,22 @@ RSpec.describe Cask::Migrator do
       end
     end
 
+    context "when the new token is an alias symlink pointing at the old directory" do
+      it "moves the old cask to the new token without copying it into itself" do
+        InstallHelper.stub_cask_installation(old_cask)
+        FileUtils.ln_s "local-caffeine", Cask::Caskroom.path/"local-transmission"
+        rename_old_cask_to_new_cask
+
+        described_class.migrate_if_needed(new_cask)
+
+        expect([
+          old_caskroom_path.symlink?,
+          new_cask.installed_version,
+          (Cask::Caskroom.path/"local-transmission/local-caffeine").exist?,
+        ]).to eq([true, old_cask.version.to_s, false])
+      end
+    end
+
     context "when the new cask is already installed" do
       before do
         Cask::Installer.new(new_cask).install


### PR DESCRIPTION
*For what it's worth (the bug is real, the conditions under which it actually happens are niche)*

The bug from [this comment on #23259](https://github.com/Homebrew/brew/pull/23259#issuecomment-5038056636): if the Caskroom holds the *new* token of a rename as an alias symlink pointing at the *old* token's real directory, `Cask::Migrator` corrupts the install instead of migrating it.

`move_old_cask` assumes the new token's path does not exist. With the alias there, `cp_r` resolves through it and copies the old directory into itself until the OS path limit stops it; the alias is deleted; and because the old directory survives, the migration retries and recurses again on every subsequent install or upgrade of that cask. The nested wreckage even survives `brew uninstall`.

**Reproduced on a real machine** (macOS, brew 6.0.12), constructing the arrangement by hand with the `tigervnc-viewer` → `tigervnc` rename:

```
brew install --cask tigervnc
cd "$(brew --prefix)/Caskroom"
mv tigervnc tigervnc-viewer
ln -s tigervnc-viewer tigervnc
(cd tigervnc-viewer/.metadata/*/*/Casks && mv tigervnc.json tigervnc-viewer.json)
brew migrate tigervnc-viewer
```

Observed result:

```
==> Migrating cask tigervnc-viewer to tigervnc
Error: File name too long @ rb_file_s_lstat - /opt/homebrew/Caskroom/tigervnc-viewer/tigervnc-viewer/tigervnc-viewer/[~58 levels]/...
```

After which the `tigervnc` alias is gone, rerunning `brew migrate` (or any install/upgrade of the cask) recurses again, `brew uninstall` removes the app but leaves the nested tree (deep enough that `find` and `du` on it fail with the same error), and only a manual `rm -rf` recovers.

How machines get into this arrangement naturally: a **rename reversal**. Migrating a rename A → B leaves the fleet with a real directory under B and an alias A → B; if the tap later reverses the rename to B → A — which happens, e.g. #147037 in homebrew-cask reverted the dbeaver renames — every machine that migrated the first direction now holds exactly this arrangement, and its next install or upgrade of the cask walks into the recursion. Every machine that migrated January's `tigervnc-viewer` → `tigervnc` rename is one catalogue edit away from it today.

The fix removes an alias symlink at the new token's path before moving (mirrored in the dry-run output), after which the migration completes normally: real directory under the new token, old token left as an alias, exactly as for any other rename. The regression test builds the same arrangement in the sandbox and asserts the migration lands in that end state with no self-nesting; it fails against current `main` by reproducing the corruption.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Written with Claude in Claude Code under my direction and review: predicted by reading the code, reproduced first in the test sandbox and then with the real commands above on a real machine, which was cleaned up afterwards. Red/green verified — the regression example fails with the migrator change stashed. `brew typecheck`, `brew style` and changed tests clean locally.
