### PR TITLE
Use .public_send instead of .send for calls to public methods

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -341,7 +341,7 @@ module Cask
     def audit_required_stanzas
       odebug "Auditing required stanzas"
       [:version, :sha256, :url, :homepage].each do |sym|
-        add_error "a #{sym} stanza is required" unless cask.send(sym)
+        add_error "a #{sym} stanza is required" unless cask.public_send(sym)
       end
       add_error "at least one name stanza is required" if cask.name.empty?
       # TODO: specific DSL knowledge should not be spread around in various files like this

--- a/Library/Homebrew/compilers/compiler_selector.rb
+++ b/Library/Homebrew/compilers/compiler_selector.rb
@@ -113,7 +113,7 @@ class CompilerSelector
     when "gcc", GNU_GCC_REGEXP
       versions.gcc_version(name.to_s)
     else
-      versions.send(:"#{name}_build_version")
+      versions.public_send(:"#{name}_build_version")
     end
   end
 end

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -199,7 +199,7 @@ module Homebrew
         old_keys.each do |key|
           next if skip_keys.include?(key)
 
-          old_value = old_bottle_spec.send(key).to_s
+          old_value = old_bottle_spec.public_send(key).to_s
           new_value = new_values[key].to_s
 
           next if old_value.present? && new_value == old_value
@@ -623,14 +623,14 @@ module Homebrew
         old_spec = formula.bottle_specification
         if args.keep_old? && !old_spec.checksums.empty?
           mismatches = [:root_url, :rebuild].reject do |key|
-            old_spec.send(key) == bottle.send(key)
+            old_spec.public_send(key) == bottle.public_send(key)
           end
           unless mismatches.empty?
             bottle_path.unlink if bottle_path.exist?
 
             mismatches.map! do |key|
-              old_value = old_spec.send(key).inspect
-              value = bottle.send(key).inspect
+              old_value = old_spec.public_send(key).inspect
+              value = bottle.public_send(key).inspect
               "#{key}: old: #{old_value}, new: #{value}"
             end
 

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -265,7 +265,7 @@ module Homebrew
           # something that should be handled by better version replacement logic
           # but this is a workaround for now.
           arch_values = arch_values.sort_by do |type|
-            new_version_value = Version.new(new_version.send(type) || "0")
+            new_version_value = Version.new(new_version.public_send(type) || "0")
             Livecheck::LivecheckVersion.create(cask, new_version_value)
           end.reverse
         end
@@ -303,7 +303,7 @@ module Homebrew
             next if unsupported_nested_arch_stanza?(contents, :version, arch) ||
                     unsupported_nested_arch_stanza?(contents, :sha256, arch)
 
-            bump_version = new_version.send(arch) || new_version.general
+            bump_version = new_version.public_send(arch) || new_version.general
             next unless bump_version
 
             version_scope = cask_stanza_scope(contents, :version, arch)

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -588,11 +588,11 @@ module Homebrew
 
         if multiple_versions[:new]
           (BumpVersionParser::VERSION_SYMBOLS - [:general]).each do |arch|
-            new_arch_version = new_version.send(arch)
+            new_arch_version = new_version.public_send(arch)
             next if new_arch_version.blank? || message?(new_arch_version)
 
             current_arch_version = if multiple_versions[:current]
-              current_version.send(arch)
+              current_version.public_send(arch)
             else
               current_version.general
             end
@@ -603,7 +603,7 @@ module Homebrew
         elsif multiple_versions[:current]
           if (new_version_general = new_version.general) && !message?(new_version_general)
             (BumpVersionParser::VERSION_SYMBOLS - [:general]).each do |arch|
-              current_arch_version = current_version.send(arch)
+              current_arch_version = current_version.public_send(arch)
               next if current_arch_version.blank? || new_version_general <= current_arch_version
 
               version_args << "--version-#{arch}=#{new_version_general}"
@@ -629,12 +629,12 @@ module Homebrew
         current_versions = {}
         new_versions = {}
         BumpVersionParser::VERSION_SYMBOLS.each do |type|
-          current_version_value = current_version.send(type)
+          current_version_value = current_version.public_send(type)
           if current_version_value
             current_versions[type] = Livecheck::LivecheckVersion.create(formula_or_cask, current_version_value)
           end
 
-          new_version_value = new_version.send(type)
+          new_version_value = new_version.public_send(type)
           if message?(new_version_value)
             # Store a string, so we can easily tell when a value is a message
             # rather than a version

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -721,7 +721,7 @@ class BuildError < RuntimeError
     require "diagnostic"
     checks = Homebrew::Diagnostic::Checks.new
     checks.build_error_checks.each do |check|
-      out = checks.send(check)
+      out = checks.public_send(check)
       next if out.nil?
 
       puts

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -415,7 +415,7 @@ class Formula
 
   sig { params(name: T.any(String, Symbol)).void }
   def spec_eval(name)
-    spec = self.class.send(name).dup
+    spec = self.class.public_send(name).dup
     return unless spec.url
 
     spec.owner = self

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -417,7 +417,7 @@ module Formulary
       if f.any_version_installed?
         tab = Tab.for_formula(f)
         resolved_spec = spec || tab.spec
-        f.active_spec = resolved_spec if f.send(resolved_spec)
+        f.active_spec = resolved_spec if f.public_send(resolved_spec)
         f.build = tab
         if f.head? && tab.tabfile
           k = Keg.new(T.must(tab.tabfile).parent)

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -535,7 +535,7 @@ module Homebrew
       when :url
         package_or_resource.url&.to_s if package_or_resource.is_a?(Cask::Cask) || package_or_resource.is_a?(Resource)
       when :head, :stable
-        package_or_resource.send(livecheck_url)&.url if package_or_resource.is_a?(Formula)
+        package_or_resource.public_send(livecheck_url)&.url if package_or_resource.is_a?(Formula)
       when :homepage
         package_or_resource.homepage unless package_or_resource.is_a?(Resource)
       end

--- a/Library/Homebrew/test_bot/test_formulae.rb
+++ b/Library/Homebrew/test_bot/test_formulae.rb
@@ -368,7 +368,7 @@ module Homebrew
       sig { params(formula: Formula).returns(T::Boolean) }
       def downloads_using_homebrew_curl?(formula)
         [:stable, :head].any? do |spec_name|
-          next false unless (spec = formula.send(spec_name))
+          next false unless (spec = formula.public_send(spec_name))
 
           spec.using == :homebrew_curl || spec.resources.values.any? { |r| r.using == :homebrew_curl }
         end

--- a/Library/Homebrew/utils/formatter.rb
+++ b/Library/Homebrew/utils/formatter.rb
@@ -120,11 +120,11 @@ module Formatter
     if prefix.nil? && color.nil?
       string.to_s
     elsif prefix.nil?
-      "#{Tty.send(T.must(color))}#{string}#{Tty.reset}"
+      "#{Tty.public_send(T.must(color))}#{string}#{Tty.reset}"
     elsif color.nil?
       "#{prefix} #{string}"
     else
-      "#{Tty.send(color)}#{prefix}#{Tty.reset} #{string}"
+      "#{Tty.public_send(color)}#{prefix}#{Tty.reset} #{string}"
     end
   end
   private_class_method :prefix


### PR DESCRIPTION
While going through the codebase for calls that use .send to invoke a method by a dynamic name, I found a batch of spots where the method being called is actually public .send was being used just to look up a method whose name isn't known until runtime (e.g. Tty.send(color), formula.send(spec_name)), not because anything private needed to be reached.

Since .send bypasses Ruby's private visibility check entirely, using it on public methods is a bit misleading to read — it makes a caller look like it might be reaching into internals when it isn't. public_send does the exact same dynamic lookup but only succeeds if the method is actually public, so it documents that intent and behaves identically here since every method involved already was public.

For each of the 20 call sites, I checked the receiver's class definition to confirm the method has no private marker before switching it over, so this should be a no-op behavior-wise.

Left untouched (need private access, so can't switch):

pour_bottle_check.rb - calls define_method, always private
api_hashable.rb - calls remove_const, always private
cli/parser.rb - calls a dynamically-named legacy _args method that may be defined by third-party tap commands; couldn't confirm it's always public, so left as-is to avoid breaking external taps

Note: This was the PR already raised and Maintainer has asked to force push once again, I have used Claude Sonnet 5 only to change in code and carefully reviewed it before pushing and this PR was raised by myself and no AI is involved in writing the pr.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
