### PR TITLE
Wrap in-place terminal redraws in synchronized updates

### DIFF
--- a/Library/Homebrew/bundle/parallel_installer.rb
+++ b/Library/Homebrew/bundle/parallel_installer.rb
@@ -5,6 +5,7 @@ require "concurrent/executors"
 require "concurrent/promises"
 require "monitor"
 require "utils"
+require "utils/tty"
 require "bundle/package_types"
 
 module Homebrew
@@ -300,7 +301,9 @@ module Homebrew
 
       sig { void }
       def clear_tty_line
-        File.open("/dev/tty", "w") { |f| f.print("\r\e[K") }
+        File.open("/dev/tty", "w") do |f|
+          f.print("#{Tty.begin_synchronized_update}\r\e[K#{Tty.end_synchronized_update}")
+        end
       rescue Errno::ENXIO, Errno::ENOENT, Errno::EACCES, Errno::EPERM
         # No TTY available (CI, piped output) - nothing to clean up.
         nil

--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -120,6 +120,7 @@ module Homebrew
         message_length_max = downloads.keys.map { |download| download.download_queue_message.length }.max || 0
         remaining_downloads = downloads.dup.to_a
         previous_pending_line_count = 0
+        max_lines = [concurrency, Tty.height].min
 
         resolution = Concurrent::Event.new
         downloads.each_value { |future| future.on_resolution! { resolution.set } }
@@ -180,6 +181,8 @@ module Homebrew
 
           until remaining_downloads.empty?
             begin
+              stdout_print_and_flush_if_tty Tty.begin_synchronized_update
+
               finished_states = [:fulfilled, :rejected]
 
               finished_downloads, remaining_downloads = remaining_downloads.partition do |_, future|
@@ -193,7 +196,6 @@ module Homebrew
               end
 
               previous_pending_line_count = 0
-              max_lines = [concurrency, Tty.height].min
               remaining_downloads.each_with_index do |(downloadable, future), i|
                 break if previous_pending_line_count >= max_lines
 
@@ -209,6 +211,8 @@ module Homebrew
                   stdout_print_and_flush_if_tty Tty.move_cursor_up_beginning(previous_pending_line_count - 1)
                 end
               end
+
+              stdout_print_and_flush_if_tty Tty.end_synchronized_update
 
               next if remaining_downloads.empty?
 
@@ -233,6 +237,7 @@ module Homebrew
             end
           end
         ensure
+          stdout_print_and_flush_if_tty Tty.end_synchronized_update
           stdout_print_and_flush_if_tty Tty.show_cursor
         end
       end

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -418,7 +418,8 @@ module Homebrew
       if progress
         progress.finish
         Tty.with($stderr) do |stderr|
-          stderr.print "#{Tty.up}#{Tty.erase_line}" * 2
+          erase = "#{Tty.up}#{Tty.erase_line}" * 2
+          stderr.print "#{Tty.begin_synchronized_update}#{erase}#{Tty.end_synchronized_update}" unless erase.empty?
         end
       end
 

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -60,6 +60,37 @@ RSpec.describe Homebrew::DownloadQueue do
     expect { download_queue.fetch }.to raise_error(Resource::BottleManifest::Error, /manifest missing/)
   end
 
+  it "brackets TTY redraw frames in a DEC 2026 synchronized update" do
+    allow($stdout).to receive(:tty?).and_return(true)
+    ENV["TERM"] = "xterm-256color"
+    allow(downloadable).to receive(:fetched_size).and_return(nil)
+    allow(retryable_download).to receive(:fetch).and_return(cached_download)
+
+    # Build the queue while stdout is a TTY so it captures the TTY render path,
+    # before the output matcher swaps $stdout to capture the redraw frames.
+    download_queue.enqueue(downloadable)
+
+    expect { download_queue.fetch }.to output(
+      include("\e[?2026h").and(
+        satisfy("closes every synchronized update it opens") do |out|
+          last_open = out.rindex("\e[?2026h")
+          last_close = out.rindex("\e[?2026l")
+          out.scan("\e[?2026h").length <= out.scan("\e[?2026l").length &&
+            !last_open.nil? && !last_close.nil? && last_close > last_open
+        end,
+      ),
+    ).to_stdout
+  end
+
+  it "emits no synchronized update sequences when stdout is not a TTY" do
+    allow($stdout).to receive(:tty?).and_return(false)
+    allow(retryable_download).to receive(:fetch).and_return(cached_download)
+
+    download_queue.enqueue(downloadable)
+
+    expect { download_queue.fetch }.not_to output(/\e\[\?2026/).to_stdout
+  end
+
   it "wakes when downloads complete instead of polling with sleep" do
     allow($stdout).to receive(:tty?).and_return(false)
     allow(retryable_download).to receive(:fetch) { sleep(0.1) }

--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -8,6 +8,18 @@ RSpec.describe Tty do
     end
   end
 
+  describe "::begin_synchronized_update" do
+    it "returns the DEC private mode 2026 set sequence" do
+      expect(described_class.begin_synchronized_update).to eq("\033[?2026h")
+    end
+  end
+
+  describe "::end_synchronized_update" do
+    it "returns the DEC private mode 2026 reset sequence" do
+      expect(described_class.end_synchronized_update).to eq("\033[?2026l")
+    end
+  end
+
   describe "::width" do
     specify do
       expect(described_class.width).to be_a(Integer)

--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -90,6 +90,16 @@ module Tty
       "\033[?25h"
     end
 
+    sig { returns(String) }
+    def begin_synchronized_update
+      "\033[?2026h"
+    end
+
+    sig { returns(String) }
+    def end_synchronized_update
+      "\033[?2026l"
+    end
+
     sig { returns(T.nilable([Integer, Integer])) }
     def size
       return @size if defined?(@size)


### PR DESCRIPTION
Homebrew's parallel download display redraws itself with many small unbuffered writes: one per status line, plus separate writes for erasing and cursor movement, every 50ms. Terminals may render between those writes, which shows up as flashing/tearing during `brew upgrade` in fast-rendering terminals. Ghostty's author [diagnosed the flicker there as exactly this multi-write redraw](https://x.com/mitchellh/status/2079333481306550772).

This wraps each redraw in the [synchronized output protocol](https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036) (DEC private mode 2026): `ESC[?2026h` before the frame, `ESC[?2026l` after, so the terminal presents the frame atomically. Terminals without mode 2026 ignore unknown DEC private modes, so the sequences are emitted unconditionally wherever output is already TTY-gated.

Three places redraw in place and get bracketed:

- the download queue's render loop (the spinner/progress display during `install`/`upgrade`/`fetch` with download concurrency above 1), which is the redraw users see most
- `livecheck`'s erase of the finished progress bar
- `brew bundle`'s leftover-prompt cleanup line

Decisions along the way:

- The download queue closes the frame unconditionally in `fetch`'s `ensure`, mirroring the existing unconditional `Tty.show_cursor`, so an exception raised mid-frame cannot leave the terminal holding an open update. A reset with no update open is a no-op.
- `Tty.height` moved out of the render loop so its `stty` subprocess never runs inside an open frame. Terminals enforce timeouts on synchronized updates, so slow work inside a frame would reintroduce tearing.
- `livecheck` skips the write entirely when the erase string is empty (stdout piped, e.g. `--json`), matching the previous behaviour of printing nothing there.

Out of scope: curl's own `--progress-bar` during single downloads is drawn by the curl subprocess and cannot be bracketed from brew.

To reproduce the flicker and verify the fix visually, run `HOMEBREW_DOWNLOAD_CONCURRENCY=8 brew fetch --formula` on several formulae in Ghostty before and after. For a terminal-independent check I also captured a concurrency-4 fetch under `script(1)` and verified every `ESC[?2026h` in the capture is followed by its `ESC[?2026l`, with no frame left open at exit.

## Screencasts

### Terminal

#### Before

(Not affected)

https://github.com/user-attachments/assets/9f99a747-36ba-4a97-bee1-66b609afa659

#### After

(Unchanged)

https://github.com/user-attachments/assets/fc6cfc7f-257b-42d2-9239-8dc1d43e47c2

### Ghostty

#### Before

Notice the flickering in the word "Downloading"

https://github.com/user-attachments/assets/939c2f48-c2ab-4d9c-89df-0d62cafb6a22

#### After

(No flicker)

https://github.com/user-attachments/assets/b8322d11-e6ee-4041-b110-20414dcd7656



-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Written with Claude Code (Claude Fable 5). I reviewed the full diff and verified the change with the new unit tests and a pty capture of the escape sequences (details above).

-----
