### PR TITLE
Allow sudo in sandboxed Cask install steps

### DIFF
--- a/Library/Homebrew/cask/artifact/install_steps.rb
+++ b/Library/Homebrew/cask/artifact/install_steps.rb
@@ -41,6 +41,7 @@ module Cask
 
         sandbox.allow_write_path cask.caskroom_path
         sandbox.allow_write_path cask.config.appdir
+        sandbox.allow_process_exec "/usr/bin/sudo", no_sandbox: true if steps.any? { |step| step["sudo"] == true }
         Keg.keg_link_directories.each { |directory| sandbox.allow_write_path HOMEBREW_PREFIX/directory }
         original_home = Pathname(Dir.home).expand_path
         runner.sandbox_write_paths(steps, phase:).each do |path|

--- a/Library/Homebrew/cask/artifact/install_steps.rb
+++ b/Library/Homebrew/cask/artifact/install_steps.rb
@@ -41,7 +41,7 @@ module Cask
 
         sandbox.allow_write_path cask.caskroom_path
         sandbox.allow_write_path cask.config.appdir
-        sandbox.allow_process_exec "/usr/bin/sudo", no_sandbox: true if steps.any? { |step| step["sudo"] == true }
+        sandbox.allow_process_exec "/usr/bin/sudo", no_sandbox: true if runner.sudo_required?(steps)
         Keg.keg_link_directories.each { |directory| sandbox.allow_write_path HOMEBREW_PREFIX/directory }
         original_home = Pathname(Dir.home).expand_path
         runner.sandbox_write_paths(steps, phase:).each do |path|

--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -873,6 +873,7 @@ module Homebrew
         temp rack
         bash_completion zsh_completion fish_completion pwsh_completion
       ].freeze
+      IMPLICIT_SUDO_STEP_TYPES = %w[delete_keychain_certificate set_ownership].freeze
 
       sig { params(context: Object, command: T.class_of(SystemCommand)).void }
       def initialize(context:, command: SystemCommand)
@@ -932,6 +933,14 @@ module Homebrew
             []
           end
         end.uniq
+      end
+
+      sig { params(steps: Steps).returns(T::Boolean) }
+      def sudo_required?(steps)
+        DSL.normalise_steps(steps).any? do |step|
+          step["sudo"] == true || step["sudo"] == "if_needed" ||
+            IMPLICIT_SUDO_STEP_TYPES.include?(step["type"])
+        end
       end
 
       private

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -297,6 +297,12 @@ class Sandbox
     add_rule allow: true, operation: "file-read*", filter: path_filter(path, type)
   end
 
+  sig { params(path: T.any(String, Pathname), no_sandbox: T::Boolean).void }
+  def allow_process_exec(path, no_sandbox: false)
+    modifier = "no-sandbox" if no_sandbox
+    add_rule allow: true, operation: "process-exec", filter: path_filter(path, :literal), modifier:
+  end
+
   sig { params(path: T.any(String, Pathname), type: Symbol).void }
   def deny_read(path:, type: :literal)
     add_rule allow: false, operation: "file-read*", filter: path_filter(path, type)

--- a/Library/Homebrew/test/cask/artifact/install_steps_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/install_steps_spec.rb
@@ -119,27 +119,34 @@ RSpec.describe Cask::Artifact::AbstractInstallSteps, :cask do
     expect(original_home/"Library/Application Support/cask-home-state").to exist
   end
 
-  it "allows explicitly privileged steps to run sudo outside the sandbox" do
-    cask = Cask::Cask.new("with-sandboxed-sudo-install-steps") do
-      version "1.2.3"
-      sha256 :no_check
-      url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
+  context "when install steps may require sudo" do
+    {
+      "an explicitly privileged command" => proc { run "/usr/bin/true", sudo: true },
+      "a conditionally privileged step"  => proc { remove "/usr/local/example", sudo: :if_needed },
+      "an ownership step"                => proc { set_ownership "/usr/local/example" },
+      "a keychain certificate step"      => proc { delete_keychain_certificates "Example" },
+    }.each do |description, step|
+      it "allows #{description} to run sudo outside the sandbox" do
+        cask = Cask::Cask.new("with-sandboxed-sudo-install-steps") do
+          version "1.2.3"
+          sha256 :no_check
+          url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
 
-      postflight_steps do
-        run "/usr/bin/true", sudo: true
+          postflight_steps(&step)
+        end
+        sandbox = instance_double(Sandbox).as_null_object
+        cask.staged_path.mkpath
+        cask.config_path.dirname.mkpath
+
+        allow(Sandbox).to receive_messages(available?: true, new: sandbox)
+        allow(sandbox).to receive(:allow_write_path)
+        allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
+        expect(sandbox).to receive(:allow_process_exec).with("/usr/bin/sudo", no_sandbox: true)
+        expect(sandbox).to receive(:run)
+
+        Cask::Installer.new(cask, command: NeverSudoSystemCommand).install_artifacts
       end
     end
-    sandbox = instance_double(Sandbox).as_null_object
-    cask.staged_path.mkpath
-    cask.config_path.dirname.mkpath
-
-    allow(Sandbox).to receive_messages(available?: true, new: sandbox)
-    allow(sandbox).to receive(:allow_write_path)
-    allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
-    expect(sandbox).to receive(:allow_process_exec).with("/usr/bin/sudo", no_sandbox: true)
-    expect(sandbox).to receive(:run)
-
-    Cask::Installer.new(cask, command: NeverSudoSystemCommand).install_artifacts
   end
 
   it "runs a flight block after matching steps during migration" do

--- a/Library/Homebrew/test/cask/artifact/install_steps_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/install_steps_spec.rb
@@ -119,6 +119,29 @@ RSpec.describe Cask::Artifact::AbstractInstallSteps, :cask do
     expect(original_home/"Library/Application Support/cask-home-state").to exist
   end
 
+  it "allows explicitly privileged steps to run sudo outside the sandbox" do
+    cask = Cask::Cask.new("with-sandboxed-sudo-install-steps") do
+      version "1.2.3"
+      sha256 :no_check
+      url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
+
+      postflight_steps do
+        run "/usr/bin/true", sudo: true
+      end
+    end
+    sandbox = instance_double(Sandbox).as_null_object
+    cask.staged_path.mkpath
+    cask.config_path.dirname.mkpath
+
+    allow(Sandbox).to receive_messages(available?: true, new: sandbox)
+    allow(sandbox).to receive(:allow_write_path)
+    allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
+    expect(sandbox).to receive(:allow_process_exec).with("/usr/bin/sudo", no_sandbox: true)
+    expect(sandbox).to receive(:run)
+
+    Cask::Installer.new(cask, command: NeverSudoSystemCommand).install_artifacts
+  end
+
   it "runs a flight block after matching steps during migration" do
     cask = Cask::Cask.new("with-install-steps-bridge") do
       version "1.2.3"

--- a/Library/Homebrew/test/sandbox_shared_spec.rb
+++ b/Library/Homebrew/test/sandbox_shared_spec.rb
@@ -318,6 +318,16 @@ RSpec.describe Sandbox do
     end
   end
 
+  describe "#allow_process_exec" do
+    it "allows a process to run outside the sandbox when requested" do
+      sandbox.allow_process_exec "/usr/bin/sudo", no_sandbox: true
+
+      rule = sandbox.profile.rules.fetch(-1)
+      expect(rule).to have_attributes(allow: true, operation: "process-exec", modifier: "no-sandbox")
+      expect(rule.filter).to have_attributes(path: "/usr/bin/sudo", type: :literal)
+    end
+  end
+
   describe "#deny_read_path" do
     it "denies reads for a subpath" do
       dir = mktmpdir/"foo"


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Codex (GPT-5.6) was used to investigate the regression, help implement the change, and draft the tests and PR description. I reviewed the diff, manually verified

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

While investigating [Homebrew/homebrew-cask#279650](https://github.com/Homebrew/homebrew-cask/issues/279650), I  installed the `parallels` Cask to reproduce its reported uninstall failure. The installation itself failed with the same `Operation not permitted - /usr/bin/sudo` error on multiple Macs.

Tracing the failure showed that structured Cask install steps have been executed inside a sandbox since #23461. Steps that explicitly specify `sudo: true` cannot launch `/usr/bin/sudo` from that sandbox on macOS and fail with `EPERM`.

For example, the `parallels` Cask contains:

```ruby
postflight_steps do
  run "Parallels Desktop.app/Contents/MacOS/inittool",
      args: ["init"],
      base: :appdir,
      sudo: true
end
```


I think this regression occurred because #23461 moved structured Cask step blocks into a sandboxed subprocess without  accounting for `sudo: true`. The tests and automated review appear to have covered only unprivileged commands, so the  interaction between the macOS sandbox and `/usr/bin/sudo` may not have been exercised before merge.


## Reproduction

```console
$ brew install --cask parallels
==> Installing Cask parallels
==> Moving App 'Parallels Desktop.app' to '/Applications/Parallels Desktop.app'
Operation not permitted - /usr/bin/sudo
Error: Failure while executing; `/usr/bin/sudo -E -- /Applications/Parallels\ Desktop.app/Contents/MacOS/inittool
init` exited with 127.
  ```

 ## Change

This change adds a sandbox rule that allows `/usr/bin/sudo` to execute without inheriting the sandbox when a structured step explicitly sets `sudo: true`.

All other structured step processing remains sandboxed. The exception is not added to step blocks that do not explicitly request `sudo`.

This preserves the structured install-step authoring enforced by #23475 while restoring support for steps that explicitly require elevated privileges.

Unit tests cover:

 - Generation of the `process-exec` rule for `/usr/bin/sudo` with the `no-sandbox` modifier.
 - Addition of that rule when a structured Cask step specifies `sudo: true`.

The unit tests verify that the correct sandbox rule is added without invoking real `sudo`. I separately verified the actual privileged execution by manually installing the `parallels` Cask.


## Verification

After applying this change, I manually verified that the original installation failure was resolved:

```console
$ brew install --cask parallels
🍺  parallels was successfully installed!
```

I also verified that another Cask could be removed successfully:

```console
$ brew remove --cask lg-onscreen-control
```

`brew remove --cask parallels` still fails due to a separate issue: `must_succeed: false` is lost while serialising Cask artifact data, causing the `pkill` command in its uninstall stanza to be treated as mandatory.

That issue is unrelated to the sandboxed `sudo` regression addressed by this PR and will be submitted separately.