### PR TITLE
Remove most forks from no-op brew startup

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -3,65 +3,9 @@
 ##### to be able to `source` in shell configurations run quickly.
 #####
 
-case "${MACHTYPE}" in
-  arm64-* | aarch64-*)
-    HOMEBREW_PROCESSOR="arm64"
-    ;;
-  x86_64-*)
-    HOMEBREW_PROCESSOR="x86_64"
-    ;;
-  *)
-    HOMEBREW_PROCESSOR="$(uname -m)"
-    ;;
-esac
-
-case "${OSTYPE}" in
-  darwin*)
-    HOMEBREW_SYSTEM="Darwin"
-    HOMEBREW_MACOS="1"
-    ;;
-  linux*)
-    HOMEBREW_SYSTEM="Linux"
-    HOMEBREW_LINUX="1"
-    ;;
-  *)
-    HOMEBREW_SYSTEM="$(uname -s)"
-    ;;
-esac
-HOMEBREW_PHYSICAL_PROCESSOR="${HOMEBREW_PROCESSOR}"
-
-HOMEBREW_MACOS_ARM_DEFAULT_PREFIX="/opt/homebrew"
-HOMEBREW_LINUX_DEFAULT_PREFIX="/home/linuxbrew/.linuxbrew"
-HOMEBREW_GENERIC_DEFAULT_PREFIX="/usr/local"
-if [[ -n "${HOMEBREW_MACOS}" && "${HOMEBREW_PROCESSOR}" == "arm64" ]]
-then
-  HOMEBREW_DEFAULT_PREFIX="${HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}"
-  HOMEBREW_DEFAULT_REPOSITORY="${HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}"
-elif [[ -n "${HOMEBREW_LINUX}" ]]
-then
-  HOMEBREW_DEFAULT_PREFIX="${HOMEBREW_LINUX_DEFAULT_PREFIX}"
-  HOMEBREW_DEFAULT_REPOSITORY="${HOMEBREW_LINUX_DEFAULT_PREFIX}/Homebrew"
-else
-  HOMEBREW_DEFAULT_PREFIX="${HOMEBREW_GENERIC_DEFAULT_PREFIX}"
-  HOMEBREW_DEFAULT_REPOSITORY="${HOMEBREW_GENERIC_DEFAULT_PREFIX}/Homebrew"
-fi
-
-if [[ -n "${HOMEBREW_MACOS}" ]]
-then
-  HOMEBREW_DEFAULT_CACHE="${HOME}/Library/Caches/Homebrew"
-  HOMEBREW_DEFAULT_LOGS="${HOME}/Library/Logs/Homebrew"
-  HOMEBREW_DEFAULT_TEMP="/private/tmp"
-else
-  CACHE_HOME="${HOMEBREW_XDG_CACHE_HOME:-${HOME}/.cache}"
-  HOMEBREW_DEFAULT_CACHE="${CACHE_HOME}/Homebrew"
-  HOMEBREW_DEFAULT_LOGS="${CACHE_HOME}/Homebrew/Logs"
-  if [[ -r "/var/tmp" && -w "/var/tmp" ]]
-  then
-    HOMEBREW_DEFAULT_TEMP="/var/tmp"
-  else
-    HOMEBREW_DEFAULT_TEMP="/tmp"
-  fi
-fi
+# HOMEBREW_LIBRARY is set by bin/brew
+# shellcheck disable=SC2154
+source "${HOMEBREW_LIBRARY}/Homebrew/utils/os.sh"
 
 realpath() {
   (cd "$1" &>/dev/null && pwd -P)
@@ -110,17 +54,6 @@ HOMEBREW_TEMP="${HOMEBREW_TEMP:-${HOMEBREW_DEFAULT_TEMP}}"
 if [[ ! -w "${HOMEBREW_TEMP}" ]]
 then
   HOMEBREW_TEMP="${HOMEBREW_DEFAULT_TEMP}"
-fi
-
-# brew shellenv needs HOMEBREW_MACOS_VERSION_NUMERIC
-if [[ -n "${HOMEBREW_MACOS}" ]]
-then
-  HOMEBREW_MACOS_VERSION="$(/usr/bin/sw_vers -productVersion)"
-
-  IFS=. read -r -a MACOS_VERSION_ARRAY < <(printf '%s' "${HOMEBREW_MACOS_VERSION}")
-  printf -v HOMEBREW_MACOS_VERSION_NUMERIC "%02d%02d%02d" "${MACOS_VERSION_ARRAY[@]}"
-
-  unset MACOS_VERSION_ARRAY
 fi
 
 # commands that take a single or no arguments.
@@ -278,140 +211,7 @@ EOS
   fi
 }
 
-# NOTE: The members of the array in the second arg must not have spaces!
-check-array-membership() {
-  local item=$1
-  shift
-
-  if [[ " ${*} " == *" ${item} "* ]]
-  then
-    return 0
-  else
-    return 1
-  fi
-}
-
-# These variables are set from various Homebrew scripts.
-# shellcheck disable=SC2154
-auto-update() {
-  [[ -z "${HOMEBREW_HELP}" ]] || return
-  [[ -z "${HOMEBREW_NO_AUTO_UPDATE}" ]] || return
-  [[ -z "${HOMEBREW_AUTO_UPDATING}" ]] || return
-  [[ -z "${HOMEBREW_UPDATE_AUTO}" ]] || return
-  [[ -z "${HOMEBREW_AUTO_UPDATE_CHECKED}" ]] || return
-  # Worktrees may share Git metadata with another checkout, so skip background updates.
-  [[ ! -f "${HOMEBREW_REPOSITORY}/.git" ]] || return
-
-  # If we've checked for updates, we don't need to check again.
-  export HOMEBREW_AUTO_UPDATE_CHECKED="1"
-
-  if [[ -n "${HOMEBREW_AUTO_UPDATE_COMMAND}" ]]
-  then
-    export HOMEBREW_AUTO_UPDATING="1"
-
-    # Look for commands that may be referring to a formula/cask in a specific
-    # 3rd-party tap so they can be auto-updated more often (as they do not get
-    # their data from the API).
-    AUTO_UPDATE_TAP_COMMANDS=(
-      install
-      outdated
-      upgrade
-    )
-    if check-array-membership "${HOMEBREW_COMMAND}" "${AUTO_UPDATE_TAP_COMMANDS[@]}"
-    then
-      for arg in "$@"
-      do
-        if [[ "${arg}" == */*/* ]] && [[ "${arg}" != Homebrew/* ]] && [[ "${arg}" != homebrew/* ]]
-        then
-
-          HOMEBREW_AUTO_UPDATE_TAP="1"
-          break
-        fi
-      done
-    fi
-
-    # When auto-updating before a zero-argument `brew upgrade` or `brew outdated`,
-    # that command lists the outdated packages itself so skip doing so here too.
-    # Two-way sync: `dump` in `Library/Homebrew/cmd/update_report/reporter_hub.rb`.
-    if [[ "${HOMEBREW_COMMAND}" == "upgrade" || "${HOMEBREW_COMMAND}" == "outdated" ]]
-    then
-      HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED="1"
-      for arg in "${@:2}"
-      do
-        [[ "${arg}" == -* ]] && continue
-        HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED=""
-        break
-      done
-      [[ -n "${HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED}" ]] && export HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED
-    fi
-
-    # Keep in sync with the HOMEBREW_AUTO_UPDATE_SECS default in
-    # Library/Homebrew/env_config.rb.
-    if [[ -z "${HOMEBREW_AUTO_UPDATE_SECS}" ]]
-    then
-      if [[ -n "${HOMEBREW_NO_INSTALL_FROM_API}" || -n "${HOMEBREW_AUTO_UPDATE_TAP}" ]]
-      then
-        # 5 minutes
-        HOMEBREW_AUTO_UPDATE_SECS="300"
-      elif [[ -n "${HOMEBREW_DEV_CMD_RUN}" ]]
-      then
-        # 1 hour
-        HOMEBREW_AUTO_UPDATE_SECS="3600"
-      else
-        # 24 hours
-        HOMEBREW_AUTO_UPDATE_SECS="86400"
-      fi
-    fi
-
-    repo_fetch_heads=("${HOMEBREW_REPOSITORY}/.git/FETCH_HEAD")
-    # We might have done an auto-update recently, but not a core/cask clone auto-update.
-    # So we check the core/cask clone FETCH_HEAD too.
-    if [[ -n "${HOMEBREW_AUTO_UPDATE_CORE_TAP}" && -d "${HOMEBREW_CORE_REPOSITORY}/.git" ]]
-    then
-      repo_fetch_heads+=("${HOMEBREW_CORE_REPOSITORY}/.git/FETCH_HEAD")
-    fi
-    if [[ -n "${HOMEBREW_AUTO_UPDATE_CASK_TAP}" && -d "${HOMEBREW_CASK_REPOSITORY}/.git" ]]
-    then
-      repo_fetch_heads+=("${HOMEBREW_CASK_REPOSITORY}/.git/FETCH_HEAD")
-    fi
-
-    # Skip auto-update if all of the selected repositories have been checked in the
-    # last $HOMEBREW_AUTO_UPDATE_SECS.
-    needs_auto_update=
-    for repo_fetch_head in "${repo_fetch_heads[@]}"
-    do
-      if [[ ! -f "${repo_fetch_head}" ]] ||
-         [[ -z "$(find "${repo_fetch_head}" -type f -newermt "-${HOMEBREW_AUTO_UPDATE_SECS} seconds" 2>/dev/null)" ]]
-      then
-        needs_auto_update=1
-        break
-      fi
-    done
-    if [[ -z "${needs_auto_update}" ]]
-    then
-      unset HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED
-      return
-    fi
-
-    brew update --auto-update
-
-    unset HOMEBREW_AUTO_UPDATING
-    unset HOMEBREW_AUTO_UPDATE_TAP
-    unset HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED
-
-    if [[ $# -gt 0 ]]
-    then
-      # exec a new process to set any new environment variables.
-      exec "${HOMEBREW_BREW_FILE}" "$@"
-    fi
-  fi
-
-  unset AUTO_UPDATE_COMMANDS
-  unset AUTO_UPDATE_CORE_TAP_COMMANDS
-  unset AUTO_UPDATE_CASK_TAP_COMMANDS
-  unset HOMEBREW_AUTO_UPDATE_CORE_TAP
-  unset HOMEBREW_AUTO_UPDATE_CASK_TAP
-}
+source "${HOMEBREW_LIBRARY}/Homebrew/utils/auto-update.sh"
 
 # Only `brew update-if-needed` should be handled here.
 # We want it as fast as possible but it needs auto-update() defined above.
@@ -448,31 +248,7 @@ then
   export HOMEBREW_SANDBOX_LINUX_LANDLOCK="1"
 fi
 
-# Force UTF-8 to avoid encoding issues for users with broken locale settings.
-if [[ -n "${HOMEBREW_MACOS}" ]]
-then
-  if [[ "$(locale charmap)" != "UTF-8" ]]
-  then
-    export LC_ALL="en_US.UTF-8"
-  fi
-else
-  if ! command -v locale >/dev/null
-  then
-    export LC_ALL=C
-  elif [[ "$(locale charmap)" != "UTF-8" ]]
-  then
-    locales="$(locale -a)"
-    c_utf_regex='\bC\.(utf8|UTF-8)\b'
-    en_us_regex='\ben_US\.(utf8|UTF-8)\b'
-    utf_regex='\b[a-z][a-z]_[A-Z][A-Z]\.(utf8|UTF-8)\b'
-    if [[ ${locales} =~ ${c_utf_regex} || ${locales} =~ ${en_us_regex} || ${locales} =~ ${utf_regex} ]]
-    then
-      export LC_ALL="${BASH_REMATCH[0]}"
-    else
-      export LC_ALL=C
-    fi
-  fi
-fi
+setup-locale
 
 #####
 ##### odie as quickly as possible.
@@ -507,86 +283,12 @@ export USER="${USER:-$(id -un)}"
 # Higher depths mean this command was invoked by another Homebrew command.
 export HOMEBREW_COMMAND_DEPTH="$((HOMEBREW_COMMAND_DEPTH + 1))"
 
-setup_curl() {
-  # This is set by the user environment.
-  # shellcheck disable=SC2154
-  HOMEBREW_BREWED_CURL_PATH="${HOMEBREW_PREFIX}/opt/curl/bin/curl"
-  if [[ -n "${HOMEBREW_FORCE_BREWED_CURL}" && -x "${HOMEBREW_BREWED_CURL_PATH}" ]] &&
-     "${HOMEBREW_BREWED_CURL_PATH}" --version &>/dev/null
-  then
-    HOMEBREW_CURL="${HOMEBREW_BREWED_CURL_PATH}"
-  elif [[ -n "${HOMEBREW_CURL_PATH}" ]]
-  then
-    HOMEBREW_CURL="${HOMEBREW_CURL_PATH}"
-  else
-    HOMEBREW_CURL="curl"
-  fi
-}
-
-setup_git() {
-  # This is set by the user environment.
-  # shellcheck disable=SC2154
-  if [[ -n "${HOMEBREW_FORCE_BREWED_GIT}" && -x "${HOMEBREW_PREFIX}/opt/git/bin/git" ]] &&
-     "${HOMEBREW_PREFIX}/opt/git/bin/git" --version &>/dev/null
-  then
-    HOMEBREW_GIT="${HOMEBREW_PREFIX}/opt/git/bin/git"
-  elif [[ -n "${HOMEBREW_GIT_PATH}" ]]
-  then
-    HOMEBREW_GIT="${HOMEBREW_GIT_PATH}"
-  else
-    HOMEBREW_GIT="git"
-  fi
-}
+source "${HOMEBREW_LIBRARY}/Homebrew/utils/curl.sh"
+source "${HOMEBREW_LIBRARY}/Homebrew/utils/git.sh"
 
 setup_git
-
-GIT_DESCRIBE_CACHE="${HOMEBREW_REPOSITORY}/.git/describe-cache"
-GIT_REVISION=$("${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" rev-parse HEAD 2>/dev/null)
-
-# safe fallback in case git rev-parse fails e.g. if this is not considered a safe git directory
-if [[ -z "${GIT_REVISION}" ]]
-then
-  read -r GIT_HEAD 2>/dev/null <"${HOMEBREW_REPOSITORY}/.git/HEAD"
-  if [[ "${GIT_HEAD}" == "ref: refs/heads/main" ]]
-  then
-    read -r GIT_REVISION 2>/dev/null <"${HOMEBREW_REPOSITORY}/.git/refs/heads/main"
-  elif [[ "${GIT_HEAD}" == "ref: refs/heads/stable" ]]
-  then
-    read -r GIT_REVISION 2>/dev/null <"${HOMEBREW_REPOSITORY}/.git/refs/heads/stable"
-  fi
-  unset GIT_HEAD
-fi
-
-if [[ -n "${GIT_REVISION}" ]]
-then
-  GIT_DESCRIBE_CACHE_FILE="${GIT_DESCRIBE_CACHE}/${GIT_REVISION}"
-  if [[ -r "${GIT_DESCRIBE_CACHE_FILE}" ]] && "${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" diff --quiet --no-ext-diff 2>/dev/null
-  then
-    read -r GIT_DESCRIBE_CACHE_HOMEBREW_VERSION <"${GIT_DESCRIBE_CACHE_FILE}"
-    if [[ -n "${GIT_DESCRIBE_CACHE_HOMEBREW_VERSION}" && "${GIT_DESCRIBE_CACHE_HOMEBREW_VERSION}" != *"-dirty" ]]
-    then
-      HOMEBREW_VERSION="${GIT_DESCRIBE_CACHE_HOMEBREW_VERSION}"
-    fi
-    unset GIT_DESCRIBE_CACHE_HOMEBREW_VERSION
-  fi
-
-  if [[ -z "${HOMEBREW_VERSION}" ]]
-  then
-    HOMEBREW_VERSION="$("${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" describe --tags --dirty --abbrev=7 2>/dev/null)"
-    # Don't output any permissions errors here. The user may not have write
-    # permissions to the cache but we don't care because it's an optional
-    # performance improvement.
-    rm -rf "${GIT_DESCRIBE_CACHE}" 2>/dev/null
-    mkdir -p "${GIT_DESCRIBE_CACHE}" 2>/dev/null
-    echo "${HOMEBREW_VERSION}" | tee "${GIT_DESCRIBE_CACHE_FILE}" &>/dev/null
-  fi
-  unset GIT_DESCRIBE_CACHE_FILE
-else
-  # Don't care about permission errors here either.
-  rm -rf "${GIT_DESCRIBE_CACHE}" 2>/dev/null
-fi
-unset GIT_REVISION
-unset GIT_DESCRIBE_CACHE
+read-homebrew-git-config
+set-homebrew-version-from-git
 
 HOMEBREW_USER_AGENT_VERSION="${HOMEBREW_VERSION}"
 if [[ -z "${HOMEBREW_VERSION}" ]]
@@ -646,140 +348,10 @@ HOMEBREW_MACOS_NEWEST_SUPPORTED="26"
 HOMEBREW_MACOS_OLDEST_SUPPORTED="14"
 HOMEBREW_MACOS_OLDEST_ALLOWED="10.15"
 
-# Some Git versions are too old for some Homebrew functionality we rely on.
-HOMEBREW_MINIMUM_GIT_VERSION="2.30.0"
+setup-os-details
+check-curl-version
+check-git-version
 
-if [[ -n "${HOMEBREW_MACOS}" ]]
-then
-  HOMEBREW_PRODUCT="Homebrew"
-  HOMEBREW_SYSTEM="Macintosh"
-  [[ "${HOMEBREW_PROCESSOR}" == "x86_64" ]] && HOMEBREW_PROCESSOR="Intel"
-  # Don't change this from Mac OS X to match what macOS itself does in Safari
-  HOMEBREW_OS_USER_AGENT_VERSION="Mac OS X ${HOMEBREW_MACOS_VERSION}"
-
-  if [[ "$(sysctl -n hw.optional.arm64 2>/dev/null)" == "1" ]]
-  then
-    # used in vendor-install.sh and update.sh
-    # shellcheck disable=SC2034
-    HOMEBREW_PHYSICAL_PROCESSOR="arm64"
-  fi
-
-  IFS=. read -r -a MACOS_VERSION_ARRAY < <(printf '%s' "${HOMEBREW_MACOS_OLDEST_ALLOWED}")
-  printf -v HOMEBREW_MACOS_OLDEST_ALLOWED_NUMERIC "%02d%02d%02d" "${MACOS_VERSION_ARRAY[@]}"
-
-  unset MACOS_VERSION_ARRAY
-
-  # Don't include minor versions for Big Sur and later.
-  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -gt "110000" ]]
-  then
-    HOMEBREW_OS_VERSION="macOS ${HOMEBREW_MACOS_VERSION%.*}"
-  else
-    HOMEBREW_OS_VERSION="macOS ${HOMEBREW_MACOS_VERSION}"
-  fi
-
-  # Refuse to run on pre-Catalina
-  # odisabled: remove support for Catalina September (or later) 2026
-  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "${HOMEBREW_MACOS_OLDEST_ALLOWED_NUMERIC}" ]]
-  then
-    printf "ERROR: Your version of macOS (%s) is too old to run Homebrew!\\n" "${HOMEBREW_MACOS_VERSION}" >&2
-    if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "100700" ]]
-    then
-      printf "         For 10.4 - 10.6 support see: https://github.com/mistydemeo/tigerbrew\\n" >&2
-    else
-      printf "         For 10.5 - %s support see: https://www.macports.org\\n" "${HOMEBREW_MACOS_VERSION}" >&2
-    fi
-    printf "\\n" >&2
-  fi
-
-  # The system libressl has a bug before macOS 10.15.6 where it incorrectly handles expired roots.
-  if [[ -z "${HOMEBREW_SYSTEM_CURL_TOO_OLD}" && "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "101506" ]]
-  then
-    HOMEBREW_SYSTEM_CA_CERTIFICATES_TOO_OLD="1"
-    HOMEBREW_FORCE_BREWED_CA_CERTIFICATES="1"
-  fi
-
-  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "110000" ]]
-  then
-    HOMEBREW_FORCE_BREWED_GIT="1"
-  fi
-else
-  if [[ -r "/proc/cpuinfo" ]] &&
-     [[ "${HOMEBREW_PROCESSOR}" == "x86_64" ]]
-  then
-    if ! grep -qE '^(flags|Features).*\bssse3\b' /proc/cpuinfo
-    then
-      odie "Homebrew's x86_64 support on Linux requires a CPU with SSSE3 support!"
-    fi
-  fi
-
-  HOMEBREW_PRODUCT="${HOMEBREW_SYSTEM}brew"
-  # Don't try to follow /etc/os-release
-  # shellcheck disable=SC1091,SC2154
-  [[ -n "${HOMEBREW_LINUX}" ]] && HOMEBREW_OS_VERSION="$(source /etc/os-release && echo "${PRETTY_NAME}")"
-  : "${HOMEBREW_OS_VERSION:=$(uname -r)}"
-  HOMEBREW_OS_USER_AGENT_VERSION="${HOMEBREW_OS_VERSION}"
-
-  # Ensure the system Curl is a version that supports modern HTTPS certificates.
-  HOMEBREW_MINIMUM_CURL_VERSION="7.41.0"
-
-  curl_version_output="$(${HOMEBREW_CURL} --version 2>/dev/null)"
-  curl_name_and_version="${curl_version_output%% (*}"
-  if [[ "$(numeric "${curl_name_and_version##* }")" -lt "$(numeric "${HOMEBREW_MINIMUM_CURL_VERSION}")" ]]
-  then
-    message="Please update your system curl or set HOMEBREW_CURL_PATH to a newer version.
-Minimum required version: ${HOMEBREW_MINIMUM_CURL_VERSION}
-       Your curl version: ${curl_name_and_version##* }
-    Your curl executable: $(type -p "${HOMEBREW_CURL}")"
-
-    if [[ -z ${HOMEBREW_CURL_PATH} ]]
-    then
-      HOMEBREW_SYSTEM_CURL_TOO_OLD=1
-      HOMEBREW_FORCE_BREWED_CURL=1
-      if [[ -z ${HOMEBREW_CURL_WARNING} ]]
-      then
-        onoe "${message}"
-        HOMEBREW_CURL_WARNING=1
-      fi
-    else
-      odie "${message}"
-    fi
-  fi
-
-  # Ensure the system Git is at or newer than the minimum required version.
-  git_version_output="$(${HOMEBREW_GIT} --version 2>/dev/null)"
-  # $extra is intentionally discarded.
-  # shellcheck disable=SC2034
-  IFS='.' read -r major minor micro build extra < <(printf '%s' "${git_version_output##* }")
-  if [[ "$(numeric "${major}.${minor}.${micro}.${build}")" -lt "$(numeric "${HOMEBREW_MINIMUM_GIT_VERSION}")" ]]
-  then
-    message="Please update your system Git or set HOMEBREW_GIT_PATH to a newer version.
-Minimum required version: ${HOMEBREW_MINIMUM_GIT_VERSION}
-        Your Git version: ${major}.${minor}.${micro}.${build}
-     Your Git executable: $(unset git && type -p "${HOMEBREW_GIT}")"
-    if [[ -z ${HOMEBREW_GIT_PATH} ]]
-    then
-      HOMEBREW_FORCE_BREWED_GIT="1"
-      if [[ -z ${HOMEBREW_GIT_WARNING} ]]
-      then
-        onoe "${message}"
-        HOMEBREW_GIT_WARNING=1
-      fi
-    else
-      odie "${message}"
-    fi
-  fi
-
-  HOMEBREW_LINUX_MINIMUM_GLIBC_VERSION="2.13"
-fi
-
-setup_ca_certificates() {
-  if [[ -n "${HOMEBREW_FORCE_BREWED_CA_CERTIFICATES}" && -f "${HOMEBREW_PREFIX}/etc/ca-certificates/cert.pem" ]]
-  then
-    export SSL_CERT_FILE="${HOMEBREW_PREFIX}/etc/ca-certificates/cert.pem"
-    export GIT_SSL_CAINFO="${HOMEBREW_PREFIX}/etc/ca-certificates/cert.pem"
-    export GIT_SSL_CAPATH="${HOMEBREW_PREFIX}/etc/ca-certificates"
-  fi
-}
 setup_ca_certificates
 
 # Redetermine curl and git paths as we may have forced some options above.
@@ -800,15 +372,7 @@ then
   unset HOMEBREW_BOTTLE_DOMAIN
 fi
 
-HOMEBREW_USER_AGENT="${HOMEBREW_PRODUCT}/${HOMEBREW_USER_AGENT_VERSION} (${HOMEBREW_SYSTEM}; ${HOMEBREW_PROCESSOR} ${HOMEBREW_OS_USER_AGENT_VERSION})"
-curl_version_output="$(curl --version 2>/dev/null)"
-curl_name_and_version="${curl_version_output%% (*}"
-HOMEBREW_USER_AGENT_CURL="${HOMEBREW_USER_AGENT} ${curl_name_and_version// //}"
-
-# Timeout values to check for dead connections
-# We don't use --max-time to support slow connections
-HOMEBREW_CURL_SPEED_LIMIT=100
-HOMEBREW_CURL_SPEED_TIME=5
+setup-user-agents
 
 export HOMEBREW_HELP_MESSAGE
 export HOMEBREW_VERSION
@@ -955,9 +519,8 @@ fi
 # This makes them behave like HOMEBREW_DEVELOPERs for brew update.
 if [[ -z "${HOMEBREW_DEVELOPER}" ]]
 then
-  export HOMEBREW_GIT_CONFIG_FILE="${HOMEBREW_REPOSITORY}/.git/config"
-  HOMEBREW_GIT_CONFIG_DEVELOPERMODE="$(git config --file="${HOMEBREW_GIT_CONFIG_FILE}" --get homebrew.devcmdrun 2>/dev/null)"
-  if [[ "${HOMEBREW_GIT_CONFIG_DEVELOPERMODE}" == "true" ]]
+  export HOMEBREW_GIT_CONFIG_FILE
+  if [[ "${HOMEBREW_GIT_CONFIG_DEVCMDRUN}" == "true" ]]
   then
     export HOMEBREW_DEV_CMD_RUN="1"
   fi
@@ -966,50 +529,7 @@ then
   unset HOMEBREW_RUBY_WARNINGS
 fi
 
-unset HOMEBREW_AUTO_UPDATE_COMMAND
-
-# Check for commands that should call `brew update --auto-update` first.
-AUTO_UPDATE_COMMANDS=(
-  install
-  outdated
-  upgrade
-  bundle
-  release
-)
-if check-array-membership "${HOMEBREW_COMMAND}" "${AUTO_UPDATE_COMMANDS[@]}" ||
-   [[ "${HOMEBREW_COMMAND}" == "tap" && "${HOMEBREW_ARG_COUNT}" -gt 1 ]]
-then
-  export HOMEBREW_AUTO_UPDATE_COMMAND="1"
-fi
-
-# Check for commands that should auto-update the homebrew-core tap.
-AUTO_UPDATE_CORE_TAP_COMMANDS=(
-  bump
-  bump-formula-pr
-)
-if check-array-membership "${HOMEBREW_COMMAND}" "${AUTO_UPDATE_CORE_TAP_COMMANDS[@]}"
-then
-  export HOMEBREW_AUTO_UPDATE_COMMAND="1"
-  export HOMEBREW_AUTO_UPDATE_CORE_TAP="1"
-elif [[ -z "${HOMEBREW_AUTO_UPDATING}" ]]
-then
-  unset HOMEBREW_AUTO_UPDATE_CORE_TAP
-fi
-
-# Check for commands that should auto-update the homebrew-cask tap.
-AUTO_UPDATE_CASK_TAP_COMMANDS=(
-  bump
-  bump-cask-pr
-  bump-unversioned-casks
-)
-if check-array-membership "${HOMEBREW_COMMAND}" "${AUTO_UPDATE_CASK_TAP_COMMANDS[@]}"
-then
-  export HOMEBREW_AUTO_UPDATE_COMMAND="1"
-  export HOMEBREW_AUTO_UPDATE_CASK_TAP="1"
-elif [[ -z "${HOMEBREW_AUTO_UPDATING}" ]]
-then
-  unset HOMEBREW_AUTO_UPDATE_CASK_TAP
-fi
+setup-auto-update
 
 if [[ -z "${HOMEBREW_RUBY_WARNINGS}" ]]
 then

--- a/Library/Homebrew/utils/analytics.sh
+++ b/Library/Homebrew/utils/analytics.sh
@@ -1,22 +1,18 @@
 # Setup analytics and delete old analytics UUIDs.
-# HOMEBREW_LINUX, HOMEBREW_REPOSITORY is set by bin/brew
+# HOMEBREW_GIT_CONFIG_FILE and HOMEBREW_GIT_CONFIG_ANALYTICS_* are parsed from
+# the repository Git configuration by brew.sh.
 # HOMEBREW_NO_ANALYTICS is from the user environment.
 # shellcheck disable=SC2154
-
 setup-analytics() {
-  local git_config_file="${HOMEBREW_REPOSITORY}/.git/config"
-
   local legacy_uuid_file="${HOME}/.homebrew_analytics_user_uuid"
   if [[ -f "${legacy_uuid_file}" ]]
   then
     rm -f "${legacy_uuid_file}"
   fi
 
-  local user_uuid
-  user_uuid="$(git config --file="${git_config_file}" --get homebrew.analyticsuuid 2>/dev/null)"
-  if [[ -n "${user_uuid}" ]]
+  if [[ -n "${HOMEBREW_GIT_CONFIG_ANALYTICS_UUID}" ]]
   then
-    git config --file="${git_config_file}" --unset-all homebrew.analyticsuuid 2>/dev/null
+    git config --file="${HOMEBREW_GIT_CONFIG_FILE}" --unset-all homebrew.analyticsuuid 2>/dev/null
   fi
 
   if [[ -n "${HOMEBREW_NO_ANALYTICS}" ]]
@@ -24,10 +20,8 @@ setup-analytics() {
     return
   fi
 
-  local message_seen analytics_disabled
-  message_seen="$(git config --file="${git_config_file}" --get homebrew.analyticsmessage 2>/dev/null)"
-  analytics_disabled="$(git config --file="${git_config_file}" --get homebrew.analyticsdisabled 2>/dev/null)"
-  if [[ "${message_seen}" != "true" || "${analytics_disabled}" == "true" ]]
+  if [[ "${HOMEBREW_GIT_CONFIG_ANALYTICS_MESSAGE_SEEN}" != "true" ||
+        "${HOMEBREW_GIT_CONFIG_ANALYTICS_DISABLED}" == "true" ]]
   then
     # Internal variable for brew's use, to differentiate from user-supplied setting
     export HOMEBREW_NO_ANALYTICS_THIS_RUN="1"

--- a/Library/Homebrew/utils/auto-update.sh
+++ b/Library/Homebrew/utils/auto-update.sh
@@ -1,0 +1,185 @@
+# Auto-update before commands that need up-to-date formula and cask data.
+
+# These variables are set by bin/brew, brew.sh or the user environment.
+# shellcheck disable=SC2154
+
+# NOTE: The members of the array in the second arg must not have spaces!
+check-array-membership() {
+  local item=$1
+  shift
+
+  if [[ " ${*} " == *" ${item} "* ]]
+  then
+    return 0
+  else
+    return 1
+  fi
+}
+
+auto-update() {
+  [[ -z "${HOMEBREW_HELP}" ]] || return
+  [[ -z "${HOMEBREW_NO_AUTO_UPDATE}" ]] || return
+  [[ -z "${HOMEBREW_AUTO_UPDATING}" ]] || return
+  [[ -z "${HOMEBREW_UPDATE_AUTO}" ]] || return
+  [[ -z "${HOMEBREW_AUTO_UPDATE_CHECKED}" ]] || return
+  # Worktrees may share Git metadata with another checkout, so skip background updates.
+  [[ ! -f "${HOMEBREW_REPOSITORY}/.git" ]] || return
+
+  # If we've checked for updates, we don't need to check again.
+  export HOMEBREW_AUTO_UPDATE_CHECKED="1"
+
+  if [[ -n "${HOMEBREW_AUTO_UPDATE_COMMAND}" ]]
+  then
+    export HOMEBREW_AUTO_UPDATING="1"
+
+    # Look for commands that may be referring to a formula/cask in a specific
+    # 3rd-party tap so they can be auto-updated more often (as they do not get
+    # their data from the API).
+    AUTO_UPDATE_TAP_COMMANDS=(
+      install
+      outdated
+      upgrade
+    )
+    if check-array-membership "${HOMEBREW_COMMAND}" "${AUTO_UPDATE_TAP_COMMANDS[@]}"
+    then
+      for arg in "$@"
+      do
+        if [[ "${arg}" == */*/* ]] && [[ "${arg}" != Homebrew/* ]] && [[ "${arg}" != homebrew/* ]]
+        then
+
+          HOMEBREW_AUTO_UPDATE_TAP="1"
+          break
+        fi
+      done
+    fi
+
+    # When auto-updating before a zero-argument `brew upgrade` or `brew outdated`,
+    # that command lists the outdated packages itself so skip doing so here too.
+    # Two-way sync: `dump` in `Library/Homebrew/cmd/update_report/reporter_hub.rb`.
+    if [[ "${HOMEBREW_COMMAND}" == "upgrade" || "${HOMEBREW_COMMAND}" == "outdated" ]]
+    then
+      HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED="1"
+      for arg in "${@:2}"
+      do
+        [[ "${arg}" == -* ]] && continue
+        HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED=""
+        break
+      done
+      [[ -n "${HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED}" ]] && export HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED
+    fi
+
+    # Keep in sync with the HOMEBREW_AUTO_UPDATE_SECS default in
+    # Library/Homebrew/env_config.rb.
+    if [[ -z "${HOMEBREW_AUTO_UPDATE_SECS}" ]]
+    then
+      if [[ -n "${HOMEBREW_NO_INSTALL_FROM_API}" || -n "${HOMEBREW_AUTO_UPDATE_TAP}" ]]
+      then
+        # 5 minutes
+        HOMEBREW_AUTO_UPDATE_SECS="300"
+      elif [[ -n "${HOMEBREW_DEV_CMD_RUN}" ]]
+      then
+        # 1 hour
+        HOMEBREW_AUTO_UPDATE_SECS="3600"
+      else
+        # 24 hours
+        HOMEBREW_AUTO_UPDATE_SECS="86400"
+      fi
+    fi
+
+    repo_fetch_heads=("${HOMEBREW_REPOSITORY}/.git/FETCH_HEAD")
+    # We might have done an auto-update recently, but not a core/cask clone auto-update.
+    # So we check the core/cask clone FETCH_HEAD too.
+    if [[ -n "${HOMEBREW_AUTO_UPDATE_CORE_TAP}" && -d "${HOMEBREW_CORE_REPOSITORY}/.git" ]]
+    then
+      repo_fetch_heads+=("${HOMEBREW_CORE_REPOSITORY}/.git/FETCH_HEAD")
+    fi
+    if [[ -n "${HOMEBREW_AUTO_UPDATE_CASK_TAP}" && -d "${HOMEBREW_CASK_REPOSITORY}/.git" ]]
+    then
+      repo_fetch_heads+=("${HOMEBREW_CASK_REPOSITORY}/.git/FETCH_HEAD")
+    fi
+
+    # Skip auto-update if all of the selected repositories have been checked in the
+    # last $HOMEBREW_AUTO_UPDATE_SECS.
+    needs_auto_update=
+    for repo_fetch_head in "${repo_fetch_heads[@]}"
+    do
+      if [[ ! -f "${repo_fetch_head}" ]] ||
+         [[ -z "$(find "${repo_fetch_head}" -type f -newermt "-${HOMEBREW_AUTO_UPDATE_SECS} seconds" 2>/dev/null)" ]]
+      then
+        needs_auto_update=1
+        break
+      fi
+    done
+    if [[ -z "${needs_auto_update}" ]]
+    then
+      unset HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED
+      return
+    fi
+
+    brew update --auto-update
+
+    unset HOMEBREW_AUTO_UPDATING
+    unset HOMEBREW_AUTO_UPDATE_TAP
+    unset HOMEBREW_AUTO_UPDATE_SKIP_OUTDATED
+
+    if [[ $# -gt 0 ]]
+    then
+      # exec a new process to set any new environment variables.
+      exec "${HOMEBREW_BREW_FILE}" "$@"
+    fi
+  fi
+
+  unset HOMEBREW_AUTO_UPDATE_CORE_TAP
+  unset HOMEBREW_AUTO_UPDATE_CASK_TAP
+}
+
+# Classify HOMEBREW_COMMAND for auto-update: whether it should run at all and
+# whether the homebrew-core or homebrew-cask taps should also be updated.
+setup-auto-update() {
+  local AUTO_UPDATE_COMMANDS AUTO_UPDATE_CORE_TAP_COMMANDS AUTO_UPDATE_CASK_TAP_COMMANDS
+
+  unset HOMEBREW_AUTO_UPDATE_COMMAND
+
+  # Check for commands that should call `brew update --auto-update` first.
+  AUTO_UPDATE_COMMANDS=(
+    install
+    outdated
+    upgrade
+    bundle
+    release
+  )
+  if check-array-membership "${HOMEBREW_COMMAND}" "${AUTO_UPDATE_COMMANDS[@]}" ||
+     [[ "${HOMEBREW_COMMAND}" == "tap" && "${HOMEBREW_ARG_COUNT}" -gt 1 ]]
+  then
+    export HOMEBREW_AUTO_UPDATE_COMMAND="1"
+  fi
+
+  # Check for commands that should auto-update the homebrew-core tap.
+  AUTO_UPDATE_CORE_TAP_COMMANDS=(
+    bump
+    bump-formula-pr
+  )
+  if check-array-membership "${HOMEBREW_COMMAND}" "${AUTO_UPDATE_CORE_TAP_COMMANDS[@]}"
+  then
+    export HOMEBREW_AUTO_UPDATE_COMMAND="1"
+    export HOMEBREW_AUTO_UPDATE_CORE_TAP="1"
+  elif [[ -z "${HOMEBREW_AUTO_UPDATING}" ]]
+  then
+    unset HOMEBREW_AUTO_UPDATE_CORE_TAP
+  fi
+
+  # Check for commands that should auto-update the homebrew-cask tap.
+  AUTO_UPDATE_CASK_TAP_COMMANDS=(
+    bump
+    bump-cask-pr
+    bump-unversioned-casks
+  )
+  if check-array-membership "${HOMEBREW_COMMAND}" "${AUTO_UPDATE_CASK_TAP_COMMANDS[@]}"
+  then
+    export HOMEBREW_AUTO_UPDATE_COMMAND="1"
+    export HOMEBREW_AUTO_UPDATE_CASK_TAP="1"
+  elif [[ -z "${HOMEBREW_AUTO_UPDATING}" ]]
+  then
+    unset HOMEBREW_AUTO_UPDATE_CASK_TAP
+  fi
+}

--- a/Library/Homebrew/utils/curl.sh
+++ b/Library/Homebrew/utils/curl.sh
@@ -1,0 +1,76 @@
+# curl selection and version checks plus Homebrew's user agents.
+
+# HOMEBREW_* variables set here are used across Homebrew's Bash scripts.
+# shellcheck disable=SC2034
+# These variables are set by bin/brew, brew.sh or the user environment.
+# shellcheck disable=SC2154
+
+# Ensure the system curl is a version that supports modern HTTPS certificates.
+HOMEBREW_MINIMUM_CURL_VERSION="7.41.0"
+
+# Timeout values to check for dead connections
+# We don't use --max-time to support slow connections
+HOMEBREW_CURL_SPEED_LIMIT=100
+HOMEBREW_CURL_SPEED_TIME=5
+
+setup_curl() {
+  HOMEBREW_BREWED_CURL_PATH="${HOMEBREW_PREFIX}/opt/curl/bin/curl"
+  if [[ -n "${HOMEBREW_FORCE_BREWED_CURL}" && -x "${HOMEBREW_BREWED_CURL_PATH}" ]] &&
+     "${HOMEBREW_BREWED_CURL_PATH}" --version &>/dev/null
+  then
+    HOMEBREW_CURL="${HOMEBREW_BREWED_CURL_PATH}"
+  elif [[ -n "${HOMEBREW_CURL_PATH}" ]]
+  then
+    HOMEBREW_CURL="${HOMEBREW_CURL_PATH}"
+  else
+    HOMEBREW_CURL="curl"
+  fi
+}
+
+setup_ca_certificates() {
+  if [[ -n "${HOMEBREW_FORCE_BREWED_CA_CERTIFICATES}" && -f "${HOMEBREW_PREFIX}/etc/ca-certificates/cert.pem" ]]
+  then
+    export SSL_CERT_FILE="${HOMEBREW_PREFIX}/etc/ca-certificates/cert.pem"
+    export GIT_SSL_CAINFO="${HOMEBREW_PREFIX}/etc/ca-certificates/cert.pem"
+    export GIT_SSL_CAPATH="${HOMEBREW_PREFIX}/etc/ca-certificates"
+  fi
+}
+
+# Ensure the system curl is at or newer than the minimum required version.
+check-curl-version() {
+  [[ -z "${HOMEBREW_MACOS}" ]] || return 0
+
+  local curl_version_output curl_name_and_version message
+  curl_version_output="$(${HOMEBREW_CURL} --version 2>/dev/null)"
+  curl_name_and_version="${curl_version_output%% (*}"
+  if [[ "$(numeric "${curl_name_and_version##* }")" -lt "$(numeric "${HOMEBREW_MINIMUM_CURL_VERSION}")" ]]
+  then
+    message="Please update your system curl or set HOMEBREW_CURL_PATH to a newer version.
+Minimum required version: ${HOMEBREW_MINIMUM_CURL_VERSION}
+       Your curl version: ${curl_name_and_version##* }
+    Your curl executable: $(type -p "${HOMEBREW_CURL}")"
+
+    if [[ -z ${HOMEBREW_CURL_PATH} ]]
+    then
+      HOMEBREW_SYSTEM_CURL_TOO_OLD=1
+      HOMEBREW_FORCE_BREWED_CURL=1
+      if [[ -z ${HOMEBREW_CURL_WARNING} ]]
+      then
+        onoe "${message}"
+        HOMEBREW_CURL_WARNING=1
+      fi
+    else
+      odie "${message}"
+    fi
+  fi
+}
+
+setup-user-agents() {
+  HOMEBREW_USER_AGENT="${HOMEBREW_PRODUCT}/${HOMEBREW_USER_AGENT_VERSION} (${HOMEBREW_SYSTEM}; ${HOMEBREW_PROCESSOR} ${HOMEBREW_OS_USER_AGENT_VERSION})"
+  # With the filtered PATH set by bin/brew this resolves to the same curl the
+  # shims/shared/curl shim would but without forking the shim script itself.
+  local curl_version_output curl_name_and_version
+  curl_version_output="$("${HOMEBREW_CURL}" --version 2>/dev/null)"
+  curl_name_and_version="${curl_version_output%% (*}"
+  HOMEBREW_USER_AGENT_CURL="${HOMEBREW_USER_AGENT} ${curl_name_and_version// //}"
+}

--- a/Library/Homebrew/utils/git.sh
+++ b/Library/Homebrew/utils/git.sh
@@ -1,0 +1,187 @@
+# git selection and version checks plus helpers to read Homebrew's repository
+# Git state, avoiding `git` forks wherever possible as they are slow enough to
+# matter on every invocation.
+
+# HOMEBREW_* variables set here are used across Homebrew's Bash scripts.
+# shellcheck disable=SC2034
+# These variables are set by bin/brew, brew.sh or the user environment.
+# shellcheck disable=SC2154
+
+# Some Git versions are too old for some Homebrew functionality we rely on.
+HOMEBREW_MINIMUM_GIT_VERSION="2.30.0"
+
+setup_git() {
+  if [[ -n "${HOMEBREW_FORCE_BREWED_GIT}" && -x "${HOMEBREW_PREFIX}/opt/git/bin/git" ]] &&
+     "${HOMEBREW_PREFIX}/opt/git/bin/git" --version &>/dev/null
+  then
+    HOMEBREW_GIT="${HOMEBREW_PREFIX}/opt/git/bin/git"
+  elif [[ -n "${HOMEBREW_GIT_PATH}" ]]
+  then
+    HOMEBREW_GIT="${HOMEBREW_GIT_PATH}"
+  else
+    HOMEBREW_GIT="git"
+  fi
+}
+
+# Ensure the system Git is at or newer than the minimum required version.
+check-git-version() {
+  [[ -z "${HOMEBREW_MACOS}" ]] || return 0
+
+  local git_version_output major minor micro build extra message
+  git_version_output="$(${HOMEBREW_GIT} --version 2>/dev/null)"
+  # $extra is intentionally discarded.
+  IFS='.' read -r major minor micro build extra < <(printf '%s' "${git_version_output##* }")
+  if [[ "$(numeric "${major}.${minor}.${micro}.${build}")" -lt "$(numeric "${HOMEBREW_MINIMUM_GIT_VERSION}")" ]]
+  then
+    message="Please update your system Git or set HOMEBREW_GIT_PATH to a newer version.
+Minimum required version: ${HOMEBREW_MINIMUM_GIT_VERSION}
+        Your Git version: ${major}.${minor}.${micro}.${build}
+     Your Git executable: $(unset git && type -p "${HOMEBREW_GIT}")"
+    if [[ -z ${HOMEBREW_GIT_PATH} ]]
+    then
+      HOMEBREW_FORCE_BREWED_GIT="1"
+      if [[ -z ${HOMEBREW_GIT_WARNING} ]]
+      then
+        onoe "${message}"
+        HOMEBREW_GIT_WARNING=1
+      fi
+    else
+      odie "${message}"
+    fi
+  fi
+}
+
+# Read all the `homebrew.*` values from Homebrew's repository Git configuration
+# in one pass rather than forking `git config` for each. Section and variable
+# names are case-insensitive in Git configuration files, hence `nocasematch`.
+# The matching Ruby is Homebrew::Settings in Library/Homebrew/settings.rb.
+read-homebrew-git-config() {
+  HOMEBREW_GIT_CONFIG_FILE="${HOMEBREW_REPOSITORY}/.git/config"
+  HOMEBREW_GIT_CONFIG_DEVCMDRUN=""
+  HOMEBREW_GIT_CONFIG_ANALYTICS_UUID=""
+  HOMEBREW_GIT_CONFIG_ANALYTICS_MESSAGE_SEEN=""
+  HOMEBREW_GIT_CONFIG_ANALYTICS_DISABLED=""
+  [[ -f "${HOMEBREW_GIT_CONFIG_FILE}" ]] || return 0
+
+  local nocasematch_enabled=""
+  shopt -q nocasematch && nocasematch_enabled="1"
+  shopt -s nocasematch
+
+  local line key value in_homebrew_section=""
+  while IFS= read -r line || [[ -n "${line}" ]]
+  do
+    # Strip leading whitespace.
+    line="${line#"${line%%[![:space:]]*}"}"
+    case "${line}" in
+      # The escaped closing bracket must match directly after the section
+      # name so e.g. [homebrew-cask] or [homebrew "cask"] don't.
+      \[homebrew\]*)
+        in_homebrew_section="1"
+        ;;
+      \[*)
+        in_homebrew_section=""
+        ;;
+      *=*)
+        [[ -n "${in_homebrew_section}" ]] || continue
+        key="${line%%=*}"
+        key="${key%"${key##*[![:space:]]}"}"
+        value="${line#*=}"
+        value="${value#"${value%%[![:space:]]*}"}"
+        # Strip any trailing comment and whitespace like `git config` does.
+        value="${value%%[#;]*}"
+        value="${value%"${value##*[![:space:]]}"}"
+        case "${key}" in
+          devcmdrun) HOMEBREW_GIT_CONFIG_DEVCMDRUN="${value}" ;;
+          analyticsuuid) HOMEBREW_GIT_CONFIG_ANALYTICS_UUID="${value}" ;;
+          analyticsmessage) HOMEBREW_GIT_CONFIG_ANALYTICS_MESSAGE_SEEN="${value}" ;;
+          analyticsdisabled) HOMEBREW_GIT_CONFIG_ANALYTICS_DISABLED="${value}" ;;
+          *) ;;
+        esac
+        ;;
+      *) ;;
+    esac
+  done <"${HOMEBREW_GIT_CONFIG_FILE}"
+
+  [[ -z "${nocasematch_enabled}" ]] && shopt -u nocasematch
+  return 0
+}
+
+# Set HOMEBREW_VERSION from `git describe`, cached in .git/describe-cache
+# keyed by the HEAD revision. Leaves HOMEBREW_VERSION unchanged when the
+# revision cannot be determined e.g. in a shallow or non-Git repository.
+set-homebrew-version-from-git() {
+  local git_describe_cache="${HOMEBREW_REPOSITORY}/.git/describe-cache"
+
+  # Read HEAD and its ref directly rather than through `git rev-parse HEAD`
+  # to avoid a fork on every invocation.
+  local git_head="" git_revision="" git_ref
+  local git_revision_regex="^([0-9a-f]{40}|[0-9a-f]{64})$"
+  read -r git_head 2>/dev/null <"${HOMEBREW_REPOSITORY}/.git/HEAD"
+  if [[ "${git_head}" == "ref: "* ]]
+  then
+    git_ref="${git_head#ref: }"
+    if [[ -f "${HOMEBREW_REPOSITORY}/.git/${git_ref}" ]]
+    then
+      read -r git_revision 2>/dev/null <"${HOMEBREW_REPOSITORY}/.git/${git_ref}"
+    elif [[ -f "${HOMEBREW_REPOSITORY}/.git/packed-refs" ]]
+    then
+      local packed_revision packed_ref
+      while read -r packed_revision packed_ref
+      do
+        if [[ "${packed_ref}" == "${git_ref}" ]]
+        then
+          git_revision="${packed_revision}"
+          break
+        fi
+      done <"${HOMEBREW_REPOSITORY}/.git/packed-refs"
+    fi
+  elif [[ "${git_head}" =~ ${git_revision_regex} ]]
+  then
+    # HEAD is detached.
+    git_revision="${git_head}"
+  fi
+  [[ "${git_revision}" =~ ${git_revision_regex} ]] || git_revision=""
+
+  # Fall back to git for anything unusual e.g. a worktree where .git is a file.
+  if [[ -z "${git_revision}" && -e "${HOMEBREW_REPOSITORY}/.git" ]]
+  then
+    git_revision=$("${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" rev-parse HEAD 2>/dev/null)
+  fi
+
+  if [[ -z "${git_revision}" ]]
+  then
+    if [[ -d "${git_describe_cache}" ]]
+    then
+      # Don't care about permission errors here.
+      rm -rf "${git_describe_cache}" 2>/dev/null
+    fi
+    return 0
+  fi
+
+  local git_describe_cache_file="${git_describe_cache}/${git_revision}"
+  local cached_version
+  # Almost only developers ever have a dirty repository so only they pay for
+  # the (slow) Git dirty working tree check that invalidates this cache.
+  if [[ -r "${git_describe_cache_file}" ]] &&
+     { [[ -z "${HOMEBREW_DEVELOPER}" && -z "${HOMEBREW_DEV_CMD_RUN}" && "${HOMEBREW_GIT_CONFIG_DEVCMDRUN}" != "true" ]] ||
+     "${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" diff --quiet --no-ext-diff 2>/dev/null; }
+  then
+    read -r cached_version <"${git_describe_cache_file}"
+    if [[ -n "${cached_version}" && "${cached_version}" != *"-dirty" ]]
+    then
+      HOMEBREW_VERSION="${cached_version}"
+    fi
+  fi
+
+  if [[ -z "${HOMEBREW_VERSION}" ]]
+  then
+    HOMEBREW_VERSION="$("${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" describe --tags --dirty --abbrev=7 2>/dev/null)"
+    # Don't output any permissions errors here. The user may not have write
+    # permissions to the cache but we don't care because it's an optional
+    # performance improvement.
+    rm -rf "${git_describe_cache}" 2>/dev/null
+    mkdir -p "${git_describe_cache}" 2>/dev/null
+    { echo "${HOMEBREW_VERSION}" >"${git_describe_cache_file}"; } 2>/dev/null
+  fi
+  return 0
+}

--- a/Library/Homebrew/utils/os.sh
+++ b/Library/Homebrew/utils/os.sh
@@ -1,0 +1,209 @@
+# Operating system detection, default paths and OS-specific behaviour.
+# This is sourced first by brew.sh so only fast, fork-free code may run at
+# source time: commands like `brew shellenv` need everything defined here.
+
+# HOMEBREW_* variables set here are used across Homebrew's Bash scripts.
+# shellcheck disable=SC2034
+# HOME is set by bin/brew and the remaining variables by the user environment.
+# shellcheck disable=SC2154
+
+case "${MACHTYPE}" in
+  arm64-* | aarch64-*)
+    HOMEBREW_PROCESSOR="arm64"
+    ;;
+  x86_64-*)
+    HOMEBREW_PROCESSOR="x86_64"
+    ;;
+  *)
+    HOMEBREW_PROCESSOR="$(uname -m)"
+    ;;
+esac
+
+case "${OSTYPE}" in
+  darwin*)
+    HOMEBREW_SYSTEM="Darwin"
+    HOMEBREW_MACOS="1"
+    ;;
+  linux*)
+    HOMEBREW_SYSTEM="Linux"
+    HOMEBREW_LINUX="1"
+    ;;
+  *)
+    HOMEBREW_SYSTEM="$(uname -s)"
+    ;;
+esac
+HOMEBREW_PHYSICAL_PROCESSOR="${HOMEBREW_PROCESSOR}"
+
+HOMEBREW_MACOS_ARM_DEFAULT_PREFIX="/opt/homebrew"
+HOMEBREW_LINUX_DEFAULT_PREFIX="/home/linuxbrew/.linuxbrew"
+HOMEBREW_GENERIC_DEFAULT_PREFIX="/usr/local"
+if [[ -n "${HOMEBREW_MACOS}" && "${HOMEBREW_PROCESSOR}" == "arm64" ]]
+then
+  HOMEBREW_DEFAULT_PREFIX="${HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}"
+  HOMEBREW_DEFAULT_REPOSITORY="${HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}"
+elif [[ -n "${HOMEBREW_LINUX}" ]]
+then
+  HOMEBREW_DEFAULT_PREFIX="${HOMEBREW_LINUX_DEFAULT_PREFIX}"
+  HOMEBREW_DEFAULT_REPOSITORY="${HOMEBREW_LINUX_DEFAULT_PREFIX}/Homebrew"
+else
+  HOMEBREW_DEFAULT_PREFIX="${HOMEBREW_GENERIC_DEFAULT_PREFIX}"
+  HOMEBREW_DEFAULT_REPOSITORY="${HOMEBREW_GENERIC_DEFAULT_PREFIX}/Homebrew"
+fi
+
+if [[ -n "${HOMEBREW_MACOS}" ]]
+then
+  HOMEBREW_DEFAULT_CACHE="${HOME}/Library/Caches/Homebrew"
+  HOMEBREW_DEFAULT_LOGS="${HOME}/Library/Logs/Homebrew"
+  HOMEBREW_DEFAULT_TEMP="/private/tmp"
+else
+  CACHE_HOME="${HOMEBREW_XDG_CACHE_HOME:-${HOME}/.cache}"
+  HOMEBREW_DEFAULT_CACHE="${CACHE_HOME}/Homebrew"
+  HOMEBREW_DEFAULT_LOGS="${CACHE_HOME}/Homebrew/Logs"
+  if [[ -r "/var/tmp" && -w "/var/tmp" ]]
+  then
+    HOMEBREW_DEFAULT_TEMP="/var/tmp"
+  else
+    HOMEBREW_DEFAULT_TEMP="/tmp"
+  fi
+fi
+
+# brew shellenv needs HOMEBREW_MACOS_VERSION_NUMERIC
+if [[ -n "${HOMEBREW_MACOS}" ]]
+then
+  # Read ProductVersion directly to avoid forking `sw_vers`, which reads the
+  # same file but costs several milliseconds on every invocation.
+  HOMEBREW_MACOS_VERSION=""
+  SYSTEM_VERSION_PLIST="/System/Library/CoreServices/SystemVersion.plist"
+  SYSTEM_VERSION_PRODUCT_VERSION_KEY=""
+  while IFS= read -r SYSTEM_VERSION_PLIST_LINE
+  do
+    if [[ -n "${SYSTEM_VERSION_PRODUCT_VERSION_KEY}" ]]
+    then
+      HOMEBREW_MACOS_VERSION="${SYSTEM_VERSION_PLIST_LINE#*<string>}"
+      HOMEBREW_MACOS_VERSION="${HOMEBREW_MACOS_VERSION%%</string>*}"
+      break
+    fi
+    [[ "${SYSTEM_VERSION_PLIST_LINE}" == *"<key>ProductVersion</key>"* ]] && SYSTEM_VERSION_PRODUCT_VERSION_KEY="1"
+  done 2>/dev/null <"${SYSTEM_VERSION_PLIST}"
+  MACOS_VERSION_REGEX="^[0-9.]+$"
+  if ! [[ "${HOMEBREW_MACOS_VERSION}" =~ ${MACOS_VERSION_REGEX} ]]
+  then
+    HOMEBREW_MACOS_VERSION="$(/usr/bin/sw_vers -productVersion)"
+  fi
+  unset SYSTEM_VERSION_PLIST SYSTEM_VERSION_PLIST_LINE SYSTEM_VERSION_PRODUCT_VERSION_KEY MACOS_VERSION_REGEX
+
+  IFS=. read -r -a MACOS_VERSION_ARRAY < <(printf '%s' "${HOMEBREW_MACOS_VERSION}")
+  printf -v HOMEBREW_MACOS_VERSION_NUMERIC "%02d%02d%02d" "${MACOS_VERSION_ARRAY[@]}"
+
+  unset MACOS_VERSION_ARRAY
+fi
+
+# Force UTF-8 to avoid encoding issues for users with broken locale settings.
+# The locale is checked by name to avoid forking `locale charmap`. When
+# bin/brew has filtered the environment no locale variables survive so a UTF-8
+# one must be set.
+setup-locale() {
+  local utf8_locale_regex='\.([Uu][Tt][Ff]-?8)(@|$)'
+  local locales c_utf_regex en_us_regex utf_regex
+  if [[ "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" =~ ${utf8_locale_regex} ]]
+  then
+    # The locale is already UTF-8.
+    :
+  elif [[ -n "${HOMEBREW_MACOS}" ]]
+  then
+    export LC_ALL="en_US.UTF-8"
+  else
+    if ! command -v locale >/dev/null
+    then
+      export LC_ALL=C
+    else
+      locales="$(locale -a)"
+      c_utf_regex='\bC\.(utf8|UTF-8)\b'
+      en_us_regex='\ben_US\.(utf8|UTF-8)\b'
+      utf_regex='\b[a-z][a-z]_[A-Z][A-Z]\.(utf8|UTF-8)\b'
+      if [[ ${locales} =~ ${c_utf_regex} || ${locales} =~ ${en_us_regex} || ${locales} =~ ${utf_regex} ]]
+      then
+        export LC_ALL="${BASH_REMATCH[0]}"
+      else
+        export LC_ALL=C
+      fi
+    fi
+  fi
+}
+
+# Derive the OS-specific product naming and user agent details and check the
+# OS version and hardware are supported.
+setup-os-details() {
+  local MACOS_VERSION_ARRAY
+  if [[ -n "${HOMEBREW_MACOS}" ]]
+  then
+    HOMEBREW_PRODUCT="Homebrew"
+    HOMEBREW_SYSTEM="Macintosh"
+    [[ "${HOMEBREW_PROCESSOR}" == "x86_64" ]] && HOMEBREW_PROCESSOR="Intel"
+    # Don't change this from Mac OS X to match what macOS itself does in Safari
+    HOMEBREW_OS_USER_AGENT_VERSION="Mac OS X ${HOMEBREW_MACOS_VERSION}"
+
+    # `sysctl` is only needed to detect Rosetta so don't fork it on ARM.
+    if [[ "${HOMEBREW_PHYSICAL_PROCESSOR}" == "x86_64" ]] &&
+       [[ "$(sysctl -n hw.optional.arm64 2>/dev/null)" == "1" ]]
+    then
+      # used in vendor-install.sh and update.sh
+      HOMEBREW_PHYSICAL_PROCESSOR="arm64"
+    fi
+
+    IFS=. read -r -a MACOS_VERSION_ARRAY < <(printf '%s' "${HOMEBREW_MACOS_OLDEST_ALLOWED}")
+    printf -v HOMEBREW_MACOS_OLDEST_ALLOWED_NUMERIC "%02d%02d%02d" "${MACOS_VERSION_ARRAY[@]}"
+
+    # Don't include minor versions for Big Sur and later.
+    if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -gt "110000" ]]
+    then
+      HOMEBREW_OS_VERSION="macOS ${HOMEBREW_MACOS_VERSION%.*}"
+    else
+      HOMEBREW_OS_VERSION="macOS ${HOMEBREW_MACOS_VERSION}"
+    fi
+
+    # Refuse to run on pre-Catalina
+    # odisabled: remove support for Catalina September (or later) 2026
+    if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "${HOMEBREW_MACOS_OLDEST_ALLOWED_NUMERIC}" ]]
+    then
+      printf "ERROR: Your version of macOS (%s) is too old to run Homebrew!\\n" "${HOMEBREW_MACOS_VERSION}" >&2
+      if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "100700" ]]
+      then
+        printf "         For 10.4 - 10.6 support see: https://github.com/mistydemeo/tigerbrew\\n" >&2
+      else
+        printf "         For 10.5 - %s support see: https://www.macports.org\\n" "${HOMEBREW_MACOS_VERSION}" >&2
+      fi
+      printf "\\n" >&2
+    fi
+
+    # The system libressl has a bug before macOS 10.15.6 where it incorrectly handles expired roots.
+    if [[ -z "${HOMEBREW_SYSTEM_CURL_TOO_OLD}" && "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "101506" ]]
+    then
+      HOMEBREW_SYSTEM_CA_CERTIFICATES_TOO_OLD="1"
+      HOMEBREW_FORCE_BREWED_CA_CERTIFICATES="1"
+    fi
+
+    if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "110000" ]]
+    then
+      HOMEBREW_FORCE_BREWED_GIT="1"
+    fi
+  else
+    if [[ -r "/proc/cpuinfo" ]] &&
+       [[ "${HOMEBREW_PROCESSOR}" == "x86_64" ]]
+    then
+      if ! grep -qE '^(flags|Features).*\bssse3\b' /proc/cpuinfo
+      then
+        odie "Homebrew's x86_64 support on Linux requires a CPU with SSSE3 support!"
+      fi
+    fi
+
+    HOMEBREW_PRODUCT="${HOMEBREW_SYSTEM}brew"
+    # Don't try to follow /etc/os-release
+    # shellcheck disable=SC1091
+    [[ -n "${HOMEBREW_LINUX}" ]] && HOMEBREW_OS_VERSION="$(source /etc/os-release && echo "${PRETTY_NAME}")"
+    : "${HOMEBREW_OS_VERSION:=$(uname -r)}"
+    HOMEBREW_OS_USER_AGENT_VERSION="${HOMEBREW_OS_VERSION}"
+
+    HOMEBREW_LINUX_MINIMUM_GLIBC_VERSION="2.13"
+  fi
+}

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -4,7 +4,7 @@
 # HOMEBREW_LIBRARY set by bin/brew
 # shellcheck disable=SC2154
 export HOMEBREW_REQUIRED_RUBY_VERSION="4.0"
-HOMEBREW_PORTABLE_RUBY_VERSION="$(cat "${HOMEBREW_LIBRARY}/Homebrew/vendor/portable-ruby-version")"
+read -r HOMEBREW_PORTABLE_RUBY_VERSION <"${HOMEBREW_LIBRARY}/Homebrew/vendor/portable-ruby-version"
 export HOMEBREW_BUNDLER_VERSION="4.0.16"
 
 # Disable Ruby options we don't need.
@@ -93,7 +93,8 @@ setup-ruby-path() {
   local vendor_ruby_root
   local vendor_ruby_path
   local vendor_ruby_terminfo
-  local vendor_ruby_current_version
+  local bootsnap_gem_paths
+  local nullglob_enabled
   local ruby_exec
   local upgrade_fail
   local install_fail
@@ -117,7 +118,6 @@ If there's no Homebrew Portable Ruby available for your processor:
   vendor_ruby_root="${vendor_dir}/portable-ruby/current"
   vendor_ruby_path="${vendor_ruby_root}/bin/ruby"
   vendor_ruby_terminfo="${vendor_ruby_root}/share/terminfo"
-  vendor_ruby_current_version="$(readlink "${vendor_ruby_root}")"
 
   unset HOMEBREW_RUBY_PATH
 
@@ -133,14 +133,17 @@ If there's no Homebrew Portable Ruby available for your processor:
   then
     HOMEBREW_RUBY_PATH="${vendor_ruby_path}"
     TERMINFO_DIRS="${vendor_ruby_terminfo}"
-    if [[ "${vendor_ruby_current_version}" != "${HOMEBREW_PORTABLE_RUBY_VERSION}" ]]
+    # `-ef` (rather than `readlink`) to check the `current` symlink without a fork.
+    if ! [[ "${vendor_ruby_root}" -ef "${vendor_dir}/portable-ruby/${HOMEBREW_PORTABLE_RUBY_VERSION}" ]]
     then
       brew vendor-install ruby || odie "${upgrade_fail}"
     fi
-    HOMEBREW_BOOTSNAP_GEM_PATH="$(
-      shopt -s nullglob
-      echo "${vendor_ruby_root}"/lib/ruby/gems/*/gems/bootsnap-*/lib/bootsnap 2>/dev/null
-    )"
+    nullglob_enabled=""
+    shopt -q nullglob && nullglob_enabled="1"
+    shopt -s nullglob
+    bootsnap_gem_paths=("${vendor_ruby_root}"/lib/ruby/gems/*/gems/bootsnap-*/lib/bootsnap)
+    [[ -z "${nullglob_enabled}" ]] && shopt -u nullglob
+    HOMEBREW_BOOTSNAP_GEM_PATH="${bootsnap_gem_paths[*]-}"
   else
     if system_ruby_supported
     then
@@ -169,7 +172,7 @@ If there's no Homebrew Portable Ruby available for your processor:
     fi
   fi
 
-  homebrew_ruby_bin="$(dirname "${HOMEBREW_RUBY_PATH}")"
+  homebrew_ruby_bin="${HOMEBREW_RUBY_PATH%/*}"
   if [[ ! -f "${homebrew_ruby_bin}/bundle" ]]
   then
     "${homebrew_ruby_bin}/gem" install bundler -v "${HOMEBREW_BUNDLER_VERSION}"

--- a/bin/brew
+++ b/bin/brew
@@ -116,10 +116,8 @@ BIN_BREW_EXPORTED_VARS=(
   HOMEBREW_USER_CONFIG_HOME
   HOMEBREW_ORIGINAL_BREW_FILE
 )
-BIN_BREW_EXPORTED_VARS_REGEX="^($(
-  IFS='|'
-  echo "${BIN_BREW_EXPORTED_VARS[*]}"
-))(=|$)"
+printf -v BIN_BREW_EXPORTED_VARS_REGEX '%s|' "${BIN_BREW_EXPORTED_VARS[@]}"
+BIN_BREW_EXPORTED_VARS_REGEX="^(${BIN_BREW_EXPORTED_VARS_REGEX%|})(=|$)"
 
 # Load Homebrew's variable configuration files from disk.
 export_homebrew_env_file() {


### PR DESCRIPTION
- Parse `.git/config` once in Bash for the `devcmdrun` and analytics settings rather than forking `git config` via the shim four times.
- Read `.git/HEAD`, loose refs and `packed-refs` directly and keep `git rev-parse` only - Parse `.git/config` once in Bash for the `devcmdrun` and analytics
  settings rather than forking `git config` via the shim four times.
- Read `.git/HEAD`, loose refs and `packed-refs` directly and keep
  `git rev-parse` only as a fallback for worktrees and symrefs.
- Only run the slow `git diff` describe-cache dirty check for
  developers as they are the only users likely to have dirty trees.
- Parse `SystemVersion.plist` rather than forking `sw_vers`, which
  reads the same file; keep `sw_vers` as a fallback.
- Check locale names rather than forking `locale charmap`; the
  filtered environment can never report UTF-8 anyway.
- Fork `sysctl` only when Rosetta is possible and run
  `${HOMEBREW_CURL}` directly rather than through the `curl` shim.
- Prefer builtins to `cat`, `readlink`, `dirname`, `tee` and
  subshells on the startup path.
- Extract the OS, auto-update, curl and Git logic from `brew.sh`
  into new `utils/os.sh`, `utils/auto-update.sh`, `utils/curl.sh`
  and `utils/git.sh` files; the same work happens in the same order.
- Warm no-op timings: `brew shellenv` 16ms to 9.5ms, `brew --version
  62ms to 11ms and full command dispatch 275ms to 83ms.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude 5 Fable max with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
