### PR TITLE
bundle add: accept fully-qualified names from untapped taps

### DIFF
--- a/Library/Homebrew/bundle/adder.rb
+++ b/Library/Homebrew/bundle/adder.rb
@@ -3,6 +3,8 @@
 
 require "bundle/brewfile"
 require "bundle/dumper"
+require "tap"
+require "trust"
 
 module Homebrew
   module Bundle
@@ -11,6 +13,27 @@ module Homebrew
 
       sig { params(args: String, type: Symbol, global: T::Boolean, file: String, describe: T::Boolean).void }
       def add(*args, type:, global:, file:, describe: false)
+        item_type = case type
+        when :brew
+          :formula
+        when :cask
+          :cask
+        end
+        if item_type
+          args.each do |arg|
+            tap_with_name = if type == :brew
+              ::Tap.with_formula_name(arg)
+            else
+              ::Tap.with_cask_token(arg)
+            end
+            next unless tap_with_name
+
+            tap, = tap_with_name
+            tap.ensure_installed!
+          end
+          Homebrew::Trust.trust_fully_qualified_items!(args, type: item_type)
+        end
+
         brewfile_path = Brewfile.path(global:, file:)
         brewfile_path.write("") unless brewfile_path.exist?
 

--- a/Library/Homebrew/test/cmd/bundle/add_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/add_subcommand_spec.rb
@@ -58,4 +58,65 @@ RSpec.describe Homebrew::Cmd::Bundle::AddSubcommand do
       expect(File.read(file)).to include("#{type} \"#{args.first}\"")
     end
   end
+
+  context "when called with a fully-qualified formula from an untapped tap" do
+    let(:args) { ["user/repo/hello"] }
+    let(:type) { :brew }
+    let(:file) { "/tmp/some_random_brewfile#{Random.rand(2 ** 16)}" }
+    let(:events) { [] }
+
+    before do
+      tap = Tap.fetch("user", "repo")
+      formula_instance = formula("hello") do
+        T.bind(self, T.class_of(Formula))
+        url "hello-1.0"
+      end
+
+      allow(Tap).to receive(:with_formula_name).with(args.first).and_return([tap, "hello"])
+      allow(tap).to receive(:ensure_installed!) { events << :tap }
+      allow(Homebrew::Trust).to receive(:trust_fully_qualified_items!).with(args, type: :formula) do
+        events << :trust
+      end
+      allow(Formulary).to receive(:factory).with(args.first) do
+        events << :load
+        formula_instance
+      end
+    end
+
+    it "installs and trusts the tap before loading the formula" do
+      add
+      expect(events).to eq([:tap, :trust, :load])
+    end
+  end
+
+  context "when called with a fully-qualified cask from an untapped tap" do
+    let(:args) { ["user/repo/alacritty"] }
+    let(:type) { :cask }
+    let(:file) { "/tmp/some_random_brewfile#{Random.rand(2 ** 16)}" }
+    let(:events) { [] }
+
+    before do
+      tap = Tap.fetch("user", "repo")
+      cask = Cask::CaskLoader::FromContentLoader.new(+<<~RUBY).load(config: nil)
+        cask "alacritty" do
+          version "1.0"
+        end
+      RUBY
+
+      allow(Tap).to receive(:with_cask_token).with(args.first).and_return([tap, "alacritty"])
+      allow(tap).to receive(:ensure_installed!) { events << :tap }
+      allow(Homebrew::Trust).to receive(:trust_fully_qualified_items!).with(args, type: :cask) do
+        events << :trust
+      end
+      allow(Cask::CaskLoader).to receive(:load).with(args.first) do
+        events << :load
+        cask
+      end
+    end
+
+    it "installs and trusts the tap before loading the cask" do
+      add
+      expect(events).to eq([:tap, :trust, :load])
+    end
+  end
 end


### PR DESCRIPTION
`brew bundle add` rejected fully-qualified formula and cask names from untapped taps, failing before it wrote anything to the Brewfile (reported in #23265). `brew install` and `brew bundle install` both treat a fully-qualified name as explicit consent to install its tap, but `brew bundle add` kept neither carve-out after the "Stop implicit tap installation" change, so the same name accepted by `brew install` was refused by the command whose whole job is writing that entry.

This mirrors `brew install`: for a fully-qualified formula or cask argument it installs the tap and applies formula- or cask-specific trust before loading the item for its description and validation. Unqualified names still never cause an implicit tap install, and tap and extension entries keep their existing behavior.

Fixes https://github.com/Homebrew/brew/issues/23265

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 4.8) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the fix and pass with it, and ran `brew lgtm` + targeted specs.

-----
