### PR TITLE
DownloadLock: wait on a blocking flock instead of failing (alternative to #23343)

### DIFF
--- a/Library/Homebrew/download_strategy/curl_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/curl_download_strategy.rb
@@ -39,7 +39,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     download_lock = DownloadLock.new(temporary_path)
     begin
-      download_lock.lock
+      download_lock.lock_or_wait
 
       urls = [url, *mirrors]
 

--- a/Library/Homebrew/lock_file.rb
+++ b/Library/Homebrew/lock_file.rb
@@ -62,33 +62,38 @@ class LockFile
   private
 
   # Returns false when the lock file changed on disk and must be reacquired.
+  # Raises `OperationInProgressError` when a non-blocking `flock` finds it held.
   sig { params(flock_operation: Integer).returns(T::Boolean) }
   def acquired?(flock_operation)
     lockfile = open_lockfile
+    acquired = false
 
-    unless lockfile.flock(flock_operation)
-      lockfile.close
-      raise OperationInProgressError, @locked_path
+    begin
+      raise OperationInProgressError, @locked_path unless lockfile.flock(flock_operation)
+
+      # This prevents a race condition in case the file we locked doesn't exist on disk anymore, e.g.:
+      #
+      # 1. Process A creates and opens the file.
+      # 2. Process A locks the file.
+      # 3. Process B opens the file.
+      # 4. Process A unlinks the file.
+      # 5. Process A unlocks the file.
+      # 6. Process B locks the file.
+      # 7. Process C creates and opens the file.
+      # 8. Process C locks the file.
+      # 9. Process B and C hold locks to files with different inode numbers. 💥
+      acquired = path.exist? && lockfile.stat.ino == path.stat.ino
+    ensure
+      # Assign or close in an `ensure` so an interrupt raised out of a blocking
+      # `flock` can't leave the lock held with nothing left to release it.
+      if acquired
+        @lockfile = lockfile
+      else
+        lockfile.close
+      end
     end
 
-    # This prevents a race condition in case the file we locked doesn't exist on disk anymore, e.g.:
-    #
-    # 1. Process A creates and opens the file.
-    # 2. Process A locks the file.
-    # 3. Process B opens the file.
-    # 4. Process A unlinks the file.
-    # 5. Process A unlocks the file.
-    # 6. Process B locks the file.
-    # 7. Process C creates and opens the file.
-    # 8. Process C locks the file.
-    # 9. Process B and C hold locks to files with different inode numbers. 💥
-    if !path.exist? || lockfile.stat.ino != path.stat.ino
-      lockfile.close
-      return false
-    end
-
-    @lockfile = lockfile
-    true
+    acquired
   end
 
   sig { returns(File) }

--- a/Library/Homebrew/lock_file.rb
+++ b/Library/Homebrew/lock_file.rb
@@ -8,11 +8,11 @@ require "utils/output"
 class LockFile
   include Utils::Output::Mixin
 
-  class OpenFileChangedOnDisk < RuntimeError; end
-  private_constant :OpenFileChangedOnDisk
-
   sig { returns(Pathname) }
   attr_reader :path
+
+  sig { returns(Pathname) }
+  attr_reader :locked_path
 
   sig { params(type: Symbol, locked_path: Pathname).void }
   def initialize(type, locked_path)
@@ -22,48 +22,20 @@ class LockFile
     @lockfile = T.let(nil, T.nilable(File))
   end
 
-  sig { void }
-  def lock
-    ignore_interrupts do
-      next if @lockfile.present?
+  # `blocking:` waits for the current holder to release rather than raising
+  # `OperationInProgressError`. That wait is not wrapped in `ignore_interrupts`
+  # (unlike the non-blocking path, which returns immediately) so `Ctrl-C` still
+  # works while waiting.
+  sig { params(blocking: T::Boolean).void }
+  def lock(blocking: false)
+    return if @lockfile.present?
 
-      path.dirname.mkpath
+    path.dirname.mkpath
 
-      begin
-        lockfile = begin
-          File.open(path, File::RDWR | File::CREAT)
-        rescue Errno::EMFILE
-          odie "The maximum number of open files on this system has been reached. " \
-               "Use `ulimit -n` to increase this limit."
-        end
-        lockfile.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
-
-        if lockfile.flock(File::LOCK_EX | File::LOCK_NB)
-          # This prevents a race condition in case the file we locked doesn't exist on disk anymore, e.g.:
-          #
-          # 1. Process A creates and opens the file.
-          # 2. Process A locks the file.
-          # 3. Process B opens the file.
-          # 4. Process A unlinks the file.
-          # 5. Process A unlocks the file.
-          # 6. Process B locks the file.
-          # 7. Process C creates and opens the file.
-          # 8. Process C locks the file.
-          # 9. Process B and C hold locks to files with different inode numbers. 💥
-          if !path.exist? || lockfile.stat.ino != path.stat.ino
-            lockfile.close
-            raise OpenFileChangedOnDisk
-          end
-
-          @lockfile = lockfile
-          next
-        end
-      rescue OpenFileChangedOnDisk
-        retry
-      end
-
-      lockfile.close
-      raise OperationInProgressError, @locked_path
+    if blocking
+      nil until acquired?(File::LOCK_EX)
+    else
+      ignore_interrupts { nil until acquired?(File::LOCK_EX | File::LOCK_NB) }
     end
   end
 
@@ -85,6 +57,50 @@ class LockFile
     yield
   ensure
     unlock
+  end
+
+  private
+
+  # Returns false when the lock file changed on disk and must be reacquired.
+  sig { params(flock_operation: Integer).returns(T::Boolean) }
+  def acquired?(flock_operation)
+    lockfile = open_lockfile
+
+    unless lockfile.flock(flock_operation)
+      lockfile.close
+      raise OperationInProgressError, @locked_path
+    end
+
+    # This prevents a race condition in case the file we locked doesn't exist on disk anymore, e.g.:
+    #
+    # 1. Process A creates and opens the file.
+    # 2. Process A locks the file.
+    # 3. Process B opens the file.
+    # 4. Process A unlinks the file.
+    # 5. Process A unlocks the file.
+    # 6. Process B locks the file.
+    # 7. Process C creates and opens the file.
+    # 8. Process C locks the file.
+    # 9. Process B and C hold locks to files with different inode numbers. 💥
+    if !path.exist? || lockfile.stat.ino != path.stat.ino
+      lockfile.close
+      return false
+    end
+
+    @lockfile = lockfile
+    true
+  end
+
+  sig { returns(File) }
+  def open_lockfile
+    lockfile = begin
+      File.open(path, File::RDWR | File::CREAT)
+    rescue Errno::EMFILE
+      odie "The maximum number of open files on this system has been reached. " \
+           "Use `ulimit -n` to increase this limit."
+    end
+    lockfile.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+    lockfile
   end
 end
 require "lock_file/formula_lock"

--- a/Library/Homebrew/lock_file/download_lock.rb
+++ b/Library/Homebrew/lock_file/download_lock.rb
@@ -3,8 +3,27 @@
 
 # A lock file for a download.
 class DownloadLock < LockFile
+  # Long enough for even a large download on a slow connection, short enough to eventually
+  # give up and report the original error if the holder is genuinely stuck.
+  MAX_WAIT_SECONDS = 3600
+
   sig { params(download_path: Pathname).void }
   def initialize(download_path)
     super(:download, download_path)
+  end
+
+  # Waits for another process's download to finish instead of failing immediately.
+  sig { void }
+  def lock_or_wait
+    lock
+  rescue OperationInProgressError
+    require "timeout"
+
+    opoo "Waiting for another Homebrew process to finish downloading #{locked_path}..."
+    begin
+      Timeout.timeout(MAX_WAIT_SECONDS) { lock(blocking: true) }
+    rescue Timeout::Error
+      raise OperationInProgressError, locked_path
+    end
   end
 end

--- a/Library/Homebrew/test/lock_file/download_lock_spec.rb
+++ b/Library/Homebrew/test/lock_file/download_lock_spec.rb
@@ -1,7 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
-require "lock_file/download_lock"
+require "lock_file"
 
 RSpec.describe DownloadLock do
   subject(:download_lock) { described_class.new(Pathname("foo-download")) }
@@ -20,23 +20,39 @@ RSpec.describe DownloadLock do
 
     it "waits for another instance's lock to release, then acquires it", timeout: 10 do
       download_lock.lock
+      waiting = Queue.new
+      # Release only once the blocking wait is about to start, so no `sleep` is needed.
+      # Releasing from another thread also covers the wait staying outside `ignore_interrupts`.
+      allow(download_lock_copy).to receive(:opoo).and_wrap_original do |original, *args|
+        original.call(*args)
+        waiting.push(true)
+      end
       releaser = Thread.new do
-        sleep 0.2
+        waiting.pop
         download_lock.unlock
       end
 
       expect { download_lock_copy.lock_or_wait }.to output(
         /Waiting for another Homebrew process to finish downloading/,
       ).to_stderr
+      expect { download_lock.lock }.to raise_error(OperationInProgressError)
     ensure
       releaser&.join(5)
     end
 
     it "gives up and raises once the maximum wait time passes", timeout: 10 do
-      stub_const("DownloadLock::MAX_WAIT_SECONDS", 0.1)
+      stub_const("DownloadLock::MAX_WAIT_SECONDS", 0.25)
       download_lock.lock
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       expect { download_lock_copy.lock_or_wait }.to raise_error(OperationInProgressError)
+      expect(Process.clock_gettime(Process::CLOCK_MONOTONIC) - started).to be >= 0.25
+    end
+
+    it "retries until it locks the file that is on disk" do
+      expect(download_lock.path).to receive(:exist?).twice.and_return(false, true)
+
+      download_lock.lock_or_wait
     end
   end
 end

--- a/Library/Homebrew/test/lock_file/download_lock_spec.rb
+++ b/Library/Homebrew/test/lock_file/download_lock_spec.rb
@@ -1,0 +1,42 @@
+# typed: true
+# frozen_string_literal: true
+
+require "lock_file/download_lock"
+
+RSpec.describe DownloadLock do
+  subject(:download_lock) { described_class.new(Pathname("foo-download")) }
+
+  let(:download_lock_copy) { described_class.new(Pathname("foo-download")) }
+
+  after do
+    download_lock.unlock
+    download_lock_copy.unlock
+  end
+
+  describe "#lock_or_wait" do
+    it "acquires the lock immediately when uncontended" do
+      expect { download_lock.lock_or_wait }.not_to raise_error
+    end
+
+    it "waits for another instance's lock to release, then acquires it", timeout: 10 do
+      download_lock.lock
+      releaser = Thread.new do
+        sleep 0.2
+        download_lock.unlock
+      end
+
+      expect { download_lock_copy.lock_or_wait }.to output(
+        /Waiting for another Homebrew process to finish downloading/,
+      ).to_stderr
+    ensure
+      releaser&.join(5)
+    end
+
+    it "gives up and raises once the maximum wait time passes", timeout: 10 do
+      stub_const("DownloadLock::MAX_WAIT_SECONDS", 0.1)
+      download_lock.lock
+
+      expect { download_lock_copy.lock_or_wait }.to raise_error(OperationInProgressError)
+    end
+  end
+end

--- a/Library/Homebrew/test/lock_file_spec.rb
+++ b/Library/Homebrew/test/lock_file_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe LockFile do
         lock_file_copy.lock
       end.to raise_error(OperationInProgressError)
     end
+
+    it "releases the lock when interrupted after acquiring it" do
+      allow(lock_file.path).to receive(:exist?).and_raise(Interrupt)
+
+      expect { lock_file.lock }.to raise_error(Interrupt)
+      expect { lock_file_copy.lock }.not_to raise_error
+    end
   end
 
   describe "#unlock" do


### PR DESCRIPTION
### What does this change do, and why?

**Draft: this is an alternative to #23343, opened for comparison rather than to merge alongside it.** Both fix the same half of #23328, so pick one and I'll close the other. Posting this because @MikeMcQuaid asked on #23343 whether we could use "signals or similar here and not just `sleep`".

It turns out no signals are needed. `flock(LOCK_EX)` *without* `LOCK_NB` is already a kernel-level blocking wait, so the kernel wakes us the instant the holder releases. The polling in #23343 only exists because `LockFile#lock` hardcodes `LOCK_NB`. So this version adds a `blocking:` option to `LockFile#lock` and moves the open/flock/inode-recheck sequence into a private `acquired?` helper.

### Measured comparison against #23343

Wake latency is how long *after* the holder releases the waiter actually acquires. 6 trials each, with deliberately non-interval-aligned hold durations so polls are never accidentally synchronised with the release.

| implementation | wake latency (mean) | wake latency (max) | CPU while waiting |
| --- | --- | --- | --- |
| polling, `sleep 0.1` (#23343) | 62.4ms | 99.4ms | 0.0038s |
| polling, `sleep 1.0` | 946.0ms | 987.1ms | 0.0010s |
| blocking flock (this PR) | **0.12ms** | **0.21ms** | **0.0020s** |

Blocking is roughly 500x more responsive than the 0.1s polling in #23343 *and* uses less CPU than it, so it removes the interval tradeoff I was weighing over there entirely.

### The subtle part, and why the diff touches `LockFile`

A naive version of this introduces a **Ctrl-C hang**. `LockFile#lock` wraps its body in `ignore_interrupts`, and a blocking flock inside `ignore_interrupts` swallows `SIGINT` completely: the process stays blocked (printing "One sec, cleaning up...") until the lock frees, which could be an hour. I verified that experimentally before writing this. The polling approach in #23343 sidesteps it only by accident, because its `sleep` happens outside `ignore_interrupts`.

So here the blocking wait deliberately sits *outside* `ignore_interrupts`, while the non-blocking path keeps its existing wrapping. `FormulaLock`, `CaskLock`, and `cleanup.rb`'s stale-download handling therefore keep their current behaviour byte for byte, and `lock_file_spec.rb` passes unchanged, which is the main evidence for that. `Timeout.timeout` caps the wait (it does interrupt a blocked flock, and `File#flock` has no timeout parameter of its own).

The cost of this approach versus #23343 is that it restructures a shared, correctness-sensitive primitive rather than only touching `DownloadLock`. That is the main thing worth weighing.

### On using `concurrent-ruby` or another library instead

Worth ruling out explicitly, since we already depend on `concurrent-ruby`: it can't address this. Every primitive it offers (`Event`, `Semaphore`, `CountDownLatch`, `ReadWriteLock`, the atomics) is built on Ruby's `Mutex`/`ConditionVariable` and coordinates threads *within one process*. There is no `flock` usage anywhere in the gem. This race is between two separate `brew` processes, so shared-memory primitives can't see each other. Cross-process advisory locking is what `flock` is for, and it's already in stdlib.

Within a single process there's nothing to fix: `DownloadQueue` already dedupes by `cached_location`, so two of its threads never race on the same download. The contention is strictly cross-process.

Third-party gems in this space (`filelock`, `lockfile`, and friends) are thin wrappers over `File#flock`, so they'd add a vendored dependency (plus `.licenses/` entries and RBIs) for no functional gain.

### Step-by-step reproduction

Same as #23328 and #23343 (two processes racing on one download). Covered here by unit tests plus a real, non-mocked check using two live `flock`s: a held lock genuinely blocks a second instance until released, a real `SIGINT` interrupts a blocked wait immediately, and the wait cap raises rather than hanging forever.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Used Claude Code to prototype this alternative, run the comparison benchmarks, and write the tests. Verified by:

- Running `brew typecheck` and `brew style --changed` (clean).
- Running the `lock_file`, `download_strategies/curl` and `cleanup` suites (all passing). `lock_file_spec.rb` passes without modification, which is the check that the non-blocking path's semantics survived the restructure.
- Establishing the `ignore_interrupts` hazard experimentally rather than assuming it: a forked child blocked on flock, sent a real `SIGINT`, comparing bare / inside-`ignore_interrupts` / inside-`Timeout.timeout`. Only the `ignore_interrupts` case swallowed the signal and hung, which is what drove the design here.
- Re-running the same real-`SIGINT` check against the finished implementation (`Interrupt` raised immediately, ~0.002s CPU).
- Benchmarking wake latency and CPU for both approaches. My first attempt reported misleadingly low polling latency (~6ms) because the hold duration was an exact multiple of both poll intervals and had accidentally synchronised the polls with the release. The table above is from the corrected benchmark.
- Reviewing the full diff by hand before opening this PR.

-----
