### PR TITLE
Ignore user-configured Git hooks for tap operations

### DIFF
--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -17,7 +17,10 @@ git() {
       odie "Can't find a working Git!"
     fi
   fi
-  "${GIT_EXECUTABLE}" "$@"
+  # Ignore hooks from a user-configured core.hooksPath (e.g. set by `git lfs install`),
+  # which can break Homebrew's Git operations.
+  # Keep in sync with `Tap#git_command!` in Library/Homebrew/tap.rb.
+  "${GIT_EXECUTABLE}" -c core.hooksPath=/dev/null "$@"
 }
 
 homebrew-update-reset() {

--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -17,7 +17,7 @@ git() {
       odie "Can't find a working Git!"
     fi
   fi
-  # Ignore hooks from a user-configured core.hooksPath (e.g. set by `git lfs install`),
+  # Disable Git hooks (e.g. a core.hooksPath set by `git lfs install`),
   # which can break Homebrew's Git operations.
   # Keep in sync with `Tap#git_command!` in Library/Homebrew/tap.rb.
   "${GIT_EXECUTABLE}" -c core.hooksPath=/dev/null "$@"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -82,7 +82,10 @@ git() {
       odie "Can't find a working Git!"
     fi
   fi
-  "${GIT_EXECUTABLE}" "$@"
+  # Ignore hooks from a user-configured core.hooksPath (e.g. set by `git lfs install`),
+  # which can break Homebrew's Git operations.
+  # Keep in sync with `Tap#git_command!` in Library/Homebrew/tap.rb.
+  "${GIT_EXECUTABLE}" -c core.hooksPath=/dev/null "$@"
 }
 
 git_init_if_necessary() {

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -82,7 +82,7 @@ git() {
       odie "Can't find a working Git!"
     fi
   fi
-  # Ignore hooks from a user-configured core.hooksPath (e.g. set by `git lfs install`),
+  # Disable Git hooks (e.g. a core.hooksPath set by `git lfs install`),
   # which can break Homebrew's Git operations.
   # Keep in sync with `Tap#git_command!` in Library/Homebrew/tap.rb.
   "${GIT_EXECUTABLE}" -c core.hooksPath=/dev/null "$@"

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -611,7 +611,7 @@ class Tap
   def git_command!(args, chdir: nil)
     require "system_command"
 
-    # Ignore hooks from a user-configured `core.hooksPath` (e.g. set by `git lfs install`),
+    # Disable Git hooks (e.g. a `core.hooksPath` set by `git lfs install`),
     # which can break tap Git operations.
     # Keep in sync with the `git` wrappers in cmd/update.sh and cmd/update-reset.sh.
     args = ["-c", "core.hooksPath=#{File::NULL}", *args]
@@ -721,7 +721,7 @@ class Tap
     begin
       if worktree_source_tap_path
         # Keep core and cask taps connected to the same local source checkout as brew.
-        # Ignore user-configured hooks as in `git_command!`.
+        # Disable Git hooks as in `git_command!`.
         worktree_args = ["-c", "core.hooksPath=#{File::NULL}", "-C", worktree_source_tap_path, "worktree", "add"]
         worktree_args << "--quiet" if quiet
         worktree_args += ["--detach", path, "HEAD"]

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -611,6 +611,10 @@ class Tap
   def git_command!(args, chdir: nil)
     require "system_command"
 
+    # Ignore hooks from a user-configured `core.hooksPath` (e.g. set by `git lfs install`),
+    # which can break tap Git operations.
+    # Keep in sync with the `git` wrappers in cmd/update.sh and cmd/update-reset.sh.
+    args = ["-c", "core.hooksPath=#{File::NULL}"] + args
     SystemCommand.run!("git", args:, chdir:, env: { "GIT_TERMINAL_PROMPT" => "0" }, print_stderr: true)
   end
 
@@ -717,7 +721,8 @@ class Tap
     begin
       if worktree_source_tap_path
         # Keep core and cask taps connected to the same local source checkout as brew.
-        worktree_args = ["-C", worktree_source_tap_path, "worktree", "add"]
+        # Ignore user-configured hooks as in `git_command!`.
+        worktree_args = ["-c", "core.hooksPath=#{File::NULL}", "-C", worktree_source_tap_path, "worktree", "add"]
         worktree_args << "--quiet" if quiet
         worktree_args += ["--detach", path, "HEAD"]
         safe_system "git", *worktree_args

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -614,7 +614,7 @@ class Tap
     # Ignore hooks from a user-configured `core.hooksPath` (e.g. set by `git lfs install`),
     # which can break tap Git operations.
     # Keep in sync with the `git` wrappers in cmd/update.sh and cmd/update-reset.sh.
-    args = ["-c", "core.hooksPath=#{File::NULL}"] + args
+    args = ["-c", "core.hooksPath=#{File::NULL}", *args]
     SystemCommand.run!("git", args:, chdir:, env: { "GIT_TERMINAL_PROMPT" => "0" }, print_stderr: true)
   end
 

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -731,9 +731,27 @@ RSpec.describe Tap do
       require "system_command"
 
       expect(SystemCommand).to receive(:run!)
-        .with("git", args: %w[fetch], chdir: path, env: { "GIT_TERMINAL_PROMPT" => "0" }, print_stderr: true)
+        .with("git", args: ["-c", "core.hooksPath=#{File::NULL}", "fetch"], chdir: path,
+              env: { "GIT_TERMINAL_PROMPT" => "0" }, print_stderr: true)
 
       homebrew_foo_tap.git_command!(%w[fetch], chdir: path)
+    end
+
+    it "ignores user-configured Git hooks" do
+      setup_tap_files
+      setup_git_repo
+
+      hooks_path = HOMEBREW_CACHE/"hooks"
+      hooks_path.mkpath
+      (hooks_path/"post-checkout").write("#!/bin/sh\nexit 2\n")
+      (hooks_path/"post-checkout").chmod(0755)
+      gitconfig_path = HOMEBREW_CACHE/"gitconfig"
+      gitconfig_path.write("[core]\n\thooksPath = #{hooks_path}\n")
+      ENV["GIT_CONFIG_GLOBAL"] = gitconfig_path.to_s
+
+      clone_path = HOMEBREW_CACHE/"hooks-test-clone"
+      homebrew_foo_tap.git_command!(["clone", path.to_s, clone_path.to_s])
+      expect(clone_path/".git").to be_a_directory
     end
 
     it "raises an error when the Tap is already tapped" do
@@ -803,7 +821,8 @@ RSpec.describe Tap do
         allow(tap).to receive_messages(command_files: [], formula_files: [], cask_files: [],
                                        formula_names: [], cask_tokens: [], link_completions_and_manpages: nil)
         expect(tap).to receive(:safe_system)
-          .with("git", "-C", source_tap, "worktree", "add", "--detach", tap.path, "HEAD")
+          .with("git", "-c", "core.hooksPath=#{File::NULL}", "-C", source_tap,
+                "worktree", "add", "--detach", tap.path, "HEAD")
           .and_wrap_original do
             tap.path.mkpath
             (tap.path/".git").write "gitdir: #{source_tap}/.git/worktrees/#{tap.full_repository.downcase}\n"
@@ -848,7 +867,8 @@ RSpec.describe Tap do
       allow(tap).to receive_messages(command_files: [], formula_files: [], cask_files: [],
                                      formula_names: [], cask_tokens: [], link_completions_and_manpages: nil)
       expect(tap).to receive(:safe_system)
-        .with("git", "-C", source_tap, "worktree", "add", "--detach", tap.path, "HEAD")
+        .with("git", "-c", "core.hooksPath=#{File::NULL}", "-C", source_tap,
+              "worktree", "add", "--detach", tap.path, "HEAD")
         .and_wrap_original do
           tap.path.mkpath
           (tap.path/".git").write "gitdir: #{source_tap}/.git/worktrees/#{tap.full_repository.downcase}\n"

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -737,13 +737,14 @@ RSpec.describe Tap do
       homebrew_foo_tap.git_command!(%w[fetch], chdir: path)
     end
 
-    it "ignores user-configured Git hooks" do
+    it "does not run Git hooks" do
       setup_tap_files
       setup_git_repo
 
+      hook_ran_path = HOMEBREW_CACHE/"hook-ran"
       hooks_path = HOMEBREW_CACHE/"hooks"
       hooks_path.mkpath
-      (hooks_path/"post-checkout").write("#!/bin/sh\nexit 2\n")
+      (hooks_path/"post-checkout").write("#!/bin/sh\ntouch #{hook_ran_path}\n")
       (hooks_path/"post-checkout").chmod(0755)
       gitconfig_path = HOMEBREW_CACHE/"gitconfig"
       gitconfig_path.write("[core]\n\thooksPath = #{hooks_path}\n")
@@ -751,7 +752,7 @@ RSpec.describe Tap do
 
       clone_path = HOMEBREW_CACHE/"hooks-test-clone"
       homebrew_foo_tap.git_command!(["clone", path.to_s, clone_path.to_s])
-      expect(clone_path/".git").to be_a_directory
+      expect(hook_ran_path).not_to exist
     end
 
     it "raises an error when the Tap is already tapped" do


### PR DESCRIPTION
A global `core.hooksPath` (e.g. set by `git lfs install`) breaks `brew tap` and `brew update`: Git hooks run with Homebrew's filtered `PATH`, which lacks `git-lfs`, so every tap clone and tap update fails. Pass `-c core.hooksPath=/dev/null` to tap and update Git operations, as `package/scripts/postinstall` already does for the installer. Requested in #21621; same failure mode as #4988, #7014 and https://github.com/orgs/Homebrew/discussions/5047. No other user Git configuration is bypassed, so credential helpers for private taps keep working (cf. #22774).

To reproduce:

```console
$ git config --global core.hooksPath ~/.githooks
$ git lfs update  # installs the stock LFS hooks into ~/.githooks
$ brew tap homebrew/command-not-found
==> Tapping homebrew/command-not-found
Cloning into '/opt/homebrew/Library/Taps/homebrew/homebrew-command-not-found'...
This repository is configured for Git LFS but 'git-lfs' was not found on your path.
Error: Failure while executing; `git clone ...` exited with 2.
```

-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Written with Claude Code, reviewed and directed by me. Verified with a red/green RSpec cycle (the new spec reproduces the hook failure before the fix) and a manual end-to-end reproduction: `brew tap` of a local repository with a hostile global `core.hooksPath` fails on `main` and succeeds with this change, with the hook confirmed not to run. `brew lgtm` passes locally.

-----

🤖 Generated with [Claude Code](https://claude.com/claude-code)
