### PR TITLE
api/cask: ignore `target` when selecting artifact stanza

### DIFF
--- a/Library/Homebrew/api/cask/cask_struct_generator.rb
+++ b/Library/Homebrew/api/cask/cask_struct_generator.rb
@@ -145,7 +145,7 @@ module Homebrew
         sig { params(artifacts: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Array[CaskStruct::ArtifactArgs]) }
         def process_artifacts(artifacts)
           artifacts.map do |artifact|
-            key = T.must(artifact.keys.first)
+            key = T.must(artifact.keys.find { |artifact_key| artifact_key != :target })
 
             # Pass an empty block to artifacts like postflight that can't be loaded from the API,
             # but need to be set to something.

--- a/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
+++ b/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
@@ -48,12 +48,27 @@ RSpec.describe Homebrew::API::Cask::CaskStructGenerator do
       { foo:       ["arg1", "arg2"] },
       { bar:       ["arg1", "arg2", { kwarg1: "value1" }] },
       { baz:       [{ kwarg1: "value1" }] },
+      {
+        target:         "$HOMEBREW_PREFIX/share/zsh/site-functions/_foo",
+        zsh_completion: ["$APPDIR/Foo.app/Contents/Resources/completions/zsh/_foo"],
+      },
+      {
+        zsh_completion: ["$APPDIR/Bar.app/Contents/Resources/completions/zsh/_bar"],
+        target:         "$HOMEBREW_PREFIX/share/zsh/site-functions/_bar",
+      },
+      {
+        target: "/Applications/Bar.app",
+        app:    ["Foo.app", { target: "Bar.app" }],
+      },
     ]
     expected_output = [
       [:preflight, [], {}, Homebrew::API::CaskStruct::EMPTY_BLOCK],
       [:foo, ["arg1", "arg2"], {}, nil],
       [:bar, ["arg1", "arg2"], { kwarg1: "value1" }, nil],
       [:baz, [], { kwarg1: "value1" }, nil],
+      [:zsh_completion, ["$APPDIR/Foo.app/Contents/Resources/completions/zsh/_foo"], {}, nil],
+      [:zsh_completion, ["$APPDIR/Bar.app/Contents/Resources/completions/zsh/_bar"], {}, nil],
+      [:app, ["Foo.app"], { target: "Bar.app" }, nil],
     ]
     output = described_class.process_artifacts(input)
     expect(output).to eq expected_output


### PR DESCRIPTION
`CaskStructGenerator.process_artifacts` picked `artifact.keys.first` as the artifact stanza name. `Cask#artifacts_list` emits a resolved `target` alongside the stanza key for `Relocated` artifacts, so anything that re-serializes the JSON on its way to `brew` can put `target` first. Homebrew then treats `target` as the stanza and calls `String#last` on its value. JSON object member order is not semantically significant, so we should not depend on it.

This breaks loading installed casks, and with that upgrade, uninstall, reinstall and metadata migration. `zsh_completion`, `vst_plugin` and `vst3_plugin` are the only stanzas that sort after `target`, so sorted keys hit exactly those.

`target` is the only sibling key `Cask#artifacts_list` ever emits and it is already discarded here, so nothing else changes: flight blocks, uninstall and zap artifacts, and explicit `target:` kwargs all parse as before. The new test uses a target-first `zsh_completion` entry and fails without the fix.

Fixes #23407

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new test fails without the fix and passes with it, and ran `brew lgtm` locally.

-----
