### PR TITLE
tap: require `trust` in `Tap#to_hash`

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1162,6 +1162,8 @@ class Tap
 
   sig { returns(T::Hash[String, T.untyped]) }
   def to_hash
+    require "trust"
+
     hash = {
       "name"          => name,
       "user"          => user,

--- a/Library/Homebrew/test/cmd/tap-info_spec.rb
+++ b/Library/Homebrew/test/cmd/tap-info_spec.rb
@@ -7,10 +7,18 @@ require "cmd/tap-info"
 RSpec.describe Homebrew::Cmd::TapInfo do
   it_behaves_like "parseable arguments"
 
-  it "gets information for a given Tap", :integration_test, :needs_network do
+  it "gets information for a given Tap", :integration_test do
     setup_test_tap
 
-    expect { brew "tap-info", "--json=v1", "--installed" }
+    # Run without the Sorbet runtime so this exercises the same `require` graph as
+    # a real `brew tap-info`, which loads fewer files.
+    brew_env = {
+      "HOMEBREW_SORBET_RUNTIME"   => nil,
+      "HOMEBREW_SORBET_RECURSIVE" => nil,
+      "HOMEBREW_NO_GITHUB_API"    => "1",
+    }
+
+    expect { brew "tap-info", "--json=v1", "--installed", brew_env }
       .to output(%r{https://github\.com/Homebrew/homebrew-foo}).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success


### PR DESCRIPTION
- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Opus 5 xhigh with manual review and testing.

-----

Fixes

```
❯ /opt/homebrew/bin/brew tap-info --installed --json=v1
Error: uninitialized constant Homebrew::Trust
/opt/homebrew/Library/Homebrew/tap.rb:1173:in 'Tap#to_hash'
/opt/homebrew/Library/Homebrew/utils.rb:88:in 'block (2 levels) in Utils.parallel_map'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
```

Also, adjust the tests to ensure this is caught next time. Unit tests can't
catch this because the missing `require` from `#to_hash` is `require`d during
the tests.
