### PR TITLE
sorbet: Fix the `formula` test helper block typing

### DIFF
--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -13,7 +13,7 @@ module Test
       sig {
         params(
           name: String, path: T.nilable(Pathname), spec: Symbol, alias_path: T.nilable(Pathname),
-          tap: T.nilable(Tap), block: T.nilable(T.proc.bind(::Formula).void)
+          tap: T.nilable(Tap), block: T.nilable(T.proc.void)
         ).returns(::Formula)
       }
       def formula(name = "formula_name", path: nil, spec: :stable, alias_path: nil, tap: nil, &block)


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

- This `formula` helper returning `Class.new(::Formula, &block)` is not of _instance_ type `Formula` (set in 540457b88ba), but `T.class_of(Formula)`.

- But the accurate `T.proc.bind(T.class_of(::Formula))` can't be used instead because Sorbet errors with: "Malformed `bind`: Can only bind to simple class names". See https://github.com/Homebrew/brew/pull/23318#issuecomment-5087573557.

- Uses of this test helper that need to be typechecked still need `T.bind(self, T.class_of(Formula))` inline until Sorbet can bind to `T.class_of` of a class with a fixed `type_template` (maybe never).
