### PR TITLE
Speed up warm-cache API loads and path lookups

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -99,7 +99,7 @@ module Homebrew
         return [{}, false]
       end
 
-      json_data = begin
+      json_data, from_payload_cache = begin
         download_succeeded = T.let(false, T::Boolean)
         begin
           args = curl_args.dup
@@ -138,8 +138,17 @@ module Homebrew
           mtime = insecure_download ? Time.new(1970, 1, 1) : Time.now
           FileUtils.touch(target, mtime:)
         end
-        # Can use `target.read` again when/if https://github.com/sorbet/sorbet/pull/8999 is merged/released.
-        JSON.parse(File.read(target, encoding: Encoding::UTF_8), freeze: true)
+
+        payload_data = cached_jws_payload(target) if endpoint.end_with?(".jws.json") && !download_succeeded
+        if payload_data
+          [payload_data, true]
+        else
+          # Stat before reading: fingerprinting a concurrently-replaced file
+          # against these bytes would poison the payload cache.
+          source_stat = target.stat
+          # Can use `target.read` again when/if https://github.com/sorbet/sorbet/pull/8999 is merged/released.
+          [JSON.parse(File.read(target, encoding: Encoding::UTF_8), freeze: true), false]
+        end
       rescue JSON::ParserError
         target.unlink
         retry_count += 1
@@ -149,7 +158,7 @@ module Homebrew
         retry
       end
 
-      if endpoint.end_with?(".jws.json")
+      if endpoint.end_with?(".jws.json") && !from_payload_cache
         success, data = verify_and_parse_jws(json_data)
         unless success
           target.unlink
@@ -159,6 +168,9 @@ module Homebrew
             Potential MITM attempt detected. Please run `brew update` and try again.
           EOS
         end
+        # Skip on insecure downloads: their pinned 1970 mtime would make the
+        # source fingerprint ambiguous (and they always re-download anyway).
+        write_jws_payload_cache(target, json_data, source_stat:) if source_stat && !insecure_download
         [data, !skip_download]
       else
         [json_data, !skip_download]
@@ -245,10 +257,20 @@ module Homebrew
       params(
         formulae:   T::Hash[String, T::Hash[String, T.untyped]],
         regenerate: T::Boolean,
+        source:     Pathname,
       ).returns(T::Boolean)
     }
-    def self.write_executables_file!(formulae, regenerate:)
+    def self.write_executables_file!(formulae, regenerate:, source:)
       executables_path = HOMEBREW_CACHE_API/"internal/executables.txt"
+      # The file is derived only from the API data in `source`, so it stays
+      # current until that file next changes or is revalidated.
+      executables_mtime, source_mtime = [executables_path, source].map do |path|
+        path.mtime
+      rescue Errno::ENOENT
+        nil
+      end
+      return false if !regenerate && executables_mtime && source_mtime && source_mtime <= executables_mtime
+
       executables_lines = formulae.filter_map do |name, hash|
         executables = T.cast(hash["executables"], T.nilable(T::Array[String]))
         next if executables.blank?
@@ -264,19 +286,9 @@ module Homebrew
         end
       end
 
-      contents = "#{executables_lines.sort.join("\n")}\n"
-      cached_contents = begin
-        executables_path.read unless regenerate
-      rescue Errno::ENOENT
-        nil
-      end
-      if regenerate || cached_contents != contents
-        executables_path.dirname.mkpath
-        executables_path.write(contents)
-        return true
-      end
-
-      false
+      executables_path.dirname.mkpath
+      executables_path.write("#{executables_lines.sort.join("\n")}\n")
+      true
     end
 
     sig { params(target: Pathname).returns(T::Boolean) }
@@ -324,28 +336,141 @@ module Homebrew
         .returns([T::Boolean, T.any(String, T::Array[T.untyped], T::Hash[String, T.untyped])])
     }
     private_class_method def self.verify_and_parse_jws(json_data)
-      signatures = json_data["signatures"]
-      homebrew_signature = signatures&.find { |sig| sig.dig("header", "kid") == "homebrew-1" }
+      homebrew_signature = homebrew_jws_signature(json_data)
       return false, "key not found" if homebrew_signature.nil?
 
-      header = JSON.parse(Base64.urlsafe_decode64(homebrew_signature["protected"]))
-      if header["alg"] != "PS512" || header["b64"] != false # NOTE: nil has a meaning of true
-        return false, "invalid algorithm"
+      payload = json_data["payload"].to_s
+      error = verify_jws_signature(homebrew_signature["protected"].to_s, homebrew_signature["signature"].to_s,
+                                   payload)
+      return false, error if error
+
+      [true, JSON.parse(payload, freeze: true)]
+    end
+
+    sig { params(json_data: T::Hash[String, T.untyped]).returns(T.nilable(T::Hash[String, T.untyped])) }
+    private_class_method def self.homebrew_jws_signature(json_data)
+      signatures = json_data["signatures"]
+      signatures&.find { |signature| signature.dig("header", "kid") == "homebrew-1" }
+    end
+
+    # Returns a short error description or `nil` if the signature verifies.
+    sig { params(protected_b64: String, signature_b64: String, payload: String).returns(T.nilable(String)) }
+    private_class_method def self.verify_jws_signature(protected_b64, signature_b64, payload)
+      header = JSON.parse(Base64.urlsafe_decode64(protected_b64))
+      if !header.is_a?(Hash) || header["alg"] != "PS512" || header["b64"] != false # NOTE: nil has a meaning of true
+        return "invalid algorithm"
       end
 
       require "openssl"
 
-      pubkey = OpenSSL::PKey::RSA.new((HOMEBREW_LIBRARY_PATH/"api/homebrew-1.pem").read)
-      signing_input = "#{homebrew_signature["protected"]}.#{json_data["payload"]}"
-      unless pubkey.verify_pss("SHA512",
-                               Base64.urlsafe_decode64(homebrew_signature["signature"]),
-                               signing_input,
-                               salt_length: :digest,
-                               mgf1_hash:   "SHA512")
-        return false, "signature mismatch"
-      end
+      pubkey = OpenSSL::PKey::RSA.new(jws_public_key_pem)
+      return "signature mismatch" unless pubkey.verify_pss("SHA512",
+                                                           Base64.urlsafe_decode64(signature_b64),
+                                                           "#{protected_b64}.#{payload}",
+                                                           salt_length: :digest,
+                                                           mgf1_hash:   "SHA512")
 
-      [true, JSON.parse(json_data["payload"], freeze: true)]
+      nil
+    end
+
+    sig { returns(String) }
+    private_class_method def self.jws_public_key_pem
+      (HOMEBREW_LIBRARY_PATH/"api/homebrew-1.pem").read
+    end
+
+    sig { params(target: Pathname).returns(Pathname) }
+    private_class_method def self.jws_payload_cache_path(target)
+      Pathname("#{target}.payload")
+    end
+
+    # Payload sidecars are only maintained for the internal packages files:
+    # `brew cleanup --scrub` and `update.sh` only prune sidecars matching
+    # `internal/packages.*.jws.json*` and the other `.jws.json` endpoints
+    # are re-downloaded whenever they are used.
+    sig { params(target: Pathname).returns(T::Boolean) }
+    private_class_method def self.jws_payload_cacheable?(target)
+      target.dirname == HOMEBREW_CACHE_API/"internal" &&
+        target.basename.to_s.match?(/\Apackages\..*\.jws\.json\z/)
+    end
+
+    # The size and modification time identify which envelope a cached
+    # payload was extracted from.
+    sig { params(stat: File::Stat).returns(T::Hash[String, Integer]) }
+    private_class_method def self.jws_source_fingerprint(stat)
+      {
+        "source_size"     => stat.size,
+        "source_mtime_ns" => (stat.mtime.to_r * 1_000_000_000).to_i,
+      }
+    end
+
+    # Loads the signed payload of a `.jws.json` file from the sidecar cache
+    # written after a previous verification, if it still matches the file.
+    # The signature is verified on every load; only re-parsing the much
+    # larger envelope is skipped.
+    sig { params(target: Pathname).returns(T.nilable(T.any(T::Array[T.untyped], T::Hash[String, T.untyped]))) }
+    private_class_method def self.cached_jws_payload(target)
+      return unless jws_payload_cacheable?(target)
+
+      expected_fingerprint = jws_source_fingerprint(target.stat)
+
+      jws_payload_cache_path(target).open("rb") do |file|
+        header_line = file.gets
+        next if header_line.nil?
+
+        header = JSON.parse(header_line)
+        next unless header.is_a?(Hash)
+        # Check the fingerprint before reading the payload so a stale
+        # sidecar does not cost a wasted multi-megabyte read.
+        next if expected_fingerprint.any? { |key, value| header[key] != value }
+
+        protected_b64 = header["protected"]
+        signature_b64 = header["signature"]
+        next if !protected_b64.is_a?(String) || !signature_b64.is_a?(String)
+
+        payload = file.read.force_encoding(Encoding::UTF_8)
+        next unless verify_jws_signature(protected_b64, signature_b64, payload).nil?
+
+        JSON.parse(payload, freeze: true)
+      end
+    rescue SystemCallError, ArgumentError, JSON::ParserError
+      nil
+    end
+
+    sig {
+      params(target: Pathname, json_data: T.any(T::Array[T.untyped], T::Hash[String, T.untyped]),
+             source_stat: File::Stat).void
+    }
+    private_class_method def self.write_jws_payload_cache(target, json_data, source_stat:)
+      return unless jws_payload_cacheable?(target)
+      # Never write to a user-owned cache as root, matching `skip_download?`.
+      return if Homebrew.running_as_root_but_not_owned_by_root?
+      return unless json_data.is_a?(Hash)
+
+      homebrew_signature = homebrew_jws_signature(json_data)
+      return if homebrew_signature.nil?
+
+      payload = json_data["payload"]
+      protected_b64 = homebrew_signature["protected"]
+      signature_b64 = homebrew_signature["signature"]
+      return if !payload.is_a?(String) || !protected_b64.is_a?(String) || !signature_b64.is_a?(String)
+
+      header = JSON.generate({
+        "protected" => protected_b64,
+        "signature" => signature_b64,
+        **jws_source_fingerprint(source_stat),
+      })
+      payload_cache_path = jws_payload_cache_path(target)
+      temporary_path = Pathname("#{payload_cache_path}.tmp")
+      begin
+        temporary_path.open("wb") do |file|
+          file.write(header, "\n", payload)
+        end
+        File.rename(temporary_path, payload_cache_path)
+      ensure
+        temporary_path.unlink if temporary_path.exist?
+      end
+    rescue SystemCallError
+      nil
     end
 
     sig { params(path: Pathname).returns(T.nilable(Tap)) }

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -194,7 +194,7 @@ module Homebrew
 
         Homebrew::API.write_names_file!(all_formulae.keys, "formula", regenerate:)
         Homebrew::API.write_aliases_file!(all_aliases, "formula", regenerate:)
-        Homebrew::API.write_executables_file!(all_formulae, regenerate:)
+        Homebrew::API.write_executables_file!(all_formulae, regenerate:, source: cached_json_file_path)
       end
     end
   end

--- a/Library/Homebrew/api/internal.rb
+++ b/Library/Homebrew/api/internal.rb
@@ -112,7 +112,7 @@ module Homebrew
 
         Homebrew::API.write_names_file!(formula_hashes.keys, "formula", regenerate:)
         Homebrew::API.write_aliases_file!(formula_aliases, "formula", regenerate:)
-        Homebrew::API.write_executables_file!(formula_hashes, regenerate:)
+        Homebrew::API.write_executables_file!(formula_hashes, regenerate:, source: cached_packages_json_file_path)
       end
 
       sig { params(regenerate: T::Boolean).void }
@@ -120,6 +120,13 @@ module Homebrew
         download_and_cache_data! unless cache.key?("cask_hashes")
 
         Homebrew::API.write_names_file!(cask_hashes.keys, "cask", regenerate:)
+      end
+
+      # Whether formula hashes are already loaded, so callers can use them
+      # opportunistically without triggering a download and full JSON parse.
+      sig { returns(T::Boolean) }
+      def self.formula_hashes_cached?
+        cache.key?("formula_hashes")
       end
 
       sig { returns(T::Hash[String, T::Hash[String, T.untyped]]) }

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -569,8 +569,14 @@ module Homebrew
       cask_files = (cache/"Cask").directory? ? (cache/"Cask").children : []
       api_internal = cache/"api/internal"
       api_package_files = if scrub? && api_internal.directory?
-        current_api_package_basename = Homebrew::API::Internal.cached_packages_json_file_path.basename
-        api_internal.glob("packages.*.jws.json").reject { |path| path.basename == current_api_package_basename }
+        current_api_package_basename = Homebrew::API::Internal.cached_packages_json_file_path.basename.to_s
+        # Keep only the current OS's envelope and its `.payload` sidecar and
+        # scrub the rest, including orphaned sidecars and temp files.
+        # Keep in sync with the previous-OS-version removal in cmd/update.sh.
+        kept_basenames = [current_api_package_basename, "#{current_api_package_basename}.payload"]
+        api_internal.glob("packages.*.jws.json*").reject do |path|
+          kept_basenames.include?(path.basename.to_s)
+        end
       else
         []
       end

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -1048,11 +1048,13 @@ EOS
     rm -f "${HOMEBREW_CACHE}"/api/internal/formula.*.jws.json
     rm -f "${HOMEBREW_CACHE}"/api/internal/cask.*.jws.json
 
-    # Remove API files from previous OS versions.
-    for f in "${HOMEBREW_CACHE}"/api/internal/packages.*.jws.json
+    # Remove API files (and their `.payload` sidecars) from previous OS
+    # versions. Keep in sync with `cache_files` in Library/Homebrew/cleanup.rb.
+    for f in "${HOMEBREW_CACHE}"/api/internal/packages.*.jws.json*
     do
       case "${f}" in
         "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json") ;;
+        "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json.payload") ;;
         *) rm -f "${f}" ;;
       esac
     done

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -1257,6 +1257,14 @@ module Formulary
       "#{name}.rb"
     end
 
+    # For API-known formulae the sharded path can be computed directly,
+    # avoiding building a map of ~8500 `Pathname`s for a single lookup.
+    # Only use already-loaded API data to avoid triggering downloads here.
+    if tap.is_a?(CoreTap) && !Homebrew::EnvConfig.no_install_from_api? &&
+       Homebrew::API::Internal.formula_hashes_cached? && Homebrew::API.formula_name?(name)
+      return tap.formula_dir/tap.new_formula_subdirectory(name)/"#{name.downcase}.rb"
+    end
+
     tap.formula_files_by_name.fetch(name, tap.formula_dir/filename)
   end
 end

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "api"
+require "openssl"
 
 RSpec.describe Homebrew::API do
   let(:text) { "foo" }
@@ -141,6 +142,104 @@ RSpec.describe Homebrew::API do
     end
   end
 
+  describe "::fetch_json_api_file with a JWS endpoint" do
+    def self.jws_test_key
+      @jws_test_key ||= OpenSSL::PKey::RSA.new(2048)
+    end
+
+    let!(:cache_dir) { mktmpdir }
+    let(:target) { cache_dir/"internal/packages.test.jws.json" }
+    let(:payload_cache) { cache_dir/"internal/packages.test.jws.json.payload" }
+    let(:private_key) { self.class.jws_test_key }
+    let(:protected_b64) { Base64.urlsafe_encode64('{"alg":"PS512","b64":false}') }
+
+    def sign_payload(payload)
+      Base64.urlsafe_encode64(
+        private_key.sign_pss("SHA512", "#{protected_b64}.#{payload}", salt_length: :digest, mgf1_hash: "SHA512"),
+      )
+    end
+
+    def envelope_json(payload, signature: sign_payload(payload))
+      JSON.generate({
+        "payload"    => payload,
+        "signatures" => [{
+          "header"    => { "kid" => "homebrew-1" },
+          "protected" => protected_b64,
+          "signature" => signature,
+        }],
+      })
+    end
+
+    def write_payload_cache(payload, signature: sign_payload(payload))
+      stat = target.stat
+      header = JSON.generate({
+        "protected"       => protected_b64,
+        "signature"       => signature,
+        "source_size"     => stat.size,
+        "source_mtime_ns" => (stat.mtime.to_r * 1_000_000_000).to_i,
+      })
+      payload_cache.binwrite("#{header}\n#{payload}")
+    end
+
+    def fetch_target
+      described_class.fetch_json_api_file("internal/packages.test.jws.json", target:, stale_seconds: 3600).first
+    end
+
+    before do
+      stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
+      allow(described_class).to receive(:jws_public_key_pem).and_return(private_key.public_key.to_pem)
+      target.dirname.mkpath
+      target.write envelope_json('{"foo":"bar"}')
+    end
+
+    it "verifies the envelope and writes a payload cache" do
+      expect(fetch_target).to eq("foo" => "bar")
+      expect(payload_cache).to exist
+    end
+
+    it "does not write a payload cache for endpoints without one" do
+      other_target = cache_dir/"internal/other.jws.json"
+      other_target.write envelope_json('{"foo":"bar"}')
+
+      data, = described_class.fetch_json_api_file("internal/other.jws.json", target:        other_target,
+                                                                             stale_seconds: 3600)
+      expect(data).to eq("foo" => "bar")
+      expect(Pathname("#{other_target}.payload")).not_to exist
+    end
+
+    it "loads a current payload cache instead of the envelope" do
+      write_payload_cache('{"foo":"baz"}')
+      expect(fetch_target).to eq("foo" => "baz")
+    end
+
+    it "falls back to the envelope when the payload cache does not match the file" do
+      write_payload_cache('{"foo":"baz"}')
+      FileUtils.touch target, mtime: Time.now + 10
+      expect(fetch_target).to eq("foo" => "bar")
+    end
+
+    it "falls back to the envelope when the payload cache signature does not verify" do
+      write_payload_cache('{"foo":"baz"}', signature: sign_payload('{"foo":"qux"}'))
+      expect(fetch_target).to eq("foo" => "bar")
+    end
+
+    it "falls back to the envelope when the payload cache is corrupt" do
+      payload_cache.write "not json"
+      expect(fetch_target).to eq("foo" => "bar")
+    end
+
+    it "falls back to the envelope when the payload cache header is not a JSON object" do
+      payload_cache.binwrite("123\n{\"foo\":\"baz\"}")
+      expect(fetch_target).to eq("foo" => "bar")
+    end
+
+    it "raises when the envelope signature does not verify" do
+      target.write envelope_json('{"foo":"bar"}', signature: sign_payload('{"foo":"evil"}'))
+      expect { fetch_target }.to raise_error(SystemExit)
+        .and output(/Failed to verify integrity \(signature mismatch\)/).to_stderr
+    end
+  end
+
   describe "::download_executables_file_from_github_packages!" do
     it "downloads executables.txt from the GitHub Packages OCI artifact" do
       target = mktmpdir/"executables.txt"
@@ -175,28 +274,47 @@ RSpec.describe Homebrew::API do
   end
 
   describe "::write_executables_file!" do
-    it "handles the executables database being removed before comparison" do
-      cache_dir = mktmpdir
-      target = cache_dir/"internal/executables.txt"
-      target.dirname.mkpath
-      target.write "stale:stale-bin\n"
+    let(:cache_dir) { mktmpdir }
+    let(:target) { cache_dir/"internal/executables.txt" }
+    let(:source) { cache_dir/"internal/packages.jws.json" }
+    let(:formulae) { { "foo" => { "executables" => ["foo-bin"] } } }
+
+    def write_executables_file!(regenerate:)
+      described_class.write_executables_file!(formulae, regenerate:, source:)
+    end
+
+    before do
       stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
+      source.dirname.mkpath
+      source.write "{}"
+    end
 
-      removed = T.let(false, T::Boolean)
-      allow_any_instance_of(Pathname).to receive(:read).and_wrap_original do |method, *args|
-        if !removed && method.receiver == target
-          removed = true
-          target.unlink
-          raise Errno::ENOENT
-        end
+    it "writes the executables database when it does not exist" do
+      expect(write_executables_file!(regenerate: false)).to be true
+      expect(target.read).to eq("foo:foo-bin\n")
+    end
 
-        method.call(*args)
-      end
+    it "does not rebuild an executables database newer than its source when not regenerating" do
+      target.write "stale:stale-bin\n"
+      FileUtils.touch target, mtime: source.mtime + 1
 
-      expect(described_class.write_executables_file!(
-               { "foo" => { "executables" => ["foo-bin"] } },
-               regenerate: false,
-             )).to be true
+      expect(write_executables_file!(regenerate: false)).to be false
+      expect(target.read).to eq("stale:stale-bin\n")
+    end
+
+    it "rebuilds the executables database when the source is newer" do
+      target.write "stale:stale-bin\n"
+      FileUtils.touch source, mtime: target.mtime + 1
+
+      expect(write_executables_file!(regenerate: false)).to be true
+      expect(target.read).to eq("foo:foo-bin\n")
+    end
+
+    it "rewrites the executables database when regenerating" do
+      target.write "stale:stale-bin\n"
+      FileUtils.touch target, mtime: source.mtime + 1
+
+      expect(write_executables_file!(regenerate: true)).to be true
       expect(target.read).to eq("foo:foo-bin\n")
     end
   end

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -565,6 +565,28 @@ RSpec.describe Homebrew::Cleanup do
       expect([*api_package_files, *api_jws_files].map(&:exist?)).to eq([true, false, true, true])
     end
 
+    it "cleans up non-current internal package API payload sidecars with scrub" do
+      cache = mktmpdir/"cache"
+      api_internal = cache/"api/internal"
+      current_basename = Homebrew::API::Internal.cached_packages_json_file_path.basename
+      kept_files = [
+        api_internal/current_basename,
+        api_internal/"#{current_basename}.payload",
+      ]
+      scrubbed_files = [
+        api_internal/"packages.stale.jws.json.payload",
+        api_internal/"#{current_basename}.payload.tmp",
+      ]
+      (kept_files + scrubbed_files).each do |file|
+        file.dirname.mkpath
+        FileUtils.touch file
+      end
+
+      described_class.new(scrub: true, cache:).cleanup_cache
+
+      expect((kept_files + scrubbed_files).map(&:exist?)).to eq([true, true, false, false])
+    end
+
     it "cleans up API source files and symlinks at any depth without cleaning directories" do
       root_file = HOMEBREW_CACHE/"api-source/Homebrew/homebrew-core/abc123/README.md"
       nested_file = HOMEBREW_CACHE/"api-source/Homebrew/homebrew-core/abc123/Formula/a/testball.rb"

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -870,6 +870,15 @@ RSpec.describe Formulary do
       expect(described_class.core_path(name))
         .to eq(Pathname.new("#{HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core/Formula/#{name}.rb"))
     end
+
+    it "returns the sharded path directly for API-known formulae" do
+      ENV.delete("HOMEBREW_NO_INSTALL_FROM_API")
+      name = "foo-bar"
+      allow(Homebrew::API::Internal).to receive(:formula_hashes_cached?).and_return(true)
+      allow(Homebrew::API).to receive(:formula_name?).with(name).and_return(true)
+      expect(described_class.core_path(name))
+        .to eq(Pathname.new("#{HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core/Formula/f/#{name}.rb"))
+    end
   end
 
   describe "::loader_for" do


### PR DESCRIPTION
- Every command loading formula data re-parsed the 15MB JWS envelope before verifying and parsing its payload. Cache the verified payload in a `.payload` sidecar keyed on the envelope's size and mtime so warm runs skip the envelope parse. The RSA-PSS signature is still verified on every load; corrupt, stale or unreadable sidecars fall back to the envelope and are rewritten.
- Sidecars are only maintained for `api/internal` packages files, are skipped for root-on-user-cache and insecure-download runs and record the envelope's identity from before it was read so a concurrent `brew update` cannot poison the cache. `brew cleanup --scrub` and `update.sh` prune stale sidecars and temp files.
- `Formulary.find_formula_in_tap` built a map of ~8500 `Pathname`s to answer a single lookup. Compute the sharded core formula path directly when the API data is already loaded.
- `Homebrew::API.write_executables_file!` rebuilt and compared all executable lines on every command. Skip the rebuild while the file is newer than the API data it is derived from.
- Warm-cache `Internal.formula_hashes` drops from ~127ms to ~100ms and the first `Formulary.factory` call from ~144ms to ~95ms, saving roughly 10% wall time on warm `brew install`/`fetch` invocations.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Fable 5 max with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
