### PR TITLE
Remove unused "fully_loaded_formula" instance variable from formula.rb

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -313,7 +313,6 @@ class Formula
     @prefix_returns_versioned_prefix = T.let(false, T.nilable(T::Boolean))
     @oldname_locks = T.let([], T::Array[FormulaLock])
     @on_system_blocks_exist = T.let(false, T::Boolean)
-    @fully_loaded_formula = T.let(nil, T.nilable(Formula))
   end
 
   sig { params(spec_sym: Symbol).void }


### PR DESCRIPTION
Vestige of https://github.com/Homebrew/brew/pull/21493/changes#diff-91b7d3ceb5b783bc460ef7957ed4a960e6d5988c20e925ee78a970e37b8b6954
