### PR TITLE
Defer multi-line download failure output until redraw finishes

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -35,6 +35,7 @@ module Homebrew
       @cancelled = T.let(Concurrent::AtomicBoolean.new(false), Concurrent::AtomicBoolean)
       @active_threads = T.let(Concurrent::Set.new, Concurrent::Set)
       @fetch_failed = T.let(false, T::Boolean)
+      @deferred_failure_messages = T.let([], T::Array[T.proc.void])
     end
 
     sig {
@@ -98,6 +99,7 @@ module Homebrew
     sig { void }
     def fetch
       @fetch_failed = false
+      @deferred_failure_messages = []
       context_before_fetch = Context.current
       return if downloads.empty?
 
@@ -141,9 +143,10 @@ module Homebrew
                 actual = Digest::SHA256.file(downloadable.cached_download).hexdigest
                 actual_message, expected_message = align_checksum_mismatch_message(downloadable.download_queue_type)
 
-                ofail "#{actual_message} #{exception.expected}"
-                puts "#{expected_message} #{actual}"
-                next 2
+                report_or_defer_failure do
+                  ofail "#{actual_message} #{exception.expected}"
+                  puts "#{expected_message} #{actual}"
+                end
               elsif exception.is_a?(CannotInstallFormulaError)
                 cached_download = downloadable.cached_download
                 cached_download.unlink if cached_download&.exist?
@@ -154,7 +157,7 @@ module Homebrew
                 # drives relocation, so abort rather than stage a broken keg.
                 raise exception
               else
-                message = if exception.is_a?(DownloadError) && exception.cause.is_a?(ErrorDuringExecution)
+                failure_message = if exception.is_a?(DownloadError) && exception.cause.is_a?(ErrorDuringExecution)
                   cause = T.cast(exception.cause, ErrorDuringExecution)
                   if (stderr_output = cause.stderr.presence)
                     "#{stderr_output}#{cause.message}"
@@ -165,8 +168,7 @@ module Homebrew
                   future.reason.to_s
                 end
                 @fetch_failed = true
-                ofail message
-                next message.count("\n")
+                report_or_defer_failure { ofail failure_message }
               end
             end
 
@@ -230,6 +232,7 @@ module Homebrew
         ensure
           stdout_print_and_flush_if_tty Tty.end_synchronized_update
           stdout_print_and_flush_if_tty Tty.show_cursor
+          @deferred_failure_messages.each(&:call)
         end
       end
     # `Interrupt` inherits from `Exception`, so rescue it to cancel active workers
@@ -297,6 +300,16 @@ module Homebrew
       return false if exception.nil?
 
       downloadable.is_a?(Resource::BottleManifest) || exception.is_a?(Resource::BottleManifest::Error)
+    end
+
+    # Deferred so a multi-row failure can't desync the redraw's one-row-per-line cursor maths.
+    sig { params(block: T.proc.void).void }
+    def report_or_defer_failure(&block)
+      if tty_with_cursor_move_support?
+        @deferred_failure_messages << block
+      else
+        yield
+      end
     end
 
     sig { type_parameters(:U).params(_block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }

--- a/Library/Homebrew/download_strategy/curl_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/curl_download_strategy.rb
@@ -109,7 +109,8 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
           begin
             _fetch(url:, resolved_url: T.must(resolved_url), timeout: Utils::Timer.remaining!(end_time))
           rescue ErrorDuringExecution => e
-            raise CurlDownloadStrategyError.new(url, e.stderr.strip)
+            clean_stderr = strip_progress_bar(Tty.collapse_carriage_returns(e.stderr)).strip
+            raise CurlDownloadStrategyError.new(url, clean_stderr)
           end
           cached_location.dirname.mkpath
           temporary_path.rename(cached_location.to_s)

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Homebrew::DownloadQueue do
     )
   end
   let(:download_error) { DownloadError.new(downloadable, RuntimeError.new("network blew up")) }
+  let(:multi_line_download_error) { DownloadError.new(downloadable, RuntimeError.new("line one\nline two")) }
   let(:retryable_download) { instance_double(Homebrew::RetryableDownload) }
 
   before do
@@ -39,6 +40,35 @@ RSpec.describe Homebrew::DownloadQueue do
 
     expect(download_queue.fetch_failed).to be(true)
     expect(Homebrew).to have_failed
+  end
+
+  it "defers multi-line failure details on a TTY until the in-place redraw has finished" do
+    allow($stdout).to receive(:tty?).and_return(true)
+    ENV["TERM"] = "xterm-256color"
+    allow(downloadable).to receive(:fetched_size).and_return(nil)
+    allow(retryable_download).to receive(:fetch).and_raise(multi_line_download_error)
+
+    download_queue.enqueue(downloadable)
+
+    # Stub the write methods (rather than reassigning $stdout/$stderr) so both
+    # streams append to one buffer in call order, the same way they'd interleave
+    # on a real terminal.
+    combined_output = +""
+    allow($stdout).to receive(:print) { |message| combined_output << message }
+    allow($stdout).to receive(:flush)
+    allow($stderr).to receive(:puts) { |message| combined_output << "#{message}\n" }
+
+    download_queue.fetch
+
+    show_cursor_index = combined_output.index(Tty.show_cursor)
+    failure_index = combined_output.index("line one\nline two")
+
+    expect(show_cursor_index).not_to be_nil
+    expect(failure_index).not_to be_nil
+    # The redraw loop assumes every line it prints in-place occupies exactly one
+    # terminal row, so a multi-line failure must be held back until the cursor is
+    # restored to normal scrolling, not printed while the redraw is still live.
+    expect(failure_index).to be > show_cursor_index
   end
 
   it "raises and clears queue state on a bottle manifest failure in parallel mode" do

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -667,6 +667,28 @@ RSpec.describe "Utils::Curl" do
     end
   end
 
+  describe "::strip_progress_bar" do
+    it "removes the percentage when other text is glued directly onto it" do
+      glued = "############# 100.0%curl: (7) Failed to connect to example.com port 443: Couldn't connect to server"
+      expected = "curl: (7) Failed to connect to example.com port 443: Couldn't connect to server"
+      expect(strip_progress_bar(glued)).to eq(expected)
+    end
+
+    it "reduces a completed progress bar with nothing else on the line to an empty string" do
+      expect(strip_progress_bar("############# 100.0%")).to eq("")
+    end
+
+    it "leaves plain curl diagnostics without a progress bar unchanged" do
+      message = "curl: (6) Could not resolve host: example.com"
+      expect(strip_progress_bar(message)).to eq(message)
+    end
+
+    it "only strips the line that actually has a progress bar" do
+      glued = "Warning: retrying\n### 50.0%curl: (7) timeout"
+      expect(strip_progress_bar(glued)).to eq("Warning: retrying\ncurl: (7) timeout")
+    end
+  end
+
   describe "::parse_curl_output" do
     it "returns a correct hash when curl output contains response(s) and body" do
       expect(parse_curl_output("#{response_text[:ok]}#{body[:default]}"))

--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -8,6 +8,26 @@ RSpec.describe Tty do
     end
   end
 
+  describe "::collapse_carriage_returns" do
+    it "keeps only the final segment of a carriage-return-delimited progress bar" do
+      expect(described_class.collapse_carriage_returns("#\r##\r### 100%")).to eq("### 100%")
+    end
+
+    it "collapses carriage returns independently on each real line" do
+      expect(described_class.collapse_carriage_returns("a\rb\nc\rd")).to eq("b\nd")
+    end
+
+    it "returns the string unchanged when it has no carriage returns" do
+      expect(described_class.collapse_carriage_returns("curl: (7) Couldn't connect to server")).to(
+        eq("curl: (7) Couldn't connect to server"),
+      )
+    end
+
+    it "keeps the last written content when the string ends with a trailing carriage return" do
+      expect(described_class.collapse_carriage_returns("### 50%\r")).to eq("### 50%")
+    end
+  end
+
   describe "::begin_synchronized_update" do
     it "returns the DEC private mode 2026 set sequence" do
       expect(described_class.begin_synchronized_update).to eq("\033[?2026h")

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -44,12 +44,16 @@ module Utils
 
     HTTPS_REDIRECT_CURL_ARGS = ["--proto-redir", "=https"].freeze
 
+    # A `--progress-bar` percentage (e.g. "50.0%"); may belong to an earlier,
+    # unrelated request, so it's stripped rather than kept.
+    PROGRESS_BAR_REGEX = /\A#*\s*\d{1,3}\.\d%\s*/
+
     private_constant :CURL_WEIRD_SERVER_REPLY_EXIT_CODE,
                      :CURL_HTTP_RETURNED_ERROR_EXIT_CODE,
                      :CURL_RECV_ERROR_EXIT_CODE,
                      :ETAG_VALUE_REGEX, :HTTP_RESPONSE_BODY_SEPARATOR,
                      :HTTP_STATUS_LINE_REGEX,
-                     :HTTPS_REDIRECT_CURL_ARGS
+                     :HTTPS_REDIRECT_CURL_ARGS, :PROGRESS_BAR_REGEX
 
     module_function
 
@@ -319,6 +323,12 @@ module Utils
       args = ["--remote-time", "--output", destination.to_s, *args]
 
       curl(*args, **options)
+    end
+
+    # Run after `Tty.collapse_carriage_returns`; a bar-only line becomes empty.
+    sig { params(string: String).returns(String) }
+    def strip_progress_bar(string)
+      string.split("\n", -1).map { |line| line.sub(PROGRESS_BAR_REGEX, "") }.join("\n")
     end
 
     sig { overridable.params(args: String, options: T.untyped).returns(SystemCommand::Result) }

--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -60,6 +60,15 @@ module Tty
       string.gsub(/\033\[\d+(;\d+)*m/, "")
     end
 
+    # Simulates a terminal rendering `\r` overwrites (e.g. curl's `--progress-bar`).
+    sig { params(string: String).returns(String) }
+    def collapse_carriage_returns(string)
+      string.split("\n", -1).map do |line|
+        # `\r` resets the cursor, it doesn't erase, so keep the last non-empty segment.
+        line.split("\r", -1).reject(&:empty?).last || ""
+      end.join("\n")
+    end
+
     sig { params(line_count: Integer).returns(String) }
     def move_cursor_up_beginning(line_count)
       "\033[#{line_count}F"


### PR DESCRIPTION
### What does this change do, and why?

Fixes #23281.

`DownloadQueue#fetch`'s concurrent progress renderer redraws multiple in-place progress lines using absolute cursor movement, and its bookkeeping (`previous_pending_line_count`) assumes every printed per-download line occupies exactly one terminal row. When a download failed, the full error detail was printed inline via `ofail`, but that message can span multiple rows — a Cask download error joins the URL and raw curl stderr with an explicit `\n`, and curl's own `--progress-bar` output uses carriage returns to animate in place. The loop that prints just-finished downloads discarded the row-count return value entirely, so after printing a multi-row failure the cursor ended up further down than the code assumed, and every subsequent redraw of other in-progress downloads landed on the wrong rows.

Concretely, from the issue, one failing download among several concurrent ones produced:

```
✘ Cask visual-studio-code (1.130.0)   ###########                                            Downloading   4.6MB/ 23.8MB
Error: Download failed on Cask 'visual-studio-code' with message: Download failed: https://update.code.visualstudio.com/1.130.0/darwin-arm64/stable9)         ####                                                   Downloading  37.4MB/568.3MB
################################################################################################################# 100.0%curl: (7) Failed to connect to vscode.download.prss.microsoft.com port 443 after 134 ms: Couldn't connect to server
✔︎ Resource sass--language             #############                                          Downloading   5.7MB/ 23.8MB
```

The VS Code failure actually printed 3 rows (its status line, the `Error:` line, and the curl-stderr line) while the redraw assumed 1, so the *next* downloads' progress fragments got overwritten onto the tail of the error text instead of their own rows.

The fix has three parts:

1. Detailed failure output (which can span multiple rows) is now queued via a small `report_or_defer_failure` helper and printed once the live in-place redraw has finished and the cursor is restored to normal scrolling, instead of being printed while the redraw is still live. Every line printed *during* the redraw is now guaranteed to be exactly one row (the same one-row-per-download invariant the success path already relies on), so the cursor maths stays correct no matter how long the eventual failure text is.
2. `Tty.collapse_carriage_returns` simulates how a terminal would actually render `\r`-based in-place overwrites, and is used to clean up curl's captured `--progress-bar` stderr before it's embedded in a download error — collapsing what can be 100+ concatenated animation frames (one per percentage tick) down to just the final one.
3. `Utils::Curl.strip_progress_bar` then removes that final percentage rather than just separating it from what follows. A leftover `--progress-bar` percentage can belong to an earlier, unrelated request within the same curl invocation (e.g. a redirect hop that completed fine before the real target failed to connect), so showing e.g. "100.0%" next to a connection failure is misleading, not just visually glued-on — there's no reliable way to tell from the captured text whether that percentage ever applied to the transfer that actually failed. A line that was only the progress bar becomes empty and is simply omitted from the final message.

With this change, the same scenario renders as clean, uncorrupted status lines while downloads are in flight, and the full failure detail prints once, on its own, after the redraw settles, with no potentially-misleading percentage:

```
✘ Cask visual-studio-code (1.130.0)
✔︎ Resource sass--language                                                                    Downloaded    5.7MB/  5.7MB
✔︎ Bottle awscli (2.36.6)                                                                     Downloaded   23.8MB/ 23.8MB
```
```
Error: Download failed on Cask 'visual-studio-code' with message: Download failed: https://update.code.visualstudio.com/1.130.0/darwin-arm64/stable
curl: (7) Failed to connect to vscode.download.prss.microsoft.com port 443 after 134 ms: Couldn't connect to server
```

### Step-by-step reproduction

Not reliably reproducible on demand (needs a real network failure mid-batch, per the original reporter), but the failure mode is deterministic given a future that rejects with a multi-line message while others are still in-progress — see the new specs, which fail against the old code and pass against this change.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Used Claude Code to investigate the root cause from the issue report (traced through `DownloadQueue#fetch`'s TTY redraw logic and the Cask/curl error message construction to identify the row-count/cursor desync), implement the fix, and write the accompanying tests. Verified by:

- Running `brew typecheck` and `brew style --changed` (clean) after every change in this PR.
- Running the full spec files touched or exercised by this change (`download_queue_spec.rb`, `utils/tty_spec.rb`, `utils/curl_spec.rb`, `download_strategies/curl_spec.rb`, `cask/download_spec.rb`, `exceptions_spec.rb`) — all passing.
- Confirming each new regression test actually exercises its bug: reverting the corresponding source change and observing the test fail with the exact reported symptom, then restoring it and confirming the test passes. Done for the cursor-desync fix, the trailing-carriage-return fix, and the progress-bar handling.
- Copilot's automated review caught a real edge case in an early version of `Tty.collapse_carriage_returns` (a trailing `\r` with nothing after it collapsed to an empty string instead of preserving the last-written content). That's fixed, with a dedicated regression test, in the code as it now stands (the fix history was squashed into this PR's single commit).
- Reviewing the full diff by hand before pushing.

-----
