### PR TITLE
Recommend Software Update for CLT updates

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -297,8 +297,6 @@ module OS
 
       sig { returns(String) }
       def self.update_instructions
-        return installation_instructions if OS::Mac.version.prerelease?
-
         software_update_location = if MacOS.version >= "13"
           "System Settings"
         else

--- a/Library/Homebrew/test/os/mac/xcode_spec.rb
+++ b/Library/Homebrew/test/os/mac/xcode_spec.rb
@@ -23,4 +23,14 @@ RSpec.describe OS::Mac::Xcode, :needs_macos do
       expect(described_class.detect_version).to eq("26.3")
     end
   end
+
+  describe OS::Mac::CLT do
+    describe ".update_instructions" do
+      it "recommends Software Update on prerelease macOS" do
+        allow(OS::Mac).to receive(:version).and_return(MacOSVersion.new(HOMEBREW_MACOS_NEWEST_UNSUPPORTED))
+
+        expect(described_class.update_instructions).to include("Update them from Software Update in System Settings.")
+      end
+    end
+  end
 end


### PR DESCRIPTION
On macOS 27 public beta, Software Updates happily listed and updated the CLT and it's much easier than trawling through the developer portal.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI GPT 5.6 Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
