### PR TITLE
Compact install step JSON (25/26)

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -311,7 +311,7 @@ module Homebrew
                  "source"      => path_spec(source, base: source_base, default_base: @default_source_base),
                  "target"      => path_spec(target, base: target_base, default_base: @default_target_base),
                  "recursive"   => recursive,
-                 "overwrite"   => overwrite,
+                 "overwrite"   => (false unless overwrite),
                  "source_glob" => source_glob)
       end
 
@@ -382,8 +382,8 @@ module Homebrew
                                     default_base: @default_source_base),
                  "target"      => path_spec(target, base: target_base, formula: target_formula,
                                     default_base: @default_target_base),
-                 "force"       => force || overwrite,
-                 "uninstall"   => uninstall || remove_on_uninstall,
+                 "force"       => (true if force || overwrite),
+                 "uninstall"   => (true if uninstall || remove_on_uninstall),
                  "source_glob" => source_glob,
                  "sudo"        => sudo.is_a?(::Symbol) ? sudo.to_s : sudo)
       end
@@ -504,7 +504,7 @@ module Homebrew
         add_step("write",
                  "path"      => path_spec(path, base:, default_base: @default_base),
                  "content"   => content,
-                 "overwrite" => overwrite)
+                 "overwrite" => (true if overwrite))
       end
 
       sig {
@@ -641,7 +641,7 @@ module Homebrew
         add_step("set_ownership",
                  "paths"         => path_specs(paths, base:, default_base: @default_base),
                  "user"          => user,
-                 "group"         => group,
+                 "group"         => (group if group != "staff"),
                  "non_recursive" => !recursive)
       end
 
@@ -710,9 +710,9 @@ module Homebrew
 
         add_step("terminate_process",
                  "name"            => name,
-                 "match"           => match,
+                 "match"           => (match if match != "name"),
                  "sudo"            => sudo,
-                 "attempts"        => attempts,
+                 "attempts"        => (attempts if attempts != 1),
                  "must_succeed"    => must_succeed,
                  "notices"         => notices,
                  "failure_message" => failure_message)
@@ -1151,7 +1151,7 @@ module Homebrew
           ohai expand_template_tokens(notice)
         end
         name = expand_template_tokens(step_string(step, "name"))
-        if step_string(step, "match") == "full"
+        if step["match"] == "full"
           command = "/usr/bin/pkill"
           args = ["-f", name]
         else

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -311,6 +311,22 @@ RSpec.describe Homebrew::InstallSteps do
     expect((root/"var/remove.txt").read).to be_empty
   end
 
+  specify "omits install step runtime defaults" do
+    steps = Homebrew::InstallSteps::DSL.build(default_base:        :staged_path,
+                                              default_source_base: :staged_path,
+                                              default_target_base: :staged_path) do
+      copy "source", "target"
+      symlink "source", "target"
+      write "config", "content"
+      set_ownership "Example.app"
+      terminate_process "Example"
+    end
+
+    expect(steps).to all(satisfy do |step|
+      (step.keys & %w[attempts force group match overwrite uninstall]).empty?
+    end)
+  end
+
   specify "writes a default config file and preserves existing ones", :aggregate_failures do
     steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
       write "config/new.conf", "fresh"


### PR DESCRIPTION
Needs https://github.com/Homebrew/brew/pull/23199

Reduce the internal JSON representation of structured install steps.

- omit values already supplied by runner defaults
- preserve explicit compatibility-sensitive behaviour
- cover compact defaults in the install-step specs

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.