### PR TITLE
Offer to uninstall packages before untapping

### DIFF
--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -1,7 +1,11 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "English"
 require "abstract_command"
+require "ask"
+require "cask/uninstall"
+require "uninstall"
 require "utils"
 
 module Homebrew
@@ -12,7 +16,7 @@ module Homebrew
           Remove a tapped formula repository.
         EOS
         switch "-f", "--force",
-               description: "Untap even if formulae or casks from this tap are currently installed."
+               description: "Uninstall all formulae and casks from this tap with `--force` before untapping."
 
         named_args :tap, min: 1
       end
@@ -36,18 +40,61 @@ module Homebrew
             installed_tap_casks = installed_casks_for(tap:)
 
             if installed_tap_formulae.present? || installed_tap_casks.present?
-              installed_names = (installed_tap_formulae + installed_tap_casks.map(&:token)).join("\n")
-              if args.force? || Homebrew::EnvConfig.developer?
+              installed_formulae_names = installed_tap_formulae.map(&:full_name)
+              installed_cask_names = installed_tap_casks.map(&:full_name)
+              installed_package_types = if installed_formulae_names.empty?
+                "casks"
+              elsif installed_cask_names.empty?
+                "formulae"
+              else
+                "formulae and casks"
+              end
+              installed_names = (installed_formulae_names + installed_cask_names).join("\n")
+              if Homebrew::EnvConfig.developer? && !args.force?
                 opoo <<~EOS
-                  Untapping #{tap} even though it contains the following installed formulae or casks:
+                  Untapping #{tap} even though it contains the following installed #{installed_package_types}:
                   #{installed_names}
                 EOS
               else
-                ofail <<~EOS
-                  Refusing to untap #{tap} because it contains the following installed formulae or casks:
-                  #{installed_names}
-                EOS
-                next
+                unless args.force?
+                  ohai "Would untap #{tap} after uninstalling the following #{installed_package_types}:"
+                  puts installed_names
+                  confirmed = begin
+                    Homebrew::Ask.confirm?(action: "changes")
+                  rescue SystemExit
+                    false
+                  end
+                  unless confirmed
+                    ofail <<~EOS
+                      Refusing to untap #{tap} because it contains the following installed #{installed_package_types}:
+                      #{installed_names}
+                    EOS
+                    next
+                  end
+                end
+
+                named_args = installed_formulae_names + installed_cask_names
+                kegs_by_rack = installed_tap_formulae.flat_map do |formula|
+                  formula.installed_kegs.select { |keg| keg.tab.tap == tap }
+                end.group_by(&:rack)
+
+                Cask::Uninstall.check_dependent_casks(*installed_tap_casks, named_args:)
+                next if Homebrew.failed?
+
+                Uninstall.uninstall_kegs(kegs_by_rack, casks: installed_tap_casks, force: args.force?, named_args:)
+                next if Homebrew.failed?
+
+                begin
+                  Cask::Uninstall.uninstall_casks(*installed_tap_casks, force: args.force?)
+                rescue
+                  ofail $ERROR_INFO
+                  next
+                end
+
+                if installed_formulae_for(tap:).present? || installed_casks_for(tap:).present?
+                  ofail "Failed to fully uninstall #{installed_package_types} from #{tap}"
+                  next
+                end
               end
             end
           end

--- a/Library/Homebrew/test/cmd/untap_spec.rb
+++ b/Library/Homebrew/test/cmd/untap_spec.rb
@@ -24,22 +24,111 @@ RSpec.describe Homebrew::Cmd::Untap do
       .and raise_error(SystemExit)
   end
 
-  it "continues untapping remaining taps when one has installed formulae" do
+  it "continues untapping remaining taps when uninstallation is declined" do
     tap1 = Tap.fetch("homebrew", "foo")
     tap2 = Tap.fetch("homebrew", "bar")
 
     cmd = described_class.new(["homebrew/foo", "homebrew/bar"])
     allow(cmd.args.named).to receive(:to_installed_taps).and_return([tap1, tap2])
 
-    allow(cmd).to receive(:installed_formulae_for).with(tap: tap1).and_return(["homebrew/foo/testball"])
+    formula = instance_double(Formula, full_name: "homebrew/foo/testball")
+    allow(cmd).to receive(:installed_formulae_for).with(tap: tap1).and_return([formula])
     allow(cmd).to receive(:installed_formulae_for).with(tap: tap2).and_return([])
     allow(cmd).to receive(:installed_casks_for).with(tap: tap1).and_return([])
     allow(cmd).to receive(:installed_casks_for).with(tap: tap2).and_return([])
 
     expect(tap1).not_to receive(:uninstall)
+    allow(Homebrew::Ask).to receive(:confirm?)
+      .with(action: "changes")
+      .and_raise(SystemExit)
     expect(tap2).to receive(:uninstall).with(manual: true)
 
-    expect { cmd.run }.to output(/Refusing to untap/).to_stderr
+    expect { cmd.run }
+      .to output(/Refusing to untap.*following installed formulae:/m).to_stderr
+      .and output(%r{Would untap homebrew/foo after uninstalling the following formulae.*testball}m).to_stdout
+    expect(Homebrew).to have_failed
+  ensure
+    Homebrew.failed = false
+  end
+
+  it "lists installed packages before offering to uninstall them and untap" do
+    tap = Tap.fetch("homebrew", "foo")
+    rack = HOMEBREW_CELLAR/"testball"
+    keg = instance_double(Keg, rack:, tab: instance_double(Tab, tap:))
+    formula = instance_double(
+      Formula,
+      full_name:      "homebrew/foo/testball",
+      installed_kegs: [keg],
+      to_s:           "homebrew/foo/testball",
+    )
+    cask = instance_double(Cask::Cask, full_name: "homebrew/foo/testcask", token: "testcask")
+    cmd = described_class.new(["homebrew/foo"])
+
+    allow(cmd.args.named).to receive(:to_installed_taps).and_return([tap])
+    allow(cmd).to receive(:installed_formulae_for).with(tap:).and_return([formula], [])
+    allow(cmd).to receive(:installed_casks_for).with(tap:).and_return([cask], [])
+    allow(Homebrew::Ask).to receive(:confirm?)
+      .with(action: "changes")
+      .and_return(true)
+
+    named_args = [formula.full_name, cask.full_name]
+    expect(Cask::Uninstall).to receive(:check_dependent_casks).with(cask, named_args:).ordered
+    expect(Homebrew::Uninstall).to receive(:uninstall_kegs)
+      .with({ rack => [keg] }, casks: [cask], force: false, named_args:).ordered
+    expect(Cask::Uninstall).to receive(:uninstall_casks).with(cask, force: false)
+    expect(tap).to receive(:uninstall).with(manual: true)
+
+    expect { cmd.run }.to output(<<~EOS).to_stdout
+      ==> Would untap homebrew/foo after uninstalling the following formulae and casks:
+      homebrew/foo/testball
+      homebrew/foo/testcask
+    EOS
+  end
+
+  it "force-uninstalls installed packages without prompting before untapping" do
+    tap = Tap.fetch("homebrew", "foo")
+    rack = HOMEBREW_CELLAR/"testball"
+    keg = instance_double(Keg, rack:, tab: instance_double(Tab, tap:))
+    formula = instance_double(
+      Formula,
+      full_name:      "homebrew/foo/testball",
+      installed_kegs: [keg],
+    )
+    cask = instance_double(Cask::Cask, full_name: "homebrew/foo/testcask")
+    cmd = described_class.new(["--force", "homebrew/foo"])
+
+    allow(cmd.args.named).to receive(:to_installed_taps).and_return([tap])
+    allow(cmd).to receive(:installed_formulae_for).with(tap:).and_return([formula], [])
+    allow(cmd).to receive(:installed_casks_for).with(tap:).and_return([cask], [])
+    expect(Homebrew::Ask).not_to receive(:confirm?)
+
+    named_args = [formula.full_name, cask.full_name]
+    expect(Cask::Uninstall).to receive(:check_dependent_casks).with(cask, named_args:).ordered
+    expect(Homebrew::Uninstall).to receive(:uninstall_kegs)
+      .with({ rack => [keg] }, casks: [cask], force: true, named_args:).ordered
+    expect(Cask::Uninstall).to receive(:uninstall_casks).with(cask, force: true)
+    expect(tap).to receive(:uninstall).with(manual: true)
+
+    expect { cmd.run }.not_to output.to_stdout
+  end
+
+  it "does not untap when an installation remains" do
+    tap = Tap.fetch("homebrew", "foo")
+    cask = instance_double(Cask::Cask, full_name: "homebrew/foo/testcask", token: "testcask")
+    cmd = described_class.new(["homebrew/foo"])
+
+    allow(cmd.args.named).to receive(:to_installed_taps).and_return([tap])
+    allow(cmd).to receive(:installed_formulae_for).with(tap:).and_return([], [])
+    allow(cmd).to receive(:installed_casks_for).with(tap:).and_return([cask], [cask])
+    allow(Homebrew::Ask).to receive(:confirm?)
+      .with(action: "changes")
+      .and_return(true)
+    allow(Homebrew::Uninstall).to receive(:uninstall_kegs)
+    allow(Cask::Uninstall).to receive(:check_dependent_casks)
+    allow(Cask::Uninstall).to receive(:uninstall_casks)
+    expect(tap).not_to receive(:uninstall)
+
+    expect { cmd.run }.to output(%r{Failed to fully uninstall casks from homebrew/foo}).to_stderr
     expect(Homebrew).to have_failed
   ensure
     Homebrew.failed = false


### PR DESCRIPTION
- Let users remove formulae and casks owned by a tap in one flow.
- Only untap after every selected package is removed successfully.

Fixes #23270

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 Sol high with local review and lots of manual local testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
