### PR TITLE
Declare cask command wrapper names

### DIFF
--- a/Library/Homebrew/cask/artifact/command_wrapper.rb
+++ b/Library/Homebrew/cask/artifact/command_wrapper.rb
@@ -18,30 +18,32 @@ module Cask
       sig {
         override.params(
           cask:    Cask,
-          source:  T.any(String, Pathname),
+          name:    T.any(String, Pathname),
           options: T.untyped,
         ).returns(T.attached_class)
       }
-      def self.from_args(cask, source, options = nil)
+      def self.from_args(cask, name, options = nil)
         options ||= {}
-        options.assert_valid_keys(:target, :content, :executable, :args, :env)
-        options[:target] = Pathname(source).basename.to_s.delete_suffix(".wrapper.sh") if options[:target].blank?
+        options.assert_valid_keys(:content, :executable, :args, :env)
 
-        new(cask, source, **options)
+        new(cask, name, **options)
       end
 
       sig {
         params(
           cask:       Cask,
-          source:     T.any(String, Pathname),
-          target:     T.any(String, Pathname),
+          name:       T.any(String, Pathname),
           content:    T.nilable(String),
           executable: T.nilable(T.any(String, Pathname)),
           args:       Arguments,
           env:        Environment,
         ).void
       }
-      def initialize(cask, source, target:, content: nil, executable: nil, args: [], env: {})
+      def initialize(cask, name, content: nil, executable: nil, args: [], env: {})
+        name = Pathname(name)
+        if name.basename != name || [".", ".."].include?(name.to_s)
+          raise CaskInvalidError.new(cask, "'command_wrapper' requires a command name without path components")
+        end
         if content.blank? && executable.to_s.blank?
           raise CaskInvalidError.new(cask, "'command_wrapper' requires content or executable")
         end
@@ -52,7 +54,7 @@ module Cask
           raise CaskInvalidError.new(cask, "'command_wrapper' args and env require executable")
         end
 
-        super(cask, source, target:)
+        super(cask, ".homebrew-command-wrappers/#{name}", target: name)
         @content = T.let(content.presence, T.nilable(String))
         @executable = T.let(executable&.to_s.presence, T.nilable(String))
         @args = T.let(Array(args).map(&:to_s), T::Array[String])
@@ -80,7 +82,7 @@ module Cask
 
       sig { override.returns(T::Array[T.anything]) }
       def to_args
-        options = { target: @target_string }
+        options = {}
         if (content = @content)
           options[:content] = content
         else
@@ -88,7 +90,7 @@ module Cask
           options[:args] = @args if @args.present?
           options[:env] = @env if @env.present?
         end
-        [@source_string, options]
+        [@target_string, options]
       end
     end
   end

--- a/Library/Homebrew/test/cask/artifact/command_wrapper_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/command_wrapper_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Cask::Artifact::CommandWrapper, :cask do
       sha256 :no_check
       url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
 
-      command_wrapper "example.wrapper.sh",
+      command_wrapper "example",
                       executable: "/Applications/Example.app/Contents/MacOS/example",
                       args:       ["--cli", "batch mode"],
                       env:        { "EXAMPLE_MODE" => "batch" }
@@ -37,14 +37,14 @@ RSpec.describe Cask::Artifact::CommandWrapper, :cask do
         EXAMPLE_MODE="batch" exec "/Applications/Example.app/Contents/MacOS/example" --cli batch\\ mode "$@"
       BASH
       executable?: true,
+      readlink:    cask.staged_path/".homebrew-command-wrappers/example",
     )
   end
 
   it "serialises the wrapper definition" do
     expect(artifact.to_args).to eq([
-      "example.wrapper.sh",
+      "example",
       {
-        target:     "example",
         executable: "/Applications/Example.app/Contents/MacOS/example",
         args:       ["--cli", "batch mode"],
         env:        { "EXAMPLE_MODE" => "batch" },
@@ -53,7 +53,7 @@ RSpec.describe Cask::Artifact::CommandWrapper, :cask do
   end
 
   it "shell-escapes a single non-array argument" do
-    wrapper = described_class.from_args(cask, "custom.wrapper.sh",
+    wrapper = described_class.from_args(cask, "custom",
                                         executable: "/usr/bin/example",
                                         args:       "two words; true")
     wrapper.install_phase(command: NeverSudoSystemCommand, force: false)
@@ -65,15 +65,14 @@ RSpec.describe Cask::Artifact::CommandWrapper, :cask do
   end
 
   it "serialises Pathname arguments and symbol environment keys as plain strings" do
-    wrapper = described_class.from_args(cask, "custom.wrapper.sh",
+    wrapper = described_class.from_args(cask, "custom",
                                         executable: Pathname("/usr/bin/example"),
                                         args:       Pathname("/etc/example.conf"),
                                         env:        { EXAMPLE_MODE: Pathname("/var/example") })
 
     expect(wrapper.to_args).to eq([
-      "custom.wrapper.sh",
+      "custom",
       {
-        target:     "custom",
         executable: "/usr/bin/example",
         args:       ["/etc/example.conf"],
         env:        { "EXAMPLE_MODE" => "/var/example" },
@@ -83,30 +82,36 @@ RSpec.describe Cask::Artifact::CommandWrapper, :cask do
 
   it "accepts custom wrapper content" do
     content = "#!/bin/sh\nexit 1\n"
-    custom_artifact = described_class.from_args(cask, "custom.wrapper.sh", content:)
+    custom_artifact = described_class.from_args(cask, "custom", content:)
     custom_artifact.install_phase(command: NeverSudoSystemCommand, force: false)
 
     expect(custom_target).to be_a_symlink.and have_attributes(read: content, executable?: true)
   end
 
   it "serialises custom wrapper content" do
-    custom_artifact = described_class.from_args(cask, "custom.wrapper.sh", content: "#!/bin/sh\nexit 1\n")
+    custom_artifact = described_class.from_args(cask, "custom", content: "#!/bin/sh\nexit 1\n")
 
     expect(custom_artifact.to_args).to eq([
-      "custom.wrapper.sh",
-      { target: "custom", content: "#!/bin/sh\nexit 1\n" },
+      "custom",
+      { content: "#!/bin/sh\nexit 1\n" },
     ])
   end
 
   it "rejects missing content and executable" do
     expect do
-      described_class.from_args(cask, "other.wrapper.sh")
+      described_class.from_args(cask, "other")
     end.to raise_error(Cask::CaskInvalidError, /requires content or executable/)
+  end
+
+  it "rejects command names containing path components" do
+    expect do
+      described_class.from_args(cask, "../other", executable: "example")
+    end.to raise_error(Cask::CaskInvalidError, /requires a command name without path components/)
   end
 
   it "rejects content with an executable" do
     expect do
-      described_class.from_args(cask, "other.wrapper.sh", content: "#!/bin/sh\n", executable: "example")
+      described_class.from_args(cask, "other", content: "#!/bin/sh\n", executable: "example")
     end.to raise_error(Cask::CaskInvalidError, /content or executable, not both/)
   end
 end

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -287,16 +287,16 @@ Behaviour and usage of `target:` is [the same as with `app`](#renaming-the-targe
 
 ### Stanza: `command_wrapper`
 
-`command_wrapper` writes an executable wrapper into the staged cask and links it like a [`binary`](#stanza-binary). The linked name is inferred by removing `.wrapper.sh` from the wrapper name. Use `target:` when it should differ. Fixed arguments and environment variables can be passed with `args:` and `env:`.
+`command_wrapper` writes an executable shim script into the staged cask and links it like a [`binary`](#stanza-binary) using the declared command name. Use it when an application does not provide a suitable command-line entry point. When using `executable:`, fixed arguments and environment variables can be passed with `args:` and `env:`.
 
 ```ruby
-command_wrapper "example.wrapper.sh",
+command_wrapper "example",
                 executable: "#{appdir}/Example.app/Contents/MacOS/example",
                 args:       ["--cli"],
                 env:        { "EXAMPLE_MODE" => "batch" }
 ```
 
-Use `content:` instead of `executable:` for wrappers which need custom shell logic.
+Use `content:` instead of `executable:` for wrappers which need custom shell logic. It contains the complete wrapper and cannot be combined with `args:` or `env:`.
 
 ### Stanza: `generated_script`
 


### PR DESCRIPTION
Command wrapper callers should declare the command users receive rather than an implementation-specific staged script filename.

See discussion in https://github.com/Homebrew/homebrew-cask/pull/275991

- treat the positional argument as the linked command name
- keep generated wrapper paths internal to the artifact
- reject names containing path components
- document command wrappers as the shim-script replacement

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 sol xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
