### PR TITLE
workflows/docker: align deprecation of 22.04 image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -144,7 +144,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # odeprecated: remove 22.04 image in Homebrew >=5.4
+        # odeprecated: remove 22.04 image in Homebrew >=6.1
         version: ["22.04", "24.04", "26.04"]
         arch: ["x86_64", "arm64"]
 
@@ -171,7 +171,7 @@ jobs:
         run: |
           # odeprecated: remove 22.04 image in Homebrew >=6.1
           if [[ "${VERSION}" == "22.04" ]]; then
-            echo "The homebrew/ubuntu22.04 image is deprecated and will soon be retired. Use homebrew/brew." > .docker-deprecate
+            echo "The homebrew/ubuntu22.04 image is deprecated and will be retired in Homebrew 6.1. Use homebrew/brew." > .docker-deprecate
           fi
 
           filter="$(printf '.["%s"]' "${VERSION}")"


### PR DESCRIPTION
Other comments were already updated to refer to 6.1.

Also including information in docker image as there are still some installs of 22.04 image (https://github.com/Homebrew/brew/pkgs/container/ubuntu22.04/versions?filters%5Bversion_type%5D=tagged), e.g. 
* 6.0.11 had 67 installs and was latest for ~6 days
* 6.0.12 had 34 installs and was latest for ~7 days
* 6.0.13 had 32 installs and has been latest for ~4 days

Could be from old CI workflows so may not go down until we remove image and introduce a breaking change that makes old images incompatible with newer Homebrew.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
