### PR TITLE
DownloadLock: wait for another process's download instead of failing

### DIFF
--- a/Library/Homebrew/download_strategy/curl_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/curl_download_strategy.rb
@@ -39,7 +39,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     download_lock = DownloadLock.new(temporary_path)
     begin
-      download_lock.lock
+      download_lock.lock_or_wait(quiet: quiet?, timeout: Utils::Timer.remaining(end_time))
 
       urls = [url, *mirrors]
 

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -490,15 +490,20 @@ class TapRedirectNotAllowedError < RuntimeError; end
 
 # Raised when another Homebrew operation is already in progress.
 class OperationInProgressError < RuntimeError
-  sig { params(locked_path: Pathname).void }
-  def initialize(locked_path)
+  sig { params(locked_path: Pathname, waited: T.nilable(Integer)).void }
+  def initialize(locked_path, waited: nil)
     full_command = Homebrew.running_command_with_args.presence || "brew"
     lock_context = if (env_lock_context = Homebrew::EnvConfig.lock_context.presence)
       "\n#{env_lock_context}"
     end
+    advice = if waited
+      "Gave up after waiting #{waited} seconds. Terminate it to continue."
+    else
+      "Please wait for it to finish or terminate it to continue."
+    end
     message = <<~EOS
       A `#{full_command}` process has already locked #{locked_path}.#{lock_context}
-      Please wait for it to finish or terminate it to continue.
+      #{advice}
     EOS
 
     super message

--- a/Library/Homebrew/lock_file.rb
+++ b/Library/Homebrew/lock_file.rb
@@ -14,6 +14,9 @@ class LockFile
   sig { returns(Pathname) }
   attr_reader :path
 
+  sig { returns(Pathname) }
+  attr_reader :locked_path
+
   sig { params(type: Symbol, locked_path: Pathname).void }
   def initialize(type, locked_path)
     @locked_path = locked_path

--- a/Library/Homebrew/lock_file/download_lock.rb
+++ b/Library/Homebrew/lock_file/download_lock.rb
@@ -3,8 +3,34 @@
 
 # A lock file for a download.
 class DownloadLock < LockFile
+  MAX_WAIT_SECONDS = 180
+
   sig { params(download_path: Pathname).void }
   def initialize(download_path)
     super(:download, download_path)
+  end
+
+  # Waits for another process's download to finish instead of failing immediately.
+  # `quiet:` suppresses the warning when the caller is already rendering its own
+  # progress, since an unscheduled write desyncs `DownloadQueue`'s redraw.
+  sig { params(quiet: T::Boolean, timeout: T.nilable(T.any(Integer, Float))).void }
+  def lock_or_wait(quiet: false, timeout: nil)
+    max_wait = MAX_WAIT_SECONDS
+    max_wait = timeout if timeout && timeout < max_wait
+    waiting_since = T.let(nil, T.nilable(Time))
+    begin
+      lock
+    rescue OperationInProgressError
+      if waiting_since.nil?
+        waiting_since = Time.now
+        opoo "Waiting for another Homebrew process to finish downloading #{locked_path}..." unless quiet
+      end
+
+      waited = Time.now - waiting_since
+      raise OperationInProgressError.new(locked_path, waited: waited.round) if waited >= max_wait
+
+      sleep 0.1
+      retry
+    end
   end
 end

--- a/Library/Homebrew/test/lock_file/download_lock_spec.rb
+++ b/Library/Homebrew/test/lock_file/download_lock_spec.rb
@@ -1,0 +1,90 @@
+# typed: true
+# frozen_string_literal: true
+
+require "lock_file/download_lock"
+
+RSpec.describe DownloadLock do
+  subject(:download_lock) { described_class.new(Pathname("foo-download")) }
+
+  let(:download_lock_copy) { described_class.new(Pathname("foo-download")) }
+
+  after do
+    download_lock.unlock
+    download_lock_copy.unlock
+  end
+
+  describe "#lock_or_wait" do
+    it "acquires the lock immediately when uncontended" do
+      expect { download_lock.lock_or_wait }.not_to raise_error
+    end
+
+    it "waits for another instance's lock to release, then acquires it" do
+      download_lock.lock
+      allow(download_lock_copy).to receive(:sleep) { download_lock.unlock }
+
+      expect { download_lock_copy.lock_or_wait }.not_to raise_error
+    end
+
+    it "retries until the other instance's lock is released" do
+      download_lock.lock
+      attempts = 0
+      allow(download_lock_copy).to receive(:sleep) do
+        attempts += 1
+        download_lock.unlock if attempts >= 3
+      end
+
+      download_lock_copy.lock_or_wait
+
+      expect(attempts).to eq(3)
+    end
+
+    it "warns only once no matter how many attempts it takes" do
+      download_lock.lock
+      attempts = 0
+      allow(download_lock_copy).to receive(:sleep) do
+        attempts += 1
+        download_lock.unlock if attempts >= 3
+      end
+
+      expect(download_lock_copy).to receive(:opoo).once.with(
+        /Waiting for another Homebrew process to finish downloading/,
+      ).and_call_original
+
+      download_lock_copy.lock_or_wait
+    end
+
+    it "stays silent while waiting when quiet" do
+      download_lock.lock
+      allow(download_lock_copy).to receive(:sleep) { download_lock.unlock }
+
+      expect { download_lock_copy.lock_or_wait(quiet: true) }.not_to output.to_stderr
+    end
+
+    it "gives up and raises the original error once the maximum wait time passes" do
+      stub_const("DownloadLock::MAX_WAIT_SECONDS", 0)
+      download_lock.lock
+      allow(download_lock_copy).to receive(:sleep)
+
+      expect { download_lock_copy.lock_or_wait(quiet: true) }.to raise_error(OperationInProgressError)
+    end
+
+    it "reports how long it waited when giving up" do
+      stub_const("DownloadLock::MAX_WAIT_SECONDS", 0)
+      download_lock.lock
+      allow(download_lock_copy).to receive(:sleep)
+
+      expect do
+        download_lock_copy.lock_or_wait(quiet: true)
+      end.to raise_error(/Gave up after waiting \d+ seconds/)
+    end
+
+    it "waits no longer than the caller's remaining time", timeout: 5 do
+      download_lock.lock
+      allow(download_lock_copy).to receive(:sleep)
+
+      expect do
+        download_lock_copy.lock_or_wait(quiet: true, timeout: 0)
+      end.to raise_error(OperationInProgressError)
+    end
+  end
+end

--- a/Library/Homebrew/test/lock_file_spec.rb
+++ b/Library/Homebrew/test/lock_file_spec.rb
@@ -28,6 +28,20 @@ RSpec.describe LockFile do
         lock_file_copy.lock
       end.to raise_error(OperationInProgressError)
     end
+
+    it "retries until it locks the file that is on disk" do
+      expect(lock_file.path).to receive(:exist?).twice.and_return(false, true)
+
+      lock_file.lock
+    end
+
+    # Deferring the interrupt can't be observed in-process, as RSpec owns the
+    # `INT` handler that `ignore_interrupts` traps.
+    it "ignores interrupts while locking" do
+      expect(lock_file).to receive(:ignore_interrupts).and_call_original
+
+      lock_file.lock
+    end
   end
 
   describe "#unlock" do


### PR DESCRIPTION
### What does this change do, and why?

Addresses one of two independent causes behind #23328 (per @MikeMcQuaid's request for a separate PR per cause).

When two separate `brew` processes need to download the same file at once (most commonly two `brew bundle` parallel-install workers that both need to fetch an undeclared implicit dependency, see #23342 for that specific scheduling gap), the loser currently dies immediately with ``Error: A `brew install ...` process has already locked ...``, because `LockFile#lock` takes a non-blocking `flock`. The error message already tells the user to "wait for it to finish or terminate it to continue", so this makes that happen automatically instead of requiring a manual retry.

`DownloadLock#lock_or_wait` retries with a short sleep between attempts until the holder releases the lock, printing a "Waiting for another Homebrew process..." warning once rather than repeatedly. Only `CurlDownloadStrategy#fetch` (the actual download path) switches to it. `FormulaLock`/`CaskLock` and `DownloadLock`'s existing usage in `cleanup.rb` (which deliberately wants to skip an in-progress download rather than wait for it) keep the current fail-fast behavior unchanged.

This is deliberately independent of #23342: it fixes the underlying race for any two processes contending on the same download, regardless of what causes them to collide, rather than trying to predict every possible cause of a collision ahead of time.

### Step-by-step reproduction

Not easily reproducible on demand outside of #23328's own repro (two processes racing to download the same file), but the fix is covered by a real (non-mocked) end-to-end check using two live `flock`s across threads, in addition to unit tests: a locked `DownloadLock` genuinely blocks a second instance's `lock_or_wait` until released, then it succeeds.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Used Claude Code to investigate #23328, design and implement this fix, and write the accompanying tests. Verified by running `brew typecheck` and `brew style --changed` (clean), running the full `lock_file`, `download_strategies/curl`, and `cleanup` spec suites (all passing, confirming the untouched fail-fast paths still work), and a manual real (non-mocked) end-to-end script using two threads and actual `flock` calls that confirmed a contended `lock_or_wait` genuinely blocks and then acquires the lock once the holder releases it, in the expected timeframe. Reviewed the full diff by hand before opening this PR.

-----
