### PR TITLE
cask/audit: reject verified parameter on new casks

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -492,6 +492,15 @@ module Cask
     end
 
     sig { void }
+    def audit_unnecessary_verified
+      return unless new_cask?
+      return unless cask.url
+      return unless verified_present?
+
+      add_error "the `verified` parameter has been deprecated; use the `url` stanza without it"
+    end
+
+    sig { void }
     def audit_generic_artifacts
       cask.artifacts.grep(Artifact::Artifact).each do |artifact|
         unless artifact.target.absolute?
@@ -1367,6 +1376,11 @@ module Cask
     sig { returns(T.nilable(String)) }
     def domain
       URI(cask.url.to_s).host
+    end
+
+    sig { returns(T::Boolean) }
+    def verified_present?
+      cask.url&.verified.present?
     end
 
     sig { returns(Tap) }

--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -35,7 +35,7 @@ module Cask
     attr_reader :using
 
     sig { returns(T.nilable(String)) }
-    attr_reader :tag, :branch, :revision, :only_path
+    attr_reader :tag, :branch, :revision, :only_path, :verified
 
     extend Forwardable
 
@@ -73,6 +73,7 @@ module Cask
       header = Array(header) unless header.nil?
 
       specs = {}
+      specs[:verified]   = @verified   = T.let(verified, T.nilable(String))
       specs[:using]      = @using      = T.let(using, T.nilable(T.any(T::Class[AbstractDownloadStrategy], Symbol)))
       specs[:tag]        = @tag        = T.let(tag, T.nilable(String))
       specs[:branch]     = @branch     = T.let(branch, T.nilable(String))

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -1530,6 +1530,55 @@ RSpec.describe Cask::Audit, :cask do
       end
     end
 
+    describe "checking verified" do
+      let(:only) { %w[unnecessary_verified] }
+      let(:cask_token) { "with-verified" }
+      let(:cask) do
+        tmp_cask cask_token.to_s, <<~RUBY
+          cask "#{cask_token}" do
+            version "1.8.0_72,8.13.0.5"
+            sha256 "8dd95daa037ac02455435446ec7bc737b34567afe9156af7d20b2a83805c1d8a"
+            url "https://brew.sh/foo-\#{version.after_comma}.zip", verified: "brew.sh/"
+            name "Audit"
+            desc "Audit Description"
+            homepage "https://foo.example.org"
+            app "Audit.app"
+          end
+        RUBY
+      end
+
+      context "when `new_cask` is true" do
+        let(:new_cask) { true }
+
+        it { is_expected.to error_with(/the `verified` parameter has been deprecated/) }
+      end
+
+      context "when `new_cask` is false" do
+        let(:new_cask) { false }
+
+        it { is_expected.to pass }
+      end
+
+      context "without verified" do
+        let(:cask_token) { "without-verified" }
+        let(:cask) do
+          tmp_cask cask_token.to_s, <<~RUBY
+            cask "#{cask_token}" do
+              version "1.8.0_72,8.13.0.5"
+              sha256 "8dd95daa037ac02455435446ec7bc737b34567afe9156af7d20b2a83805c1d8a"
+              url "https://brew.sh/foo-\#{version.after_comma}.zip"
+              name "Audit"
+              desc "Audit Description"
+              homepage "https://foo.example.org"
+              app "Audit.app"
+            end
+          RUBY
+        end
+
+        it { is_expected.to pass }
+      end
+    end
+
     describe "checking deprecate/disable" do
       let(:only) { ["deprecate_disable"] }
       let(:cask_token) { "deprecated-cask" }

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -412,14 +412,6 @@ RSpec.describe Cask::DSL, :cask, :no_api do
     it "prevents defining multiple urls" do
       expect { cask }.to raise_error(Cask::CaskInvalidError, /'url' stanza may only appear once/)
     end
-
-    it "allows the `verified` parameter as a no-op" do
-      cask = Cask::Cask.new("cask-with-verified-url") do
-        url "https://brew.sh/test.zip", verified: "brew.sh"
-      end
-
-      expect(cask.url.specs).not_to have_key(:verified)
-    end
   end
 
   describe "homepage stanza" do


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

I noticed that a lot of new casks are still declaring the `verified` parameter despite its removal in #23280.

This adds an audit that should make it abundantly clear that it is not needed any more. Existing casks should remain unaffected.