### PR TITLE
Complete Cask stanza ordering coverage

### DIFF
--- a/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
@@ -21,6 +21,17 @@ RSpec.describe RuboCop::Cop::Cask::StanzaGrouping, :config do
     CASK
   end
 
+  it "groups completion generation with artifacts" do
+    expect_no_offenses <<~CASK
+      cask 'foo' do
+        binary 'foo'
+        generate_completions_from_executable 'foo', 'completions'
+
+        zap trash: '~/.foo'
+      end
+    CASK
+  end
+
   it "requires a group boundary after completion generation" do
     expect_offense <<~CASK
       cask 'foo' do

--- a/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
@@ -11,6 +11,43 @@ RSpec.describe RuboCop::Cop::Cask::StanzaOrder, :config do
     ])
   end
 
+  it "registers every new top-level cask DSL" do
+    expect(RuboCop::Cask::Constants::STANZA_ORDER).to include(
+      :on_macos,
+      :on_linux,
+      :on_system_conditional,
+      :appimage,
+      :generated_script,
+      :command_wrapper,
+      :generate_completions_from_executable,
+      :preflight_steps,
+      :postflight_steps,
+      :uninstall_preflight_steps,
+      :uninstall_postflight_steps,
+    )
+  end
+
+  it "orders system conditionals before version and URL stanzas" do
+    expect_offense <<~CASK
+      cask 'foo' do
+        version :latest
+        ^^^^^^^^^^^^^^^ `version` stanza out of order
+        url 'https://foo.brew.sh/foo.zip'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `url` stanza out of order
+        artifact = on_system_conditional macos: 'foo.dmg', linux: 'foo.AppImage'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `on_system_conditional` stanza out of order
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask 'foo' do
+        artifact = on_system_conditional macos: 'foo.dmg', linux: 'foo.AppImage'
+        version :latest
+        url 'https://foo.brew.sh/foo.zip'
+      end
+    CASK
+  end
+
   it "accepts a sole stanza" do
     expect_no_offenses <<~CASK
       cask 'foo' do

--- a/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
@@ -11,6 +11,43 @@ RSpec.describe RuboCop::Cop::Cask::StanzaOrder, :config do
     ])
   end
 
+  it "registers every new top-level cask DSL" do
+    expect(RuboCop::Cask::Constants::STANZA_ORDER).to include(
+      :on_macos,
+      :on_linux,
+      :on_system_conditional,
+      :appimage,
+      :generated_script,
+      :command_wrapper,
+      :generate_completions_from_executable,
+      :preflight_steps,
+      :postflight_steps,
+      :uninstall_preflight_steps,
+      :uninstall_postflight_steps,
+    )
+  end
+
+  it "orders system conditionals before URL stanzas" do
+    expect_offense <<~CASK
+      cask 'foo' do
+        version :latest
+        ^^^^^^^^^^^^^^^ `version` stanza out of order
+        url 'https://foo.brew.sh/foo.zip'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `url` stanza out of order
+        artifact = on_system_conditional macos: 'foo.dmg', linux: 'foo.AppImage'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `on_system_conditional` stanza out of order
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask 'foo' do
+        artifact = on_system_conditional macos: 'foo.dmg', linux: 'foo.AppImage'
+        version :latest
+        url 'https://foo.brew.sh/foo.zip'
+      end
+    CASK
+  end
+
   it "accepts a sole stanza" do
     expect_no_offenses <<~CASK
       cask 'foo' do

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -49,7 +49,7 @@ Having a common order for stanzas makes casks easier to update and parse. Below 
     version
     sha256
 
-    on_<system> # <system> blocks may be any supported macOS release (descending from oldest), `macos`, or `linux`
+    on_<system> # arm, intel, supported macOS releases (oldest first), macos, then linux
 
     language
 

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -49,7 +49,7 @@ Having a common order for stanzas makes casks easier to update and parse. Below 
     version
     sha256
 
-    on_<system> # <system> blocks may be any supported macOS release (descending from oldest), `macos`, or `linux`
+    on_<system> # supported macOS releases (oldest first), macos, then linux
 
     language
 


### PR DESCRIPTION
Needs https://github.com/Homebrew/brew/pull/23331

Complete regression and documentation coverage for Cask stanza ordering.

- verify every new top-level Cask DSL is registered
- require completion generation to remain with artifact stanzas
- verify system conditionals precede version and URL stanzas
- document the ordering of macOS and Linux conditional blocks

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.
