### PR TITLE
Remove dead code from brew info and which-formula

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -174,20 +174,6 @@ module Homebrew
         end
       end
 
-      sig { params(formula_or_cask: T.any(Formula, Cask::Cask)).returns(T::Array[String]) }
-      def self.requirements_lines(formula_or_cask)
-        return [] unless $stdout.tty?
-
-        case formula_or_cask
-        when Formula
-          []
-        when Cask::Cask
-          cask_requirements_lines(formula_or_cask)
-        else
-          T.absurd(formula_or_cask)
-        end
-      end
-
       sig { params(tab: T.any(Tab, Cask::Tab)).returns(String) }
       def self.installation_status(tab)
         # TODO: Deprecate reading `installed_as_dependency`; `installed_on_request`
@@ -267,27 +253,6 @@ module Homebrew
         metadata
       end
 
-      sig { params(cask: Cask::Cask).returns(T::Array[String]) }
-      def self.cask_requirements_lines(cask)
-        macos_requirements = [cask.depends_on.macos, cask.depends_on.maximum_macos].compact
-        requirement = if macos_requirements.present?
-          requirement = macos_requirements.filter_map do |macos_requirement|
-            macos_requirement.display_s.delete_suffix(" (or Linux)").delete_prefix("macOS").strip.presence
-          end
-          requirement = requirement.present? ? "macOS #{requirement.join(", ")}" : "macOS"
-          requirement += " or Linux" if cask.supports_linux?
-          requirement
-        elsif cask.supports_macos? && cask.supports_linux?
-          "macOS or Linux"
-        elsif cask.supports_macos?
-          "macOS"
-        elsif cask.supports_linux?
-          "Linux"
-        end
-
-        requirement ? [requirement] : []
-      end
-
       sig { params(time: T.any(Integer, Time)).returns(String) }
       def self.formatted_time(time)
         time = Time.at(time) if time.is_a?(Integer)
@@ -347,7 +312,7 @@ module Homebrew
       end
 
       private_class_method :formula_metadata_lines, :formatted_time, :pin_path_mtime,
-                           :formula_installs_from_source?, :cask_requirements_lines
+                           :formula_installs_from_source?
 
       private
 

--- a/Library/Homebrew/cmd/which-formula.rb
+++ b/Library/Homebrew/cmd/which-formula.rb
@@ -11,9 +11,6 @@ require "shell_command"
 module Homebrew
   module Cmd
     class WhichFormula < AbstractCommand
-      ENDPOINT = "internal/executables.txt"
-      DATABASE_FILE = T.let((Homebrew::API::HOMEBREW_CACHE_API/ENDPOINT).freeze, Pathname)
-
       include ShellCommand
 
       cmd_args do

--- a/Library/Homebrew/test/cmd/which-formula_spec.rb
+++ b/Library/Homebrew/test/cmd/which-formula_spec.rb
@@ -19,11 +19,9 @@ RSpec.describe Homebrew::Cmd::WhichFormula do
     end
 
     before do
-      # Override DATABASE_FILE to use test environment's HOMEBREW_CACHE
-      test_db_file = HOMEBREW_CACHE/"api"/Homebrew::Cmd::WhichFormula::ENDPOINT
-      stub_const("#{described_class}::DATABASE_FILE", test_db_file)
-
-      db = Homebrew::Cmd::WhichFormula::DATABASE_FILE
+      # Write the database where `brew which-formula` (a Bash command) reads it:
+      # the same path `Homebrew::API.write_executables_file!` writes to.
+      db = Homebrew::API::HOMEBREW_CACHE_API/"internal/executables.txt"
       db.dirname.mkpath
       db.write(<<~EOS)
         foo(1.0.0):foo2 foo3


### PR DESCRIPTION
Removes dead code from two commands.

**`brew info`**: `Info.requirements_lines` has no callers, and its only callee `Info.cask_requirements_lines` becomes unused once it is removed. Both are deleted (and `cask_requirements_lines` dropped from the `private_class_method` list).

**`brew which-formula`**: the command is a `ShellCommand` implemented in Bash (`utils/executables.sh`, which uses its own `HOMEBREW_EXECUTABLES_TXT_ENDPOINT`), so the Ruby `ENDPOINT` and `DATABASE_FILE` constants were never read at runtime. Only the spec referenced `DATABASE_FILE`. Both constants are removed, and the spec now writes its test database to the same path `Homebrew::API.write_executables_file!` uses (`Homebrew::API::HOMEBREW_CACHE_API/"internal/executables.txt"`).

None of the removed definitions have any remaining references (verified with `git grep`).

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

The dead code was identified by a draft `brew deadcode` command (backed by [Spoom](https://github.com/Shopify/spoom)) on the experimental `typecheck-deadcode` branch, which reports definitions with no callers once test code is excluded from the analysis. Claude (Claude Code) applied the removal and updated the spec. I verified locally that none of the removed definitions are referenced anywhere (`git grep`) and ran `brew lgtm` (style, typecheck, tests) successfully.

-----
