### PR TITLE
cask/config: define instance variables in a consistent order

### DIFF
--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -110,22 +110,25 @@ module Cask
       ).void
     }
     def initialize(default: nil, env: nil, explicit: {}, ignore_invalid_keys: false)
-      if default
-        @default = T.let(
-          self.class.canonicalize(self.class.defaults.merge(default)),
-          T.nilable(ConfigHash),
-        )
-      end
-      if env
-        @env = T.let(
-          self.class.canonicalize(env),
-          T.nilable(ConfigHash),
-        )
-      end
+      # Define all instance variables in a consistent order so every instance
+      # shares one object shape, avoiding Ruby's shape-variation warning.
+      @default = T.let(
+        default ? self.class.canonicalize(self.class.defaults.merge(default)) : nil,
+        T.nilable(ConfigHash),
+      )
+      @env = T.let(
+        env ? self.class.canonicalize(env) : nil,
+        T.nilable(ConfigHash),
+      )
       @explicit = T.let(
         self.class.canonicalize(explicit),
         ConfigHash,
       )
+      @binarydir = T.let(nil, T.nilable(Pathname))
+      @manpagedir = T.let(nil, T.nilable(Pathname))
+      @bash_completion = T.let(nil, T.nilable(Pathname))
+      @zsh_completion = T.let(nil, T.nilable(Pathname))
+      @fish_completion = T.let(nil, T.nilable(Pathname))
 
       if ignore_invalid_keys
         @env&.delete_if { |key, _| self.class.defaults.keys.exclude?(key) }
@@ -164,27 +167,27 @@ module Cask
 
     sig { returns(Pathname) }
     def binarydir
-      @binarydir ||= T.let(HOMEBREW_PREFIX/"bin", T.nilable(Pathname))
+      @binarydir ||= HOMEBREW_PREFIX/"bin"
     end
 
     sig { returns(Pathname) }
     def manpagedir
-      @manpagedir ||= T.let(HOMEBREW_PREFIX/"share/man", T.nilable(Pathname))
+      @manpagedir ||= HOMEBREW_PREFIX/"share/man"
     end
 
     sig { returns(Pathname) }
     def bash_completion
-      @bash_completion ||= T.let(HOMEBREW_PREFIX/"etc/bash_completion.d", T.nilable(Pathname))
+      @bash_completion ||= HOMEBREW_PREFIX/"etc/bash_completion.d"
     end
 
     sig { returns(Pathname) }
     def zsh_completion
-      @zsh_completion ||= T.let(HOMEBREW_PREFIX/"share/zsh/site-functions", T.nilable(Pathname))
+      @zsh_completion ||= HOMEBREW_PREFIX/"share/zsh/site-functions"
     end
 
     sig { returns(Pathname) }
     def fish_completion
-      @fish_completion ||= T.let(HOMEBREW_PREFIX/"share/fish/vendor_completions.d", T.nilable(Pathname))
+      @fish_completion ||= HOMEBREW_PREFIX/"share/fish/vendor_completions.d"
     end
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/test/cask/config_spec.rb
+++ b/Library/Homebrew/test/cask/config_spec.rb
@@ -4,6 +4,26 @@
 RSpec.describe Cask::Config, :cask do
   subject(:config) { described_class.new }
 
+  describe "#initialize" do
+    it "defines all instance variables in a consistent order" do
+      configs = [
+        described_class.new,
+        described_class.new(default: {}, env: {}, explicit: {}),
+      ]
+
+      expect(configs.map(&:instance_variables)).to all(eq([
+        :@default,
+        :@env,
+        :@explicit,
+        :@binarydir,
+        :@manpagedir,
+        :@bash_completion,
+        :@zsh_completion,
+        :@fish_completion,
+      ]))
+    end
+  end
+
   describe "::from_json" do
     it "deserializes a configuration in JSON format" do
       config = described_class.from_json <<~EOS


### PR DESCRIPTION
Follows #22362 by defining all of `Cask::Config`'s instance variables up front in `#initialize`, in a consistent order, so every instance shares one object shape. One `Config` is built per `Cask`, plus more via `.from_args`, `.from_json` and `#merge`.

`@default` and `@env` were only assigned when the matching keyword argument was passed, and the five directory accessors created their ivars lazily on first read, so instances took different shape transitions depending on which arguments were given and which accessor was hit first. On `main`:

```console
$ brew ruby -- -W:performance -I Library/Homebrew -r cask/config -e '%i[default env binarydir manpagedir bash_completion zsh_completion fish_completion].each { |m| Cask::Config.new.public_send(m) }; Cask::Config.new(default: {}); Cask::Config.new(env: {})'
Library/Homebrew/cask/config.rb:125: warning: The class Cask::Config reached 8 shape variations, instance variables accesses will be slower and memory usage increased.
It is recommended to define instance variables in a consistent order, for instance by eagerly defining them all in the #initialize method.
```

That is silent with this change.

The accessors keep their `||=` memoization and the ivars are predeclared as `nil`, so nothing is computed any earlier than before. Evaluation order in `#initialize` is unchanged, so an invalid `default:` still raises before an invalid `explicit:`.

A `config_spec.rb` example locks the ivar list and its order so a new lazy ivar added without predeclaring it is caught in CI.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new spec fails against the old initializer and passes with it, confirmed the warning reproduces on `main` and is silent here, and ran `brew lgtm` locally.

-----
