### PR TITLE
unpack_strategy/dmg: use `diskutil image` on macOS 14+

### DIFF
--- a/Library/Homebrew/extend/os/mac/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/extend/os/mac/unpack_strategy/dmg.rb
@@ -1,0 +1,11 @@
+# typed: strict
+# frozen_string_literal: true
+
+module UnpackStrategy
+  class Dmg
+    sig { returns(T::Boolean) }
+    def self.diskutil_image?
+      MacOS.version >= :sonoma
+    end
+  end
+end

--- a/Library/Homebrew/extend/os/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/extend/os/unpack_strategy/dmg.rb
@@ -1,0 +1,4 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "extend/os/mac/unpack_strategy/dmg" if OS.mac?

--- a/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
@@ -4,6 +4,75 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Dmg, :needs_macos do
+  describe ".can_extract?" do
+    let(:path) { TEST_FIXTURE_DIR/"cask/container.dmg" }
+    let(:status) { instance_double(Process::Status, success?: true) }
+    let(:result) { instance_double(SystemCommand::Result, to_a: ["plist", "", status]) }
+
+    before do
+      allow(described_class).to receive(:system_command).and_return(result)
+    end
+
+    it "uses diskutil on the oldest supported macOS" do
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:sonoma))
+      expect(described_class).to receive(:system_command)
+        .with("diskutil", args: ["image", "info", "--plist", "--", path], print_stderr: false)
+        .and_return(result)
+
+      expect(described_class.can_extract?(path)).to be true
+    end
+
+    it "uses hdiutil before macOS Sonoma" do
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:ventura))
+      expect(described_class).to receive(:system_command)
+        .with("hdiutil", args: ["imageinfo", "-format", path], print_stderr: false)
+        .and_return(result)
+
+      expect(described_class.can_extract?(path)).to be true
+    end
+
+    it "detects a disk image when diskutil returns a license agreement" do
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:sonoma))
+      failure_status = instance_double(Process::Status, success?: false)
+      diskutil_result = instance_double(SystemCommand::Result, to_a: ["license agreement", "", failure_status])
+
+      expect(described_class).to receive(:system_command)
+        .with("diskutil", args: ["image", "info", "--plist", "--", path], print_stderr: false)
+        .and_return(diskutil_result)
+      expect(described_class).not_to receive(:system_command).with("hdiutil", anything)
+
+      expect(described_class.can_extract?(path)).to be true
+    end
+
+    it "rejects unexpected stdout from a failed diskutil image info" do
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:sonoma))
+      path = TEST_FIXTURE_DIR/"cask/container.xar"
+      failure_status = instance_double(Process::Status, success?: false)
+      diskutil_result = instance_double(SystemCommand::Result, to_a: ["unexpected output", "", failure_status])
+
+      expect(described_class).to receive(:system_command)
+        .with("diskutil", args: ["image", "info", "--plist", "--", path], print_stderr: false)
+        .and_return(diskutil_result)
+      expect(described_class).not_to receive(:system_command).with("hdiutil", anything)
+
+      expect(described_class.can_extract?(path)).to be false
+    end
+
+    it "rejects files too small to contain a UDIF trailer" do
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:sonoma))
+      path = TEST_FIXTURE_DIR/"cask/container.tar.gz"
+      failure_status = instance_double(Process::Status, success?: false)
+      diskutil_result = instance_double(SystemCommand::Result, to_a: ["unexpected output", "", failure_status])
+
+      expect(described_class).to receive(:system_command)
+        .with("diskutil", args: ["image", "info", "--plist", "--", path], print_stderr: false)
+        .and_return(diskutil_result)
+      expect(described_class).not_to receive(:system_command).with("hdiutil", anything)
+
+      expect(described_class.can_extract?(path)).to be false
+    end
+  end
+
   describe "#mount" do
     let(:path) { TEST_FIXTURE_DIR/"cask/container.dmg" }
 
@@ -29,15 +98,142 @@ RSpec.describe UnpackStrategy::Dmg, :needs_macos do
     end
 
     it "does not treat an unrelated attach failure as a license agreement" do
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:sonoma))
       unpack_strategy = described_class.new(path)
       attach_result = instance_double(SystemCommand::Result, success?: false, stdout: "")
-      attach_error = ErrorDuringExecution.new(["hdiutil", "attach"], status: 1)
+      attach_error = ErrorDuringExecution.new(["diskutil", "image", "attach"], status: 1)
 
       allow(unpack_strategy).to receive(:system_command).and_return(attach_result)
       expect(attach_result).to receive(:assert_success!).and_raise(attach_error)
       expect(unpack_strategy).not_to receive(:system_command!)
 
       expect { unpack_strategy.mount { nil } }.to raise_error(attach_error)
+    end
+
+    it "uses an isolated diskutil mount point" do
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:sonoma))
+      attach_result = instance_double(
+        SystemCommand::Result,
+        success?: true,
+        plist:    { "system-entities" => [] },
+      )
+      unpack_strategy = described_class.new(path)
+
+      expect(unpack_strategy).to receive(:system_command).with(
+        "diskutil",
+        args:         [
+          "image", "attach", "--plist", "--readOnly", "--mountOptions", "nobrowse",
+          "--mountPoint", kind_of(Pathname), path
+        ],
+        input:        "qn\n",
+        print_stderr: false,
+        verbose:      false,
+      ).and_return(attach_result)
+
+      unpack_strategy.mount { |mounts| expect(mounts).to be_empty }
+    end
+
+    it "retries without a mount point for multi-volume disk images" do
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:sonoma))
+      mount_point_result = instance_double(SystemCommand::Result, success?: false, stdout: "")
+      fallback_result = instance_double(
+        SystemCommand::Result,
+        success?: true,
+        plist:    { "system-entities" => [] },
+      )
+      unpack_strategy = described_class.new(path)
+
+      expect(unpack_strategy).to receive(:system_command).with(
+        "diskutil",
+        args:         [
+          "image", "attach", "--plist", "--readOnly", "--mountOptions", "nobrowse",
+          "--mountPoint", kind_of(Pathname), path
+        ],
+        input:        "qn\n",
+        print_stderr: false,
+        verbose:      false,
+      ).ordered.and_return(mount_point_result)
+      expect(unpack_strategy).to receive(:system_command).with(
+        "diskutil",
+        args:         ["image", "attach", "--plist", "--readOnly", "--mountOptions", "nobrowse", path],
+        input:        "qn\n",
+        print_stderr: false,
+        verbose:      false,
+      ).ordered.and_return(fallback_result)
+
+      unpack_strategy.mount { |mounts| expect(mounts).to be_empty }
+    end
+
+    it "uses hdiutil before macOS Sonoma" do
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:ventura))
+      attach_result = instance_double(
+        SystemCommand::Result,
+        success?: true,
+        plist:    { "system-entities" => [] },
+      )
+      unpack_strategy = described_class.new(path)
+
+      expect(unpack_strategy).to receive(:system_command).with(
+        "hdiutil",
+        args:         [
+          "attach", "-plist", "-nobrowse", "-readonly",
+          "-mountrandom", kind_of(Pathname), path
+        ],
+        input:        "qn\n",
+        print_stderr: false,
+        verbose:      false,
+      ).and_return(attach_result)
+
+      unpack_strategy.mount { |mounts| expect(mounts).to be_empty }
+    end
+
+    it "converts disk images with license agreements using diskutil" do
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:sonoma))
+      eula_result = instance_double(SystemCommand::Result, success?: false, stdout: "license agreement")
+      converted_result = instance_double(
+        SystemCommand::Result,
+        success?:        true,
+        assert_success!: nil,
+        plist:           { "system-entities" => [] },
+      )
+      unpack_strategy = described_class.new(path)
+
+      allow(unpack_strategy).to receive(:system_command).and_return(eula_result, converted_result)
+      expect(unpack_strategy).to receive(:system_command!).with(
+        "diskutil",
+        args:         [
+          "image", "create", "from", "--format", "RAW", path,
+          satisfy { |output| output.is_a?(Pathname) && output.extname == ".dmg" }
+        ],
+        print_stderr: false,
+        verbose:      false,
+      ).and_return(instance_double(SystemCommand::Result))
+
+      unpack_strategy.mount { |mounts| expect(mounts).to be_empty }
+    end
+
+    it "converts disk images with license agreements using hdiutil before macOS Sonoma" do
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.from_symbol(:ventura))
+      eula_result = instance_double(SystemCommand::Result, success?: false, stdout: "license agreement")
+      converted_result = instance_double(
+        SystemCommand::Result,
+        success?:        true,
+        assert_success!: nil,
+        plist:           { "system-entities" => [] },
+      )
+      unpack_strategy = described_class.new(path)
+
+      allow(unpack_strategy).to receive(:system_command).and_return(eula_result, converted_result)
+      expect(unpack_strategy).to receive(:system_command!).with(
+        "hdiutil",
+        args:    [
+          "convert", "-quiet", "-format", "UDTO", "-o",
+          satisfy { |output| output.is_a?(Pathname) && output.extname == ".cdr" }, path
+        ],
+        verbose: false,
+      ).and_return(instance_double(SystemCommand::Result))
+
+      unpack_strategy.mount { |mounts| expect(mounts).to be_empty }
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -177,10 +177,25 @@ module UnpackStrategy
       [".dmg"]
     end
 
+    sig { returns(T::Boolean) }
+    def self.diskutil_image? = false
+
     sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
-      stdout, _, status = system_command("hdiutil", args: ["imageinfo", "-format", path], print_stderr: false).to_a
-      (status.success? && !stdout.empty?) || false
+      result = if diskutil_image?
+        system_command("diskutil", args: ["image", "info", "--plist", "--", path], print_stderr: false)
+      else
+        system_command("hdiutil", args: ["imageinfo", "-format", path], print_stderr: false)
+      end
+
+      stdout, _, status = result.to_a
+      return !stdout.empty? if status.success?
+      return false unless diskutil_image?
+      return false if stdout.empty?
+      return false if path.size < 512
+
+      # `diskutil` exits unsuccessfully after printing an SLA. Confirm its UDIF trailer directly.
+      path.binread(4, path.size - 512) == "koly"
     end
 
     sig { params(verbose: T::Boolean, _block: T.proc.params(arg0: T::Array[Mount]).void).void }
@@ -188,12 +203,9 @@ module UnpackStrategy
       Dir.mktmpdir("homebrew-dmg", HOMEBREW_TEMP) do |mount_dir|
         mount_dir = Pathname(mount_dir)
 
-        without_eula = system_command(
-          "hdiutil",
-          args:         [
-            "attach", "-plist", "-nobrowse", "-readonly",
-            "-mountrandom", mount_dir, path
-          ],
+        without_eula = attach_image(
+          path,
+          mount_dir:,
           input:        "qn\n",
           print_stderr: false,
           verbose:,
@@ -205,26 +217,15 @@ module UnpackStrategy
         else
           without_eula.assert_success! if without_eula.stdout.empty?
 
-          cdr_path = mount_dir/path.basename.sub_ext(".cdr")
+          converted_path = convert_image(path, mount_dir:, verbose:)
 
-          quiet_flag = "-quiet" unless verbose
-
-          system_command!(
-            "hdiutil",
-            args:    [
-              "convert", *quiet_flag, "-format", "UDTO", "-o", cdr_path, path
-            ],
+          with_eula = attach_image(
+            converted_path,
+            mount_dir:,
+            print_stderr: true,
             verbose:,
           )
-
-          with_eula = system_command!(
-            "hdiutil",
-            args:    [
-              "attach", "-plist", "-nobrowse", "-readonly",
-              "-mountrandom", mount_dir, cdr_path
-            ],
-            verbose:,
-          )
+          with_eula.assert_success!
 
           if verbose && !(eula_text = without_eula.stdout).empty?
             ohai "Software License Agreement for '#{path}':", eula_text
@@ -253,6 +254,75 @@ module UnpackStrategy
 
     private
 
+    sig {
+      params(
+        image_path:   Pathname,
+        mount_dir:    Pathname,
+        input:        T.any(String, T::Array[String]),
+        print_stderr: T::Boolean,
+        verbose:      T::Boolean,
+      ).returns(SystemCommand::Result)
+    }
+    def attach_image(image_path, mount_dir:, input: [], print_stderr: true, verbose: false)
+      unless self.class.diskutil_image?
+        return system_command(
+          "hdiutil",
+          args:         [
+            "attach", "-plist", "-nobrowse", "-readonly",
+            "-mountrandom", mount_dir, image_path
+          ],
+          input:,
+          print_stderr:,
+          verbose:,
+        )
+      end
+
+      args = ["image", "attach", "--plist", "--readOnly", "--mountOptions", "nobrowse"]
+      mount_point = mount_dir/"mount"
+      mount_point.mkpath
+
+      result = system_command(
+        "diskutil",
+        args:         [*args, "--mountPoint", mount_point, image_path],
+        input:,
+        print_stderr: false,
+        verbose:,
+      )
+      return result if result.success?
+      return result unless result.stdout.empty?
+
+      system_command(
+        "diskutil",
+        args:         [*args, image_path],
+        input:,
+        print_stderr:,
+        verbose:,
+      )
+    end
+
+    sig { params(image_path: Pathname, mount_dir: Pathname, verbose: T::Boolean).returns(Pathname) }
+    def convert_image(image_path, mount_dir:, verbose:)
+      if self.class.diskutil_image?
+        converted_path = mount_dir/image_path.basename.sub_ext(".dmg")
+        system_command!(
+          "diskutil",
+          args:         ["image", "create", "from", "--format", "RAW", image_path, converted_path],
+          print_stderr: verbose,
+          verbose:,
+        )
+      else
+        converted_path = mount_dir/image_path.basename.sub_ext(".cdr")
+        quiet_flag = "-quiet" unless verbose
+        system_command!(
+          "hdiutil",
+          args:    ["convert", *quiet_flag, "-format", "UDTO", "-o", converted_path, image_path],
+          verbose:,
+        )
+      end
+
+      converted_path
+    end
+
     sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       mount(verbose:) do |mounts|
@@ -265,3 +335,5 @@ module UnpackStrategy
     end
   end
 end
+
+require "extend/os/unpack_strategy/dmg"

--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -172,6 +172,10 @@ module UnpackStrategy
     end
     private_constant :Mount
 
+    # UDIF disk images store the "koly" signature at the start of a 512-byte trailer.
+    UDIF_TRAILER_SIZE = 512
+    private_constant :UDIF_TRAILER_SIZE
+
     sig { override.returns(T::Array[String]) }
     def self.extensions
       [".dmg"]
@@ -182,20 +186,32 @@ module UnpackStrategy
 
     sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
-      result = if diskutil_image?
-        system_command("diskutil", args: ["image", "info", "--plist", "--", path], print_stderr: false)
+      if diskutil_image?
+        can_extract_with_diskutil?(path)
       else
-        system_command("hdiutil", args: ["imageinfo", "-format", path], print_stderr: false)
+        can_extract_with_hdiutil?(path)
       end
+    end
+
+    sig { params(path: Pathname).returns(T::Boolean) }
+    private_class_method def self.can_extract_with_diskutil?(path)
+      result = system_command("diskutil", args: ["image", "info", "--plist", "--", path], print_stderr: false)
 
       stdout, _, status = result.to_a
       return !stdout.empty? if status.success?
-      return false unless diskutil_image?
       return false if stdout.empty?
-      return false if path.size < 512
+      return false if path.size < UDIF_TRAILER_SIZE
 
-      # `diskutil` exits unsuccessfully after printing an SLA. Confirm its UDIF trailer directly.
-      path.binread(4, path.size - 512) == "koly"
+      # `diskutil` exits unsuccessfully after printing an SLA. Confirm the image directly.
+      path.binread(4, path.size - UDIF_TRAILER_SIZE) == "koly"
+    end
+
+    sig { params(path: Pathname).returns(T::Boolean) }
+    private_class_method def self.can_extract_with_hdiutil?(path)
+      stdout, _, status = system_command(
+        "hdiutil", args: ["imageinfo", "-format", path], print_stderr: false
+      ).to_a
+      (status.success? && !stdout.empty?) || false
     end
 
     sig { params(verbose: T::Boolean, _block: T.proc.params(arg0: T::Array[Mount]).void).void }
@@ -264,19 +280,35 @@ module UnpackStrategy
       ).returns(SystemCommand::Result)
     }
     def attach_image(image_path, mount_dir:, input: [], print_stderr: true, verbose: false)
-      unless self.class.diskutil_image?
-        return system_command(
-          "hdiutil",
-          args:         [
-            "attach", "-plist", "-nobrowse", "-readonly",
-            "-mountrandom", mount_dir, image_path
-          ],
+      if self.class.diskutil_image?
+        attach_image_with_diskutil(
+          image_path,
+          mount_dir:,
+          input:,
+          print_stderr:,
+          verbose:,
+        )
+      else
+        attach_image_with_hdiutil(
+          image_path,
+          mount_dir:,
           input:,
           print_stderr:,
           verbose:,
         )
       end
+    end
 
+    sig {
+      params(
+        image_path:   Pathname,
+        mount_dir:    Pathname,
+        input:        T.any(String, T::Array[String]),
+        print_stderr: T::Boolean,
+        verbose:      T::Boolean,
+      ).returns(SystemCommand::Result)
+    }
+    def attach_image_with_diskutil(image_path, mount_dir:, input:, print_stderr:, verbose:)
       args = ["image", "attach", "--plist", "--readOnly", "--mountOptions", "nobrowse"]
       mount_point = mount_dir/"mount"
       mount_point.mkpath
@@ -300,26 +332,58 @@ module UnpackStrategy
       )
     end
 
+    sig {
+      params(
+        image_path:   Pathname,
+        mount_dir:    Pathname,
+        input:        T.any(String, T::Array[String]),
+        print_stderr: T::Boolean,
+        verbose:      T::Boolean,
+      ).returns(SystemCommand::Result)
+    }
+    def attach_image_with_hdiutil(image_path, mount_dir:, input:, print_stderr:, verbose:)
+      system_command(
+        "hdiutil",
+        args:         [
+          "attach", "-plist", "-nobrowse", "-readonly",
+          "-mountrandom", mount_dir, image_path
+        ],
+        input:,
+        print_stderr:,
+        verbose:,
+      )
+    end
+
     sig { params(image_path: Pathname, mount_dir: Pathname, verbose: T::Boolean).returns(Pathname) }
     def convert_image(image_path, mount_dir:, verbose:)
       if self.class.diskutil_image?
-        converted_path = mount_dir/image_path.basename.sub_ext(".dmg")
-        system_command!(
-          "diskutil",
-          args:         ["image", "create", "from", "--format", "RAW", image_path, converted_path],
-          print_stderr: verbose,
-          verbose:,
-        )
+        convert_image_with_diskutil(image_path, mount_dir:, verbose:)
       else
-        converted_path = mount_dir/image_path.basename.sub_ext(".cdr")
-        quiet_flag = "-quiet" unless verbose
-        system_command!(
-          "hdiutil",
-          args:    ["convert", *quiet_flag, "-format", "UDTO", "-o", converted_path, image_path],
-          verbose:,
-        )
+        convert_image_with_hdiutil(image_path, mount_dir:, verbose:)
       end
+    end
 
+    sig { params(image_path: Pathname, mount_dir: Pathname, verbose: T::Boolean).returns(Pathname) }
+    def convert_image_with_diskutil(image_path, mount_dir:, verbose:)
+      converted_path = mount_dir/image_path.basename.sub_ext(".dmg")
+      system_command!(
+        "diskutil",
+        args:         ["image", "create", "from", "--format", "RAW", image_path, converted_path],
+        print_stderr: verbose,
+        verbose:,
+      )
+      converted_path
+    end
+
+    sig { params(image_path: Pathname, mount_dir: Pathname, verbose: T::Boolean).returns(Pathname) }
+    def convert_image_with_hdiutil(image_path, mount_dir:, verbose:)
+      converted_path = mount_dir/image_path.basename.sub_ext(".cdr")
+      quiet_flag = "-quiet" unless verbose
+      system_command!(
+        "hdiutil",
+        args:    ["convert", *quiet_flag, "-format", "UDTO", "-o", converted_path, image_path],
+        verbose:,
+      )
       converted_path
     end
 


### PR DESCRIPTION
`hdiutil` is deprecated on macOS 27 and prints a deprecation warning on every `attach`, `imageinfo`, and `convert` call, each one pointing at `diskutil image` as the replacement (also reported in #23401). `diskutil image attach` was added in macOS 13, while image creation was added in macOS 14. Because SLA conversion requires `diskutil image create from`, this moves the DMG unpack strategy to `diskutil image` on macOS 14 and newer and retains the existing `hdiutil` path for older releases.

On macOS 14 and newer we detect images with `diskutil image info --plist`, attach read-only with `nobrowse` into an isolated temporary mount point, fall back to a plain attach when an image has multiple mountable volumes (`--mountPoint` only supports a single mountable entity), and convert SLA-bearing images with `diskutil image create from`. Both tools emit the same `system-entities`/`mount-point` plist structure, so mount handling and ejection are unchanged.

One detection difference is worth calling out. `diskutil image info` exits nonzero after printing the license agreement for an SLA-bearing image. When that occurs, detection confirms the file has a valid `koly` UDIF trailer directly. This avoids treating arbitrary failure output as a disk image without falling back to deprecated `hdiutil` on the new path.

Validated end-to-end on macOS 27 beta build 26A5388g, including SLA-bearing, multi-volume, and combined SLA/multi-volume images. The macOS 14 floor is based on the capability history documented by `diskutil(8)`; macOS 14 through 26 have not been exercised directly. `diskutil image create from --format UDRO` preserves embedded SLAs, while `RAW` strips them like the legacy UDTO conversion. This is observed prerelease behavior and should be rechecked before macOS 27 GA.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the fix and pass with it, exercised real SLA-bearing and multi-volume disk images end-to-end on macOS 27, and ran `brew lgtm` + targeted specs.

-----
