### PR TITLE
remove accidentally quadratic behavior in `brew cleanup`.

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -401,7 +401,7 @@ module Homebrew
                .sort_by(&:name)
                .reject { |f| Cleanup.skip_clean_formula?(f) }
                .each do |formula|
-          cleanup_formula(formula, quiet:, ds_store: false, cache_db: false)
+          cleanup_formula(formula, quiet:, ds_store: false, cache_db: false, cleanup_unreferenced: false)
         end
 
         if ENV["HOMEBREW_AUTOREMOVE"].present?
@@ -479,11 +479,17 @@ module Homebrew
       cleanup_cache(cache_entries(paths, type:), cleanup_unreferenced:)
     end
 
-    sig { params(formula: Formula, quiet: T::Boolean, ds_store: T::Boolean, cache_db: T::Boolean).void }
-    def cleanup_formula(formula, quiet: false, ds_store: true, cache_db: true)
+    sig {
+      params(formula: Formula, quiet: T::Boolean, ds_store: T::Boolean, cache_db: T::Boolean,
+             cleanup_unreferenced: T::Boolean).void
+    }
+    def cleanup_formula(formula, quiet: false, ds_store: true, cache_db: true, cleanup_unreferenced: true)
       formula.eligible_kegs_for_cleanup(quiet:)
              .each { |keg| cleanup_keg(keg) }
-      cleanup_cache_entries(Pathname.glob(cache/"#{formula.name}{_bottle_manifest,}--*"), type: nil)
+      cleanup_cache_entries(
+        Pathname.glob(cache/"#{formula.name}{_bottle_manifest,}--*"),
+        type: nil, cleanup_unreferenced:,
+      )
       rm_ds_store([formula.rack]) if ds_store
       cleanup_cache_db(formula.rack) if cache_db
       cleanup_lockfiles(FormulaLock.new(formula.name).path)

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -277,6 +277,7 @@ module Homebrew
       @days = T.let(days || Homebrew::EnvConfig.cleanup_max_age_days.to_i, Integer)
       @cache = cache
       @cleaned_up_paths = T.let(Set.new, T::Set[Pathname])
+      @formula_cache_paths = T.let(nil, T.nilable(T::Hash[String, T::Array[Pathname]]))
     end
 
     sig { returns(T::Boolean) }
@@ -479,6 +480,21 @@ module Homebrew
       cleanup_cache(cache_entries(paths, type:), cleanup_unreferenced:)
     end
 
+    sig { params(formula: Formula).returns(T::Array[Pathname]) }
+    def formula_cache_paths(formula)
+      index = @formula_cache_paths ||= begin
+        children = cache.directory? ? cache.children : []
+        children.each_with_object({}) do |path, hash|
+          prefix, separator, = path.basename.to_s.partition("--")
+          next if separator.empty? || prefix.start_with?(".")
+
+          (hash[prefix] ||= []) << path
+        end
+      end
+
+      (index.fetch(formula.name, []) + index.fetch("#{formula.name}_bottle_manifest", [])).sort
+    end
+
     sig {
       params(formula: Formula, quiet: T::Boolean, ds_store: T::Boolean, cache_db: T::Boolean,
              cleanup_unreferenced: T::Boolean).void
@@ -486,10 +502,7 @@ module Homebrew
     def cleanup_formula(formula, quiet: false, ds_store: true, cache_db: true, cleanup_unreferenced: true)
       formula.eligible_kegs_for_cleanup(quiet:)
              .each { |keg| cleanup_keg(keg) }
-      cleanup_cache_entries(
-        Pathname.glob(cache/"#{formula.name}{_bottle_manifest,}--*"),
-        type: nil, cleanup_unreferenced:,
-      )
+      cleanup_cache_entries(formula_cache_paths(formula), type: nil, cleanup_unreferenced:)
       rm_ds_store([formula.rack]) if ds_store
       cleanup_cache_db(formula.rack) if cache_db
       cleanup_lockfiles(FormulaLock.new(formula.name).path)


### PR DESCRIPTION
I guess #23419 needed more explanation.  So I'm going to split it into two changes.  This is the first.

I have a brew installation with thousands of packages and noticed that ``brew cleanup`` was slow:

```
$ time brew cleanup
brew cleanup  930.86s user 487.52s system 96% cpu 24:22.47 total
```

In the process of figuring out why that was, I made this first change:

`brew cleanup` with no arguments loops over every installed formula calling `cleanup_formula`, which reached `cleanup_cache` with `cleanup_unreferenced` defaulting to true. That ran `cleanup_unreferenced_downloads` once per formula, and each run walks the whole cache to rebuild the referenced-download set. 

We now instead pass `cleanup_unreferenced: false` from the loop instead. `clean!` already calls `cleanup_cache` immediately afterwards, which prunes unreferenced downloads once against the final on-disk state.

After (8x faster):

```
$ time brew cleanup
brew cleanup  115.12s user 106.34s system 79% cpu 4:40.31 total
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
