### PR TITLE
rubocops: adjust `depends_on` checks for Linux

### DIFF
--- a/Library/Homebrew/rubocops/os_depends_on.rb
+++ b/Library/Homebrew/rubocops/os_depends_on.rb
@@ -28,9 +28,11 @@ module RuboCop
           :vst_plugin,
           :vst3_plugin,
         ].freeze
+        LINUX_ONLY_CASK_STANZAS = [:app_image].freeze
 
         CASK_STANZA_ORDER = T.let(RuboCop::Cask::Constants::STANZA_ORDER, T::Array[Symbol])
         MACOS_DEPENDENCY_STANZAS = [:macos, :maximum_macos].freeze
+        LINUX_DEPENDENCY_STANZAS = [:linux].freeze
 
         RESTRICT_ON_SEND = [:depends_on].freeze
 
@@ -41,6 +43,7 @@ module RuboCop
           return if send_node.method_name != :cask
 
           add_missing_macos_dependency(node)
+          add_missing_linux_dependency(node)
         end
 
         sig { params(node: RuboCop::AST::SendNode).void }
@@ -114,19 +117,14 @@ module RuboCop
           return if os_depends_on?(body)
 
           macos_stanza = stanzas.find do |stanza|
-            case stanza.method_name
-            when :installer
+            if stanza.method_name == :installer
               stanza.arguments.any? do |argument|
-                argument.hash_type? && argument.pairs.any? { |pair| symbol_key(pair) == :manual }
+                argument.hash_type? && argument.pairs.any? do |pair|
+                  symbol_key(pair) == :manual
+                end
               end
-            when :os
-              pairs = depends_on_pairs(stanza)
-              pairs.any? { |pair| symbol_key(pair) == :macos } &&
-                pairs.none? { |pair| symbol_key(pair) == :linux }
-            when *MACOS_ONLY_CASK_STANZAS
-              true
             else
-              false
+              MACOS_ONLY_CASK_STANZAS.include?(stanza.method_name)
             end
           end
           return unless macos_stanza
@@ -145,18 +143,50 @@ module RuboCop
                 range_by_whole_lines(following_stanza.source_range, include_final_newline: false),
                 "  depends_on :macos\n\n",
               )
-            elsif (preceding_stanza = stanzas.rfind do |stanza|
-              stanza_index = CASK_STANZA_ORDER.index(stanza.method_name)
-              stanza_index && stanza_index <= depends_on_stanza_index
-            end)
-              corrector.insert_after(
-                range_by_whole_lines(preceding_stanza.source_range, include_final_newline: true),
-                "\n  depends_on :macos\n",
-              )
             else
               corrector.insert_before(
                 range_by_whole_lines(macos_stanza.source_range, include_final_newline: false),
                 "  depends_on :macos\n\n",
+              )
+            end
+          end
+        end
+
+        sig { params(node: RuboCop::AST::BlockNode).void }
+        def add_missing_linux_dependency(node)
+          body = node.body
+          return unless body
+
+          stanzas = (body.begin_type? ? body.child_nodes : [body]).filter_map do |child|
+            if child.send_type?
+              T.cast(child, RuboCop::AST::SendNode)
+            elsif child.block_type?
+              T.cast(child, RuboCop::AST::BlockNode).send_node
+            end
+          end
+          return if os_depends_on?(body)
+
+          linux_stanza = stanzas.find { |stanza| LINUX_ONLY_CASK_STANZAS.include?(stanza.method_name) }
+          return unless linux_stanza
+
+          add_offense(linux_stanza.source_range,
+                      message: "Add `depends_on :linux` for Linux-only casks.") do |corrector|
+            depends_on_stanza_index = CASK_STANZA_ORDER.index(:depends_on) ||
+                                      raise("unexpected nil value for depends_on stanza index")
+            following_stanza = stanzas.find do |stanza|
+              stanza_index = CASK_STANZA_ORDER.index(stanza.method_name)
+              stanza_index && stanza_index > depends_on_stanza_index
+            end
+
+            if following_stanza
+              corrector.insert_before(
+                range_by_whole_lines(following_stanza.source_range, include_final_newline: false),
+                "  depends_on :linux\n\n",
+              )
+            else
+              corrector.insert_before(
+                range_by_whole_lines(linux_stanza.source_range, include_final_newline: false),
+                "  depends_on :linux\n\n",
               )
             end
           end
@@ -198,8 +228,7 @@ module RuboCop
             next false if send_node.method_name != :depends_on
 
             bare_os_depends_on?(send_node, :macos) || bare_os_depends_on?(send_node, :linux) ||
-              top_level_macos_depends_on?(send_node) ||
-              depends_on_pairs(send_node).any? { |pair| symbol_key(pair) == :linux }
+              top_level_macos_depends_on?(send_node) || top_level_linux_depends_on?(send_node)
           end
         end
 
@@ -211,6 +240,11 @@ module RuboCop
         sig { params(node: RuboCop::AST::SendNode).returns(T::Boolean) }
         def top_level_macos_depends_on?(node)
           depends_on_pairs(node).any? { |pair| MACOS_DEPENDENCY_STANZAS.include?(symbol_key(pair)) }
+        end
+
+        sig { params(node: RuboCop::AST::SendNode).returns(T::Boolean) }
+        def top_level_linux_depends_on?(node)
+          depends_on_pairs(node).any? { |pair| LINUX_DEPENDENCY_STANZAS.include?(symbol_key(pair)) }
         end
       end
     end

--- a/Library/Homebrew/test/rubocops/os_depends_on_spec.rb
+++ b/Library/Homebrew/test/rubocops/os_depends_on_spec.rb
@@ -157,7 +157,102 @@ RSpec.describe RuboCop::Cop::Homebrew::OSDependsOn, :config do
     RUBY
   end
 
-  it "accepts casks without macOS-only stanzas" do
+  it "autocorrects missing bare Linux dependencies for Linux-only cask stanzas" do
+    expect_offense(<<~RUBY)
+      cask "basic" do
+        version "1.0"
+        sha256 "abc"
+        url "https://example.com/basic.zip"
+        homepage "https://example.com"
+
+        app_image "Basic.AppImage"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add `depends_on :linux` for Linux-only casks.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      cask "basic" do
+        version "1.0"
+        sha256 "abc"
+        url "https://example.com/basic.zip"
+        homepage "https://example.com"
+
+        depends_on :linux
+
+        app_image "Basic.AppImage"
+      end
+    RUBY
+  end
+
+  it "autocorrects missing bare Linux dependencies using cask stanza order" do
+    expect_offense(<<~RUBY)
+      cask "ordered" do
+        version "1.0"
+        sha256 "abc"
+        url "https://example.com/ordered.zip"
+        name "Ordered"
+        desc "Ordered"
+        homepage "https://example.com"
+
+        livecheck do
+          skip "example"
+        end
+
+        auto_updates true
+        conflicts_with cask: "old-ordered"
+        container nested: "Ordered"
+
+        app_image "Ordered.AppImage"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add `depends_on :linux` for Linux-only casks.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      cask "ordered" do
+        version "1.0"
+        sha256 "abc"
+        url "https://example.com/ordered.zip"
+        name "Ordered"
+        desc "Ordered"
+        homepage "https://example.com"
+
+        livecheck do
+          skip "example"
+        end
+
+        auto_updates true
+        conflicts_with cask: "old-ordered"
+        depends_on :linux
+
+        container nested: "Ordered"
+
+        app_image "Ordered.AppImage"
+      end
+    RUBY
+  end
+
+  it "autocorrects missing bare Linux dependencies before Linux-only cask stanzas" do
+    expect_offense(<<~RUBY)
+      cask "basic" do
+        version "1.0"
+
+        app_image "Basic.AppImage"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add `depends_on :linux` for Linux-only casks.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      cask "basic" do
+        version "1.0"
+
+        depends_on :linux
+
+        app_image "Basic.AppImage"
+      end
+    RUBY
+  end
+
+  it "accepts casks without macOS-only or Linux-only stanzas" do
     expect_no_offenses(<<~RUBY)
       cask "basic" do
         version "1.0"


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

This adjusts the `Homebrew/OSDependsOn` cop in two ways:

The first change makes it so that declaring `depends_on :linux` is explicitly required for Linux-only casks as well (like in [`koreader`](https://github.com/Homebrew/homebrew-cask/blob/c17ec3591cf528d05e04be1fdf62bc8fdb4b7aed/Casks/k/koreader.rb#L19)).

The second change relaxes dependency declarations when using the `os` stanza; IMO, the current check does not make a lot of sense. Consider a cask that supports both macOS and Linux, and has a URL like this:

```ruby
url "https://download.example.com/stable#{os}/#{version}/Foo.zip"
```

Where there is only a differentiator for the macOS artifact with the suffix `-darwin`.

With the current check, we would either need to declare an empty string for the `:linux` parameter like so:

```ruby
os macos: "-darwin", linux: ""
```

Or replace the `os` stanza with an `on_system_conditional` call, which does not have this restriction.

```ruby
os_suffix = on_system_conditional macos: "-darwin"
```