### PR TITLE
install: isolate formula and cask fetch errors

### DIFF
--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -359,16 +359,7 @@ module Homebrew
           download_queue.fetch
 
           [:prelude, :enqueue_fetch].each do |step|
-            valid_formula_installers.select! do |fi|
-              fi.public_send(step)
-              true
-            rescue CannotInstallFormulaError => e
-              ofail e.message
-              false
-            rescue UnsatisfiedRequirements, DownloadError, ChecksumMismatchError => e
-              ofail "#{fi.formula}: #{e}"
-              false
-            end
+            valid_formula_installers = select_formula_installers(valid_formula_installers, step:)
             next if step == :enqueue_fetch && !fetch_after_enqueue
 
             download_queue.fetch
@@ -391,13 +382,20 @@ module Homebrew
           fi.download_queue = download_queue
         end
 
+        select_formula_installers(formula_installers, step: :prelude_fetch)
+      end
+
+      sig {
+        params(formula_installers: T::Array[FormulaInstaller], step: Symbol).returns(T::Array[FormulaInstaller])
+      }
+      def select_formula_installers(formula_installers, step:)
         formula_installers.select do |fi|
-          fi.prelude_fetch
+          fi.public_send(step)
           true
         rescue CannotInstallFormulaError => e
           ofail e.message
           false
-        rescue UnsatisfiedRequirements, DownloadError, ChecksumMismatchError => e
+        rescue => e
           ofail "#{fi.formula}: #{e}"
           false
         end
@@ -425,16 +423,29 @@ module Homebrew
 
       sig { params(cask_installers: T::Array[T.untyped], download_queue: Homebrew::DownloadQueue).void }
       def enqueue_cask_installers(cask_installers, download_queue:)
-        if cask_installers.any?(&:source_download_requires_pre_fetch?)
-          source_downloads = cask_installers.filter_map(&:prelude_fetch_download)
-          if source_downloads.any?
-            oh1 "Downloading Cask files"
-            source_downloads.each { |source_download| download_queue.enqueue(source_download) }
-            download_queue.fetch
+        source_downloads = []
+        valid_cask_installers = cask_installers.select do |cask_installer|
+          if cask_installer.source_download_requires_pre_fetch? &&
+             (source_download = cask_installer.prelude_fetch_download)
+            source_downloads << source_download
           end
+          true
+        rescue => e
+          ofail "#{cask_installer.cask}: #{e}"
+          false
         end
 
-        cask_installers.each(&:enqueue_downloads)
+        if source_downloads.any?
+          oh1 "Downloading Cask files"
+          source_downloads.each { |source_download| download_queue.enqueue(source_download) }
+          download_queue.fetch
+        end
+
+        valid_cask_installers.each do |cask_installer|
+          cask_installer.enqueue_downloads
+        rescue => e
+          ofail "#{cask_installer.cask}: #{e}"
+        end
       end
 
       sig {

--- a/Library/Homebrew/test/install_spec.rb
+++ b/Library/Homebrew/test/install_spec.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "cask/installer"
 require "install"
 require "dependency"
 require "test/support/fixtures/testball"
@@ -22,6 +23,49 @@ RSpec.describe Homebrew::Install do
       .ordered
 
     described_class.perform_preinstall_checks
+  end
+
+  describe "::fetch_formulae" do
+    it "skips formulae whose fetch steps raise and continues with the rest" do
+      good_fi = FormulaInstaller.new(formula("good-bottle") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end)
+      bad_fi = FormulaInstaller.new(formula("bad-bottle") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end)
+      [good_fi, bad_fi].each do |fi|
+        allow(fi).to receive(:prelude_fetch)
+        allow(fi).to receive(:prelude)
+      end
+      allow(good_fi).to receive(:enqueue_fetch)
+      allow(bad_fi).to receive(:enqueue_fetch).and_raise("unexpected failure")
+
+      expect do
+        expect(described_class.fetch_formulae([good_fi, bad_fi])).to eq([good_fi])
+      end.to output(/Error: bad-bottle: unexpected failure/).to_stderr
+    end
+  end
+
+  describe "::enqueue_cask_installers" do
+    it "skips casks whose enqueue raises and continues with the rest" do
+      bad_cask = instance_double(Cask::Cask, to_s: "bad-cask")
+      bad_installer = instance_double(Cask::Installer, cask:                                bad_cask,
+                                                       source_download_requires_pre_fetch?: false)
+      allow(bad_installer).to receive(:enqueue_downloads)
+        .and_raise(URI::InvalidURIError, 'bad URI (is not URI?): "https://example.com/bad -cask.dmg"')
+      good_installer = instance_double(Cask::Installer, source_download_requires_pre_fetch?: false)
+      expect(good_installer).to receive(:enqueue_downloads)
+
+      download_queue = Homebrew::DownloadQueue.new(pour: true)
+      begin
+        expect { described_class.enqueue_cask_installers([bad_installer, good_installer], download_queue:) }
+          .to output(/Error: bad-cask: bad URI/).to_stderr
+      ensure
+        download_queue.shutdown
+      end
+    end
   end
 
   describe "::print_dry_run_dependencies" do


### PR DESCRIPTION
- One malformed formula or cask (e.g. a bottle `root_url` that is an invalid URI) raised while enqueueing downloads and aborted the whole `brew upgrade` batch with an internal stack trace.
- Rescue anything raised by an individual formula's or cask's prelude and enqueue steps so the offending package is reported and skipped, the rest still proceed and the command exits nonzero.

Fixes https://github.com/Homebrew/brew/issues/23377.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Fable 5 with local review and testing.

-----
