### PR TITLE
livecheck: fix throttle detached head on CI

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -1243,6 +1243,7 @@ module Homebrew
       refs = [
         default_branch,
         default_branch&.delete_prefix("origin/"),
+        "origin/HEAD",
         "origin/main",
         "main",
         "HEAD",

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -804,10 +804,12 @@ module Homebrew
         }
 
         if livecheck_throttle || livecheck_throttle_days
-          if livecheck_throttle
-            throttled_match_version_map = match_version_map.select do |_match, version|
+          throttled_match_version_map = if livecheck_throttle
+            match_version_map.select do |_match, version|
               throttle_allows_bump?(formula_or_cask, version, throttle_rate: livecheck_throttle)
             end
+          else
+            {}
           end
 
           if livecheck_throttle_days &&
@@ -1232,19 +1234,34 @@ module Homebrew
         "symbolic-ref",
         "refs/remotes/origin/HEAD",
         "--short",
-      ).chomp.delete_prefix("origin/").presence || "main"
+        chdir: tap.path,
+        err:   :close,
+      ).chomp.presence
+
+      # A detached checkout, as used for pull request CI, has no local branch,
+      # so fall back to the remote-tracking ref and finally the current commit.
+      refs = [
+        default_branch,
+        default_branch&.delete_prefix("origin/"),
+        "origin/main",
+        "main",
+        "HEAD",
+      ].compact.uniq
 
       relative_sourcefile = sourcefile.relative_path_from(tap.path).to_s
-      timestamp = Utils.popen_read(
-        Utils::Git.git,
-        "log",
-        default_branch,
-        "-1",
-        "--format=%ct",
-        "--",
-        relative_sourcefile,
-        chdir: tap.path,
-      ).chomp.presence
+      timestamp = refs.lazy.filter_map do |ref|
+        Utils.popen_read(
+          Utils::Git.git,
+          "log",
+          ref,
+          "-1",
+          "--format=%ct",
+          "--",
+          relative_sourcefile,
+          chdir: tap.path,
+          err:   :close,
+        ).chomp.presence
+      end.first
       return if timestamp.nil?
 
       Integer(timestamp, exception: false)


### PR DESCRIPTION
Casks with a `livecheck` `throttle` always fail `brew audit` in pull request CI:

```
Error: Version '17075,156bc8c814292349981f3adbfb1120c3d4f02020' differs from '' retrieved by livecheck.
```

Because CI checks out the PR in a detached head state, `git log main` doesn't return anything.
So that we can complete a comparison, we fallback to the `HEAD` of the PR branch, so there is a timestamp to compare to.

Example PR: https://github.com/Homebrew/homebrew-cask/pull/280061

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

I used `claude-code` with Opus 5 to help analyse, debug and fix the issue.