### PR TITLE
Add per-service user environment variable overrides

### DIFF
--- a/Library/Homebrew/cmd/services.rb
+++ b/Library/Homebrew/cmd/services.rb
@@ -17,6 +17,12 @@ module Homebrew
 
           If `sudo` is passed, operate on `/Library/LaunchDaemons` or `/usr/lib/systemd/system` (started at boot).
           Otherwise, operate on `~/Library/LaunchAgents` or `~/.config/systemd/user` (started at login).
+
+          Environment variables can be added or overridden for a service by creating
+          `$HOMEBREW_USER_CONFIG_HOME/services/<formula>.env` (defaults to
+          `~/.homebrew/services/<formula>.env`). The file uses `KEY=value`
+          format, one per line; lines starting with `#` are comments. Changes take
+          effect on the next `brew services restart` and persist across upgrades.
         EOS
         flag   "--sudo-service-user=",
                description: "When run as root on macOS, run the service(s) as this user."

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -13,6 +13,7 @@ module Homebrew
   class Service
     extend Forwardable
     include OnSystem::MacOSAndLinux
+    include Utils::Output::Mixin
     include Utils::Path
 
     RUN_TYPE_IMMEDIATE = :immediate
@@ -435,6 +436,57 @@ module Homebrew
       @environment_variables = variables.transform_values(&:to_s)
     end
 
+    # Returns the effective environment variables with user overrides merged
+    # in from `$HOMEBREW_USER_CONFIG_HOME/services/<formula>.env`.  User
+    # overrides take precedence over formula-defined variables.
+    sig { returns(T::Hash[Symbol, String]) }
+    def effective_environment_variables
+      env_vars = @environment_variables.dup
+
+      env_file = Pathname.new("#{ENV.fetch("HOMEBREW_USER_CONFIG_HOME")}/services/#{@formula.name}.env")
+      return env_vars unless env_file.file?
+
+      # User env overrides are not supported for root services.
+      # `sudo -E` can preserve a caller-controlled HOME, and TOCTOU
+      # between symlink resolution, permission checks, and reading makes
+      # it impossible to safely validate a user-owned override file when
+      # generating a root service definition.
+      if Process.euid.zero?
+        opoo "Skipping #{env_file}: user env overrides are not supported for root services."
+        return env_vars
+      end
+
+      if env_file.world_writable?
+        opoo "Skipping #{env_file}: file is world-writable."
+        return env_vars
+      end
+
+      if env_file.stat.mode.anybits?(020)
+        opoo "Skipping #{env_file}: file is group-writable."
+        return env_vars
+      end
+
+      # Read each line, strip whitespace, and remove blank lines and
+      # comments (lines starting with `#`). Then parse remaining lines
+      # as KEY=value pairs, warning on lines missing a `=` separator.
+      overrides = env_file.each_line
+                          .map(&:strip)
+                          .reject { |line| line.empty? || line.start_with?("#") }
+                          .each_with_object({}) do |line, hash|
+                            key, value = line.split("=", 2)
+                            if key.blank? || value.nil?
+                              opoo "Skipping invalid line in #{env_file}: #{line}"
+                              next
+                            end
+
+                            hash[key.strip] = value.strip
+                          end
+
+      overrides.each { |key, value| env_vars[key.to_sym] = value }
+
+      env_vars
+    end
+
     # Timers created by `launchd` jobs are coalesced unless this is set.
     #
     # @api public
@@ -496,11 +548,11 @@ module Homebrew
     # Returns the `String` command to run manually instead of the service.
     sig { returns(String) }
     def manual_command
-      vars = @environment_variables.except(:PATH)
-                                   .map { |k, v| "#{k}=\"#{v}\"" }
+      env_vars = effective_environment_variables.except(:PATH)
+                                                .map { |k, v| "#{k}=\"#{v}\"" }
 
-      vars.concat(command.map { |arg| Utils::Shell.sh_quote(arg) })
-      vars.join(" ")
+      env_vars.concat(command.map { |arg| Utils::Shell.sh_quote(arg) })
+      env_vars.join(" ")
     end
 
     # Returns a `Boolean` describing if a service is timed.
@@ -532,7 +584,9 @@ module Homebrew
       base[:StandardInPath] = File.expand_path(@input_path) if @input_path.present?
       base[:StandardOutPath] = File.expand_path(@log_path) if @log_path.present?
       base[:StandardErrorPath] = File.expand_path(@error_log_path) if @error_log_path.present?
-      base[:EnvironmentVariables] = @environment_variables unless @environment_variables.empty?
+      if (env_vars = effective_environment_variables).present?
+        base[:EnvironmentVariables] = env_vars
+      end
 
       if keep_alive?
         if (always = @keep_alive[:always].presence)
@@ -600,7 +654,11 @@ module Homebrew
       options << "StandardInput=file:#{File.expand_path(@input_path)}" if @input_path.present?
       options << "StandardOutput=append:#{File.expand_path(@log_path)}" if @log_path.present?
       options << "StandardError=append:#{File.expand_path(@error_log_path)}" if @error_log_path.present?
-      options += @environment_variables.map { |k, v| "Environment=\"#{k}=#{v}\"" } if @environment_variables.present?
+      if (env_vars = effective_environment_variables).present?
+        options += env_vars.map do |k, v|
+          "Environment=\"#{k}=#{v}\""
+        end
+      end
 
       <<~SYSTEMD
         [Unit]

--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -414,7 +414,7 @@ module Homebrew
 
         temp = Tempfile.new(service.service_name)
         temp << if file.nil?
-          contents = service.service_file.read
+          contents = service.service_contents
 
           if sudo_service_user && System.launchctl?
             # set the username in the new plist file

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -262,6 +262,17 @@ module Homebrew
         hash
       end
 
+      # Generate the service file content (plist or systemd unit),
+      # including any per-service user environment variable overrides.
+      sig { returns(String) }
+      def service_contents
+        if System.launchctl?
+          formula.service.to_plist
+        else
+          formula.service.to_systemd_unit
+        end
+      end
+
       private
 
       # The purpose of this function is to lazy load the Homebrew::Service class

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -1639,4 +1639,226 @@ RSpec.describe Homebrew::Service do
       end
     end
   end
+
+  describe "#effective_environment_variables" do
+    it "returns formula vars when no env override file exists" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          environment_variables FOO: "BAR"
+        end
+      end
+
+      vars = f.service.effective_environment_variables
+      expect(vars).to eq({ FOO: "BAR" })
+    end
+
+    it "merges user env overrides with formula vars" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          environment_variables FOO: "BAR"
+        end
+      end
+
+      with_env(HOMEBREW_USER_CONFIG_HOME: Dir.mktmpdir) do
+        services_dir = Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME")) / "services"
+        services_dir.mkpath
+        env_file = services_dir / "formula_name.env"
+        env_file.write <<~ENV
+          OLLAMA_HOST=0.0.0.0
+        ENV
+
+        vars = f.service.effective_environment_variables
+        expect(vars).to eq({ FOO: "BAR", OLLAMA_HOST: "0.0.0.0" })
+      end
+    end
+
+    it "user env overrides take precedence over formula vars" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          environment_variables FOO: "BAR"
+        end
+      end
+
+      with_env(HOMEBREW_USER_CONFIG_HOME: Dir.mktmpdir) do
+        services_dir = Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME")) / "services"
+        services_dir.mkpath
+        env_file = services_dir / "formula_name.env"
+        env_file.write <<~ENV
+          FOO=QUX
+        ENV
+
+        vars = f.service.effective_environment_variables
+        expect(vars).to eq({ FOO: "QUX" })
+      end
+    end
+
+    it "ignores comments and blank lines in env file" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          environment_variables FOO: "BAR"
+        end
+      end
+
+      with_env(HOMEBREW_USER_CONFIG_HOME: Dir.mktmpdir) do
+        services_dir = Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME")) / "services"
+        services_dir.mkpath
+        env_file = services_dir / "formula_name.env"
+        env_file.write <<~ENV
+          # This is a comment
+
+          OLLAMA_HOST=0.0.0.0
+          # Another comment
+          OLLAMA_ORIGINS=*
+        ENV
+
+        vars = f.service.effective_environment_variables
+        expect(vars).to eq({ FOO: "BAR", OLLAMA_HOST: "0.0.0.0", OLLAMA_ORIGINS: "*" })
+      end
+    end
+
+    it "skips lines without = and strips whitespace around =" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+        end
+      end
+
+      with_env(HOMEBREW_USER_CONFIG_HOME: Dir.mktmpdir) do
+        services_dir = Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME")) / "services"
+        services_dir.mkpath
+        env_file = services_dir / "formula_name.env"
+        env_file.write <<~ENV
+          # comment
+          MALFORMED_LINE
+          FOO = BAR
+          BLANK_KEY = value
+          KEY_WITH_NO_VALUE
+          NORMAL=BAZ
+          KEY_EMPTY_VALUE=
+        ENV
+
+        expect { f.service.effective_environment_variables }
+          .to output(/invalid line.*MALFORMED_LINE/).to_stderr
+        expect { f.service.effective_environment_variables }
+          .to output(/invalid line.*KEY_WITH_NO_VALUE/).to_stderr
+        vars = f.service.effective_environment_variables
+        expect(vars).to eq({ FOO: "BAR", BLANK_KEY: "value", NORMAL: "BAZ", KEY_EMPTY_VALUE: "" })
+      end
+    end
+
+    it "includes user env overrides in to_plist" do
+      f = stub_formula do
+        service do
+          run [opt_bin/"beanstalkd", "test"]
+          environment_variables FOO: "BAR"
+        end
+      end
+
+      with_env(HOMEBREW_USER_CONFIG_HOME: Dir.mktmpdir) do
+        services_dir = Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME")) / "services"
+        services_dir.mkpath
+        env_file = services_dir / "formula_name.env"
+        env_file.write <<~ENV
+          OLLAMA_HOST=0.0.0.0
+        ENV
+
+        plist = f.service.to_plist
+        expect(plist).to include("<key>OLLAMA_HOST</key>")
+        expect(plist).to include("<string>0.0.0.0</string>")
+        expect(plist).to include("<key>FOO</key>")
+        expect(plist).to include("<string>BAR</string>")
+      end
+    end
+
+    it "includes user env overrides in to_systemd_unit" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          environment_variables FOO: "BAR"
+        end
+      end
+
+      with_env(HOMEBREW_USER_CONFIG_HOME: Dir.mktmpdir) do
+        services_dir = Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME")) / "services"
+        services_dir.mkpath
+        env_file = services_dir / "formula_name.env"
+        env_file.write <<~ENV
+          OLLAMA_HOST=0.0.0.0
+        ENV
+
+        unit = f.service.to_systemd_unit
+        expect(unit).to include("Environment=\"FOO=BAR\"")
+        expect(unit).to include("Environment=\"OLLAMA_HOST=0.0.0.0\"")
+      end
+    end
+
+    it "skips world-writable env files" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          environment_variables FOO: "BAR"
+        end
+      end
+
+      with_env(HOMEBREW_USER_CONFIG_HOME: Dir.mktmpdir) do
+        services_dir = Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME")) / "services"
+        services_dir.mkpath
+        env_file = services_dir / "formula_name.env"
+        env_file.write "OLLAMA_HOST=0.0.0.0"
+        File.chmod 0666, env_file
+
+        expect { f.service.effective_environment_variables }.to output(/world-writable/).to_stderr
+        vars = f.service.effective_environment_variables
+        expect(vars).to eq({ FOO: "BAR" })
+      end
+    end
+
+    it "skips group-writable env files" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          environment_variables FOO: "BAR"
+        end
+      end
+
+      with_env(HOMEBREW_USER_CONFIG_HOME: Dir.mktmpdir) do
+        services_dir = Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME")) / "services"
+        services_dir.mkpath
+        env_file = services_dir / "formula_name.env"
+        env_file.write "OLLAMA_HOST=0.0.0.0"
+        File.chmod 0664, env_file
+
+        expect { f.service.effective_environment_variables }.to output(/group-writable/).to_stderr
+        vars = f.service.effective_environment_variables
+        expect(vars).to eq({ FOO: "BAR" })
+      end
+    end
+
+    it "follows symlinks to a safe target" do
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          environment_variables FOO: "BAR"
+        end
+      end
+
+      with_env(HOMEBREW_USER_CONFIG_HOME: Dir.mktmpdir) do
+        services_dir = Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME")) / "services"
+        services_dir.mkpath
+        target = services_dir / "actual.env"
+        target.write "OLLAMA_HOST=0.0.0.0"
+        File.chmod 0644, target
+
+        symlink = services_dir / "formula_name.env"
+        File.symlink(target, symlink)
+
+        vars = f.service.effective_environment_variables
+        expect(vars).to eq({ FOO: "BAR", OLLAMA_HOST: "0.0.0.0" })
+      end
+    end
+  end
 end

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -336,15 +336,16 @@ RSpec.describe Homebrew::Services::Cli do
       timer_file.write("timer")
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
-        name:         "name",
-        service_name: "homebrew.name",
-        installed?:   true,
+        name:             "name",
+        service_name:     "homebrew.name",
+        installed?:       true,
         service_file:,
-        dest:         dest_dir/service_file.basename,
+        service_contents: "service",
+        dest:             dest_dir/service_file.basename,
         dest_dir:,
-        timed?:       true,
+        timed?:           true,
         timer_file:,
-        timer_dest:   dest_dir/timer_file.basename,
+        timer_dest:       dest_dir/timer_file.basename,
       )
 
       services_cli.install_service_file(service, nil)
@@ -354,10 +355,8 @@ RSpec.describe Homebrew::Services::Cli do
 
     context "when given `--sudo-service-user`" do
       let(:dest_dir) { mktmpdir }
-      let(:service) do
-        source_dir = mktmpdir
-        service_file = source_dir/"homebrew.test.plist"
-        service_file.write <<~XML
+      let(:plist_xml) do
+        <<~XML
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -371,13 +370,19 @@ RSpec.describe Homebrew::Services::Cli do
           </dict>
           </plist>
         XML
+      end
+      let(:service) do
+        source_dir = mktmpdir
+        service_file = source_dir/"homebrew.test.plist"
+        service_file.write(plist_xml)
         instance_double(
           Homebrew::Services::FormulaWrapper,
-          name:         "name",
-          service_name: "homebrew.test",
-          installed?:   true,
+          name:             "name",
+          service_name:     "homebrew.test",
+          installed?:       true,
           service_file:,
-          dest:         dest_dir/"homebrew.test.plist",
+          service_contents: plist_xml,
+          dest:             dest_dir/"homebrew.test.plist",
           dest_dir:,
         )
       end


### PR DESCRIPTION
<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] ~~For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?~~
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

This PR was developed with Claude Code (claude-opus-5). AI assistance was used for code exploration, understanding the service plist generation architecture, and drafting the implementation. All AI-generated code was reviewed, typechecked with Sorbet, linted with RuboCop, and verified with the full test suite via `brew lgtm --online` before submission.

-----

## What this does

Adds support for per-service user environment variable overrides via a simple file convention. When `brew services start/restart` generates a plist or systemd unit, it now checks for `$HOMEBREW_USER_CONFIG_HOME/services/<formula>.env` (defaults to `~/.homebrew/services/<formula>.env`) and merges any `KEY=value` pairs into the `EnvironmentVariables` of the generated service file.

## Why

**The problem:** macOS `launchd` doesn't run a login shell, so environment variables set in `.zprofile`/`.bash_profile` are invisible to Homebrew services. Users currently have no supported way to set e.g. `OLLAMA_HOST` for `brew services`-managed plists — manually editing the plist is overwritten on every `brew services restart`, and `launchctl setenv` doesn't survive reboots without additional machinery.

This has been discussed at length in [Homebrew/discussions#6196](https://github.com/orgs/Homebrew/discussions/6196) since May 2025 with no resolution.

**Real-world impact:** 51 formulae in homebrew-core use `environment_variables` in their `service` blocks. Many hardcode values users need to change:

- **ollama** — users want to set `OLLAMA_HOST`, `OLLAMA_ORIGINS`, etc. but the formula hardcodes `OLLAMA_FLASH_ATTENTION` and `OLLAMA_KV_CACHE_TYPE`
- **teslamate** — maintains a wrapper script solely to `source #{etc}/teslamate.env` before running. With this feature, teslamate could drop the wrapper entirely
- **launch_socket_server** — hardcodes `LAUNCH_PROGRAM_TCP_ADDRESS: "127.0.0.1:8080"` with no way to override
- **hbase** — 11 hardcoded env vars for JVM tuning, log paths, and PID directories
- **caddy/vulcain** — force `XDG_DATA_HOME` and `HOME` to specific paths
- **postgresql@15–18** — force `LC_ALL: "en_US.UTF-8"` across all four versioned formulae

## How it works

The env file location follows the existing `~/.homebrew/` user config pattern (`trust.json`, `livecheck_watchlist.txt`, `brew.env`):

```
~/.homebrew/services/ollama.env
```

Format is `KEY=value`, one per line, with `#` comments:

```
# Set Ollama to listen on all interfaces
OLLAMA_HOST=0.0.0.0
OLLAMA_ORIGINS=*
```

User overrides take precedence over formula-defined variables. The file is read at plist/systemd unit generation time (every `start`/`restart`), so changes take effect on the next `brew services restart`. The file survives `brew upgrade` because it lives outside the keg.

## Implementation

Three files changed in core, two test files updated:

- **`service.rb`** — three new methods: `effective_environment_variables` (merges formula vars + user overrides), `user_env_override_path`, and `load_user_env_overrides` (reads and parses the env file, ignoring comments and blank lines)
- **`formula_wrapper.rb`** — new public `service_content` method that regenerates plist/systemd content (so the env merge happens on every start/restart, not just on install)
- **`cli.rb`** — `install_service_file` now uses `service_content` instead of reading the pre-generated keg file, so user overrides are always applied
- **6 new test cases** covering: no file, merge, precedence, comments/blank lines, to_plist output, to_systemd_unit output
- **2 existing tests updated** to stub the new `service_content` method