### PR TITLE
cask/audit: allow linux-only casks

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -263,6 +263,10 @@ module Homebrew
           path = cask.sourcefile_path
 
           errors = os_arch_combinations.flat_map do |os, arch|
+            # Linux-only casks have no stanza values for macOS, so audit them
+            # under Linux instead.
+            os = :linux if os != :linux && !cask.supports_macos?
+
             SimulateSystem.with(os:, arch:) do
               odebug "Auditing Cask #{cask} on os #{os} and arch #{arch}"
 

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -13,7 +13,11 @@ RSpec.describe Homebrew::DevCmd::Audit do
     let(:tap_path) { mktmpdir }
     let(:macos_only_cask_file) { tap_path/"Casks/macos-only-example.rb" }
     let(:linux_cask_file) { tap_path/"Casks/linux-example.rb" }
-    let(:tap) { instance_double(Tap, formula_files: [], cask_files: [macos_only_cask_file, linux_cask_file]) }
+    let(:linux_only_cask_file) { tap_path/"Casks/linux-only-example.rb" }
+    let(:tap) do
+      instance_double(Tap, formula_files: [], cask_files: [macos_only_cask_file, linux_cask_file,
+                                                           linux_only_cask_file])
+    end
 
     before do
       macos_only_cask_file.dirname.mkpath
@@ -22,11 +26,11 @@ RSpec.describe Homebrew::DevCmd::Audit do
           version "1.0"
           sha256 arm:   "0000000000000000000000000000000000000000000000000000000000000000",
                  intel: "1111111111111111111111111111111111111111111111111111111111111111"
-          url "https://example.invalid/x.pkg"
+          url "https://example.invalid/x-\#{version}.pkg"
           name "Example"
           desc "macOS-only cask"
           homepage "https://example.invalid/"
-          depends_on macos: ">= :ventura"
+          depends_on macos: :ventura
           binary "x"
         end
       RUBY
@@ -35,10 +39,23 @@ RSpec.describe Homebrew::DevCmd::Audit do
           version "1.0"
           sha256 arm:   "0000000000000000000000000000000000000000000000000000000000000000",
                  intel: "1111111111111111111111111111111111111111111111111111111111111111"
-          url "https://example.invalid/x.tar.gz"
+          url "https://example.invalid/x-\#{version}.tar.gz"
           name "Example"
           desc "Linux-supported cask"
           homepage "https://example.invalid/"
+          binary "x"
+        end
+      RUBY
+      linux_only_cask_file.write <<~RUBY
+        cask "linux-only-example" do
+          version "1.0"
+          sha256 arm64_linux:  "0000000000000000000000000000000000000000000000000000000000000000",
+                 x86_64_linux: "1111111111111111111111111111111111111111111111111111111111111111"
+          url "https://example.invalid/x-\#{version}.tar.gz"
+          name "Example"
+          desc "Linux-only cask"
+          homepage "https://example.invalid/"
+          depends_on :linux
           binary "x"
         end
       RUBY
@@ -59,6 +76,12 @@ RSpec.describe Homebrew::DevCmd::Audit do
       Homebrew::SimulateSystem.with(os: :linux) do
         expect { audit.run }.to output(problems).to_stdout
                                                 .and output(/1 problem in 1 cask detected/).to_stderr
+      end
+    end
+
+    it "audits Linux-only casks under Linux when running on macOS" do
+      Homebrew::SimulateSystem.with(os: :macos) do
+        expect { audit.run }.not_to output.to_stdout
       end
     end
   end


### PR DESCRIPTION
Follow-up to #23122. That change let a Linux-only cask load on macOS with a nil `sha256`, but `brew audit` still audits every cask under the host OS, so the required-stanzas check fails instead:

```
brew audit --except=installed --tap=homebrew/cask
koreader
  * a sha256 stanza is required
```
See [Homebrew/homebrew-cask#274338](https://github.com/Homebrew/homebrew-cask/pull/274338) (the first Linux-only cask).

The change simulates Linux in the cask audit loop for casks that don't support macOS, mirroring the existing handling for macOS-only casks when auditing on Linux. Under Linux simulation the Linux checksums resolve and the audit passes, and the macOS-specific checks already early-return in the offline tap audit.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

I used `claude-code` with fable-5 to help create the fix and tests.