### PR TITLE
Deduplicate install step source globs

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -1014,10 +1014,11 @@ module Homebrew
 
       sig { params(step: Step).returns(Pathname) }
       def resolve_step_source(step)
-        source = resolve_path(step_path(step, "source"))
+        source_spec = step_path(step, "source")
+        source = resolve_path(source_spec)
         return source if step["source_glob"] != true
 
-        sources = Pathname.glob(source.to_s)
+        sources = expand_path_glob(source_spec).select { |path| path.exist? || path.symlink? }.uniq
         raise ArgumentError, "install step source glob must match exactly one path: #{source}" if sources.length != 1
 
         sources.fetch(0)

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -341,6 +341,27 @@ RSpec.describe Homebrew::InstallSteps do
       .to raise_error(ArgumentError, /exactly one path/)
   end
 
+  specify "requires a match for literal glob sources" do
+    steps = Homebrew::InstallSteps::DSL.build(default_source_base: :staged_path, default_target_base: :var) do
+      copy "missing.txt", "copied.txt", source_glob: true
+    end
+
+    expect { Homebrew::InstallSteps::Runner.new(context:).run(steps) }
+      .to raise_error(ArgumentError, /exactly one path/)
+  end
+
+  specify "deduplicates overlapping move source globs" do
+    steps = Homebrew::InstallSteps::DSL.build(default_source_base: :staged_path,
+                                              default_target_base: :staged_path) do
+      move "{WezTerm-*,WezTerm-*}/WezTerm.app", ".", source_glob: true
+    end
+    (root/"stage/WezTerm-nightly/WezTerm.app").mkpath
+
+    Homebrew::InstallSteps::Runner.new(context:).run(steps)
+
+    expect(root/"stage/WezTerm.app").to be_a_directory
+  end
+
   specify "removes paths and expands globs", :aggregate_failures do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
       remove ["obsolete.txt", "obsolete-*"], recursive: true


### PR DESCRIPTION
Brace alternatives can resolve the same pathname more than once on case-insensitive filesystems. Single-source moves then reject one real match as multiple paths.

- resolve move and copy source globs through the shared path expander
- deduplicate matches before enforcing single-source behaviour
- cover overlapping brace alternatives used by `wezterm@nightly`

Raised by @samford in https://github.com/Homebrew/homebrew-cask/pull/275989#issuecomment-5052405762.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 sol xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
