### PR TITLE
Add homepage browser check DSL

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -1176,6 +1176,7 @@ module Cask
     def audit_homepage_https_availability
       return unless online?
       return unless (homepage = cask.homepage)
+      return if SharedAudits.homepage_browsed_recently?(cask.homepage_browsed)
 
       user_agents = if cask.tap&.audit_exception(:simple_user_agent_for_homepage, cask.token)
         ["curl"]

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -111,6 +111,7 @@ module Cask
       :desc,
       :depends_on,
       :homepage,
+      :homepage_browsed,
       :language,
       :name,
       :os,
@@ -190,6 +191,9 @@ module Cask
     sig { returns(T.nilable(String)) }
     attr_reader :disable_replacement_formula
 
+    sig { returns(T.nilable(Date)) }
+    attr_reader :homepage_browsed
+
     sig { returns(T.nilable(T::Hash[Symbol, T.nilable(T.any(String, Symbol))])) }
     attr_reader :disable_args
 
@@ -230,6 +234,7 @@ module Cask
       @disable_args = T.let(nil, T.nilable(T::Hash[Symbol, T.nilable(T.any(String, Symbol))]))
       @disabled = T.let(false, T::Boolean)
       @homepage = T.let(nil, T.nilable(String))
+      @homepage_browsed = T.let(nil, T.nilable(Date))
       @homepage_set_in_block = T.let(false, T::Boolean)
       @language_blocks = T.let({}, T::Hash[T::Array[String], Proc])
       @language_eval = T.let(nil, T.nilable(String))
@@ -343,13 +348,21 @@ module Cask
     # ### Example
     #
     # ```ruby
-    # homepage "https://code.visualstudio.com/"
+    # homepage "https://code.visualstudio.com/", browsed: "2026-07-26"
     # ```
     #
+    # `browsed` is the date when a human last checked the homepage in a browser.
+    # Automated homepage availability audits are skipped for one year.
+    #
     # @api public
-    sig { params(homepage: T.nilable(String)).returns(T.nilable(String)) }
-    def homepage(homepage = nil)
-      set_unique_stanza(:homepage, homepage.nil?) { homepage }
+    sig { params(homepage: T.nilable(String), browsed: T.nilable(String)).returns(T.nilable(String)) }
+    def homepage(homepage = nil, browsed: nil)
+      raise CaskInvalidError.new(cask, "`browsed` requires a homepage URL") if homepage.nil? && browsed
+
+      set_unique_stanza(:homepage, homepage.nil?) do
+        @homepage_browsed = Date.parse(browsed) if browsed
+        homepage
+      end
     end
 
     # Specifies language-specific values for the cask.

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -577,6 +577,11 @@ class Formula
   # @see .homepage
   delegate homepage: :"self.class"
 
+  # The date when a human last browsed the homepage.
+  # @!method homepage_browsed
+  # @see .homepage_browsed
+  delegate homepage_browsed: :"self.class"
+
   # The `livecheck` specification for the software.
   # @!method livecheck
   # @see .livecheck
@@ -3795,6 +3800,7 @@ class Formula
         @loaded_from_internal_api = T.let(false, T.nilable(T::Boolean))
         @api_source = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
         @on_system_blocks_exist = T.let(false, T.nilable(T::Boolean))
+        @homepage_browsed = T.let(nil, T.nilable(Date))
         @network_access_allowed = T.let(SUPPORTED_NETWORK_ACCESS_PHASES.to_h do |phase|
           [phase, DEFAULT_NETWORK_ACCESS_ALLOWED]
         end, T.nilable(T::Hash[Symbol, T::Boolean]))
@@ -4038,14 +4044,27 @@ class Formula
     # ### Example
     #
     # ```ruby
-    # homepage "https://www.example.com"
+    # homepage "https://www.example.com", browsed: "2026-07-26"
     # ```
     #
+    # `browsed` is the date when a human last checked the homepage in a browser.
+    # Automated homepage availability audits are skipped for one year.
+    #
     # @api public
-    sig { params(val: String).returns(T.nilable(String)) }
-    def homepage(val = T.unsafe(nil))
-      val.nil? ? @homepage : @homepage = T.let(val, T.nilable(String))
+    sig { params(val: String, browsed: T.nilable(String)).returns(T.nilable(String)) }
+    def homepage(val = T.unsafe(nil), browsed: nil)
+      if val.nil?
+        raise ArgumentError, "`browsed` requires a homepage URL" if browsed
+
+        return @homepage
+      end
+
+      @homepage_browsed = Date.parse(browsed) if browsed
+      @homepage = T.let(val, T.nilable(String))
     end
+
+    sig { returns(T.nilable(Date)) }
+    attr_reader :homepage_browsed
 
     # Checks whether a `livecheck` specification is defined or not.
     #

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -630,6 +630,7 @@ module Homebrew
       homepage = formula.homepage
 
       return if homepage.blank?
+      return if SharedAudits.homepage_browsed_recently?(formula.homepage_browsed)
 
       return unless @online
 

--- a/Library/Homebrew/sorbet/rbi/dsl/cask/cask.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/cask/cask.rbi
@@ -124,6 +124,9 @@ class Cask::Cask
   def homepage(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def homepage_browsed(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def input_method(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }

--- a/Library/Homebrew/sorbet/rbi/dsl/formula.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/formula.rbi
@@ -100,6 +100,9 @@ class Formula
   def homepage(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def homepage_browsed(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def keg_only_reason(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -172,6 +172,43 @@ RSpec.describe Cask::Audit, :cask do
       end
     end
 
+    describe "checking homepage availability" do
+      let(:online) { true }
+      let(:only) { ["homepage_https_availability"] }
+      let(:browsed) { "2025-07-27" }
+      let(:cask) do
+        browsed_ = browsed
+        Cask::Cask.new("browsed-homepage") do
+          homepage "https://brew.sh/", browsed: browsed_
+        end
+      end
+
+      before { allow(Date).to receive(:today).and_return(Date.new(2026, 7, 26)) }
+
+      it "skips homepages browsed by a human less than a year ago" do
+        expect(audit).not_to receive(:validate_url_for_https_availability)
+        run
+      end
+
+      context "when the homepage was browsed a year ago" do
+        let(:browsed) { "2025-07-26" }
+
+        it "audits the homepage" do
+          expect(audit).to receive(:validate_url_for_https_availability)
+          run
+        end
+      end
+
+      context "when the homepage browser check date is in the future" do
+        let(:browsed) { "2026-07-27" }
+
+        it "audits the homepage" do
+          expect(audit).to receive(:validate_url_for_https_availability)
+          run
+        end
+      end
+    end
+
     describe "token validation" do
       let(:strict) { true }
       let(:only) { ["token"] }

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -426,6 +426,22 @@ RSpec.describe Cask::DSL, :cask, :no_api do
     it "prevents defining multiple homepages" do
       expect { cask }.to raise_error(Cask::CaskInvalidError, /'homepage' stanza may only appear once/)
     end
+
+    it "records when a human browsed the homepage" do
+      cask = Cask::Cask.new("cask-with-browsed-homepage") do
+        homepage "https://brew.sh/", browsed: "2026-07-26"
+      end
+
+      expect(cask.homepage_browsed).to eq(Date.new(2026, 7, 26))
+    end
+
+    it "requires a homepage URL when a human browser check is specified" do
+      expect do
+        Cask::Cask.new("cask-without-homepage") do
+          homepage browsed: "2026-07-26"
+        end
+      end.to raise_error(Cask::CaskInvalidError, /`browsed` requires a homepage URL/)
+    end
   end
 
   describe "version stanza" do

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -97,6 +97,49 @@ RSpec.describe Homebrew::FormulaAuditor do
     end
   end
 
+  describe "#audit_homepage" do
+    before do
+      allow(Date).to receive(:today).and_return(Date.new(2026, 7, 26))
+      allow(DevelopmentTools).to receive(:curl_handles_most_https_certificates?).and_return(true)
+    end
+
+    it "skips homepages browsed by a human less than a year ago" do
+      fa = formula_auditor "foo", <<~RUBY, online: true
+        class Foo < Formula
+          homepage "https://brew.sh", browsed: "2025-07-27"
+          url "https://brew.sh/foo-1.0.tar.gz"
+        end
+      RUBY
+
+      expect(fa).not_to receive(:curl_check_http_content)
+      fa.audit_homepage
+    end
+
+    it "audits homepages browsed by a human a year ago" do
+      fa = formula_auditor "foo", <<~RUBY, online: true
+        class Foo < Formula
+          homepage "https://brew.sh", browsed: "2025-07-26"
+          url "https://brew.sh/foo-1.0.tar.gz"
+        end
+      RUBY
+
+      expect(fa).to receive(:curl_check_http_content)
+      fa.audit_homepage
+    end
+
+    it "audits homepages with a future browser check date" do
+      fa = formula_auditor "foo", <<~RUBY, online: true
+        class Foo < Formula
+          homepage "https://brew.sh", browsed: "2026-07-27"
+          url "https://brew.sh/foo-1.0.tar.gz"
+        end
+      RUBY
+
+      expect(fa).to receive(:curl_check_http_content)
+      fa.audit_homepage
+    end
+  end
+
   describe "#audit_license" do
     let(:spdx_license_data) { SPDX.license_data }
     let(:spdx_exception_data) { SPDX.exception_data }

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -924,6 +924,25 @@ RSpec.describe Formula do
     expect(f.class.url).to eq("foo-1.0")
   end
 
+  specify ".homepage with a human browser check" do
+    f = formula do
+      T.bind(self, T.class_of(Formula))
+      homepage "https://brew.sh", browsed: "2026-07-26"
+      url "https://brew.sh/test-1.0.tar.gz"
+    end
+
+    expect(f.homepage_browsed).to eq(Date.new(2026, 7, 26))
+  end
+
+  specify ".homepage requires a URL with a human browser check" do
+    expect do
+      formula do
+        T.bind(self, T.class_of(Formula))
+        homepage browsed: "2026-07-26"
+      end
+    end.to raise_error(ArgumentError, "`browsed` requires a homepage URL")
+  end
+
   specify "spec integration" do
     f = formula do
       T.bind(self, T.class_of(Formula))

--- a/Library/Homebrew/test/utils/shared_audits_spec.rb
+++ b/Library/Homebrew/test/utils/shared_audits_spec.rb
@@ -36,6 +36,26 @@ RSpec.describe SharedAudits do
     allow(Utils::Curl).to receive(:curl_output).and_return curl_output
   end
 
+  describe "::homepage_browsed_recently?" do
+    before { allow(Date).to receive(:today).and_return(Date.new(2026, 7, 26)) }
+
+    it "returns true for a date less than a year ago" do
+      expect(described_class.homepage_browsed_recently?(Date.new(2025, 7, 27))).to be(true)
+    end
+
+    it "returns false for a date a year ago" do
+      expect(described_class.homepage_browsed_recently?(Date.new(2025, 7, 26))).to be(false)
+    end
+
+    it "returns false for a future date" do
+      expect(described_class.homepage_browsed_recently?(Date.new(2026, 7, 27))).to be(false)
+    end
+
+    it "returns false without a date" do
+      expect(described_class.homepage_browsed_recently?(nil)).to be(false)
+    end
+  end
+
   describe "::eol_data" do
     it "returns a parsed JSON object if the product is found" do
       mock_curl_output stdout: eol_json_text

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -16,6 +16,14 @@ module SharedAudits
   @pull_request_author_computed = T.let(false, T::Boolean)
   @self_submission_cache = T.let({}, T::Hash[String, T::Boolean])
 
+  sig { params(browsed: T.nilable(Date)).returns(T::Boolean) }
+  def self.homepage_browsed_recently?(browsed)
+    return false unless browsed
+
+    today = Date.today
+    browsed <= today && browsed.next_year > today
+  end
+
   sig { returns(T.nilable(String)) }
   def self.pull_request_author
     return @pull_request_author if @pull_request_author_computed

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -130,6 +130,14 @@ Submissions to `homebrew/cask` may require additional stanzas such as `livecheck
 | [`desc`](#stanza-desc)             | no                            | One-line description of the cask. Shown when running `brew info`. |
 | `homepage`                         | no                            | Application homepage; used for the `brew home` command. |
 
+If a homepage blocks automated requests but works in a browser, record the date it was last checked by a human:
+
+```ruby
+homepage "https://www.example.com/", browsed: "2026-07-26"
+```
+
+This skips automated homepage availability audits for one year. Do not use a future date.
+
 ### At least one artifact stanza is also required
 
 Each cask must declare one or more [artifacts](/rubydoc/Cask/Artifact.html) (i.e. something to install).

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -78,6 +78,14 @@ Homebrew will try to guess the formula’s name from its URL. If it fails to do 
 
 An SSL/TLS (https) [`homepage`](/rubydoc/Formula.html#homepage-class_method) is preferred, if one is available.
 
+If a homepage blocks automated requests but works in a browser, record the date it was last checked by a human:
+
+```ruby
+homepage "https://www.example.com", browsed: "2026-07-26"
+```
+
+This skips automated homepage availability audits for one year. Do not use a future date.
+
 Try to summarise from the [`homepage`](/rubydoc/Formula.html#homepage-class_method) what the formula does in the [`desc`](/rubydoc/Formula.html#desc-class_method)ription. Note that the [`desc`](/rubydoc/Formula.html#desc-class_method)ription is automatically prepended with the formula name when printed.
 
 ### Fill in the `license`


### PR DESCRIPTION
- Avoid false homepage audits when sites block automated requests
- Resume automated checks one year after a human browser check

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 sol xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
