### PR TITLE
audit: patches from files should not warn if there is no sha, since we don't allow shas for file patches

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -885,6 +885,19 @@ module Homebrew
           end
         end
 
+        spec.patches.each do |patch|
+          next unless patch.external?
+
+          ra = ResourceAuditor.new(
+            patch.resource, spec_name,
+            online: @online, strict: @strict, only: @only, except: @except,
+            use_homebrew_curl: patch.resource.using == :homebrew_curl
+          ).audit
+          ra.problems.each do |message|
+            problem "#{name} patch: #{message}"
+          end
+        end
+
         next if spec.patches.empty?
         next if !@new_formula || !@core_tap
 

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -139,6 +139,7 @@ module Homebrew
     sig { void }
     def audit_checksum
       return if spec_name == :head
+      return if url.blank?
       # This condition is non-invertible.
       # rubocop:disable Style/InvertibleUnlessCondition
       return unless DownloadStrategyDetector.detect(url.to_s, using) <= CurlDownloadStrategy

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -841,6 +841,34 @@ RSpec.describe Homebrew::FormulaAuditor do
       expect(fa.problems).to be_empty
     end
 
+    it "does not allow an external patch to miss a checksum" do
+      fa = formula_auditor "foo", <<~RUBY
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
+          patch do
+            url "https://brew.sh/patch.patch"
+          end
+        end
+      RUBY
+
+      fa.audit_specs
+      expect(fa.problems.first[:message]).to match "Stable patch: Checksum is missing"
+    end
+
+    it "allows file patches without a checksum" do
+      fa = formula_auditor "foo", <<~RUBY
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
+          patch :p1, "file.patch"
+        end
+      RUBY
+
+      fa.audit_specs
+      expect(fa.problems).to be_empty
+    end
+
     it "accepts a curl dependency with a working HTTP mirror" do
       sha256 = "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
       mirror_url = "http://brew.sh/mirror/foo-1.0.tgz"


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

I worked with Antigravity/Gemini to generate this change, which I am in the process of reviewing myself. 

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
