### PR TITLE
test/ENV_spec: compare only singleton methods

### DIFF
--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -46,13 +46,14 @@ RSpec.describe "ENV" do
       end
 
       it "does not mutate the interface" do
-        expected = subject.methods
+        # Lazy-loaded gems may add methods to Hash without extending this object.
+        expected = subject.singleton_methods
 
         subject.with_build_environment do
-          expect(subject.methods).to eq(expected)
+          expect(subject.singleton_methods).to eq(expected)
         end
 
-        expect(subject.methods).to eq(expected)
+        expect(subject.singleton_methods).to eq(expected)
       end
     end
 


### PR DESCRIPTION
`ENV_spec`'s "does not mutate the interface" example compared `subject.methods` before, during and after `with_build_environment`. On macOS that block runs the fatal setup build environment checks, which reach `MacOS::Xcode.detect_version` and lazily `require "plist"`. The `plist` gem mixes `Plist::Emit` into `Hash`, so when this example is the first in a run to load it, `save_plist` and `to_plist` appear in `subject.methods` mid-block and the example fails. Detection is memoized, so it passes whenever something else loaded `plist` first, which makes this seed dependent rather than consistently broken.

Comparing `singleton_methods` keeps the invariant the example was written for, that `with_build_environment` must not extend or otherwise mutate the ENV object's own interface, while ignoring unrelated methods added to `Hash` itself. Extending the object with `Stdenv`, `Superenv` or anything else still changes `singleton_methods`, so the regression coverage is unchanged. `singleton_class.ancestors` is not a workable alternative because `plist` includes a module rather than reopening the class, so it moves for the same reason `methods` does.

Reproduce on `main` with:

```
brew tests --only=ENV:48 --seed=49228
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) did the work: narrowed the assertion and added the explanatory comment; I reviewed the diff, verified the example fails at seed 49228 without the change and passes with it, and ran `brew lgtm`.

-----
