### PR TITLE
Skip cask link when symlink already correct

### DIFF
--- a/Library/Homebrew/cask/artifact/symlinked.rb
+++ b/Library/Homebrew/cask/artifact/symlinked.rb
@@ -79,6 +79,9 @@ module Cask
              (target.realpath == source.realpath || target.realpath.to_s.start_with?("#{cask.caskroom_path}/"))
             opoo "#{message}; overwriting."
             Utils.gain_permissions_remove(target, command:)
+          elsif target_links_to_source?
+            ohai "#{self.class.english_name} '#{source.basename}' is already linked to '#{target}'"
+            return
           elsif (formula = conflicting_formula)
             opoo "#{message} from formula #{formula}; skipping link."
             return
@@ -111,6 +114,14 @@ module Cask
 
         command.run! "/bin/ln", args: ["--no-dereference", "--force", "--symbolic", source, target],
                                 sudo: !target.dirname.writable?
+      end
+
+      sig { returns(T::Boolean) }
+      def target_links_to_source?
+        target.symlink? && target.realpath == source.realpath
+      rescue => e
+        odebug "Error checking whether #{target} links to #{source}: #{e}"
+        false
       end
 
       # Check if the target file is a symlink that originates from a formula

--- a/Library/Homebrew/test/cask/artifact/binary_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/binary_spec.rb
@@ -86,6 +86,27 @@ RSpec.describe Cask::Artifact::Binary, :cask do
     expect(File.readlink(expected_path)).to eq("/tmp")
   end
 
+  it "skips linking when the target is already a symlink to the source" do
+    artifact = artifacts.first
+    expected_path.make_symlink(artifact.source)
+
+    expect do
+      artifact.install_phase(command: NeverSudoSystemCommand, force: false)
+    end.to output(/is already linked/).to_stdout
+
+    expect(expected_path.readlink).to eq(artifact.source)
+  end
+
+  it "raises a clean error when the target symlink cannot be resolved" do
+    artifact = artifacts.first
+    expected_path.make_symlink(artifact.source)
+    allow(artifact.target).to receive(:realpath).and_raise(Errno::EACCES)
+
+    expect do
+      artifact.install_phase(command: NeverSudoSystemCommand, force: false)
+    end.to raise_error(Cask::CaskError, /already a Binary/)
+  end
+
   it "creates parent directory if it doesn't exist" do
     FileUtils.rmdir binarydir
 


### PR DESCRIPTION
- A plain `brew upgrade` raised "It seems there is already a Binary at ..." even when the existing symlink resolved to the exact source about to be linked, because the realpath check sat behind `force`/`adopt`. The revert left the symlink in place so every retry failed identically until manual intervention.
- Treat an already-correct symlink as a no-op: log and skip the link. Genuine conflicts, such as a real file at the target or a symlink elsewhere, still require `--force` or `--adopt`.

Fixes Homebrew/brew#23426.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Fable 5 max with local review, iterating and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
