### PR TITLE
vulns/osv_export: deduplicate references from OSV.dev

### DIFF
--- a/Library/Homebrew/test/vulns/osv_export_spec.rb
+++ b/Library/Homebrew/test/vulns/osv_export_spec.rb
@@ -122,6 +122,25 @@ RSpec.describe Homebrew::Vulns::OsvExport do
       expect(record[:references]).to eq upstream["references"]
     end
 
+    it "deduplicates references that differ only by percent-encoding, preserving distinct types" do
+      upstream = {
+        "references" => [
+          { "type" => "WEB", "url" => "https://lists.example.org/announce%40lists/msg" },
+          { "type" => "WEB", "url" => "https://lists.example.org/announce@lists/msg" },
+          { "type" => "REPORT", "url" => "https://bugs.example.org/+bug/1" },
+          { "type" => "ADVISORY", "url" => "https://bugs.example.org/+bug/1" },
+        ],
+      }
+
+      record = described_class.record_for(nvi, "CVE-2015-2305", upstream:, now:)
+
+      expect(record[:references]).to eq [
+        { "type" => "WEB", "url" => "https://lists.example.org/announce%40lists/msg" },
+        { "type" => "REPORT", "url" => "https://bugs.example.org/+bug/1" },
+        { "type" => "ADVISORY", "url" => "https://bugs.example.org/+bug/1" },
+      ]
+    end
+
     it "percent-encodes @ in the purl but not the package name" do
       glibc = formula("glibc@2.13") do
         url "https://ftp.gnu.org/gnu/glibc/glibc-2.13.tar.gz"

--- a/Library/Homebrew/vulns/osv_export.rb
+++ b/Library/Homebrew/vulns/osv_export.rb
@@ -3,6 +3,7 @@
 
 require "json"
 require "fileutils"
+require "uri"
 require "vulns/osv"
 require "vulns/scanner"
 
@@ -135,7 +136,15 @@ module Homebrew
           record[:details] = upstream["details"] if upstream["details"]
           record[:severity] = upstream["severity"] if upstream["severity"]
           record[:upstream] = ([vuln_id] + Array(upstream["aliases"])).uniq
-          record[:references] = upstream["references"] if upstream["references"]
+          if (refs = upstream["references"])
+            # OSV.dev merges NVD and cve.org reference lists without normalising
+            # percent-encoding, so the same URL can appear twice (e.g. `%40` vs
+            # `@`). Collapse those while keeping the same URL under distinct
+            # `type` values, which the schema allows and which carries meaning.
+            record[:references] = refs.uniq do |r|
+              [r["type"], URI::RFC2396_PARSER.unescape(r["url"].to_s)]
+            end
+          end
         end
 
         record


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I used Claude Code to draft the patch and test after spotting duplicate reference URLs in Homebrew/advisory-database#24. I reviewed the diff, confirmed the OSV.dev response contains the duplicates, and checked that keying on `[type, decoded_url]` preserves legitimate same-URL-different-type entries in the existing advisory set.

-----

`brew generate-vulns-advisories` copies the `references` array from `GET https://api.osv.dev/v1/vulns/{id}` verbatim into the emitted OSV record. OSV.dev merges NVD and cve.org reference lists without normalising percent-encoding, so the same URL can appear twice under the same `type`:

```console
$ curl -s https://api.osv.dev/v1/vulns/CVE-2019-17362 | jq -r '.references[].url' | grep fedora
https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/47YP5SXQ4RY6KMTK2HI5ZZR244XKRMCZ/
https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/YU5OMCY3PX54YVI4FMNDEENHDJZJ3RJW/
https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/47YP5SXQ4RY6KMTK2HI5ZZR244XKRMCZ/
https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/YU5OMCY3PX54YVI4FMNDEENHDJZJ3RJW/
```

which then lands in the generated advisory (Homebrew/advisory-database#24).

This dedups on `[type, URI::RFC2396_PARSER.unescape(url)]` so `%40`/`@` collapse while the same URL under distinct `type` values (e.g. `ADVISORY` vs `REPORT`, which OSV.dev also emits and the schema allows) is kept. `RFC2396_PARSER.unescape` matches existing usage in `AbstractFileDownloadStrategy`, leaves literal `+` in paths alone (Launchpad `+bug/` URLs), and passes invalid `%XX` sequences through unchanged rather than raising.

To reproduce before this change:

```console
$ brew generate-vulns-advisories /tmp/adv
$ jq -r '.references[].url' /tmp/adv/BREW-libtomcrypt-CVE-2019-17362.json | sort | uniq -d
```
