### PR TITLE
cask/audit: require "macho" before use

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -942,6 +942,7 @@ module Cask
             next unless (main_binary = get_plist_main_binary(app_bundle_path))
             next if !File.exist?(main_binary) || File.open(main_binary, "rb") { |f| f.read(2) == "#!" }
 
+            require "macho"
             macho = MachO.open(main_binary)
             min_os = case macho
             when MachO::MachOFile


### PR DESCRIPTION


-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb). <!-- One-line require fix; the existing `cask/audit` specs exercise this code path and pass. No new isolated test added since the failure only manifests via an online bundle download. -->
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- Claude Code assisted: located the missing require, applied the fix, ran brew lgtm --online and the emacs-app@nightly online audit. Changes were reviewed and verified by me (single-line require matching os/mac/mach.rb). -->

-----


Fixes `uninitialized constant Cask::Audit::MachO` raised during online cask audits.

## What

`Cask::Audit#min_os_from_bundle` calls `MachO.open` (added in #20119) but the `macho` gem was never required in this scope, so the constant is undefined when the min-OS binary check runs. This loads the gem lazily inline, matching the existing pattern in `os/mac/mach.rb` (which requires it at point of use to keep it off the Linux load path).

## Why

Any `brew audit --cask --online` that reaches the binary min-OS check crashes instead of auditing. This is currently breaking automated cask bump CI.

## Reproduce

Surfaced by Homebrew/homebrew-cask#277654 ([failed CI run](https://github.com/Homebrew/homebrew-cask/actions/runs/30350989016/job/90248383630)):

```
brew audit --cask --online emacs-app@nightly
...
exception while auditing emacs-app@nightly: uninitialized constant Cask::Audit::MachO
```

After this change the same command audits without raising.