### PR TITLE
Suppress brew services tmux caveat on Linux

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -299,7 +299,7 @@ class Caveats
 
     # pbpaste is the system clipboard tool on macOS and fails with `tmux` by default
     # check if this is being run under `tmux` to avoid failing
-    if ENV["HOMEBREW_TMUX"] && !quiet_system("/usr/bin/pbpaste")
+    if ENV.fetch("HOMEBREW_TMUX", nil) && File.exist?("/usr/bin/pbpaste") && !quiet_system("/usr/bin/pbpaste")
       s << "" << "WARNING: brew services will fail when run under tmux."
     end
 

--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -299,7 +299,7 @@ class Caveats
 
     # pbpaste is the system clipboard tool on macOS and fails with `tmux` by default
     # check if this is being run under `tmux` to avoid failing
-    if ENV.fetch("HOMEBREW_TMUX", nil) && File.exist?("/usr/bin/pbpaste") && !quiet_system("/usr/bin/pbpaste")
+    if ENV.fetch("HOMEBREW_TMUX", false) && File.executable?("/usr/bin/pbpaste") && !quiet_system("/usr/bin/pbpaste")
       s << "" << "WARNING: brew services will fail when run under tmux."
     end
 


### PR DESCRIPTION
brew services works on Linux but the caveat was firing because it interpreted the nonexistence of /usr/bin/pbpaste as failure. Now the check is identical to that in the services subcommand itself.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [ ] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
