### PR TITLE
Group `on_system_conditional` after `os`

### DIFF
--- a/Library/Homebrew/rubocops/cask/constants/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/constants/stanza.rb
@@ -20,9 +20,8 @@ module RuboCop
 
       STANZA_GROUPS = T.let(
         [
-          [:arch, :on_arch_conditional, :os],
+          [:arch, :on_arch_conditional, :os, :on_system_conditional],
           [:version, :sha256],
-          [:on_system_conditional],
           ON_SYSTEM_METHODS_STANZA_ORDER,
           [:language],
           [:url, :appcast, :name, :desc, :homepage],

--- a/Library/Homebrew/rubocops/cask/stanza_grouping.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_grouping.rb
@@ -45,6 +45,10 @@ module RuboCop
             next if !stanza || !next_stanza
 
             if missing_line_after?(stanza, next_stanza)
+              next if [stanza, next_stanza].any? do |candidate|
+                candidate.stanza_name == :os
+              end
+
               add_offense_missing_line(stanza)
             elsif extra_line_after?(stanza, next_stanza)
               next if [stanza, next_stanza].any? do |candidate|

--- a/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
@@ -4,11 +4,10 @@
 require "rubocops/rubocop-cask"
 
 RSpec.describe RuboCop::Cop::Cask::StanzaOrder, :config do
-  it "registers system conditionals after version stanzas" do
-    expect(RuboCop::Cask::Constants::STANZA_GROUPS.take(3)).to eq([
-      [:arch, :on_arch_conditional, :os],
+  it "registers system conditionals after os stanzas" do
+    expect(RuboCop::Cask::Constants::STANZA_GROUPS.take(2)).to eq([
+      [:arch, :on_arch_conditional, :os, :on_system_conditional],
       [:version, :sha256],
-      [:on_system_conditional],
     ])
   end
 


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Needed before merging:

- https://github.com/Homebrew/homebrew-cask/pull/277510
- https://github.com/Homebrew/homebrew-cask/pull/277547
- https://github.com/Homebrew/homebrew-cask/pull/277548
- https://github.com/Homebrew/homebrew-cask/pull/277549
- https://github.com/Homebrew/homebrew-cask/pull/277550
- https://github.com/Homebrew/brew/pull/23321

Temporarely disables `missing_line_after?` check for `os` stanza. Will be reverted in https://github.com/Homebrew/brew/pull/23321.