### PR TITLE
formula: support common goreleaser ldflags via `ldflags: :goreleaser`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2141,20 +2141,48 @@ class Formula
 
   # Standard parameters for Go builds.
   #
+  # ### Example
+  #
+  # A special ldflags of `:goreleaser` will output ldflags similar to GoReleaser's
+  # defaults (https://goreleaser.com/customization/builds/builders/go/#options).
+  # This uses formula metadata so it should not be used inside staged resources.
+  #
+  # ```ruby
+  # std_go_args(ldflags: :goreleaser)
+  # ```
+  #
   # @api public
   sig {
     params(
       output:  T.any(String, Pathname),
-      ldflags: T.nilable(T.any(String, T::Array[String])),
+      ldflags: T.nilable(T.any(String, T::Array[String], Symbol)),
       gcflags: T.nilable(T.any(String, T::Array[String])),
       tags:    T.nilable(T.any(String, T::Array[String])),
     ).returns(T::Array[String])
   }
   def std_go_args(output: bin/name, ldflags: nil, gcflags: nil, tags: nil)
+    case ldflags
+    when :goreleaser
+      # If building from a git archive, we use the tap owner as a placeholder.
+      # This can help upstream identify the exact code that was used in binary.
+      built_by = tap&.user || "Homebrew"
+      repo = buildpath
+      commit = Utils.git_head(repo, safe: false) if repo
+      commit ||= built_by
+      ldflags = %W[
+        -X 'main.version=#{version}'
+        -X 'main.commit=#{commit}'
+        -X 'main.date=#{time.iso8601}'
+        -X 'main.builtBy=#{built_by}'
+      ]
+    when Symbol
+      raise ArgumentError, "Invalid ldflags: #{ldflags.inspect}"
+    end
+
     ldflags = ["-s", "-w"].concat(Array(ldflags)) unless ENV.debug_symbols?
 
     args = ["-trimpath", "-o=#{output}"]
-    args << "-tags=#{Array(tags).join(" ")}" if tags
+    args << "-tags=#{Array(tags).join(",")}" if tags
     args << "-ldflags=#{Array(ldflags).join(" ")}" if ldflags
     args << "-gcflags=#{Array(gcflags).join(" ")}" if gcflags
     args

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2143,8 +2143,8 @@ class Formula
   #
   # ### Example
   #
-  # A special ldflags of `:goreleaser` will output ldflags similar to GoReleaser's
-  # defaults (https://goreleaser.com/customization/builds/builders/go/#options).
+  # A special `ldflags` value of `:goreleaser` will output ldflags similar to GoReleaser's
+  # defaults listed at https://goreleaser.com/customization/builds/builders/go/#options.
   # This uses formula metadata so it should not be used inside staged resources.
   #
   # ```ruby

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -3284,6 +3284,70 @@ RSpec.describe Formula do
       ldflags = "-X main.version=1.0.0"
       expect(f.std_go_args(ldflags:)).to include("-ldflags=#{ldflags}")
     end
+
+    it "raises an error when provided an invalid ldflags symbol" do
+      expect { f.std_go_args(ldflags: :foo) }.to raise_error(ArgumentError, "Invalid ldflags: :foo")
+    end
+
+    context "with `ldflags: :goreleaser`" do
+      subject(:std_go_args) { f.std_go_args(ldflags: :goreleaser) }
+
+      let(:built_by) { "Homebrew" }
+      let(:commit) { built_by }
+      let(:date) { "2026-01-01T12:00:00Z" }
+      let(:expected_ldflags) do
+        "-s -w " \
+          "-X 'main.version=1.0' " \
+          "-X 'main.commit=#{commit}' " \
+          "-X 'main.date=#{date}' " \
+          "-X 'main.builtBy=#{built_by}'"
+      end
+
+      before { allow(f).to receive(:time).and_return(Time.parse(date)) }
+
+      context "when in a git repository" do
+        let(:buildpath) { mktmpdir }
+        let(:commit) { Utils.popen_read("git", "-C", buildpath, "rev-parse", "HEAD").chomp }
+
+        before { allow(f).to receive(:buildpath).and_return(buildpath) }
+
+        around do |example|
+          buildpath.cd do
+            FileUtils.touch "LICENSE"
+            system "git", "init"
+            system "git", "add", "--all"
+            system "git", "commit", "-m", "Initial commit"
+            example.run
+          end
+        end
+
+        it "uses git commit for main.commit" do
+          expect(std_go_args).to include("-ldflags=#{expected_ldflags}")
+        end
+      end
+
+      context "when not in a git repository and tap is available" do
+        let(:built_by) { "someone" }
+
+        before { allow(f).to receive(:tap).and_return(Tap.fetch(built_by, "repo")) }
+
+        it "uses tap user for main.commit" do
+          expect(std_go_args).to include("-ldflags=#{expected_ldflags}")
+        end
+      end
+
+      context "when not in a git repository and tap is not available" do
+        before { allow(f).to receive(:tap).and_return(nil) }
+
+        it "uses Homebrew for main.commit" do
+          expect(std_go_args).to include("-ldflags=#{expected_ldflags}")
+        end
+      end
+    end
+
+    it "includes a comma-separated list of input tags" do
+      expect(f.std_go_args(tags: %w[foo bar baz])).to include("-tags=foo,bar,baz")
+    end
   end
 
   describe "#std_pip_args" do


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Simplify some Go formulae that use GoReleaser's default ldflags: https://goreleaser.com/customization/builds/builders/go/#options
> Default: '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser'.

This does not parse .goreleaser.yaml or other configs and only supports defaults.

In Homebrew/core, we've used the tap owner as a placeholder for commit to allow building off of git archive. There may be some cases this doesn't work but those can still directly pass in ldflags.

In the future, we could consider one of the following:
1. use `git get-tar-commit-id` to extract the commit out of the git archive
2. extend the url DSL to allow `revision:` on git tarball as metadata

---

Also update delimiter for tags to use non-deprecated commas:

> a comma-separated list of additional build tags to consider satisfied
> during the build. For more information about build tags, see
> 'go help buildconstraint'. (Earlier versions of Go used a
> space-separated list, and that form is deprecated but still recognized.)