### PR TITLE
Fix GitHub release version detection

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -997,10 +997,11 @@ module Homebrew
       current_version_scheme = formula.version_scheme
 
       previous_version_info, base_ref_version_info = committed_version_info
+      return unless (base_ref_version = base_ref_version_info[:version])
 
-      if (base_ref_version = base_ref_version_info[:version]) &&
-         current_version < base_ref_version &&
-         current_version_scheme == previous_version_info[:version_scheme]
+      if current_version == base_ref_version && current_version.to_s != base_ref_version.to_s
+        problem "Stable: version should not change from #{base_ref_version} to #{current_version}"
+      elsif current_version < base_ref_version && current_version_scheme == previous_version_info[:version_scheme]
         problem "Stable: version should not decrease (from #{base_ref_version} to #{current_version})"
       end
     end

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -1427,6 +1427,12 @@ RSpec.describe Homebrew::FormulaAuditor do
     end
 
     describe "versions" do
+      context "when uncommitted should not change formatting" do
+        before { formula_gsub "foo-1.0.tar.gz", "foo-1.0.0.tar.gz" }
+
+        it { is_expected.to match("Stable: version should not change from 1.0 to 1.0.0") }
+      end
+
       context "when uncommitted should not decrease" do
         before { formula_gsub "foo-1.0.tar.gz", "foo-0.9.tar.gz" }
 

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -691,6 +691,12 @@ RSpec.describe Version do
         .to be_detected_from("https://wwwlehre.dhbw-stuttgart.de/~sschulz/WORK/E_DOWNLOAD/V_1.9/E.tgz")
     end
 
+    specify "GitHub release tag takes precedence over asset filename" do
+      url = "https://github.com/dvorka-oss/hstr/releases/download/v3.2/hstr-3.2.0-tarball.tgz"
+
+      expect(described_class.detect(url).to_s).to eq("3.2")
+    end
+
     specify "w.x.y.z url-only version style" do
       expect(described_class.new("2.3.2.0"))
         .to be_detected_from("https://github.com/JustArchi/ArchiSteamFarm/releases/download/2.3.2.0/ASF.zip")

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -388,6 +388,10 @@ class Version
     # e.g. `https://github.com/petdance/ack/tarball/1.93_02`
     UrlParser.new(%r{github\.com/.+/(?:zip|tar)ball/(?:v|\w+-)?((?:\d+[._-])+\d*)$}),
 
+    # GitHub releases
+    # e.g. `https://github.com/foo/bar/releases/download/v1.2/foo-1.2.0.tar.gz`
+    UrlParser.new(%r{github\.com/.+/releases/download/(?:[rvV]_?)?(#{NUMERIC_WITH_DOTS})/}),
+
     # e.g. `https://github.com/erlang/otp/tarball/OTP_R15B01 (erlang style)`
     UrlParser.new(/[_-]([Rr]\d+[AaBb]\d*(?:-\d+)?)/),
 


### PR DESCRIPTION
- Prefer numeric release tags over asset filename versions.
- Audit equivalent versions with different string forms.

Fixes Homebrew/brew#23336.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 Sol xhigh with local review and testing.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
