### PR TITLE
Bridge cask flight step migrations (19/26)

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_artifact.rb
+++ b/Library/Homebrew/cask/artifact/abstract_artifact.rb
@@ -71,9 +71,9 @@ module Cask
       def sort_order
         @sort_order ||= T.let(
           [
-            PreflightBlock,
             PreflightSteps,
             UninstallPreflightSteps,
+            PreflightBlock,
             # The `uninstall` stanza should be run first, as it may
             # depend on other artifacts still being installed.
             Uninstall,

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -87,20 +87,6 @@ module Cask
       Artifact::UninstallPostflightSteps,
     ].freeze
 
-    InstallStepFlightBlockClasses = T.type_alias do
-      T::Hash[
-        T.class_of(Artifact::AbstractInstallSteps),
-        [T.class_of(Artifact::AbstractFlightBlock), Symbol],
-      ]
-    end
-
-    INSTALL_STEP_FLIGHT_BLOCK_CLASSES = T.let({
-      Artifact::PreflightSteps           => [Artifact::PreflightBlock, :preflight],
-      Artifact::PostflightSteps          => [Artifact::PostflightBlock, :postflight],
-      Artifact::UninstallPreflightSteps  => [Artifact::PreflightBlock, :uninstall_preflight],
-      Artifact::UninstallPostflightSteps => [Artifact::PostflightBlock, :uninstall_postflight],
-    }.freeze, InstallStepFlightBlockClasses)
-
     DSL_METHODS = T.let(Set.new([
       :arch,
       :artifacts,
@@ -872,11 +858,7 @@ module Cask
       [klass.dsl_key, klass.uninstall_dsl_key].each do |dsl_key|
         define_method(dsl_key) do |&block|
           T.bind(self, DSL)
-          if install_step_artifact_defined?(dsl_key)
-            warn_on_install_step_conflict(dsl_key, T.must(install_step_artifact_class(dsl_key)).dsl_key)
-          else
-            artifacts.add(klass.new(cask, dsl_key => block))
-          end
+          artifacts.add(klass.new(cask, dsl_key => block))
         end
       end
     end
@@ -890,43 +872,8 @@ module Cask
         else
           Homebrew::InstallSteps::DSL.normalise_steps([kwargs[:steps] || steps].flatten.compact)
         end
-        remove_conflicting_flight_blocks(klass)
         artifacts.add(klass.new(cask, steps))
       end
-    end
-
-    sig { params(dsl_key: Symbol).returns(T::Boolean) }
-    def install_step_artifact_defined?(dsl_key)
-      return false unless (klass = install_step_artifact_class(dsl_key))
-
-      artifacts.any?(klass)
-    end
-
-    sig { params(dsl_key: Symbol).returns(T.nilable(T.class_of(Artifact::AbstractInstallSteps))) }
-    def install_step_artifact_class(dsl_key)
-      INSTALL_STEP_FLIGHT_BLOCK_CLASSES.find do |_step_class, (_block_class, block_dsl_key)|
-        block_dsl_key == dsl_key
-      end&.first
-    end
-
-    sig { params(klass: T.class_of(Artifact::AbstractInstallSteps)).void }
-    def remove_conflicting_flight_blocks(klass)
-      flight_block_class, dsl_key = INSTALL_STEP_FLIGHT_BLOCK_CLASSES.fetch(klass)
-      conflicting_flight_blocks = artifacts.select do |artifact|
-        next false unless artifact.is_a?(flight_block_class)
-
-        artifact.directives.key?(dsl_key)
-      end
-
-      conflicting_flight_blocks.each do |artifact|
-        warn_on_install_step_conflict(dsl_key, klass.dsl_key)
-        artifacts.delete(artifact)
-      end
-    end
-
-    sig { params(dsl_key: Symbol, steps_key: Symbol).void }
-    def warn_on_install_step_conflict(dsl_key, steps_key)
-      opoo "#{token}: `#{dsl_key}` is ignored because `#{steps_key}` is defined!"
     end
 
     sig { override.params(method: Symbol, _args: T.anything).returns(T.noreturn) }

--- a/Library/Homebrew/test/cask/artifact/install_steps_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/install_steps_spec.rb
@@ -15,18 +15,18 @@ RSpec.describe Cask::Artifact::AbstractInstallSteps, :cask do
       end
 
       postflight_steps do
-        mv "move-source", "Prepared/moved"
-        ln_s "Prepared/moved", "PreparedLink", source_base: :relative, uninstall: true
+        move "move-source", "Prepared/moved"
+        symlink "Prepared/moved", "PreparedLink", source_base: :relative, remove_on_uninstall: true
         run "/usr/bin/true"
       end
 
       uninstall_preflight_steps do
-        mkdir "UninstallPrepared"
+        mkdir_p "UninstallPrepared"
         touch "UninstallPrepared/touched"
       end
 
       uninstall_postflight_steps do
-        move_children "UninstallPrepared", "UninstallMoved"
+        move_contents "UninstallPrepared", "UninstallMoved"
       end
     end
   end
@@ -63,31 +63,29 @@ RSpec.describe Cask::Artifact::AbstractInstallSteps, :cask do
     expect(run_step).not_to include("print_stdout", "suppress_stderr")
   end
 
-  it "ignores a flight block when matching steps are defined" do
-    cask = T.let(nil, T.nilable(Cask::Cask))
-    expect do
-      cask = Cask::Cask.new("with-install-steps-conflict") do
-        version "1.2.3"
-        sha256 :no_check
-        url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
+  it "runs a flight block after matching steps during migration" do
+    cask = Cask::Cask.new("with-install-steps-bridge") do
+      version "1.2.3"
+      sha256 :no_check
+      url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
 
-        preflight do
-          touch "ruby-block-ran"
-        end
-
-        preflight_steps do
-          touch "steps-ran"
-        end
+      preflight_steps do
+        touch "steps-ran"
       end
-    end.to output(/`preflight` is ignored because `preflight_steps` is defined/).to_stderr
 
-    cask = T.must(cask)
+      preflight do
+        raise "preflight steps did not run first" unless (staged_path/"steps-ran").exist?
+
+        FileUtils.touch staged_path/"ruby-block-ran"
+      end
+    end
+
     cask.staged_path.mkpath
     cask.config_path.dirname.mkpath
 
     Cask::Installer.new(cask, command: NeverSudoSystemCommand).install_artifacts
 
-    expect(cask.staged_path/"ruby-block-ran").not_to exist
+    expect(cask.staged_path/"ruby-block-ran").to exist
     expect(cask.staged_path/"steps-ran").to exist
   end
 end


### PR DESCRIPTION
Repeat of https://github.com/Homebrew/brew/pull/23194

Tap migrations cannot replace every cask flight block atomically. Matching step and Ruby forms must coexist until the tap reaches zero hooks.

- retain both artifacts instead of discarding either declaration
- execute declarative steps before the matching Ruby flight block
- use the shared command output default in every step phase

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.