### PR TITLE
brew services: use package-provided service file when no run command

### DIFF
--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -414,7 +414,11 @@ module Homebrew
 
         temp = Tempfile.new(service.service_name)
         temp << if file.nil?
-          contents = service.service_contents
+          contents = if service.command?
+            service.service_contents
+          else
+            service.service_file.read
+          end
 
           if sudo_service_user && System.launchctl?
             # set the username in the new plist file

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -49,6 +49,15 @@ module Homebrew
         @service ||= T.let(formula.service?, T.nilable(T::Boolean))
       end
 
+      # Delegate access to `formula.service.command?`.
+      sig { returns(T::Boolean) }
+      def command?
+        return @command unless @command.nil?
+
+        @command = T.let(service? && load_service.command?, T.nilable(T::Boolean))
+        @command ||= false
+      end
+
       # Delegate access to `formula.service.timed?`.
       sig { returns(T::Boolean) }
       def timed?

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -339,6 +339,7 @@ RSpec.describe Homebrew::Services::Cli do
         name:             "name",
         service_name:     "homebrew.name",
         installed?:       true,
+        command?:         true,
         service_file:,
         service_contents: "service",
         dest:             dest_dir/service_file.basename,
@@ -351,6 +352,29 @@ RSpec.describe Homebrew::Services::Cli do
       services_cli.install_service_file(service, nil)
 
       expect(service.timer_dest.read).to eq("timer")
+    end
+
+    it "uses the installed service file when the formula does not define a run command" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: true, systemctl?: false)
+
+      source_dir = mktmpdir
+      dest_dir = mktmpdir
+      service_file = source_dir/"homebrew.name.plist"
+      service_file.write("bundled plist")
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:         "name",
+        service_name: "homebrew.name",
+        installed?:   true,
+        command?:     false,
+        service_file:,
+        dest:         dest_dir/"homebrew.name.plist",
+        dest_dir:,
+      )
+
+      services_cli.install_service_file(service, nil)
+
+      expect(service.dest.read).to eq("bundled plist")
     end
 
     context "when given `--sudo-service-user`" do
@@ -380,6 +404,7 @@ RSpec.describe Homebrew::Services::Cli do
           name:             "name",
           service_name:     "homebrew.test",
           installed?:       true,
+          command?:         true,
           service_file:,
           service_contents: plist_xml,
           dest:             dest_dir/"homebrew.test.plist",


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

## What this does

`brew services start`/`restart` again uses the service file installed by the formula (the package-provided plist/systemd unit) when the formula's `service do` block does not define a `run` command.

PR #23312 changed `install_service_file` to always regenerate the service file from the `service do` block via `service_contents`. Formulas that ship their own service file only define `name` (without `run`), so the regenerated plist had an empty `ProgramArguments` and `launchctl bootstrap` failed with exit code 5 (`Input/output error`). Examples in homebrew-core: `dbus`, `xinit`.

This restores the documented contract from the Formula Cookbook: if `name` is defined without `run`, Homebrew makes no attempt to change the package-provided service file. It matches the logic already used by `FormulaInstaller#install_service`, which only writes a generated plist when `formula.service.command?` is true.

The per-service environment variable overrides from #23312 still apply whenever Homebrew generates the service file (i.e. when a `run` command is defined).

## Why

PR #23312 unintentionally dropped support for package-provided service files, breaking `brew services start` for formulae that ship their own plist/systemd unit (e.g. `dbus`, `xinit` in homebrew-core). The generated file is invalid for such formulae because the `service do` block contains only `name`, so `launchctl bootstrap` rejects it with exit code 5.

## Step-by-step reproduction

```shell
brew install zhyu/tap/roused
brew services start roused
```

Before this fix:

```shell
Bootstrap failed: 5: Input/output error
Error: Failure while executing; `/bin/launchctl bootstrap gui/501 /Users/.../io.github.zhyu.roused.plist` exited with 5.
```

## How it was verified

- `brew tests --only=services --no-parallel`: 119 examples, 0 failures
- `brew style` on the changed files: no offenses
- `brew typecheck`: no errors
- New unit test covers the fallback to the installed service file

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI (Claude Code via Codex) was used to analyze the issue, implement the fix, and prepare this PR. The change was reviewed, typechecked with Sorbet, linted with RuboCop, and verified with the services test suite locally before submission.

-----

Fixes #23408
