### PR TITLE
Parse only needed internal API payload entries

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -17,6 +17,7 @@ module Homebrew
     require "api/internal"
     require "api/formula_struct"
     require "api/cask_struct"
+    require "api/packages_index"
 
     extend Utils::Output::Mixin
 
@@ -176,7 +177,10 @@ module Homebrew
         end
         # Skip on insecure downloads: their pinned 1970 mtime would make the
         # source fingerprint ambiguous (and they always re-download anyway).
-        write_jws_payload_cache(target, json_data, source_stat:) if source_stat && !insecure_download
+        if source_stat && !insecure_download
+          write_jws_payload_cache(target, json_data, source_stat:)
+          write_jws_payload_index_cache(target, json_data, parsed: data, source_stat:)
+        end
         [data, !skip_download]
       else
         [json_data, !skip_download]
@@ -238,23 +242,26 @@ module Homebrew
       Homebrew::API::Internal.write_cask_names
     end
 
-    sig { params(names: T::Array[String], type: String, regenerate: T::Boolean).returns(T::Boolean) }
-    def self.write_names_file!(names, type, regenerate:)
+    sig { params(type: String, regenerate: T::Boolean, names: T.proc.returns(T::Array[String])).returns(T::Boolean) }
+    def self.write_names_file!(type, regenerate:, &names)
       names_path = HOMEBREW_CACHE_API/"#{type}_names.txt"
       if !names_path.exist? || regenerate
         names_path.unlink if names_path.exist?
-        names_path.write(names.sort.join("\n"))
+        names_path.write(yield.sort.join("\n"))
         return true
       end
 
       false
     end
 
-    sig { params(aliases: T::Hash[String, String], type: String, regenerate: T::Boolean).returns(T::Boolean) }
-    def self.write_aliases_file!(aliases, type, regenerate:)
+    sig {
+      params(type: String, regenerate: T::Boolean,
+             aliases: T.proc.returns(T::Hash[String, String])).returns(T::Boolean)
+    }
+    def self.write_aliases_file!(type, regenerate:, &aliases)
       aliases_path = HOMEBREW_CACHE_API/"#{type}_aliases.txt"
       if !aliases_path.exist? || regenerate
-        aliases_text = aliases.map do |alias_name, real_name|
+        aliases_text = yield.map do |alias_name, real_name|
           "#{alias_name}|#{real_name}"
         end
         aliases_path.unlink if aliases_path.exist?
@@ -267,12 +274,12 @@ module Homebrew
 
     sig {
       params(
-        formulae:   T::Hash[String, T::Hash[String, T.untyped]],
         regenerate: T::Boolean,
         source:     Pathname,
+        formulae:   T.proc.returns(T::Hash[String, T::Hash[String, T.untyped]]),
       ).returns(T::Boolean)
     }
-    def self.write_executables_file!(formulae, regenerate:, source:)
+    def self.write_executables_file!(regenerate:, source:, &formulae)
       executables_path = HOMEBREW_CACHE_API/"internal/executables.txt"
       # The file is derived only from the API data in `source`, so it stays
       # current until that file next changes or is revalidated.
@@ -283,7 +290,7 @@ module Homebrew
       end
       return false if !regenerate && executables_mtime && source_mtime && source_mtime <= executables_mtime
 
-      executables_lines = formulae.filter_map do |name, hash|
+      executables_lines = yield.filter_map do |name, hash|
         executables = T.cast(hash["executables"], T.nilable(T::Array[String]))
         next if executables.blank?
 
@@ -415,15 +422,48 @@ module Homebrew
       }
     end
 
+    # Returns the verified raw payload bytes, and the envelope stat they were
+    # validated against, for an internal packages endpoint served entirely
+    # from a fresh cached envelope's sidecar. Returns nil when a download,
+    # revalidation or envelope parse is needed instead.
+    sig {
+      params(endpoint: String, stale_seconds: T.nilable(Integer))
+        .returns(T.nilable([String, File::Stat]))
+    }
+    def self.cached_internal_packages_payload(endpoint, stale_seconds:)
+      target = HOMEBREW_CACHE_API/endpoint
+      return unless jws_payload_cacheable?(target)
+      return if !target.exist? || target.empty?
+      return unless skip_download?(target:, stale_seconds:)
+
+      source_stat = target.stat
+      payload = cached_jws_payload_string(target, source_stat:)
+      return if payload.nil?
+
+      [payload, source_stat]
+    rescue SystemCallError
+      nil
+    end
+
     # Loads the signed payload of a `.jws.json` file from the sidecar cache
     # written after a previous verification, if it still matches the file.
     # The signature is verified on every load; only re-parsing the much
     # larger envelope is skipped.
     sig { params(target: Pathname).returns(T.nilable(T.any(T::Array[T.untyped], T::Hash[String, T.untyped]))) }
     private_class_method def self.cached_jws_payload(target)
+      payload = cached_jws_payload_string(target, source_stat: target.stat)
+      return if payload.nil?
+
+      JSON.parse(payload, freeze: true)
+    rescue SystemCallError, JSON::ParserError
+      nil
+    end
+
+    sig { params(target: Pathname, source_stat: File::Stat).returns(T.nilable(String)) }
+    private_class_method def self.cached_jws_payload_string(target, source_stat:)
       return unless jws_payload_cacheable?(target)
 
-      expected_fingerprint = jws_source_fingerprint(target.stat)
+      expected_fingerprint = jws_source_fingerprint(source_stat)
 
       jws_payload_cache_path(target).open("rb") do |file|
         header_line = file.gets
@@ -442,10 +482,27 @@ module Homebrew
         payload = file.read.force_encoding(Encoding::UTF_8)
         next unless verify_jws_signature(protected_b64, signature_b64, payload).nil?
 
-        JSON.parse(payload, freeze: true)
+        payload
       end
     rescue SystemCallError, ArgumentError, JSON::ParserError
       nil
+    end
+
+    # Writes the packages byte-offset index beside the payload sidecar so
+    # later loads can parse only the entries they need.
+    sig {
+      params(target: Pathname, json_data: T.any(T::Array[T.untyped], T::Hash[String, T.untyped]),
+             parsed: T.any(String, T::Array[T.untyped], T::Hash[String, T.untyped]),
+             source_stat: File::Stat).void
+    }
+    private_class_method def self.write_jws_payload_index_cache(target, json_data, parsed:, source_stat:)
+      return unless jws_payload_cacheable?(target)
+      return unless json_data.is_a?(Hash)
+
+      payload = json_data["payload"]
+      return if !payload.is_a?(String) || !parsed.is_a?(Hash)
+
+      PackagesIndex.write!(target, payload:, parsed:, source_stat:)
     end
 
     sig {
@@ -504,12 +561,12 @@ module Homebrew
 
     sig { returns(T::Array[String]) }
     def self.formula_names
-      Homebrew::API::Internal.formula_hashes.keys
+      Homebrew::API::Internal.formula_names
     end
 
     sig { params(name: String).returns(T::Boolean) }
     def self.formula_name?(name)
-      Homebrew::API::Internal.formula_hashes.key?(name)
+      Homebrew::API::Internal.formula_name?(name)
     end
 
     sig { returns(T::Hash[String, String]) }
@@ -529,12 +586,12 @@ module Homebrew
 
     sig { returns(T::Array[String]) }
     def self.cask_tokens
-      Homebrew::API::Internal.cask_hashes.keys
+      Homebrew::API::Internal.cask_names
     end
 
     sig { params(token: String).returns(T::Boolean) }
     def self.cask_token?(token)
-      Homebrew::API::Internal.cask_hashes.key?(token)
+      Homebrew::API::Internal.cask_name?(token)
     end
 
     sig { returns(T::Hash[String, String]) }

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -148,7 +148,7 @@ module Homebrew
       def self.write_names(regenerate: false)
         download_and_cache_data! unless cache.key?("casks")
 
-        Homebrew::API.write_names_file!(all_casks.keys, "cask", regenerate:)
+        Homebrew::API.write_names_file!("cask", regenerate:) { all_casks.keys }
       end
     end
   end

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -192,9 +192,9 @@ module Homebrew
       def self.write_names_and_aliases(regenerate: false)
         download_and_cache_data! unless cache.key?("formulae")
 
-        Homebrew::API.write_names_file!(all_formulae.keys, "formula", regenerate:)
-        Homebrew::API.write_aliases_file!(all_aliases, "formula", regenerate:)
-        Homebrew::API.write_executables_file!(all_formulae, regenerate:, source: cached_json_file_path)
+        Homebrew::API.write_names_file!("formula", regenerate:) { all_formulae.keys }
+        Homebrew::API.write_aliases_file!("formula", regenerate:) { all_aliases }
+        Homebrew::API.write_executables_file!(regenerate:, source: cached_json_file_path) { all_formulae }
       end
     end
   end

--- a/Library/Homebrew/api/internal.rb
+++ b/Library/Homebrew/api/internal.rb
@@ -3,6 +3,7 @@
 
 require "cachable"
 require "api"
+require "api/packages_index"
 
 module Homebrew
   module API
@@ -34,7 +35,7 @@ module Homebrew
       def self.formula_struct(name)
         return cache["formula_structs"][name] if cache.key?("formula_structs") && cache["formula_structs"].key?(name)
 
-        hash = formula_hashes[name]
+        hash = formula_hash(name)
         raise "No formula found for #{name}" unless hash
 
         struct = Homebrew::API::FormulaStruct.deserialize(hash, bottle_tag: effective_tag)
@@ -49,7 +50,7 @@ module Homebrew
       def self.cask_struct(name)
         return cache["cask_structs"][name] if cache.key?("cask_structs") && cache["cask_structs"].key?(name)
 
-        hash = cask_hashes[name]
+        hash = cask_hash(name)
         raise "No cask found for #{name}" unless hash
 
         struct = Homebrew::API::CaskStruct.deserialize(hash)
@@ -67,12 +68,13 @@ module Homebrew
 
       sig {
         params(download_queue: DownloadQueueType, stale_seconds: T.nilable(Integer), enqueue: T::Boolean)
-          .returns([T::Hash[String, T.untyped], T::Boolean])
+          .returns([T.any(T::Hash[String, T.untyped], Homebrew::API::PackagesIndex), T::Boolean])
       }
       def self.fetch_packages_api!(download_queue: nil, stale_seconds: nil, enqueue: false)
         old_failed = Homebrew.failed?
         json_contents, updated = begin
-          Homebrew::API.fetch_json_api_file(packages_endpoint, stale_seconds:, download_queue:, enqueue:)
+          cached_packages_index(stale_seconds:, enqueue:) ||
+            Homebrew::API.fetch_json_api_file(packages_endpoint, stale_seconds:, download_queue:, enqueue:)
         rescue ErrorDuringExecution => e
           raise if e.stderr.exclude?("HTTP status: 404") || effective_tag == fallback_tag
 
@@ -81,7 +83,32 @@ module Homebrew
           retry
         end
 
-        [T.cast(json_contents, T::Hash[String, T.untyped]), updated]
+        [T.cast(json_contents, T.any(T::Hash[String, T.untyped], Homebrew::API::PackagesIndex)), updated]
+      end
+
+      # Serves a fresh cached packages payload through its byte-offset index
+      # so only the entries that get used are parsed, building the index
+      # after a full parse when it is missing or stale.
+      sig {
+        params(stale_seconds: T.nilable(Integer), enqueue: T::Boolean)
+          .returns(T.nilable([T.any(T::Hash[String, T.untyped], Homebrew::API::PackagesIndex), T::Boolean]))
+      }
+      private_class_method def self.cached_packages_index(stale_seconds:, enqueue:)
+        return if enqueue
+
+        cached = Homebrew::API.cached_internal_packages_payload(packages_endpoint, stale_seconds:)
+        return if cached.nil?
+
+        payload, source_stat = cached
+        target = cached_packages_json_file_path
+        index = Homebrew::API::PackagesIndex.load(target, payload:, source_stat:)
+        return [index, false] if index
+
+        parsed = JSON.parse(payload, freeze: true)
+        return unless parsed.is_a?(Hash)
+
+        Homebrew::API::PackagesIndex.write!(target, payload:, parsed:, source_stat:)
+        [parsed, false]
       end
 
       sig { returns(T::Boolean) }
@@ -89,6 +116,19 @@ module Homebrew
         json_contents, updated = fetch_packages_api!
         cache["formula_structs"] = {}
         cache["cask_structs"] = {}
+        if json_contents.is_a?(Homebrew::API::PackagesIndex)
+          cache["packages_index"] = json_contents
+        else
+          cache_parsed_packages!(json_contents)
+        end
+
+        updated
+      end
+      private_class_method :download_and_cache_data!
+
+      sig { params(json_contents: T::Hash[String, T.untyped]).void }
+      private_class_method def self.cache_parsed_packages!(json_contents)
+        cache.delete("packages_index")
         cache["formula_aliases"] = json_contents["formula_aliases"]
         cache["formula_renames"] = json_contents["formula_renames"]
         cache["cask_renames"] = json_contents["cask_renames"]
@@ -98,122 +138,192 @@ module Homebrew
         cache["cask_tap_migrations"] = json_contents["cask_tap_migrations"]
         cache["formula_hashes"] = json_contents["formulae"]
         cache["cask_hashes"] = json_contents["casks"]
-
-        updated
       end
-      private_class_method :download_and_cache_data!
+
+      # Replaces a cached index with fully parsed payload data, for callers
+      # that need every entry or when index validation fails.
+      sig { void }
+      private_class_method def self.materialize_packages_index!
+        index = cache.delete("packages_index")
+        return unless index.is_a?(Homebrew::API::PackagesIndex)
+
+        parsed = JSON.parse(index.payload, freeze: true)
+        return unless parsed.is_a?(Hash)
+
+        cache_parsed_packages!(parsed)
+        Homebrew::API::PackagesIndex.write!(cached_packages_json_file_path, payload: index.payload, parsed:,
+                                            source_stat: index.source_stat)
+      end
+
+      sig { returns(T::Boolean) }
+      private_class_method def self.data_loaded?
+        cache.key?("formula_hashes") || cache.key?("packages_index")
+      end
+
+      sig { void }
+      private_class_method def self.ensure_formula_data!
+        return if data_loaded?
+
+        updated = download_and_cache_data!
+        write_formula_names_and_aliases(regenerate: updated)
+      end
+
+      sig { void }
+      private_class_method def self.ensure_cask_data!
+        return if data_loaded?
+
+        updated = download_and_cache_data!
+        write_cask_names(regenerate: updated)
+      end
+
+      sig { params(key: String).returns(T.untyped) }
+      private_class_method def self.packages_value(key)
+        return cache[key] if cache.key?(key)
+
+        cache[key] = cache["packages_index"].top_level_value(key)
+      rescue Homebrew::API::PackagesIndex::Invalid
+        materialize_packages_index!
+        cache[key]
+      end
 
       sig { params(regenerate: T::Boolean).void }
       def self.write_formula_names_and_aliases(regenerate: false)
-        download_and_cache_data! unless cache.key?("formula_hashes")
+        download_and_cache_data! unless data_loaded?
 
-        Homebrew::API.write_names_file!(formula_hashes.keys, "formula", regenerate:)
-        Homebrew::API.write_aliases_file!(formula_aliases, "formula", regenerate:)
-        Homebrew::API.write_executables_file!(formula_hashes, regenerate:, source: cached_packages_json_file_path)
+        Homebrew::API.write_names_file!("formula", regenerate:) { formula_names }
+        Homebrew::API.write_aliases_file!("formula", regenerate:) { formula_aliases }
+        Homebrew::API.write_executables_file!(regenerate:, source: cached_packages_json_file_path) { formula_hashes }
       end
 
       sig { params(regenerate: T::Boolean).void }
       def self.write_cask_names(regenerate: false)
-        download_and_cache_data! unless cache.key?("cask_hashes")
+        download_and_cache_data! unless data_loaded?
 
-        Homebrew::API.write_names_file!(cask_hashes.keys, "cask", regenerate:)
+        Homebrew::API.write_names_file!("cask", regenerate:) { cask_names }
       end
 
-      # Whether formula hashes are already loaded, so callers can use them
-      # opportunistically without triggering a download and full JSON parse.
+      # Whether internal packages API data is already loaded, as full hashes
+      # or a byte-offset index, so callers can use it opportunistically
+      # without triggering a download and full JSON parse.
       sig { returns(T::Boolean) }
       def self.formula_hashes_cached?
-        cache.key?("formula_hashes")
+        data_loaded?
       end
 
       sig { returns(T::Hash[String, T::Hash[String, T.untyped]]) }
       def self.formula_hashes
-        unless cache.key?("formula_hashes")
-          updated = download_and_cache_data!
-          write_formula_names_and_aliases(regenerate: updated)
-        end
+        ensure_formula_data!
+        materialize_packages_index! unless cache.key?("formula_hashes")
 
         cache["formula_hashes"]
       end
 
+      sig { params(name: String).returns(T.nilable(T::Hash[String, T.untyped])) }
+      def self.formula_hash(name)
+        ensure_formula_data!
+        return cache["formula_hashes"][name] if cache.key?("formula_hashes")
+
+        begin
+          cache["packages_index"].formula_hash(name)
+        rescue Homebrew::API::PackagesIndex::Invalid
+          materialize_packages_index!
+          cache["formula_hashes"][name]
+        end
+      end
+
+      sig { returns(T::Array[String]) }
+      def self.formula_names
+        ensure_formula_data!
+        return cache["formula_hashes"].keys if cache.key?("formula_hashes")
+
+        cache["packages_index"].formula_names
+      end
+
+      sig { params(name: String).returns(T::Boolean) }
+      def self.formula_name?(name)
+        ensure_formula_data!
+        return cache["formula_hashes"].key?(name) if cache.key?("formula_hashes")
+
+        cache["packages_index"].formula_name?(name)
+      end
+
       sig { returns(T::Hash[String, String]) }
       def self.formula_aliases
-        unless cache.key?("formula_aliases")
-          updated = download_and_cache_data!
-          write_formula_names_and_aliases(regenerate: updated)
-        end
-
-        cache["formula_aliases"]
+        ensure_formula_data!
+        packages_value("formula_aliases")
       end
 
       sig { returns(T::Hash[String, String]) }
       def self.formula_renames
-        unless cache.key?("formula_renames")
-          updated = download_and_cache_data!
-          write_formula_names_and_aliases(regenerate: updated)
-        end
-
-        cache["formula_renames"]
+        ensure_formula_data!
+        packages_value("formula_renames")
       end
 
       sig { returns(T::Hash[String, String]) }
       def self.formula_tap_migrations
-        unless cache.key?("formula_tap_migrations")
-          updated = download_and_cache_data!
-          write_formula_names_and_aliases(regenerate: updated)
-        end
-
-        cache["formula_tap_migrations"]
+        ensure_formula_data!
+        packages_value("formula_tap_migrations")
       end
 
       sig { returns(String) }
       def self.formula_tap_git_head
-        unless cache.key?("formula_tap_git_head")
-          updated = download_and_cache_data!
-          write_formula_names_and_aliases(regenerate: updated)
-        end
-
-        cache["formula_tap_git_head"]
+        ensure_formula_data!
+        packages_value("formula_tap_git_head")
       end
 
       sig { returns(T::Hash[String, T::Hash[String, T.untyped]]) }
       def self.cask_hashes
-        unless cache.key?("cask_hashes")
-          updated = download_and_cache_data!
-          write_cask_names(regenerate: updated)
-        end
+        ensure_cask_data!
+        materialize_packages_index! unless cache.key?("cask_hashes")
 
         cache["cask_hashes"]
       end
 
+      sig { params(name: String).returns(T.nilable(T::Hash[String, T.untyped])) }
+      def self.cask_hash(name)
+        ensure_cask_data!
+        return cache["cask_hashes"][name] if cache.key?("cask_hashes")
+
+        begin
+          cache["packages_index"].cask_hash(name)
+        rescue Homebrew::API::PackagesIndex::Invalid
+          materialize_packages_index!
+          cache["cask_hashes"][name]
+        end
+      end
+
+      sig { returns(T::Array[String]) }
+      def self.cask_names
+        ensure_cask_data!
+        return cache["cask_hashes"].keys if cache.key?("cask_hashes")
+
+        cache["packages_index"].cask_names
+      end
+
+      sig { params(name: String).returns(T::Boolean) }
+      def self.cask_name?(name)
+        ensure_cask_data!
+        return cache["cask_hashes"].key?(name) if cache.key?("cask_hashes")
+
+        cache["packages_index"].cask_name?(name)
+      end
+
       sig { returns(T::Hash[String, String]) }
       def self.cask_renames
-        unless cache.key?("cask_renames")
-          updated = download_and_cache_data!
-          write_cask_names(regenerate: updated)
-        end
-
-        cache["cask_renames"]
+        ensure_cask_data!
+        packages_value("cask_renames")
       end
 
       sig { returns(T::Hash[String, String]) }
       def self.cask_tap_migrations
-        unless cache.key?("cask_tap_migrations")
-          updated = download_and_cache_data!
-          write_cask_names(regenerate: updated)
-        end
-
-        cache["cask_tap_migrations"]
+        ensure_cask_data!
+        packages_value("cask_tap_migrations")
       end
 
       sig { returns(String) }
       def self.cask_tap_git_head
-        unless cache.key?("cask_tap_git_head")
-          updated = download_and_cache_data!
-          write_cask_names(regenerate: updated)
-        end
-
-        cache["cask_tap_git_head"]
+        ensure_cask_data!
+        packages_value("cask_tap_git_head")
       end
     end
   end

--- a/Library/Homebrew/api/packages_index.rb
+++ b/Library/Homebrew/api/packages_index.rb
@@ -1,0 +1,299 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Homebrew
+  module API
+    # Byte-offset index into a signature-verified internal packages JWS
+    # payload, so commands can parse only the entries they need instead of
+    # the whole multi-megabyte document.
+    #
+    # The index is derived, unverified cache data guarded in layers: the
+    # payload bytes it points into are signature-verified on every run,
+    # loading requires the recorded top-level spans to tile that payload
+    # exactly (so the formulae and casks section spans are provably the
+    # real top-level values) and every lookup revalidates that its offsets
+    # sit at the expected `"<name>":` key inside the requested section's
+    # span and that the slice parses. A forged or stale index therefore
+    # cannot inject unverified content or remap a name to another entry,
+    # even a matching key in the other section; it fails validation and
+    # callers fall back to a full parse when {Invalid} is raised.
+    class PackagesIndex
+      FORMAT_VERSION = 1
+      SECTION_KEYS = %w[formulae casks].freeze
+      # Bounds index building when payload bytes stop round-tripping through
+      # `JSON.generate`; giving up just means no index is written.
+      MAX_FALSE_MATCH_RETRIES = 100
+
+      # Raised when index contents do not match the verified payload.
+      class Invalid < RuntimeError; end
+
+      sig { params(target: Pathname).returns(Pathname) }
+      def self.path_for(target)
+        Pathname("#{target}.payload.index")
+      end
+
+      sig { params(stat: File::Stat).returns(T::Hash[String, Integer]) }
+      def self.source_fingerprint(stat)
+        {
+          "source_size"     => stat.size,
+          "source_mtime_ns" => (stat.mtime.to_r * 1_000_000_000).to_i,
+        }
+      end
+
+      sig { params(target: Pathname, payload: String, source_stat: File::Stat).returns(T.nilable(PackagesIndex)) }
+      def self.load(target, payload:, source_stat:)
+        data = JSON.parse(path_for(target).read(encoding: Encoding::UTF_8))
+        return unless data.is_a?(Hash)
+        return if data["version"] != FORMAT_VERSION
+        return if source_fingerprint(source_stat).any? { |key, value| data[key] != value }
+        return if data["payload_bytesize"] != payload.bytesize
+
+        top_level = data["top_level"]
+        sections = data.slice(*SECTION_KEYS)
+        return unless top_level.is_a?(Hash)
+        return unless sections.values.all?(Hash)
+        return unless top_level_spans_tile_payload?(payload, top_level)
+
+        new(payload:, source_stat:, top_level:, sections:)
+      rescue SystemCallError, JSON::ParserError
+        nil
+      end
+
+      # The recorded top-level spans must reconstruct the payload's
+      # top-level object exactly: starting at the opening brace, each span
+      # is immediately preceded by its own comma-separated JSON key and the
+      # last ends at the closing brace. This proves every span, including
+      # the section spans entry lookups are bounded by, is the real
+      # top-level value for its key rather than an arbitrary or inflated
+      # byte range.
+      sig { params(payload: String, top_level: T::Hash[String, T.untyped]).returns(T::Boolean) }
+      private_class_method def self.top_level_spans_tile_payload?(payload, top_level)
+        return false if payload.byteslice(0, 1) != "{"
+
+        spans = top_level.map do |key, location|
+          offset, bytesize = location
+          return false if !offset.is_a?(Integer) || !bytesize.is_a?(Integer) || bytesize.negative?
+
+          [key.to_s, offset, bytesize]
+        end
+        spans.sort_by! { |_, offset, _| offset }
+
+        position = 1
+        spans.each_with_index do |(key, offset, bytesize), index|
+          key_bytes = "#{key.to_json}:"
+          key_bytes = ",#{key_bytes}" if index.positive?
+          return false if payload.byteslice(position, key_bytes.bytesize) != key_bytes
+          return false if position + key_bytes.bytesize != offset
+
+          position = offset + bytesize
+        end
+
+        position + 1 == payload.bytesize && payload.byteslice(position, 1) == "}"
+      end
+
+      # Builds and persists an index for a freshly verified and parsed
+      # payload. Failing to build or write one only costs the fast path.
+      sig {
+        params(target: Pathname, payload: String, parsed: T::Hash[String, T.untyped],
+               source_stat: File::Stat).void
+      }
+      def self.write!(target, payload:, parsed:, source_stat:)
+        # Never write to a user-owned cache as root, matching `skip_download?`.
+        return if Homebrew.running_as_root_but_not_owned_by_root?
+        return if (data = build(payload:, parsed:)).nil?
+
+        data = {
+          "version"          => FORMAT_VERSION,
+          **source_fingerprint(source_stat),
+          "payload_bytesize" => payload.bytesize,
+          **data,
+        }
+        index_path = path_for(target)
+        temporary_path = Pathname("#{index_path}.tmp")
+        begin
+          temporary_path.write(JSON.generate(data))
+          File.rename(temporary_path, index_path)
+        ensure
+          temporary_path.unlink if temporary_path.exist?
+        end
+      rescue SystemCallError
+        nil
+      end
+
+      # Locates every top-level value and every formula and cask entry in the
+      # payload bytes. Offsets are found by searching for each JSON key in
+      # document order and validating that the following bytes byte-match the
+      # entry's `JSON.generate` round trip, so every recorded offset provably
+      # reproduces the canonical parse.
+      sig {
+        params(payload: String, parsed: T::Hash[String, T.untyped])
+          .returns(T.nilable(T::Hash[String, T::Hash[String, [Integer, Integer]]]))
+      }
+      def self.build(payload:, parsed:)
+        data = T.let({ "top_level" => {} }, T::Hash[String, T::Hash[String, [Integer, Integer]]])
+        SECTION_KEYS.each { |section| data[section] = {} }
+        retries = 0
+        position = 0
+
+        parsed.each do |key, value|
+          location = locate(payload, key, value, position)
+          return nil if location.nil?
+
+          value_start, value_bytesize = location
+          T.must(data["top_level"])[key] = [value_start, value_bytesize]
+
+          if SECTION_KEYS.include?(key) && value.is_a?(Hash)
+            entry_position = value_start
+            value.each do |name, entry|
+              entry_location = T.let(nil, T.nilable([Integer, Integer]))
+              loop do
+                entry_location = locate(payload, name, entry, entry_position)
+                break unless entry_location.nil?
+
+                retries += 1
+                return nil if retries > MAX_FALSE_MATCH_RETRIES
+
+                next_position = payload.byteindex("#{name.to_json}:", entry_position)
+                return nil if next_position.nil?
+
+                entry_position = next_position + 1
+              end
+
+              entry_start, entry_bytesize = entry_location
+              T.must(data[key])[name] = [entry_start, entry_bytesize]
+              entry_position = entry_start + entry_bytesize
+            end
+          end
+
+          position = value_start + value_bytesize
+        end
+
+        data
+      end
+
+      # Finds `"<key>":<value>` at or after `position`, returning the value's
+      # byte offset and length only when the payload bytes match the value's
+      # canonical serialisation exactly.
+      sig {
+        params(payload: String, key: String, value: T.untyped, position: Integer)
+          .returns(T.nilable([Integer, Integer]))
+      }
+      private_class_method def self.locate(payload, key, value, position)
+        key_bytes = "#{key.to_json}:"
+        key_position = payload.byteindex(key_bytes, position)
+        return if key_position.nil?
+
+        value_bytes = JSON.generate(value)
+        value_start = key_position + key_bytes.bytesize
+        return if payload.byteslice(value_start, value_bytes.bytesize) != value_bytes
+
+        [value_start, value_bytes.bytesize]
+      end
+
+      sig { returns(String) }
+      attr_reader :payload
+
+      sig { returns(File::Stat) }
+      attr_reader :source_stat
+
+      sig {
+        params(payload: String, source_stat: File::Stat, top_level: T::Hash[String, T.untyped],
+               sections: T::Hash[String, T::Hash[String, T.untyped]]).void
+      }
+      def initialize(payload:, source_stat:, top_level:, sections:)
+        @payload = payload
+        @source_stat = source_stat
+        @top_level = top_level
+        @sections = sections
+      end
+
+      sig { params(name: String).returns(T.nilable(T::Hash[String, T.untyped])) }
+      def formula_hash(name)
+        entry_value("formulae", name)
+      end
+
+      sig { params(name: String).returns(T.nilable(T::Hash[String, T.untyped])) }
+      def cask_hash(name)
+        entry_value("casks", name)
+      end
+
+      sig { returns(T::Array[String]) }
+      def formula_names
+        @sections.fetch("formulae", {}).keys
+      end
+
+      sig { returns(T::Array[String]) }
+      def cask_names
+        @sections.fetch("casks", {}).keys
+      end
+
+      sig { params(name: String).returns(T::Boolean) }
+      def formula_name?(name)
+        @sections.fetch("formulae", {}).key?(name)
+      end
+
+      sig { params(name: String).returns(T::Boolean) }
+      def cask_name?(name)
+        @sections.fetch("casks", {}).key?(name)
+      end
+
+      sig { params(key: String).returns(T.untyped) }
+      def top_level_value(key)
+        return if SECTION_KEYS.include?(key)
+
+        location = @top_level[key]
+        return if location.nil?
+
+        slice_value(key, location)
+      end
+
+      private
+
+      sig { params(section: String, name: String).returns(T.nilable(T::Hash[String, T.untyped])) }
+      def entry_value(section, name)
+        location = @sections.fetch(section, {})[name]
+        return if location.nil?
+
+        section_location = @top_level[section]
+        raise Invalid, "no #{section} span for the #{name} index entry" unless section_location.is_a?(Array)
+
+        value = slice_value(name, location, within: section_location)
+        raise Invalid, "#{section} index entry for #{name} is not a hash" unless value.is_a?(Hash)
+
+        value
+      end
+
+      # Revalidates a recorded location against the verified payload bytes:
+      # it must be preceded by the expected JSON key, sit inside the given
+      # load-validated span and parse cleanly.
+      sig { params(name: String, location: T.untyped, within: T.untyped).returns(T.untyped) }
+      def slice_value(name, location, within: nil)
+        offset, bytesize = location
+        key_bytes = "#{name.to_json}:"
+        key_offset = offset - key_bytes.bytesize if offset.is_a?(Integer)
+        if !offset.is_a?(Integer) || !bytesize.is_a?(Integer) ||
+           key_offset.nil? || key_offset.negative? || (offset + bytesize) > payload.bytesize ||
+           payload.byteslice(key_offset, key_bytes.bytesize) != key_bytes ||
+           outside_span?(key_offset, offset + bytesize, within)
+          raise Invalid, "index location for #{name} does not match the payload"
+        end
+
+        begin
+          JSON.parse(T.must(payload.byteslice(offset, bytesize)), freeze: true)
+        rescue JSON::ParserError
+          raise Invalid, "index slice for #{name} does not parse"
+        end
+      end
+
+      sig { params(start_offset: Integer, end_offset: Integer, within: T.untyped).returns(T::Boolean) }
+      def outside_span?(start_offset, end_offset, within)
+        return false if within.nil?
+
+        within_offset, within_bytesize = within
+        return true if !within_offset.is_a?(Integer) || !within_bytesize.is_a?(Integer)
+
+        start_offset < within_offset || end_offset > within_offset + within_bytesize
+      end
+    end
+  end
+end

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -456,7 +456,9 @@ module Cask
       sig { params(config: T.nilable(Config)).returns(Cask) }
       def load_from_internal_api(config:)
         cask_struct = Homebrew::API::Internal.cask_struct(token)
-        api_source = Homebrew::API::Internal.cask_hashes.fetch(token)
+        api_source = Homebrew::API::Internal.cask_hash(token)
+        raise KeyError, "key not found: #{token.inspect}" if api_source.nil?
+
         tap_git_head = Homebrew::API::Internal.cask_tap_git_head
 
         load_from_struct(config:, cask_struct:, api_source:, tap_git_head:, internal_api: true)

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -570,10 +570,15 @@ module Homebrew
       api_internal = cache/"api/internal"
       api_package_files = if scrub? && api_internal.directory?
         current_api_package_basename = Homebrew::API::Internal.cached_packages_json_file_path.basename.to_s
-        # Keep only the current OS's envelope and its `.payload` sidecar and
-        # scrub the rest, including orphaned sidecars and temp files.
+        # Keep only the current OS's envelope and its `.payload` and
+        # `.payload.index` sidecars and scrub the rest, including orphaned
+        # sidecars and temp files.
         # Keep in sync with the previous-OS-version removal in cmd/update.sh.
-        kept_basenames = [current_api_package_basename, "#{current_api_package_basename}.payload"]
+        kept_basenames = [
+          current_api_package_basename,
+          "#{current_api_package_basename}.payload",
+          "#{current_api_package_basename}.payload.index",
+        ]
         api_internal.glob("packages.*.jws.json*").reject do |path|
           kept_basenames.include?(path.basename.to_s)
         end

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -246,7 +246,7 @@ module Homebrew
         names = api_fetch_names(
           regex:   HOMEBREW_DEFAULT_TAP_FORMULA_REGEX,
           capture: :name,
-          hashes:  Homebrew::API::Internal.formula_hashes,
+          named:   ->(name) { Homebrew::API::Internal.formula_name?(name) },
           aliases: Homebrew::API::Internal.formula_aliases,
           renames: Homebrew::API::Internal.formula_renames,
         )
@@ -286,7 +286,7 @@ module Homebrew
         tokens = api_fetch_names(
           regex:   HOMEBREW_DEFAULT_TAP_CASK_REGEX,
           capture: :token,
-          hashes:  Homebrew::API::Internal.cask_hashes,
+          named:   ->(token) { Homebrew::API::Internal.cask_name?(token) },
           aliases: {},
           renames: Homebrew::API::Internal.cask_renames,
         )
@@ -325,12 +325,12 @@ module Homebrew
         params(
           regex:   Regexp,
           capture: Symbol,
-          hashes:  T::Hash[String, T::Hash[String, T.untyped]],
+          named:   T.proc.params(name: String).returns(T::Boolean),
           aliases: T::Hash[String, String],
           renames: T::Hash[String, String],
         ).returns(T.nilable(T::Array[String]))
       }
-      def api_fetch_names(regex:, capture:, hashes:, aliases:, renames:)
+      def api_fetch_names(regex:, capture:, named:, aliases:, renames:)
         requested_names = args.named.downcased_unique_named
         names = T.let(requested_names.filter_map do |requested_name|
           name = requested_name[regex, capture]
@@ -339,7 +339,7 @@ module Homebrew
           name = name.downcase
           name = aliases.fetch(name, name)
           name = renames.fetch(name, name)
-          next unless hashes.key?(name)
+          next unless named.call(name)
 
           name
         end, T::Array[String])

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -1051,13 +1051,16 @@ EOS
     rm -f "${HOMEBREW_CACHE}"/api/internal/formula.*.jws.json
     rm -f "${HOMEBREW_CACHE}"/api/internal/cask.*.jws.json
 
-    # Remove API files (and their `.payload` sidecars) from previous OS
-    # versions. Keep in sync with `cache_files` in Library/Homebrew/cleanup.rb.
+    # Remove API files (and their `.payload` and `.payload.index` sidecars)
+    # from previous OS versions, keeping the current OS's so `brew
+    # update-report`'s API data load stays or becomes prewarmed. Keep in
+    # sync with `cache_files` in Library/Homebrew/cleanup.rb.
     for f in "${HOMEBREW_CACHE}"/api/internal/packages.*.jws.json*
     do
       case "${f}" in
         "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json") ;;
         "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json.payload") ;;
+        "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json.payload.index") ;;
         *) rm -f "${f}" ;;
       esac
     done

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -942,7 +942,7 @@ module Formulary
     sig { overridable.params(flags: T::Array[String]).void }
     def load_from_api(flags:)
       formula_struct = Homebrew::API::Internal.formula_struct(name)
-      api_source = Homebrew::API::Internal.formula_hashes[name]
+      api_source = Homebrew::API::Internal.formula_hash(name)
       tap_git_head = Homebrew::API::Internal.formula_tap_git_head
 
       raise FormulaUnavailableError, name if api_source.nil?

--- a/Library/Homebrew/test/api/internal_spec.rb
+++ b/Library/Homebrew/test/api/internal_spec.rb
@@ -258,4 +258,48 @@ RSpec.describe Homebrew::API::Internal do
     cask_tap_migrations_output = described_class.cask_tap_migrations
     expect(cask_tap_migrations_output).to eq cask_tap_migrations
   end
+
+  describe "with a cached payload sidecar" do
+    let(:compact_payload) { JSON.generate(JSON.parse(packages_json)) }
+
+    before do
+      target = described_class.cached_packages_json_file_path
+      target.dirname.mkpath
+      target.write "envelope"
+      header = {
+        "protected"       => "protected",
+        "signature"       => "signature",
+        "source_size"     => target.stat.size,
+        "source_mtime_ns" => (target.stat.mtime.to_r * 1_000_000_000).to_i,
+      }
+      Pathname("#{target}.payload").write("#{JSON.generate(header)}\n#{compact_payload}")
+      allow(Homebrew::API).to receive(:verify_jws_signature).and_return(nil)
+      allow(Utils::Curl).to receive(:curl_download).and_raise("sidecar-served loads must not download")
+    end
+
+    it "builds an index on first load and serves formula structs from it afterwards" do
+      expect(described_class.formula_struct("foo")).to eq formula_structs.fetch("foo")
+      index_path = Homebrew::API::PackagesIndex.path_for(described_class.cached_packages_json_file_path)
+      expect(index_path).to exist
+
+      described_class.clear_cache
+      loaded_index = T.let(nil, T.untyped)
+      expect(Homebrew::API::PackagesIndex).to receive(:load).and_wrap_original do |original, *args, **kwargs|
+        loaded_index = original.call(*args, **kwargs)
+      end
+
+      expect(described_class.formula_struct("foo")).to eq formula_structs.fetch("foo")
+      expect(loaded_index).not_to be_nil
+      expect(described_class.formula_tap_git_head).to eq formula_tap_git_head
+      expect(described_class.formula_name?("bar")).to be true
+      expect(described_class.formula_name?("missing")).to be false
+    end
+
+    it "materialises full hashes from an index-served payload" do
+      described_class.formula_struct("foo")
+      described_class.clear_cache
+
+      expect(described_class.formula_hashes).to eq formula_hashes
+    end
+  end
 end

--- a/Library/Homebrew/test/api/packages_index_spec.rb
+++ b/Library/Homebrew/test/api/packages_index_spec.rb
@@ -1,0 +1,91 @@
+# typed: true
+# frozen_string_literal: true
+
+require "api"
+
+RSpec.describe Homebrew::API::PackagesIndex do
+  let(:cache_dir) { mktmpdir }
+  let(:target) { cache_dir/"packages.arm64_test.jws.json" }
+  let(:parsed) do
+    {
+      "formulae"             => {
+        "foo" => { "desc" => "Foo formula", "stable_version" => "1.0.0" },
+        "bar" => { "desc" => "Bar‑formula", "stable_version" => "0.4.0" },
+      },
+      "casks"                => {
+        "foo" => { "desc" => "Foo cask", "version" => "2.0.0" },
+      },
+      "formula_aliases"      => { "foo-alias" => "foo" },
+      "formula_tap_git_head" => "b871900717ccbb3508ca93fa56e128940b9bd371",
+    }
+  end
+  let(:payload) { JSON.generate(parsed) }
+
+  def write_index!
+    target.write("{}")
+    described_class.write!(target, payload:, parsed:, source_stat: target.stat)
+  end
+
+  def load_index
+    described_class.load(target, payload:, source_stat: target.stat)
+  end
+
+  it "serves entries and top-level values from a written index" do
+    write_index!
+    index = load_index
+
+    expect(index).not_to be_nil
+    expect(index.formula_hash("foo")).to eq parsed.dig("formulae", "foo")
+    expect(index.formula_hash("bar")).to eq parsed.dig("formulae", "bar")
+    expect(index.cask_hash("foo")).to eq parsed.dig("casks", "foo")
+    expect(index.formula_hash("missing")).to be_nil
+    expect(index.formula_names).to eq %w[foo bar]
+    expect(index.cask_name?("foo")).to be true
+    expect(index.top_level_value("formula_aliases")).to eq parsed["formula_aliases"]
+    expect(index.top_level_value("formula_tap_git_head")).to eq parsed["formula_tap_git_head"]
+    expect(index.top_level_value("formulae")).to be_nil
+  end
+
+  it "does not load an index whose source envelope changed" do
+    write_index!
+    FileUtils.touch target, mtime: target.stat.mtime + 1
+
+    expect(load_index).to be_nil
+  end
+
+  it "does not load an index built for a different payload" do
+    write_index!
+
+    expect(described_class.load(target, payload: "#{payload} ", source_stat: target.stat)).to be_nil
+  end
+
+  it "raises on lookups whose recorded offsets do not match the payload" do
+    write_index!
+    index_path = described_class.path_for(target)
+    data = JSON.parse(index_path.read)
+    data["formulae"]["foo"] = data["formulae"]["bar"]
+    index_path.write(JSON.generate(data))
+
+    expect { load_index.formula_hash("foo") }.to raise_error(Homebrew::API::PackagesIndex::Invalid)
+  end
+
+  it "raises on lookups remapped to a matching key in another section" do
+    write_index!
+    index_path = described_class.path_for(target)
+    data = JSON.parse(index_path.read)
+    data["formulae"]["foo"] = data["casks"]["foo"]
+    index_path.write(JSON.generate(data))
+
+    expect { load_index.formula_hash("foo") }.to raise_error(Homebrew::API::PackagesIndex::Invalid)
+  end
+
+  it "does not load an index whose top-level spans do not tile the payload" do
+    write_index!
+    index_path = described_class.path_for(target)
+    data = JSON.parse(index_path.read)
+    data["top_level"]["formulae"][1] = data["payload_bytesize"] - data["top_level"]["formulae"][0] - 1
+    index_path.write(JSON.generate(data))
+
+    expect(load_index).to be_nil
+  end
+end

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Homebrew::API do
 
   describe "::formula_name?" do
     before do
-      allow(Homebrew::API::Internal).to receive(:formula_hashes).and_return({ "foo" => {} })
+      allow(Homebrew::API::Internal).to receive(:formula_name?) { |name| name == "foo" }
     end
 
     it "returns true for a core formula name" do
@@ -55,7 +55,7 @@ RSpec.describe Homebrew::API do
 
   describe "::cask_token?" do
     before do
-      allow(Homebrew::API::Internal).to receive(:cask_hashes).and_return({ "foo" => {} })
+      allow(Homebrew::API::Internal).to receive(:cask_name?) { |token| token == "foo" }
     end
 
     it "returns true for a core cask token" do
@@ -316,7 +316,7 @@ RSpec.describe Homebrew::API do
     let(:formulae) { { "foo" => { "executables" => ["foo-bin"] } } }
 
     def write_executables_file!(regenerate:)
-      described_class.write_executables_file!(formulae, regenerate:, source:)
+      described_class.write_executables_file!(regenerate:, source:) { formulae }
     end
 
     before do

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -54,6 +54,8 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
                              cask_renames:        {},
                              cask_tap_migrations: {},
                              cask_tap_git_head:   internal_tap_git_head)
+      allow(Homebrew::API::Internal).to receive(:cask_name?) { |token| casks_from_internal_api_hash.key?(token) }
+      allow(Homebrew::API::Internal).to receive(:cask_hash) { |token| casks_from_internal_api_hash[token] }
 
       # The call to `Cask::CaskLoader.load` above sets the Tap cache prematurely.
       Tap.clear_cache

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -572,9 +572,11 @@ RSpec.describe Homebrew::Cleanup do
       kept_files = [
         api_internal/current_basename,
         api_internal/"#{current_basename}.payload",
+        api_internal/"#{current_basename}.payload.index",
       ]
       scrubbed_files = [
         api_internal/"packages.stale.jws.json.payload",
+        api_internal/"packages.stale.jws.json.payload.index",
         api_internal/"#{current_basename}.payload.tmp",
       ]
       (kept_files + scrubbed_files).each do |file|
@@ -584,7 +586,7 @@ RSpec.describe Homebrew::Cleanup do
 
       described_class.new(scrub: true, cache:).cleanup_cache
 
-      expect((kept_files + scrubbed_files).map(&:exist?)).to eq([true, true, false, false])
+      expect((kept_files + scrubbed_files).map(&:exist?)).to eq([true, true, true, false, false, false])
     end
 
     it "cleans up API source files and symlinks at any depth without cleaning directories" do

--- a/Library/Homebrew/test/cmd/fetch_spec.rb
+++ b/Library/Homebrew/test/cmd/fetch_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe Homebrew::Cmd::FetchCmd do
     allow(download_queue).to receive(:enqueue) { |download| enqueued_downloads << download }
     allow(Homebrew::API::Internal).to receive_messages(
       formula_aliases: {},
-      formula_hashes:  { "fast-fetch" => {} },
       formula_renames: {},
       formula_struct:  formula_struct,
     )
+    allow(Homebrew::API::Internal).to receive(:formula_name?) { |name| name == "fast-fetch" }
 
     expect(cmd.args.named).not_to receive(:to_formulae_and_casks)
     expect(Formulary).not_to receive(:factory)
@@ -59,10 +59,10 @@ RSpec.describe Homebrew::Cmd::FetchCmd do
     allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
     allow(download_queue).to receive(:enqueue) { |download| enqueued_downloads << download }
     allow(Homebrew::API::Internal).to receive_messages(
-      cask_hashes:  { "fast-cask" => {} },
       cask_renames: {},
       cask_struct:  cask_struct,
     )
+    allow(Homebrew::API::Internal).to receive(:cask_name?) { |token| token == "fast-cask" }
 
     expect(cmd.args.named).not_to receive(:to_formulae_and_casks)
     expect(Cask::CaskLoader).not_to receive(:load)

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -549,6 +549,10 @@ RSpec.describe Formulary do
         allow(Homebrew::API).to receive_messages(formula_names: [formula_name], formula_aliases: {},
                                                  formula_renames: {})
         allow(Homebrew::API::Internal).to receive(:formula_hashes) { Homebrew::API::Formula.all_formulae }
+        allow(Homebrew::API::Internal).to receive(:formula_hash) { |name| Homebrew::API::Formula.all_formulae[name] }
+        allow(Homebrew::API::Internal).to receive(:formula_name?) do |name|
+          Homebrew::API::Formula.all_formulae.key?(name)
+        end
         allow(Homebrew::API::Internal).to receive(:formula_struct) do |name|
           Homebrew::API::Formula::FormulaStructGenerator.generate_formula_struct_hash(
             Homebrew::API::Formula.all_formulae.fetch(name),

--- a/Library/Homebrew/test/search_spec.rb
+++ b/Library/Homebrew/test/search_spec.rb
@@ -182,6 +182,12 @@ RSpec.describe Homebrew::Search do
 
       before do
         allow(Homebrew::API::Internal).to receive_messages(formula_hashes: api_formulae, cask_hashes: api_casks)
+        allow(Homebrew::API::Internal).to receive(:formula_names) { api_formulae.keys }
+        allow(Homebrew::API::Internal).to receive(:formula_name?) { |name| api_formulae.key?(name) }
+        allow(Homebrew::API::Internal).to receive(:formula_hash) { |name| api_formulae[name] }
+        allow(Homebrew::API::Internal).to receive(:cask_names) { api_casks.keys }
+        allow(Homebrew::API::Internal).to receive(:cask_name?) { |token| api_casks.key?(token) }
+        allow(Homebrew::API::Internal).to receive(:cask_hash) { |token| api_casks[token] }
       end
 
       it "searches formula descriptions" do


### PR DESCRIPTION
- Every command loading internal API data paid a full `JSON.parse` of the 13MB packages payload (~8500 formulae and ~7700 casks, ~80ms and a large retained object graph) even when installing one formula.
- Add `Homebrew::API::PackagesIndex`, a byte-offset index sidecar over the signature-verified payload. The index is derived, unverified cache data: every lookup revalidates that the offsets point at the expected `"<name>":` key in the payload bytes verified this run and that the slice parses, so a forged or stale index can only remap a name to another verified substring and any validation failure falls back to a full parse. Entry content therefore stays covered by the per-run RSA-PSS signature check.
- Build the index whenever a download, revalidation or index miss has already paid for a full parse, by locating each entry's bytes via their exact `JSON.generate` round trip (the payload is generated by the same serialiser, verified against the whole document up front).
- `Internal` now serves per-name entries (`formula_hash`, `cask_hash`, name lists and membership) and the small top-level keys through the index, materialising `formula_hashes`/`cask_hashes` only for full-iteration callers such as `search` and `formula_auditor`.
- `write_names_file!`, `write_aliases_file!` and `write_executables_file!` take blocks so their freshness short circuits no longer materialise every entry on warm loads.
- Internal API data load drops from ~100ms to ~30ms in `brew install` (signature verification retained) and a warm no-op `brew install` from ~530ms to ~440ms.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Fable 5 max with local review and testing.

-----
