### PR TITLE
workflows: skip signing/pushing for dependabot

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -35,6 +35,7 @@ jobs:
           username: BrewTestBot
 
       - name: Set up commit signing
+        if: github.actor != 'dependabot[bot]'
         uses: Homebrew/actions/setup-commit-signing@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026.07.20.1
         with:
           signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
@@ -78,7 +79,7 @@ jobs:
           fi
 
       - name: Push commits
-        if: steps.update.outputs.committed == 'true'
+        if: steps.update.outputs.committed == 'true' && github.actor != 'dependabot[bot]'
         uses: Homebrew/actions/git-try-push@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026.07.20.1
         with:
           token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
@@ -88,7 +89,7 @@ jobs:
           origin_branch: "HEAD"
 
       - name: Open a pull request
-        if: steps.update.outputs.pull_request == 'true'
+        if: steps.update.outputs.pull_request == 'true' && github.actor != 'dependabot[bot]'
         run: gh pr create --fill
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}

--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -42,7 +42,7 @@ jobs:
           username: BrewTestBot
 
       - name: Set up commit signing
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.actor != 'dependabot[bot]'
         uses: Homebrew/actions/setup-commit-signing@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026.07.20.1
         with:
           signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
@@ -98,7 +98,7 @@ jobs:
           fi
 
       - name: Push commits
-        if: steps.commit.outputs.committed == 'true'
+        if: steps.commit.outputs.committed == 'true' && github.actor != 'dependabot[bot]'
         uses: Homebrew/actions/git-try-push@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026.07.20.1
         with:
           token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
@@ -108,7 +108,7 @@ jobs:
           origin_branch: "HEAD"
 
       - name: Open a pull request
-        if: steps.commit.outputs.pull_request == 'true'
+        if: steps.commit.outputs.pull_request == 'true' && github.actor != 'dependabot[bot]'
         run: gh pr create --fill
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -35,6 +35,7 @@ jobs:
           username: BrewTestBot
 
       - name: Set up commit signing
+        if: github.actor != 'dependabot[bot]'
         uses: Homebrew/actions/setup-commit-signing@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026.07.20.1
         with:
           signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
@@ -72,7 +73,7 @@ jobs:
           fi
 
       - name: Push commits
-        if: steps.update.outputs.committed == 'true'
+        if: steps.update.outputs.committed == 'true' && github.actor != 'dependabot[bot]'
         uses: Homebrew/actions/git-try-push@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026.07.20.1
         with:
           token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
@@ -82,7 +83,7 @@ jobs:
           origin_branch: "HEAD"
 
       - name: Open a pull request
-        if: steps.update.outputs.pull_request == 'true'
+        if: steps.update.outputs.pull_request == 'true' && github.actor != 'dependabot[bot]'
         run: gh pr create --fill
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}


### PR DESCRIPTION
- Dependabot-triggered push runs only get Dependabot secrets, so `BREWTESTBOT_SSH_SIGNING_KEY` is unavailable and the `setup-commit-signing` step fails in `spdx.yml`, `sbom.yml` and `sorbet.yml` when Dependabot pushes to its branches.
- Skip commit signing, pushing and pull request creation in these runs instead so the rest of each job still runs as a smoke test.
- Fork runs are already excluded by the existing job-level `github.repository` checks.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Fable 5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
