### PR TITLE
Output Landlock ABI version in `brew config`

### DIFF
--- a/Library/Homebrew/extend/os/linux/sandbox/landlock.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox/landlock.rb
@@ -107,6 +107,18 @@ class Sandbox
         @abi_version
       end
 
+      # The Landlock ABI version provided by the running kernel, regardless of
+      # whether Homebrew's Linux sandbox is enabled or usable.
+      sig { returns(T.nilable(Integer)) }
+      def kernel_abi_version
+        require "fiddle"
+
+        version = landlock_create_ruleset(nil, 0, CREATE_RULESET_VERSION)
+        version if version.positive?
+      rescue LoadError, Fiddle::DLError
+        nil
+      end
+
       sig { returns(T.nilable(String)) }
       def failure_reason
         case state
@@ -260,8 +272,8 @@ class Sandbox
           return :missing_fiddle
         end
 
-        version = landlock_create_ruleset(nil, 0, CREATE_RULESET_VERSION)
-        if version.positive?
+        version = kernel_abi_version
+        if version
           @abi_version = T.let(version, T.nilable(Integer))
           if version >= MINIMUM_ABI
             :available

--- a/Library/Homebrew/extend/os/linux/system_config.rb
+++ b/Library/Homebrew/extend/os/linux/system_config.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "compilers"
+require "extend/os/linux/sandbox/landlock"
 require "os/linux/glibc"
 require "os/linux/libstdcxx"
 require "system_command"
@@ -106,6 +107,7 @@ module OS
         sig { params(out: T.any(File, StringIO, IO)).void }
         def linux_config(out = $stdout)
           out.puts "Kernel: #{Utils.safe_popen_read("uname", "-mors").chomp}"
+          out.puts "Landlock ABI: #{::Sandbox::Landlock.kernel_abi_version || "N/A"}"
           out.puts "OS: #{OS::Linux.os_version}"
           if OS.wsl?
             out.puts "WSL: #{OS::Linux.wsl_version}"

--- a/Library/Homebrew/test/cmd/config_spec.rb
+++ b/Library/Homebrew/test/cmd/config_spec.rb
@@ -88,6 +88,23 @@ RSpec.describe Homebrew::Cmd::Config do
     expect(output.string).to include("Windows: Windows 11 Pro (25H2) [26200.8457]\n")
   end
 
+  it "prints the Landlock ABI in config output", :needs_linux do
+    output = StringIO.new
+
+    allow(Sandbox::Landlock).to receive(:kernel_abi_version).and_return(6)
+    allow(SystemConfig).to receive_messages(
+      homebrew_config:      nil,
+      core_tap_config:      nil,
+      homebrew_env_config:  nil,
+      hardware:             nil,
+      host_software_config: nil,
+    )
+
+    SystemConfig.dump_verbose_config(output)
+
+    expect(output.string).to include("Landlock ABI: 6\n")
+  end
+
   it "prints config sections in order" do
     output = StringIO.new
 

--- a/Library/Homebrew/test/sandbox_landlock_spec.rb
+++ b/Library/Homebrew/test/sandbox_landlock_spec.rb
@@ -80,6 +80,28 @@ RSpec.describe Sandbox::Landlock do
     end
   end
 
+  describe "::kernel_abi_version" do
+    it "reports the kernel ABI even when Linux sandboxing is disabled" do
+      allow(Homebrew::EnvConfig).to receive(:sandbox_linux?).and_return(false)
+      allow(described_class).to receive(:landlock_create_ruleset).with(nil, 0, 1).and_return(6)
+
+      expect(described_class.kernel_abi_version).to eq(6)
+    end
+
+    it "returns nil for a kernel without Landlock support" do
+      allow(described_class).to receive(:landlock_create_ruleset).with(nil, 0, 1).and_return(-1)
+
+      expect(described_class.kernel_abi_version).to be_nil
+    end
+
+    it "returns nil when Fiddle function setup fails" do
+      require "fiddle"
+      allow(described_class).to receive(:landlock_create_ruleset).and_raise(Fiddle::DLError)
+
+      expect(described_class.kernel_abi_version).to be_nil
+    end
+  end
+
   describe "#apply!" do
     let(:writable_dir) { mktmpdir }
     let(:tmpdir) { mktmpdir }


### PR DESCRIPTION
- Landlock is a kernel ABI with no user-visible version so there was no easy way to see what a given system supports.
- `Sandbox::Landlock.kernel_abi_version` probes the kernel even when `HOMEBREW_NO_SANDBOX_LINUX` is set so `brew config` reports what the system provides rather than what Homebrew will use.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Fable 5 xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
