### PR TITLE
update: revalidate API cache with ETags, not cache mtime

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -570,14 +570,15 @@ module Homebrew
       api_internal = cache/"api/internal"
       api_package_files = if scrub? && api_internal.directory?
         current_api_package_basename = Homebrew::API::Internal.cached_packages_json_file_path.basename.to_s
-        # Keep only the current OS's envelope and its `.payload` and
-        # `.payload.index` sidecars and scrub the rest, including orphaned
-        # sidecars and temp files.
+        # Keep only the current OS's envelope and its `.payload`,
+        # `.payload.index` and `.etag` sidecars and scrub the rest, including
+        # orphaned sidecars and temp files.
         # Keep in sync with the previous-OS-version removal in cmd/update.sh.
         kept_basenames = [
           current_api_package_basename,
           "#{current_api_package_basename}.payload",
           "#{current_api_package_basename}.payload.index",
+          "#{current_api_package_basename}.etag",
         ]
         api_internal.glob("packages.*.jws.json*").reject do |path|
           kept_basenames.include?(path.basename.to_s)

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -443,21 +443,26 @@ fetch_api_file() {
   fi
 
   local arg curl_exit_code json_url last_json_url
-  local -a time_cond
+  local -a conditional_args etag_save_args
   while read -r json_url
   do
-    time_cond=()
+    conditional_args=()
     while read -r arg
     do
-      time_cond+=("${arg}")
-    done < <(api_time_cond_args "${cache_path}")
-    api_curl_download "${json_url}" "${cache_path}" "${time_cond[@]}"
+      conditional_args+=("${arg}")
+    done < <(api_conditional_args "${cache_path}")
+    api_curl_download "${json_url}" "${cache_path}" "${conditional_args[@]}"
     curl_exit_code=$?
     # A conditional request can fail with a receive error (curl exit code 56) when
     # an unconditional request for the same URL succeeds, so retry exactly once.
-    if [[ ${curl_exit_code} -eq 56 ]] && [[ ${#time_cond[@]} -gt 0 ]]
+    if [[ ${curl_exit_code} -eq 56 ]] && [[ ${#conditional_args[@]} -gt 0 ]]
     then
-      api_curl_download "${json_url}" "${cache_path}"
+      etag_save_args=()
+      while read -r arg
+      do
+        etag_save_args+=("${arg}")
+      done < <(api_etag_save_args "${cache_path}")
+      api_curl_download "${json_url}" "${cache_path}" "${etag_save_args[@]}"
       curl_exit_code=$?
     fi
     last_json_url="${json_url}"
@@ -472,6 +477,8 @@ fetch_api_file() {
   then
     mv -f "${api_cache}/cask_names.txt" "${api_cache}/cask_names.before.txt"
   fi
+
+  api_promote_etag "${cache_path}"
 
   if [[ ${curl_exit_code} -eq 0 ]]
   then
@@ -1067,8 +1074,8 @@ EOS
     rm -f "${HOMEBREW_CACHE}"/api/internal/formula.*.jws.json
     rm -f "${HOMEBREW_CACHE}"/api/internal/cask.*.jws.json
 
-    # Remove API files (and their `.payload` and `.payload.index` sidecars)
-    # from previous OS versions, keeping the current OS's so `brew
+    # Remove API files (and their `.payload`, `.payload.index` and `.etag`
+    # sidecars) from previous OS versions, keeping the current OS's so `brew
     # update-report`'s API data load stays or becomes prewarmed. Keep in
     # sync with `cache_files` in Library/Homebrew/cleanup.rb.
     for f in "${HOMEBREW_CACHE}"/api/internal/packages.*.jws.json*
@@ -1077,6 +1084,7 @@ EOS
         "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json") ;;
         "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json.payload") ;;
         "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json.payload.index") ;;
+        "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json.etag") ;;
         *) rm -f "${f}" ;;
       esac
     done

--- a/Library/Homebrew/test/bash_spec.rb
+++ b/Library/Homebrew/test/bash_spec.rb
@@ -77,6 +77,112 @@ RSpec.describe "Bash" do
     end
   end
 
+  describe "utils/api.sh" do
+    def run_api_sh(body, env = {})
+      Open3.capture3(
+        env,
+        "/bin/bash", "-c", "source \"$1\"\n#{body}", "bash", (HOMEBREW_LIBRARY_PATH/"utils/api.sh").to_s
+      )
+    end
+
+    describe "api_conditional_args" do
+      it "prefers `--etag-compare` over `--time-cond` when an ETag is cached" do
+        mktmpdir do |dir|
+          cache = dir/"packages.jws.json"
+          cache.write "envelope"
+          (dir/"packages.jws.json.etag").write '"abc"'
+
+          stdout, stderr, status = run_api_sh(%Q(api_conditional_args "#{cache}"),
+                                              { "HOMEBREW_CURL_SUPPORTS_ETAG" => "1" })
+
+          expect(stderr).to be_empty
+          expect(status).to be_a_success
+          expect(stdout.lines.map(&:chomp))
+            .to eq(["--etag-compare", "#{cache}.etag", "--etag-save", "#{cache}.etag.incoming"])
+        end
+      end
+
+      it "falls back to `--time-cond` when no ETag has been cached yet" do
+        mktmpdir do |dir|
+          cache = dir/"packages.jws.json"
+          cache.write "envelope"
+
+          stdout, stderr, status = run_api_sh(%Q(api_conditional_args "#{cache}"),
+                                              { "HOMEBREW_CURL_SUPPORTS_ETAG" => "1" })
+
+          expect(stderr).to be_empty
+          expect(status).to be_a_success
+          expect(stdout.lines.map(&:chomp))
+            .to eq(["--time-cond", cache.to_s, "--etag-save", "#{cache}.etag.incoming"])
+        end
+      end
+
+      it "falls back to `--time-cond` when curl is too old for ETag options" do
+        mktmpdir do |dir|
+          cache = dir/"packages.jws.json"
+          cache.write "envelope"
+          (dir/"packages.jws.json.etag").write '"abc"'
+
+          stdout, stderr, status = run_api_sh(%Q(api_conditional_args "#{cache}"),
+                                              { "HOMEBREW_CURL_SUPPORTS_ETAG" => "0" })
+
+          expect(stderr).to be_empty
+          expect(status).to be_a_success
+          expect(stdout.lines.map(&:chomp)).to eq(["--time-cond", cache.to_s])
+        end
+      end
+
+      it "requests no validator when nothing is cached" do
+        mktmpdir do |dir|
+          cache = dir/"packages.jws.json"
+
+          stdout, stderr, status = run_api_sh(%Q(api_conditional_args "#{cache}"),
+                                              { "HOMEBREW_CURL_SUPPORTS_ETAG" => "1" })
+
+          expect(stderr).to be_empty
+          expect(status).to be_a_success
+          expect(stdout.lines.map(&:chomp)).to eq(["--etag-save", "#{cache}.etag.incoming"])
+        end
+      end
+    end
+
+    describe "api_promote_etag" do
+      it "keeps the previous ETag when curl emptied the incoming file on a 304" do
+        mktmpdir do |dir|
+          cache = dir/"packages.jws.json"
+          etag = dir/"packages.jws.json.etag"
+          incoming = dir/"packages.jws.json.etag.incoming"
+          etag.write '"kept"'
+          incoming.write ""
+
+          _, stderr, status = run_api_sh(%Q(api_promote_etag "#{cache}"))
+
+          expect(stderr).to be_empty
+          expect(status).to be_a_success
+          expect(etag.read).to eq('"kept"')
+          expect(incoming).not_to exist
+        end
+      end
+
+      it "promotes a newly received ETag" do
+        mktmpdir do |dir|
+          cache = dir/"packages.jws.json"
+          etag = dir/"packages.jws.json.etag"
+          incoming = dir/"packages.jws.json.etag.incoming"
+          etag.write '"old"'
+          incoming.write '"new"'
+
+          _, stderr, status = run_api_sh(%Q(api_promote_etag "#{cache}"))
+
+          expect(stderr).to be_empty
+          expect(status).to be_a_success
+          expect(etag.read).to eq('"new"')
+          expect(incoming).not_to exist
+        end
+      end
+    end
+  end
+
   describe "every `.sh` file" do
     it "has valid Bash syntax" do
       Pathname.glob("#{HOMEBREW_LIBRARY_PATH}/**/*.sh").each do |path|

--- a/Library/Homebrew/utils/api.sh
+++ b/Library/Homebrew/utils/api.sh
@@ -1,7 +1,7 @@
 # API helpers for Homebrew's Bash scripts.
 
-# HOMEBREW_API_DEFAULT_DOMAIN HOMEBREW_API_DOMAIN HOMEBREW_CURLRC are set by brew.sh
-# shellcheck disable=SC2154
+# HOMEBREW_API_DEFAULT_DOMAIN HOMEBREW_API_DOMAIN HOMEBREW_CURL HOMEBREW_CURLRC are set by brew.sh
+# shellcheck disable=SC2154,SC2153
 api_urls() {
   local filename="$1"
 
@@ -32,5 +32,80 @@ api_time_cond_args() {
   then
     echo "--time-cond"
     echo "${cache_path}"
+  fi
+}
+
+# `--etag-compare` and `--etag-save` were added in curl 7.68.0, which is newer
+# than HOMEBREW_MINIMUM_CURL_VERSION, so fall back to `--time-cond` below when
+# they are unavailable.
+HOMEBREW_MINIMUM_CURL_ETAG_VERSION="7.68.0"
+
+api_curl_supports_etag() {
+  if [[ -z "${HOMEBREW_CURL_SUPPORTS_ETAG:-}" ]]
+  then
+    local curl_version_output curl_name_and_version
+    curl_version_output="$("${HOMEBREW_CURL}" --version 2>/dev/null)"
+    curl_name_and_version="${curl_version_output%% (*}"
+    if [[ "$(numeric "${curl_name_and_version##* }")" -ge "$(numeric "${HOMEBREW_MINIMUM_CURL_ETAG_VERSION}")" ]]
+    then
+      HOMEBREW_CURL_SUPPORTS_ETAG="1"
+    else
+      HOMEBREW_CURL_SUPPORTS_ETAG="0"
+    fi
+  fi
+
+  [[ "${HOMEBREW_CURL_SUPPORTS_ETAG}" == "1" ]]
+}
+
+api_etag_save_args() {
+  local cache_path="$1"
+
+  api_curl_supports_etag || return 0
+
+  # Save to a scratch path rather than the stored ETag: curl empties the
+  # `--etag-save` file when the server answers 304, which would make every
+  # other request unconditional. `api_promote_etag` only keeps non-empty ones.
+  echo "--etag-save"
+  echo "${cache_path}.etag.incoming"
+}
+
+# Emit the curl arguments used to revalidate an already-cached API file.
+#
+# Prefer `If-None-Match` over `If-Modified-Since`. The cache file's mtime is
+# also used as a "last checked at" marker by `skip_download?` in api.rb, so it
+# is deliberately advanced to the current time after every successful
+# revalidation. That makes the mtime unsafe as a validator: it can drift ahead
+# of the `Last-Modified` of a newer object, after which every conditional
+# request keeps returning 304 and the stale body is pinned indefinitely. An
+# ETag is compared exactly, so it cannot drift in the same way.
+api_conditional_args() {
+  local cache_path="$1"
+  local etag_path="${cache_path}.etag"
+
+  if [[ -s "${cache_path}" ]]
+  then
+    if api_curl_supports_etag && [[ -s "${etag_path}" ]]
+    then
+      echo "--etag-compare"
+      echo "${etag_path}"
+    else
+      api_time_cond_args "${cache_path}"
+    fi
+  fi
+
+  api_etag_save_args "${cache_path}"
+}
+
+# Keep a newly received ETag, or retain the previous one when the server
+# answered 304 (curl empties the `--etag-save` file in that case).
+api_promote_etag() {
+  local cache_path="$1"
+  local incoming="${cache_path}.etag.incoming"
+
+  if [[ -s "${incoming}" ]]
+  then
+    mv -f "${incoming}" "${cache_path}.etag"
+  else
+    rm -f "${incoming}"
   fi
 }


### PR DESCRIPTION
-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

**AI disclosure:** drafted with an AI coding assistant (Cursor). I reviewed the diff line by line, ran every command myself, verified curl's actual 304/ETag behaviour empirically (including the `--etag-save` truncation quirk below) rather than taking the model's word for it, and wrote/ran the new specs. No commit is attributed to AI. I will answer review comments myself without AI/LLM. This is my only AI-assisted PR open.

-----

## What

Use `If-None-Match` instead of `If-Modified-Since` to revalidate the cached JSON API files in `brew update`, falling back to today's `--time-cond` behaviour when curl is too old.

## Why

`fetch_api_file` passes `--time-cond "${cache_path}"` and then unconditionally `touch`es the cache file after **any** successful curl — including a **304**:

https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/cmd/update.sh#L476-L478

That `touch` is not incidental: the same mtime is the "last checked at" marker read by `skip_download?` in `api.rb`, so it has to be advanced to now or every `brew` command would revalidate.

```ruby
(Time.now - stale_seconds) < target.mtime
```

So one mtime serves two incompatible purposes:

| Consumer | Wants mtime to mean |
| --- | --- |
| `skip_download?` (`api.rb`) | "last checked at" → **now** |
| `--time-cond` (`api_curl_download`) | "`Last-Modified` of the body we hold" → **the object's timestamp** |

`api_curl_download` already passes `--remote-time`, so after a 200 the mtime *is* the object's `Last-Modified` — and then `touch` overwrites it with now. Once the mtime drifts ahead of the `Last-Modified` of a newer object (a stale intermediary answering 304 while origin has already published is enough), every later conditional request keeps returning 304 and the stale body is pinned **indefinitely**.

I hit exactly this: `packages.arm64_tahoe.jws.json` stuck one version behind, `brew update` reporting `Already up-to-date`, and `brew outdated --cask` reporting an old version — while `api/cask/<token>.json` and the live API both had the newer data.

```
local  packages.arm64_tahoe.jws.json  → cursor 3.14.27  (15597989 bytes)
live   packages.arm64_tahoe.jws.json  → cursor 3.15.6   (15609041 bytes)
local+live api/cask/cursor.json       → cursor 3.15.6
```

The poisoned mtime was `Mon, 10 Aug 2026 03:21:04 GMT` (confirmed as the `If-Modified-Since` curl actually sends, via `curl -v --time-cond <file>`); the object it could no longer see had `Last-Modified: Mon, 10 Aug 2026 03:01:44 GMT`. `03:21:04 > 03:01:44`, so every request was a 304 forever.

An ETag is compared exactly, so it cannot drift with the clock: as soon as the intermediary serves the newer object, its ETag differs from the stored one and we get a 200. That fixes the failure mode rather than narrowing the window.

Related but distinct from #22089 / #22093, which fixed touching the mtime after a **failed** download. This is the **successful 304** path.

Background discussion, with the full investigation: https://github.com/orgs/Homebrew/discussions/6997

## How

- `api_conditional_args` emits `--etag-compare` when an ETag sidecar exists, else `--time-cond` as before.
- Gated on curl >= 7.68.0 (`--etag-compare`/`--etag-save` were added there, which is newer than `HOMEBREW_MINIMUM_CURL_VERSION`), so older curl keeps today's behaviour exactly.
- Incoming ETags are saved to `.etag.incoming` and only promoted when non-empty. This is deliberate: **curl empties the `--etag-save` file when the server answers 304**, so saving directly onto the stored ETag would make every other request unconditional. Verified against `formulae.brew.sh` on curl 8.7.1.
- The `.etag` sidecar is preserved in both cache cleanup paths (`cmd/update.sh` and `cleanup.rb#cache_files`), which are already documented as needing to stay in sync.

Behaviour is unchanged when the server sends no ETag, and no extra requests are added.

## Reproduction

The original trigger needs a stale intermediary, so it isn't reliably reproducible on demand. The *mechanism* is, and the poisoning is one command:

```bash
# 1. Populate the cache.
brew update

# 2. Poison the validator the way `touch` does on a 304 with a stale body.
touch ~/Library/Caches/Homebrew/api/internal/packages."$(brew --prefix >/dev/null; uname -m)"*.jws.json

# 3. Any object published before that mtime is now invisible: brew keeps
#    reporting "Already up-to-date" with the stale body.
brew update
brew outdated --cask   # stale versions

# Recovery before this change:
rm -f ~/Library/Caches/Homebrew/api/internal/packages.*
brew update
```

With this change, step 3 revalidates by ETag, so the mtime is irrelevant to correctness and step 2 cannot pin a stale body.

## Tests

Six new examples in `Library/Homebrew/test/bash_spec.rb` covering `api_conditional_args` (ETag preferred, `--time-cond` fallback with no ETag, `--time-cond` fallback on old curl, no validator when nothing is cached) and `api_promote_etag` (retains the previous ETag on an emptied incoming file, promotes a new one).

`brew lgtm` passes locally: typecheck clean, style clean, `brew tests --changed` green.

## Not included

`Homebrew::API.fetch_json_api_file` in `api.rb` has the same "freshen mtime after a conditional success" shape for the Ruby-side download path. I kept this PR to the `brew update` path that actually broke for me; happy to extend it there in the same PR if you'd prefer.