### PR TITLE
Convert Tab attributes to keyword arguments

### DIFF
--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -179,7 +179,7 @@ class Bottle
   sig { returns(T::Boolean) }
   def skip_relocation?
     attrs = tab_attributes
-    tab = Tab.new(attrs) unless attrs.empty?
+    tab = Tab.new(**attrs.transform_keys(&:to_sym)) unless attrs.empty?
     @spec.skip_relocation?(tag: @tag, tab:)
   end
 

--- a/Library/Homebrew/cask/tab.rb
+++ b/Library/Homebrew/cask/tab.rb
@@ -14,12 +14,16 @@ module Cask
     sig { returns(T.nilable(T::Array[T.untyped])) }
     attr_accessor :uninstall_artifacts
 
-    sig { params(attributes: T.any(T::Hash[String, T.untyped], T::Hash[Symbol, T.untyped])).void }
-    def initialize(attributes = {})
-      @uninstall_flight_blocks = T.let(nil, T.nilable(T::Boolean))
-      @uninstall_artifacts = T.let(nil, T.nilable(T::Array[T.untyped]))
+    sig {
+      params(uninstall_flight_blocks: T.nilable(T::Boolean),
+             uninstall_artifacts:     T.nilable(T::Array[T.untyped]),
+             rest:                    T.untyped).void
+    }
+    def initialize(uninstall_flight_blocks: nil, uninstall_artifacts: nil, **rest)
+      @uninstall_flight_blocks = uninstall_flight_blocks
+      @uninstall_artifacts = uninstall_artifacts
 
-      super
+      super(**rest)
     end
 
     # Instantiates a {Tab} for a new installation of a cask.

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -58,52 +58,53 @@ class AbstractTab
   sig { returns(RuntimeDependencies) }
   attr_accessor :runtime_dependencies
 
-  # TODO: Update attributes to only accept symbol keys (kwargs style).
-  sig { params(attributes: T.any(T::Hash[String, T.untyped], T::Hash[Symbol, T.untyped])).void }
-  def initialize(attributes = {})
-    @installed_on_request = T.let(false, T::Boolean)
-    @installed_on_request_present = T.let(false, T::Boolean)
-    @homebrew_version = T.let(nil, T.nilable(String))
-    @tabfile = T.let(nil, T.nilable(Pathname))
-    @loaded_from_api = T.let(nil, T.nilable(T::Boolean))
-    @loaded_from_internal_api = T.let(nil, T.nilable(T::Boolean))
-    @time = T.let(nil, T.nilable(Integer))
-    @arch = T.let(nil, T.nilable(T.any(String, Symbol)))
-    @source = T.let({}, T::Hash[String, T.untyped])
-    @built_on = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
-    @runtime_dependencies = T.let(nil, RuntimeDependencies)
-
-    attributes.each do |key, value|
-      case key.to_sym
-      when :installed_on_request
-        @installed_on_request = value.nil? ? false : value
-        @installed_on_request_present = true
-      when :changed_files
-        @changed_files = T.let(value&.map { |f| Pathname(f) }, T.nilable(T::Array[Pathname]))
-      else
-        instance_variable_set(:"@#{key}", value)
-      end
-    end
+  # Unrecognised attributes are ignored so that receipts written by other
+  # Homebrew versions (e.g. the long-removed `installed_as_dependency`) still load.
+  sig {
+    params(homebrew_version:         T.nilable(String),
+           tabfile:                  T.nilable(T.any(Pathname, String)),
+           loaded_from_api:          T.nilable(T::Boolean),
+           loaded_from_internal_api: T.nilable(T::Boolean),
+           installed_on_request:     T.nilable(T::Boolean),
+           time:                     T.nilable(Integer),
+           arch:                     T.nilable(T.any(String, Symbol)),
+           source:                   T.nilable(T::Hash[String, T.untyped]),
+           built_on:                 T.nilable(T::Hash[String, T.untyped]),
+           runtime_dependencies:     RuntimeDependencies,
+           _unknown:                 T.untyped).void
+  }
+  def initialize(homebrew_version: nil, tabfile: nil, loaded_from_api: nil, loaded_from_internal_api: nil,
+                 installed_on_request: nil, time: nil, arch: nil, source: nil, built_on: nil,
+                 runtime_dependencies: nil, **_unknown)
+    @installed_on_request = T.let(installed_on_request || false, T::Boolean)
+    @installed_on_request_present = T.let(!installed_on_request.nil?, T::Boolean)
+    @homebrew_version = homebrew_version
+    @tabfile = T.let(tabfile.nil? ? nil : Pathname(tabfile), T.nilable(Pathname))
+    @loaded_from_api = loaded_from_api
+    @loaded_from_internal_api = loaded_from_internal_api
+    @time = time
+    @arch = arch
+    @source = T.let(source || {}, T::Hash[String, T.untyped])
+    @built_on = built_on
+    @runtime_dependencies = runtime_dependencies
   end
 
   # Instantiates a {Tab} for a new installation of a formula or cask.
   sig { params(formula_or_cask: T.any(Formula, Cask::Cask)).returns(T.attached_class) }
   def self.create(formula_or_cask)
-    attributes = {
-      "homebrew_version"         => HOMEBREW_VERSION,
-      "installed_on_request"     => false,
-      "loaded_from_api"          => formula_or_cask.loaded_from_api?,
-      "loaded_from_internal_api" => formula_or_cask.loaded_from_internal_api?,
-      "time"                     => Time.now.to_i,
-      "arch"                     => Hardware::CPU.arch,
-      "source"                   => {
+    new(
+      homebrew_version:         HOMEBREW_VERSION,
+      installed_on_request:     false,
+      loaded_from_api:          formula_or_cask.loaded_from_api?,
+      loaded_from_internal_api: formula_or_cask.loaded_from_internal_api?,
+      time:                     Time.now.to_i,
+      arch:                     Hardware::CPU.arch,
+      source:                   {
         "tap"          => formula_or_cask.tap&.name,
         "tap_git_head" => formula_or_cask.tap_git_head,
       },
-      "built_on"                 => DevelopmentTools.build_system_info,
-    }
-
-    new(attributes)
+      built_on:                 DevelopmentTools.build_system_info,
+    )
   end
 
   # Returns the {Tab} for a formula or cask install receipt at `path`.
@@ -129,28 +130,26 @@ class AbstractTab
     end
     attributes["tabfile"] = path
 
-    new(attributes)
+    new(**attributes.transform_keys(&:to_sym))
   end
 
   sig { returns(T.attached_class) }
   def self.empty
-    attributes = {
-      "homebrew_version"         => HOMEBREW_VERSION,
-      "installed_on_request"     => false,
-      "loaded_from_api"          => false,
-      "loaded_from_internal_api" => false,
-      "time"                     => nil,
-      "runtime_dependencies"     => nil,
-      "arch"                     => nil,
-      "source"                   => {
+    new(
+      homebrew_version:         HOMEBREW_VERSION,
+      installed_on_request:     false,
+      loaded_from_api:          false,
+      loaded_from_internal_api: false,
+      time:                     nil,
+      runtime_dependencies:     nil,
+      arch:                     nil,
+      source:                   {
         "path"         => nil,
         "tap"          => nil,
         "tap_git_head" => nil,
       },
-      "built_on"                 => DevelopmentTools.build_system_info,
-    }
-
-    new(attributes)
+      built_on:                 DevelopmentTools.build_system_info,
+    )
   end
 
   sig { params(formula: Formula, declared_deps: T::Array[String]).returns(T::Hash[String, T.untyped]) }

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -71,7 +71,7 @@ class AbstractTab
            source:                   T.nilable(T::Hash[String, T.untyped]),
            built_on:                 T.nilable(T::Hash[String, T.untyped]),
            runtime_dependencies:     RuntimeDependencies,
-           _unknown:                 T.untyped).void
+           _unknown:                 T.anything).void
   }
   def initialize(homebrew_version: nil, tabfile: nil, loaded_from_api: nil, loaded_from_internal_api: nil,
                  installed_on_request: nil, time: nil, arch: nil, source: nil, built_on: nil,

--- a/Library/Homebrew/tab/tab.rb
+++ b/Library/Homebrew/tab/tab.rb
@@ -37,20 +37,34 @@ class Tab < AbstractTab
   sig { returns(T.nilable(T::Array[Pathname])) }
   attr_accessor :changed_files
 
-  sig { params(attributes: T.any(T::Hash[String, T.untyped], T::Hash[Symbol, T.untyped])).void }
-  def initialize(attributes = {})
-    @poured_from_bottle = T.let(nil, T.nilable(T::Boolean))
-    @built_as_bottle = T.let(nil, T.nilable(T::Boolean))
-    @changed_files = T.let(nil, T.nilable(T::Array[Pathname]))
-    @stdlib = T.let(nil, T.nilable(T.any(String, Symbol)))
-    @aliases = T.let(nil, T.nilable(T::Array[String]))
-    @used_options = T.let(nil, T.nilable(T::Array[String]))
-    @unused_options = T.let(nil, T.nilable(T::Array[String]))
-    @compiler = T.let(nil, T.nilable(T.any(String, Symbol)))
-    @source_modified_time = T.let(nil, T.nilable(Integer))
-    @tapped_from = T.let(nil, T.nilable(String))
+  sig {
+    params(poured_from_bottle:   T.nilable(T::Boolean),
+           built_as_bottle:      T.nilable(T::Boolean),
+           changed_files:        T.nilable(T::Array[T.any(Pathname, String)]),
+           stdlib:               T.nilable(T.any(String, Symbol)),
+           aliases:              T.nilable(T::Array[String]),
+           used_options:         T.nilable(T::Array[String]),
+           unused_options:       T.nilable(T::Array[String]),
+           compiler:             T.nilable(T.any(String, Symbol)),
+           source_modified_time: T.nilable(Integer),
+           tapped_from:          T.nilable(String),
+           rest:                 T.untyped).void
+  }
+  def initialize(poured_from_bottle: nil, built_as_bottle: nil, changed_files: nil, stdlib: nil, aliases: nil,
+                 used_options: nil, unused_options: nil, compiler: nil, source_modified_time: nil,
+                 tapped_from: nil, **rest)
+    @poured_from_bottle = poured_from_bottle
+    @built_as_bottle = built_as_bottle
+    @changed_files = T.let(changed_files&.map { |f| Pathname(f) }, T.nilable(T::Array[Pathname]))
+    @stdlib = stdlib
+    @aliases = aliases
+    @used_options = used_options
+    @unused_options = unused_options
+    @compiler = compiler
+    @source_modified_time = source_modified_time
+    @tapped_from = tapped_from
 
-    super
+    super(**rest)
   end
 
   # Instantiates a {Tab} for a new installation of a formula.

--- a/Library/Homebrew/test/cask/tab_spec.rb
+++ b/Library/Homebrew/test/cask/tab_spec.rb
@@ -6,24 +6,24 @@ require "cask"
 RSpec.describe Cask::Tab, :cask do
   subject(:tab) do
     described_class.new(
-      "homebrew_version"         => HOMEBREW_VERSION,
-      "loaded_from_api"          => false,
-      "loaded_from_internal_api" => false,
-      "uninstall_flight_blocks"  => true,
-      "installed_on_request"     => true,
-      "time"                     => time,
-      "runtime_dependencies"     => {
+      homebrew_version:         HOMEBREW_VERSION,
+      loaded_from_api:          false,
+      loaded_from_internal_api: false,
+      uninstall_flight_blocks:  true,
+      installed_on_request:     true,
+      time:,
+      runtime_dependencies:     {
         "cask" => [{ "full_name" => "bar", "version" => "2.0", "declared_directly" => false }],
       },
-      "source"                   => {
+      source:                   {
         "path"         => CoreCaskTap.instance.path.to_s,
         "tap"          => CoreCaskTap.instance.to_s,
         "tap_git_head" => "8b79aa759500f0ffdf65a23e12950cbe3bf8fe17",
         "version"      => "1.2.3",
       },
-      "arch"                     => Hardware::CPU.arch,
-      "uninstall_artifacts"      => [{ "app" => ["Foo.app"] }],
-      "built_on"                 => DevelopmentTools.build_system_info,
+      arch:                     Hardware::CPU.arch,
+      uninstall_artifacts:      [{ "app" => ["Foo.app"] }],
+      built_on:                 DevelopmentTools.build_system_info,
     )
   end
 
@@ -301,7 +301,7 @@ RSpec.describe Cask::Tab, :cask do
   end
 
   specify "#to_json" do
-    json_tab = described_class.new(JSON.parse(tab.to_json))
+    json_tab = described_class.new(**JSON.parse(tab.to_json).transform_keys(&:to_sym))
     expect(json_tab.homebrew_version).to eq(tab.homebrew_version)
     expect(json_tab.loaded_from_api).to eq(tab.loaded_from_api)
     expect(json_tab.loaded_from_internal_api).to eq(tab.loaded_from_internal_api)

--- a/Library/Homebrew/test/installed_dependents_spec.rb
+++ b/Library/Homebrew/test/installed_dependents_spec.rb
@@ -44,11 +44,11 @@ RSpec.describe InstalledDependents do
     def setup_test_keg(name, version, &block)
       keg = super
       tab = Tab.new(
-        "homebrew_version"         => HOMEBREW_VERSION,
-        "installed_on_request"     => false,
-        "loaded_from_api"          => false,
-        "loaded_from_internal_api" => false,
-        "source"                   => {
+        homebrew_version:         HOMEBREW_VERSION,
+        installed_on_request:     false,
+        loaded_from_api:          false,
+        loaded_from_internal_api: false,
+        source:                   {
           "path"         => nil,
           "tap"          => "homebrew/core",
           "tap_git_head" => nil,
@@ -60,7 +60,7 @@ RSpec.describe InstalledDependents do
             "compatibility_version" => nil,
           },
         },
-        "built_on"                 => {},
+        built_on:                 {},
       )
       tab.tabfile = keg/AbstractTab::FILENAME
       tab.stdlib = :libcxx

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -7,19 +7,19 @@ require "formula"
 RSpec.describe Tab do
   subject(:tab) do
     described_class.new(
-      "homebrew_version"     => HOMEBREW_VERSION,
-      "used_options"         => used_options.as_flags,
-      "unused_options"       => unused_options.as_flags,
-      "built_as_bottle"      => false,
-      "poured_from_bottle"   => true,
-      "installed_on_request" => true,
-      "changed_files"        => [],
-      "time"                 => time,
-      "source_modified_time" => 0,
-      "compiler"             => "clang",
-      "stdlib"               => "libcxx",
-      "runtime_dependencies" => [],
-      "source"               => {
+      homebrew_version:     HOMEBREW_VERSION,
+      used_options:         used_options.as_flags,
+      unused_options:       unused_options.as_flags,
+      built_as_bottle:      false,
+      poured_from_bottle:   true,
+      installed_on_request: true,
+      changed_files:        [],
+      time:,
+      source_modified_time: 0,
+      compiler:             "clang",
+      stdlib:               "libcxx",
+      runtime_dependencies: [],
+      source:               {
         "tap"          => CoreTap.instance.to_s,
         "path"         => CoreTap.instance.path.to_s,
         "spec"         => "stable",
@@ -29,8 +29,8 @@ RSpec.describe Tab do
           "head"   => "HEAD-1111111",
         },
       },
-      "arch"                 => Hardware::CPU.arch,
-      "built_on"             => DevelopmentTools.build_system_info,
+      arch:                 Hardware::CPU.arch,
+      built_on:             DevelopmentTools.build_system_info,
     )
   end
 
@@ -141,6 +141,17 @@ RSpec.describe Tab do
     expect(tab).to be_installed_on_request
     expect(tab).not_to be_loaded_from_api
     expect(tab).not_to be_loaded_from_internal_api
+  end
+
+  specify "#initialize" do
+    # Receipts written by other Homebrew versions carry attributes we no longer know about.
+    tab = described_class.new(installed_as_dependency: true, homebrew_version: "1.2.3")
+    expect(tab.homebrew_version).to eq("1.2.3")
+  end
+
+  specify "#installed_on_request_present?" do
+    expect(described_class.new).not_to be_installed_on_request_present
+    expect(described_class.new(installed_on_request: false)).to be_installed_on_request_present
   end
 
   specify "#parsed_homebrew_version" do
@@ -544,7 +555,7 @@ RSpec.describe Tab do
   end
 
   specify "#to_json" do
-    json_tab = described_class.new(JSON.parse(tab.to_json))
+    json_tab = described_class.new(**JSON.parse(tab.to_json).transform_keys(&:to_sym))
     expect(json_tab.homebrew_version).to eq(tab.homebrew_version)
     expect(json_tab.used_options.sort).to eq(tab.used_options.sort)
     expect(json_tab.unused_options.sort).to eq(tab.unused_options.sort)
@@ -566,7 +577,7 @@ RSpec.describe Tab do
   end
 
   specify "#to_bottle_hash" do
-    json_tab = described_class.new(JSON.parse(tab.to_bottle_hash.to_json))
+    json_tab = described_class.new(**JSON.parse(tab.to_bottle_hash.to_json).transform_keys(&:to_sym))
     expect(json_tab.homebrew_version).to eq(tab.homebrew_version)
     expect(json_tab.changed_files).to eq(tab.changed_files)
     expect(json_tab.source_modified_time).to eq(tab.source_modified_time)


### PR DESCRIPTION
`AbstractTab#initialize` took a hash and assigned attributes via `instance_variable_set`, so Sorbet checked nothing — a typo (`homebrew_versoin`) or a wrong type (`time: "yesterday"`) was silently ignored and only surfaced later. Subclasses also needed `T.let(nil, ...)` for every ivar just to give Sorbet a type. A `TODO` already asked for this change.

`AbstractTab`, `Tab` and `Cask::Tab` now take keyword arguments:
- Each class reads its own attributes and passes the rest to `super`.
- Unknown keys are swallowed by `**` and ignored, so receipts from other Homebrew versions (e.g. the removed `installed_as_dependency`) still load.
- The two JSON callers symbolize top-level keys only — `source` and `built_on` stay string-keyed, since the code reads them as `source["tap"]`.
- One behaviour change: `tabfile` is now always a `Pathname`; it could previously hold a `String`, which did not match its signature.

Most typing-only `T.let(nil, ...)` lines are gone, and every attribute is now listed in one place in the signatures. I added two tests first (unknown attributes, `installed_on_request_present?`); both pass before and after. Refactor, not a bug fix.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
AI (Claude Code) assisted in writing the code and tests.
I reviewed the change and ran brew lgtm locally