### PR TITLE
Use codesign to sign patched binaries on Intel

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -64,7 +64,10 @@ module OS
             check_access_directories
           ]
 
-          # Developer tools are checked when building from source.
+          # We need the developer tools for `codesign` on Intel:
+          # https://github.com/Homebrew/brew/issues/23418
+          checks << "check_for_installed_developer_tools" unless ::Hardware::CPU.arm?
+
           checks.freeze
         end
 

--- a/Library/Homebrew/extend/os/mac/keg.rb
+++ b/Library/Homebrew/extend/os/mac/keg.rb
@@ -108,6 +108,43 @@ module OS
       def codesign_patched_binary(file)
         return if MacOS.version < :big_sur
 
+        unless ::Hardware::CPU.arm?
+          # Intel macOS rejects ruby-macho's ad-hoc signatures on larger
+          # binaries and does not require unsigned binaries to be signed,
+          # so use `codesign` to re-sign only the binaries whose existing
+          # signature our modifications have just broken:
+          # https://github.com/Homebrew/brew/issues/23418
+          result = system_command("codesign", args: ["--verify", file], print_stderr: false)
+          return unless result.stderr.match?(/invalid signature/i)
+
+          odebug "Codesigning #{file}"
+          return if quiet_system("codesign", "--sign", "-", "--force",
+                                 "--preserve-metadata=entitlements,requirements,flags,runtime",
+                                 file)
+
+          # If the codesigning fails, it may be a bug in Apple's codesign utility.
+          # A known workaround is to copy the file to another inode, then move it back
+          # erasing the previous file. Then sign again.
+          Dir::Tmpname.create("workaround") do |tmppath|
+            FileUtils.cp file, tmppath
+            FileUtils.mv tmppath, file, force: true
+          end
+
+          odebug "Codesigning (2nd try) #{file}"
+          result = system_command("codesign", args: [
+            "--sign", "-", "--force",
+            "--preserve-metadata=entitlements,requirements,flags,runtime",
+            file
+          ], print_stderr: false)
+          return if result.success?
+
+          onoe <<~EOS
+            Failed applying an ad-hoc signature to #{file}:
+            #{result.stderr}
+          EOS
+          return
+        end
+
         require "macho"
 
         odebug "Codesigning #{file}"

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -68,6 +68,12 @@ RSpec.describe Homebrew::Diagnostic::Checks do
 
       expect(checks.fatal_preinstall_checks).not_to include("check_for_installed_developer_tools")
     end
+
+    it "requires developer tools on Intel" do
+      allow(Hardware::CPU).to receive(:arm?).and_return(false)
+
+      expect(checks.fatal_preinstall_checks).to include("check_for_installed_developer_tools")
+    end
   end
 
   describe "#fatal_build_from_source_checks" do

--- a/Library/Homebrew/test/os/mac/keg_spec.rb
+++ b/Library/Homebrew/test/os/mac/keg_spec.rb
@@ -43,10 +43,36 @@ RSpec.describe Keg do
       allow(MacOS).to receive(:version).and_return(MacOSVersion.new("11"))
     end
 
-    it "signs patched binaries using ruby-macho" do
+    it "signs patched binaries using ruby-macho on Apple Silicon" do
+      allow(Hardware::CPU).to receive(:arm?).and_return(true)
       expect(keg).not_to receive(:system_command).with("codesign", any_args)
       expect(keg).not_to receive(:quiet_system).with("codesign", any_args)
       expect(MachO).to receive(:codesign!).with(file)
+
+      keg.codesign_patched_binary(file)
+    end
+
+    it "re-signs binaries whose signature has been broken using codesign on Intel" do
+      allow(Hardware::CPU).to receive(:arm?).and_return(false)
+      expect(MachO).not_to receive(:codesign!)
+      expect(keg).to receive(:system_command)
+        .with("codesign", args: ["--verify", file], print_stderr: false)
+        .and_return(instance_double(SystemCommand::Result, stderr: "#{file}: invalid signature"))
+      expect(keg).to receive(:quiet_system)
+        .with("codesign", "--sign", "-", "--force",
+              "--preserve-metadata=entitlements,requirements,flags,runtime", file)
+        .and_return(true)
+
+      keg.codesign_patched_binary(file)
+    end
+
+    it "does not sign unsigned binaries on Intel" do
+      allow(Hardware::CPU).to receive(:arm?).and_return(false)
+      expect(MachO).not_to receive(:codesign!)
+      expect(keg).to receive(:system_command)
+        .with("codesign", args: ["--verify", file], print_stderr: false)
+        .and_return(instance_double(SystemCommand::Result, stderr: "#{file}: code object is not signed at all"))
+      expect(keg).not_to receive(:quiet_system).with("codesign", any_args)
 
       keg.codesign_patched_binary(file)
     end


### PR DESCRIPTION
- Since the switch to `MachO.codesign!` in ruby-macho 6.0, Intel macOS rejects the ad-hoc signatures on larger relocated binaries (e.g. `libruby`, the Python framework) and kills hardened-runtime programs such as MacVim's `vim` at launch with `CODESIGNING, Invalid Page`: https://github.com/Homebrew/brew/issues/23418
- The signatures have correct page hashes and pass `codesign --verify` on newer macOS, so this looks like an Intel macOS verifier quirk rather than simple corruption.
- Restore the pre-6.0 behaviour on Intel: leave unsigned binaries unsigned and use `codesign` to re-sign only the binaries whose existing signature our modifications have just broken, e.g. MacVim's Xcode-ad-hoc-signed hardened-runtime `vim`.
- Restore the fatal preinstall developer tools check, now skipped on Apple Silicon rather than gated to it, as `codesign` requires the Command Line Tools while ruby-macho does not.
- Keep `MachO.codesign!` on Apple Silicon, where it is required, proven and avoids a `codesign` subprocess per relocated file.

Fixes https://github.com/Homebrew/brew/issues/23418

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Fable 5 max with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
