### PR TITLE
formula: allow changing install args in std_cabal_v2_args

### DIFF
--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -50,8 +50,8 @@ module OS
         supports_linux?
       end
 
-      sig { returns(T::Array[String]) }
-      def std_cabal_v2_args
+      sig { params(installdir: T.any(String, ::Pathname, FalseClass)).returns(T::Array[String]) }
+      def std_cabal_v2_args(installdir: bin)
         args = super
         args << "--ghc-option=-pie" if ::Hardware::CPU.arm?
         args

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2062,15 +2062,18 @@ class Formula
   # Standard parameters for Cabal-v2 builds.
   #
   # @api public
-  sig { returns(T::Array[String]) }
-  def std_cabal_v2_args
+  # @param installdir directory for `--installdir`. Set to false if using v2-configure or v2-build
+  sig { params(installdir: T.any(String, Pathname, FalseClass)).returns(T::Array[String]) }
+  def std_cabal_v2_args(installdir: bin)
     # cabal-install's dependency-resolution backtracking strategy can
     # easily need more than the default 2,000 maximum number of
     # "backjumps," since Hackage is a fast-moving, rolling-release
     # target. The highest known needed value by a formula was 43,478
     # for git-annex, so 100,000 should be enough to avoid most
     # gratuitous backjumps build failures.
-    ["--jobs=#{ENV.make_jobs}", "--max-backjumps=100000", "--install-method=copy", "--installdir=#{bin}"]
+    args = ["--jobs=#{ENV.make_jobs}", "--max-backjumps=100000"]
+    args += ["--install-method=copy", "--installdir=#{installdir}"] if installdir
+    args
   end
 
   # Standard parameters for Cargo builds.

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -3222,6 +3222,14 @@ RSpec.describe Formula do
       end
     end
 
+    it "allows changing the installation directory" do
+      expect(f.std_cabal_v2_args(installdir: "/tmp/foo")).to include("--installdir=/tmp/foo")
+    end
+
+    it "excludes installation arguments when `installdir: false`" do
+      expect(f.std_cabal_v2_args(installdir: false)).not_to include(a_string_starting_with("--install"))
+    end
+
     context "when running on Linux", :needs_linux do
       it "includes flag for PIE on arm" do
         allow(Hardware::CPU).to receive(:arm?).and_return(true)


### PR DESCRIPTION
`installdir: false` uses the same approach as std_npm_args and std_pip_args to provide a different set of arguments when not installing into Cellar. This is needed when running `v2-configure` or `v2-build`.

Also provide similar functionality as other std_*_args to handle alternative installation directories. This avoids formulae having to manually remove the unwanted arguments.

Can be used by `ghc*`, `koka` and `elm-format`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
