### PR TITLE
contributions: clarify Maintainer team access

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -40,7 +40,8 @@ module Homebrew
         EOS
         comma_array "--user=",
                     description: "Specify a comma-separated list of GitHub usernames or email addresses to find " \
-                                 "contributions from. Omitting this flag searches Homebrew maintainers. " \
+                                 "contributions from. Omitting this flag searches Homebrew maintainers and " \
+                                 "requires access to the `Homebrew/maintainers` team. " \
                                  "With `--maintainer-report-csv`, only matching quarter-end Maintainers are included."
         comma_array "--repositories",
                     description: "Specify a comma-separated list of repositories to search. " \

--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -4,6 +4,24 @@
 require "utils/github"
 
 RSpec.describe GitHub do
+  describe "::members_by_team" do
+    it "reports an inaccessible team without assuming the token scope is missing" do
+      allow(GitHub::API).to receive(:open_graphql).and_return({
+        "organization" => {
+          "teams" => { "nodes" => [] },
+          "team"  => nil,
+        },
+      })
+
+      expect { described_class.members_by_team("Homebrew", "maintainers") }
+        .to raise_error(
+          GitHub::API::Error,
+          "Could not access the team Homebrew/maintainers. Please check that your GitHub account has access to the " \
+          "team and that your token has the required permissions.",
+        )
+    end
+  end
+
   describe "::API.commit" do
     it "fetches the main branch commit by default" do
       commit = { "sha" => "abc123" }

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -411,11 +411,11 @@ module GitHub
     EOS
     result = API.open_graphql(query, scopes: ["read:org", "user"])
 
-    if result["organization"]["teams"]["nodes"].blank?
-      raise API::Error,
-            "Your token needs the 'read:org' scope to access this API"
+    if result.dig("organization", "teams", "nodes").blank? || result.dig("organization", "team").blank?
+      raise API::Error, "Could not access the team #{org}/#{team}. " \
+                        "Please check that your GitHub account has access to the team and that your token has the " \
+                        "required permissions."
     end
-    raise API::Error, "The team #{org}/#{team} does not exist" if result["organization"]["team"].blank?
 
     result["organization"]["team"]["members"]["nodes"].to_h { |member| [member["login"], member["name"]] }
   end

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -876,7 +876,7 @@ __fish_brew_complete_arg 'contributions' -l quiet -d 'Make some output more quie
 __fish_brew_complete_arg 'contributions' -l repositories -d 'Specify a comma-separated list of repositories to search. All repositories must be under the same user or organisation. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: `Homebrew/brew`, `Homebrew/homebrew-core`, `Homebrew/homebrew-cask`'
 __fish_brew_complete_arg 'contributions' -l team -d 'Specify the team to populate users from. The first part of the team name will be used as the organisation'
 __fish_brew_complete_arg 'contributions' -l to -d 'Date (ISO 8601 format) to stop searching contributions'
-__fish_brew_complete_arg 'contributions' -l user -d 'Specify a comma-separated list of GitHub usernames or email addresses to find contributions from. Omitting this flag searches Homebrew maintainers. With `--maintainer-report-csv`, only matching quarter-end Maintainers are included'
+__fish_brew_complete_arg 'contributions' -l user -d 'Specify a comma-separated list of GitHub usernames or email addresses to find contributions from. Omitting this flag searches Homebrew maintainers and requires access to the `Homebrew/maintainers` team. With `--maintainer-report-csv`, only matching quarter-end Maintainers are included'
 __fish_brew_complete_arg 'contributions' -l verbose -d 'Make some output more verbose'
 
 

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -1150,7 +1150,7 @@ _brew_contributions() {
     '(--organisation --maintainer-report-csv)--repositories[Specify a comma-separated list of repositories to search. All repositories must be under the same user or organisation. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: `Homebrew/brew`, `Homebrew/homebrew-core`, `Homebrew/homebrew-cask`]' \
     '(--organisation --user --maintainer-report-csv)--team[Specify the team to populate users from. The first part of the team name will be used as the organisation]' \
     '(--maintainer-report-csv)--to[Date (ISO 8601 format) to stop searching contributions]' \
-    '(--team)--user[Specify a comma-separated list of GitHub usernames or email addresses to find contributions from. Omitting this flag searches Homebrew maintainers. With `--maintainer-report-csv`, only matching quarter-end Maintainers are included]' \
+    '(--team)--user[Specify a comma-separated list of GitHub usernames or email addresses to find contributions from. Omitting this flag searches Homebrew maintainers and requires access to the `Homebrew/maintainers` team. With `--maintainer-report-csv`, only matching quarter-end Maintainers are included]' \
     '--verbose[Make some output more verbose]'
 }
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -3150,7 +3150,8 @@ Summarise contributions to Homebrew repositories.
 `--user`
 
 : Specify a comma-separated list of GitHub usernames or email addresses to find
-  contributions from. Omitting this flag searches Homebrew maintainers. With
+  contributions from. Omitting this flag searches Homebrew maintainers and
+  requires access to the `Homebrew/maintainers` team. With
   `--maintainer-report-csv`, only matching quarter-end Maintainers are included.
 
 `--repositories`

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1998,7 +1998,7 @@ Treat all named arguments as casks\.
 Summarise contributions to Homebrew repositories\.
 .TP
 \fB\-\-user\fP
-Specify a comma\-separated list of GitHub usernames or email addresses to find contributions from\. Omitting this flag searches Homebrew maintainers\. With \fB\-\-maintainer\-report\-csv\fP, only matching quarter\-end Maintainers are included\.
+Specify a comma\-separated list of GitHub usernames or email addresses to find contributions from\. Omitting this flag searches Homebrew maintainers and requires access to the \fBHomebrew/maintainers\fP team\. With \fB\-\-maintainer\-report\-csv\fP, only matching quarter\-end Maintainers are included\.
 .TP
 \fB\-\-repositories\fP
 Specify a comma\-separated list of repositories to search\. All repositories must be under the same user or organisation\. Omitting this flag, or specifying \fB\-\-repositories=primary\fP, searches only the main repositories: \fBHomebrew/brew\fP, \fBHomebrew/homebrew\-core\fP, \fBHomebrew/homebrew\-cask\fP\&\.


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex (GPT-5) assisted with investigating the issue, drafting the implementation and tests. I reviewed the resulting diff, reproduced the issue and fallback locally, and ran the relevant tests and brew lgtm --online.


-----

`brew contributions` fetches the `Homebrew/maintainers` team by default. When the current GitHub account cannot view organization teams, the command incorrectly reports that the token needs `read:org`, even when that scope is already present.

This change replaces the scope-specific error with an actionable message covering both GitHub account access and 
token permissions. It also documents that the default Maintainer search requires access to the `Homebrew/maintainers` team.

### Reproduction

```sh
$ gh auth status
Token scopes: 'gist', 'read:org', 'repo', 'workflow'

$ brew contributions
Error: Your token needs the 'read:org' scope to access this API

```
With this change:

```sh
$ brew contributions
 Error: Could not access the team Homebrew/maintainers. Please check that your GitHub account has access to the team and that your token has the required permissions.
```

### Testing

Added a test covering an inaccessible team without assuming that the token is missing a particular scope.

```sh
$ brew lgtm --online
```