### PR TITLE
Fix SimpleCov coverage for parallel runs

### DIFF
--- a/Library/Homebrew/.simplecov
+++ b/Library/Homebrew/.simplecov
@@ -5,7 +5,7 @@ require "English"
 
 SimpleCov.configure do
   merge_subprocesses true
-  finalize_merge false
+  finalize_merge SimpleCov.final_result_process?
   coverage_dir File.expand_path("../test/coverage", File.realpath(__FILE__))
   root File.expand_path("..", File.realpath(__FILE__))
   command_name "brew"

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -100,14 +100,6 @@ module Homebrew
             end
           end
 
-          # We use `ParallelTests.last_process?` in `test/spec_helper.rb` to
-          # handle SimpleCov output but, due to how the method is implemented,
-          # it doesn't work as expected if the number of processes is greater
-          # than one but lower than the number of CPU cores in the execution
-          # environment. Coverage information isn't saved in that scenario,
-          # so we disable parallel testing as a workaround in this case.
-          parallel = false if args.coverage? && files.length < Hardware::CPU.cores
-
           parallel_rspec_log_name = "parallel_runtime_rspec"
           parallel_rspec_log_name = "#{parallel_rspec_log_name}.generic" if args.generic?
           parallel_rspec_log_name = "#{parallel_rspec_log_name}.online" if args.online?

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -11,17 +11,6 @@ if ENV["HOMEBREW_TESTS_COVERAGE"]
     SimpleCov::Formatter::CoberturaFormatter,
   ]
   SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)
-
-  # Needed for outputting coverage reporting only once for parallel_tests.
-  # Otherwise, "Coverage report generated" will get spammed for each process.
-  if ENV["TEST_ENV_NUMBER"]
-    SimpleCov.at_exit do
-      result = SimpleCov.result
-      # `SimpleCov.result` calls `ParallelTests.wait_for_other_processes_to_finish`
-      # internally for you on the last process.
-      result.format! if ParallelTests.last_process?
-    end
-  end
 end
 
 require_relative "../standalone"


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I used Claude Opus 5 (High) to identify the issue and implement the fixes. I reviewed the changes (having read the upstream SimpleCov documentation and changelog), made some tweaks, and compared `brew tests --coverage` output to confirm the fix (comparing the output for 0.22.0, the `main` branch, and this PR branch).

-----

We recently updated SimpleCov from 0.22.0 to 1.0.1 but 1.0 involves some changes to how coverage data is merged/finalized when run in parallel and our preexisting setup doesn't quite work as expected. We addressed API deprecations when upgrading and `brew tests --coverage` works but it produces incomplete coverage data (i.e., the percentages are much lower than expected).

This appears to be due to a couple of issues:

* In SimpleCov 1.0, `finalize_merge false` causes `SimpleCov.result` to return early, so workers will return their result without waiting for and merging results from other workers. We use it explicitly in `.simplecov` but it would also be set by default for parallel runs when a custom `coverage_dir` is set, as in our case. I think the expectation is that we would use `SimpleCov.collate` but our logic in `spec_helper.rb` doesn't.
* We use `result.format! if ParallelTests.last_process?` in the `SimpleCov.at_exit` logic in `spec_helper.rb` but SimpleCov 1.0 switched to using `first_process?` (to align with `parallel_tests`), so that no longer works as expected.

This addresses the issue by using `finalize_merge
SimpleCov.final_result_process?` and removing the now-unnecessary `SimpleCov.at_exit` logic in `spec_helper.rb`, as the default behavior in 1.0 already does what we want. `finalize_merge true` technically works but it's notably slower for no added benefit (i.e., only one worker needs to merge and format the results).

This also removes the `parallel = false if args.coverage? && files.length < Hardware::CPU.cores` workaround in `dev-cmd/tests.rb`, as the related issues have been resolved in 1.0.

-----

I tested this by running `brew tests --coverage` using the commit before the SimpleCov 1.0 upgrade (09ad50f, which uses 0.22.0) and comparing that to the output on `main` (using 1.0.1). After implementing these changes, I ran it again and compared the previous 0.22.0 output to the output from this PR branch and confirmed that the coverage was generally what we would expect. I noticed a few small differences in the coverage but that may be attributable to how SimpleCov behaves in 1.0 (though that's something we can address in a follow-up PR, if needed).