### PR TITLE
pathname: build eager-init type objects once, not per allocation

### DIFF
--- a/Library/Homebrew/extend/pathname/eager_initialize_extension.rb
+++ b/Library/Homebrew/extend/pathname/eager_initialize_extension.rb
@@ -11,14 +11,22 @@ module EagerInitializeExtension
 
   requires_ancestor { Pathname }
 
+  # These aliases hoist the `T.nilable(...)` type objects out of the hot path.
+  # `#initialize` runs on every {Pathname} allocation, and with runtime
+  # checks disabled `T.let` discards its type argument, so evaluating
+  # `T.nilable(...)` inline would rebuild the same type objects each time.
+  NilableString = T.type_alias { T.nilable(String) }
+  NilableInteger = T.type_alias { T.nilable(Integer) }
+  NilableStringArray = T.type_alias { T.nilable(T::Array[String]) }
+
   sig { params(args: T.untyped).void }
   def initialize(*args)
-    @magic_number = T.let(nil, T.nilable(String))
-    @file_type = T.let(nil, T.nilable(String))
-    @zipinfo = T.let(nil, T.nilable(T::Array[String]))
-    @which_install_info = T.let(nil, T.nilable(String))
-    @disk_usage = T.let(nil, T.nilable(Integer))
-    @file_count = T.let(nil, T.nilable(Integer))
+    @magic_number = T.let(nil, NilableString)
+    @file_type = T.let(nil, NilableString)
+    @zipinfo = T.let(nil, NilableStringArray)
+    @which_install_info = T.let(nil, NilableString)
+    @disk_usage = T.let(nil, NilableInteger)
+    @file_count = T.let(nil, NilableInteger)
     super
   end
 end


### PR DESCRIPTION
By default, runtime type checking is off. In that mode, `standalone/sorbet.rb`
replaces `T.let` with a version that ignores the type argument. But Ruby still
evaluates that argument first. So `T.let(nil, T.nilable(String))` builds a type
object and then throws it away. `EagerInitializeExtension#initialize` runs every
time a `Pathname` is created, and it does this six times. #23078 found this was
one of the biggest remaining CPU costs in `brew upgrade --dry-run` and
`brew outdated`.

This change moves the three types into `T.type_alias` constants. They are built
once, and `#initialize` just uses the constants. The types themselves do not
change, so Sorbet still sees `@magic_number` as `T.nilable(String)` and so on.

This change does not touch sorbet-runtime itself. #23078 tried to make
`T.nilable`, `T::Array[]` and friends share instances globally, but that broke
how `T::Props` reads optionality and was reverted in #23091. Moving only these
constants avoids that problem.

Behaviour is the same: `brew outdated` and `brew info --installed --json=v2`
print byte-identical output before and after. With the runtime disabled,
Hyperfine shows a consistent speedup (three alternating rounds of 20 runs,
3 warmup, `main` vs this branch):

| Command | before (main) | after | speedup | user CPU |
|---|---|---|---|---|
| `brew outdated` | 1.163 s | 1.071 s | 1.09× | 0.747 s → 0.668 s |
| `brew info --installed --json=v2` | 1.449 s | 1.349 s | 1.07× | 0.931 s → 0.829 s |

The ratio was stable across all three rounds (1.08–1.09 and 1.07–1.08). Commands
that create fewer Pathnames show no measurable change. A stackprof profile of
`brew outdated` shows the union-type construction dropping from 36 samples to 9.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
AI (Claude Code) found the cost by profiling `brew outdated`, wrote the change,
and ran the benchmarks. I reviewed the change and ran `brew lgtm` locally.