### PR TITLE
test/os/mac/keg: require `macho`

### DIFF
--- a/Library/Homebrew/test/os/mac/keg_spec.rb
+++ b/Library/Homebrew/test/os/mac/keg_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "keg"
+require "macho"
 
 RSpec.describe Keg do
   subject(:keg) { described_class.new(keg_path) }


### PR DESCRIPTION
- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Opus 5 xhigh with manual review and testing.

-----

Fixes

```
  1) Keg#codesign_patched_binary signs patched binaries using ruby-macho
     Failure/Error: expect(MachO).to receive(:codesign!).with(file)

     NameError:
       uninitialized constant MachO
     # ./test/os/mac/keg_spec.rb:48:in 'block (3 levels) in <top (required)>'
```

https://github.com/Homebrew/brew/actions/runs/30348581931/job/90241094273?pr=23333#step:12:56
