### PR TITLE
sorbet: Type blocks at source more precisely than `T.untyped`

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -722,7 +722,7 @@ module Cask
     # Automatically fetch the latest version of a cask from changelogs.
     #
     # @api public
-    sig { params(block: T.nilable(T.proc.void)).returns(Livecheck) }
+    sig { params(block: T.nilable(T.proc.bind(Livecheck).void)).returns(Livecheck) }
     def livecheck(&block)
       return @livecheck unless block
 

--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -76,7 +76,7 @@ module Cask
         :built_in_caveat
       end
 
-      sig { params(block: T.proc.returns(T.nilable(T.any(Symbol, String)))).void }
+      sig { params(block: T.proc.bind(Caveats).returns(T.nilable(T.any(Symbol, String)))).void }
       def eval_caveats(&block)
         result = instance_eval(&block)
         return unless result

--- a/Library/Homebrew/compilers/compiler_failure.rb
+++ b/Library/Homebrew/compilers/compiler_failure.rb
@@ -21,7 +21,12 @@ class CompilerFailure
   def cause(_); end
 
   sig {
-    params(spec: T.any(Symbol, T::Hash[Symbol, String]), block: T.nilable(T.proc.void)).returns(T.attached_class)
+    params(
+      spec:  T.any(Symbol, T::Hash[Symbol, String]),
+      block: T.nilable(T.proc.bind(CompilerFailure).void),
+    ).returns(
+      T.attached_class,
+    )
   }
   def self.create(spec, &block)
     # Non-Apple compilers are in the format fails_with compiler => version
@@ -65,7 +70,7 @@ class CompilerFailure
       type:              Symbol,
       version:           T.any(Integer, String),
       exact_major_match: T::Boolean,
-      block:             T.nilable(T.proc.void),
+      block:             T.nilable(T.proc.bind(CompilerFailure).void),
     ).void
   }
   def initialize(type, version, exact_major_match:, &block)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4008,7 +4008,14 @@ class Formula
     # ```
     #
     # @api public
-    sig { params(steps: T.untyped, block: T.nilable(T.proc.void)).returns(Homebrew::InstallSteps::Steps) }
+    sig {
+      params(
+        steps: Homebrew::InstallSteps::RawStep,
+        block: T.nilable(T.proc.bind(Homebrew::InstallSteps::DSL).void),
+      ).returns(
+        Homebrew::InstallSteps::Steps,
+      )
+    }
     def post_install_steps(*steps, &block)
       current_steps = @post_install_steps || []
       return current_steps if steps.empty? && block.nil?
@@ -4281,7 +4288,7 @@ class Formula
     # ```
     #
     # @api public
-    sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+    sig { params(block: T.nilable(T.proc.bind(SoftwareSpec).void)).returns(T.untyped) }
     def stable(&block)
       return T.must(@stable) unless block
 
@@ -4314,8 +4321,13 @@ class Formula
     #
     # @api public
     sig {
-      params(val: T.nilable(String), specs: T::Hash[Symbol, T.untyped], block: T.nilable(T.proc.void))
-        .returns(T.untyped)
+      params(
+        val:   T.nilable(String),
+        specs: T::Hash[Symbol, T.untyped],
+        block: T.nilable(T.proc.bind(SoftwareSpec).void),
+      ).returns(
+        T.untyped,
+      )
     }
     def head(val = nil, specs = {}, &block)
       if block
@@ -4570,7 +4582,11 @@ class Formula
     # @see https://docs.brew.sh/Formula-Cookbook#patches Patches
     # @api public
     sig {
-      params(strip: T.any(String, Symbol), src: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.void)).void
+      params(
+        strip: T.any(String, Symbol),
+        src:   T.nilable(T.any(String, Symbol)),
+        block: T.nilable(T.proc.bind(Resource::Patch).void),
+      ).void
     }
     def patch(strip = :p1, src = nil, &block)
       specs.each { |spec| spec.patch(strip, src, &block) }
@@ -4825,11 +4841,17 @@ class Formula
     # ```
     #
     # @api public
-    sig { params(block: T.nilable(T.proc.returns(T.untyped))).returns(T.nilable(T.proc.returns(T.untyped))) }
+    sig {
+      params(
+        block: T.nilable(T.proc.bind(Homebrew::Service).void),
+      ).returns(
+        T.nilable(T.proc.void),
+      )
+    }
     def service(&block)
       return @service_block unless block
 
-      @service_block = T.let(block, T.nilable(T.proc.returns(T.untyped)))
+      @service_block = T.let(block, T.nilable(T.proc.void))
     end
 
     # Defines whether the {Formula}'s bottle can be used on the given Homebrew
@@ -4860,7 +4882,7 @@ class Formula
     sig {
       params(
         only_if: T.nilable(Symbol),
-        block:   T.nilable(T.proc.params(arg0: T.untyped).returns(T.any(T::Boolean, Symbol))),
+        block:   T.nilable(T.proc.bind(PourBottleCheck).params(arg0: T.untyped).void),
       ).void
     }
     def pour_bottle?(only_if: nil, &block)
@@ -4871,7 +4893,7 @@ class Formula
         raise ArgumentError, "Do not pass both a preset condition and a block to `pour_bottle?`"
       end
 
-      block ||= case only_if
+      bottle_check_block = block || case only_if
       when :clt_installed
         lambda do |_|
           on_macos do
@@ -4898,7 +4920,7 @@ class Formula
         raise ArgumentError, "Invalid preset `pour_bottle?` condition" if only_if.present?
       end
 
-      @pour_bottle_check.instance_eval(&T.unsafe(block))
+      @pour_bottle_check.instance_eval(&T.unsafe(bottle_check_block))
     end
 
     # Deprecates a {Formula} (on the given date) so a warning is

--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -102,7 +102,7 @@ module Homebrew
           default_base:        ::T.nilable(::T.any(::String, ::Symbol)),
           default_source_base: ::T.nilable(::T.any(::String, ::Symbol)),
           default_target_base: ::T.nilable(::T.any(::String, ::Symbol)),
-          block:               ::T.nilable(::T.proc.void),
+          block:               ::T.nilable(::T.proc.bind(DSL).void),
         ).returns(Steps)
       }
       def self.build(default_base: nil, default_source_base: nil, default_target_base: nil, &block)
@@ -536,7 +536,7 @@ module Homebrew
 
       private
 
-      sig { params(guard: PathSpec, block: ::T.proc.void).void }
+      sig { params(guard: PathSpec, block: ::T.proc.bind(DSL).void).void }
       def with_guard(guard, &block)
         previous_guards = ::T.let(nil, ::T.nilable(PathSpecs))
         previous_guards = @guards

--- a/Library/Homebrew/pour_bottle_check.rb
+++ b/Library/Homebrew/pour_bottle_check.rb
@@ -14,7 +14,7 @@ class PourBottleCheck
     @formula.pour_bottle_check_unsatisfied_reason = reason
   end
 
-  sig { params(block: T.proc.void).void }
+  sig { params(block: T.proc.bind(::Formula).returns(T::Boolean)).void }
   def satisfy(&block)
     @formula.send(:define_method, :pour_bottle?, &block)
   end

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -34,7 +34,7 @@ module Homebrew
     sig { returns(String) }
     attr_reader :plist_name, :service_name
 
-    sig { params(formula: Formula, block: T.nilable(T.proc.void)).void }
+    sig { params(formula: Formula, block: T.nilable(T.proc.bind(Homebrew::Service).void)).void }
     def initialize(formula, &block)
       @cron = T.let({}, T::Hash[Symbol, T.any(Integer, String)])
       @environment_variables = T.let({}, T::Hash[Symbol, String])

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -390,7 +390,7 @@ class SoftwareSpec
 
   sig {
     params(strip: T.any(Symbol, String), src: T.nilable(T.any(String, Symbol)),
-           block: T.nilable(T.proc.bind(Patch).void)).void
+           block: T.nilable(T.proc.bind(Resource::Patch).void)).void
   }
   def patch(strip = :p1, src = T.unsafe(nil), &block)
     p = Patch.create(strip, src, &block)

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "install_steps"

--- a/Library/Homebrew/test/support/fixtures/formulae/install-steps.rb
+++ b/Library/Homebrew/test/support/fixtures/formulae/install-steps.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 class InstallSteps < Formula


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Copilot CLI with Claude Opus 5 (High). I've been doing a bunch of Sorbet typing work with it in `srb-bump-more-tests` which I'm now splitting out because otherwise it'll be a massive, unreviewable PR.

-----

- Moving towards getting all of the Homebrew test suite typechecked.

- AI suggested putting `T.bind(self, Homebrew::Service)` in each of the tests' `service` methods to get `service_spec.rb` to typecheck, but editing the signature directly is much cleaner.

- The same for `Formula#patch`'s block being a `Resource::Patch`, and others.

- (Worth noting that we can't do the same `T.proc.bind` for all of the `T.bind(self, T.class_of(Formula))` because Sorbet won't take a `T.class_of` in a `T.proc.bind`.)