### PR TITLE
Add stop_timeout to service DSL for graceful stop timeout

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -59,6 +59,7 @@ module Homebrew
       @run_type = T.let(RUN_TYPE_IMMEDIATE, Symbol)
       @service_name = T.let(default_service_name, String)
       @sockets = T.let({}, Sockets)
+      @stop_timeout = T.let(nil, T.nilable(Integer))
       @working_dir = T.let(nil, T.nilable(String))
       instance_eval(&block) if block
 
@@ -266,6 +267,13 @@ module Homebrew
       @throttle_interval = value
     end
 
+    sig { params(value: Integer).returns(T.nilable(Integer)) }
+    def stop_timeout(value = T.unsafe(nil))
+      return @stop_timeout if value.nil?
+
+      @stop_timeout = value
+    end
+
     sig { params(value: Symbol).returns(T.nilable(Symbol)) }
     def process_type(value = T.unsafe(nil))
       case value
@@ -438,6 +446,7 @@ module Homebrew
 
       base[:LaunchOnlyOnce] = @launch_only_once if @launch_only_once == true
       base[:LegacyTimers] = @macos_legacy_timers if @macos_legacy_timers == true
+      base[:ExitTimeOut] = @stop_timeout if @stop_timeout.present?
       base[:TimeOut] = @restart_delay if @restart_delay.present?
       base[:ThrottleInterval] = @throttle_interval if @throttle_interval.present?
       base[:ProcessType] = @process_type.to_s.capitalize if @process_type.present?
@@ -508,6 +517,7 @@ module Homebrew
         end
       end
       options << "RestartSec=#{restart_delay}" if @restart_delay.present?
+      options << "TimeoutStopSec=#{@stop_timeout}" if @stop_timeout.present?
       options << "Nice=#{@nice}" if @nice.present?
       options << "WorkingDirectory=#{File.expand_path(@working_dir)}" if @working_dir.present?
       options << "RootDirectory=#{File.expand_path(@root_dir)}" if @root_dir.present?
@@ -614,6 +624,7 @@ module Homebrew
         error_log_path:        @error_log_path,
         restart_delay:         @restart_delay,
         throttle_interval:     @throttle_interval,
+        stop_timeout:          @stop_timeout,
         nice:                  @nice,
         process_type:          @process_type,
         macos_legacy_timers:   @macos_legacy_timers,
@@ -669,7 +680,7 @@ module Homebrew
         hash[key.to_sym] = replace_placeholders(value)
       end
 
-      %w[interval cron launch_only_once require_root restart_delay throttle_interval nice
+      %w[interval cron launch_only_once require_root restart_delay throttle_interval stop_timeout nice
          macos_legacy_timers].each do |key|
         next if (value = api_hash[key]).nil?
 

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -271,6 +271,8 @@ module Homebrew
     def stop_timeout(value = T.unsafe(nil))
       return @stop_timeout if value.nil?
 
+      raise TypeError, "Service#stop_timeout must be a non-negative integer" if value.negative?
+
       @stop_timeout = value
     end
 

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -123,6 +123,66 @@ RSpec.describe Homebrew::Service do
     end
   end
 
+  describe "#stop_timeout" do
+    it "accepts a valid stop_timeout value" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          stop_timeout 10
+        end
+      end
+
+      expect(f.service.stop_timeout).to be(10)
+    end
+
+    it "includes ExitTimeOut in plist output" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          stop_timeout 15
+        end
+      end
+
+      plist = f.service.to_plist
+      expect(plist).to include("<key>ExitTimeOut</key>")
+      expect(plist).to include("<integer>15</integer>")
+    end
+
+    it "does not include ExitTimeOut in plist when not set" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+        end
+      end
+
+      plist = f.service.to_plist
+      expect(plist).not_to include("<key>ExitTimeOut</key>")
+    end
+
+    it "includes TimeoutStopSec in systemd unit output" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          stop_timeout 20
+        end
+      end
+
+      unit = f.service.to_systemd_unit
+      expect(unit).to include("TimeoutStopSec=20")
+    end
+
+    it "does not include TimeoutStopSec in systemd unit when not set" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+        end
+      end
+
+      unit = f.service.to_systemd_unit
+      expect(unit).not_to include("TimeoutStopSec=")
+    end
+  end
+
   describe "#nice" do
     it "accepts a valid nice level" do
       f = stub_formula do
@@ -425,6 +485,7 @@ RSpec.describe Homebrew::Service do
           process_type :interactive
           restart_delay 30
           throttle_interval 5
+          stop_timeout 60
           nice 5
           interval 5
           macos_legacy_timers true
@@ -446,6 +507,8 @@ RSpec.describe Homebrew::Service do
         \t\t<key>PATH</key>
         \t\t<string>#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         \t</dict>
+        \t<key>ExitTimeOut</key>
+        \t<integer>60</integer>
         \t<key>KeepAlive</key>
         \t<true/>
         \t<key>Label</key>
@@ -937,6 +1000,7 @@ RSpec.describe Homebrew::Service do
           keep_alive true
           process_type :interactive
           restart_delay 30
+          stop_timeout 45
           nice(-15)
           macos_legacy_timers true
         end
@@ -956,6 +1020,7 @@ RSpec.describe Homebrew::Service do
         ExecStart="#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd" "test"
         Restart=on-failure
         RestartSec=30
+        TimeoutStopSec=45
         Nice=-15
         WorkingDirectory=#{HOMEBREW_PREFIX}/var
         RootDirectory=#{HOMEBREW_PREFIX}/var
@@ -1060,6 +1125,30 @@ RSpec.describe Homebrew::Service do
         Type=simple
         ExecStart="#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd"
         Restart=on-success
+      SYSTEMD
+      expect(unit).to eq(unit_expect)
+    end
+
+    it "returns valid unit with stop_timeout" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          stop_timeout 25
+        end
+      end
+
+      unit = f.service.to_systemd_unit
+      unit_expect = <<~SYSTEMD
+        [Unit]
+        Description=Homebrew generated unit for formula_name
+
+        [Install]
+        WantedBy=default.target
+
+        [Service]
+        Type=simple
+        ExecStart="#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd"
+        TimeoutStopSec=25
       SYSTEMD
       expect(unit).to eq(unit_expect)
     end
@@ -1369,6 +1458,7 @@ RSpec.describe Homebrew::Service do
         run_type:              :immediate,
         working_dir:           "/$HOME",
         cron:                  "0 0 * * 0",
+        stop_timeout:          15,
         sockets:               "tcp://0.0.0.0:80",
       }
     end
@@ -1382,6 +1472,7 @@ RSpec.describe Homebrew::Service do
           environment_variables PATH: std_service_path_env
           working_dir Dir.home
           cron "@weekly"
+          stop_timeout 15
           sockets "tcp://0.0.0.0:80"
         end
       end
@@ -1457,6 +1548,16 @@ RSpec.describe Homebrew::Service do
             linux: "#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd",
             macos: ["#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd", "--option"],
           },
+        })
+      end
+
+      it "handles stop_timeout argument correctly" do
+        expect(described_class.from_hash({
+          "run"          => "$HOMEBREW_PREFIX/opt/formula_name/bin/beanstalkd",
+          "stop_timeout" => 30,
+        })).to eq({
+          run:          "#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd",
+          stop_timeout: 30,
         })
       end
     end

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -135,6 +135,17 @@ RSpec.describe Homebrew::Service do
       expect(f.service.stop_timeout).to be(10)
     end
 
+    it "throws for negative stop_timeout" do
+      expect do
+        stub_formula do
+          service do
+            run opt_bin/"beanstalkd"
+            stop_timeout(-5)
+          end
+        end.service
+      end.to raise_error TypeError, "Service#stop_timeout must be a non-negative integer"
+    end
+
     it "includes ExitTimeOut in plist output" do
       f = stub_formula do
         service do
@@ -144,8 +155,7 @@ RSpec.describe Homebrew::Service do
       end
 
       plist = f.service.to_plist
-      expect(plist).to include("<key>ExitTimeOut</key>")
-      expect(plist).to include("<integer>15</integer>")
+      expect(plist).to include("<key>ExitTimeOut</key>\n\t<integer>15</integer>")
     end
 
     it "does not include ExitTimeOut in plist when not set" do


### PR DESCRIPTION
-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

## What this does
Adds `stop_timeout` as a first-class service DSL method for controlling how long the service manager waits for a graceful shutdown before forcibly killing the process.

- **macOS (launchd)**: sets `ExitTimeOut` in the generated plist
- **Linux (systemd)**: sets `TimeoutStopSec` in the generated service unit

## Why we'd like this included
Services like databases and other stateful applications often need more than the default timeout to flush data and shut down cleanly. Without this, `brew services stop` can lead to data loss or corruption when the service manager kills the process before it finishes its cleanup. This gives formula authors a way to declare how long their service needs.

## Changes
- `Library/Homebrew/service.rb`: Added `@stop_timeout` instance variable, `stop_timeout` DSL method, `ExitTimeOut` in `to_plist`, `TimeoutStopSec` in `to_systemd_unit`, and serialization in `to_hash`/`from_hash`
- `Library/Homebrew/test/service_spec.rb`: 7 new tests covering getter/setter, plist output, systemd unit output, and serialization; also updated the full plist and systemd unit tests

-----

- [x] AI was used to generate or assist with generating this PR.

AI assisted with the implementation. All changes were verified by running `brew lgtm --online` (typecheck, style, tests — all green) and manually reviewing the diff.

-----