### PR TITLE
Support Landlock ABI 2 on Linux kernel 6.1

### DIFF
--- a/Library/Homebrew/extend/os/linux/sandbox/landlock.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox/landlock.rb
@@ -54,10 +54,19 @@ class Sandbox
     ACCESS_NET_BIND_UDP = 0x04
     ACCESS_NET_CONNECT_SEND_UDP = 0x08
     SCOPE_ABSTRACT_UNIX_SOCKET = 0x01
-    # ABI 3 is the first version that can restrict both cross-directory
-    # renames and truncation:
+    # ABI 2 is the first version that can permit cross-directory renames and
+    # links, which earlier ABIs always deny for sandboxed processes:
     # https://www.kernel.org/doc/html/latest/userspace-api/landlock.html#previous-limitations
-    MINIMUM_ABI = 3
+    MINIMUM_ABI = 2
+    # File truncation cannot be restricted before ABI 3, letting sandboxed
+    # processes truncate files outside allowed write paths. Every profile
+    # needs write isolation, so unlike `@deny_all_network` there is no
+    # profile-specific check that could gate a warning:
+    # https://www.kernel.org/doc/html/latest/userspace-api/landlock.html#previous-limitations
+    MINIMUM_TRUNCATE_ABI = 3
+    # TCP bind and connect restrictions were added in ABI 4:
+    # https://www.kernel.org/doc/html/latest/userspace-api/landlock.html#network-flags
+    MINIMUM_NETWORK_ABI = 4
     # UDP controls required to block all network access were added in ABI 10:
     # https://www.kernel.org/doc/html/latest/userspace-api/landlock.html#network-flags
     MINIMUM_FULL_NETWORK_ABI = 10
@@ -80,8 +89,8 @@ class Sandbox
                      :ACCESS_FS_IOCTL_DEV,
                      :ACCESS_NET_BIND_TCP, :ACCESS_NET_CONNECT_TCP, :ACCESS_NET_BIND_UDP,
                      :ACCESS_NET_CONNECT_SEND_UDP, :SCOPE_ABSTRACT_UNIX_SOCKET, :MINIMUM_ABI,
-                     :MINIMUM_FULL_NETWORK_ABI, :WRITE_ACCESS_FS, :FILE_WRITE_ACCESS_FS, :FILE_READ_ACCESS_FS,
-                     :READ_ACCESS_FS
+                     :MINIMUM_TRUNCATE_ABI, :MINIMUM_NETWORK_ABI, :MINIMUM_FULL_NETWORK_ABI,
+                     :WRITE_ACCESS_FS, :FILE_WRITE_ACCESS_FS, :FILE_READ_ACCESS_FS, :READ_ACCESS_FS
 
     class << self
       # Landlock cannot restrict chmod, chown, extended attributes or timestamp
@@ -321,8 +330,13 @@ class Sandbox
       end
 
       if @deny_all_network && abi < MINIMUM_FULL_NETWORK_ABI
+        network_restrictions = if abi >= MINIMUM_NETWORK_ABI
+          "Applying the network restrictions supported by this kernel."
+        else
+          "This kernel cannot restrict network access."
+        end
         opoo "Landlock ABI #{MINIMUM_FULL_NETWORK_ABI} or later is required to deny all network access; " \
-             "found ABI #{abi}. Applying the network restrictions supported by this kernel."
+             "found ABI #{abi}. #{network_restrictions}"
       end
 
       attributes, handled_access_fs, allowed_write_access_fs = ruleset_attributes(abi)
@@ -357,7 +371,7 @@ class Sandbox
         device_path_rules.each do |path, allowed_access|
           next unless File.exist?(path)
 
-          add_path_rule(ruleset_fd, path, allowed_access)
+          add_path_rule(ruleset_fd, path, allowed_access & handled_access_fs)
         end
 
         error_pipe_path = @error_pipe_path
@@ -389,8 +403,8 @@ class Sandbox
     sig { params(abi: Integer).returns([String, Integer, Integer]) }
     def ruleset_attributes(abi)
       allowed_access_fs = WRITE_ACCESS_FS
-      allowed_access_fs |= ACCESS_FS_REFER if abi >= 2
-      allowed_access_fs |= ACCESS_FS_TRUNCATE if abi >= 3
+      allowed_access_fs |= ACCESS_FS_REFER if abi >= MINIMUM_ABI
+      allowed_access_fs |= ACCESS_FS_TRUNCATE if abi >= MINIMUM_TRUNCATE_ABI
       handled_access_fs = allowed_access_fs
       # IOCTL_DEV is available from ABI 5 and deliberately remains absent from
       # allowed path rules, denying device ioctls opened inside the sandbox:
@@ -402,7 +416,7 @@ class Sandbox
       # Optional ruleset fields are appended as `__u64` members, so only pass
       # the prefix needed for features supported by the running kernel.
       attributes = [handled_access_fs]
-      if @deny_all_network && abi >= 4
+      if @deny_all_network && abi >= MINIMUM_NETWORK_ABI
         handled_access_net = ACCESS_NET_BIND_TCP | ACCESS_NET_CONNECT_TCP
         handled_access_net |= ACCESS_NET_BIND_UDP | ACCESS_NET_CONNECT_SEND_UDP if abi >= MINIMUM_FULL_NETWORK_ABI
         attributes << handled_access_net

--- a/Library/Homebrew/test/sandbox_landlock_spec.rb
+++ b/Library/Homebrew/test/sandbox_landlock_spec.rb
@@ -63,13 +63,19 @@ RSpec.describe Sandbox::Landlock do
       expect(described_class.failure_reason).to include("Fiddle")
     end
 
-    it "returns false for an ABI without truncate restrictions" do
+    it "is available for an ABI without truncate restrictions" do
       allow(described_class).to receive(:landlock_create_ruleset).with(nil, 0, 1).and_return(2)
+
+      expect(described_class).to be_available
+    end
+
+    it "returns false for an ABI that always denies cross-directory renames" do
+      allow(described_class).to receive(:landlock_create_ruleset).with(nil, 0, 1).and_return(1)
 
       expect(described_class).not_to be_available
       expect(described_class.state).to eq(:unsupported_abi)
-      expect(described_class.abi_version).to eq(2)
-      expect(described_class.failure_reason).to eq("Landlock ABI 3 or later is required; found ABI 2.")
+      expect(described_class.abi_version).to eq(1)
+      expect(described_class.failure_reason).to eq("Landlock ABI 2 or later is required; found ABI 1.")
     end
 
     it "only raises when explicitly configuring unavailable Landlock" do
@@ -116,13 +122,13 @@ RSpec.describe Sandbox::Landlock do
       allow(File).to receive(:exist?).with("/dev/tty").and_return(false)
     end
 
-    it "rejects an ABI without complete write restrictions" do
-      allow(described_class).to receive_messages(abi_version:    2,
-                                                 failure_reason: "Landlock ABI 3 or later is required; found ABI 2.")
+    it "rejects an ABI without cross-directory rename restrictions" do
+      allow(described_class).to receive_messages(abi_version:    1,
+                                                 failure_reason: "Landlock ABI 2 or later is required; found ABI 1.")
       expect(described_class).not_to receive(:landlock_create_ruleset)
 
       expect { landlock.apply! }
-        .to raise_error(RuntimeError, "Landlock ABI 3 or later is required; found ABI 2.")
+        .to raise_error(RuntimeError, "Landlock ABI 2 or later is required; found ABI 1.")
     end
 
     it "restricts writes and network access using the supported ABI" do
@@ -317,6 +323,49 @@ RSpec.describe Sandbox::Landlock do
         attributes, = landlock.ruleset_attributes(7)
 
         expect(attributes.unpack("Q3")).to eq([65_522, 3, 1])
+      end
+    end
+
+    context "with the oldest supported ABI" do
+      before do
+        allow(landlock).to receive(:open_path).and_return(18)
+        allow(described_class).to receive_messages(abi_version: 2, landlock_create_ruleset: 17, landlock_add_rule: 0,
+                                                   set_no_new_privileges: 0, landlock_restrict_self: 0)
+        allow(landlock).to receive(:close_file_descriptor)
+      end
+
+      it "does not warn without network denial" do
+        landlock.command(["true"], tmpdir.to_s)
+
+        expect { landlock.apply! }.not_to output.to_stderr
+      end
+
+      it "warns that network access cannot be restricted" do
+        sandbox.deny_all_network
+        landlock.command(["true"], tmpdir.to_s)
+
+        expect { landlock.apply! }
+          .to output(/found ABI 2\. This kernel cannot restrict network access/).to_stderr
+      end
+
+      it "omits unsupported access rights from device path rules" do
+        allow(File).to receive(:exist?).with("/dev/full").and_return(true)
+        landlock.command(["true"], tmpdir.to_s)
+
+        expect(landlock).to receive(:open_path).with("/dev/full").and_return(19)
+        expect(described_class).to receive(:landlock_add_rule)
+          .with(17, 1, [2, 19].pack("Ql"), 0).and_return(0)
+
+        landlock.apply!
+      end
+
+      it "handles only the supported filesystem access rights" do
+        sandbox.deny_all_network
+        landlock.command(["true"], tmpdir.to_s)
+
+        attributes, = landlock.ruleset_attributes(2)
+
+        expect(attributes.unpack("Q*")).to eq([16_370])
       end
     end
   end


### PR DESCRIPTION
- Amazon Fargate's kernel 6.1 only provides Landlock ABI 2, which the previous `MINIMUM_ABI` of 3 rejected outright.
- ABI 2 can still permit cross-directory renames via `ACCESS_FS_REFER`; it only lacks `ACCESS_FS_TRUNCATE`, noted on `MINIMUM_TRUNCATE_ABI` as truncation has no profile rule that could gate a warning.
- Mask device path rules with `handled_access_fs` so the `/dev/full` truncate bit no longer makes `landlock_add_rule(2)` fail with `EINVAL` on ABI 2.
- Warn that network access cannot be restricted at all below ABI 4 rather than implying partial restrictions were applied.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude 5 Fable max with local review and (macOS unit) testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
