### PR TITLE
Preserve false values in Cask artifact serialization

### DIFF
--- a/Library/Homebrew/api/cask_struct.rb
+++ b/Library/Homebrew/api/cask_struct.rb
@@ -141,7 +141,7 @@ module Homebrew
 
         hash["raw_artifacts"] = ::Utils.deep_compact_blank(raw_artifacts.map do |artifact|
           serialize_artifact_args(artifact)
-        end, compact_zero: false)
+        end, compact_zero: false, compact_false: false)
 
         hash = ::Utils.deep_stringify_symbols(hash)
         raw_artifacts = hash["raw_artifacts"]

--- a/Library/Homebrew/test/api/cask_struct_spec.rb
+++ b/Library/Homebrew/test/api/cask_struct_spec.rb
@@ -195,6 +195,30 @@ RSpec.describe Homebrew::API::CaskStruct do
       ])
   end
 
+  it "preserves false values in serialized artifact arguments" do
+    struct = described_class.new(
+      sha256:               "abc123",
+      version:              "1.0.0",
+      ruby_source_checksum: { sha256: "def456" },
+      raw_artifacts:        [
+        [
+          :uninstall,
+          [],
+          { script: { executable: "/usr/bin/pkill", must_succeed: false } },
+          nil,
+        ],
+      ],
+    )
+
+    expect(struct.serialize.fetch("raw_artifacts"))
+      .to eq([
+        [
+          ":uninstall",
+          { ":script" => { ":executable" => "/usr/bin/pkill", ":must_succeed" => false } },
+        ],
+      ])
+  end
+
   specify "::deserialize_artifact_args", :aggregate_failures do
     expect(described_class.deserialize_artifact_args([:foo]))
       .to eq([:foo, [], {}, nil])

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -269,5 +269,11 @@ RSpec.describe Utils do
 
       expect(described_class.deep_compact_blank(input)).to eq(expected_output)
     end
+
+    it "preserves false when compact_false is disabled" do
+      input = { a: false, b: [false], c: { d: false } }
+
+      expect(described_class.deep_compact_blank(input, compact_false: false)).to eq(input)
+    end
   end
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -216,21 +216,25 @@ module Utils
 
   sig {
     type_parameters(:U)
-      .params(obj: T.all(T.type_parameter(:U), Object), compact_zero: T::Boolean)
+      .params(obj: T.all(T.type_parameter(:U), Object), compact_zero: T::Boolean, compact_false: T::Boolean)
       .returns(T.nilable(T.type_parameter(:U)))
   }
-  def self.deep_compact_blank(obj, compact_zero: true)
+  def self.deep_compact_blank(obj, compact_zero: true, compact_false: true)
     obj = case obj
     when Hash
-      obj.transform_values { |v| deep_compact_blank(v, compact_zero:) }
+      obj.transform_values { |v| deep_compact_blank(v, compact_zero:, compact_false:) }
          .compact
     when Array
-      obj.filter_map { |v| deep_compact_blank(v, compact_zero:) }
+      obj.each_with_object([]) do |v, compacted|
+        value = deep_compact_blank(v, compact_zero:, compact_false:)
+        compacted << value unless value.nil?
+      end
     else
       obj
     end
 
-    return if obj.blank? || (compact_zero && obj.is_a?(Numeric) && obj.zero?)
+    return if (compact_false || obj != false) &&
+              (obj.blank? || (compact_zero && obj.is_a?(Numeric) && obj.zero?))
 
     obj
   end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex (GPT-5.6) was used to investigate the serialization issue, help implement the change, I reviewed the diff, inspected the generated internal API data, and manually verified the corrected Parallels uninstall behavior.

-----

While investigating [Homebrew/homebrew-cask#279650](https://github.com/Homebrew/homebrew-cask/issues/279650), I found that `parallels` could not be uninstalled when its background process was not running.

The Cask defines the uninstall script with `must_succeed: false`:

```ruby
uninstall signal: ["TERM", "com.parallels.desktop.console"],
          script: {
            executable:   "/usr/bin/pkill",
            args:         ["-TERM", "prl_client_app"],
            must_succeed: false,
          }
```

`pkill` exits with status 1 when no matching process exists. This should not interrupt the uninstall because the Cask explicitly sets `must_succeed: false`.

However, the generated Cask API artifact omits this value:

```ruby
script: {
  executable: "/usr/bin/pkill",
  args: ["-TERM", "prl_client_app"],
}
```

Without the explicit value, the uninstall script falls back to the default `must_succeed: true` and aborts.


## Reproduction

Ensure that `prl_client_app` is not running, then run:

```console
$ brew install --cask parallels
$ /usr/bin/pkill -TERM prl_client_app || true
$ brew remove --cask parallels
==> Uninstalling Cask parallels
==> Running uninstall script /usr/bin/pkill
Error: Failure while executing; `/usr/bin/env /usr/bin/pkill -TERM prl_client_app` exited with 1.
```


## Cause

`CaskStruct#serialize` compacts serialized artifact arguments using `Utils.deep_compact_blank`.

Boolean `false` is considered blank, so meaningful values such as `must_succeed: false` are removed. Additionally, the previous Array implementation used `filter_map`, which also removes `false` results.


## Changes

This adds a `compact_false` option to `Utils.deep_compact_blank`.

Its default remains `true`, preserving the existing behavior for all current callers. Cask artifact serialization passes `compact_false: false` so Boolean false values remain in `raw_artifacts`.

The Array implementation now removes only `nil` results, allowing `false` to be retained when requested.


## Verification

The serialization tests verify that `must_succeed: false` remains in `raw_artifacts`.

Separately, I loaded the local `parallels` Cask definition while bypassing the stale installed API metadata. This confirmed that, when `must_succeed: false` is present, the failing `pkill` command does not interrupt the uninstall and Parallels is removed successfully.

The currently published internal API was generated before this fix and still omits `must_succeed: false`, so a regular uninstall would continue to use the stale serialized data during this manual verification.

