### PR TITLE
Remove test-only FormulaInstaller.clear_* class methods

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -209,29 +209,14 @@ class FormulaInstaller
     @attempted ||= T.let(Set.new, T.nilable(T::Set[Formula]))
   end
 
-  sig { void }
-  def self.clear_attempted
-    @attempted = T.let(Set.new, T.nilable(T::Set[Formula]))
-  end
-
   sig { returns(T::Set[Formula]) }
   def self.installed
     @installed ||= T.let(Set.new, T.nilable(T::Set[Formula]))
   end
 
-  sig { void }
-  def self.clear_installed
-    @installed = T.let(Set.new, T.nilable(T::Set[Formula]))
-  end
-
   sig { returns(T::Set[Formula]) }
   def self.fetched
     @fetched ||= T.let(Set.new, T.nilable(T::Set[Formula]))
-  end
-
-  sig { void }
-  def self.clear_fetched
-    @fetched = T.let(Set.new, T.nilable(T::Set[Formula]))
   end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/test/reinstall_spec.rb
+++ b/Library/Homebrew/test/reinstall_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Homebrew::Reinstall do
       expect(keg.linked?).to be(true)
       expect(Pathname.new("#{keg}.reinstall")).not_to exist
     ensure
-      FormulaInstaller.clear_attempted
+      FormulaInstaller.attempted.clear
     end
   end
 

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -287,9 +287,9 @@ RSpec.configure do |config|
 
     Tap.installed.each(&:clear_cache)
     Cachable::Registry.clear_all_caches
-    FormulaInstaller.clear_attempted
-    FormulaInstaller.clear_installed
-    FormulaInstaller.clear_fetched
+    FormulaInstaller.attempted.clear
+    FormulaInstaller.installed.clear
+    FormulaInstaller.fetched.clear
     Utils::Curl.clear_path_cache
 
     TEST_DIRECTORIES.each(&:mkpath)


### PR DESCRIPTION
`FormulaInstaller.clear_attempted`, `clear_installed` and `clear_fetched` exist only to reset the class-level tracking sets (`attempted`, `installed`, `fetched`) between test examples. They have no production callers. This keeps such test-only helpers out of the runtime class by removing the three methods and resetting the sets directly with `Set#clear` in the specs that need it (`spec_helper.rb` teardown and one `reinstall_spec.rb` example).

Behavior change worth noting: the removed methods reassigned the class instance variable to a fresh set (e.g. `@attempted = Set.new`), whereas `Set#clear` empties the existing set object in place. For the test teardown the end state is the same (an empty set), but any reference held to the previous set object now observes it emptied rather than retaining the old contents. Nothing relies on that identity today.

Note on the Law of Demeter: the specs now reach into the sets (`FormulaInstaller.attempted.clear`), which depends on the knowledge that these are clearable collections. If reviewers would prefer the specs not depend on that, I'm happy to follow up with a small test helper (e.g. `reset_formula_installer_state!`) that encapsulates the reset.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude (Claude Code) identified the methods as test-only and drafted the removal and spec changes. I verified locally by confirming the three methods have no production callers (only the test suite referenced them) and by running `brew lgtm` (style, typecheck, tests) successfully.

-----
