### PR TITLE
Make formula install-step var bases explicit

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4083,6 +4083,8 @@ class Formula
       current_steps.concat(
         if block
           Homebrew::InstallSteps::DSL.build(
+            # TODO: Remove the undocumented `default_base: :var` compatibility default after official taps use
+            # explicit bases.
             default_base:        :var,
             default_source_base: :prefix,
             default_target_base: :prefix,

--- a/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
+++ b/Library/Homebrew/json_api_postinstall_preflight_postflight_plan.md
@@ -18,9 +18,9 @@ The canonical step methods follow existing Formula, Cask, `Pathname`,
 `FileUtils`, `SystemCommand` and utility naming where practical. Shared file
 operations use `mkdir_p`, `touch`, `move`, `move_contents`, `copy`, `remove`,
 `inreplace`, `symlink`, `symlink_tree`, `symlink_children` and `write_file`.
-Formula steps default `mkdir_p` and `touch` paths to `var`, and source/target
-paths to `prefix`. Cask steps default `base`, `source_base` and `target_base`
-to `staged_path`.
+Formula steps should specify `base: :var` for paths under `var`, while
+source/target paths default to `prefix`. Cask steps default `base`,
+`source_base` and `target_base` to `staged_path`.
 
 Formula `post_install_steps` may temporarily coexist with `post_install` so tap
 conversions can peel supported repeated statements out of larger hooks. Runtime
@@ -427,8 +427,10 @@ is stripped during metadata serialisation.
   directory and `17` certificate/trust formulae could also move once their
   operations fit the supported step set. Runtime behaviour changes only for
   formulae that opt into `post_install_steps`.
-  Notes for implementation: default `mkdir_p`/`touch` to `var` and source/target
-  paths to `prefix`; expose the ordered array through `FormulaStruct`; make
+  Notes for implementation: formula definitions should specify `base: :var`
+  explicitly for `mkdir_p`/`touch` and other single-path steps, while
+  source/target paths default to `prefix`; expose the ordered array through
+  `FormulaStruct`; make
   `post_install_steps` run before any remaining `post_install`; document that
   the two forms may coexist only as an incremental conversion bridge. Keep the
   tap-wide autocorrect audit in a follow-up commit so the implementation can
@@ -687,3 +689,12 @@ is stripped during metadata serialisation.
 - [ ] PR 32, close the bridges and deprecate legacy hooks.
   Hard prerequisite: the merged `homebrew/core` head has no `post_install`
   methods and the merged `homebrew/cask` head has no legacy flight blocks.
+- [ ] PR 33, remove the documented formula `var` default while retaining it
+  temporarily as a runtime compatibility fallback.
+- [ ] PR 34, migrate every implicit `var` path in `homebrew/core` to an
+  explicit `base: :var`. `homebrew/cask` uses `staged_path` rather than `var`
+  as its install-step default and requires no matching migration.
+- [ ] PR 35, audit and autocorrect implicit formula `var` paths so new
+  official-tap uses cannot be introduced.
+- [ ] PR 36, remove the formula runtime compatibility fallback after the
+  official-tap migration and enforcement have landed.

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1075,8 +1075,8 @@ class Foo < Formula
   url "https://example.com/foo-1.0.tar.gz"
 
   post_install_steps do
-    mkdir_p "log/foo"
-    touch "foo/state"
+    mkdir_p "log/foo", base: :var
+    touch "foo/state", base: :var
     move "default.conf", "foo/default.conf"
     symlink "cert.pem", "foo/cert.pem", source_base: :relative
   end
@@ -1091,35 +1091,35 @@ represented by structured steps.
 
 #### File preparation steps
 
-`mkdir_p`, `touch`, `remove`, `inreplace`, `write_file`, `set_permissions` and guard paths default to paths relative to `var`. File steps with separate sources and targets default both to `prefix`. Use `base:`, `source_base:` or `target_base:` when a step needs another formula path such as `pkgetc`; use `source_base: :relative` for relative symlink sources.
+Specify `base:` for paths such as `var`, `etc` or `pkgetc`. File steps with separate source and target paths default those paths to `prefix`; use `source_base:` or `target_base:` to select another formula path and `source_base: :relative` for relative symlink sources.
 
-* `mkdir_p`: create a directory and any missing parents; example: `mkdir_p "log/foo"`.
-* `touch`: create or update a file timestamp; example: `touch "foo/state"`.
+* `mkdir_p`: create a directory and any missing parents; example: `mkdir_p "log/foo", base: :var`.
+* `touch`: create or update a file timestamp; example: `touch "foo/state", base: :var`.
 * `move`: move one file or directory; example: `move "default.conf", "foo/default.conf"`.
 * `move_contents`: move the contents of one directory into another; example: `move_contents "defaults", "foo/defaults"`.
 * `copy`: copy a file or, with `recursive: true`, a directory; example: `copy "default.conf", "foo/default.conf"`.
-* `remove`: remove one or more paths; example: `remove ["old.conf", "foo/*.bak"]`. Use `recursive: true` for directories.
-* `inreplace`: replace a string or regular expression in a file; example: `inreplace "foo.conf", "@PREFIX@", "{{HOMEBREW_PREFIX}}"`. Its `audit_result:` and `global:` options match the formula `inreplace` helper.
+* `remove`: remove one or more paths; example: `remove ["old.conf", "foo/*.bak"], base: :var`. Use `recursive: true` for directories.
+* `inreplace`: replace a string or regular expression in a file; example: `inreplace "foo.conf", "@PREFIX@", "{{HOMEBREW_PREFIX}}", base: :etc`. Its `audit_result:` and `global:` options match the formula `inreplace` helper.
 * `symlink`: create a symlink; example: `symlink "cert.pem", "foo/cert.pem", source_base: :relative`.
 * `symlink_tree`: recursively symlink a directory's contents while preserving real target directories.
 * `symlink_children`: symlink each direct child of a directory, optionally adding a `prefix:` or `suffix:`.
-* `set_permissions`: change existing path permissions; example: `set_permissions "foo", "0755"`.
+* `set_permissions`: change existing path permissions; example: `set_permissions "foo", "0755", base: :var`.
 * `change_dylib_id`: change one Mach-O dynamic library ID; pass the complete source and new ID, use `resolve_source: true` for a source symlink and wrap the step in `on_macos`.
 
 `move` and `copy` replace an existing target by default, matching the corresponding file helpers; pass `overwrite: false` to reject replacement. `symlink` preserves an existing target by default, so pass `overwrite: true` when replacement is intentional. `move` and `copy` accept `source_glob: true` when the glob must resolve to exactly one source; `symlink` accepts one or more matching sources. Path collections used by `remove` and `set_permissions` expand globs automatically. `remove` ignores missing paths and may additionally be restricted with `symlink_target_contains:` or `content_contains:`. It accepts `sudo: true` or `sudo: :if_needed` for paths requiring elevated permissions.
 
-Use `if_path_exists`, `unless_path_exists`, `on_macos` and `on_linux` blocks to guard one or more steps. A condition is evaluated once when its scope begins, so related steps make the same decision:
+Use `if_path_exists`, `unless_path_exists`, `on_macos` and `on_linux` blocks to guard one or more steps. Specify the guard path's `base:` explicitly. A condition is evaluated once when its scope begins, so related steps make the same decision:
 
 ```ruby
-unless_path_exists "foo/default.conf" do
-  mkdir_p "foo"
+unless_path_exists "foo/default.conf", base: :var do
+  mkdir_p "foo", base: :var
   copy "default.conf", "foo/default.conf"
 end
 ```
 
 #### Default config and template steps
 
-`write_file` atomically writes its exact literal content, replacing an existing file. It defaults to the same base as the other file preparation steps; pass `base:` (such as `base: :etc`) to target another formula path. Use `unless_path_exists` when a default file should preserve user edits across upgrades:
+`write_file` atomically writes its exact literal content, replacing an existing file. Specify its `base:`, such as `base: :etc`. Use `unless_path_exists` when a default file should preserve user edits across upgrades:
 
 ```ruby
 unless_path_exists "foo.conf", base: :etc do
@@ -1171,18 +1171,18 @@ Use the named actions below for formula families that share post-install algorit
 
 `init_data_dir` creates a database service data directory and runs a supported
 bootstrap command unless the directory already contains the default marker
-file. It defaults to paths relative to `var` and skips the bootstrap command in
-Homebrew's GitHub Actions jobs. It does not change permissions or ownership.
+file. Specify its `base:`, normally `base: :var`. It skips the bootstrap command
+in Homebrew's GitHub Actions jobs and does not change permissions or ownership.
 
 * `init_data_dir` with `using: :postgresql`: initialise PostgreSQL with
-  `initdb`; example: `init_data_dir "postgresql@16", using: :postgresql`.
+  `initdb`; example: `init_data_dir "postgresql@16", using: :postgresql, base: :var`.
   PostgreSQL defaults to `locale: "en_US.UTF-8"` and can set another locale,
-  for example `init_data_dir "postgresql@12", using: :postgresql, locale: "C"`.
+  for example `init_data_dir "postgresql@12", using: :postgresql, locale: "C", base: :var`.
 * `init_data_dir` with `using: :mysql`: initialise MySQL with
   `mysqld --initialize-insecure`; example:
-  `init_data_dir "mysql", using: :mysql`.
+  `init_data_dir "mysql", using: :mysql, base: :var`.
 * `init_data_dir` with `using: :mariadb`: initialise MariaDB with
-  `mysql_install_db`; example: `init_data_dir "mysql", using: :mariadb`.
+  `mysql_install_db`; example: `init_data_dir "mysql", using: :mariadb, base: :var`.
 
 `symlink_tree` recursively links a source directory's contents into a target
 directory, preserving existing real directories and skipping `.DS_Store` files.


### PR DESCRIPTION
Formula install steps currently default relative paths to `var`. Retain that behaviour temporarily for compatibility while removing it from the documented API.

- Update cookbook examples to specify their intended bases.
- Record the core migration, enforcement and fallback removal sequence.
- Leave an internal compatibility comment until the migration is complete.

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.
