### PR TITLE
Retry API downloads without --time-cond on curl receive errors

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -398,6 +398,21 @@ EOWARN
   trap - SIGINT
 }
 
+api_curl_download() {
+  local json_url="$1"
+  local cache_path="$2"
+  shift 2
+
+  curl \
+    "${CURL_DISABLE_CURLRC_ARGS[@]}" \
+    --fail --compressed --silent \
+    --speed-limit "${HOMEBREW_CURL_SPEED_LIMIT}" --speed-time "${HOMEBREW_CURL_SPEED_TIME}" \
+    --location --remote-time --output "${cache_path}" \
+    "$@" \
+    --user-agent "${HOMEBREW_USER_AGENT_CURL}" \
+    "${json_url}"
+}
+
 fetch_api_file() {
   local filename="$1"
   local update_failed_file="$2"
@@ -436,23 +451,15 @@ fetch_api_file() {
     do
       time_cond+=("${arg}")
     done < <(api_time_cond_args "${cache_path}")
-    while true
-    do
-      curl \
-        "${CURL_DISABLE_CURLRC_ARGS[@]}" \
-        --fail --compressed --silent \
-        --speed-limit "${HOMEBREW_CURL_SPEED_LIMIT}" --speed-time "${HOMEBREW_CURL_SPEED_TIME}" \
-        --location --remote-time --output "${cache_path}" \
-        "${time_cond[@]}" \
-        --user-agent "${HOMEBREW_USER_AGENT_CURL}" \
-        "${json_url}"
+    api_curl_download "${json_url}" "${cache_path}" "${time_cond[@]}"
+    curl_exit_code=$?
+    # A conditional request can fail with a receive error (curl exit code 56) when
+    # an unconditional request for the same URL succeeds, so retry exactly once.
+    if [[ ${curl_exit_code} -eq 56 ]] && [[ ${#time_cond[@]} -gt 0 ]]
+    then
+      api_curl_download "${json_url}" "${cache_path}"
       curl_exit_code=$?
-      if [[ ${curl_exit_code} -ne 56 ]] || [[ ${#time_cond[@]} -eq 0 ]]
-      then
-        break
-      fi
-      time_cond=()
-    done
+    fi
     last_json_url="${json_url}"
     [[ ${curl_exit_code} -eq 0 ]] && break
   done < <(api_urls "${filename}")

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -427,7 +427,8 @@ fetch_api_file() {
     echo "Checking if we need to fetch ${filename}..."
   fi
 
-  local arg json_url last_json_url
+  local arg curl_exit_code json_url last_json_url
+  local -a time_cond
   while read -r json_url
   do
     time_cond=()
@@ -435,15 +436,23 @@ fetch_api_file() {
     do
       time_cond+=("${arg}")
     done < <(api_time_cond_args "${cache_path}")
-    curl \
-      "${CURL_DISABLE_CURLRC_ARGS[@]}" \
-      --fail --compressed --silent \
-      --speed-limit "${HOMEBREW_CURL_SPEED_LIMIT}" --speed-time "${HOMEBREW_CURL_SPEED_TIME}" \
-      --location --remote-time --output "${cache_path}" \
-      "${time_cond[@]}" \
-      --user-agent "${HOMEBREW_USER_AGENT_CURL}" \
-      "${json_url}"
-    curl_exit_code=$?
+    while true
+    do
+      curl \
+        "${CURL_DISABLE_CURLRC_ARGS[@]}" \
+        --fail --compressed --silent \
+        --speed-limit "${HOMEBREW_CURL_SPEED_LIMIT}" --speed-time "${HOMEBREW_CURL_SPEED_TIME}" \
+        --location --remote-time --output "${cache_path}" \
+        "${time_cond[@]}" \
+        --user-agent "${HOMEBREW_USER_AGENT_CURL}" \
+        "${json_url}"
+      curl_exit_code=$?
+      if [[ ${curl_exit_code} -ne 56 ]] || [[ ${#time_cond[@]} -eq 0 ]]
+      then
+        break
+      fi
+      time_cond=()
+    done
     last_json_url="${json_url}"
     [[ ${curl_exit_code} -eq 0 ]] && break
   done < <(api_urls "${filename}")

--- a/Library/Homebrew/test/cmd/update_spec.rb
+++ b/Library/Homebrew/test/cmd/update_spec.rb
@@ -35,6 +35,45 @@ RSpec.describe Homebrew::Cmd::Update do
     end
   end
 
+  it "retries a failed conditional API download without the time condition" do
+    cache_path = test_root/"cache/api/formula.jws.json"
+    requests_file = test_root/"requests.txt"
+    update_failed_file = test_root/"update_failed.txt"
+    setup_update_utils
+    cache_path.dirname.mkpath
+    cache_path.write "cached"
+
+    _stdout, stderr, status = run_update_shell(
+      <<~SH,
+        source "#{update_script}"
+        curl() {
+          if [[ "$*" == *"--time-cond"* ]]
+          then
+            echo conditional >> "#{requests_file}"
+            return 56
+          fi
+
+          echo unconditional >> "#{requests_file}"
+          printf fresh > "#{cache_path}"
+        }
+        fetch_api_file formula.jws.json "#{update_failed_file}"
+      SH
+      {
+        "HOMEBREW_API_DEFAULT_DOMAIN" => "https://formulae.example/api",
+        "HOMEBREW_API_DOMAIN"         => nil,
+        "HOMEBREW_CACHE"              => (test_root/"cache").to_s,
+        "HOMEBREW_CURL_SPEED_LIMIT"   => "100",
+        "HOMEBREW_CURL_SPEED_TIME"    => "5",
+        "HOMEBREW_LIBRARY"            => (test_root/"Library").to_s,
+        "HOMEBREW_USER_AGENT_CURL"    => "Homebrew/test",
+      },
+    )
+
+    expect([status.success?, stderr, requests_file.read, cache_path.read, update_failed_file.exist?]).to eq(
+      [true, "", "conditional\nunconditional\n", "fresh", false],
+    )
+  end
+
   it "passes all arguments through to delegated upgrades" do
     args_file = test_root/"brew-args.txt"
     brew_wrapper = test_root/"brew-wrapper"


### PR DESCRIPTION
`brew update` can intermittently fail with `Failed to download` errors on API JSON files when `/usr/bin/curl` exits 56 (receive error) on a conditional request, as reported in https://github.com/orgs/Homebrew/discussions/6987. There the `--time-cond` request against a valid cached file failed repeatedly while an unconditional request for the same URL succeeded, and deleting the cached file worked around it.

This retries the same URL exactly once without `--time-cond` when a conditional API download exits 56, before falling back to the next API domain or recording an update failure. Other curl exit codes and the custom/default API domain fallback are unchanged, and a successful retry also rewrites any partial output left by the failed attempt. A new regression test stubs curl to fail the conditional request with exit 56 and asserts the unconditional retry succeeds, refreshes the cache, and records no failure.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5) drafted the implementation and tests; I reviewed the diff, verified the regression test fails without the fix and passes with it, and ran `brew lgtm --online` plus the targeted update specs.

-----
