### PR TITLE
Simplify cask command wrappers

### DIFF
--- a/Library/Homebrew/cask/artifact/command_wrapper.rb
+++ b/Library/Homebrew/cask/artifact/command_wrapper.rb
@@ -2,11 +2,16 @@
 # frozen_string_literal: true
 
 require "cask/artifact/binary"
+require "extend/pathname"
+require "shellwords"
 
 module Cask
   module Artifact
     # Artifact corresponding to the `command_wrapper` stanza.
     class CommandWrapper < Binary
+      Arguments = T.type_alias { T.any(String, Pathname, T::Array[T.any(String, Pathname)]) }
+      Environment = T.type_alias { T::Hash[T.any(String, Symbol), T.any(String, Pathname)] }
+
       sig { override.returns(Symbol) }
       def self.dirmethod = :binarydir
 
@@ -19,26 +24,39 @@ module Cask
       }
       def self.from_args(cask, source, options = nil)
         options ||= {}
-        options.assert_valid_keys(:target, :content)
-        raise CaskInvalidError.new(cask, "'command_wrapper' requires target") unless options.key?(:target)
-        raise CaskInvalidError.new(cask, "'command_wrapper' requires content") unless options.key?(:content)
+        options.assert_valid_keys(:target, :content, :executable, :args, :env)
+        options[:target] = Pathname(source).basename.to_s.delete_suffix(".wrapper.sh") if options[:target].blank?
 
         new(cask, source, **options)
       end
 
       sig {
         params(
-          cask:    Cask,
-          source:  T.any(String, Pathname),
-          target:  T.any(String, Pathname),
-          content: String,
+          cask:       Cask,
+          source:     T.any(String, Pathname),
+          target:     T.any(String, Pathname),
+          content:    T.nilable(String),
+          executable: T.nilable(T.any(String, Pathname)),
+          args:       Arguments,
+          env:        Environment,
         ).void
       }
-      def initialize(cask, source, target:, content:)
-        raise CaskInvalidError.new(cask, "'command_wrapper' requires content") if content.blank?
+      def initialize(cask, source, target:, content: nil, executable: nil, args: [], env: {})
+        if content.blank? && executable.to_s.blank?
+          raise CaskInvalidError.new(cask, "'command_wrapper' requires content or executable")
+        end
+        if content.present? && executable.to_s.present?
+          raise CaskInvalidError.new(cask, "'command_wrapper' requires content or executable, not both")
+        end
+        if content.present? && (args.present? || env.present?)
+          raise CaskInvalidError.new(cask, "'command_wrapper' args and env require executable")
+        end
 
         super(cask, source, target:)
-        @content = content
+        @content = T.let(content.presence, T.nilable(String))
+        @executable = T.let(executable&.to_s.presence, T.nilable(String))
+        @args = T.let(Array(args).map(&:to_s), T::Array[String])
+        @env = T.let(env.to_h { |key, value| [key.to_s, value.to_s] }, T::Hash[String, String])
       end
 
       sig {
@@ -50,14 +68,27 @@ module Cask
         ).void
       }
       def install_phase(force: false, adopt: false, command: SystemCommand, **options)
-        source.dirname.mkpath
-        source.write(@content)
+        if (content = @content)
+          source.dirname.mkpath
+          source.write(content)
+        elsif (executable = @executable)
+          args = @args.map { |arg| Shellwords.shellescape(arg) }
+          source.write_env_script(executable, args, @env)
+        end
         super
       end
 
       sig { override.returns(T::Array[T.anything]) }
       def to_args
-        [@source_string, { target: @target_string, content: @content }]
+        options = { target: @target_string }
+        if (content = @content)
+          options[:content] = content
+        else
+          options[:executable] = @executable
+          options[:args] = @args if @args.present?
+          options[:env] = @env if @env.present?
+        end
+        [@source_string, options]
       end
     end
   end

--- a/Library/Homebrew/test/cask/artifact/command_wrapper_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/command_wrapper_spec.rb
@@ -9,15 +9,14 @@ RSpec.describe Cask::Artifact::CommandWrapper, :cask do
       url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
 
       command_wrapper "example.wrapper.sh",
-                      target:  "example",
-                      content: <<~SH
-                        #!/bin/sh
-                        exec '/Applications/Example.app/Contents/MacOS/example' "$@"
-                      SH
+                      executable: "/Applications/Example.app/Contents/MacOS/example",
+                      args:       ["--cli", "batch mode"],
+                      env:        { "EXAMPLE_MODE" => "batch" }
     end
   end
   let(:artifact) { cask.artifacts.find { |candidate| candidate.is_a?(described_class) } }
   let(:target) { cask.config.binarydir/"example" }
+  let(:custom_target) { cask.config.binarydir/"custom" }
 
   around do |example|
     cask.staged_path.mkpath
@@ -25,35 +24,89 @@ RSpec.describe Cask::Artifact::CommandWrapper, :cask do
     example.run
   ensure
     FileUtils.rm_f target
+    FileUtils.rm_f custom_target
     FileUtils.rm_rf cask.staged_path
   end
 
   it "writes and links an executable command wrapper" do
     artifact.install_phase(command: NeverSudoSystemCommand, force: false)
 
-    expect(target).to be_a_symlink.and have_attributes(read:        include("Contents/MacOS/example"),
-                                                       executable?: true)
+    expect(target).to be_a_symlink.and have_attributes(
+      read:        <<~BASH,
+        #!/bin/bash
+        EXAMPLE_MODE="batch" exec "/Applications/Example.app/Contents/MacOS/example" --cli batch\\ mode "$@"
+      BASH
+      executable?: true,
+    )
   end
 
   it "serialises the wrapper definition" do
     expect(artifact.to_args).to eq([
       "example.wrapper.sh",
       {
-        target:  "example",
-        content: "#!/bin/sh\nexec '/Applications/Example.app/Contents/MacOS/example' \"$@\"\n",
+        target:     "example",
+        executable: "/Applications/Example.app/Contents/MacOS/example",
+        args:       ["--cli", "batch mode"],
+        env:        { "EXAMPLE_MODE" => "batch" },
       },
     ])
   end
 
-  it "rejects a missing target" do
-    expect do
-      described_class.from_args(cask, "other.wrapper.sh", content: "#!/bin/sh\n")
-    end.to raise_error(Cask::CaskInvalidError, /'command_wrapper' requires target/)
+  it "shell-escapes a single non-array argument" do
+    wrapper = described_class.from_args(cask, "custom.wrapper.sh",
+                                        executable: "/usr/bin/example",
+                                        args:       "two words; true")
+    wrapper.install_phase(command: NeverSudoSystemCommand, force: false)
+
+    expect(custom_target.read).to eq(<<~BASH)
+      #!/bin/bash
+      exec "/usr/bin/example" two\\ words\\;\\ true "$@"
+    BASH
   end
 
-  it "rejects missing content" do
+  it "serialises Pathname arguments and symbol environment keys as plain strings" do
+    wrapper = described_class.from_args(cask, "custom.wrapper.sh",
+                                        executable: Pathname("/usr/bin/example"),
+                                        args:       Pathname("/etc/example.conf"),
+                                        env:        { EXAMPLE_MODE: Pathname("/var/example") })
+
+    expect(wrapper.to_args).to eq([
+      "custom.wrapper.sh",
+      {
+        target:     "custom",
+        executable: "/usr/bin/example",
+        args:       ["/etc/example.conf"],
+        env:        { "EXAMPLE_MODE" => "/var/example" },
+      },
+    ])
+  end
+
+  it "accepts custom wrapper content" do
+    content = "#!/bin/sh\nexit 1\n"
+    custom_artifact = described_class.from_args(cask, "custom.wrapper.sh", content:)
+    custom_artifact.install_phase(command: NeverSudoSystemCommand, force: false)
+
+    expect(custom_target).to be_a_symlink.and have_attributes(read: content, executable?: true)
+  end
+
+  it "serialises custom wrapper content" do
+    custom_artifact = described_class.from_args(cask, "custom.wrapper.sh", content: "#!/bin/sh\nexit 1\n")
+
+    expect(custom_artifact.to_args).to eq([
+      "custom.wrapper.sh",
+      { target: "custom", content: "#!/bin/sh\nexit 1\n" },
+    ])
+  end
+
+  it "rejects missing content and executable" do
     expect do
-      described_class.from_args(cask, "other.wrapper.sh", target: "other")
-    end.to raise_error(Cask::CaskInvalidError, /'command_wrapper' requires content/)
+      described_class.from_args(cask, "other.wrapper.sh")
+    end.to raise_error(Cask::CaskInvalidError, /requires content or executable/)
+  end
+
+  it "rejects content with an executable" do
+    expect do
+      described_class.from_args(cask, "other.wrapper.sh", content: "#!/bin/sh\n", executable: "example")
+    end.to raise_error(Cask::CaskInvalidError, /content or executable, not both/)
   end
 end

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -287,16 +287,16 @@ Behaviour and usage of `target:` is [the same as with `app`](#renaming-the-targe
 
 ### Stanza: `command_wrapper`
 
-`command_wrapper` writes literal wrapper content into the staged cask, makes it executable and links it like a [`binary`](#stanza-binary). Use it when a command needs to invoke an executable inside an application bundle with fixed arguments or environment setup.
+`command_wrapper` writes an executable wrapper into the staged cask and links it like a [`binary`](#stanza-binary). The linked name is inferred by removing `.wrapper.sh` from the wrapper name. Use `target:` when it should differ. Fixed arguments and environment variables can be passed with `args:` and `env:`.
 
 ```ruby
 command_wrapper "example.wrapper.sh",
-                target:  "example",
-                content: <<~SH
-                  #!/bin/sh
-                  exec '#{appdir}/Example.app/Contents/MacOS/example' "$@"
-                SH
+                executable: "#{appdir}/Example.app/Contents/MacOS/example",
+                args:       ["--cli"],
+                env:        { "EXAMPLE_MODE" => "batch" }
 ```
+
+Use `content:` instead of `executable:` for wrappers which need custom shell logic.
 
 ### Stanza: `generated_script`
 


### PR DESCRIPTION
Most command wrappers only execute one binary with optional fixed arguments or environment variables. Repeating their complete shell content makes casks harder to audit and maintain.

- generate wrappers from `executable`, `args` and `env` options
- infer the linked target by removing the `.wrapper.sh` suffix
- retain `content` for wrappers which need custom shell logic

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI GPT 5.6 Sol xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
