### PR TITLE
Document install step interpolation

### DIFF
--- a/Library/Homebrew/rubocops/install_steps.rb
+++ b/Library/Homebrew/rubocops/install_steps.rb
@@ -263,12 +263,12 @@ module RuboCop
             case normalised_install_step_source(node)
             when POSTGRESQL_LINK_DIR_SOURCE
               step_nodes[node] = [
-                "link_dir \"include/postgresql\", \"include/\#{name}\"",
-                "link_dir \"lib/postgresql\", \"lib/\#{name}\"",
-                "link_dir \"share/postgresql\", \"share/\#{name}\"",
+                "link_dir \"include/postgresql\", \"include/{{name}}\"",
+                "link_dir \"lib/postgresql\", \"lib/{{name}}\"",
+                "link_dir \"share/postgresql\", \"share/{{name}}\"",
               ]
             when POSTGRESQL_LINK_CHILDREN_SOURCE
-              step_nodes[node] = ["link_children \"bin\", suffix: \"-\#{version.major}\""]
+              step_nodes[node] = ["link_children \"bin\", suffix: \"-{{version.major}}\""]
             end
           end
         end

--- a/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/install_steps_spec.rb
@@ -87,6 +87,20 @@ RSpec.describe RuboCop::Cop::Cask::InstallSteps, :config do
     CASK
   end
 
+  it "reports an offense when a step string uses unsupported interpolation" do
+    expect_offense <<~'CASK'
+      cask "foo" do
+        version :latest
+        sha256 :no_check
+
+        preflight_steps do
+          touch "#{appdir}/state"
+                 ^^^^^^^^^ Steps blocks may only contain install step DSL calls: `mkdir`, `mkdir_p`, `touch`, `move`, `mv`, `move_children`, `move_contents`, `copy`, `remove`, `inreplace`, `symlink`, `ln_s`, `ln_sf`, `write`, `delete_keychain_certificate`, `set_permissions`, `set_ownership`, `run`, `terminate_process`, `if_path_exists`, `unless_path_exists`, `on_macos`, `on_linux`.
+        end
+      end
+    CASK
+  end
+
   it "reports an offense when a scope contains Ruby code" do
     expect_offense <<~CASK
       cask "foo" do

--- a/Library/Homebrew/test/rubocops/install_steps_spec.rb
+++ b/Library/Homebrew/test/rubocops/install_steps_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
           inreplace "foo.conf", /@PREFIX@/, "{{HOMEBREW_PREFIX}}"
           ln_sf "source", "target", source_base: :relative, uninstall: true
           write "foo.conf", "key = value\n", base: :etc
+          write "foo/adjacent", "first" "second"
           set_permissions "foo", "0755"
           run "foo", args: ["--repair"]
           terminate_process "foo", attempts: 3
@@ -273,17 +274,17 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
       end
     RUBY
 
-    expect_correction(<<~'RUBY')
+    expect_correction(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
 
         post_install_steps do
           touch "postgresql/state"
           mkdir_p "log"
-          link_dir "include/postgresql", "include/#{name}"
-          link_dir "lib/postgresql", "lib/#{name}"
-          link_dir "share/postgresql", "share/#{name}"
-          link_children "bin", suffix: "-#{version.major}"
+          link_dir "include/postgresql", "include/{{name}}"
+          link_dir "lib/postgresql", "lib/{{name}}"
+          link_dir "share/postgresql", "share/{{name}}"
+          link_children "bin", suffix: "-{{version.major}}"
           init_data_dir name, using: :postgresql_initdb
         end
 
@@ -434,13 +435,13 @@ RSpec.describe RuboCop::Cop::FormulaAudit::InstallSteps do
   end
 
   it "does not re-report declarative database and link steps" do
-    expect_no_offenses(<<~'RUBY')
+    expect_no_offenses(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
 
         post_install_steps do
-          link_dir "include/postgresql", "include/#{name}"
-          link_children "bin", suffix: "-#{version.major}"
+          link_dir "include/postgresql", "include/{{name}}"
+          link_children "bin", suffix: "-{{version.major}}"
           init_data_dir name, using: :postgresql_initdb
           symlink "cert.pem", "cert.pem",
                   source_formula: "ca-certificates",

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -670,7 +670,15 @@ Use `if_path_exists` and `unless_path_exists` blocks to guard one or more steps 
 
 `run` does not evaluate a shell command string. It supports a literal `env:`, `stdin_path:`, `stdout_path:`, `chdir:`, `sudo:`, `print_stdout:` and `print_stderr:`. Wrap it in one of the guard blocks described above when it should be conditional.
 
-Content, replacements, command arguments and command environments may use fixed install-time tokens. These include `{{HOMEBREW_BREW_FILE}}`, `{{HOMEBREW_CELLAR}}`, `{{HOMEBREW_PREFIX}}`, `{{name}}`, `{{user}}`, `{{staged_path}}`, `{{appdir}}`, `{{caskroom_path}}`, `{{temp}}`, `{{version}}`, `{{version.major}}` and `{{version.major_minor}}`. Any other `{{...}}` is left verbatim.
+#### Interpolation in steps blocks
+
+Ruby `#{...}` interpolation is normally evaluated before structured steps are serialised. The Ruby expression does not pass through the JSON API; only the string it produced does. A concrete result is safe only when it is identical for every installation represented by the JSON. RuboCop cannot generally establish that from arbitrary Ruby, so use interpolation in ordinary cask stanzas, for example `command_wrapper "example", executable: "#{appdir}/Example.app/Contents/MacOS/example"`.
+
+`{{...}}` is not Ruby interpolation. It remains literal in the JSON API and the install-step runner expands supported tokens at install time. Use this form for install-time values inside `preflight_steps`, `postflight_steps`, `uninstall_preflight_steps` and `uninstall_postflight_steps`. When a path argument supports `base:`, `source_base:` or `target_base:`, prefer those options to embedding a path token.
+
+The runtime steps DSL retains compatibility helpers for `token`, `name`, `version`, `version.major` and `version.major_minor`. Interpolating these helpers is safe and permitted by RuboCop because they return the corresponding `{{...}}` token text rather than a concrete value. Other Ruby interpolation is rejected. Prefer explicit `{{...}}` tokens in new steps so it is clear that expansion is deferred until installation.
+
+Content, replacements, command arguments and command environments may use fixed install-time tokens. These include `{{HOMEBREW_BREW_FILE}}`, `{{HOMEBREW_CELLAR}}`, `{{HOMEBREW_PREFIX}}`, `{{name}}`, `{{user}}`, `{{staged_path}}`, `{{appdir}}`, `{{caskroom_path}}`, `{{temp}}`, `{{version}}`, `{{version.major}}` and `{{version.major_minor}}`. Any other `{{...}}` is left verbatim. For example: `write "settings.conf", "application = {{appdir}}/Example.app"`.
 
 {% endraw %}
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1103,7 +1103,16 @@ Use `if_path_exists` and `unless_path_exists` blocks to guard one or more steps 
 A trailing newline is appended unless the content already ends with one, so written files end in a newline as POSIX expects.
 
 {% raw %}
-Content, replacements, command arguments and command environments may use a fixed set of `{{...}}` tokens that are expanded at install time so values are not hardcoded into the JSON API: `{{HOMEBREW_BREW_FILE}}`, `{{HOMEBREW_CELLAR}}`, `{{HOMEBREW_PREFIX}}`, `{{name}}`, `{{user}}`, `{{prefix}}`, `{{opt_prefix}}`, `{{bin}}`, `{{sbin}}`, `{{lib}}`, `{{libexec}}`, `{{share}}`, `{{pkgshare}}`, `{{rack}}`, `{{var}}`, `{{etc}}`, `{{pkgetc}}`, `{{version}}`, `{{version.major}}` and `{{version.major_minor}}`. Completion directory tokens are also available. Any other `{{...}}` is left verbatim, so literal braces are never rewritten. Use tokens instead of Ruby interpolation, for example `write "foo.conf", "prefix = {{HOMEBREW_PREFIX}}", base: :etc`.
+
+#### Interpolation in steps blocks
+
+Ruby `#{...}` interpolation is normally evaluated before structured steps are serialised. The Ruby expression does not pass through the JSON API; only the string it produced does. A concrete result is safe only when it is identical for every installation represented by the JSON. RuboCop cannot generally establish that from arbitrary Ruby, so use interpolation in ordinary formula methods such as `install`, where Ruby code is evaluated locally.
+
+`{{...}}` is not Ruby interpolation. It remains literal in the JSON API and the install-step runner expands supported tokens at install time. Use this form for install-time values in `post_install_steps`, especially values that depend on the current Homebrew installation. When a path argument supports `base:`, `source_base:` or `target_base:`, prefer those options to embedding a path token.
+
+The runtime steps DSL retains compatibility helpers for `formula_name`, `name`, `version`, `version.major` and `version.major_minor`. Interpolating these helpers is safe and permitted by RuboCop because they return the corresponding `{{...}}` token text rather than a concrete value. Other Ruby interpolation is rejected. Prefer explicit `{{...}}` tokens in new steps so it is clear that expansion is deferred until installation.
+
+Content, replacements, command arguments and command environments may use a fixed set of `{{...}}` tokens: `{{HOMEBREW_BREW_FILE}}`, `{{HOMEBREW_CELLAR}}`, `{{HOMEBREW_PREFIX}}`, `{{name}}`, `{{user}}`, `{{prefix}}`, `{{opt_prefix}}`, `{{bin}}`, `{{sbin}}`, `{{lib}}`, `{{libexec}}`, `{{share}}`, `{{pkgshare}}`, `{{rack}}`, `{{var}}`, `{{etc}}`, `{{pkgetc}}`, `{{version}}`, `{{version.major}}` and `{{version.major_minor}}`. Completion directory tokens are also available. Any other `{{...}}` is left verbatim, so literal braces are never rewritten. For example: `write "foo.conf", "prefix = {{HOMEBREW_PREFIX}}", base: :etc`.
 {% endraw %}
 
 #### Command and lifecycle steps
@@ -1153,8 +1162,8 @@ directory, defaulting the target to the same path as the source, and can add a
 `prefix` or `suffix` to each linked name. For example:
 
 ```ruby
-link_dir "share/postgresql", "share/#{name}"
-link_children "bin", suffix: "-#{version.major}"
+link_dir "share/postgresql", "share/{{name}}"
+link_children "bin", suffix: "-{{version.major}}"
 ```
 
 #### Desktop and cache rebuild steps


### PR DESCRIPTION
- Distinguish Ruby interpolation from install-time tokens that survive JSON serialisation.
- Keep token-producing compatibility helpers valid while rejecting arbitrary interpolation.
- Emit explicit install-time tokens from formula autocorrections.

As requested by @SMillerDev 

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex GPT 5.6 Sol max with local review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
