### PR TITLE
Pass the download queue to FormulaInstaller when upgrading

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -55,6 +55,7 @@ class FormulaInstaller
   sig {
     params(
       formula:                    Formula,
+      download_queue:             Homebrew::DownloadQueue,
       link_keg:                   T::Boolean,
       installed_on_request:       T::Boolean,
       show_header:                T::Boolean,
@@ -83,6 +84,7 @@ class FormulaInstaller
   }
   def initialize(
     formula,
+    download_queue: Homebrew.default_download_queue,
     link_keg: false,
     installed_on_request: false,
     show_header: false,
@@ -143,7 +145,7 @@ class FormulaInstaller
     @hold_locks = T.let(false, T::Boolean)
     @show_summary_heading = T.let(false, T::Boolean)
     @etc_var_preinstall = T.let([], T::Array[Pathname])
-    @download_queue = T.let(Homebrew.default_download_queue, Homebrew::DownloadQueue)
+    @download_queue = download_queue
     @api_bottle = T.let(nil, T.nilable(Bottle))
     @api_bottle_loaded = T.let(false, T::Boolean)
     @enqueued_bottle_download = T.let(nil, T.nilable(Downloadable))

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -1017,6 +1017,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     allow(formula).to receive(:latest_formula).and_return(formula)
     allow(Migrator).to receive(:migrate_if_needed)
     allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
+    expect(Homebrew).not_to receive(:default_download_queue)
     expect(download_queue).to receive(:fetch)
       .with(only: Resource::BottleManifest, heading: "Downloading bottle manifests", allow_failures: true)
 

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -111,6 +111,7 @@ module Homebrew
               fi = create_formula_installer(
                 formula,
                 flags:,
+                download_queue:,
                 force_bottle:,
                 build_from_source_formulae:,
                 interactive:,
@@ -122,7 +123,6 @@ module Homebrew
                 quiet:,
                 verbose:,
               )
-              fi.download_queue = download_queue
               fi.fetch_bottle_tab(quiet: !debug, enqueue: true)
               fi
             rescue CannotInstallFormulaError => e
@@ -512,7 +512,8 @@ module Homebrew
       end
 
       sig {
-        params(formula: Formula, flags: T::Array[String], force_bottle: T::Boolean,
+        params(formula: Formula, flags: T::Array[String], download_queue: Homebrew::DownloadQueue,
+               force_bottle: T::Boolean,
                build_from_source_formulae: T::Array[String], interactive: T::Boolean,
                keep_tmp: T::Boolean, debug_symbols: T::Boolean, force: T::Boolean,
                overwrite: T::Boolean, debug: T::Boolean, quiet: T::Boolean, verbose: T::Boolean).returns(FormulaInstaller)
@@ -520,6 +521,7 @@ module Homebrew
       def create_formula_installer(
         formula,
         flags:,
+        download_queue:,
         force_bottle: false,
         build_from_source_formulae: [],
         interactive: false,
@@ -556,6 +558,7 @@ module Homebrew
         FormulaInstaller.new(
           formula,
           **{
+            download_queue:,
             options:,
             link_keg:,
             installed_on_request:,


### PR DESCRIPTION
`FormulaInstaller#initialize` memoized `Homebrew.default_download_queue` before the upgrade path replaced the installer's queue through its accessor. In tests that let a stubbed `Homebrew::DownloadQueue.new` double become the process-global default queue, which `at_exit` then called `shutdown` on after RSpec had torn down its mock lifecycle. Several `tests (generic OS)` runs failed this way: every example passed, then the process exited 1 with `RSpec::Mocks::OutsideOfExampleError` in `Homebrew.shutdown_default_download_queue`.

`FormulaInstaller` now takes an optional `download_queue:` that defaults to `Homebrew.default_download_queue`, so every existing caller is unchanged. `Upgrade.formula_installers` passes the queue it already owns and no longer initializes or replaces the global default. Upgrades also stop allocating a default queue thread pool they never use.

Reproduce with `./bin/brew tests --only=cmd/upgrade:1004 --seed=32372`, which reports one passing example and then exits 1 without this change.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new test fails without the fix and passes with it, and ran `brew lgtm` + targeted specs.

-----
