### PR TITLE
formula: std_go_args always add -s -w to ldflags

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -36,9 +36,6 @@ module SharedEnvExtension
   ].freeze
   private_constant :SANITIZED_VARS
 
-  sig { returns(T.nilable(T::Boolean)) }
-  attr_reader :build_bottle
-
   sig { returns(T.nilable(String)) }
   attr_reader :bottle_arch
 
@@ -62,6 +59,12 @@ module SharedEnvExtension
     @testing_formula = T.let(testing_formula, T.nilable(T::Boolean))
     reset
   end
+
+  sig { returns(T::Boolean) }
+  def build_bottle? = @build_bottle == true
+
+  sig { returns(T::Boolean) }
+  def debug_symbols? = @debug_symbols == true
 
   sig { void }
   def reset

--- a/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
@@ -10,9 +10,9 @@ module OS
 
       sig { returns(Symbol) }
       def effective_arch
-        if build_bottle && (bottle_arch = self.bottle_arch)
+        if build_bottle? && (bottle_arch = self.bottle_arch)
           bottle_arch.to_sym
-        elsif build_bottle
+        elsif build_bottle?
           ::Hardware.oldest_cpu
         elsif ::Hardware::CPU.intel? || ::Hardware::CPU.arm?
           :native

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2146,10 +2146,12 @@ class Formula
     ).returns(T::Array[String])
   }
   def std_go_args(output: bin/name, ldflags: nil, gcflags: nil, tags: nil)
+    ldflags = ["-s", "-w"].concat(Array(ldflags)) unless ENV.debug_symbols?
+
     args = ["-trimpath", "-o=#{output}"]
-    args += ["-tags=#{Array(tags).join(" ")}"] if tags
-    args += ["-ldflags=#{Array(ldflags).join(" ")}"] if ldflags
-    args += ["-gcflags=#{Array(gcflags).join(" ")}"] if gcflags
+    args << "-tags=#{Array(tags).join(" ")}" if tags
+    args << "-ldflags=#{Array(ldflags).join(" ")}" if ldflags
+    args << "-gcflags=#{Array(gcflags).join(" ")}" if gcflags
     args
   end
 

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -239,7 +239,7 @@ module Homebrew
             system "shards", "build", "--release"
             bin.install "bin/#{name}"
         <% elsif @mode == :go %>
-            system "go", "build", *std_go_args(ldflags: "-s -w")
+            system "go", "build", *std_go_args
         <% elsif @mode == :meson %>
             system "meson", "setup", "build", *std_meson_args
             system "meson", "compile", "-C", "build", "--verbose"

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -3243,6 +3243,30 @@ RSpec.describe Formula do
     end
   end
 
+  describe "#std_go_args" do
+    let(:f) do
+      formula do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+    end
+
+    it "defaults to stripping binaries" do
+      expect(f.std_go_args).to include("-ldflags=-s -w")
+
+      ldflags = "-X main.version=1.0.0"
+      expect(f.std_go_args(ldflags:)).to include("-ldflags=-s -w #{ldflags}")
+    end
+
+    it "does not strip binaries when building with debug symbols" do
+      allow(ENV).to receive(:debug_symbols?).and_return(true)
+      expect(f.std_go_args).not_to include(a_string_starting_with("-ldflags"))
+
+      ldflags = "-X main.version=1.0.0"
+      expect(f.std_go_args(ldflags:)).to include("-ldflags=#{ldflags}")
+    end
+  end
+
   describe "#std_pip_args" do
     let(:f) do
       formula do


### PR DESCRIPTION
Previous attempt:
- https://github.com/Homebrew/brew/pull/15988

For simplicity, don't try to remove duplicates. There is no issue with specifying -s or -w multiple times so only cosmetic and we can clean this up later on formula side.

Also add support for `brew install --build-from-source --debug-symbols` so the handling of `-s -w` is aligned with how we handle `-g` in C/C++.

If there is ever a case we need to allow symbols within a formula, we can add a new parameter, e.g. `strip: true`, which can be set false to restore original behaviour. Currently doesn't seem to be needed based on existing formulae in Homebrew/core.

---

Out of the ~30 non-deprecated formulae in Homebrew/core missing this (< 2.5%), I didn't see any issues running local `brew install -s ... && brew test ...`

Also didn't see any issue running with duplicates when formula already has `ldflags: "-s -w"`.

---

Some other minor touch ups in PR:
- Exposed debug symbol status via `ENV.debug_symbols?`
- Also changed `ENV.build_bottle -> ENV.build_bottle?` to align with above and other usage. 

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
