### PR TITLE
Document service block methods and tidy Homebrew::Services

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -92,6 +92,7 @@ Style/Documentation:
     - os.rb
     - os/mac.rb
     - resource.rb
+    - service.rb
     - startup/config.rb
     - utils/gzip.rb
     - utils/inreplace.rb

--- a/Library/Homebrew/rubocops/public_api_cookbook.rb
+++ b/Library/Homebrew/rubocops/public_api_cookbook.rb
@@ -18,6 +18,10 @@ module RuboCop
                                    "`FORMULA_COOKBOOK_METHODS`: %<methods>s."
         MISSING_CASK_LIST_MSG = "Method `%<method>s` is annotated with `@api public` in `%<file>s` but is " \
                                 "missing from `CASK_COOKBOOK_METHODS`."
+        MISSING_SERVICE_LIST_MSG = "Method `%<method>s` is annotated with `@api public` in `service.rb` but is " \
+                                   "missing from the Formula Cookbook's \"Service block methods\" table."
+        MISMATCHED_SERVICE_LIST_MSG = "`SERVICE_COOKBOOK_METHODS` is out of sync with the Formula Cookbook's " \
+                                      "\"Service block methods\" table: %<diff>s."
 
         sig { void }
         def on_new_investigation
@@ -49,6 +53,8 @@ module RuboCop
               )
             end
 
+            check_service_cookbook_list
+
             return
           end
 
@@ -58,6 +64,7 @@ module RuboCop
                                  "Formula Cookbook", relative_path, api_public_targets)
           check_cookbook_methods(ApiAnnotationHelper::CASK_COOKBOOK_METHODS,
                                  "Cask Cookbook", relative_path, api_public_targets)
+          check_service_methods(relative_path, api_public_targets)
 
           return unless %w[cask/dsl.rb cask/cask.rb cask/dsl/version.rb].include?(relative_path)
 
@@ -167,6 +174,65 @@ module RuboCop
 
             add_offense(node, message: format(MSG, method: method_name, cookbook: cookbook_name))
           end
+        end
+
+        # Ensure `SERVICE_COOKBOOK_METHODS` stays a 1:1 mirror of the cookbook's
+        # "Service block methods" table.
+        sig { void }
+        def check_service_cookbook_list
+          table = parse_service_block_table
+          list = ApiAnnotationHelper::SERVICE_COOKBOOK_METHODS
+          return if table == list
+
+          diff = []
+          if (missing_from_list = (table - list).to_a.sort).any?
+            diff << "missing from the list: #{missing_from_list.map { |m| "`#{m}`" }.join(", ")}"
+          end
+          if (missing_from_table = (list - table).to_a.sort).any?
+            diff << "not in the cookbook table: #{missing_from_table.map { |m| "`#{m}`" }.join(", ")}"
+          end
+
+          node = processed_source.ast&.each_descendant(:casgn)&.find do |casgn|
+            casgn.const_name == "SERVICE_COOKBOOK_METHODS"
+          end
+          add_offense(node || processed_source.ast || processed_source.buffer.source_range,
+                      message: format(MISMATCHED_SERVICE_LIST_MSG, diff: diff.join("; ")))
+        end
+
+        # Cross-check `service.rb`'s `@api public` annotations against the
+        # "Service block methods" table: every documented method must be
+        # `@api public` and every `@api public` method must be documented.
+        sig { params(relative_path: String, api_public_targets: T::Set[Integer]).void }
+        def check_service_methods(relative_path, api_public_targets)
+          return if relative_path != "service.rb"
+
+          documented = ApiAnnotationHelper::SERVICE_COOKBOOK_METHODS
+          processed_source.ast&.each_descendant(:def, :defs) do |node|
+            method_name = node.method_name.to_s
+            annotated = api_public_targets.include?(node.loc.line)
+
+            if documented.include?(method_name) && !annotated
+              add_offense(node, message: format(MSG, method: method_name, cookbook: "Formula Cookbook"))
+            elsif annotated && !documented.include?(method_name)
+              add_offense(node, message: format(MISSING_SERVICE_LIST_MSG, method: method_name))
+            end
+          end
+        end
+
+        # Method names in the first (backticked) column of the "Service block
+        # methods" table in docs/Formula-Cookbook.md.
+        sig { returns(T::Set[String]) }
+        def parse_service_block_table
+          path = HOMEBREW_LIBRARY_PATH.parent.parent/"docs/Formula-Cookbook.md"
+          return Set.new unless path.exist?
+
+          lines = path.readlines
+          start = lines.index { |line| line.start_with?("#### Service block methods") }
+          return Set.new if start.nil?
+
+          rest = lines[(start + 1)..] || []
+          finish = rest.index { |line| line.start_with?("#") } || rest.length
+          rest[0, finish].filter_map { |line| line[/\A\|\s*`([^`]+)`/, 1] }.to_set
         end
       end
     end

--- a/Library/Homebrew/rubocops/shared/api_annotation_helper.rb
+++ b/Library/Homebrew/rubocops/shared/api_annotation_helper.rb
@@ -120,6 +120,35 @@ module RuboCop
         "zap"                  => "cask/dsl.rb",
       }.freeze, T::Hash[String, String])
 
+      # Methods listed in the "Service block methods" table of
+      # docs/Formula-Cookbook.md. All live in `service.rb`.
+      # Validated by `Homebrew/PublicApiCookbook` against that table and against
+      # the `@api public` annotations in `service.rb` (a 1:1 correspondence).
+      SERVICE_COOKBOOK_METHODS = T.let(%w[
+        cron
+        environment_variables
+        error_log_path
+        input_path
+        interval
+        keep_alive
+        launch_only_once
+        log_path
+        macos_legacy_timers
+        name
+        nice
+        process_type
+        require_root
+        restart_delay
+        root_dir
+        run
+        run_at_load
+        run_type
+        sockets
+        stop_timeout
+        throttle_interval
+        working_dir
+      ].to_set.freeze, T::Set[String])
+
       # Returns the set of method names annotated with a given `@api` level
       # (e.g. `"internal"`, `"private"`, `"public"`) in the given Ruby source file.
       sig { params(source_path: String, level: String).returns(T::Set[String]) }

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -86,6 +86,11 @@ module Homebrew
       "homebrew.#{@formula.name}"
     end
 
+    # A hash with the `launchd` service name on macOS and/or the `systemd`
+    # service name on Linux. Homebrew generates a default name for the service
+    # file if this is not present.
+    #
+    # @api public
     sig { params(macos: T.nilable(String), linux: T.nilable(String)).void }
     def name(macos: nil, linux: nil)
       raise TypeError, "Service#name expects at least one String" if [macos, linux].none?(String)
@@ -94,12 +99,15 @@ module Homebrew
       @service_name = linux if linux
     end
 
+    # The command to execute: an array with arguments or a path.
+    #
+    # @api public
     sig {
       params(
         command: T.nilable(RunParam),
         macos:   T.nilable(RunParam),
         linux:   T.nilable(RunParam),
-      ).returns(T.nilable(T::Array[T.any(String, Pathname)]))
+      ).returns(T.nilable(T::Array[String]))
     }
     def run(command = nil, macos: nil, linux: nil)
       # Save parameters for serialization
@@ -120,6 +128,9 @@ module Homebrew
       end
     end
 
+    # Directory to operate from.
+    #
+    # @api public
     sig { params(path: T.any(String, Pathname)).returns(T.nilable(String)) }
     def working_dir(path = T.unsafe(nil))
       if path
@@ -129,6 +140,9 @@ module Homebrew
       end
     end
 
+    # Directory to use as a chroot for the process.
+    #
+    # @api public
     sig { params(path: T.any(String, Pathname)).returns(T.nilable(String)) }
     def root_dir(path = T.unsafe(nil))
       if path
@@ -138,6 +152,9 @@ module Homebrew
       end
     end
 
+    # Path to use as input for the process.
+    #
+    # @api public
     sig { params(path: T.any(String, Pathname)).returns(T.nilable(String)) }
     def input_path(path = T.unsafe(nil))
       if path
@@ -147,6 +164,9 @@ module Homebrew
       end
     end
 
+    # Path to write `stdout` to.
+    #
+    # @api public
     sig { params(path: T.any(String, Pathname)).returns(T.nilable(String)) }
     def log_path(path = T.unsafe(nil))
       if path
@@ -156,6 +176,9 @@ module Homebrew
       end
     end
 
+    # Path to write `stderr` to.
+    #
+    # @api public
     sig { params(path: T.any(String, Pathname)).returns(T.nilable(String)) }
     def error_log_path(path = T.unsafe(nil))
       if path
@@ -165,6 +188,9 @@ module Homebrew
       end
     end
 
+    # Sets contexts in which the service will keep the process running.
+    #
+    # @api public
     sig {
       params(value: T.any(T::Boolean, T::Hash[Symbol, T.untyped]))
         .returns(T.nilable(T::Hash[Symbol, T.untyped]))
@@ -184,6 +210,10 @@ module Homebrew
       end
     end
 
+    # Whether the service requires root access. If true, Homebrew hints at using
+    # `sudo` on various occasions, but does not enforce it.
+    #
+    # @api public
     sig { params(value: T::Boolean).returns(T::Boolean) }
     def require_root(value = T.unsafe(nil))
       if value.nil?
@@ -199,6 +229,9 @@ module Homebrew
       @require_root.present? && @require_root == true
     end
 
+    # Whether the command should run when the service is loaded.
+    #
+    # @api public
     sig { params(value: T::Boolean).returns(T.nilable(T::Boolean)) }
     def run_at_load(value = T.unsafe(nil))
       if value.nil?
@@ -208,6 +241,9 @@ module Homebrew
       end
     end
 
+    # Socket that is created as an access point to the service.
+    #
+    # @api public
     sig {
       params(value: T.any(String, T::Hash[Symbol, String]))
         .returns(T::Hash[Symbol, T::Hash[Symbol, String]])
@@ -242,6 +278,9 @@ module Homebrew
       !@keep_alive.empty? && @keep_alive[:always] != false
     end
 
+    # Whether the command should only run once.
+    #
+    # @api public
     sig { params(value: T::Boolean).returns(T::Boolean) }
     def launch_only_once(value = T.unsafe(nil))
       if value.nil?
@@ -251,6 +290,9 @@ module Homebrew
       end
     end
 
+    # Number of seconds to delay before restarting a process.
+    #
+    # @api public
     sig { params(value: Integer).returns(T.nilable(Integer)) }
     def restart_delay(value = T.unsafe(nil))
       if value
@@ -260,6 +302,9 @@ module Homebrew
       end
     end
 
+    # Minimum seconds to wait before invocations (macOS default is `10`).
+    #
+    # @api public
     sig { params(value: Integer).returns(T.nilable(Integer)) }
     def throttle_interval(value = T.unsafe(nil))
       return @throttle_interval if value.nil?
@@ -267,6 +312,9 @@ module Homebrew
       @throttle_interval = value
     end
 
+    # Number of seconds to wait before forcibly stopping a process.
+    #
+    # @api public
     sig { params(value: Integer).returns(T.nilable(Integer)) }
     def stop_timeout(value = T.unsafe(nil))
       return @stop_timeout if value.nil?
@@ -276,6 +324,10 @@ module Homebrew
       @stop_timeout = value
     end
 
+    # Type of process to manage: `:background`, `:standard`, `:interactive` or
+    # `:adaptive`.
+    #
+    # @api public
     sig { params(value: Symbol).returns(T.nilable(Symbol)) }
     def process_type(value = T.unsafe(nil))
       case value
@@ -290,6 +342,9 @@ module Homebrew
       end
     end
 
+    # The type of service: `:immediate`, `:interval` or `:cron`.
+    #
+    # @api public
     sig { params(value: Symbol).returns(T.nilable(Symbol)) }
     def run_type(value = T.unsafe(nil))
       case value
@@ -302,6 +357,9 @@ module Homebrew
       end
     end
 
+    # Controls the start interval, required for the `:interval` type.
+    #
+    # @api public
     sig { params(value: Integer).returns(T.nilable(Integer)) }
     def interval(value = T.unsafe(nil))
       if value
@@ -311,6 +369,9 @@ module Homebrew
       end
     end
 
+    # Controls the trigger times, required for the `:cron` type.
+    #
+    # @api public
     sig { params(value: String).returns(T::Hash[Symbol, T.any(Integer, String)]) }
     def cron(value = T.unsafe(nil))
       if value
@@ -366,11 +427,17 @@ module Homebrew
       parsed
     end
 
+    # Hash of variables to set.
+    #
+    # @api public
     sig { params(variables: T::Hash[Symbol, T.any(Pathname, String)]).returns(T.nilable(T::Hash[Symbol, String])) }
     def environment_variables(variables = {})
       @environment_variables = variables.transform_values(&:to_s)
     end
 
+    # Timers created by `launchd` jobs are coalesced unless this is set.
+    #
+    # @api public
     sig { params(value: T::Boolean).returns(T::Boolean) }
     def macos_legacy_timers(value = T.unsafe(nil))
       if value.nil?
@@ -380,6 +447,11 @@ module Homebrew
       end
     end
 
+    # Default scheduling priority (nice level), from `-20` highest to `19`
+    # lowest. **Note:** Negative nice values (higher priority) require
+    # `require_root: true` to be set.
+    #
+    # @api public
     sig { params(value: Integer).returns(T.nilable(Integer)) }
     def nice(value = T.unsafe(nil))
       return @nice if value.nil?
@@ -391,6 +463,7 @@ module Homebrew
 
     delegate [:bin, :etc, :libexec, :opt_bin, :opt_libexec, :opt_pkgshare, :opt_prefix, :opt_sbin, :var] => :@formula
 
+    # @api internal
     sig { returns(String) }
     def std_service_path_env
       "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:/usr/bin:/bin:/usr/sbin:/sbin"

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -144,19 +144,6 @@ module Homebrew
         formula.any_version_installed?
       end
 
-      # Returns `true` if the plist file exists.
-      sig { returns(T::Boolean) }
-      def plist?
-        return false unless installed?
-        return true if service_file.file?
-        return false unless formula.opt_prefix.exist?
-        return true if Keg.for(formula.opt_prefix).plist_installed?
-
-        false
-      rescue NotAKegError
-        false
-      end
-
       sig { void }
       def reset_cache!
         @status_output_success_type = nil

--- a/Library/Homebrew/services/system.rb
+++ b/Library/Homebrew/services/system.rb
@@ -19,11 +19,6 @@ module Homebrew
         @launchctl ||= T.let(which("launchctl"), T.nilable(Pathname))
       end
 
-      sig { void }
-      def self.reset_launchctl!
-        @launchctl = nil
-      end
-
       # Is this a launchctl system
       sig { returns(T::Boolean) }
       def self.launchctl?
@@ -46,15 +41,6 @@ module Homebrew
       sig { returns(T.nilable(String)) }
       def self.user
         @user ||= T.let(ENV["USER"].presence || Utils.safe_popen_read("/usr/bin/whoami").chomp, T.nilable(String))
-      end
-
-      sig { params(pid: T.nilable(Integer)).returns(T.nilable(String)) }
-      def self.user_of_process(pid)
-        if pid.nil? || pid.zero?
-          user
-        else
-          Utils.safe_popen_read("ps", "-o", "user", "-p", pid.to_s).lines.second&.chomp
-        end
       end
 
       sig { params(username: String).returns(T::Boolean) }

--- a/Library/Homebrew/services/system/systemctl.rb
+++ b/Library/Homebrew/services/system/systemctl.rb
@@ -10,11 +10,6 @@ module Homebrew
           @executable ||= T.let(which("systemctl"), T.nilable(Pathname))
         end
 
-        sig { void }
-        def self.reset_executable!
-          @executable = nil
-        end
-
         sig { returns(String) }
         def self.scope
           System.root? ? "--system" : "--user"

--- a/Library/Homebrew/test/rubocops/public_api_cookbook_spec.rb
+++ b/Library/Homebrew/test/rubocops/public_api_cookbook_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe RuboCop::Cop::Homebrew::PublicApiCookbook do
   let(:cask_dsl_path) { "cask/dsl.rb" }
   let(:helper_path) { "rubocops/shared/api_annotation_helper.rb" }
 
+  let(:service_path) { "service.rb" }
+
   context "when a cookbook-referenced method lacks `@api public`" do
     it "reports an offense for a formula method" do
       expect_offense(<<~RUBY, formula_path)
@@ -96,6 +98,7 @@ RSpec.describe RuboCop::Cop::Homebrew::PublicApiCookbook do
       end
 
       stub_const("RuboCop::Cop::ApiAnnotationHelper::FORMULA_COOKBOOK_METHODS", {})
+      stub_const("RuboCop::Cop::ApiAnnotationHelper::SERVICE_COOKBOOK_METHODS", Set.new)
     end
 
     it "reports an offense" do
@@ -123,6 +126,75 @@ RSpec.describe RuboCop::Cop::Homebrew::PublicApiCookbook do
             ^^^^^^^^^^^^^ Homebrew/PublicApiCookbook: Method `new_stanza` is annotated with `@api public` in `cask/dsl.rb` but is missing from `CASK_COOKBOOK_METHODS`.
             def new_stanza; end
           end
+        end
+      RUBY
+    end
+  end
+
+  context "when a documented service block method lacks `@api public`" do
+    it "reports an offense" do
+      expect_offense(<<~RUBY, service_path)
+        class Service
+          def require_root(value = nil); end
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Homebrew/PublicApiCookbook: Method `require_root` is referenced in the Formula Cookbook but is not annotated with `@api public`.
+        end
+      RUBY
+    end
+  end
+
+  context "when a documented service block method has `@api public`" do
+    it "does not report an offense" do
+      expect_no_offenses(<<~RUBY, service_path)
+        class Service
+          # Whether the service requires root access.
+          #
+          # @api public
+          def require_root(value = nil); end
+        end
+      RUBY
+    end
+  end
+
+  context "when a service method has `@api public` but is not documented" do
+    it "reports an offense" do
+      expect_offense(<<~RUBY, service_path)
+        class Service
+          # An undocumented method.
+          #
+          # @api public
+          def undocumented; end
+          ^^^^^^^^^^^^^^^^^^^^^ Homebrew/PublicApiCookbook: Method `undocumented` is annotated with `@api public` in `service.rb` but is missing from the Formula Cookbook's "Service block methods" table.
+        end
+      RUBY
+    end
+  end
+
+  context "when `SERVICE_COOKBOOK_METHODS` does not match the cookbook table" do
+    before do
+      (mktmpdir/"docs").tap do |docs|
+        docs.mkpath
+        (docs/"Formula-Cookbook.md").write <<~MARKDOWN
+          #### Service block methods
+
+          | method  | description |
+          | ------- | ----------- |
+          | `run`   | command     |
+
+          #### Next section
+        MARKDOWN
+
+        stub_const("HOMEBREW_LIBRARY_PATH", docs.parent/"Library/Homebrew")
+      end
+
+      stub_const("RuboCop::Cop::ApiAnnotationHelper::FORMULA_COOKBOOK_METHODS", {})
+      stub_const("RuboCop::Cop::ApiAnnotationHelper::SERVICE_COOKBOOK_METHODS", Set["run", "extra"])
+    end
+
+    it "reports an offense" do
+      expect_offense(<<~RUBY, helper_path)
+        module ApiAnnotationHelper
+          SERVICE_COOKBOOK_METHODS = [].to_set.freeze
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Homebrew/PublicApiCookbook: `SERVICE_COOKBOOK_METHODS` is out of sync with the Formula Cookbook's "Service block methods" table: not in the cookbook table: `extra`.
         end
       RUBY
     end

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -4,8 +4,11 @@
 require "services/cli"
 require "services/system"
 require "services/formula_wrapper"
+require "test/support/helper/services"
 
 RSpec.describe Homebrew::Services::Cli do
+  include Test::Helper::Services
+
   subject(:services_cli) { described_class }
 
   let(:service_string) { "service" }
@@ -407,7 +410,7 @@ RSpec.describe Homebrew::Services::Cli do
         printf '%s\\n' "$*" >> "#{log}"
       SH
       (bindir/"systemctl").chmod 0755
-      Homebrew::Services::System::Systemctl.reset_executable!
+      reset_services_memoization!
     end
 
     it "checks non-enabling run" do
@@ -466,7 +469,7 @@ RSpec.describe Homebrew::Services::Cli do
         printf '%s\\n' "$*" >> "#{log}"
       SH
       (bindir/"launchctl").chmod 0755
-      Homebrew::Services::System.reset_launchctl!
+      reset_services_memoization!
     end
 
     it "checks non-enabling run" do

--- a/Library/Homebrew/test/services/formula_wrapper_spec.rb
+++ b/Library/Homebrew/test/services/formula_wrapper_spec.rb
@@ -170,28 +170,6 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
     end
   end
 
-  describe "#plist?" do
-    it "false if not installed" do
-      allow(service).to receive(:installed?).and_return(false)
-      expect(service.plist?).to be(false)
-    end
-
-    it "true if installed and file" do
-      tempfile = File.new("/tmp/foo", File::CREAT)
-      allow(service).to receive_messages(installed?: true, service_file: tempfile_path = Pathname.new(tempfile))
-      expect(service.plist?).to be(true)
-      File.delete(tempfile_path)
-    end
-
-    it "false if opt_prefix missing" do
-      allow(service).to receive_messages(installed?:   true,
-                                         service_file: Pathname.new(File::NULL),
-                                         formula:      instance_double(Formula,
-                                                                       opt_prefix: Pathname.new("/dfslkfhjdsolshlk")))
-      expect(service.plist?).to be(false)
-    end
-  end
-
   describe "#owner" do
     it "root if file present" do
       allow(service).to receive(:boot_path_service_file_present?).and_return(true)

--- a/Library/Homebrew/test/services/system/systemctl_spec.rb
+++ b/Library/Homebrew/test/services/system/systemctl_spec.rb
@@ -3,8 +3,11 @@
 
 require "services/system"
 require "services/system/systemctl"
+require "test/support/helper/services"
 
 RSpec.describe Homebrew::Services::System::Systemctl do
+  include Test::Helper::Services
+
   let(:bindir) { mktmpdir }
 
   describe ".scope" do
@@ -27,7 +30,7 @@ RSpec.describe Homebrew::Services::System::Systemctl do
         exit 0
       SH
       systemctl.chmod 0755
-      described_class.reset_executable!
+      reset_services_memoization!
 
       with_env(PATH: bindir.to_s) do
         expect(described_class.executable).to eq(systemctl)

--- a/Library/Homebrew/test/services/system_spec.rb
+++ b/Library/Homebrew/test/services/system_spec.rb
@@ -2,14 +2,14 @@
 # frozen_string_literal: true
 
 require "services/system"
+require "test/support/helper/services"
 
 RSpec.describe Homebrew::Services::System do
+  include Test::Helper::Services
+
   let(:bindir) { mktmpdir }
 
-  before do
-    described_class.reset_launchctl!
-    Homebrew::Services::System::Systemctl.reset_executable!
-  end
+  before { reset_services_memoization! }
 
   describe "#launchctl" do
     it "returns the launchctl command location when available and nil when unavailable" do
@@ -24,7 +24,7 @@ RSpec.describe Homebrew::Services::System do
         expect(described_class.launchctl).to eq(launchctl)
       end
 
-      described_class.reset_launchctl!
+      reset_services_memoization!
       launchctl.unlink
 
       with_env(PATH: bindir.to_s) do
@@ -46,7 +46,7 @@ RSpec.describe Homebrew::Services::System do
         expect(described_class.launchctl?).to be(true)
       end
 
-      described_class.reset_launchctl!
+      reset_services_memoization!
       launchctl.unlink
 
       with_env(PATH: bindir.to_s) do
@@ -68,7 +68,7 @@ RSpec.describe Homebrew::Services::System do
         expect(described_class.systemctl?).to be(true)
       end
 
-      Homebrew::Services::System::Systemctl.reset_executable!
+      reset_services_memoization!
       systemctl.unlink
 
       with_env(PATH: bindir.to_s) do
@@ -86,27 +86,6 @@ RSpec.describe Homebrew::Services::System do
   describe "#user" do
     it "returns the current username" do
       expect(described_class.user).to eq(ENV.fetch("USER"))
-    end
-  end
-
-  describe "#user_of_process" do
-    it "returns the username for empty PID" do
-      expect(described_class.user_of_process(nil)).to eq(ENV.fetch("USER"))
-    end
-
-    it "returns the PID username" do
-      allow(Utils).to receive(:safe_popen_read).and_return <<~EOS
-        USER
-        user
-      EOS
-      expect(described_class.user_of_process(50)).to eq("user")
-    end
-
-    it "returns nil if unavailable" do
-      allow(Utils).to receive(:safe_popen_read).and_return <<~EOS
-        USER
-      EOS
-      expect(described_class.user_of_process(50)).to be_nil
     end
   end
 

--- a/Library/Homebrew/test/support/helper/services.rb
+++ b/Library/Homebrew/test/support/helper/services.rb
@@ -1,0 +1,22 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "services/system"
+require "services/system/systemctl"
+
+module Test
+  module Helper
+    # Helpers for the `Homebrew::Services` specs.
+    module Services
+      # `Homebrew::Services::System.launchctl` and
+      # `Homebrew::Services::System::Systemctl.executable` memoize their lookups
+      # for the life of the process. Examples that manipulate `PATH` to probe
+      # discovery must clear those caches so they don't leak across examples.
+      sig { void }
+      def reset_services_memoization!
+        Homebrew::Services::System.instance_variable_set(:@launchctl, nil)
+        Homebrew::Services::System::Systemctl.instance_variable_set(:@executable, nil)
+      end
+    end
+  end
+end

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1248,10 +1248,11 @@ This table lists the options you can set within a `service` block. The `run` or 
 | `log_path`              | -            |  yes  |  yes  | path to write `stdout` to |
 | `error_log_path`        | -            |  yes  |  yes  | path to write `stderr` to |
 | `restart_delay`         | -            |  yes  |  yes  | number of seconds to delay before restarting a process |
+| `stop_timeout`          | -            |  yes  |  yes  | number of seconds to wait before forcibly stopping a process |
 | `throttle_interval`     | -            |  yes  | no-op | minimum seconds to wait before invocations (macOS default is `10`) |
 | `process_type`          | -            |  yes  | no-op | type of process to manage: `:background`, `:standard`, `:interactive` or `:adaptive` |
 | `macos_legacy_timers`   | -            |  yes  | no-op | timers created by `launchd` jobs are coalesced unless this is set |
-| `sockets`               | -            |  yes  | no-op | socket that is created as an accesspoint to the service |
+| `sockets`               | -            |  yes  | no-op | socket that is created as an access point to the service |
 | `nice`                  | -            |  yes  |  yes  | default scheduling priority (nice level), from `-20` highest to `19` lowest. **Note:** Negative nice values (higher priority) require `require_root: true` to be set. |
 | `name`                  | -            |  yes  |  yes  | a hash with the `launchd` service name on macOS and/or the `systemd` service name on Linux. Homebrew generates a default name for the service file if this is not present |
 


### PR DESCRIPTION
Two related pieces of `service` cleanup.

**Document the service block DSL as public API**

Every method in the [Formula Cookbook](https://docs.brew.sh/Formula-Cookbook#service-files)'s "Service block methods" table is formula-facing DSL, but only a handful were annotated `@api public` in `Service`. This annotates all of them, with each method's documentation matching the wording of the cookbook's description column, and adds the missing `stop_timeout` row to the table.

To keep the table and the annotations from drifting, the `Homebrew/PublicApiCookbook` cop now enforces a 1:1 correspondence between the "Service block methods" table and the `@api public` methods in `service.rb`, backed by a new `SERVICE_COOKBOOK_METHODS` list (validated against the table, the same way `FORMULA_COOKBOOK_METHODS`/`CASK_COOKBOOK_METHODS` are). A documented method missing `@api public`, an `@api public` method missing from the table, or a list that no longer matches the table all become style offenses.

One method, `std_service_path_env`, is marked `@api internal` rather than `@api public`. Formulae call it inside `service` blocks (e.g. `environment_variables PATH: std_service_path_env`), so it has no callers within this repository and is part of the cross-repo API surface, but it is not one of the documented "Service block methods". Because the cop requires every `@api public` service method to appear in the cookbook table, `@api internal` is the correct marker here: it keeps the method from being reported as unused without adding it to the documented public DSL.

**Remove dead `Homebrew::Services` code and extract a test-only helper**

`FormulaWrapper#plist?` and `System.user_of_process` have no callers. `System.reset_launchctl!` and `Systemctl.reset_executable!` existed only so specs could clear the memoized `launchctl`/`systemctl` lookups between examples. All four are removed from the runtime classes; the cache reset moves into `Test::Helper::Services#reset_services_memoization!`, used by the specs that manipulate `PATH`.

These methods were identified by a draft `brew deadcode` command (backed by [Spoom](https://github.com/Shopify/spoom)) on the experimental `typecheck-deadcode` branch, which reports definitions with no callers once test code is excluded from the analysis, surfacing both truly-unused methods and those reached only by their own tests.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude (Claude Code) drafted the annotations, the cookbook table update, the cop enforcement, and the services cleanup. I verified locally with `brew lgtm` (style, typecheck, tests), confirmed the removed methods have no production callers, and added cop specs (with a red/green check) for the new documented/undocumented and list-vs-table cases.

-----
