### PR TITLE
Use workflow result for commit style

### DIFF
--- a/.github/workflows/commit-style.yml
+++ b/.github/workflows/commit-style.yml
@@ -3,6 +3,7 @@ name: Commit Style
 on:
   pull_request:
     branches: ["**"]
+  merge_group:
 
 permissions: {}
 
@@ -12,10 +13,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      statuses: write
     steps:
       - name: Check commit format
-        uses: Homebrew/actions/check-commit-format@9af03b7ae3f9e2ae5c174f659d5c3909f7e7dbac # 2026.07.29.1
+        if: github.event_name == 'pull_request'
+        uses: Homebrew/actions/check-commit-format@fd832223f9f99ebf0244dd20658680e5d4aca049 # 2026.08.03.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           check_package_commit_format: false


### PR DESCRIPTION
Needs https://github.com/Homebrew/actions/pull/905

- Drop the status write that fork pull requests cannot receive.
- Pin the action version for now that fails the workflow on validation errors.
- Report the required check for synthetic merge queue commits.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI GPT 5.6 sol xhigh with local review.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
