### PR TITLE
api: track cache freshness separately from the response mtime

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -30,6 +30,11 @@ module Homebrew
     HOMEBREW_CACHE_API_SOURCE = T.let((HOMEBREW_CACHE/"api-source").freeze, Pathname)
     DEFAULT_API_STALE_SECONDS = T.let(7 * 24 * 60 * 60, Integer) # 7 days
 
+    sig { params(target: Pathname).returns(Pathname) }
+    private_class_method def self.last_checked_path(target)
+      Pathname("#{target}.last_checked")
+    end
+
     sig { params(endpoint: String).returns(T::Hash[String, T.untyped]) }
     def self.fetch(endpoint)
       return cache[endpoint] if cache.present? && cache.key?(endpoint)
@@ -54,7 +59,10 @@ module Homebrew
       return false if !target.exist? || target.empty?
       return true unless stale_seconds
 
-      (Time.now - stale_seconds) < target.mtime
+      last_checked = last_checked_path(target)
+      return false unless last_checked.exist?
+
+      (Time.now - stale_seconds) < last_checked.mtime
     end
 
     sig {
@@ -75,6 +83,7 @@ module Homebrew
       retry_count = 0
       url = "#{Homebrew::EnvConfig.api_domain}/#{endpoint}"
       default_url = "#{HOMEBREW_API_DEFAULT_DOMAIN}/#{endpoint}"
+      last_checked = last_checked_path(target)
 
       if Homebrew.running_as_root_but_not_owned_by_root? &&
          (!target.exist? || target.empty?)
@@ -110,7 +119,10 @@ module Homebrew
         download_succeeded = T.let(false, T::Boolean)
         begin
           args = curl_args.dup
-          args.prepend("--time-cond", target.to_s) if target.exist? && !target.empty?
+          # Keep in sync with `api_time_cond_args` in `utils/api.sh`.
+          if target.exist? && !target.empty? && last_checked.exist? && !insecure_download
+            args.prepend("--time-cond", target.to_s)
+          end
           if insecure_download
             opoo DevelopmentTools.insecure_download_warning(endpoint)
             args.append("--insecure")
@@ -138,12 +150,11 @@ module Homebrew
           opoo "#{target.basename}: update failed, falling back to cached version."
         end
 
-        # Only refresh the cache mtime after a successful curl revalidation/download.
-        # Touching after a failed download would mark a stale cache as fresh and
-        # cause `skip_download?` to short-circuit subsequent retries until cleanup.
+        # Preserve the response mtime for `--time-cond`; use the sidecar for freshness.
+        # Missing sidecars force one unconditional migration download.
         if download_succeeded
           mtime = insecure_download ? Time.new(1970, 1, 1) : Time.now
-          FileUtils.touch(target, mtime:)
+          FileUtils.touch(last_checked, mtime:)
         end
 
         payload_data = cached_jws_payload(target) if endpoint.end_with?(".jws.json") && !download_succeeded
@@ -175,8 +186,7 @@ module Homebrew
             Potential MITM attempt detected. Please run `brew update` and try again.
           EOS
         end
-        # Skip on insecure downloads: their pinned 1970 mtime would make the
-        # source fingerprint ambiguous (and they always re-download anyway).
+        # Insecure API data always re-downloads and should not seed the payload cache.
         if source_stat && !insecure_download
           write_jws_payload_cache(target, json_data, source_stat:)
           write_jws_payload_index_cache(target, json_data, parsed: data, source_stat:)
@@ -281,13 +291,17 @@ module Homebrew
     }
     def self.write_executables_file!(regenerate:, source:, &formulae)
       executables_path = HOMEBREW_CACHE_API/"internal/executables.txt"
-      # The file is derived only from the API data in `source`, so it stays
-      # current until that file next changes or is revalidated.
-      executables_mtime, source_mtime = [executables_path, source].map do |path|
-        path.mtime
+      # Rebuild after the source changes or is revalidated.
+      executables_mtime = begin
+        executables_path.mtime
       rescue Errno::ENOENT
         nil
       end
+      source_mtime = [source, last_checked_path(source)].filter_map do |path|
+        path.mtime
+      rescue Errno::ENOENT
+        nil
+      end.max
       return false if !regenerate && executables_mtime && source_mtime && source_mtime <= executables_mtime
 
       executables_lines = yield.filter_map do |name, hash|
@@ -403,7 +417,7 @@ module Homebrew
     end
 
     # Payload sidecars are only maintained for the internal packages files:
-    # `brew cleanup --scrub` and `update.sh` only prune sidecars matching
+    # `brew cleanup --scrub` and `update.sh` prune sidecars matching
     # `internal/packages.*.jws.json*` and the other `.jws.json` endpoints
     # are re-downloaded whenever they are used.
     sig { params(target: Pathname).returns(T::Boolean) }

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -570,12 +570,11 @@ module Homebrew
       api_internal = cache/"api/internal"
       api_package_files = if scrub? && api_internal.directory?
         current_api_package_basename = Homebrew::API::Internal.cached_packages_json_file_path.basename.to_s
-        # Keep only the current OS's envelope and its `.payload` and
-        # `.payload.index` sidecars and scrub the rest, including orphaned
-        # sidecars and temp files.
+        # Keep the current OS envelope and sidecars; scrub stale and orphaned files.
         # Keep in sync with the previous-OS-version removal in cmd/update.sh.
         kept_basenames = [
           current_api_package_basename,
+          "#{current_api_package_basename}.last_checked",
           "#{current_api_package_basename}.payload",
           "#{current_api_package_basename}.payload.index",
         ]

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -420,6 +420,7 @@ fetch_api_file() {
   local api_cache="${HOMEBREW_CACHE}/api"
 
   local cache_path="${api_cache}/${filename}"
+  local last_checked_path="${cache_path}.last_checked"
   mkdir -p "$(dirname "${cache_path}")"
 
   if [[ "${filename}" == "formula.jws.json" ]] || [[ "${filename}" == "internal/packages.$(bottle_tag).jws.json" ]]
@@ -475,7 +476,9 @@ fetch_api_file() {
 
   if [[ ${curl_exit_code} -eq 0 ]]
   then
-    touch "${cache_path}"
+    # Preserve the response mtime for `--time-cond`; use the sidecar for freshness.
+    # Keep in sync with `Homebrew::API.fetch_json_api_file` in `api.rb`.
+    touch "${last_checked_path}"
 
     CURRENT_JSON_BYTESIZE="$(wc -c "${cache_path}")"
     if [[ "${INITIAL_JSON_BYTESIZE}" != "${CURRENT_JSON_BYTESIZE}" ]]
@@ -1059,22 +1062,27 @@ EOS
       fetch_api_file "${filename}" "${update_failed_file}"
     done
 
-    rm -f "${HOMEBREW_CACHE}/api/formula.jws.json" "${HOMEBREW_CACHE}/api/cask.jws.json"
-    rm -f "${HOMEBREW_CACHE}/api/formula_tap_migrations.jws.json" "${HOMEBREW_CACHE}/api/cask_tap_migrations.jws.json"
+    rm -f \
+      "${HOMEBREW_CACHE}/api/formula.jws.json" "${HOMEBREW_CACHE}/api/formula.jws.json.last_checked" \
+      "${HOMEBREW_CACHE}/api/cask.jws.json" "${HOMEBREW_CACHE}/api/cask.jws.json.last_checked"
+    rm -f \
+      "${HOMEBREW_CACHE}/api/formula_tap_migrations.jws.json" \
+      "${HOMEBREW_CACHE}/api/formula_tap_migrations.jws.json.last_checked" \
+      "${HOMEBREW_CACHE}/api/cask_tap_migrations.jws.json" \
+      "${HOMEBREW_CACHE}/api/cask_tap_migrations.jws.json.last_checked"
 
     # Not a typo, these are the files we used to download that no longer need so should cleanup.
     rm -f "${HOMEBREW_CACHE}/api/formula.json" "${HOMEBREW_CACHE}/api/cask.json"
     rm -f "${HOMEBREW_CACHE}"/api/internal/formula.*.jws.json
     rm -f "${HOMEBREW_CACHE}"/api/internal/cask.*.jws.json
 
-    # Remove API files (and their `.payload` and `.payload.index` sidecars)
-    # from previous OS versions, keeping the current OS's so `brew
-    # update-report`'s API data load stays or becomes prewarmed. Keep in
-    # sync with `cache_files` in Library/Homebrew/cleanup.rb.
+    # Remove previous OS API files and sidecars; keep the current OS for `update-report`.
+    # Keep in sync with `cache_files` in `cleanup.rb`.
     for f in "${HOMEBREW_CACHE}"/api/internal/packages.*.jws.json*
     do
       case "${f}" in
         "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json") ;;
+        "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json.last_checked") ;;
         "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json.payload") ;;
         "${HOMEBREW_CACHE}/api/internal/packages.$(bottle_tag).jws.json.payload.index") ;;
         *) rm -f "${f}" ;;

--- a/Library/Homebrew/retryable_download.rb
+++ b/Library/Homebrew/retryable_download.rb
@@ -81,8 +81,6 @@ module Homebrew
       json_download = downloadable.is_a?(API::JSONDownload)
       downloadable.verify_download_integrity(download) if verify_download_integrity && !json_download
 
-      FileUtils.touch(download, mtime: Time.now) if json_download
-
       download
     rescue DownloadError, ChecksumMismatchError, Resource::BottleManifest::Error => e
       tries_remaining = @tries - @try

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "api"
+require "development_tools"
 require "openssl"
 
 RSpec.describe Homebrew::API do
@@ -93,11 +94,13 @@ RSpec.describe Homebrew::API do
       end.to raise_error(SystemExit)
     end
 
-    it "does not refresh the cache mtime when the download fails" do
+    it "does not refresh the last-checked mtime when the download fails" do
       target = cache_dir/"bar.json"
+      last_checked = Pathname("#{target}.last_checked")
       target.write json
       stale_mtime = Time.now - 7200
       FileUtils.touch(target, mtime: stale_mtime)
+      FileUtils.touch(last_checked, mtime: stale_mtime)
 
       allow(Utils::Curl).to receive(:curl_download).and_raise(ErrorDuringExecution.new(["curl"], status: 1))
 
@@ -109,14 +112,17 @@ RSpec.describe Homebrew::API do
         )
       end.to output(/update failed, falling back to cached version/).to_stderr
 
-      expect(target.mtime.to_i).to eq stale_mtime.to_i
+      expect([target.mtime.to_i, last_checked.mtime.to_i]).to eq([stale_mtime.to_i, stale_mtime.to_i])
     end
 
-    it "refreshes the cache mtime when a fallback to the default API domain succeeds" do
+    it "refreshes the last-checked mtime when a fallback to the default API domain succeeds" do
       target = cache_dir/"bar.json"
+      last_checked = Pathname("#{target}.last_checked")
       target.write json
       stale_mtime = Time.now - 7200
+      response_mtime = Time.now - 3600
       FileUtils.touch(target, mtime: stale_mtime)
+      FileUtils.touch(last_checked, mtime: stale_mtime)
 
       allow(Homebrew::EnvConfig).to receive(:api_domain).and_return("https://example.invalid/api")
 
@@ -126,6 +132,7 @@ RSpec.describe Homebrew::API do
         raise ErrorDuringExecution.new(["curl"], status: 1) if requested_urls.length == 1
 
         kwargs[:to].write json
+        FileUtils.touch(kwargs[:to], mtime: response_mtime)
       end
 
       described_class.fetch_json_api_file(
@@ -138,7 +145,80 @@ RSpec.describe Homebrew::API do
         "https://example.invalid/api/bar.json",
         "#{HOMEBREW_API_DEFAULT_DOMAIN}/bar.json",
       ])
-      expect(target.mtime.to_i).to be > stale_mtime.to_i
+      expect([target.mtime.to_i, last_checked.mtime > response_mtime]).to eq([response_mtime.to_i, true])
+    end
+
+    it "keeps the API response mtime when a conditional download succeeds" do
+      target = cache_dir/"bar.json"
+      last_checked = Pathname("#{target}.last_checked")
+      response_mtime = Time.now - 7200
+      target.write json
+      FileUtils.touch(target, mtime: response_mtime)
+      FileUtils.touch(last_checked, mtime: response_mtime)
+
+      expect(Utils::Curl).to receive(:curl_download).with(
+        "--time-cond", target.to_s, any_args,
+        hash_including(to: target)
+      )
+
+      described_class.fetch_json_api_file(
+        "bar.json",
+        target:,
+        stale_seconds: 3600,
+      )
+
+      expect([target.mtime.to_i, last_checked.mtime > response_mtime]).to eq([response_mtime.to_i, true])
+    end
+
+    it "unconditionally refreshes a cache without a last-checked file" do
+      target = cache_dir/"bar.json"
+      target.write json
+
+      expect(Utils::Curl).to receive(:curl_download) do |*args, **kwargs|
+        expect(args).not_to include("--time-cond")
+        expect(args.last).to eq("#{HOMEBREW_API_DEFAULT_DOMAIN}/bar.json")
+        expect(kwargs).to include(to: target)
+        kwargs[:to].write json
+      end
+
+      described_class.fetch_json_api_file(
+        "bar.json",
+        target:,
+        stale_seconds: 3600,
+      )
+
+      expect(Pathname("#{target}.last_checked")).to exist
+    end
+
+    it "does not conditionally reuse a cache for an insecure download" do
+      target = cache_dir/"bar.json"
+      last_checked = Pathname("#{target}.last_checked")
+      response_mtime = Time.now - 3600
+      target.write json
+      FileUtils.touch(target, mtime: response_mtime)
+      FileUtils.touch(last_checked, mtime: Time.new(1970, 1, 1))
+
+      allow(DevelopmentTools).to receive_messages(
+        ca_file_substitution_required?: true,
+        curl_substitution_required?:    false,
+      )
+      allow(described_class).to receive(:opoo)
+      expect(Utils::Curl).to receive(:curl_download) do |*args, **kwargs|
+        expect(args).to include("--insecure")
+        expect(args).not_to include("--time-cond")
+        kwargs[:to].write json
+        FileUtils.touch(kwargs[:to], mtime: response_mtime)
+      end
+
+      described_class.fetch_json_api_file(
+        "bar.json",
+        target:,
+        stale_seconds: 3600,
+      )
+
+      expect([target.mtime.to_i, last_checked.mtime.to_i]).to eq(
+        [response_mtime.to_i, Time.new(1970, 1, 1).to_i],
+      )
     end
   end
 
@@ -194,6 +274,7 @@ RSpec.describe Homebrew::API do
       allow(described_class).to receive(:jws_public_key_pem).and_return(private_key.public_key.to_pem)
       target.dirname.mkpath
       target.write envelope_json('{"foo":"bar"}')
+      FileUtils.touch "#{target}.last_checked"
     end
 
     it "verifies the envelope and writes a payload cache" do
@@ -204,6 +285,7 @@ RSpec.describe Homebrew::API do
     it "does not write a payload cache for endpoints without one" do
       other_target = cache_dir/"internal/other.jws.json"
       other_target.write envelope_json('{"foo":"bar"}')
+      FileUtils.touch "#{other_target}.last_checked"
 
       data, = described_class.fetch_json_api_file("internal/other.jws.json", target:        other_target,
                                                                              stale_seconds: 3600)
@@ -341,6 +423,15 @@ RSpec.describe Homebrew::API do
     it "rebuilds the executables database when the source is newer" do
       target.write "stale:stale-bin\n"
       FileUtils.touch source, mtime: target.mtime + 1
+
+      expect(write_executables_file!(regenerate: false)).to be true
+      expect(target.read).to eq("foo:foo-bin\n")
+    end
+
+    it "rebuilds the executables database when the source is revalidated" do
+      target.write "stale:stale-bin\n"
+      FileUtils.touch source, mtime: target.mtime - 1
+      FileUtils.touch "#{source}.last_checked", mtime: target.mtime + 1
 
       expect(write_executables_file!(regenerate: false)).to be true
       expect(target.read).to eq("foo:foo-bin\n")

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -565,18 +565,20 @@ RSpec.describe Homebrew::Cleanup do
       expect([*api_package_files, *api_jws_files].map(&:exist?)).to eq([true, false, true, true])
     end
 
-    it "cleans up non-current internal package API payload sidecars with scrub" do
+    it "cleans up non-current internal package API sidecars with scrub" do
       cache = mktmpdir/"cache"
       api_internal = cache/"api/internal"
       current_basename = Homebrew::API::Internal.cached_packages_json_file_path.basename
       kept_files = [
         api_internal/current_basename,
+        api_internal/"#{current_basename}.last_checked",
         api_internal/"#{current_basename}.payload",
         api_internal/"#{current_basename}.payload.index",
       ]
       scrubbed_files = [
         api_internal/"packages.stale.jws.json.payload",
         api_internal/"packages.stale.jws.json.payload.index",
+        api_internal/"packages.stale.jws.json.last_checked",
         api_internal/"#{current_basename}.payload.tmp",
       ]
       (kept_files + scrubbed_files).each do |file|
@@ -586,7 +588,9 @@ RSpec.describe Homebrew::Cleanup do
 
       described_class.new(scrub: true, cache:).cleanup_cache
 
-      expect((kept_files + scrubbed_files).map(&:exist?)).to eq([true, true, true, false, false, false])
+      expect((kept_files + scrubbed_files).map(&:exist?)).to eq(
+        [true, true, true, true, false, false, false, false],
+      )
     end
 
     it "cleans up API source files and symlinks at any depth without cleaning directories" do

--- a/Library/Homebrew/test/cmd/update_spec.rb
+++ b/Library/Homebrew/test/cmd/update_spec.rb
@@ -37,11 +37,13 @@ RSpec.describe Homebrew::Cmd::Update do
 
   it "retries a failed conditional API download without the time condition" do
     cache_path = test_root/"cache/api/formula.jws.json"
+    last_checked_path = Pathname("#{cache_path}.last_checked")
     requests_file = test_root/"requests.txt"
     update_failed_file = test_root/"update_failed.txt"
     setup_update_utils
     cache_path.dirname.mkpath
     cache_path.write "cached"
+    FileUtils.touch last_checked_path
 
     _stdout, stderr, status = run_update_shell(
       <<~SH,
@@ -72,6 +74,40 @@ RSpec.describe Homebrew::Cmd::Update do
     expect([status.success?, stderr, requests_file.read, cache_path.read, update_failed_file.exist?]).to eq(
       [true, "", "conditional\nunconditional\n", "fresh", false],
     )
+  end
+
+  it "keeps the API response mtime when a conditional download succeeds" do
+    cache_path = test_root/"cache/api/formula.jws.json"
+    last_checked_path = Pathname("#{cache_path}.last_checked")
+    update_failed_file = test_root/"update_failed.txt"
+    response_mtime = Time.now - 7200
+    setup_update_utils
+    cache_path.dirname.mkpath
+    cache_path.write "cached"
+    FileUtils.touch cache_path, mtime: response_mtime
+    FileUtils.touch last_checked_path, mtime: response_mtime
+
+    _stdout, stderr, status = run_update_shell(
+      <<~SH,
+        source "#{update_script}"
+        curl() { :; }
+        fetch_api_file formula.jws.json "#{update_failed_file}"
+      SH
+      {
+        "HOMEBREW_API_DEFAULT_DOMAIN" => "https://formulae.example/api",
+        "HOMEBREW_API_DOMAIN"         => nil,
+        "HOMEBREW_CACHE"              => (test_root/"cache").to_s,
+        "HOMEBREW_CURL_SPEED_LIMIT"   => "100",
+        "HOMEBREW_CURL_SPEED_TIME"    => "5",
+        "HOMEBREW_LIBRARY"            => (test_root/"Library").to_s,
+        "HOMEBREW_USER_AGENT_CURL"    => "Homebrew/test",
+      },
+    )
+
+    expect([
+      status.success?, stderr, cache_path.mtime.to_i, last_checked_path.mtime > response_mtime,
+      update_failed_file.exist?
+    ]).to eq([true, "", response_mtime.to_i, true, false])
   end
 
   it "passes all arguments through to delegated upgrades" do
@@ -142,6 +178,56 @@ RSpec.describe Homebrew::Cmd::Update do
     expect(status.success?).to be true
     expect(stderr).to be_empty
     expect(args_file.read).to eq("update-report\n--auto-update\n")
+  end
+
+  it "removes obsolete API files and their last-checked sidecars" do
+    api_cache = test_root/"cache/api"
+    obsolete_api_files = %w[
+      formula.jws.json
+      cask.jws.json
+      formula_tap_migrations.jws.json
+      cask_tap_migrations.jws.json
+    ].flat_map { |name| [api_cache/name, api_cache/"#{name}.last_checked"] }
+    setup_update_utils
+    (test_root/"repository").mkpath
+    obsolete_api_files.each do |path|
+      path.dirname.mkpath
+      FileUtils.touch path
+    end
+
+    _stdout, stderr, status = run_update_shell(
+      <<~SH,
+        source "#{update_script}"
+        bottle_tag() { echo test; }
+        brew() { :; }
+        fetch_api_file() { :; }
+        git_init_if_necessary() { :; }
+        git() {
+          [[ "$1" == "--version" ]] && return 0
+          return 1
+        }
+        lock() { :; }
+        odie() { echo "Error: $*" >&2; exit 1; }
+        ohai() { :; }
+        onoe() { echo "Error: $*" >&2; }
+        safe_cd() { cd "$1" >/dev/null || exit 1; }
+        setup_ca_certificates() { :; }
+        setup_curl() { :; }
+        setup_git() { :; }
+        homebrew-update --auto-update
+      SH
+      {
+        "HOMEBREW_CACHE"      => (test_root/"cache").to_s,
+        "HOMEBREW_CELLAR"     => (test_root/"cellar").to_s,
+        "HOMEBREW_LIBRARY"    => (test_root/"Library").to_s,
+        "HOMEBREW_PREFIX"     => (test_root/"prefix").to_s,
+        "HOMEBREW_REPOSITORY" => (test_root/"repository").to_s,
+      },
+    )
+
+    expect([status.success?, stderr, obsolete_api_files.map(&:exist?)]).to eq(
+      [true, "", Array.new(obsolete_api_files.length, false)],
+    )
   end
 
   it "does not query redirected remote metadata for no-op tap updates" do

--- a/Library/Homebrew/test/retryable_download_spec.rb
+++ b/Library/Homebrew/test/retryable_download_spec.rb
@@ -1,0 +1,20 @@
+# typed: true
+# frozen_string_literal: true
+
+require "retryable_download"
+
+RSpec.describe Homebrew::RetryableDownload do
+  it "preserves the response mtime for API JSON downloads" do
+    target = mktmpdir/"api.json"
+    response_mtime = Time.now - 3600
+    target.write "{}"
+    FileUtils.touch(target, mtime: response_mtime)
+
+    download = Homebrew::API::JSONDownload.new("api.json", target:, stale_seconds: 3600)
+    allow(download).to receive(:fetch).and_return(target)
+
+    described_class.new(download, tries: 1).fetch(quiet: true)
+
+    expect(target.mtime.to_i).to eq(response_mtime.to_i)
+  end
+end

--- a/Library/Homebrew/utils/api.sh
+++ b/Library/Homebrew/utils/api.sh
@@ -28,7 +28,8 @@ api_curlrc_args() {
 api_time_cond_args() {
   local cache_path="$1"
 
-  if [[ -s "${cache_path}" ]]
+  # Keep in sync with `Homebrew::API.fetch_json_api_file` in `api.rb`.
+  if [[ -s "${cache_path}" ]] && [[ -f "${cache_path}.last_checked" ]]
   then
     echo "--time-cond"
     echo "${cache_path}"


### PR DESCRIPTION
Each API cache file’s mtime was doing two incompatible jobs: it was both the `--time-cond` validator and the local freshness timestamp. The post-success `touch` overwrote curl’s server-supplied `--remote-time` timestamp with the client’s clock. If that clock was ahead by more than the interval between checks, each 304 advanced the validator again before a new server timestamp could exceed it, leaving newer API data invisible even with a healthy origin. Reported in https://github.com/orgs/Homebrew/discussions/6997.

The response file now keeps curl's `--remote-time` mtime so `--time-cond` describes the cached response, and an empty `<cache>.last_checked` sidecar records the last successful validation and drives `skip_download?`. Caches from older versions have no sidecar and take one unconditional download to migrate. Failed downloads do not refresh the sidecar and stay retryable, insecure downloads stay unconditional with the sidecar pinned to 1970, and the Ruby and Bash paths implement the same rules.

`RetryableDownload` was also stamping `Time.now` on the response file after every queued API JSON download, which is how `internal/packages.<tag>.jws.json` is refreshed on most commands, so that is removed. `executables.txt` now rebuilds off the sidecar instead of the response mtime, which is no longer on the same clock as its own. `brew cleanup --scrub` and `brew update` prune the new sidecars alongside the files they belong to, including the obsolete top-level API bodies. This overlaps #23486’s ETag change to the Bash update path, but applies the separation across both Bash and Ruby.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the fix and pass with it, and ran `brew lgtm` + targeted specs.

-----
