### PR TITLE
Stage bottles using the path returned by fetch

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -67,12 +67,16 @@ module Homebrew
             next cached_location
           end
 
-          download.fetch(quiet:)
+          downloaded_path = download.fetch(quiet:)
           raise CancelledDownloadError if cancelled.true?
 
           check_bottle_attestation(downloadable, check_attestation:)
-          create_symlinks_for_shared_download(cached_location)
-          cached_location
+          if downloaded_path != cached_location
+            @symlink_targets[downloaded_path] ||= Set.new
+            @symlink_targets.fetch(downloaded_path).merge(@symlink_targets.fetch(cached_location, Set.new))
+          end
+          create_symlinks_for_shared_download(downloaded_path)
+          downloaded_path
         end
       end
 

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -123,7 +123,10 @@ RSpec.describe Homebrew::DownloadQueue do
 
   it "wakes when downloads complete instead of polling with sleep" do
     allow($stdout).to receive(:tty?).and_return(false)
-    allow(retryable_download).to receive(:fetch) { sleep(0.1) }
+    allow(retryable_download).to receive(:fetch) do
+      sleep 0.1
+      cached_download
+    end
 
     expect(download_queue).not_to receive(:sleep)
 
@@ -152,6 +155,19 @@ RSpec.describe Homebrew::DownloadQueue do
     expect(downloadable).to receive(:stage_from_download_queue?).with(cached_download, pour: false).and_return(true)
     expect(downloadable).to receive(:extracting!).ordered
     expect(downloadable).to receive(:stage_from_download_queue).with(cached_download, pour: false).ordered
+    expect(downloadable).to receive(:downloaded!).ordered
+
+    download_queue.enqueue(downloadable, stage: true)
+    download_queue.fetch
+  end
+
+  it "uses the fetched path for queued staging when it changes during fetch" do
+    fetched_download = HOMEBREW_CACHE/"downloads/fetched-testball--0.1.tar.gz"
+    allow(retryable_download).to receive(:fetch).and_return(fetched_download)
+
+    expect(downloadable).to receive(:stage_from_download_queue?).with(fetched_download, pour: false).and_return(true)
+    expect(downloadable).to receive(:extracting!).ordered
+    expect(downloadable).to receive(:stage_from_download_queue).with(fetched_download, pour: false).ordered
     expect(downloadable).to receive(:downloaded!).ordered
 
     download_queue.enqueue(downloadable, stage: true)


### PR DESCRIPTION
## What this does

Fixes queued bottle staging when bottle-domain fallback changes the fetched cache path.

`DownloadQueue#enqueue` captures `cached_location = downloadable.cached_download` before the fetch runs, then returns that stale snapshot to the queued staging hook after `download.fetch` completes.

When a bottle isn't present on a `$HOMEBREW_BOTTLE_DOMAIN` mirror, `Bottle#fetch` takes its documented fallback: it rescues `DownloadError` and, via `fallback_on_error?`, calls `root_url(HOMEBREW_BOTTLE_DEFAULT_DOMAIN)`. That reassigns `@resource.url`, which clears the memoised downloader, and `cached_location` is keyed on `Digest::SHA256.hexdigest(url)` — so the real download lands at a different path than the pre-fetch snapshot. The fallback download itself succeeds; staging then tries to open the stale path and fails with:

```
Error: No such file or directory @ rb_sysopen
```

This regressed in 8dd46b7b7873fd288896e48d91a0fd9fa2870349, which moved bottle extraction out of `RetryableDownload#fetch` (where the actual fetched path was used) into the download queue's `then_on` staging hook (which uses the pre-fetch snapshot). 6.0.9 was unaffected.

This change uses the path returned by `download.fetch` for attestation, symlinking and staging instead. When the fetched path differs from the pre-fetch snapshot, queued symlink targets are migrated from the stale `cached_location` key so shared-download symlinks still point at the real file.

## Reproduction

```bash
# Serve an empty directory, so every bottle URL under it 404s.
mkdir -p /tmp/empty-bottle-mirror
python3 -m http.server 8080 --directory /tmp/empty-bottle-mirror &
export HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080

brew uninstall --force hello 2>/dev/null
rm -f "$(brew --cache)"/downloads/*hello*

brew install hello
```

The mirror 404s, Homebrew falls back to the default domain and downloads the bottle successfully, then staging fails on the pre-fallback path. `brew fetch hello` succeeds under the identical environment, because it builds its queue without `pour: true` and so never runs the staging hook — only `install`/`upgrade`/`reinstall` do.

Note that `$HOMEBREW_ARTIFACT_DOMAIN` and resource-level `mirror`s are *not* affected: they fall back within `CurlDownloadStrategy#_fetch`'s `urls` list on the same downloader, so `cached_location` never moves.

## Testing

Adds a unit test asserting queued staging uses the fetched path when it changes during fetch. `brew lgtm` ran locally.

<details>
<summary>Root cause analysis</summary>

The bug was introduced in 8dd46b7b7873fd288896e48d91a0fd9fa2870349, which moved bottle extraction out of `RetryableDownload#fetch` and into `DownloadQueue#enqueue` via a `then_on` staging hook. In that refactor, the queue started capturing and returning an early `cached_location` snapshot:

- [`download_queue.rb#L49`](https://github.com/Homebrew/brew/blob/78430a54dd972a9725cf5f9a862bacd330303906/Library/Homebrew/download_queue.rb#L49) — `cached_location = downloadable.cached_download` is computed **before** the fetch runs. It resolves to [`downloader.cached_location`](https://github.com/Homebrew/brew/blob/78430a54dd972a9725cf5f9a862bacd330303906/Library/Homebrew/downloadable.rb#L147-L150), which is [`HOMEBREW_CACHE/downloads/#{Digest::SHA256.hexdigest(url)}--#{basename}`](``https://github.com/Homebrew/brew/blob/78430a54dd972a9725cf5f9a862bacd330303906/Library/Homebrew/download_strategy/abstract_file_download_strategy.rb#L31-L47``) — i.e. **keyed on the download URL**.
- [`download_queue.rb#L69`](https://github.com/Homebrew/brew/blob/78430a54dd972a9725cf5f9a862bacd330303906/Library/Homebrew/download_queue.rb#L69) — the return value of `download.fetch(quiet:)` (the path actually written) is discarded.
- [`download_queue.rb#L72-L74`](https://github.com/Homebrew/brew/blob/78430a54dd972a9725cf5f9a862bacd330303906/Library/Homebrew/download_queue.rb#L72-L74) — the stale pre-fetch `cached_location` is used for symlinking and returned as the future's value.
- [`download_queue.rb#L85-L87`](https://github.com/Homebrew/brew/blob/78430a54dd972a9725cf5f9a862bacd330303906/Library/Homebrew/download_queue.rb#L85-L87) — the staging hook receives that stale value as `downloaded_path` and passes it to `stage_from_download_queue`, which [`UnpackStrategy.detect`s and extracts it](https://github.com/Homebrew/brew/blob/78430a54dd972a9725cf5f9a862bacd330303906/Library/Homebrew/bottle.rb#L265-L296) — the `rb_sysopen` failure point.

The URL changes mid-fetch on bottle-domain fallback, and with it the computed cache path:

- [`bottle.rb#L137-L144`](https://github.com/Homebrew/brew/blob/78430a54dd972a9725cf5f9a862bacd330303906/Library/Homebrew/bottle.rb#L137-L144) — `Bottle#fetch` rescues `DownloadError` and retries when `fallback_on_error?` is true.
- [`bottle.rb#L354-L366`](https://github.com/Homebrew/brew/blob/78430a54dd972a9725cf5f9a862bacd330303906/Library/Homebrew/bottle.rb#L354-L366) — `fallback_on_error?` calls `root_url(HOMEBREW_BOTTLE_DEFAULT_DOMAIN)`.
- [`bottle.rb#L369-L386`](https://github.com/Homebrew/brew/blob/78430a54dd972a9725cf5f9a862bacd330303906/Library/Homebrew/bottle.rb#L369-L386) → [`resource.rb#L217-L230`](https://github.com/Homebrew/brew/blob/78430a54dd972a9725cf5f9a862bacd330303906/Library/Homebrew/resource.rb#L217-L230) — `root_url` reassigns `@resource.url`, which sets `@downloader = nil`. The replacement downloader has a different URL, so a **different `cached_location`**.

So staging receives a path that was never written, and fails with the `rb_sysopen` error above.

### Why 6.0.9 worked

Before that commit, extraction happened inside `RetryableDownload#fetch` using the actual fetched file path, so URL-fallback-induced cache-path changes didn't break staging.

</details>

-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Co-authored with Claude (model: Claude Opus 5) via [Claude Code](https://claude.com/claude-code). AI drafted the fix, the regression analysis and the unit test.