### PR TITLE
Allow PTYs in Landlock sandboxes

### DIFF
--- a/Library/Homebrew/extend/os/linux/sandbox/landlock.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox/landlock.rb
@@ -318,6 +318,19 @@ class Sandbox
       raise_system_call_error("landlock_create_ruleset") if ruleset_fd.negative?
 
       begin
+        # PTY allocation opens `/dev/ptmx` read-write, then configures its
+        # dynamically allocated `/dev/pts/*` slave with device ioctls:
+        # https://github.com/torvalds/linux/blob/master/drivers/tty/pty.c
+        # https://www.kernel.org/doc/html/latest/userspace-api/landlock.html#ioctl-support
+        pty_access = ACCESS_FS_WRITE_FILE
+        pty_access |= ACCESS_FS_IOCTL_DEV if abi >= 5
+        pty_access |= ACCESS_FS_READ_FILE if @deny_read
+        ["/dev/ptmx", "/dev/pts"].each do |path|
+          next unless File.exist?(path)
+
+          add_path_rule(ruleset_fd, path, pty_access)
+        end
+
         error_pipe_path = @error_pipe_path
         if @deny_all_network && abi >= 9 && error_pipe_path
           add_path_rule(ruleset_fd, error_pipe_path, ACCESS_FS_RESOLVE_UNIX)

--- a/Library/Homebrew/test/sandbox_landlock_spec.rb
+++ b/Library/Homebrew/test/sandbox_landlock_spec.rb
@@ -84,6 +84,12 @@ RSpec.describe Sandbox::Landlock do
     let(:writable_dir) { mktmpdir }
     let(:tmpdir) { mktmpdir }
 
+    before do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("/dev/ptmx").and_return(true)
+      allow(File).to receive(:exist?).with("/dev/pts").and_return(true)
+    end
+
     it "rejects an ABI without complete write restrictions" do
       allow(described_class).to receive_messages(abi_version:    2,
                                                  failure_reason: "Landlock ABI 3 or later is required; found ABI 2.")
@@ -109,8 +115,10 @@ RSpec.describe Sandbox::Landlock do
       expect(landlock).to receive(:open_path).with(File::NULL).and_return(19)
       allow(landlock).to receive(:open_path).with(tmpdir.to_s).and_return(20)
       expect(landlock).to receive(:open_path).with("#{tmpdir}/socket").and_return(21)
+      expect(landlock).to receive(:open_path).with("/dev/ptmx").and_return(22)
+      expect(landlock).to receive(:open_path).with("/dev/pts").and_return(23)
       path_rules = []
-      expect(described_class).to receive(:landlock_add_rule).exactly(4).times do |ruleset_fd, type, attributes, flags|
+      expect(described_class).to receive(:landlock_add_rule).exactly(6).times do |ruleset_fd, type, attributes, flags|
         expect(ruleset_fd).to eq(17)
         expect(type).to eq(1)
         expect(attributes.bytesize).to eq(12)
@@ -120,6 +128,8 @@ RSpec.describe Sandbox::Landlock do
       end
       expect(described_class).to receive(:set_no_new_privileges).and_return(0)
       expect(described_class).to receive(:landlock_restrict_self).with(17, 0).and_return(0)
+      expect(landlock).to receive(:close_file_descriptor).with(22).ordered
+      expect(landlock).to receive(:close_file_descriptor).with(23).ordered
       expect(landlock).to receive(:close_file_descriptor).with(21).ordered
       expect(landlock).to receive(:close_file_descriptor).with(18).ordered
       expect(landlock).to receive(:close_file_descriptor).with(19).ordered
@@ -128,7 +138,9 @@ RSpec.describe Sandbox::Landlock do
 
       landlock.apply!
 
-      expect(path_rules).to eq([[65_536, 21], [32_754, 18], [16_386, 19], [32_754, 20]])
+      expect(path_rules).to eq([
+        [32_770, 22], [32_770, 23], [65_536, 21], [32_754, 18], [16_386, 19], [32_754, 20]
+      ])
     end
 
     it "handles reads, directory listings, and execution outside denied hierarchies" do
@@ -152,8 +164,10 @@ RSpec.describe Sandbox::Landlock do
       expect(landlock).to receive(:open_path).with(readable_file.to_s).and_return(19)
       expect(landlock).to receive(:open_path).with(File::NULL).and_return(20)
       expect(landlock).to receive(:open_path).with(tmpdir.to_s).and_return(21)
+      expect(landlock).to receive(:open_path).with("/dev/ptmx").and_return(22)
+      expect(landlock).to receive(:open_path).with("/dev/pts").and_return(23)
       path_rules = []
-      expect(described_class).to receive(:landlock_add_rule).exactly(4).times do |ruleset_fd, type, attributes, flags|
+      expect(described_class).to receive(:landlock_add_rule).exactly(6).times do |ruleset_fd, type, attributes, flags|
         expect(ruleset_fd).to eq(17)
         expect(type).to eq(1)
         path_rules << attributes.unpack("Ql")
@@ -166,7 +180,43 @@ RSpec.describe Sandbox::Landlock do
 
       landlock.apply!
 
-      expect(path_rules).to eq([[13, 18], [5, 19], [16_386, 20], [32_754, 21]])
+      expect(path_rules).to eq([
+        [32_774, 22], [32_774, 23], [13, 18], [5, 19], [16_386, 20], [32_754, 21]
+      ])
+    end
+
+    it "allows pseudo-terminal device access" do
+      landlock.command(["true"], tmpdir.to_s)
+
+      allow(described_class).to receive_messages(abi_version: 10, landlock_create_ruleset: 17,
+                                                 landlock_add_rule: 0, set_no_new_privileges: 0,
+                                                 landlock_restrict_self: 0)
+      allow(landlock).to receive(:open_path).and_return(18)
+      allow(landlock).to receive(:close_file_descriptor)
+      expect(landlock).to receive(:open_path).with("/dev/ptmx").and_return(19)
+      expect(landlock).to receive(:open_path).with("/dev/pts").and_return(20)
+      expect(described_class).to receive(:landlock_add_rule)
+        .with(17, 1, [32_770, 19].pack("Ql"), 0).and_return(0)
+      expect(described_class).to receive(:landlock_add_rule)
+        .with(17, 1, [32_770, 20].pack("Ql"), 0).and_return(0)
+
+      landlock.apply!
+    end
+
+    it "skips unavailable pseudo-terminal device paths" do
+      landlock.command(["true"], tmpdir.to_s)
+
+      allow(File).to receive(:exist?).with("/dev/ptmx").and_return(false)
+      allow(File).to receive(:exist?).with("/dev/pts").and_return(false)
+      allow(described_class).to receive_messages(abi_version: 10, landlock_create_ruleset: 17,
+                                                 landlock_add_rule: 0, set_no_new_privileges: 0,
+                                                 landlock_restrict_self: 0)
+      allow(landlock).to receive(:open_path).and_return(18)
+      allow(landlock).to receive(:close_file_descriptor)
+      expect(landlock).not_to receive(:open_path).with("/dev/ptmx")
+      expect(landlock).not_to receive(:open_path).with("/dev/pts")
+
+      landlock.apply!
     end
 
     context "with an older ABI" do

--- a/Library/Homebrew/test/sandbox_linux_spec.rb
+++ b/Library/Homebrew/test/sandbox_linux_spec.rb
@@ -478,6 +478,14 @@ RSpec.describe Sandbox, :needs_linux do
       expect { sandbox.run "false" }.to raise_error(ErrorDuringExecution)
     end
 
+    it "allows spawning a pseudo-terminal" do
+      sandbox.deny_read_path mktmpdir
+
+      expect do
+        sandbox.run RUBY_PATH, "-rpty", "-e", 'PTY.spawn("true") { |_, _, pid| Process.wait(pid) }'
+      end.not_to raise_error
+    end
+
     it "prevents listing a denied read hierarchy" do
       denied_dir = mktmpdir
       FileUtils.touch denied_dir/"secret"


### PR DESCRIPTION
- Grant write and ABI-aware ioctl access only to Linux PTY devices.
- Cover the Ruby `PTY.spawn` regression.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 sol xhigh with local review and (unit, not on Linux) testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
