### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🍺 Homebrew
 
+[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2Fhomebrew%2FHomebrew.svg)](https://mcptoplist.com/server/mcp.so%2Fhomebrew%2FHomebrew)
+
 [![Latest GitHub release](https://img.shields.io/github/release/Homebrew/brew.svg)](https://github.com/Homebrew/brew/releases)
 [![BSD-2-Clause License](https://img.shields.io/github/license/Homebrew/brew)](https://github.com/Homebrew/brew/blob/HEAD/LICENSE.txt)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/homebrew?label=GitHub%20Sponsors)](https://github.com/sponsors/Homebrew)


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,432 MCP servers across the major
registries, and **Homebrew MCP Server** is currently ranked **#11**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2Fhomebrew%2FHomebrew.svg)](https://mcptoplist.com/server/mcp.so%2Fhomebrew%2FHomebrew)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building Homebrew MCP Server!
