### PR TITLE
requirements/macos_requirement: fix handling for Linux

### DIFF
--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -238,7 +238,7 @@ module Homebrew
 
           requirements = f.recursive_requirements
           if @bottle_tag.linux?
-            if requirements.any? { |r| r.is_a?(MacOSRequirement) && !r.version }
+            if requirements.any?(MacOSRequirement)
               puts "#{Tty.bold}#{Tty.red}#{name}#{Tty.reset}: requires macOS" if any_named_args
               next
             elsif requirements.any? { |r| r.is_a?(ArchRequirement) && r.arch != @bottle_tag.arch }

--- a/Library/Homebrew/extend/os/mac/requirements/macos_requirement.rb
+++ b/Library/Homebrew/extend/os/mac/requirements/macos_requirement.rb
@@ -1,0 +1,50 @@
+# typed: strict
+# frozen_string_literal: true
+
+module OS
+  module Mac
+    module MacOSRequirement
+      extend T::Helpers
+
+      requires_ancestor { ::MacOSRequirement }
+
+      sig { returns(T::Boolean) }
+      def macos_version_satisfied?
+        !version_specified? || Array(version).any? { |v| OS::Mac.version.compare(comparator, v) }
+      end
+
+      sig { params(type: Symbol).returns(String) }
+      def message(type: :formula)
+        subject = (type == :cask) ? "This cask" : "This formula"
+
+        return "#{subject} requires macOS." unless version_specified?
+
+        case comparator
+        when ">="
+          "#{subject} does not run on macOS versions older than #{T.cast(version, MacOSVersion).pretty_name}."
+        when "<="
+          case type
+          when :formula
+            <<~EOS
+              #{subject} either does not compile or function as expected on macOS
+              versions newer than #{T.cast(version, MacOSVersion).pretty_name} due to an upstream incompatibility.
+            EOS
+          when :cask
+            "#{subject} does not run on macOS versions newer than #{T.cast(version, MacOSVersion).pretty_name}."
+          else
+            ""
+          end
+        else
+          if version.respond_to?(:to_ary) || version.is_a?(Array)
+            *versions, last = T.unsafe(version).map(&:pretty_name)
+            return "#{subject} does not run on macOS versions other than #{versions.join(", ")} and #{last}."
+          end
+
+          "#{subject} does not run on macOS versions other than #{T.cast(version, MacOSVersion).pretty_name}."
+        end
+      end
+    end
+  end
+end
+
+MacOSRequirement.prepend(OS::Mac::MacOSRequirement)

--- a/Library/Homebrew/extend/os/requirements/macos_requirement.rb
+++ b/Library/Homebrew/extend/os/requirements/macos_requirement.rb
@@ -1,0 +1,4 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "extend/os/mac/requirements/macos_requirement" if OS.mac?

--- a/Library/Homebrew/requirements/macos_requirement.rb
+++ b/Library/Homebrew/requirements/macos_requirement.rb
@@ -96,12 +96,11 @@ class MacOSRequirement < Requirement
 
   satisfy(build_env: false) do
     T.bind(self, MacOSRequirement)
-    next Array(version).any? { |v| OS::Mac.version.compare(comparator, v) } if OS.mac? && version_specified?
-    next true if OS.mac?
-    next true if version
-
-    false
+    macos_version_satisfied?
   end
+
+  sig { returns(T::Boolean) }
+  def macos_version_satisfied? = false
 
   sig { returns(T.nilable(MacOSVersion)) }
   def minimum_version
@@ -137,33 +136,7 @@ class MacOSRequirement < Requirement
   sig { override.params(type: Symbol).returns(String) }
   def message(type: :formula)
     subject = (type == :cask) ? "This cask" : "This formula"
-
-    return "#{subject} requires macOS." unless version_specified?
-
-    version = @version
-    case @comparator
-    when ">="
-      "#{subject} does not run on macOS versions older than #{T.cast(version, MacOSVersion).pretty_name}."
-    when "<="
-      case type
-      when :formula
-        <<~EOS
-          #{subject} either does not compile or function as expected on macOS
-          versions newer than #{T.cast(version, MacOSVersion).pretty_name} due to an upstream incompatibility.
-        EOS
-      when :cask
-        "#{subject} does not run on macOS versions newer than #{T.cast(version, MacOSVersion).pretty_name}."
-      else
-        ""
-      end
-    else
-      if version.respond_to?(:to_ary) || version.is_a?(Array)
-        *versions, last = T.unsafe(version).map(&:pretty_name)
-        return "#{subject} does not run on macOS versions other than #{versions.join(", ")} and #{last}."
-      end
-
-      "#{subject} does not run on macOS versions other than #{T.cast(version, MacOSVersion).pretty_name}."
-    end
+    "#{subject} requires macOS."
   end
 
   sig { override.params(other: T.untyped).returns(T::Boolean) }
@@ -186,9 +159,9 @@ class MacOSRequirement < Requirement
   def display_s
     if version_specified?
       if @version.respond_to?(:to_ary) || @version.is_a?(Array)
-        "macOS #{@comparator} #{T.unsafe(@version).join(" / ")} (or Linux)"
+        "macOS #{@comparator} #{T.unsafe(@version).join(" / ")}"
       else
-        "macOS #{@comparator} #{@version} (or Linux)"
+        "macOS #{@comparator} #{@version}"
       end
     else
       "macOS"
@@ -210,3 +183,5 @@ class MacOSRequirement < Requirement
     to_h.to_json(options)
   end
 end
+
+require "extend/os/requirements/macos_requirement"

--- a/Library/Homebrew/test/requirements/macos_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/macos_requirement_spec.rb
@@ -11,18 +11,30 @@ RSpec.describe MacOSRequirement do
   let(:tahoe_major) { MacOSVersion.new("26.0") }
 
   describe "#satisfied?" do
-    it "returns true on macOS" do
-      expect(requirement.satisfied?).to eq OS.mac?
+    context "when running on macOS", :needs_macos do
+      it "returns true" do
+        expect(requirement.satisfied?).to be true
+      end
+
+      it "supports version symbols" do
+        requirement = described_class.new([MacOS.version.to_sym])
+        expect(requirement).to be_satisfied
+      end
+
+      it "supports maximum versions" do
+        requirement = described_class.new([:catalina], comparator: "<=")
+        expect(requirement.satisfied?).to eq MacOS.version <= :catalina
+      end
     end
 
-    it "supports version symbols", :needs_macos do
-      requirement = described_class.new([MacOS.version.to_sym])
-      expect(requirement).to be_satisfied
-    end
-
-    it "supports maximum versions", :needs_macos do
-      requirement = described_class.new([:catalina], comparator: "<=")
-      expect(requirement.satisfied?).to eq MacOS.version <= :catalina
+    context "when running on Linux", :needs_linux do
+      it "returns false" do
+        expect(requirement.satisfied?).to be false
+        requirement = described_class.new([macos_newest_allowed.to_sym])
+        expect(requirement.satisfied?).to be false
+        requirement = described_class.new([macos_newest_allowed.to_sym], comparator: "<=")
+        expect(requirement.satisfied?).to be false
+      end
     end
   end
 
@@ -65,17 +77,32 @@ RSpec.describe MacOSRequirement do
     expect(range_requirement.allows?(tahoe_major)).to be true
   end
 
-  specify "#message reflects the dependent type" do
-    min_requirement = described_class.new([:tahoe], comparator: ">=")
-    max_requirement = described_class.new([:monterey], comparator: "<=")
-    no_requirement = described_class.new
-    expect(min_requirement.message)
-      .to eq "This formula does not run on macOS versions older than Tahoe."
-    expect(min_requirement.message(type: :cask))
-      .to eq "This cask does not run on macOS versions older than Tahoe."
-    expect(max_requirement.message(type: :cask))
-      .to eq "This cask does not run on macOS versions newer than Monterey."
-    expect(no_requirement.message).to eq "This formula requires macOS."
-    expect(no_requirement.message(type: :cask)).to eq "This cask requires macOS."
+  describe "#message" do
+    let(:min_requirement) { described_class.new([:tahoe], comparator: ">=") }
+    let(:max_requirement) { described_class.new([:monterey], comparator: "<=") }
+    let(:no_requirement) { described_class.new }
+
+    context "when running on macOS", :needs_macos do
+      it "reflects the dependent type" do
+        expect(min_requirement.message)
+          .to eq "This formula does not run on macOS versions older than Tahoe."
+        expect(min_requirement.message(type: :cask))
+          .to eq "This cask does not run on macOS versions older than Tahoe."
+        expect(max_requirement.message(type: :cask))
+          .to eq "This cask does not run on macOS versions newer than Monterey."
+        expect(no_requirement.message).to eq "This formula requires macOS."
+        expect(no_requirement.message(type: :cask)).to eq "This cask requires macOS."
+      end
+    end
+
+    context "when running on Linux", :needs_linux do
+      it "always outputs incompatible OS" do
+        expect(min_requirement.message).to eq "This formula requires macOS."
+        expect(min_requirement.message(type: :cask)).to eq "This cask requires macOS."
+        expect(max_requirement.message(type: :cask)).to eq "This cask requires macOS."
+        expect(no_requirement.message).to eq "This formula requires macOS."
+        expect(no_requirement.message(type: :cask)).to eq "This cask requires macOS."
+      end
+    end
   end
 end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Fix a side effect of changes in following PR where removal of `depends_on :macos` from macOS-only formulae makes brew think the formula can now be installed on Linux
- https://github.com/Homebrew/homebrew-core/pull/282148

For example, prior to PR if we take `mlx` (an Apple Silicon-specific formula):
* `brew install mlx` will not fail on Linux and attempt installation
* `brew unbottled --tag arm64_linux` incorrectly shows macOS-only formulae
* `brew info mlx` shows `(or Linux)` when it isn't valid.