### PR TITLE
contaier: add init option

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -199,7 +199,7 @@ class GitHubRunnerMatrix
     unless self_hosted
       container = {
         image:   "ghcr.io/homebrew/brew:main",
-        options: "--user linuxbrew --env HOMEBREW_SANDBOX_LINUX_LANDLOCK=1",
+        options: "--init --user linuxbrew --env HOMEBREW_SANDBOX_LINUX_LANDLOCK=1",
       }
       workdir = "/github/home"
     end

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
       expect(linux_containers).to eq(Array.new(2) do
         {
           image:   "ghcr.io/homebrew/brew:main",
-          options: "--user linuxbrew --env HOMEBREW_SANDBOX_LINUX_LANDLOCK=1",
+          options: "--init --user linuxbrew --env HOMEBREW_SANDBOX_LINUX_LANDLOCK=1",
         }
       end)
     end


### PR DESCRIPTION
Add `--init` option to prevent zombie process on linux. brew container run

```
--entrypoint tail -f /dev/null
```
and tail doesn't trigger any `wait()`. So use `docker-init` to remove child process correctly.

Example:
- https://github.com/Homebrew/homebrew-core/pull/295499

and `openliberty-*` formulae
- https://github.com/Homebrew/homebrew-core/pull/295197
where this can be reverted after this PR.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude is used to check the reason why some formulae tests are failed. It suggests to add `--init` option.
-----
