### PR TITLE
Remove unused instance variables in API code

### DIFF
--- a/Library/Homebrew/api/json_download.rb
+++ b/Library/Homebrew/api/json_download.rb
@@ -6,13 +6,6 @@ require "downloadable"
 module Homebrew
   module API
     class JSONDownloadStrategy < AbstractDownloadStrategy
-      sig { params(url: String, name: String, version: T.nilable(T.any(String, Version)), meta: T.untyped).void }
-      def initialize(url, name, version, **meta)
-        super
-        @target = T.let(meta.fetch(:target), Pathname)
-        @stale_seconds = T.let(meta[:stale_seconds], T.nilable(Integer))
-      end
-
       sig { override.params(timeout: T.nilable(T.any(Integer, Float))).returns(Pathname) }
       def fetch(timeout: nil)
         with_context quiet: quiet? do
@@ -39,8 +32,6 @@ module Homebrew
       def initialize(url, target:, stale_seconds:)
         super()
         @url = T.let(URL.new(url, using: API::JSONDownloadStrategy, target:, stale_seconds:), URL)
-        @target = target
-        @stale_seconds = stale_seconds
       end
 
       sig { override.returns(API::JSONDownloadStrategy) }

--- a/Library/Homebrew/api_hashable.rb
+++ b/Library/Homebrew/api_hashable.rb
@@ -9,7 +9,6 @@ module APIHashable
 
     # Apply monkeypatches for API generation
     @old_homebrew_prefix = T.let(HOMEBREW_PREFIX, T.nilable(Pathname))
-    @old_homebrew_cellar = T.let(HOMEBREW_CELLAR, T.nilable(Pathname))
     @old_home = T.let(Dir.home, T.nilable(String))
     @old_git_config_global = T.let(ENV.fetch("GIT_CONFIG_GLOBAL", nil), T.nilable(String))
     Object.send(:remove_const, :HOMEBREW_PREFIX)


### PR DESCRIPTION
Removes instance-variable assignments that are never read.

- In `Homebrew::API::JSONDownloadStrategy` and `Homebrew::API::JSONDownload`, `@stale_seconds` and `@target` are assigned in `initialize` but never read (not in these classes, nor in the `AbstractDownloadStrategy` parent or `Downloadable` mixin). The value is used through `meta[:target]`/`meta[:stale_seconds]` and the `target`/`stale_seconds` arguments instead. With both ivars gone, `JSONDownloadStrategy#initialize` only called `super`, so it is removed too.
- `APIHashable#@old_homebrew_cellar` is saved in `generating_hash!` but never restored anywhere (only `@old_homebrew_prefix`, `@old_home` and `@old_git_config_global` are restored, and `HOMEBREW_CELLAR` is not monkeypatched in the first place).

Instance-variable assignments like these aren't reported by `brew deadcode` (Spoom models methods and constants, not ivars), which is why they lingered. Verified with `git grep` that nothing reads them.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude (Claude Code) found the initial write-only instance variables (`@stale_seconds`, `@old_homebrew_cellar`) and drafted the removal. The `@target` removal was prompted by Copilot's review. I verified with `git grep` that nothing reads them and ran `brew lgtm` (style, typecheck, tests) successfully.

-----
