### PR TITLE
install_steps/formula_actions: write GCC specs only once

### DIFF
--- a/Library/Homebrew/install_steps/formula_actions.rb
+++ b/Library/Homebrew/install_steps/formula_actions.rb
@@ -46,7 +46,7 @@ module Homebrew
         end
         link_libgcc = glibc_installed ? "-nostdlib -L#{libgcc} -L#{glibc_lib}" : "+"
         homebrew_rpath = version_major.to_i >= 11
-        specs.write specs_string + <<~EOS
+        specs_string += <<~EOS
           *cpp_unique_options:
           + -isysroot #{HOMEBREW_PREFIX}/nonexistent #{system_header_dirs.map { |p| "-idirafter #{p}" }.join(" ")}
 
@@ -58,7 +58,8 @@ module Homebrew
 
           #{"*homebrew_rpath:\n-rpath #{HOMEBREW_PREFIX}/lib\n" if homebrew_rpath}
         EOS
-        specs.write(specs.read.gsub(" %o ", "\\0%(homebrew_rpath) ")) if homebrew_rpath
+        specs_string.gsub!(" %o ", "\\0%(homebrew_rpath) ") if homebrew_rpath
+        specs.write specs_string
       end
 
       sig { params(step: Step).void }


### PR DESCRIPTION
`WriteMkpathExtension#write` raises an exception if file already exists, which causes `brew postinstall gcc` failures (https://github.com/Homebrew/homebrew-core/actions/runs/30483501320/job/90684706907)

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb). (Nope, but tested on my Linux server that it works)
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
