### PR TITLE
system_config: show core cask tap output on Linux

### DIFF
--- a/Library/Homebrew/extend/os/mac/system_config.rb
+++ b/Library/Homebrew/extend/os/mac/system_config.rb
@@ -13,16 +13,17 @@ module OS
 
         sig { void }
         def initialize
+          super
           @xcode = T.let(nil, T.nilable(String))
           @clt = T.let(nil, T.nilable(Version))
         end
 
         sig { returns(String) }
         def describe_clang
-          return "N/A" if ::SystemConfig.clang.null?
+          return "N/A" if clang.null?
 
-          clang_build_info = ::SystemConfig.clang_build.null? ? "(parse error)" : ::SystemConfig.clang_build
-          "#{::SystemConfig.clang} build #{clang_build_info}"
+          clang_build_info = clang_build.null? ? "(parse error)" : clang_build
+          "#{clang} build #{clang_build_info}"
         end
 
         sig { returns(T.nilable(String)) }
@@ -37,12 +38,6 @@ module OS
         sig { returns(T.nilable(Version)) }
         def clt
           @clt ||= MacOS::CLT.version if MacOS::CLT.installed?
-        end
-
-        sig { params(out: T.any(File, StringIO, IO)).void }
-        def core_tap_config(out = $stdout)
-          dump_tap_config(CoreTap.instance, out)
-          dump_tap_config(CoreCaskTap.instance, out)
         end
 
         sig { returns(T.nilable(String)) }
@@ -81,4 +76,5 @@ module OS
     end
   end
 end
+
 SystemConfig.singleton_class.prepend(OS::Mac::SystemConfig::ClassMethods)

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -153,6 +153,7 @@ module SystemConfig
     sig { params(out: T.any(File, StringIO, IO)).void }
     def core_tap_config(out = $stdout)
       dump_tap_config(CoreTap.instance, out)
+      dump_tap_config(CoreCaskTap.instance, out)
     end
 
     sig { params(out: T.any(File, StringIO, IO)).void }


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Linux has supported casks for a while now. With these changes, `brew config` should now output the same core cask tap info shown on macOS.

<details>

<summary>Sample <code>brew config</code> output</summary>

```
% brew config
HOMEBREW_VERSION: 6.0.15-51-gb36f326
ORIGIN: https://github.com/Homebrew/brew
HEAD: b36f3269ee1c071bba854b547146ad0a89fd5678
Last commit: 15 minutes ago
Branch: config-show-cask-info-on-linux
Core tap JSON: 04 Aug 15:24 UTC
Core cask tap HEAD: 97274269f80b61dd67063780a4a3951d7d75b9d8
Core cask tap last commit: 44 minutes ago
HOMEBREW_PREFIX: /home/linuxbrew/.linuxbrew
Homebrew Ruby: 4.0.6 => /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/4.0.6/bin/ruby
CPU: hexa-core 64-bit arm
Clang: N/A
Git: 2.53.0 => /bin/git
Curl: 8.18.0 => /bin/curl
Kernel: Linux 7.0.0-28-generic aarch64 GNU/Linux
Landlock ABI: 8
OS: Ubuntu 26.04 LTS (resolute)
Host glibc: 2.43
Host libstdc++: 6.0.35
/usr/bin/gcc: 15.2.0
/usr/bin/ruby: N/A
glibc: N/A
gcc@13: N/A
gcc: N/A
xorg: N/A
```
</details>