### PR TITLE
DeprecateDisable: add formula unreachable reason

### DIFF
--- a/Library/Homebrew/deprecate_disable.rb
+++ b/Library/Homebrew/deprecate_disable.rb
@@ -12,6 +12,7 @@ module DeprecateDisable
     repo_archived:       "has an archived upstream repository",
     repo_removed:        "has a removed upstream repository",
     unmaintained:        "is not maintained upstream",
+    unreachable:         "is no longer reliably reachable upstream",
     unsupported:         "is not supported upstream",
     deprecated_upstream: "is deprecated upstream",
     versioned_formula:   "is a versioned formula",

--- a/docs/Deprecating-Disabling-and-Removing.md
+++ b/docs/Deprecating-Disabling-and-Removing.md
@@ -107,6 +107,7 @@ disable! date: "2020-01-01", because: "invalid licence"
 - `:repo_archived`: upstream repository archived with no usable replacement
 - `:repo_removed`: upstream repository removed with no usable replacement
 - `:unmaintained`: project abandoned (no commits for a year and unresolved critical bugs or CVEs; note that some software is "done", so inactivity alone does not imply removal)
+- `:unreachable`: no longer reliably reachable upstream
 - `:unsupported`: compilation not supported by upstream (e.g. only supports macOS older than 10.15)
 - `:deprecated_upstream`: deprecated upstream with no usable replacement
 - `:versioned_formula`: versioned formula that no longer [meets the requirements](Versions.md)


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Casks have a `DeprecateDisable` `unreachable` reason that we use when a website is unreachable (e.g., anti-bot protections make the asset inaccessible). Formulae have similar reasons like `repo_archived` but none of the existing reasons account for the situation where a project is supported and maintained but it's not possible to reach the server outside of a browser to download release assets. This adds the `unreachable` reason to the `FORMULA_DEPRECATE_DISABLE_REASONS` hash, so we can use it in formulae as well.

One example of this is the `diary` formula. The tarball is hosted on a server that uses Anubis anti-scraping software, which effectively prevents anyone from downloading it outside of a browser. In this case, the software is still available but we can't download it, so the existing reasons arguably don't really cover this situation. "Unreachable" is the appropriate reason in this scenario, so I think it makes sense to be able to use it in formulae like we do in casks.