### PR TITLE
bundle cleanup: document trust store reset

### DIFF
--- a/Library/Homebrew/bundle/subcommand/cleanup.rb
+++ b/Library/Homebrew/bundle/subcommand/cleanup.rb
@@ -23,13 +23,16 @@ module Homebrew
 
             This workflow is useful for maintainers or testers who regularly install lots of formulae.
 
+            When cleanup is performed, Homebrew's global trust store is reset to the trust values declared by the `Brewfile`, removing trust entries not declared there.
+
             Unless `--force` is passed, this prompts before removing anything and returns a 1 exit code if the prompt is declined or cannot be shown.
           EOS
           named_args :none
           switch "--install",
                  description: "Run `install` before cleaning up dependencies."
           switch "-f", "--force",
-                 description: "Actually perform cleanup operations."
+                 description: "Actually perform cleanup operations and reset Homebrew's global trust store " \
+                              "to the `Brewfile` values."
           switch "--all",
                  description: "Clean up all supported dependencies."
           switch "--formula", "--formulae", "--brews",

--- a/Library/Homebrew/test/cmd/bundle_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle_spec.rb
@@ -100,6 +100,8 @@ RSpec.describe Homebrew::Cmd::Bundle do
     expect(subcommand_options.call("cleanup")["--no-mas"])
       .to include("`cleanup` without Mac App Store dependencies.")
     expect(subcommand_options.call("cleanup")["--all"]).to eq("Clean up all supported dependencies.")
+    expect(subcommand_options.call("cleanup")["--force"])
+      .to eq("Actually perform cleanup operations and reset Homebrew's global trust store to the `Brewfile` values.")
     expect(subcommand_options.call("dump")["--no-describe"]).to include("Description comments are the default")
     expect(subcommand_options.call("add")["--no-describe"]).to include("Description comments are the default")
     expect(subcommand_options.call("add")["--vscode"])

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -713,7 +713,7 @@ __fish_brew_complete_sub_arg 'bundle' 'cleanup' -l cask -d 'Clean up Homebrew ca
 __fish_brew_complete_sub_arg 'bundle' 'cleanup' -l debug -d 'Display any debugging information'
 __fish_brew_complete_sub_arg 'bundle' 'cleanup' -l file -d 'Read from or write to the `Brewfile` from this location. Use `--file=-` to pipe to stdin/stdout'
 __fish_brew_complete_sub_arg 'bundle' 'cleanup' -l flatpak -d 'Clean up Flatpak packages. Note: Linux only'
-__fish_brew_complete_sub_arg 'bundle' 'cleanup' -l force -d 'Actually perform cleanup operations'
+__fish_brew_complete_sub_arg 'bundle' 'cleanup' -l force -d 'Actually perform cleanup operations and reset Homebrew\'s global trust store to the `Brewfile` values'
 __fish_brew_complete_sub_arg 'bundle' 'cleanup' -l formula -d 'Clean up Homebrew formula dependencies'
 __fish_brew_complete_sub_arg 'bundle' 'cleanup' -l global -d 'Read from or write to the `Brewfile` from `$HOMEBREW_BUNDLE_FILE_GLOBAL` (if set), `${XDG_CONFIG_HOME}/homebrew/Brewfile` (if `$XDG_CONFIG_HOME` is set), `~/.homebrew/Brewfile` or `~/.Brewfile` otherwise'
 __fish_brew_complete_sub_arg 'bundle' 'cleanup' -l go -d 'Clean up Go packages'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -926,7 +926,7 @@ cleanup)
           '--debug[Display any debugging information]' \
           '(--global)--file[Read from or write to the `Brewfile` from this location. Use `--file=-` to pipe to stdin/stdout]' \
           '(--no-flatpak --no-cleanup-flatpak --no-dump-flatpak)--flatpak[Clean up Flatpak packages. Note: Linux only]' \
-          '--force[Actually perform cleanup operations]' \
+          '--force[Actually perform cleanup operations and reset Homebrew'\''s global trust store to the `Brewfile` values]' \
           '(--no-formula --no-formulae --no-brews --no-cleanup-brew --no-dump-brew)--formula[Clean up Homebrew formula dependencies]' \
           '(--file)--global[Read from or write to the `Brewfile` from `$HOMEBREW_BUNDLE_FILE_GLOBAL` (if set), `${XDG_CONFIG_HOME}/homebrew/Brewfile` (if `$XDG_CONFIG_HOME` is set), `~/.homebrew/Brewfile` or `~/.Brewfile` otherwise]' \
           '(--no-go --no-cleanup-go --no-dump-go)--go[Clean up Go packages]' \

--- a/docs/Brew-Bundle-and-Brewfile.md
+++ b/docs/Brew-Bundle-and-Brewfile.md
@@ -152,6 +152,11 @@ Uninstalling gcc... (1,914 files, 459.8MB)
 Uninstalled 1 formula
 ```
 
+Cleanup also makes Homebrew's global trust store match the selected `Brewfile`.
+It removes trust entries granted manually or by another `Brewfile` if they are
+not declared in the selected file. A `Brewfile` with no trust declarations
+removes every explicit trust entry.
+
 ### `brew bundle list`
 
 If you want to get a list of all the formulae in your `Brewfile`, you can use:
@@ -391,9 +396,12 @@ trusted `brew`, `cask` and whole-tap entries. It writes tap-level trust hashes
 for trusted formulae, casks and commands from a tap that are not otherwise
 present in the dumped `Brewfile`.
 
-When `brew bundle cleanup --force` runs, it resets Homebrew's tap trust file to
-the trust values declared by the `Brewfile` and removes trust entries that are
-not declared there.
+Whenever `brew bundle cleanup` performs cleanup, either because `--force` was
+passed or the confirmation prompt was accepted, it resets Homebrew's global
+trust store to the values declared by the selected `Brewfile`. This removes
+trust granted manually or by another `Brewfile` when it is not declared in the
+selected file. If the selected `Brewfile` has no trust declarations, every
+explicit trust entry is removed.
 
 ## Versions
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -613,6 +613,9 @@ flags which will help with finding keg-only dependencies like `openssl`,
 This workflow is useful for maintainers or testers who regularly install lots of
 formulae.
 
+When cleanup is performed, Homebrew's global trust store is reset to the trust
+values declared by the `Brewfile`, removing trust entries not declared there.
+
 Unless `--force` is passed, this prompts before removing anything and returns a
 1 exit code if the prompt is declined or cannot be shown.
 
@@ -622,7 +625,8 @@ Unless `--force` is passed, this prompts before removing anything and returns a
 
 `-f`, `--force`
 
-: Actually perform cleanup operations.
+: Actually perform cleanup operations and reset Homebrew's global trust store to
+  the `Brewfile` values.
 
 `--all`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -395,13 +395,15 @@ Uninstall all dependencies not present in the \fBBrewfile\fP\&\.
 .P
 This workflow is useful for maintainers or testers who regularly install lots of formulae\.
 .P
+When cleanup is performed, Homebrew\[u2019]s global trust store is reset to the trust values declared by the \fBBrewfile\fP, removing trust entries not declared there\.
+.P
 Unless \fB\-\-force\fP is passed, this prompts before removing anything and returns a 1 exit code if the prompt is declined or cannot be shown\.
 .TP
 \fB\-\-install\fP
 Run \fBinstall\fP before cleaning up dependencies\.
 .TP
 \fB\-f\fP, \fB\-\-force\fP
-Actually perform cleanup operations\.
+Actually perform cleanup operations and reset Homebrew\[u2019]s global trust store to the \fBBrewfile\fP values\.
 .TP
 \fB\-\-all\fP
 Clean up all supported dependencies\.


### PR DESCRIPTION
`brew bundle cleanup` resets Homebrew's global trust store to the values declared by the selected `Brewfile`, removing trust that was granted by hand or by another `Brewfile`. Nothing says so, which is how it caught out the reporter in https://github.com/orgs/Homebrew/discussions/6988 who lost their `trustedcasks` entries.

This is consistent with how `--force` treats everything else in a `Brewfile`, so the behavior stays and the documentation catches up instead. The `cleanup` help banner and the `-f`/`--force` description now state that the trust store is reset, and the `brew bundle` docs spell out that a `Brewfile` with no trust declarations removes every explicit trust entry.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the documentation and test changes; I reviewed the diff and ran `brew lgtm` + targeted specs.

-----
