### PR TITLE
shared_audits: print repo age if too new

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -248,9 +248,10 @@ module SharedAudits
              "<#{notability_thresholds.fetch(:stars)} stars)"
     end
 
-    return if Date.parse(metadata["created_at"]) <= (Date.today - 30)
+    age_days = (Date.today - Date.parse(metadata["created_at"])).to_i
+    return if age_days >= 30
 
-    "GitHub repository too new (<30 days old)"
+    "GitHub repository too new (#{age_days} days old, 30 days required)"
   end
 
   sig { params(user: String, repo: String, self_submission: T::Boolean).returns(T.nilable(String)) }
@@ -273,9 +274,10 @@ module SharedAudits
              "<#{notability_thresholds.fetch(:stars)} stars)"
     end
 
-    return if Date.parse(metadata["created_at"]) <= (Date.today - 30)
+    age_days = (Date.today - Date.parse(metadata["created_at"])).to_i
+    return if age_days >= 30
 
-    "GitLab repository too new (<30 days old)"
+    "GitLab repository too new (#{age_days} days old, 30 days required)"
   end
 
   sig { params(user: String, repo: String, self_submission: T::Boolean).returns(T.nilable(String)) }
@@ -291,7 +293,8 @@ module SharedAudits
 
     return "Bitbucket fork (not canonical repository)" unless metadata["parent"].nil?
 
-    return "Bitbucket repository too new (<30 days old)" if Date.parse(metadata["created_on"]) >= (Date.today - 30)
+    age_days = (Date.today - Date.parse(metadata["created_on"])).to_i
+    return "Bitbucket repository too new (#{age_days} days old, 30 days required)" if age_days < 30
 
     forks_result = Utils::Curl.curl_output("--request", "GET", "#{api_url}/forks")
     return unless forks_result.status.success?
@@ -339,9 +342,10 @@ module SharedAudits
              "<#{notability_thresholds.fetch(:stars)} stars)"
     end
 
-    return if Date.parse(metadata["created_at"]) <= (Date.today - 30)
+    age_days = (Date.today - Date.parse(metadata["created_at"])).to_i
+    return if age_days >= 30
 
-    "Forgejo repository too new (<30 days old)"
+    "Forgejo repository too new (#{age_days} days old, 30 days required)"
   end
 
   sig { params(url: String).returns(T.nilable(String)) }


### PR DESCRIPTION
Repo creation date is usually not visible to end users, and the repo age is being calculated anyway. This eliminates guesswork when adding new formulae, contributors will now know exactly how many days to wait before pushing a PR.

Before:
```
% brew audit --new --fix usbtree
usbtree
  * GitHub repository too new (<30 days old)
Error: 1 problem in 1 formula detected.
```

After:
```
% brew audit --new --fix usbtree
usbtree
  * GitHub repository too new (29 days old, 30 days required)
Error: 1 problem in 1 formula detected.
```

Also fixes the incorrect age test for Bitbucket.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
