### PR TITLE
sorbet: More `T.bind(self, T.class_of(Formula))`

### DIFF
--- a/Library/Homebrew/test/checksum_verification_spec.rb
+++ b/Library/Homebrew/test/checksum_verification_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "formula"
@@ -16,6 +16,7 @@ RSpec.describe Formula do
     it "does not raise an error when the checksum matches" do
       expect do
         f = formula do
+          T.bind(self, T.class_of(Formula))
           sha256 TESTBALL_SHA256
         end
 
@@ -28,6 +29,7 @@ RSpec.describe Formula do
     it "raises an error when the checksum doesn't match" do
       expect do
         f = formula do
+          T.bind(self, T.class_of(Formula))
           sha256 "dcbf5f44743b74add648c7e35e414076632fa3b24463d68d1f6afc5be77024f8"
         end
 

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -300,6 +300,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "shows a conflict by its resolved full name" do
     info = described_class.new([])
     formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
       url "https://brew.sh/testball-0.1.tar.gz"
       conflicts_with "other"
     end
@@ -315,6 +316,7 @@ RSpec.describe Homebrew::Cmd::Info do
   it "omits a stale conflict that resolves to the formula itself" do
     info = described_class.new([])
     formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
       url "https://brew.sh/testball-0.1.tar.gz"
       conflicts_with "testball"
     end

--- a/Library/Homebrew/test/cmd/vulns_spec.rb
+++ b/Library/Homebrew/test/cmd/vulns_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/vulns"
@@ -67,6 +67,7 @@ RSpec.describe Homebrew::Cmd::Vulns do
 
     let(:act) do
       formula("act") do
+        T.bind(self, T.class_of(Formula))
         url "https://github.com/nektos/act/archive/refs/tags/v0.2.84.tar.gz"
       end
     end

--- a/Library/Homebrew/test/dev-cmd/generate-vulns-advisories_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-vulns-advisories_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Homebrew::DevCmd::GenerateVulnsAdvisories do
 
   it "writes advisories for core formulae with security patch resolves" do
     nvi = formula("nvi") do
+      T.bind(self, T.class_of(Formula))
       url "https://deb.debian.org/debian/pool/main/n/nvi/nvi_1.81.6.orig.tar.gz"
       version "1.81.6"
       revision 6
@@ -47,6 +48,7 @@ RSpec.describe Homebrew::DevCmd::GenerateVulnsAdvisories do
 
   it "writes nothing with --dry-run" do
     nvi = formula("nvi") do
+      T.bind(self, T.class_of(Formula))
       url "https://example.com/nvi-1.81.6.tar.gz"
       patch do
         url "https://example.com/fix.patch"

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -667,6 +667,7 @@ RSpec.describe Formula do
                                                   .and_return(["same-name-cask"])
 
     expect(formula("same-name-cask", tap:) do
+      T.bind(self, T.class_of(Formula))
       url "https://brew.sh/same-name-cask-1.0.tar.gz"
     end.oldnames).to be_empty
   end
@@ -1241,6 +1242,7 @@ RSpec.describe Formula do
 
   specify "#run_post_install_steps uses the versioned prefix" do
     f = formula "post-install-steps-prefix" do
+      T.bind(self, T.class_of(Formula))
       url "foo-1.0"
 
       post_install_steps do
@@ -1784,6 +1786,7 @@ RSpec.describe Formula do
 
     it "serialises type and explicit resolves on an external patch" do
       f = formula "foo" do
+        T.bind(self, T.class_of(Formula))
         url "foo-1.0"
         patch do
           url "https://example.com/foo.diff"
@@ -1809,6 +1812,7 @@ RSpec.describe Formula do
 
     it "serialises resolves inferred from url and apply paths" do
       f = formula "foo" do
+        T.bind(self, T.class_of(Formula))
         url "foo-1.0"
         patch do
           url "https://example.com/debian.tar.xz"
@@ -1825,6 +1829,7 @@ RSpec.describe Formula do
 
     it "serialises non-CVE resolves entries with the appropriate issue type" do
       f = formula "foo" do
+        T.bind(self, T.class_of(Formula))
         url "foo-1.0"
         patch do
           url "https://example.com/foo.diff"
@@ -1842,6 +1847,7 @@ RSpec.describe Formula do
 
     it "serialises type on a local file patch" do
       f = formula "foo" do
+        T.bind(self, T.class_of(Formula))
         url "foo-1.0"
         patch do
           file "Patches/foo.diff"
@@ -3259,6 +3265,7 @@ RSpec.describe Formula do
   describe "#std_zig_args" do
     let(:f) do
       formula do
+        T.bind(self, T.class_of(Formula))
         url "foo-1.0"
       end
     end
@@ -3280,6 +3287,7 @@ RSpec.describe Formula do
   describe "#common_sandbox_env" do
     let(:f) do
       formula do
+        T.bind(self, T.class_of(Formula))
         url "foo-1.0"
       end
     end

--- a/Library/Homebrew/test/formula_validation_spec.rb
+++ b/Library/Homebrew/test/formula_validation_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Formula do
     it "can't override the `brew` method" do
       expect do
         formula do
+          T.bind(self, T.class_of(Formula))
           def brew; end
         end
       end.to raise_error(
@@ -92,6 +93,7 @@ RSpec.describe Formula do
     it "fails when Formula is empty" do
       expect do
         formula do
+          T.bind(self, T.class_of(Formula))
           # do nothing
         end
       end.to raise_error(FormulaSpecificationError)

--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "language/python"
@@ -10,6 +10,7 @@ RSpec.describe Language::Python::Virtualenv, :needs_python do
     let(:f) do
       virtualenv_module = described_class
       formula "foo" do
+        T.bind(self, T.class_of(Formula))
         include virtualenv_module
 
         T.bind(self, T.class_of(Formula))

--- a/Library/Homebrew/test/os/linux/formula_spec.rb
+++ b/Library/Homebrew/test/os/linux/formula_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Formula do
 
     it "acts like #depends_on" do
       f = formula "foo" do
+        T.bind(self, T.class_of(Formula))
         url "foo-1.0"
 
         uses_from_macos("foo")
@@ -23,6 +24,7 @@ RSpec.describe Formula do
 
     it "ignores OS version specifications" do
       f = formula "foo" do
+        T.bind(self, T.class_of(Formula))
         url "foo-1.0"
 
         uses_from_macos "foo", since: :sequoia
@@ -36,6 +38,7 @@ RSpec.describe Formula do
   describe "#on_linux" do
     it "adds a dependency on Linux only" do
       f = formula do
+        T.bind(self, T.class_of(Formula))
         homepage "https://brew.sh"
 
         url "https://brew.sh/test-0.1.tbz"
@@ -59,6 +62,7 @@ RSpec.describe Formula do
 
     it "adds a patch on Linux only" do
       f = formula do
+        T.bind(self, T.class_of(Formula))
         homepage "https://brew.sh"
 
         url "https://brew.sh/test-0.1.tbz"
@@ -82,6 +86,7 @@ RSpec.describe Formula do
 
     it "uses on_linux within a resource block" do
       f = formula do
+        T.bind(self, T.class_of(Formula))
         homepage "https://brew.sh"
 
         url "https://brew.sh/test-0.1.tbz"

--- a/Library/Homebrew/test/os/mac/formula_spec.rb
+++ b/Library/Homebrew/test/os/mac/formula_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Formula do
 
     it "adds a macOS dependency to all specs if the OS version meets requirements" do
       f = formula "foo" do
+        T.bind(self, T.class_of(Formula))
         url "foo-1.0"
 
         uses_from_macos("foo", since: :big_sur)
@@ -28,6 +29,7 @@ RSpec.describe Formula do
 
     it "adds a dependency to any spec if the OS version doesn't meet requirements" do
       f = formula "foo" do
+        T.bind(self, T.class_of(Formula))
         url "foo-1.0"
 
         uses_from_macos("foo", since: :tahoe)
@@ -45,6 +47,7 @@ RSpec.describe Formula do
   describe "#on_macos" do
     it "adds a dependency on macos only" do
       f = formula do
+        T.bind(self, T.class_of(Formula))
         homepage "https://brew.sh"
 
         url "https://brew.sh/test-0.1.tbz"
@@ -68,6 +71,7 @@ RSpec.describe Formula do
 
     it "adds a patch on Mac only" do
       f = formula do
+        T.bind(self, T.class_of(Formula))
         homepage "https://brew.sh"
 
         url "https://brew.sh/test-0.1.tbz"
@@ -91,6 +95,7 @@ RSpec.describe Formula do
 
     it "uses on_macos within a resource block" do
       f = formula do
+        T.bind(self, T.class_of(Formula))
         homepage "https://brew.sh"
 
         url "https://brew.sh/test-0.1.tbz"

--- a/Library/Homebrew/test/patching_spec.rb
+++ b/Library/Homebrew/test/patching_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe "patching", type: :system do
   specify "single_patch_dsl" do
     expect(
       formula do
+        T.bind(self, T.class_of(Formula))
         patch do
           url "file://#{patch_fixture("noop-a")}"
           sha256 patch_fixture_sha256("noop-a")
@@ -113,6 +114,7 @@ RSpec.describe "patching", type: :system do
   specify "local_patch_dsl_resolves_path_loaded_formulae_from_formula_directory" do
     expect(
       formula(path: fixture("testball.rb")) do
+        T.bind(self, T.class_of(Formula))
         patch do
           file "patches/noop-a.diff"
         end
@@ -123,6 +125,7 @@ RSpec.describe "patching", type: :system do
   specify "local_patch_dsl_with_directory" do
     expect(
       formula(path: fixture("testball.rb")) do
+        T.bind(self, T.class_of(Formula))
         patch do
           file "patches/noop-b.diff"
           directory "libexec"
@@ -134,6 +137,7 @@ RSpec.describe "patching", type: :system do
   specify "local_patch_dsl_with_strip" do
     expect(
       formula(path: fixture("testball.rb")) do
+        T.bind(self, T.class_of(Formula))
         patch :p0 do
           file "patches/noop-b.diff"
         end
@@ -144,6 +148,7 @@ RSpec.describe "patching", type: :system do
   specify "local_patch_dsl_with_homebrew_prefix" do
     expect(
       formula(path: fixture("testball.rb")) do
+        T.bind(self, T.class_of(Formula))
         patch do
           file "patches/noop-d.diff"
         end
@@ -159,6 +164,7 @@ RSpec.describe "patching", type: :system do
 
     expect(
       formula(path: tap.path/"Formula/testball.rb", tap:) do
+        T.bind(self, T.class_of(Formula))
         patch do
           file "patches/noop-a.diff"
         end
@@ -170,6 +176,7 @@ RSpec.describe "patching", type: :system do
 
   specify "local_patch_dsl_missing_file_fail" do
     f = formula(path: fixture("testball.rb")) do
+      T.bind(self, T.class_of(Formula))
       patch do
         file "patches/missing.diff"
       end
@@ -181,6 +188,7 @@ RSpec.describe "patching", type: :system do
 
   specify "local_patch_dsl_directory_fail" do
     f = formula(path: fixture("testball.rb")) do
+      T.bind(self, T.class_of(Formula))
       patch do
         file "patches"
       end
@@ -198,6 +206,7 @@ RSpec.describe "patching", type: :system do
       FileUtils.ln_s tmpdir/"outside.diff", repository/"escape.diff"
 
       f = formula(path: repository/"testball.rb") do
+        T.bind(self, T.class_of(Formula))
         patch do
           file "escape.diff"
         end
@@ -211,6 +220,7 @@ RSpec.describe "patching", type: :system do
   specify "single_patch_dsl_for_resource" do
     expect(
       formula do
+        T.bind(self, T.class_of(Formula))
         resource "some_resource" do
           url "file://#{tarball_fixture("testball-0.1.tbz")}"
           sha256 tarball_fixture_sha256("testball-0.1.tbz")
@@ -227,6 +237,7 @@ RSpec.describe "patching", type: :system do
   specify "single_patch_dsl_with_apply" do
     expect(
       formula do
+        T.bind(self, T.class_of(Formula))
         patch do
           url "file://#{tarball_fixture("testball-0.1-patches.tgz")}"
           sha256 tarball_fixture_sha256("testball-0.1-patches.tgz")
@@ -239,6 +250,7 @@ RSpec.describe "patching", type: :system do
   specify "single_patch_dsl_with_sequential_apply" do
     expect(
       formula do
+        T.bind(self, T.class_of(Formula))
         patch do
           url "file://#{tarball_fixture("testball-0.1-patches.tgz")}"
           sha256 tarball_fixture_sha256("testball-0.1-patches.tgz")
@@ -251,6 +263,7 @@ RSpec.describe "patching", type: :system do
   specify "single_patch_dsl_with_strip" do
     expect(
       formula do
+        T.bind(self, T.class_of(Formula))
         patch :p1 do
           url "file://#{patch_fixture("noop-a")}"
           sha256 patch_fixture_sha256("noop-a")
@@ -261,6 +274,7 @@ RSpec.describe "patching", type: :system do
 
   specify "single_patch_dsl_with_strip_with_apply" do
     external_patch = formula do
+      T.bind(self, T.class_of(Formula))
       patch :p1 do
         url "file://#{tarball_fixture("testball-0.1-patches.tgz")}"
         sha256 tarball_fixture_sha256("testball-0.1-patches.tgz")
@@ -278,6 +292,7 @@ RSpec.describe "patching", type: :system do
   specify "single_patch_dsl_with_incorrect_strip" do
     expect do
       f = formula do
+        T.bind(self, T.class_of(Formula))
         patch :p0 do
           url "file://#{patch_fixture("noop-a")}"
           sha256 patch_fixture_sha256("noop-a")
@@ -291,6 +306,7 @@ RSpec.describe "patching", type: :system do
   specify "single_patch_dsl_with_incorrect_strip_with_apply" do
     expect do
       f = formula do
+        T.bind(self, T.class_of(Formula))
         patch :p0 do
           url "file://#{tarball_fixture("testball-0.1-patches.tgz")}"
           sha256 tarball_fixture_sha256("testball-0.1-patches.tgz")
@@ -305,6 +321,7 @@ RSpec.describe "patching", type: :system do
   specify "patch_p0_dsl" do
     expect(
       formula do
+        T.bind(self, T.class_of(Formula))
         patch :p0 do
           url "file://#{patch_fixture("noop-b")}"
           sha256 patch_fixture_sha256("noop-b")
@@ -316,6 +333,7 @@ RSpec.describe "patching", type: :system do
   specify "patch_p0_dsl_with_apply" do
     expect(
       formula do
+        T.bind(self, T.class_of(Formula))
         patch :p0 do
           url "file://#{tarball_fixture("testball-0.1-patches.tgz")}"
           sha256 tarball_fixture_sha256("testball-0.1-patches.tgz")
@@ -328,6 +346,7 @@ RSpec.describe "patching", type: :system do
   specify "patch_string" do
     expect(
       formula do
+        T.bind(self, T.class_of(Formula))
         patch File.read(patch_fixture("noop-a"))
       end,
     ).to be_patched
@@ -336,6 +355,7 @@ RSpec.describe "patching", type: :system do
   specify "patch_string_with_strip" do
     expect(
       formula do
+        T.bind(self, T.class_of(Formula))
         patch :p0, File.read(patch_fixture("noop-b"))
       end,
     ).to be_patched
@@ -344,6 +364,7 @@ RSpec.describe "patching", type: :system do
   specify "single_patch_dsl_missing_apply_fail" do
     expect(
       formula do
+        T.bind(self, T.class_of(Formula))
         patch do
           url "file://#{tarball_fixture("testball-0.1-patches.tgz")}"
           sha256 tarball_fixture_sha256("testball-0.1-patches.tgz")
@@ -355,6 +376,7 @@ RSpec.describe "patching", type: :system do
   specify "single_patch_dsl_with_apply_enoent_fail" do
     expect do
       f = formula do
+        T.bind(self, T.class_of(Formula))
         patch do
           url "file://#{tarball_fixture("testball-0.1-patches.tgz")}"
           sha256 tarball_fixture_sha256("testball-0.1-patches.tgz")
@@ -369,6 +391,7 @@ RSpec.describe "patching", type: :system do
   specify "patch_dsl_with_homebrew_prefix" do
     expect(
       formula do
+        T.bind(self, T.class_of(Formula))
         patch do
           url "file://#{patch_fixture("noop-d")}"
           sha256 patch_fixture_sha256("noop-d")

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Homebrew::Service do
 
   def stub_formula_with_service_sockets(sockets_var)
     stub_formula do
+      T.bind(self, T.class_of(Formula))
       service do
         run opt_bin/"beanstalkd"
         sockets sockets_var
@@ -28,6 +29,7 @@ RSpec.describe Homebrew::Service do
   describe "#std_service_path_env" do
     it "returns valid std_service_path_env" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           run_type :immediate
@@ -47,6 +49,7 @@ RSpec.describe Homebrew::Service do
   describe "#formula_opt_bin" do
     it "is available in service blocks" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run formula_opt_bin("foo")/"foo"
         end
@@ -59,6 +62,7 @@ RSpec.describe Homebrew::Service do
   describe "#process_type" do
     it "throws for unexpected type" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           process_type :cow
@@ -74,6 +78,7 @@ RSpec.describe Homebrew::Service do
   describe "#throttle_interval" do
     it "accepts a valid throttle_interval value" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           throttle_interval 5
@@ -85,6 +90,7 @@ RSpec.describe Homebrew::Service do
 
     it "includes throttle_interval value in plist output" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           throttle_interval 15
@@ -100,6 +106,7 @@ RSpec.describe Homebrew::Service do
     # https://gist.github.com/dabrahams/4092951#:~:text=Set%20%3CThrottleInterval%3E%20to,than%2010%20seconds.
     it "includes throttle_interval value of zero in plist output" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           throttle_interval 0
@@ -113,6 +120,7 @@ RSpec.describe Homebrew::Service do
 
     it "does not include throttle_interval in plist when not set" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
         end
@@ -126,6 +134,7 @@ RSpec.describe Homebrew::Service do
   describe "#stop_timeout" do
     it "accepts a valid stop_timeout value" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           stop_timeout 10
@@ -138,6 +147,7 @@ RSpec.describe Homebrew::Service do
     it "throws for negative stop_timeout" do
       expect do
         stub_formula do
+          T.bind(self, T.class_of(Formula))
           service do
             run opt_bin/"beanstalkd"
             stop_timeout(-5)
@@ -148,6 +158,7 @@ RSpec.describe Homebrew::Service do
 
     it "includes ExitTimeOut in plist output" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           stop_timeout 15
@@ -160,6 +171,7 @@ RSpec.describe Homebrew::Service do
 
     it "does not include ExitTimeOut in plist when not set" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
         end
@@ -171,6 +183,7 @@ RSpec.describe Homebrew::Service do
 
     it "includes TimeoutStopSec in systemd unit output" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           stop_timeout 20
@@ -183,6 +196,7 @@ RSpec.describe Homebrew::Service do
 
     it "does not include TimeoutStopSec in systemd unit when not set" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
         end
@@ -196,6 +210,7 @@ RSpec.describe Homebrew::Service do
   describe "#nice" do
     it "accepts a valid nice level" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           nice 5
@@ -208,6 +223,7 @@ RSpec.describe Homebrew::Service do
     it "throws error for negative nice values without require_root" do
       expect do
         stub_formula do
+          T.bind(self, T.class_of(Formula))
           service do
             run opt_bin/"beanstalkd"
             nice(-10)
@@ -218,6 +234,7 @@ RSpec.describe Homebrew::Service do
 
     it "allows negative nice values when require_root is set" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           require_root true
@@ -231,6 +248,7 @@ RSpec.describe Homebrew::Service do
 
     it "does not require require_root for positive nice values" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           nice 10
@@ -243,6 +261,7 @@ RSpec.describe Homebrew::Service do
 
     it "accepts nice value of zero" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           nice 0
@@ -255,6 +274,7 @@ RSpec.describe Homebrew::Service do
 
     it "includes nice value in plist output" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           nice 5
@@ -268,6 +288,7 @@ RSpec.describe Homebrew::Service do
 
     it "includes nice value in systemd unit output" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           require_root true
@@ -281,6 +302,7 @@ RSpec.describe Homebrew::Service do
 
     it "does not include nice in plist when not set" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
         end
@@ -292,6 +314,7 @@ RSpec.describe Homebrew::Service do
 
     it "does not include nice in systemd unit when not set" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
         end
@@ -304,6 +327,7 @@ RSpec.describe Homebrew::Service do
     it "throws for nice too low" do
       expect do
         stub_formula do
+          T.bind(self, T.class_of(Formula))
           service do
             run opt_bin/"beanstalkd"
             nice(-21)
@@ -315,6 +339,7 @@ RSpec.describe Homebrew::Service do
     it "throws for nice too high" do
       expect do
         stub_formula do
+          T.bind(self, T.class_of(Formula))
           service do
             run opt_bin/"beanstalkd"
             nice 20
@@ -327,6 +352,7 @@ RSpec.describe Homebrew::Service do
   describe "#keep_alive" do
     it "throws for unexpected keys" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           keep_alive test: "key"
@@ -342,6 +368,7 @@ RSpec.describe Homebrew::Service do
   describe "#requires_root?" do
     it "returns status when set" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           require_root true
@@ -353,6 +380,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns status when not set" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
         end
@@ -365,6 +393,7 @@ RSpec.describe Homebrew::Service do
   describe "#run_type" do
     it "throws for unexpected type" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           run_type :cow
@@ -422,6 +451,7 @@ RSpec.describe Homebrew::Service do
   describe "#manual_command" do
     it "returns valid manual_command" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run "#{HOMEBREW_PREFIX}/bin/beanstalkd"
           run_type :immediate
@@ -439,6 +469,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid manual_command without variables" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           run_type :immediate
@@ -458,6 +489,7 @@ RSpec.describe Homebrew::Service do
   describe "#path_dirs" do
     it "returns directories needed by service paths" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run [opt_bin/"beanstalkd", "-l", var/"run/beanstalkd.sock", "relative/path"]
           error_log_path var/"log/beanstalkd.error.log"
@@ -480,6 +512,7 @@ RSpec.describe Homebrew::Service do
   describe "#to_plist" do
     it "returns valid plist" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run [opt_bin/"beanstalkd", "test"]
           run_type :immediate
@@ -615,6 +648,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid plist with multiple sockets" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run [opt_bin/"beanstalkd", "test"]
           sockets socket: "tcp://0.0.0.0:80", socket_tls: "tcp://0.0.0.0:443"
@@ -673,6 +707,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid partial plist" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           run_type :immediate
@@ -709,6 +744,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid partial plist with run_at_load being false" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           run_type :immediate
@@ -746,6 +782,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid interval plist" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           run_type :interval
@@ -785,6 +822,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid cron plist" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           run_type :cron
@@ -829,6 +867,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid keepalive-exit plist" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           keep_alive successful_exit: false
@@ -870,6 +909,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid keepalive-crashed plist" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           keep_alive crashed: true
@@ -911,6 +951,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid keepalive-path plist" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           keep_alive path: opt_pkgshare/"test-path"
@@ -952,6 +993,7 @@ RSpec.describe Homebrew::Service do
 
     it "expands paths" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run [opt_sbin/"sleepwatcher", "-V", "-s", "~/.sleep", "-w", "~/.wakeup"]
           working_dir "~"
@@ -997,6 +1039,7 @@ RSpec.describe Homebrew::Service do
   describe "#to_systemd_unit" do
     it "returns valid unit" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run [opt_bin/"beanstalkd", "test"]
           run_type :immediate
@@ -1045,6 +1088,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid partial oneshot unit" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           run_type :immediate
@@ -1069,6 +1113,7 @@ RSpec.describe Homebrew::Service do
 
     it "expands paths" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           working_dir "~"
@@ -1093,6 +1138,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid unit with keep_alive crashed" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           keep_alive crashed: true
@@ -1117,6 +1163,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid unit with keep_alive successful_exit" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           keep_alive successful_exit: true
@@ -1141,6 +1188,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid unit with stop_timeout" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           stop_timeout 25
@@ -1165,6 +1213,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid unit without restart when keep_alive is false" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           keep_alive false
@@ -1190,6 +1239,7 @@ RSpec.describe Homebrew::Service do
   describe "#to_systemd_timer" do
     it "returns valid timer" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run [opt_bin/"beanstalkd", "test"]
           run_type :interval
@@ -1214,6 +1264,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns valid partial timer" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           run_type :immediate
@@ -1237,6 +1288,7 @@ RSpec.describe Homebrew::Service do
 
     it "throws on incomplete cron" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run opt_bin/"beanstalkd"
           run_type :cron
@@ -1262,6 +1314,7 @@ RSpec.describe Homebrew::Service do
 
       styles.each do |cron, calendar|
         f = stub_formula do
+          T.bind(self, T.class_of(Formula))
           service do
             run opt_bin/"beanstalkd"
             run_type :cron
@@ -1290,6 +1343,7 @@ RSpec.describe Homebrew::Service do
   describe "#timed?" do
     it "returns false for immediate" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run [opt_bin/"beanstalkd", "test"]
           run_type :immediate
@@ -1301,6 +1355,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns true for interval" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run [opt_bin/"beanstalkd", "test"]
           run_type :interval
@@ -1314,6 +1369,7 @@ RSpec.describe Homebrew::Service do
   describe "#keep_alive?" do
     it "returns true when keep_alive set to hash" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run [opt_bin/"beanstalkd", "test"]
           keep_alive crashed: true
@@ -1325,6 +1381,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns true when keep_alive set to true" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run [opt_bin/"beanstalkd", "test"]
           keep_alive true
@@ -1336,6 +1393,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns false when keep_alive not set" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run [opt_bin/"beanstalkd", "test"]
         end
@@ -1346,6 +1404,7 @@ RSpec.describe Homebrew::Service do
 
     it "returns false when keep_alive set to false" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run [opt_bin/"beanstalkd", "test"]
           keep_alive false
@@ -1359,6 +1418,7 @@ RSpec.describe Homebrew::Service do
   describe "#command" do
     it "returns @run data" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run [opt_bin/"beanstalkd", "test"]
           run_type :immediate
@@ -1378,6 +1438,7 @@ RSpec.describe Homebrew::Service do
 
       it "returns @run data" do
         f = stub_formula do
+          T.bind(self, T.class_of(Formula))
           service do
             run linux: [opt_bin/"beanstalkd", "test"]
             run_type :immediate
@@ -1390,6 +1451,7 @@ RSpec.describe Homebrew::Service do
 
       it "returns empty for macOS-only commands" do
         f = stub_formula do
+          T.bind(self, T.class_of(Formula))
           service do
             run macos: [opt_bin/"beanstalkd", "test"]
             run_type :immediate
@@ -1402,6 +1464,7 @@ RSpec.describe Homebrew::Service do
 
       it "returns the Linux command when both OS commands are defined" do
         f = stub_formula do
+          T.bind(self, T.class_of(Formula))
           service do
             run macos: [opt_bin/"beanstalkd", "test", "macos"], linux: [opt_bin/"beanstalkd", "test", "linux"]
             run_type :immediate
@@ -1422,6 +1485,7 @@ RSpec.describe Homebrew::Service do
 
       it "returns @run data" do
         f = stub_formula do
+          T.bind(self, T.class_of(Formula))
           service do
             run macos: [opt_bin/"beanstalkd", "test"]
             run_type :immediate
@@ -1434,6 +1498,7 @@ RSpec.describe Homebrew::Service do
 
       it "returns empty for Linux-only commands" do
         f = stub_formula do
+          T.bind(self, T.class_of(Formula))
           service do
             run linux: [opt_bin/"beanstalkd", "test"]
             run_type :immediate
@@ -1446,6 +1511,7 @@ RSpec.describe Homebrew::Service do
 
       it "returns the macOS command when both OS commands are defined" do
         f = stub_formula do
+          T.bind(self, T.class_of(Formula))
           service do
             run macos: [opt_bin/"beanstalkd", "test", "macos"], linux: [opt_bin/"beanstalkd", "test", "linux"]
             run_type :immediate
@@ -1477,6 +1543,7 @@ RSpec.describe Homebrew::Service do
     #       are not idempotent so they can only be used in one test.
     it "replaces local paths with placeholders" do
       f = stub_formula do
+        T.bind(self, T.class_of(Formula))
         service do
           run [opt_bin/"beanstalkd", "test"]
           environment_variables PATH: std_service_path_env

--- a/Library/Homebrew/test/vulns/osv_export_spec.rb
+++ b/Library/Homebrew/test/vulns/osv_export_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Homebrew::Vulns::OsvExport do
 
   let(:nvi) do
     formula("nvi") do
+      T.bind(self, T.class_of(Formula))
       url "https://deb.debian.org/debian/pool/main/n/nvi/nvi_1.81.6.orig.tar.gz"
       version "1.81.6"
       revision 6
@@ -26,6 +27,7 @@ RSpec.describe Homebrew::Vulns::OsvExport do
 
   let(:libquicktime) do
     formula("libquicktime") do
+      T.bind(self, T.class_of(Formula))
       url "https://downloads.sourceforge.net/project/libquicktime/libquicktime-1.2.4.tar.gz"
       revision 5
       patch do
@@ -74,6 +76,7 @@ RSpec.describe Homebrew::Vulns::OsvExport do
 
     it "emits file for local patches and drops entries with no locator" do
       f = formula("x") do
+        T.bind(self, T.class_of(Formula))
         url "https://example.com/x-1.0.tar.gz"
         patch do
           file "Patches/x/fix.patch"
@@ -124,6 +127,7 @@ RSpec.describe Homebrew::Vulns::OsvExport do
 
     it "percent-encodes @ in the purl but not the package name" do
       glibc = formula("glibc@2.13") do
+        T.bind(self, T.class_of(Formula))
         url "https://ftp.gnu.org/gnu/glibc/glibc-2.13.tar.gz"
         patch do
           url "https://example.com/fix.patch"
@@ -140,6 +144,7 @@ RSpec.describe Homebrew::Vulns::OsvExport do
 
     it "percent-encodes + in the purl" do
       libsigcxx = formula("libsigc++") do
+        T.bind(self, T.class_of(Formula))
         url "https://download.gnome.org/sources/libsigc++/3.6/libsigc++-3.6.0.tar.xz"
         patch do
           url "https://example.com/fix.patch"
@@ -163,6 +168,7 @@ RSpec.describe Homebrew::Vulns::OsvExport do
 
     it "omits the revision suffix when revision is zero" do
       f = formula("x") do
+        T.bind(self, T.class_of(Formula))
         url "https://example.com/x-1.0.tar.gz"
         patch do
           url "https://example.com/fix.patch"
@@ -247,6 +253,7 @@ RSpec.describe Homebrew::Vulns::OsvExport do
       let(:earlier) { Time.utc(2026, 6, 1, 0, 0, 0) }
       let(:nvi_bumped) do
         formula("nvi") do
+          T.bind(self, T.class_of(Formula))
           url "https://deb.debian.org/debian/pool/main/n/nvi/nvi_1.81.6.orig.tar.gz"
           version "1.81.6"
           revision 7

--- a/Library/Homebrew/test/vulns/scanner_spec.rb
+++ b/Library/Homebrew/test/vulns/scanner_spec.rb
@@ -164,6 +164,7 @@ RSpec.describe Homebrew::Vulns::Scanner do
   describe "#build_target" do
     it "derives repo from head and tag from stable version for a non-forge tarball" do
       curl = formula("curl") do
+        T.bind(self, T.class_of(Formula))
         url "https://curl.se/download/curl-8.5.0.tar.bz2"
         head "https://github.com/curl/curl.git"
       end
@@ -177,6 +178,7 @@ RSpec.describe Homebrew::Vulns::Scanner do
 
     it "queries a non-forge head URL verbatim when no candidate is a supported forge" do
       bash = formula("bash") do
+        T.bind(self, T.class_of(Formula))
         homepage "https://www.gnu.org/software/bash/"
         url "https://ftpmirror.gnu.org/gnu/bash/bash-5.3.tar.gz"
         head "https://git.savannah.gnu.org/git/bash.git"
@@ -190,6 +192,7 @@ RSpec.describe Homebrew::Vulns::Scanner do
 
     it "queries a non-forge stable URL verbatim when its path yields a tag" do
       thing = formula("thing") do
+        T.bind(self, T.class_of(Formula))
         url "https://gitea.example.com/owner/thing/archive/v1.2.3.tar.gz"
       end
 
@@ -201,6 +204,7 @@ RSpec.describe Homebrew::Vulns::Scanner do
 
     it "prefers an explicit stable tag over the derived version" do
       aom = formula("aom") do
+        T.bind(self, T.class_of(Formula))
         homepage "https://github.com/AomediaOrg/aom"
         url "https://aomedia.googlesource.com/aom.git", tag: "v3.13.1"
       end
@@ -213,6 +217,7 @@ RSpec.describe Homebrew::Vulns::Scanner do
 
     it "queries the SBOM versionInfo when the SBOM downloadLocation has no extractable tag" do
       curl = formula("curl") do
+        T.bind(self, T.class_of(Formula))
         url "https://curl.se/download/curl-8.5.0.tar.bz2"
         head "https://github.com/curl/curl.git"
       end
@@ -238,6 +243,7 @@ RSpec.describe Homebrew::Vulns::Scanner do
 
     it "queries a non-forge head URL verbatim when the SBOM downloadLocation host is unsupported" do
       bash = formula("bash") do
+        T.bind(self, T.class_of(Formula))
         homepage "https://www.gnu.org/software/bash/"
         url "https://ftpmirror.gnu.org/gnu/bash/bash-5.3.tar.gz"
         head "https://git.savannah.gnu.org/git/bash.git"
@@ -266,24 +272,28 @@ RSpec.describe Homebrew::Vulns::Scanner do
   describe "#scan" do
     let(:act) do
       formula("act") do
+        T.bind(self, T.class_of(Formula))
         url "https://github.com/nektos/act/archive/refs/tags/v0.2.84.tar.gz"
       end
     end
 
     let(:openssl) do
       formula("openssl@3") do
+        T.bind(self, T.class_of(Formula))
         url "https://github.com/openssl/openssl/releases/download/openssl-3.0.0/openssl-3.0.0.tar.gz"
       end
     end
 
     let(:unsupported) do
       formula("aom") do
+        T.bind(self, T.class_of(Formula))
         url "https://aomedia.googlesource.com/aom.git", tag: "v3.13.1"
       end
     end
 
     let(:libquicktime) do
       formula("libquicktime") do
+        T.bind(self, T.class_of(Formula))
         url "https://github.com/owner/libquicktime/archive/refs/tags/v1.2.4.tar.gz"
         patch do
           url "https://deb.debian.org/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-12.debian.tar.xz"
@@ -420,9 +430,11 @@ RSpec.describe Homebrew::Vulns::Scanner do
 
     it "does not conflate formulae with the same short name from different taps" do
       core_thing = formula("thing", tap: CoreTap.instance) do
+        T.bind(self, T.class_of(Formula))
         url "https://github.com/owner-a/thing/archive/refs/tags/v1.0.0.tar.gz"
       end
       tap_thing = formula("thing", tap: Tap.fetch("someone", "tap")) do
+        T.bind(self, T.class_of(Formula))
         url "https://github.com/owner-b/thing/archive/refs/tags/v2.0.0.tar.gz"
       end
       expect(core_thing.name).to eq tap_thing.name


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Copilot CLI with Claude Opus 5 (High). I've been doing a bunch of Sorbet typing work with it in srb-bump-more-tests which I'm now splitting out because otherwise it'll be a massive, unreviewable PR.

-----

- Increases the Sorbet typechecking for tests.
- Add more `T.bind(self, T.class_of(Formula))` to `formula(name) do` blocks.
- (Unlike #23318 we can't migrate these to the `def formula` test helper method because Sorbet doesn't support `T.bind` against a `class_of`.)
- Some of these mean immediate `typed: true` bumps, but a lot of them do not. The ones that do not, however, _do_ decrease the number of required fixes for other files to be bumped eventually, so let's go with it.