### PR TITLE
Allow mixed env keys in script wrappers

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -356,7 +356,7 @@ class Pathname
   # Writes a wrapper env script and moves all files to the dst.
   #
   # @api public
-  sig { params(dst: Pathname, env: T::Hash[Symbol, T.any(String, Pathname)]).void }
+  sig { params(dst: Pathname, env: T::Hash[T.any(String, Symbol), T.any(String, Pathname)]).void }
   def env_script_all_files(dst, env)
     dst.mkpath
     Pathname.glob("#{self}/*") do |file|

--- a/Library/Homebrew/test/extend/pathname_spec.rb
+++ b/Library/Homebrew/test/extend/pathname_spec.rb
@@ -38,13 +38,15 @@ RSpec.describe Pathname do
   end
 
   describe ".env_script_all_files" do
-    it "create scipts for files" do
+    it "creates scripts for files with mixed environment key types" do
       mktmpdir do |input_dir|
         FileUtils.touch input_dir/"foo"
         FileUtils.touch input_dir/"bar"
 
         mktmpdir do |output_dir|
-          input_dir.env_script_all_files(output_dir, FOO: "foo", BAR: input_dir/"test")
+          env = { FOO: "foo" }
+          env["BAR"] = input_dir/"test"
+          input_dir.env_script_all_files(output_dir, env)
 
           expect((input_dir/"foo").read).to eq(<<~BASH)
             #!/bin/bash


### PR DESCRIPTION
- Match `env_script_all_files` with `write_env_script`
- Avoid Sorbet failures when formulae extend environment hashes

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 Sol xhigh  with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
