### PR TITLE
cask/audit: fix nil crash in min_os check

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -849,11 +849,11 @@ module Cask
       cask_min_os = [on_system_block_min_os, depends_on_min_os].compact.max
       debug_messages = []
       debug_messages << "from on_system block: #{on_system_block_min_os.to_sym}" if on_system_block_min_os
-      if depends_on_min_os > HOMEBREW_MACOS_OLDEST_ALLOWED
+      if depends_on_min_os && depends_on_min_os > HOMEBREW_MACOS_OLDEST_ALLOWED
         debug_messages << "from depends_on stanza: #{depends_on_min_os.to_sym}"
       end
-      odebug "Declared minimum macOS: #{cask_min_os.to_sym} (#{debug_messages.join(" | ").presence || "default"})"
-      return if cask_min_os.to_sym == app_min_os.to_sym
+      odebug "Declared minimum macOS: #{cask_min_os&.to_sym} (#{debug_messages.join(" | ").presence || "default"})"
+      return if cask_min_os&.to_sym == app_min_os.to_sym
       # ignore declared minimum OS < 11.x when auditing as ARM a cask with arch-specific artifacts
       return if OnSystem.arch_condition_met?(:arm) &&
                 cask.on_system_blocks_exist? &&
@@ -861,7 +861,7 @@ module Cask
                 app_min_os < MacOSVersion.new("11") &&
                 app_min_os < cask_min_os
 
-      min_os_definition = if cask_min_os > HOMEBREW_MACOS_OLDEST_ALLOWED
+      min_os_definition = if cask_min_os && cask_min_os > HOMEBREW_MACOS_OLDEST_ALLOWED
         definition = if T.must(on_system_block_min_os.to_s <=> depends_on_min_os.to_s).positive?
           "an on_system block"
         else

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -1214,6 +1214,28 @@ RSpec.describe Cask::Audit, :cask do
         it { is_expected.to error_with(/cask declared no minimum macOS version/) }
       end
 
+      context "when the app requires a newer macOS but the cask declares no macOS dependency" do
+        let(:cask) do
+          tmp_cask "no-min-os", <<~RUBY
+            cask 'no-min-os' do
+              version '1.0'
+              sha256 :no_check
+              url 'https://brew.sh/no-min-os.zip'
+              name 'No Min OS'
+              homepage 'https://brew.sh/'
+
+              on_macos do
+                depends_on arch: :arm64
+
+                app 'No Min OS.app'
+              end
+            end
+          RUBY
+        end
+
+        it { is_expected.to error_with(/cask declared no minimum macOS version/) }
+      end
+
       it "normalizes 10.16.0 minimum macOS to Big Sur" do
         expect(audit.send(:normalize_min_os, "10.16.0")).to eq(MacOSVersion.from_symbol(:big_sur))
       end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I identified the crash when working on the `lm-studio` cask, debugged with Opus 4.8 and tested both by Opus and by hand.  Tests run using `brew lgtm --online`

-----

`audit_min_os` compares `depends_on_min_os` and `cask_min_os` against `HOMEBREW_MACOS_OLDEST_ALLOWED` without nil guards. Both are nil for a cask with no `depends_on macos:` and no versioned `on_system` block, so when the artifact's minimum macOS exceeds the floor the audit raises `undefined method '>' for nil` (reported as "exception while auditing <cask>") instead of the intended "cask declared no minimum macOS version" error.

macOS-only casks declare a minimum OS requirement using the `depends_on macos:` syntax, so the nil path was only exposed by cross-platform casks that scope macOS artifacts in an `on_macos` block and declare no macOS version.

This guards the nil cases so the audit doesn't crash and add a regression test for an app requiring a newer macOS with no declared minimum.