### PR TITLE
ReporterHub#select_formula_or_cask: fix type

### DIFF
--- a/Library/Homebrew/cmd/update_report/reporter_hub.rb
+++ b/Library/Homebrew/cmd/update_report/reporter_hub.rb
@@ -9,15 +9,15 @@ class ReporterHub
 
   sig { void }
   def initialize
-    @hash = T.let({}, T::Hash[Symbol, T::Array[T.any(String, [String, String])]])
+    @hash = T.let({}, T::Hash[Symbol, T.any(T::Array[String], T::Array[[String, String]])])
     @reporters = T.let([], T::Array[Reporter])
   end
 
-  sig { params(key: Symbol).returns(T::Array[String]) }
+  sig { params(key: Symbol).returns(T.any(T::Array[String], T::Array[[String, String]])) }
   def select_formula_or_cask(key)
     raise "Unsupported key #{key}" unless [:A, :AC, :D, :DC, :M, :MC, :R, :RC, :T].include?(key)
 
-    T.cast(@hash.fetch(key, []), T::Array[String])
+    @hash.fetch(key, [])
   end
 
   sig { returns(T::Array[[String, String]]) }
@@ -99,7 +99,7 @@ class ReporterHub
 
   sig { void }
   def dump_new_formula_report
-    formulae = select_formula_or_cask(:A).sort.reject { |name| installed?(name) }
+    formulae = T.cast(select_formula_or_cask(:A), T::Array[String]).sort.reject { |name| installed?(name) }
     return if formulae.blank?
 
     ohai "New Formulae"
@@ -121,7 +121,7 @@ class ReporterHub
   def dump_new_cask_report
     return unless Cask::Caskroom.any_casks_installed?
 
-    casks = select_formula_or_cask(:AC).sort.reject { |name| cask_installed?(name) }
+    casks = T.cast(select_formula_or_cask(:AC), T::Array[String]).sort.reject { |name| cask_installed?(name) }
     return if casks.blank?
 
     ohai "New Casks"
@@ -142,7 +142,7 @@ class ReporterHub
 
   sig { void }
   def dump_deleted_formula_report
-    formulae = select_formula_or_cask(:D).sort.filter_map do |name|
+    formulae = T.cast(select_formula_or_cask(:D), T::Array[String]).sort.filter_map do |name|
       pretty_uninstalled(name) if installed?(name)
     end
 
@@ -153,7 +153,7 @@ class ReporterHub
   def dump_deleted_cask_report
     return if Homebrew::SimulateSystem.simulating_or_running_on_linux?
 
-    casks = select_formula_or_cask(:DC).sort.filter_map do |name|
+    casks = T.cast(select_formula_or_cask(:DC), T::Array[String]).sort.filter_map do |name|
       name = Utils.name_from_full_name(name)
       pretty_uninstalled(name) if cask_installed?(name)
     end

--- a/Library/Homebrew/description_cache_store.rb
+++ b/Library/Homebrew/description_cache_store.rb
@@ -56,14 +56,20 @@ class DescriptionCacheStore < CacheStore
     return populate_if_empty! if database.empty?
     return if report.empty?
 
-    renamings   = T.cast(report.select_formula_or_cask(:R), T::Array[T::Array[String]])
-    alterations = report.select_formula_or_cask(:A) +
-                  report.select_formula_or_cask(:M) +
-                  renamings.filter_map(&:last)
+    renamings = T.cast(report.select_formula_or_cask(:R), T::Array[[String, String]])
+    alterations = T.cast(
+      report.select_formula_or_cask(:A) +
+      report.select_formula_or_cask(:M) +
+      renamings.filter_map(&:last),
+      T::Array[String],
+    )
+    deletions = T.cast(
+      report.select_formula_or_cask(:D) + renamings.filter_map(&:first),
+      T::Array[String],
+    )
 
     update_from_formula_names!(alterations)
-    delete_from_formula_names!(report.select_formula_or_cask(:D) +
-                               renamings.filter_map(&:first))
+    delete_from_formula_names!(deletions)
   end
 
   # Use an array of formula names to update the {DescriptionCacheStore}.

--- a/Library/Homebrew/description_cache_store/cask_description_cache_store.rb
+++ b/Library/Homebrew/description_cache_store/cask_description_cache_store.rb
@@ -36,11 +36,15 @@ class CaskDescriptionCacheStore < DescriptionCacheStore
     return populate_if_empty! if database.empty?
     return if report.empty?
 
-    alterations = report.select_formula_or_cask(:AC) +
-                  report.select_formula_or_cask(:MC)
+    alterations = T.cast(
+      report.select_formula_or_cask(:AC) +
+      report.select_formula_or_cask(:MC),
+      T::Array[String],
+    )
+    deletions = T.cast(report.select_formula_or_cask(:DC), T::Array[String])
 
     update_from_cask_tokens!(alterations)
-    delete_from_cask_tokens!(report.select_formula_or_cask(:DC))
+    delete_from_cask_tokens!(deletions)
   end
 
   # Use an array of cask tokens to update the {CaskDescriptionCacheStore}.


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`ReporterHub#select_formula_or_cask` has a method signature suggesting that it only returns an array of strings and it uses `T.cast` internally but the array values from `@hash` can be a string or `[String, String]` array. The latter occurs when the `:R` key is used to represent a package rename, where the first string in the array is the previous name and the second string is the new/current name. `select_formula_or_cask(:R)` is used in the
`DescriptionCacheStore#update_from_report!` method and this produces a type error when the `HOMEBREW_SORBET_RECURSIVE=1` environment variable is set and a renamed package is updated, as the aforementioned `T.cast(..., T::Array[String])` in `select_formula_or_cask` is incorrect in this scenario.

This addresses the issue by updating the `@hash` type, aligning the return type of `select_formula_or_cask`, and removing the cast inside the method. This predictably causes `brew typecheck` to surface type errors in areas where `select_formula_or_cask` is called and the value isn't cast, as Sorbet doesn't know whether the value is an array of strings or `[String, String]` based on the argument. I've accounted for this by adding `T.cast` calls to the related areas to define the type.