### PR TITLE
Align EnvConfig RBI types with runtime value

### DIFF
--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -13,7 +13,7 @@ module Homebrew::EnvConfig
     sig { returns(T.nilable(::String)) }
     def allowed_taps; end
 
-    sig { returns(Integer) }
+    sig { returns(String) }
     def api_auto_update_secs; end
 
     sig { returns(String) }
@@ -31,7 +31,7 @@ module Homebrew::EnvConfig
     sig { returns(T::Boolean) }
     def ask?; end
 
-    sig { returns(T.nilable(::String)) }
+    sig { returns(String) }
     def auto_update_secs; end
 
     sig { returns(T::Boolean) }
@@ -163,10 +163,10 @@ module Homebrew::EnvConfig
     sig { returns(T.nilable(::String)) }
     def cask_opts_require_sha; end
 
-    sig { returns(Integer) }
+    sig { returns(String) }
     def cleanup_max_age_days; end
 
-    sig { returns(Integer) }
+    sig { returns(String) }
     def cleanup_periodic_full_days; end
 
     sig { returns(T::Boolean) }
@@ -178,7 +178,7 @@ module Homebrew::EnvConfig
     sig { returns(String) }
     def curl_path; end
 
-    sig { returns(Integer) }
+    sig { returns(String) }
     def curl_retries; end
 
     sig { returns(T::Boolean) }
@@ -220,7 +220,7 @@ module Homebrew::EnvConfig
     sig { returns(T::Boolean) }
     def eval_all?; end
 
-    sig { returns(Integer) }
+    sig { returns(String) }
     def fail_log_lines; end
 
     sig { returns(T::Boolean) }
@@ -403,7 +403,7 @@ module Homebrew::EnvConfig
     sig { returns(T::Boolean) }
     def no_verify_attestations?; end
 
-    sig { returns(T.nilable(::String)) }
+    sig { returns(String) }
     def pip_index_url; end
 
     sig { returns(T::Boolean) }
@@ -430,7 +430,7 @@ module Homebrew::EnvConfig
     sig { returns(T::Boolean) }
     def sorbet_runtime?; end
 
-    sig { returns(T.nilable(::String)) }
+    sig { returns(String) }
     def ssh_config_path; end
 
     sig { returns(T.nilable(::String)) }

--- a/Library/Homebrew/sorbet/tapioca/compilers/env_config.rb
+++ b/Library/Homebrew/sorbet/tapioca/compilers/env_config.rb
@@ -25,11 +25,11 @@ module Tapioca
 
           dynamic_methods.each do |method, default|
             return_type = if method.end_with?("?")
-              T::Boolean
+              "T::Boolean"
             elsif default
-              default.class
+              "String"
             else
-              T.nilable(String)
+              "T.nilable(::String)"
             end
 
             mod.create_method(method, return_type:, class_method: true)


### PR DESCRIPTION
Followup to https://github.com/Homebrew/brew/pull/23290. Evaluates callable EnvConfig defaults before inferring their RBI return types, preventing lambda-backed defaults from being generated as `Proc`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
