### PR TITLE
diagnostic: allowlist Apple Immersive Audio SDK dylib

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -261,6 +261,7 @@ module Homebrew
           "libsymsea*.dylib", # Symantec Endpoint Protection
           "sentinel.dylib", # SentinelOne
           "sentinel-*.dylib", # SentinelOne
+          "libASAF.dylib", # Apple Immersive Audio SDK
         ]
 
         msg = __check_stray_files "/usr/local/lib", "*.dylib", allow_list, <<~EOS


### PR DESCRIPTION
## What

Allowlist `libASAF.dylib` in the stray dylib diagnostic.

## Why

DaVinci Resolve installs this library as part of Apple's Immersive Audio SDK. It is intentional and is required by the installed ASAF Audio Unit components, but `brew doctor` currently reports it as an unexpected unbrewed dylib.

The installed file was verified as:

- Package: `com.Apple.pkg.ASAF.SDK` version `2.1.11`
- Signature authority: `Developer ID Application: Apple Inc. - Apple Immersive Audio (F8U5DM6Y33)`
- Architectures: `arm64` and `x86_64`
- Referenced by the ASAF Audio Unit plug-ins installed in `/Library/Audio/Plug-Ins/Components`

This matches the existing policy in `check_for_stray_dylibs`, whose allowlist contains known intentional libraries from MacFUSE, VPN clients, filesystem drivers, and endpoint-security software.

## Reproduction

1. Install DaVinci Resolve with its Immersive Audio components.
2. Run:

```sh
brew update
brew doctor
```

The diagnostic reports:

```text
Warning: Unbrewed dylibs were found in /usr/local/lib.
Unexpected dylibs:
  /usr/local/lib/libASAF.dylib
```

## Verification

- Confirmed the resulting diff contains one allowlist entry and no unrelated changes.
- Ran `brew lgtm` successfully; typechecking passed, and Homebrew reported no style checks or directly associated tests for this file change.
- No new test was added because this only extends the existing static allowlist.

-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI/LLM disclosure: I used OpenAI Codex to inspect the local package metadata and code signature, locate the existing allowlist, and help draft this change and description. I reviewed the one-line diff, verified the package and linkage evidence on my Mac, and ran `brew lgtm` successfully. I will answer maintainer questions and review comments myself without AI/LLM.

-----
