### PR TITLE
Add autobump option to tap-new

### DIFF
--- a/.github/workflows/tap-new-autobump.yml
+++ b/.github/workflows/tap-new-autobump.yml
@@ -39,4 +39,4 @@ jobs:
           HOMEBREW_GIT_COMMITTER_NAME: ${{ steps.git_setup.outputs.name }}
           HOMEBREW_GIT_COMMITTER_EMAIL: ${{ steps.git_setup.outputs.email }}
           TAP_NAME: ${{ steps.set-up-homebrew.outputs.tap-name }}
-        run: brew bump --no-fork --open-pr --formulae --bump-synced--tap="$TAP_NAME"
+        run: brew bump --no-fork --open-pr --formulae --bump-synced --tap="$TAP_NAME"

--- a/.github/workflows/tap-new-autobump.yml
+++ b/.github/workflows/tap-new-autobump.yml
@@ -1,0 +1,42 @@
+# brew tap-new uses this file to generate an autobump workflow for the new tap
+name: tap-new autobump template
+
+on:
+  push:
+    branches:
+      - TAP_NEW_BRANCH
+    paths:
+      - .github/workflows/autobump.yml
+  schedule:
+    # Every day at 01:45 UTC, randomised by brew tap-new
+    - cron: "45 1 * * *"
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
+
+jobs:
+  autobump:
+    if: github.repository == ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026.07.20.1
+
+      - name: Set up git
+        id: git_setup
+        uses: Homebrew/actions/git-user-config@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026.07.20.1
+
+      - name: Bump formulae
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_GIT_COMMITTER_NAME: ${{ steps.git_setup.outputs.name }}
+          HOMEBREW_GIT_COMMITTER_EMAIL: ${{ steps.git_setup.outputs.email }}
+          TAP_NAME: ${{ steps.set-up-homebrew.outputs.tap-name }}
+        run: brew bump --no-fork --open-pr --formulae --bump-synced--tap="$TAP_NAME"

--- a/.github/workflows/tap-new-autobump.yml
+++ b/.github/workflows/tap-new-autobump.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026.07.20.1
+        uses: Homebrew/actions/setup-homebrew@5037c6f1012cc5ea0b9f03fedbaf9955ed9e51e0 # 2026.08.03.1
 
       - name: Set up git
         id: git_setup

--- a/.github/workflows/tap-new-autobump.yml
+++ b/.github/workflows/tap-new-autobump.yml
@@ -8,8 +8,8 @@ on:
     paths:
       - .github/workflows/autobump.yml
   schedule:
-    # Every day at 01:45 UTC, randomised by brew tap-new
-    - cron: "45 1 * * *"
+    # this will be changed later and randomised by brew tap-new
+    - cron: "1 1 1 1 1"
 
 permissions: {}
 

--- a/.github/workflows/tap-new-publish.yml
+++ b/.github/workflows/tap-new-publish.yml
@@ -1,3 +1,4 @@
+# brew tap-new uses this file to generate a bottle publish workflow for the new tap
 name: tap-new publish template
 
 on:
@@ -8,6 +9,12 @@ on:
         required: true
       head_sha:
         description: Expected pull request head commit SHA (optional)
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
 
 jobs:
   pr-pull:
@@ -29,11 +36,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up git
+        id: git_setup
         uses: Homebrew/actions/git-user-config@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026.07.20.1
 
       - name: Pull bottles
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_GIT_COMMITTER_NAME: ${{ steps.git_setup.outputs.name }}
+          HOMEBREW_GIT_COMMITTER_EMAIL: ${{ steps.git_setup.outputs.email }}
           # tap-new-github-packages-start
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.repository_owner }}

--- a/.github/workflows/tap-new-tests.yml
+++ b/.github/workflows/tap-new-tests.yml
@@ -1,7 +1,14 @@
+# brew tap-new uses this file to generate a PR test workflow for the new tap
 name: tap-new tests template
 
 on:
   workflow_dispatch:
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
 
 jobs:
   test-bot:

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -90,10 +90,14 @@ module Homebrew
         publish_yml = render_workflow_template(
           "tap-new-publish.yml", branch:, github_packages: args.github_packages?
         )
+        autobump_yml = render_workflow_template(
+          "tap-new-autobump.yml", branch:, github_packages: args.github_packages?
+        )
         (tap.path/".github/workflows").mkpath
         write_path(tap, ".github/dependabot.yml", dependabot_yml)
         write_path(tap, ".github/workflows/tests.yml", tests_yml)
         write_path(tap, ".github/workflows/publish.yml", publish_yml)
+        write_path(tap, ".github/workflows/autobump.yml", autobump_yml)
 
         unless args.no_git?
           cd tap.path do |path|
@@ -148,6 +152,7 @@ module Homebrew
         workflow = (HOMEBREW_LIBRARY_PATH.parent.parent/".github/workflows"/filename).read
         workflow.sub!("name: tap-new tests template", "name: brew test-bot")
         workflow.sub!("name: tap-new publish template", "name: brew pr-pull")
+        workflow.sub!("name: tap-new autobump template", "name: brew bump")
         if filename == "tap-new-tests.yml"
           workflow.sub!("on:\n  workflow_dispatch:\n", <<~YAML)
             on:
@@ -157,6 +162,12 @@ module Homebrew
               pull_request:
           YAML
         end
+        # Pick a random 5 minute block in which to execute the autobump action to avoid peak GitHub loads
+        hour = Random.rand(23)
+        minute = Random.rand(11) * 5
+        workflow.gsub!("at 01:45 UTC") { "at #{hour}:#{minute} UTC" }
+        workflow.gsub!("\"45 1 * * *\"") { "#{minute} #{hour} * * *" }
+
         workflow.sub!("    if: github.repository == ''\n", "")
         workflow.gsub!("TAP_NEW_BRANCH") { branch }
         workflow.gsub!("TAP_NEW_ROOT_URL_ARGUMENT") { root_url ? " --root-url=#{root_url}" : "" }

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -165,8 +165,10 @@ module Homebrew
         # Pick a random 5 minute block in which to execute the autobump action to avoid peak GitHub loads
         hour = Random.rand(23)
         minute = Random.rand(11) * 5
-        workflow.gsub!("at 01:45 UTC") { "at #{hour}:#{minute} UTC" }
-        workflow.gsub!("\"45 1 * * *\"") { "#{minute} #{hour} * * *" }
+        workflow.gsub!("this will be changed later and randomised by brew tap-new") do
+          "Every day at #{hour}:#{minute} UTC"
+        end
+        workflow.gsub!("\"1 1 1 1 1\"") { "#{minute} #{hour} * * *" }
 
         workflow.sub!("    if: github.repository == ''\n", "")
         workflow.gsub!("TAP_NEW_BRANCH") { branch }

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -100,9 +100,7 @@ module Homebrew
             Utils::Git.set_name_email!
             Utils::Git.setup_gpg!
 
-            # Would be nice to use --initial-branch here but it's not available in
-            # older versions of Git that we support.
-            safe_system "git", "-c", "init.defaultBranch=#{branch}", "init"
+            safe_system "git", "init", "--initial-branch=#{branch}"
 
             args = []
             git_owner = File.stat(File.join(path, ".git")).uid

--- a/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Homebrew::DevCmd::TapNew do
     dependabot_yml = (HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/dependabot.yml").read
     tests_yml = (HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/tests.yml").read
     publish_yml = (HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/publish.yml").read
+    autobump_yml = (HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/autobump.yml").read
     [dependabot_yml, tests_yml, publish_yml].each { YAML.parse(it) }
     expect(tests_yml).not_to include("HOMEBREW_DEVELOPER")
     expect(tests_yml).to include("options: --privileged")
@@ -32,5 +33,12 @@ RSpec.describe Homebrew::DevCmd::TapNew do
     expect(publish_yml).not_to include("gh pr view")
     expect(publish_yml).to include('brew pr-pull --debug --tap="$GITHUB_REPOSITORY" --head-sha="$HEAD_SHA"')
     expect(publish_yml).to include('brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"')
+    expect(autobump_yml).not_to include("HOMEBREW_DEVELOPER")
+    expect(autobump_yml).not_to include("pull_request_target")
+    expect(autobump_yml).not_to include("workflow_run")
+    expect(autobump_yml).not_to include("TAP_NEW_")
+    expect(autobump_yml).to include("TAP_NAME: homebrew/foo")
+    expect(autobump_yml).to include("- main")
+    expect(autobump_yml).to include('brew bump --no-fork --open-pr --formulae --bump-synced--tap="$TAP_NAME"')
   end
 end

--- a/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Homebrew::DevCmd::TapNew do
     expect(autobump_yml).not_to include("pull_request_target")
     expect(autobump_yml).not_to include("workflow_run")
     expect(autobump_yml).not_to include("TAP_NEW_")
-    expect(autobump_yml).to include("TAP_NAME: homebrew/foo")
+    expect(autobump_yml).not_to include("cron: \"1 1 1 1 1\"")
+    expect(autobump_yml).not_to include("# this will be changed later and randomised by brew tap-new")
     expect(autobump_yml).to include("- main")
     expect(autobump_yml).to include('brew bump --no-fork --open-pr --formulae --bump-synced--tap="$TAP_NAME"')
   end

--- a/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
@@ -40,6 +40,6 @@ RSpec.describe Homebrew::DevCmd::TapNew do
     expect(autobump_yml).not_to include("cron: \"1 1 1 1 1\"")
     expect(autobump_yml).not_to include("# this will be changed later and randomised by brew tap-new")
     expect(autobump_yml).to include("- main")
-    expect(autobump_yml).to include('brew bump --no-fork --open-pr --formulae --bump-synced--tap="$TAP_NAME"')
+    expect(autobump_yml).to include('brew bump --no-fork --open-pr --formulae --bump-synced --tap="$TAP_NAME"')
   end
 end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [ ] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

This will make it easier for users to set up taps with software that is not fit for Homebrew, but should be kept up to date.