### PR TITLE
Add missing stanza sorting

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_artifact.rb
+++ b/Library/Homebrew/cask/artifact/abstract_artifact.rb
@@ -86,6 +86,7 @@ module Cask
             Pkg,
             [
               App,
+              AppImage,
               Suite,
               Artifact,
               Colorpicker,
@@ -113,6 +114,7 @@ module Cask
               FishCompletion,
               ZshCompletion,
             ],
+            GeneratedCompletion,
             PostflightSteps,
             UninstallPostflightSteps,
             PostflightBlock,


### PR DESCRIPTION
I have the Cask containing following stanzas:
* `app`
* `(bash|fish|zsh)_completion`
* `generate_completions_from_executable`

Since `GeneratedCompletion` is missing from `sort_order`, during `brew install` this stanza can get executed at random time. If `generate_completions_from_executable` executes after all `*_completion` stanzas, everything is fine. If, however, `generate_completions_from_executable` executes before any of `*_completion` stanzas, the following issue happens:

* Since `generate_completions_from_executable` uses binary from app bundle, the whole bundle gets flagged by macOS (Gatekeeper popup appears).
* Later, when `*_completion` stanza tries to set Spotlight attribute (`com.apple.metadata:kMDItemAlternateNames`) on a file inside an app bundle, macOS blocks that operation as an attempt to modify external application.

Of course, one way of mitigating this issue is to give Terminal.app full disk access or permission to manage apps. However, enforcing stanza execution order also helps with that issue.

I also found that `AppImage` is missing from sort order. Not sure whether it's a right place for it.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
