### PR TITLE
service: fix caveat for SSH sessions

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -3,6 +3,7 @@
 
 require "timeout"
 
+require "services/system"
 require "utils/user"
 require "cask/artifact/abstract_artifact"
 require "cask/pkg"
@@ -222,14 +223,8 @@ module Cask
         all_services.each do |service|
           ohai "Removing launchctl service #{service}"
           booleans.each do |sudo|
-            plist_status = command.run(
-              "/bin/launchctl",
-              args:         ["list", service],
-              sudo:,
-              sudo_as_root: sudo,
-              print_stderr: false,
-            ).stdout
-            if plist_status.start_with?("{")
+            _, found, = Homebrew::Services::System.launchctl_find_service(service, sudo:)
+            if found
               result = command.run(
                 "/bin/launchctl",
                 args:         ["remove", service],

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -292,18 +292,7 @@ module Homebrew
       sig { returns(StatusOutputSuccessType) }
       def status_output_success_type
         @status_output_success_type ||= if System.launchctl?
-          cmd = [System.launchctl.to_s, "print", "#{System.domain_target}/#{service_name}"]
-          output = Utils.popen_read(*cmd).chomp
-          if $CHILD_STATUS.present? && $CHILD_STATUS.success? && output.present?
-            success = true
-            type = :launchctl_print
-          else
-            cmd = [System.launchctl.to_s, "list", service_name]
-            output = Utils.popen_read(*cmd).chomp
-            success = T.cast($CHILD_STATUS.present? && $CHILD_STATUS.success? && output.present?, T::Boolean)
-            type = :launchctl_list
-          end
-          odebug cmd.join(" "), output
+          output, success, type = System.launchctl_find_service(service_name)
           StatusOutputSuccessType.new(output, success, type)
         else # System.systemctl?
           cmd = ["status", service_name]

--- a/Library/Homebrew/services/system.rb
+++ b/Library/Homebrew/services/system.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "etc"
+require "system_command"
 require_relative "system/systemctl"
 require "utils/output"
 
@@ -124,6 +125,57 @@ module Homebrew
         candidates += ["user/#{Process.euid}", "gui/#{Process.uid}"] unless root?
         candidates.uniq
       end
+
+      # Probe for a launchd service across all candidate domains.
+      # Returns output text, success flag, and the command type used
+      # (`:launchctl_print` or `:launchctl_list`). Pass `sudo: true` to run
+      # the probe with elevated privileges (e.g. for system-owned services).
+      sig { params(label: String, sudo: T::Boolean).returns([String, T::Boolean, Symbol]) }
+      def self.launchctl_find_service(label, sudo: false)
+        launchctl_path = launchctl
+        return ["", false, :launchctl_list] unless launchctl_path
+
+        candidate_domain_targets.each do |domain|
+          cmd = [launchctl_path.to_s, "print", "#{domain}/#{label}"]
+          output, success = launchctl_run(cmd, sudo:)
+          if success && output.present?
+            odebug cmd.join(" "), output
+            return [output, true, :launchctl_print]
+          end
+        end
+
+        cmd = [launchctl_path.to_s, "list", label]
+        output, success = launchctl_run(cmd, sudo:)
+        odebug cmd.join(" "), output
+        [output, success && output.present?, :launchctl_list]
+      end
+
+      # Check if a launchd service is running, given its label (e.g. `homebrew.mxcl.foo`).
+      # Tries domain-qualified lookups first, then falls back to a bare label search.
+      sig { params(label: String, sudo: T::Boolean).returns(T::Boolean) }
+      def self.launchctl_service_running?(label, sudo: false)
+        _, success, = launchctl_find_service(label, sudo:)
+        success
+      end
+
+      # Run a launchctl command, optionally via sudo, capturing its output.
+      sig { params(cmd: T::Array[String], sudo: T::Boolean).returns([String, T::Boolean]) }
+      def self.launchctl_run(cmd, sudo:)
+        if sudo
+          result = SystemCommand.run(
+            cmd.fetch(0),
+            args:         cmd.drop(1),
+            sudo:         true,
+            sudo_as_root: true,
+            print_stderr: false,
+          )
+          [result.stdout.chomp, result.success?]
+        else
+          output = Utils.popen_read(*cmd).chomp
+          [output, ($CHILD_STATUS.present? && $CHILD_STATUS.success?) || false]
+        end
+      end
+      private_class_method :launchctl_run
     end
   end
 end

--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "benchmark"
+require "services/system"
 
 RSpec.shared_examples "#uninstall_phase or #zap_phase" do
   subject { artifact }
@@ -18,7 +19,6 @@ RSpec.shared_examples "#uninstall_phase or #zap_phase" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-#{artifact_dsl_key}-launchctl")) }
     let(:launchctl_list_cmd) { %w[/bin/launchctl list my.fancy.package.service] }
     let(:launchctl_remove_cmd) { %w[/bin/launchctl remove my.fancy.package.service] }
-    let(:unknown_response) { "launchctl list returned unknown response\n" }
     let(:service_info) do
       <<~EOS
         {
@@ -35,24 +35,12 @@ RSpec.shared_examples "#uninstall_phase or #zap_phase" do
     end
 
     it "works when job is owned by user" do
-      allow(fake_system_command).to receive(:run)
-        .with(
-          "/bin/launchctl",
-          args:         ["list", "my.fancy.package.service"],
-          print_stderr: false,
-          sudo:         false,
-          sudo_as_root: false,
-        )
-        .and_return(instance_double(SystemCommand::Result, stdout: service_info))
-      allow(fake_system_command).to receive(:run)
-        .with(
-          "/bin/launchctl",
-          args:         ["list", "my.fancy.package.service"],
-          print_stderr: false,
-          sudo:         true,
-          sudo_as_root: true,
-        )
-        .and_return(instance_double(SystemCommand::Result, stdout: unknown_response))
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("my.fancy.package.service", sudo: false)
+        .and_return([service_info, true, :launchctl_print])
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("my.fancy.package.service", sudo: true)
+        .and_return(["", false, :launchctl_list])
 
       expect(fake_system_command).to receive(:run)
         .with("/bin/launchctl", args: ["remove", "my.fancy.package.service"],
@@ -63,24 +51,12 @@ RSpec.shared_examples "#uninstall_phase or #zap_phase" do
     end
 
     it "works when job is owned by system" do
-      allow(fake_system_command).to receive(:run)
-        .with(
-          "/bin/launchctl",
-          args:         ["list", "my.fancy.package.service"],
-          print_stderr: false,
-          sudo:         false,
-          sudo_as_root: false,
-        )
-        .and_return(instance_double(SystemCommand::Result, stdout: unknown_response))
-      allow(fake_system_command).to receive(:run)
-        .with(
-          "/bin/launchctl",
-          args:         ["list", "my.fancy.package.service"],
-          print_stderr: false,
-          sudo:         true,
-          sudo_as_root: true,
-        )
-        .and_return(instance_double(SystemCommand::Result, stdout: service_info))
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("my.fancy.package.service", sudo: false)
+        .and_return(["", false, :launchctl_list])
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("my.fancy.package.service", sudo: true)
+        .and_return([service_info, true, :launchctl_print])
 
       expect(fake_system_command).to receive(:run)
         .with("/bin/launchctl", args: ["remove", "my.fancy.package.service"],
@@ -91,24 +67,12 @@ RSpec.shared_examples "#uninstall_phase or #zap_phase" do
     end
 
     it "does not fail when sudo removal fails" do
-      allow(fake_system_command).to receive(:run)
-        .with(
-          "/bin/launchctl",
-          args:         ["list", "my.fancy.package.service"],
-          print_stderr: false,
-          sudo:         false,
-          sudo_as_root: false,
-        )
-        .and_return(instance_double(SystemCommand::Result, stdout: unknown_response))
-      allow(fake_system_command).to receive(:run)
-        .with(
-          "/bin/launchctl",
-          args:         ["list", "my.fancy.package.service"],
-          print_stderr: false,
-          sudo:         true,
-          sudo_as_root: true,
-        )
-        .and_return(instance_double(SystemCommand::Result, stdout: service_info))
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("my.fancy.package.service", sudo: false)
+        .and_return(["", false, :launchctl_list])
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("my.fancy.package.service", sudo: true)
+        .and_return([service_info, true, :launchctl_print])
 
       expect(fake_system_command).to receive(:run)
         .with("/bin/launchctl", args: ["remove", "my.fancy.package.service"],
@@ -124,7 +88,6 @@ RSpec.shared_examples "#uninstall_phase or #zap_phase" do
   context "when using :launchctl with regex wildcard" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-#{artifact_dsl_key}-launchctl-wildcard")) }
     let(:launchctl_regex) { "my.fancy.package.service.*" }
-    let(:unknown_response) { "launchctl list returned unknown response\n" }
     let(:service_info) do
       <<~EOS
         {
@@ -149,29 +112,20 @@ RSpec.shared_examples "#uninstall_phase or #zap_phase" do
       EOS
     end
 
+    before do
+      allow(fake_system_command).to receive(:run)
+        .with("/bin/launchctl", hash_including(args: ["print", anything]))
+        .and_return(instance_double(SystemCommand::Result, success?: false))
+    end
+
     it "searches installed launchctl items" do
       expect(subject).to receive(:find_launchctl_with_wildcard)
         .with(launchctl_regex)
         .and_return(["my.fancy.package.service.12345"])
 
-      allow(fake_system_command).to receive(:run)
-        .with(
-          "/bin/launchctl",
-          args:         ["list", "my.fancy.package.service.12345"],
-          print_stderr: false,
-          sudo:         false,
-          sudo_as_root: false,
-        )
-        .and_return(instance_double(SystemCommand::Result, stdout: unknown_response))
-      allow(fake_system_command).to receive(:run)
-        .with(
-          "/bin/launchctl",
-          args:         ["list", "my.fancy.package.service.12345"],
-          print_stderr: false,
-          sudo:         true,
-          sudo_as_root: true,
-        )
-        .and_return(instance_double(SystemCommand::Result, stdout: service_info))
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service) do |_label, sudo:|
+        sudo ? [service_info, true, :launchctl_print] : ["", false, :launchctl_list]
+      end
 
       expect(fake_system_command).to receive(:run)
         .with("/bin/launchctl", args: ["remove", "my.fancy.package.service.12345"],

--- a/Library/Homebrew/test/services/system_spec.rb
+++ b/Library/Homebrew/test/services/system_spec.rb
@@ -154,6 +154,27 @@ RSpec.describe Homebrew::Services::System do
     end
   end
 
+  describe "#launchctl_find_service" do
+    let(:label) { "homebrew.mxcl.foo" }
+
+    it "returns failure when launchctl is not available" do
+      allow(described_class).to receive(:launchctl).and_return(nil)
+      _, success, type = described_class.launchctl_find_service(label)
+      expect(success).to be false
+      expect(type).to eq(:launchctl_list)
+    end
+  end
+
+  describe "#launchctl_service_running?" do
+    let(:label) { "homebrew.mxcl.foo" }
+
+    it "delegates to launchctl_find_service" do
+      allow(described_class).to receive(:launchctl_find_service)
+        .with(label, sudo: false).and_return(["output", true, :launchctl_print])
+      expect(described_class.launchctl_service_running?(label)).to be true
+    end
+  end
+
   describe "#path" do
     it "macOS - user - returns the current relevant path" do
       ENV["HOME"] = "/tmp_home"

--- a/Library/Homebrew/test/utils/service_spec.rb
+++ b/Library/Homebrew/test/utils/service_spec.rb
@@ -4,6 +4,41 @@
 require "utils/service"
 
 RSpec.describe Utils::Service do
+  describe "::running?" do
+    it "returns false when neither launchctl nor systemctl is available" do
+      f = formula do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      allow(described_class).to receive_messages(launchctl: nil, systemctl?: false)
+      expect(described_class.running?(f)).to be false
+    end
+
+    it "delegates to System.launchctl_service_running? on macOS" do
+      f = formula do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      allow(described_class).to receive(:launchctl?).and_return(true)
+      allow(Homebrew::Services::System).to receive(:launchctl_service_running?)
+        .with(f.plist_name).and_return(true)
+      expect(described_class.running?(f)).to be true
+    end
+
+    it "uses systemctl is-active when systemctl is available" do
+      f = formula do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      allow(described_class).to receive_messages(launchctl: nil, systemctl?: true,
+                                                 systemctl: Pathname("/bin/systemctl"))
+      expect(described_class).to receive(:quiet_system)
+        .with(instance_of(Pathname), "is-active", "--quiet", f.service_name)
+        .and_return(true)
+      expect(described_class.running?(f)).to be true
+    end
+  end
+
   describe "::systemd_quote" do
     it "quotes empty strings correctly" do
       expect(described_class.systemd_quote("")).to eq '""'

--- a/Library/Homebrew/utils/service.rb
+++ b/Library/Homebrew/utils/service.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "services/system"
+
 module Utils
   # Helpers for `brew services` related code.
   module Service
@@ -8,7 +10,7 @@ module Utils
     sig { params(formula: Formula).returns(T::Boolean) }
     def self.running?(formula)
       if launchctl?
-        quiet_system(launchctl, "list", formula.plist_name)
+        Homebrew::Services::System.launchctl_service_running?(formula.plist_name)
       elsif systemctl?
         quiet_system(systemctl, "is-active", "--quiet", formula.service_name)
       else


### PR DESCRIPTION
When connected via SSH, `launchctl list <label>` only searches the system domain, so it won't find services loaded in the `gui/<uid>` domain. This caused `Utils::Service.running?` to incorrectly return false for running services, which in turn made `brew upgrade` print "brew services start" instead of the correct "brew services restart".

Fix by using `launchctl print <domain>/<label>` (which works across sessions) for the gui and user domains, falling back to the bare `launchctl list <label>` for backward compatibility. This mirrors how `FormulaWrapper#status_output_success_type` already checks service status for `brew services`.

Output for a running service over SSH before this PR:
```
❯ brew info redis
==> redis ✔: stable 8.10.0 (bottled), HEAD
Persistent key-value database, with built-in net interface
[…]
==> Caveats
To start redis now and restart at login:
  brew services start redis
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/redis/bin/redis-server /opt/homebrew/etc/redis.conf
```

Output with this PR:
```
❯ brew info redis
==> redis ✔: stable 8.10.0 (bottled), HEAD
Persistent key-value database, with built-in net interface
[…]
==> Caveats
To restart redis after an upgrade:
  brew services restart redis
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/redis/bin/redis-server /opt/homebrew/etc/redis.conf
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Opus 5 was used to find the discrepancy between `brew info` and `brew services` and create the patch.

-----
