### PR TITLE
Remove the formula install-step var default (29/29)

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4086,9 +4086,6 @@ class Formula
       current_steps.concat(
         if block
           Homebrew::InstallSteps::DSL.build(
-            # TODO: Remove the undocumented `default_base: :var` compatibility default after official taps use
-            # explicit bases.
-            default_base:        :var,
             default_source_base: :prefix,
             default_target_base: :prefix,
             &block

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4083,9 +4083,6 @@ class Formula
       current_steps.concat(
         if block
           Homebrew::InstallSteps::DSL.build(
-            # TODO: Remove the undocumented `default_base: :var` compatibility default after official taps use
-            # explicit bases.
-            default_base:        :var,
             default_source_base: :prefix,
             default_target_base: :prefix,
             &block

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1354,10 +1354,10 @@ on_request: installed_on_request?, options:)
     @show_summary_heading = true
   end
 
-  sig { returns(Pathname) }
+  sig { returns(T.any(String, Pathname)) }
   def post_install_formula_path
     # Use the formula from the keg when any of the following is true:
-    # * We're installing from the JSON API
+    # * We're installing from the JSON API and it has a Ruby post-install hook
     # * We're installing a local bottle file
     # * We're building from source
     # * The formula doesn't exist in the tap (or the tap isn't installed)
@@ -1372,7 +1372,11 @@ on_request: installed_on_request?, options:)
     return tap_formula_path if installed_prefix.nil?
 
     keg_formula_path = installed_prefix/".brew/#{formula.name}.rb"
-    return keg_formula_path if formula.loaded_from_api?
+    if formula.loaded_from_api?
+      return formula.full_name unless formula.post_install_defined?
+
+      return keg_formula_path
+    end
     return keg_formula_path if formula.local_bottle_path
     return keg_formula_path if build_from_source?
 

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -181,6 +181,35 @@ RSpec.describe FormulaInstaller do
     end
   end
 
+  describe "#post_install_formula_path" do
+    it "uses the API formula for structured-only post-installs" do
+      formula = formula("api-install-steps") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      installer = described_class.new(formula)
+
+      allow(formula).to receive_messages(any_installed_prefix: mktmpdir, loaded_from_api?: true,
+                                         post_install_defined?: false)
+
+      expect(installer.post_install_formula_path).to eq(formula.full_name)
+    end
+
+    it "uses the keg formula for API post-installs with Ruby hooks" do
+      formula = formula("api-post-install-hook") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      installer = described_class.new(formula)
+      installed_prefix = mktmpdir
+
+      allow(formula).to receive_messages(any_installed_prefix: installed_prefix, loaded_from_api?: true,
+                                         post_install_defined?: true)
+
+      expect(installer.post_install_formula_path).to eq(installed_prefix/".brew/api-post-install-hook.rb")
+    end
+  end
+
   describe "#pour" do
     let(:f) do
       formula("missing-bottle-tab") do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1193,8 +1193,8 @@ RSpec.describe Formula do
       url "foo-1.0"
 
       post_install_steps do
-        mkdir_p "log/foo"
-        touch "foo/marker"
+        mkdir_p "log/foo", base: :var
+        touch "foo/marker", base: :var
         move "move-source", "move-target"
         move_contents "children-source", "children-target"
         symlink "move-target", "linked-target", source_base: :relative, remove_on_uninstall: true
@@ -1224,6 +1224,21 @@ RSpec.describe Formula do
     ])
     expect(f.post_install_steps_defined?).to be(true)
     expect(f.to_hash["post_install_steps"]).to eq(f.post_install_steps)
+  end
+
+  specify "#post_install_steps does not default paths to var" do
+    f = formula do
+      T.bind(self, T.class_of(Formula))
+      url "foo-1.0"
+
+      post_install_steps do
+        touch "foo/marker"
+      end
+    end
+
+    expect(f.post_install_steps).to eq([
+      { "type" => "touch", "path" => { "path" => "foo/marker" } },
+    ])
   end
 
   specify "#post_install_steps_defined? with an empty block" do


### PR DESCRIPTION
Needs https://github.com/Homebrew/brew/pull/23404
Needs https://github.com/Homebrew/homebrew-core/pull/296288

Stop adding base: var implicitly when formula install steps are serialised.

Official taps are protected by the preceding RuboCop enforcement and have migrated existing paths to explicit bases.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.

-----
