### PR TITLE
Restore use of package-provided service files

### DIFF
--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -263,13 +263,17 @@ module Homebrew
       end
 
       # Generate the service file content (plist or systemd unit),
-      # including any per-service user environment variable overrides.
+      # including any per-service user environment variable overrides,
+      # or read the package-provided service file if the formula's
+      # service block does not define a command.
       sig { returns(String) }
       def service_contents
-        if System.launchctl?
-          formula.service.to_plist
+        if !service? || !load_service.command?
+          service_file.read
+        elsif System.launchctl?
+          load_service.to_plist
         else
-          formula.service.to_systemd_unit
+          load_service.to_systemd_unit
         end
       end
 

--- a/Library/Homebrew/test/services/formula_wrapper_spec.rb
+++ b/Library/Homebrew/test/services/formula_wrapper_spec.rb
@@ -66,6 +66,41 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
     end
   end
 
+  describe "#service_contents" do
+    it "macOS - generates the plist from the formula service block" do
+      allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
+      allow(service).to receive(:service?).and_return(true)
+      allow(service_object).to receive_messages(command?: true, to_plist: "plist contents")
+
+      expect(service.service_contents).to eq("plist contents")
+    end
+
+    it "systemD - generates the unit from the formula service block" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      allow(service).to receive(:service?).and_return(true)
+      allow(service_object).to receive_messages(command?: true, to_systemd_unit: "unit contents")
+
+      expect(service.service_contents).to eq("unit contents")
+    end
+
+    it "reads the package-provided service file when the service block has no command" do
+      service_file = mktmpdir/"custom.name.plist"
+      service_file.write("package plist")
+      allow(service).to receive_messages(service?: true, service_file:)
+      allow(service_object).to receive(:command?).and_return(false)
+
+      expect(service.service_contents).to eq("package plist")
+    end
+
+    it "reads the package-provided service file when the formula has no service block" do
+      service_file = mktmpdir/"custom.name.plist"
+      service_file.write("package plist")
+      allow(service).to receive(:service_file).and_return(service_file)
+
+      expect(service.service_contents).to eq("package plist")
+    end
+  end
+
   describe "#service_name" do
     it "macOS - outputs the service name" do
       allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)


### PR DESCRIPTION
- Since #23312, `brew services start` always regenerated the service definition from the formula `service` block. Formulae that bundle their own service file only declare `name` there, so the generated plist had empty `ProgramArguments` and `launchctl bootstrap` failed with `Input/output error`.
- Read the installed service file instead unless the `service` block defines a command, the same gate `FormulaInstaller#install_service` uses when writing generated service files into the keg.

Fixes https://github.com/Homebrew/brew/issues/23408
Closes https://github.com/Homebrew/brew/pull/23413

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Fable 5 Max with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
