### PR TITLE
Improve PythonVersions cop to reject hardcoded pythonX.Y assignment

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -319,6 +319,7 @@ class Formula
 
     @active_spec = T.let(determine_active_spec(spec), SoftwareSpec)
     @active_spec_sym = T.let(head? ? :head : :stable, Symbol)
+    @python3 = T.let(nil, T.nilable(Pathname))
     validate_attributes!
     @build = T.let(active_spec.build, T.any(BuildOptions, Tab))
     @pin = T.let(FormulaPin.new(self), FormulaPin)
@@ -341,6 +342,7 @@ class Formula
 
     return if spec_sym == old_spec_sym
 
+    @python3 = nil
     Dependency.clear_cache
     Requirement.clear_cache
   end
@@ -931,6 +933,8 @@ class Formula
   # @api public
   sig { returns(Pathname) }
   def python3
+    return @python3 if @python3
+
     python_deps = Language::Python.direct_dependency_paths(self, pattern: /\Apython@3\.\d+\z/)
 
     if python_deps.length != 1
@@ -938,7 +942,7 @@ class Formula
       raise "`#{full_name}` must have exactly one `python@3.x` dependency to use `python3`; found #{found}."
     end
 
-    python_deps.values.fetch(0)
+    @python3 = python_deps.values.fetch(0)
   end
 
   # The declared {Dependency}s for the currently active {SoftwareSpec} (i.e. including those provided by macOS).

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -585,9 +585,32 @@ module RuboCop
       class PythonVersions < FormulaCop
         extend AutoCorrector
 
+        PYTHON_VERSION_REFERENCE_REGEX = /^python(@)?(\d\.\d+)$/
+
+        HARDCODED_PYTHON_ASSIGNMENT_MSG =
+          "`python = \"pythonX.Y\"` should use dynamic version detection: " \
+          "`python = \"python\#{python_major_minor(libexec/\"bin/python)\")}\"`"
+
         sig { override.params(formula_nodes: FormulaNodes).void }
         def audit_formula(formula_nodes)
           return if (body_node = formula_nodes.body_node).nil?
+
+          body_node.each_descendant(:lvasgn) do |assignment_node|
+            variable_name = assignment_node.children.first
+            next unless [:python, :python3].include?(variable_name)
+
+            value = assignment_node.children.last
+            next unless value.is_a?(RuboCop::AST::StrNode)
+            next unless PYTHON_VERSION_REFERENCE_REGEX.match?(string_content(value))
+
+            offending_node(value)
+            problem HARDCODED_PYTHON_ASSIGNMENT_MSG do |corrector|
+              corrector.replace(
+                value.source_range,
+                "\"python\#{python_major_minor(libexec/\"bin/python)\")}\"",
+              )
+            end
+          end
 
           python_formula_node = find_every_method_call_by_name(body_node, :depends_on).find do |dep|
             string_content(parameters(dep).fetch(0)).start_with? "python@"
@@ -609,7 +632,7 @@ module RuboCop
           find_strings(body_node).each do |str|
             content = string_content(str)
 
-            next unless (match = content.match(/^python(@)?(\d\.\d+)$/))
+            next unless (match = content.match(PYTHON_VERSION_REFERENCE_REGEX))
             next if python_version == match[2]
 
             fix = if match[1]

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -585,48 +585,41 @@ module RuboCop
       class PythonVersions < FormulaCop
         extend AutoCorrector
 
-        PYTHON_VERSION_REFERENCE_REGEX = /^python(@)?(\d\.\d+)$/
-
-        HARDCODED_PYTHON_ASSIGNMENT_MSG =
-          "`python = \"pythonX.Y\"` should use dynamic version detection: " \
-          "`python = \"python\#{python_major_minor(libexec/\"bin/python)\")}\"`"
+        PYTHON_VERSION_REFERENCE_REGEX = /\Apython(@)?(\d\.\d+)\z/
 
         sig { override.params(formula_nodes: FormulaNodes).void }
         def audit_formula(formula_nodes)
           return if (body_node = formula_nodes.body_node).nil?
 
-          body_node.each_descendant(:lvasgn) do |assignment_node|
-            variable_name = assignment_node.children.first
-            next unless [:python, :python3].include?(variable_name)
+          python_versions = find_every_method_call_by_name(body_node, :depends_on).filter_map do |dep|
+            first_param = parameters(dep).first
+            first_param = first_param.keys.first if first_param.is_a?(RuboCop::AST::HashNode)
+            match = string_content(first_param).rpartition("/").last.match(PYTHON_VERSION_REFERENCE_REGEX)
+            match[2] if match && match[1]
+          end.uniq
+          return if python_versions.size != 1
 
-            value = assignment_node.children.last
-            next unless value.is_a?(RuboCop::AST::StrNode)
-            next unless PYTHON_VERSION_REFERENCE_REGEX.match?(string_content(value))
+          python_version = python_versions.fetch(0)
+          if python_version.start_with?("3.") && !find_method_def(body_node, :python3)
+            hardcoded_python_assignment(body_node) do |value|
+              next unless (match = string_content(value).match(PYTHON_VERSION_REFERENCE_REGEX))
+              next if match[1]
+              next unless value.each_ancestor(:def, :block).any? do |node|
+                node.def_type? || (node.is_a?(RuboCop::AST::BlockNode) && node.method_name == :test)
+              end
 
-            offending_node(value)
-            problem HARDCODED_PYTHON_ASSIGNMENT_MSG do |corrector|
-              corrector.replace(
-                value.source_range,
-                "\"python\#{python_major_minor(libexec/\"bin/python)\")}\"",
-              )
+              assignment = value.parent
+              offending_node(value)
+              if assignment.children.first == :python
+                problem "Use `python = python3` instead of a hardcoded Python executable." do |corrector|
+                  corrector.replace(value.source_range, "python3")
+                end
+              else
+                problem "Use `python3` directly instead of assigning a hardcoded Python executable." do |corrector|
+                  corrector.remove(range_by_whole_lines(assignment.source_range, include_final_newline: true))
+                end
+              end
             end
-          end
-
-          python_formula_node = find_every_method_call_by_name(body_node, :depends_on).find do |dep|
-            string_content(parameters(dep).fetch(0)).start_with? "python@"
-          end
-
-          python_version = if python_formula_node.blank?
-            other_python_nodes = find_every_method_call_by_name(body_node, :depends_on).select do |dep|
-              first_param = parameters(dep).first
-              first_param.instance_of?(RuboCop::AST::HashNode) &&
-                string_content(first_param.keys.first).start_with?("python@")
-            end
-            return if other_python_nodes.size != 1
-
-            string_content(T.cast(parameters(other_python_nodes.fetch(0)).fetch(0), RuboCop::AST::HashNode).keys.first).split("@").last
-          else
-            string_content(parameters(python_formula_node).fetch(0)).split("@").last
           end
 
           find_strings(body_node).each do |str|
@@ -648,6 +641,10 @@ module RuboCop
             end
           end
         end
+
+        def_node_search :hardcoded_python_assignment, <<~PATTERN
+          (lvasgn {:python :python3} $str)
+        PATTERN
       end
 
       # This cop makes sure that OS conditionals are consistent.

--- a/Library/Homebrew/sorbet/rbi/dsl/rubo_cop/cop/formula_audit/python_versions.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/rubo_cop/cop/formula_audit/python_versions.rbi
@@ -5,4 +5,14 @@
 # Please instead update this file by running `bin/tapioca dsl RuboCop::Cop::FormulaAudit::PythonVersions`.
 
 
-class RuboCop::Cop::FormulaAudit::PythonVersions; end
+class RuboCop::Cop::FormulaAudit::PythonVersions
+  sig do
+    params(
+      node: RuboCop::AST::Node,
+      pattern: T.any(String, Symbol),
+      kwargs: T.untyped,
+      block: T.untyped
+    ).returns(T.untyped)
+  end
+  def hardcoded_python_assignment(node, *pattern, **kwargs, &block); end
+end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -167,6 +167,33 @@ RSpec.describe Formula do
       expect(f.python3).to eq HOMEBREW_PREFIX/"opt/python@3.14/bin/python3.14"
     end
 
+    it "memoises the executable" do
+      f = formula "memoized-python-dependent" do
+        url "foo-1.0"
+        depends_on "python@3.14"
+      end
+
+      expect(f.python3).to equal(f.python3)
+    end
+
+    it "clears the memoised executable when the active spec changes" do
+      f = formula "python-stable-and-head-dependent" do
+        stable do
+          url "foo-1.0"
+          depends_on "python@3.13"
+        end
+        head do
+          url "foo.git"
+          depends_on "python@3.14"
+        end
+      end
+
+      f.python3
+      f.active_spec = :head
+
+      expect(f.python3).to eq HOMEBREW_PREFIX/"opt/python@3.14/bin/python3.14"
+    end
+
     it "includes build and test dependencies" do
       f = formula "python-build-test-dependent" do
         url "foo-1.0"

--- a/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
@@ -220,5 +220,75 @@ RSpec.describe RuboCop::Cop::FormulaAudit::PythonVersions do
         end
       RUBY
     end
+
+    it "reports and corrects hardcoded `python = \"pythonX.Y\"` assignments" do
+      expect_offense(<<~'RUBY')
+        class Foo < Formula
+          depends_on "python@3.14"
+
+          def install
+            python = "python3.12"
+                     ^^^^^^^^^^^^ FormulaAudit/PythonVersions: `python = "pythonX.Y"` should use dynamic version detection: `python = "python#{python_major_minor(libexec/"bin/python)")}"`
+          end
+        end
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        class Foo < Formula
+          depends_on "python@3.14"
+
+          def install
+            python = "python#{python_major_minor(libexec/"bin/python)")}"
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses for dynamic python assignments" do
+      expect_no_offenses(<<~'RUBY')
+        class Foo < Formula
+          depends_on "python@3.14"
+
+          def install
+            python = "python#{python_major_minor(libexec/"bin/python)")}"
+          end
+        end
+      RUBY
+    end
+
+    it "reports and corrects hardcoded `python3 = \"pythonX.Y\"` assignments" do
+      expect_offense(<<~'RUBY')
+        class Foo < Formula
+          depends_on "python@3.14"
+
+          def install
+            python3 = "python3.12"
+                      ^^^^^^^^^^^^ FormulaAudit/PythonVersions: `python = "pythonX.Y"` should use dynamic version detection: `python = "python#{python_major_minor(libexec/"bin/python)")}"`
+          end
+        end
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        class Foo < Formula
+          depends_on "python@3.14"
+
+          def install
+            python3 = "python#{python_major_minor(libexec/"bin/python)")}"
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses for hardcoded python version assigned to non-python local" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.14"
+
+          def install
+            interpreter = "python3.14"
+          end
+        end
+      RUBY
+    end
   end
 end

--- a/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
@@ -222,58 +222,82 @@ RSpec.describe RuboCop::Cop::FormulaAudit::PythonVersions do
     end
 
     it "reports and corrects hardcoded `python = \"pythonX.Y\"` assignments" do
-      expect_offense(<<~'RUBY')
+      expect_offense(<<~RUBY)
         class Foo < Formula
           depends_on "python@3.14"
 
           def install
             python = "python3.12"
-                     ^^^^^^^^^^^^ FormulaAudit/PythonVersions: `python = "pythonX.Y"` should use dynamic version detection: `python = "python#{python_major_minor(libexec/"bin/python)")}"`
+                     ^^^^^^^^^^^^ FormulaAudit/PythonVersions: Use `python = python3` instead of a hardcoded Python executable.
           end
         end
       RUBY
 
-      expect_correction(<<~'RUBY')
+      expect_correction(<<~RUBY)
         class Foo < Formula
           depends_on "python@3.14"
 
           def install
-            python = "python#{python_major_minor(libexec/"bin/python)")}"
+            python = python3
           end
         end
       RUBY
     end
 
     it "reports no offenses for dynamic python assignments" do
-      expect_no_offenses(<<~'RUBY')
+      expect_no_offenses(<<~RUBY)
         class Foo < Formula
           depends_on "python@3.14"
 
           def install
-            python = "python#{python_major_minor(libexec/"bin/python)")}"
+            python = python3
           end
         end
       RUBY
     end
 
     it "reports and corrects hardcoded `python3 = \"pythonX.Y\"` assignments" do
-      expect_offense(<<~'RUBY')
+      expect_offense(<<~RUBY)
         class Foo < Formula
           depends_on "python@3.14"
 
           def install
             python3 = "python3.12"
-                      ^^^^^^^^^^^^ FormulaAudit/PythonVersions: `python = "pythonX.Y"` should use dynamic version detection: `python = "python#{python_major_minor(libexec/"bin/python)")}"`
+                      ^^^^^^^^^^^^ FormulaAudit/PythonVersions: Use `python3` directly instead of assigning a hardcoded Python executable.
+            system python3, "--version"
           end
         end
       RUBY
 
-      expect_correction(<<~'RUBY')
+      expect_correction(<<~RUBY)
         class Foo < Formula
           depends_on "python@3.14"
 
           def install
-            python3 = "python#{python_major_minor(libexec/"bin/python)")}"
+            system python3, "--version"
+          end
+        end
+      RUBY
+    end
+
+    it "reports and corrects a hardcoded version matching the python dependency" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.14"
+
+          def install
+            python = "python3.14"
+                     ^^^^^^^^^^^^ FormulaAudit/PythonVersions: Use `python = python3` instead of a hardcoded Python executable.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.14"
+
+          def install
+            python = python3
           end
         end
       RUBY
@@ -286,6 +310,136 @@ RSpec.describe RuboCop::Cop::FormulaAudit::PythonVersions do
 
           def install
             interpreter = "python3.14"
+          end
+        end
+      RUBY
+    end
+
+    it "reports and corrects assignments with a tagged Python dependency" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.14" => [:build, :test]
+
+          test do
+            python = "python3.14"
+                     ^^^^^^^^^^^^ FormulaAudit/PythonVersions: Use `python = python3` instead of a hardcoded Python executable.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.14" => [:build, :test]
+
+          test do
+            python = python3
+          end
+        end
+      RUBY
+    end
+
+    it "reports and corrects assignments with duplicate Python dependencies" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          depends_on "homebrew/core/python@3.14" => :build
+          depends_on "python@3.14" => :test
+
+          def install
+            python = "python3.14"
+                     ^^^^^^^^^^^^ FormulaAudit/PythonVersions: Use `python = python3` instead of a hardcoded Python executable.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          depends_on "homebrew/core/python@3.14" => :build
+          depends_on "python@3.14" => :test
+
+          def install
+            python = python3
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses for assignments without a Python dependency" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          def install
+            python = "python3.14"
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses for assignments with multiple Python dependencies" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.13"
+          depends_on "python@3.14" => :test
+
+          def install
+            python = "python3.13"
+          end
+
+          test do
+            python3 = "python3.14"
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses for assignments of formula names or paths" do
+      expect_no_offenses(<<~'RUBY')
+        class Foo < Formula
+          depends_on "python@3.14"
+
+          def install
+            python = "python@3.14"
+            python3 = "bin/python3.14"
+            python = "python3.14\npython3.14"
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses for Python 2 assignments" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@2.7"
+
+          def install
+            python = "python2.7"
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses for assignments outside instance methods and tests" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.14"
+          python = "python3.14"
+
+          def self.foo
+            python3 = "python3.14"
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses for assignments when the python3 method is overridden" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.14"
+
+          def python3
+            "python3.14"
+          end
+
+          def install
+            python = "python3.14"
           end
         end
       RUBY


### PR DESCRIPTION
Enforce dynamic Python version detection in formula code by flagging hardcoded pythonX.Y strings assigned to python and autocorrecting to Language::Python.major_minor_version with libexec/bin/python. Generalize detection using a shared Python version regex and update PythonVersions specs accordingly.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [ ] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
