### PR TITLE
shared_audits: pass --fail when fetching Forgejo repo data

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -143,7 +143,7 @@ module SharedAudits
   def self.forgejo_repo_data(user, repo)
     @forgejo_repo_data ||= T.let({}, T.nilable(T::Hash[String, T.untyped]))
     @forgejo_repo_data["#{user}/#{repo}"] ||= begin
-      result = Utils::Curl.curl_output("https://codeberg.org/api/v1/repos/#{user}/#{repo}")
+      result = Utils::Curl.curl_output("https://codeberg.org/api/v1/repos/#{user}/#{repo}", "--fail")
 
       JSON.parse(result.stdout) if result.status.success?
     end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Opus 4.8 with manual testing and review with and without patch, ran `brew lgtm --online`.

-----

I uncovered this while debugging for #23268.

`forgejo_repo_data` fetched repository metadata without `--fail`, so a 404 (Codeberg returns one for a missing user/repo) still exits 0 and `result.status.success?` stays true. The 404 error body was parsed as if it were a repository, and `SharedAudits.forgejo` raised `undefined method '<' for nil` on the absent `*_count` fields while checking notability.

Pass `--fail`, matching `gitlab_release_data` and `forgejo_release_data`, so a failed request is treated as no data.