### PR TITLE
download_queue: print fetch heading to stderr when stdout is not a TTY

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -120,10 +120,14 @@ module Homebrew
       return if fetchable_downloads.empty?
 
       if heading
-        oh1 heading, truncate: false
-        # Reach the pipe before any unbuffered stderr report lines when
-        # stdout is block-buffered.
-        $stdout.flush
+        if tty
+          oh1 heading, truncate: false
+          $stdout.flush
+        else
+          # Keep the heading off parsed stdout (e.g. `brew info --json | jq`)
+          # and on the same stream as the non-TTY report lines below.
+          $stderr.puts oh1_title(heading, truncate: false)
+        end
       end
 
       if concurrency == 1

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Cask::Reinstall, :cask do
     Cask::Installer.new(caffeine).install
 
     output = Regexp.new <<~EOS
-      ==> Fetching downloads for:.*caffeine
       ==> Uninstalling Cask local-caffeine
       ==> Backing up App 'Caffeine.app' to '.*Caffeine.app'
       ==> Removing App '.*Caffeine.app'
@@ -23,7 +22,7 @@ RSpec.describe Cask::Reinstall, :cask do
 
     expect do
       described_class.reinstall_casks(Cask::CaskLoader.load("local-caffeine"))
-    end.to output(output).to_stdout
+    end.to output(output).to_stdout.and output(/==> Fetching downloads for:.*caffeine/).to_stderr
   end
 
   it "displays the reinstallation progress with zapping" do
@@ -32,7 +31,6 @@ RSpec.describe Cask::Reinstall, :cask do
     Cask::Installer.new(caffeine).install
 
     output = Regexp.new <<~EOS
-      ==> Fetching downloads for:.*caffeine
       ==> Backing up App 'Caffeine.app' to '.*Caffeine.app'
       ==> Removing App '.*Caffeine.app'
       ==> Dispatching zap stanza
@@ -46,7 +44,7 @@ RSpec.describe Cask::Reinstall, :cask do
 
     expect do
       described_class.reinstall_casks(Cask::CaskLoader.load("local-caffeine"), zap: true)
-    end.to output(output).to_stdout
+    end.to output(output).to_stdout.and output(/==> Fetching downloads for:.*caffeine/).to_stderr
   end
 
   it "allows reinstalling a Cask" do

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -161,6 +161,36 @@ RSpec.describe Homebrew::DownloadQueue do
     expect { download_queue.fetch }.not_to output(/\e\[\?2026/).to_stdout
   end
 
+  it "prints the heading to stderr when stdout is not a TTY" do
+    allow(retryable_download).to receive(:fetch).and_return(cached_download)
+    download_queue.enqueue(downloadable)
+
+    expect { download_queue.fetch(heading: "Downloading Homebrew API data") }
+      .to output(/^==> Downloading Homebrew API data$/).to_stderr
+  end
+
+  it "keeps the heading off stdout when stdout is not a TTY" do
+    allow(retryable_download).to receive(:fetch).and_return(cached_download)
+    download_queue.enqueue(downloadable)
+
+    expect { download_queue.fetch(heading: "Downloading Homebrew API data") }
+      .not_to output(/Downloading Homebrew API data/).to_stdout
+  end
+
+  it "prints the heading to stdout on a TTY" do
+    allow($stdout).to receive(:tty?).and_return(true)
+    ENV["TERM"] = "xterm-256color"
+    allow(downloadable).to receive(:fetched_size).and_return(nil)
+    allow(retryable_download).to receive(:fetch).and_return(cached_download)
+
+    # Build the queue while stdout is a TTY so it captures the TTY render path,
+    # before the output matcher swaps $stdout to capture the heading.
+    download_queue.enqueue(downloadable)
+
+    expect { download_queue.fetch(heading: "Downloading Homebrew API data") }
+      .to output(/==>.*Downloading Homebrew API data/).to_stdout
+  end
+
   it "wakes when downloads complete instead of polling with sleep" do
     allow($stdout).to receive(:tty?).and_return(false)
     allow(retryable_download).to receive(:fetch) do

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -162,6 +162,7 @@ RSpec.describe Homebrew::DownloadQueue do
   end
 
   it "prints the heading to stderr when stdout is not a TTY" do
+    allow($stdout).to receive(:tty?).and_return(false)
     allow(retryable_download).to receive(:fetch).and_return(cached_download)
     download_queue.enqueue(downloadable)
 
@@ -170,6 +171,7 @@ RSpec.describe Homebrew::DownloadQueue do
   end
 
   it "keeps the heading off stdout when stdout is not a TTY" do
+    allow($stdout).to receive(:tty?).and_return(false)
     allow(retryable_download).to receive(:fetch).and_return(cached_download)
     download_queue.enqueue(downloadable)
 


### PR DESCRIPTION
- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Fable xhigh with manual review and testing.

-----

Running `brew info --installed --json=v2` with a stale cache prints
```
==> Downloading Homebrew API data
```
to stdout, which breaks JSON parsing. Let's fix this the same way as #20980.