### PR TITLE
Block releases on open release blockers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,37 @@ jobs:
       contents: write # for creating tags and releases
       attestations: write # for actions/attest
       id-token: write # for actions/attest
+      issues: read # for checking release blocker labels
+      pull-requests: read # for checking release blocker labels
     steps:
+      - name: Check for release blockers
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        # Keep in sync with the release blocker check in
+        # Library/Homebrew/dev-cmd/release.rb.
+        run: |
+          labels=("release blocker")
+          if [[ "${TAG}" =~ ^[0-9]+\.[0-9]+\.0$ ]]
+          then
+            labels+=("major/minor release blocker")
+          fi
+
+          blockers="$(for label in "${labels[@]}"
+          do
+            gh api --method GET repos/Homebrew/brew/issues \
+              --raw-field state=open --raw-field labels="${label}" \
+              --jq '.[].html_url'
+          done | sort -u)"
+
+          if [[ -n "${blockers}" ]]
+          then
+            echo "Open issues or pull requests are blocking this release:"
+            echo "${blockers}"
+            exit 1
+          fi
+
       - name: Remove existing API cache (to force update)
         run: rm -rvf ~/Library/Caches/Homebrew/api
 

--- a/Library/Homebrew/dev-cmd/release.rb
+++ b/Library/Homebrew/dev-cmd/release.rb
@@ -41,6 +41,20 @@ module Homebrew
 
         require "utils/github"
 
+        # Keep in sync with the "Check for release blockers" step in
+        # .github/workflows/release.yml.
+        blocking_labels = ["release blocker"]
+        blocking_labels << "major/minor release blocker" if args.major? || args.minor?
+        release_blockers = blocking_labels.flat_map do |label|
+          GitHub.issues(repo: "Homebrew/brew", state: "open", labels: label)
+        rescue *GitHub::API::ERRORS => e
+          odie "Unable to check for release blockers: #{e.message}!"
+        end
+        if release_blockers.present?
+          blocker_urls = release_urls(release_blockers).uniq.join("\n")
+          odie "Open issues or pull requests are blocking this release:\n#{blocker_urls}"
+        end
+
         begin
           latest_release = GitHub.get_latest_release "Homebrew", "brew"
         rescue GitHub::API::HTTPNotFoundError

--- a/Library/Homebrew/test/dev-cmd/release_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/release_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Homebrew::DevCmd::Release do
 
       allow(Homebrew::EnvConfig).to receive(:no_auto_update?).and_return(false)
       allow(GitHub).to receive_messages(
+        issues:                 [],
         get_latest_release:     { "tag_name" => "1.2.3" },
         generate_release_notes: { "body" => "Release notes" },
       )
@@ -30,6 +31,35 @@ RSpec.describe Homebrew::DevCmd::Release do
       expect { command.run }
         .to raise_error(SystemExit)
         .and output(/Run `brew update` before `brew release --force`\./).to_stderr
+    end
+
+    it "refuses to release when open release blockers exist" do
+      command = described_class.new([])
+
+      allow(Homebrew::EnvConfig).to receive(:no_auto_update?).and_return(false)
+      allow(GitHub).to receive(:issues)
+        .with(repo: "Homebrew/brew", state: "open", labels: "release blocker")
+        .and_return([{ "html_url" => "https://github.com/Homebrew/brew/issues/12345" }])
+
+      expect { command.run }
+        .to raise_error(SystemExit)
+        .and output(%r{issues/12345}).to_stderr
+    end
+
+    it "refuses to release when open major/minor release blockers exist for a major release" do
+      command = described_class.new(["--major"])
+
+      allow(Homebrew::EnvConfig).to receive(:no_auto_update?).and_return(false)
+      allow(GitHub).to receive(:issues)
+        .with(repo: "Homebrew/brew", state: "open", labels: "release blocker")
+        .and_return([])
+      allow(GitHub).to receive(:issues)
+        .with(repo: "Homebrew/brew", state: "open", labels: "major/minor release blocker")
+        .and_return([{ "html_url" => "https://github.com/Homebrew/brew/pull/54321" }])
+
+      expect { command.run }
+        .to raise_error(SystemExit)
+        .and output(%r{pull/54321}).to_stderr
     end
   end
 

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -1,5 +1,5 @@
 ---
-last_review_date: "2026-07-18"
+last_review_date: "2026-07-24"
 ---
 
 # Releases
@@ -14,9 +14,11 @@ Only maintainers with write access to Homebrew/brew can create a release.
    - [`Homebrew/brew` issues](https://github.com/Homebrew/brew/issues)
    - [`Homebrew/homebrew-core` issues](https://github.com/Homebrew/homebrew-core/issues)
    - [Homebrew Discussions](https://github.com/orgs/Homebrew/discussions)
-2. Confirm that the workflows on Homebrew/brew's `main` branch are passing and that at least one recent Homebrew/homebrew-core pull request has completed CI successfully.
-3. Allow enough time after the last code change to detect regressions before releasing.
-4. Confirm that the current `main` branch is suitable for release.
+2. Label any Homebrew/brew issues or pull requests that must be resolved before any release with `release blocker`, or before the next major or minor release with `major/minor release blocker`.
+   While any open Homebrew/brew issue or pull request has a relevant label, `brew release` and the release workflow will refuse to create a release.
+3. Confirm that the workflows on Homebrew/brew's `main` branch are passing and that at least one recent Homebrew/homebrew-core pull request has completed CI successfully.
+4. Allow enough time after the last code change to detect regressions before releasing.
+5. Confirm that the current `main` branch is suitable for release.
 
 Do not create a release from an older commit on `main`.
 If unreleased changes must be excluded from an urgent patch release, revert those changes, complete the release process and then reapply them.


### PR DESCRIPTION
- Labelling any open Homebrew/brew issue or pull request with `release blocker` now stops `brew release` and the `release.yml` `workflow_dispatch` run before a release is created.
- `major/minor release blocker` only blocks releases whose version ends in `.0`.
- Checking in the workflow as well as the command means releases triggered directly from the GitHub UI are also blocked.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude 5 Fable xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
