### PR TITLE
util: spdx license tag limit from 256 to 255

### DIFF
--- a/Library/Homebrew/utils/spdx.rb
+++ b/Library/Homebrew/utils/spdx.rb
@@ -202,12 +202,13 @@ module SPDX
   end
 
   # The `org.opencontainers.image.licenses` OCI annotation only accepts a limited
-  # length (`limit`), so shorten an over-long licence to a valid prefix rather than
+  # length (`limit`). GHCR rejects 256-character values on OCI child manifests, so
+  # the default is 255. Shorten an over-long licence to a valid prefix rather than
   # discarding it entirely. Only top-level `AND` expressions can be shortened safely:
   # a prefix of "A AND B AND ..." still holds, whereas dropping `OR` alternatives
   # would change the licence, so those fall back to `:cannot_represent`.
   sig { params(license: String, limit: Integer).returns(String) }
-  def truncate_license(license, limit: 256)
+  def truncate_license(license, limit: 255)
     return license if license.length <= limit
 
     fallback = license_expression_to_string(:cannot_represent) || license


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] AI was used to generate or assist with generating this PR.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

License tag for OCI image limit 256 chars by documentation but it is actually failed with 256 chars. I have tested my own private repo for this and 255 is fine to use. 

`mesa` is failed because of this,
- https://github.com/Homebrew/homebrew-core/pull/294670