### PR TITLE
sbom: build pkg:brew purls via Vulns::Purl

### DIFF
--- a/Library/Homebrew/sbom.rb
+++ b/Library/Homebrew/sbom.rb
@@ -5,6 +5,7 @@ require "json"
 require "development_tools"
 require "utils/curl"
 require "utils/output"
+require "vulns/purl"
 
 # Rather than calling `new` directly, use one of the class methods like {SBOM.create}.
 class SBOM
@@ -144,7 +145,7 @@ class SBOM
       "externalRefs"     => [
         {
           "referenceCategory" => "PACKAGE-MANAGER",
-          "referenceLocator"  => "pkg:brew/#{formula_full_name}@#{version}",
+          "referenceLocator"  => brew_purl(formula_full_name, version),
           "referenceType"     => "purl",
         },
       ],
@@ -157,6 +158,17 @@ class SBOM
     }
   end
   private_class_method :bottle_package
+
+  sig { params(full_name: String, version: T.nilable(T.any(String, Version))).returns(String) }
+  def self.brew_purl(full_name, version)
+    namespace, _, name = full_name.rpartition("/")
+    Homebrew::Vulns::Purl.new(
+      type:      "brew",
+      namespace: namespace.presence,
+      name:,
+      version:   version&.to_s,
+    ).to_s
+  end
 
   sig {
     params(
@@ -497,7 +509,7 @@ class SBOM
         externalRefs:     [
           {
             referenceCategory: "PACKAGE-MANAGER",
-            referenceLocator:  "pkg:brew/#{tap}/#{name}@#{stable_version}",
+            referenceLocator:  SBOM.brew_purl([source.tap_name, name].compact.join("/"), stable_version),
             referenceType:     "purl",
           },
         ],
@@ -616,7 +628,7 @@ class SBOM
         externalRefs:     [
           {
             referenceCategory: "PACKAGE-MANAGER",
-            referenceLocator:  "pkg:brew/#{dependency["full_name"]}@#{dependency_pkg_version}",
+            referenceLocator:  SBOM.brew_purl(dependency.fetch("full_name").to_s, dependency_pkg_version),
             referenceType:     "purl",
           },
         ],

--- a/Library/Homebrew/test/sbom_spec.rb
+++ b/Library/Homebrew/test/sbom_spec.rb
@@ -262,4 +262,19 @@ RSpec.describe SBOM do
       end
     end
   end
+
+  describe ".brew_purl" do
+    it "percent-encodes @ in versioned formula names" do
+      expect(described_class.brew_purl("homebrew/core/python@3.12", "3.12.8"))
+        .to eq("pkg:brew/homebrew/core/python%403.12@3.12.8")
+    end
+
+    it "omits the namespace for a bare formula name" do
+      expect(described_class.brew_purl("zlib", "1.3.1")).to eq("pkg:brew/zlib@1.3.1")
+    end
+
+    it "omits the version segment when version is nil" do
+      expect(described_class.brew_purl("homebrew/core/foo", nil)).to eq("pkg:brew/homebrew/core/foo")
+    end
+  end
 end


### PR DESCRIPTION
Replace the three string-interpolated `pkg:brew/...` purls in `sbom.rb` with a single `SBOM.brew_purl` helper backed by `Homebrew::Vulns::Purl`, so formula names are percent-encoded per purl-spec.

Before, `python@3.12` produced `pkg:brew/homebrew/core/python@3.12@3.12.8` (unencoded `@` in the name), a formula with no tap produced `pkg:brew//name@ver`, and a nil version produced a trailing `@`. After, these emit `python%403.12`, `pkg:brew/name@ver`, and no `@` segment respectively. The `%40` encoding matches what `vulns/osv_export.rb` already produces for brew purls.

Noticed while reviewing #23459, which adds a fourth `pkg:brew` purl; that one can switch to `SBOM.brew_purl` on rebase.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Written with Claude Code; I reviewed the diff and verified output with `brew ruby -e 'require "sbom"; puts SBOM.brew_purl("homebrew/core/python@3.12", "3.12.8")'`.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----