### PR TITLE
diagnostic: add warning for macOS Intel users

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -157,6 +157,25 @@ module OS
           )
         end
 
+        # TODO: Merge this into check_for_unsupported_macos when officially Tier 3
+        sig { returns(T.nilable(::Homebrew::Diagnostic::Finding)) }
+        def check_for_future_unsupported_macos
+          return if Homebrew::EnvConfig.developer?
+          return if ENV["HOMEBREW_INTEGRATION_TEST"]
+          return if ::Hardware::CPU.physical_cpu_arm64?
+          return unless ::Hardware::CPU.intel?
+
+          # Avoid breaking CI workflows while macOS Intel is still Tier 1
+          return if ENV["CI"] || GitHub::Actions.env_set?
+
+          ::Homebrew::Diagnostic::Finding.new(
+            <<~EOS,
+              You are using macOS Intel which will be Tier 3 in or after September 2026.
+              See planned timeline at #{Formatter.url("https://docs.brew.sh/Support-Tiers#future-macos-support")}
+            EOS
+          )
+        end
+
         sig { returns(T.nilable(::Homebrew::Diagnostic::Finding)) }
         def check_for_opencore
           return if ::Hardware::CPU.physical_cpu_arm64?


### PR DESCRIPTION
Trying to add some advance warnings to hopefully inform more users of upcoming plans. Analytics data still shows 3.4M non-CI events in 30 days - https://formulae.brew.sh/analytics/homebrew-os-arch-ci/30d/

Otherwise a lot of users will only find out when `brew install` starts performing source builds when bottles are lost.

Though I don't expect many users will run `brew doctor` but hopefully some will see it. Perhaps outputting a one-time warning on any brew command could help.

Message looks like:
```
Warning: You are using macOS Intel which will be Tier 3 in or after September 2026.
See planned timeline at https://docs.brew.sh/Support-Tiers#future-macos-support
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
