### PR TITLE
Report skipped dependent upgrades

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -636,7 +636,8 @@ module Homebrew
 
         formula_version_changes = formula_upgrade_descriptions(context.formulae_installer.map(&:formula),
                                                                include_sizes: dry_run)
-        dependent_version_changes = formula_upgrade_descriptions(context.dependants.upgradeable,
+        dependent_formulae = context.dependants.upgradeable.dup
+        dependent_version_changes = formula_upgrade_descriptions(dependent_formulae,
                                                                  include_sizes: dry_run)
         if dry_run
           record_formula_upgrade_summary(context,
@@ -663,7 +664,7 @@ module Homebrew
           skip_formula_names:,
         )
 
-        Upgrade.upgrade_dependents(
+        upgraded_dependent_formulae = Upgrade.upgrade_dependents(
           context.dependants, context.formulae_to_install,
           flags:                      args.flags_only,
           dry_run:,
@@ -680,17 +681,18 @@ module Homebrew
         )
 
         unless dry_run
-          upgraded_formula_installers_by_identity = T.let({}.compare_by_identity,
-                                                          T::Hash[FormulaInstaller, T::Boolean])
-          upgraded_formula_installers.each do |formula_installer|
-            upgraded_formula_installers_by_identity[formula_installer] = true
+          upgraded_formulae_by_identity = T.let({}.compare_by_identity, T::Hash[Formula, T::Boolean])
+          (upgraded_formula_installers.map(&:formula) + upgraded_dependent_formulae).each do |formula|
+            upgraded_formulae_by_identity[formula] = true
           end
+          planned_formulae = context.formulae_installer.map(&:formula) + dependent_formulae
+          version_changes = formula_version_changes + dependent_version_changes
           record_formula_upgrade_summary(
             context,
             formulae_installer: upgraded_formula_installers,
-            version_changes:    context.formulae_installer.each_with_index.filter_map do |formula_installer, index|
-              formula_version_changes.fetch(index) if upgraded_formula_installers_by_identity.key?(formula_installer)
-            end + dependent_version_changes,
+            version_changes:    planned_formulae.each_with_index.filter_map do |formula, index|
+              version_changes.fetch(index) if upgraded_formulae_by_identity.key?(formula)
+            end,
           )
         end
 

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -687,6 +687,25 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     end
   end
 
+  it "does not claim to upgrade dependents whose runtime dependencies are satisfied" do
+    formula = formula("sqlite") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/sqlite-3.53.2.tar.gz"
+    end
+    dependent = formula("python@3.14") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/python@3.14-3.14.5.tar.gz"
+    end
+    dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [dependent], pinned: [], skipped: [])
+
+    allow(Homebrew::Upgrade).to receive(:formula_installers).and_return([])
+    allow(FormulaInstaller).to receive(:installed).and_return([])
+
+    expect do
+      Homebrew::Upgrade.upgrade_dependents(dependants, [formula], flags: [])
+    end.not_to output(/Upgrading.*python@3\.14/m).to_stdout
+  end
+
   it "does not print aggregate package sizes" do
     cmd = described_class.new(["--dry-run"])
     summary = Homebrew::Cmd::UpgradeCmd::FinalUpgradeSummary.new(
@@ -1200,7 +1219,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       allow(formula).to receive(:opt_prefix).and_return(new_keg)
       [formula_installer]
     end
-    allow(Homebrew::Upgrade).to receive(:upgrade_dependents)
+    allow(Homebrew::Upgrade).to receive(:upgrade_dependents).and_return([])
 
     cmd.upgrade_outdated_formulae!([])
 
@@ -1234,8 +1253,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
         dependants:          Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: []),
       ),
     )
-    allow(Homebrew::Upgrade).to receive(:upgrade_formulae).and_return([successful_formula_installer])
-    allow(Homebrew::Upgrade).to receive(:upgrade_dependents)
+    allow(Homebrew::Upgrade).to receive_messages(upgrade_formulae:   [successful_formula_installer],
+                                                 upgrade_dependents: [])
 
     cmd.upgrade_outdated_formulae!([])
 
@@ -1243,6 +1262,51 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       version_changes: contain_exactly("testball 0.1 -> 0.2"),
       deprecated:      contain_exactly("failball"),
     )
+  end
+
+  it "reports only successful dependent version changes in the final summary" do
+    formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/testball-0.2"
+    end
+    upgraded_dependent = formula("upgraded-dependent") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/upgraded-dependent-0.2"
+    end
+    skipped_dependent = formula("skipped-dependent") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/skipped-dependent-0.2"
+    end
+    formula_installer = FormulaInstaller.new(formula)
+    old_formula_keg = HOMEBREW_CELLAR/"testball/0.1"
+    old_upgraded_dependent_keg = HOMEBREW_CELLAR/"upgraded-dependent/0.1"
+    old_skipped_dependent_keg = HOMEBREW_CELLAR/"skipped-dependent/0.1"
+    old_formula_keg.mkpath
+    old_upgraded_dependent_keg.mkpath
+    old_skipped_dependent_keg.mkpath
+    allow(formula).to receive_messages(optlinked?: true, opt_prefix: old_formula_keg)
+    allow(upgraded_dependent).to receive_messages(optlinked?: true, opt_prefix: old_upgraded_dependent_keg)
+    allow(skipped_dependent).to receive_messages(optlinked?: true, opt_prefix: old_skipped_dependent_keg)
+    cmd = described_class.new([])
+
+    allow(cmd).to receive(:formulae_upgrade_context).and_return(
+      Homebrew::Cmd::UpgradeCmd::FormulaeUpgradeContext.new(
+        formulae_to_install: [formula],
+        formulae_installer:  [formula_installer],
+        dependants:          Homebrew::Upgrade::Dependents.new(
+          upgradeable: [upgraded_dependent, skipped_dependent], pinned: [], skipped: [],
+        ),
+      ),
+    )
+    allow(Homebrew::Upgrade).to receive_messages(
+      upgrade_formulae:   [formula_installer],
+      upgrade_dependents: [upgraded_dependent],
+    )
+
+    cmd.upgrade_outdated_formulae!([])
+
+    expect(cmd.final_upgrade_summary.version_changes)
+      .to contain_exactly("testball 0.1 -> 0.2", "upgraded-dependent 0.1 -> 0.2")
   end
 
   it_behaves_like "reinstall_pkgconf_if_needed"

--- a/Library/Homebrew/test/upgrade_spec.rb
+++ b/Library/Homebrew/test/upgrade_spec.rb
@@ -70,4 +70,56 @@ RSpec.describe Homebrew::Upgrade do
         .to output(/Would upgrade.*python@3.14 3.7.1 -> 3.14.6/m).to_stdout
     end
   end
+
+  describe "::formula_installers" do
+    it "explains when installed dependencies satisfy the bottle metadata" do
+      dependent = formula("dependent") do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/dependent-2.0"
+      end
+      formula_installer = instance_double(
+        FormulaInstaller,
+        bottle_tab_runtime_dependencies: { "dependency" => { "version" => "2.0", "revision" => "0" } },
+        determine_bottle_tab_attributes: nil,
+        fetch_bottle_tab:                nil,
+        formula:                         dependent,
+      )
+      dependency = instance_double(Dependency)
+      download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil)
+
+      allow(Migrator).to receive(:migrate_if_needed)
+      allow(described_class).to receive(:create_formula_installer).and_return(formula_installer)
+      allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
+      allow(Dependency).to receive(:new).with("dependency").and_return(dependency)
+      allow(dependency).to receive(:installed?)
+        .with(minimum_version: Version.new("2.0"), minimum_revision: 0)
+        .and_return(true)
+
+      expect do
+        described_class.formula_installers([dependent], flags: [], dependents: true)
+      end.to output(
+        "==> Not upgrading dependent: installed runtime dependencies satisfy bottle metadata\n",
+      ).to_stdout
+    end
+  end
+
+  describe "::upgrade_dependents" do
+    it "returns installed dependents unless they are primary formulae" do
+      installed_dependent = formula("installed-dependent") do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/installed-dependent-2.0"
+      end
+      primary_formula = formula("primary") do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/primary-2.0"
+      end
+      FormulaInstaller.installed.merge([installed_dependent, primary_formula])
+      dependants = Homebrew::Upgrade::Dependents.new(
+        upgradeable: [installed_dependent, primary_formula], pinned: [], skipped: [],
+      )
+
+      expect(described_class.upgrade_dependents(dependants, [primary_formula], flags: []))
+        .to contain_exactly(installed_dependent)
+    end
+  end
 end

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -152,8 +152,8 @@ module Homebrew
             end
 
             if all_runtime_deps_installed
-              # Don't need to install this bottle if all of the runtime
-              # dependencies have the same or newer version already installed.
+              ohai "Not upgrading #{fi.formula.full_specified_name}: " \
+                   "installed runtime dependencies satisfy bottle metadata"
               next
             end
           end
@@ -278,7 +278,7 @@ module Homebrew
                dry_run: T::Boolean, installed_on_request: T::Boolean, force_bottle: T::Boolean,
                build_from_source_formulae: T::Array[String], interactive: T::Boolean, keep_tmp: T::Boolean,
                debug_symbols: T::Boolean, force: T::Boolean, debug: T::Boolean, quiet: T::Boolean,
-               verbose: T::Boolean, skip_formula_names: T::Array[String]).void
+               verbose: T::Boolean, skip_formula_names: T::Array[String]).returns(T::Array[Formula])
       }
       def upgrade_dependents(deps, formulae,
                              flags:,
@@ -294,7 +294,7 @@ module Homebrew
                              quiet: false,
                              verbose: false,
                              skip_formula_names: [])
-        return if deps.blank?
+        return [] if deps.blank?
 
         upgradeable = deps.upgradeable
         pinned      = deps.pinned
@@ -314,8 +314,38 @@ module Homebrew
           EOS
         end
 
+        installed_formulae = FormulaInstaller.installed
+        upgraded_formulae = T.let([], T::Array[Formula])
+        unless dry_run
+          primary_formula_names = formulae.map(&:full_name)
+          upgraded_formulae.concat(upgradeable.select do |f|
+            installed_formulae.include?(f) && primary_formula_names.exclude?(f.full_name)
+          end)
+        end
+
         upgradeable.reject! do |f|
-          FormulaInstaller.installed.include?(f) || (dry_run && skip_formula_names.include?(f.full_name))
+          installed_formulae.include?(f) || (dry_run && skip_formula_names.include?(f.full_name))
+        end
+
+        return upgraded_formulae if upgradeable.blank?
+
+        dependent_installers = T.let([], T::Array[FormulaInstaller])
+        unless dry_run
+          dependent_installers = formula_installers(
+            upgradeable.dup,
+            flags:,
+            force_bottle:,
+            build_from_source_formulae:,
+            dependents:                 true,
+            interactive:,
+            keep_tmp:,
+            debug_symbols:,
+            force:,
+            debug:,
+            quiet:,
+            verbose:,
+          )
+          upgradeable = dependent_installers.map(&:formula)
         end
 
         # Print the upgradable dependents.
@@ -337,30 +367,12 @@ module Homebrew
           puts format_upgrade_summary(formulae_upgrades).join("\n")
         end
 
-        return if upgradeable.blank?
-
-        unless dry_run
-          dependent_installers = formula_installers(
-            upgradeable,
-            flags:,
-            force_bottle:,
-            build_from_source_formulae:,
-            dependents:                 true,
-            interactive:,
-            keep_tmp:,
-            debug_symbols:,
-            force:,
-            debug:,
-            quiet:,
-            verbose:,
-          )
-          upgrade_formulae(dependent_installers, dry_run:, verbose:)
-        end
+        upgraded_formulae.concat(upgrade_formulae(dependent_installers, verbose:).map(&:formula)) unless dry_run
 
         # Update non-core installed formulae for linkage checks after upgrading
         # Don't need to check core formulae because we do so at CI time.
         installed_non_core_formulae = FormulaInstaller.installed.to_a.reject(&:core_formula?)
-        return if installed_non_core_formulae.blank?
+        return upgraded_formulae if installed_non_core_formulae.blank?
 
         # Assess the dependents tree again now we've upgraded.
         unless dry_run
@@ -376,7 +388,7 @@ module Homebrew
           else
             ohai "No broken dependents found!"
           end
-          return
+          return upgraded_formulae
         end
 
         reinstallable_broken_dependents =
@@ -409,7 +421,7 @@ module Homebrew
                                               .join(", ")
         end
 
-        return if dry_run
+        return upgraded_formulae if dry_run
 
         reinstall_contexts = reinstallable_broken_dependents.map do |formula|
           Reinstall.build_install_context(
@@ -444,6 +456,7 @@ module Homebrew
           puts
           Homebrew.failed = true
         end
+        upgraded_formulae
       end
 
       sig {


### PR DESCRIPTION
`brew upgrade` discovers outdated reverse dependants before it upgrades formulae named on the command line. This candidate list is also needed for the confirmation prompt.

After named formulae finish, Homebrew checks the latest bottle metadata for each candidate. If installed runtime dependencies satisfy it, the automatic dependant upgrade is unnecessary and its installer is discarded. The ask preview cannot know the exact result because named upgrades may fail and installed state has not changed yet.

The execution heading and final summary used the earlier candidate list. They therefore claimed a filtered dependant was upgraded, although its installed version remained unchanged.

- Print the execution heading only after filtering installers.
- Return only successfully upgraded dependants for the final summary.
- Explain briefly when an unrequested dependant is not required.
- Cover filtered and successful dependants with regression tests.

Fixes #23483

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
