### PR TITLE
cask/audit: detect incorrect app case

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -687,6 +687,55 @@ module Cask
     end
 
     sig { void }
+    def audit_artifact_case
+      return if (url = cask.url).nil?
+      return unless online?
+
+      odebug "Auditing artifact case"
+
+      extract_artifacts(include_manual_installers: true) do |artifacts, tmpdir|
+        artifacts.each do |artifact|
+          source = case artifact
+          when Artifact::Pkg, Artifact::Installer
+            artifact.path
+          else
+            artifact.source
+          end
+
+          source = if source.to_s.start_with?("#{cask.appdir}/")
+            Pathname(source.to_s.delete_prefix("#{cask.appdir}/"))
+          elsif source.absolute?
+            source.relative_path_from(cask.staged_path)
+          else
+            source
+          end
+
+          components = source.each_filename.to_a
+          current = tmpdir
+          on_disk = []
+          components.each do |component|
+            break unless current.directory?
+
+            children = current.children.map { |child| child.basename.to_s }
+            match = children.find { |name| name == component } ||
+                    children.find { |name| name.casecmp?(component) }
+            break if match.nil?
+
+            on_disk << match
+            current /= match
+          end
+
+          next if on_disk.length != components.length
+          next if on_disk == components
+
+          add_error "Artifact #{source} does not match the case of the extracted " \
+                    "#{File.join(on_disk)}; this fails on case-sensitive filesystems.",
+                    location: url.location
+        end
+      end
+    end
+
+    sig { void }
     def audit_rosetta
       return if (url = cask.url).nil?
       return unless online?

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -1205,6 +1205,93 @@ RSpec.describe Cask::Audit, :cask do
       end
     end
 
+    describe "artifact case checks" do
+      let(:online) { true }
+      let(:only) { ["artifact_case"] }
+      let(:tmpdir) { mktmpdir }
+      let(:cask) do
+        Cask::Cask.new("artifact-case") do
+          version "1.0"
+          sha256 :no_check
+          url "https://brew.sh/artifact-case.zip"
+          name "Artifact Case"
+          homepage "https://brew.sh/"
+
+          app "artifact case.app"
+        end
+      end
+
+      before do
+        allow(audit).to receive(:extract_artifacts).and_yield(cask.artifacts, tmpdir)
+      end
+
+      context "when the case matches" do
+        before { (tmpdir/"artifact case.app").mkpath }
+
+        it { is_expected.to pass }
+      end
+
+      context "when the case does not match" do
+        before { (tmpdir/"Artifact Case.app").mkpath }
+
+        it { is_expected.to error_with(/does not match the case of the extracted/) }
+      end
+
+      context "when both cases are present on disk" do
+        # Both spellings cannot be created on a case-insensitive filesystem.
+        before do
+          allow(tmpdir).to receive(:children)
+            .and_return([tmpdir/"Artifact Case.app", tmpdir/"artifact case.app"])
+        end
+
+        it { is_expected.to pass }
+      end
+
+      context "when the artifact is missing" do
+        it { is_expected.to pass }
+      end
+
+      context "when a binary in the appdir has the wrong case" do
+        let(:cask) do
+          Cask::Cask.new("artifact-case") do
+            version "1.0"
+            sha256 :no_check
+            url "https://brew.sh/artifact-case.zip"
+            name "Artifact Case"
+            homepage "https://brew.sh/"
+
+            app "Artifact Case.app"
+            binary "#{appdir}/Artifact Case.app/Contents/MacOS/artifact"
+          end
+        end
+
+        before do
+          (tmpdir/"Artifact Case.app/Contents/MacOS").mkpath
+          FileUtils.touch tmpdir/"Artifact Case.app/Contents/MacOS/Artifact"
+        end
+
+        it { is_expected.to error_with(/does not match the case of the extracted/) }
+      end
+
+      context "when a manual installer has the wrong case" do
+        let(:cask) do
+          Cask::Cask.new("artifact-case") do
+            version "1.0"
+            sha256 :no_check
+            url "https://brew.sh/artifact-case.zip"
+            name "Artifact Case"
+            homepage "https://brew.sh/"
+
+            installer manual: "Artifact Case.app"
+          end
+        end
+
+        before { (tmpdir/"Artifact Case.APP").mkpath }
+
+        it { is_expected.to error_with(/does not match the case of the extracted/) }
+      end
+    end
+
     describe "minimum OS checks" do
       let(:online) { true }
       let(:only) { ["min_os"] }


### PR DESCRIPTION
Occasionally we get PR's or issues in homebrew/cask due to applications not matching the right case name on case-sensitive filesystems.  These are relatively rare since most users run with the standard case-insensitive, but it's still a negative user experience.

This audit is intended to catch these cases.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Opus 5 / Fable 5, validated manually and ran tests locally with `brew lgtm --online`

-----
