### PR TITLE
Use cask dependencies for platform support

### DIFF
--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -59,7 +59,8 @@ module Cask
         .returns(Pathname)
     }
     def fetch(quiet: nil, verify_download_integrity: true, timeout: nil)
-      verify_has_sha if @require_sha
+      verify_has_sha if @require_sha ||
+                        (@cask.sha256.nil? && (@cask.on_system_blocks_exist? || @cask.loaded_from_api?))
       downloader.quiet! if quiet
 
       begin
@@ -233,7 +234,14 @@ module Cask
 
     sig { void }
     def verify_has_sha
-      return if @cask.sha256 != :no_check
+      return if @cask.sha256.is_a?(Checksum)
+
+      unless @require_sha
+        raise CaskError, <<~EOS
+          Cask '#{@cask}' does not have a sha256 checksum defined for this platform.
+          Add an appropriate `depends_on` stanza if the cask does not support this platform.
+        EOS
+      end
 
       raise CaskError, <<~EOS
         Cask '#{@cask}' does not have a sha256 checksum defined.

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -562,21 +562,6 @@ module Cask
         when String
           Checksum.new(val)
         when nil
-          # Checksums declared for only the other OS mean no checksum for the
-          # running OS, matching `sha256` inside an `on_macos`/`on_linux` block;
-          # `depends_on` governs whether the cask is usable there. A checksum
-          # declared for the running OS but missing the running architecture
-          # still raises on the real system but is nil under simulation so
-          # API variations can be generated for the missing architecture.
-          running_os_checksums = if OnSystem.os_condition_met?(:linux)
-            [x86_64_linux, arm64_linux]
-          else
-            [arm, x86_64]
-          end
-          if running_os_checksums.any?(&:present?) && !Homebrew::SimulateSystem.simulating?
-            raise CaskInvalidError.new(cask, "invalid 'sha256' value: nil")
-          end
-
           nil
         else
           raise CaskInvalidError.new(cask, "invalid 'sha256' value: #{val.inspect}")

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -293,6 +293,9 @@ module Homebrew
         generate_system_options(cask, new_version).each do |os, arch|
           tag = Utils::Bottles::Tag.new(system: os, arch:)
           old_cask.refresh_for_tag(tag) do
+            next if tag.macos? && !old_cask.supports_macos?
+            next if tag.linux? && !old_cask.supports_linux?
+
             # Skip archs excluded by the cask's `depends_on arch:`.
             reloaded_archs = old_cask.depends_on.arch&.filter_map { |a| a[:type] }&.uniq
             next if reloaded_archs.present? && reloaded_archs.exclude?(arch)
@@ -317,6 +320,11 @@ module Homebrew
             tmp_cask = Cask::CaskLoader::FromContentLoader.new(contents)
                                                           .load(config: nil)
             old_hash = tmp_cask.sha256
+            if old_hash.nil?
+              raise Cask::CaskError, "#{cask}: No checksum is defined for #{tag.to_sym.inspect}. " \
+                                     "Add `depends_on arch:` or an operating system `depends_on` to " \
+                                     "declare unsupported platforms."
+            end
             next if new_hash.is_a?(String) && old_hash.to_s == new_hash
 
             checksum_scope = cask_stanza_scope(contents, :sha256, arch)

--- a/Library/Homebrew/test/cask/download_spec.rb
+++ b/Library/Homebrew/test/cask/download_spec.rb
@@ -55,6 +55,28 @@ RSpec.describe Cask::Download, :cask do
       expect(download).not_to receive(:downloader)
       expect { download.fetch }.to raise_error(/--require-sha/)
     end
+
+    it "fails before downloading if sha256 is nil with --require-sha" do
+      missing_checksum = Cask::CaskLoader.load(cask_path("missing-checksum"))
+      download = described_class.new(missing_checksum, require_sha: true)
+      allow(download).to receive(:downloader) { raise "download attempted" }
+
+      expect { download.fetch }.to raise_error(Cask::CaskError, /--require-sha/)
+    end
+
+    it "fails before downloading if a platform checksum is missing" do
+      Homebrew::SimulateSystem.with(os: :macos, arch: :intel) do
+        cask = Cask::Cask.new("missing-platform-checksum") do
+          version "1.2.3"
+          sha256 arm: "0000000000000000000000000000000000000000000000000000000000000000"
+          url "https://brew.sh/example.zip"
+        end
+        download = described_class.new(cask)
+        allow(download).to receive(:downloader) { raise "download attempted" }
+
+        expect { download.fetch }.to raise_error(Cask::CaskError, /`depends_on`/)
+      end
+    end
   end
 
   describe "#stage_from_download_queue?" do

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -195,15 +195,16 @@ RSpec.describe Cask::DSL, :cask, :no_api do
         end
       end
 
-      it "raises on the real system when the running-architecture checksum is missing" do
+      it "loads the architecture requirement when the running-architecture checksum is missing" do
         allow(Homebrew::SimulateSystem).to receive(:simulating?).and_return(false)
 
         Homebrew::SimulateSystem.with(os: :linux, arch: :intel) do
-          expect do
-            Cask::Cask.new("checksum-cask") do
-              sha256 arm64_linux: "imasha2armlinux", intel: "imasha2intel"
-            end
-          end.to raise_error(Cask::CaskInvalidError, /invalid 'sha256' value/)
+          cask = Cask::Cask.new("checksum-cask") do
+            sha256 arm64_linux: "imasha2armlinux", intel: "imasha2intel"
+            depends_on arch: :arm64
+          end
+
+          expect([cask.sha256, cask.depends_on.arch]).to eq([nil, [{ type: :arm, bits: 64 }]])
         end
       end
     end

--- a/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
@@ -350,6 +350,7 @@ RSpec.describe Homebrew::DevCmd::BumpCaskPr do
 
           url "https://brew.sh/foo-\#{arch}-\#{version}.dmg"
           name "Foo"
+          depends_on :macos
         end
       RUBY
       cask = Homebrew::SimulateSystem.with(os: newest_macos, arch: :arm) { cask_from_contents(contents) }
@@ -371,6 +372,7 @@ RSpec.describe Homebrew::DevCmd::BumpCaskPr do
 
             url "https://brew.sh/foo-\#{arch}-\#{version}.dmg"
             name "Foo"
+            depends_on :macos
           end
         RUBY
     end
@@ -519,6 +521,37 @@ RSpec.describe Homebrew::DevCmd::BumpCaskPr do
           name "Foo"
         end
       RUBY
+    end
+
+    it "requires depends_on arch when a checksum is missing" do
+      contents = <<~RUBY
+        cask "foo" do
+          arch arm: "arm64", intel: "x64"
+          os macos: "macos", linux: "linux"
+
+          version "1.0"
+          sha256 arm:          "#{old_hash}",
+                 arm64_linux:  "#{new_hash}",
+                 x86_64_linux: "#{intel_hash}"
+
+          url "https://brew.sh/foo-\#{os}-\#{arch}-\#{version}.zip"
+          name "Foo"
+
+          on_macos do
+            app "Foo.app"
+          end
+          on_linux do
+            binary "foo"
+          end
+        end
+      RUBY
+      cask = cask_from_contents(contents)
+      new_version = Homebrew::BumpVersionParser.new(general: "2.0")
+      allow(Cask::Download).to receive(:new) { raise "download attempted" }
+
+      expect do
+        bump_cask_pr.replace_version_and_checksum(cask, nil, new_version, contents)
+      end.to raise_error(Cask::CaskError, /No checksum.*`depends_on arch:`/)
     end
 
     it "leaves nested architecture stanzas unchanged when matching values could be replaced globally" do


### PR DESCRIPTION
- Keep `sha256` responsible only for selecting a checksum.
- Use OS and architecture `depends_on` declarations as the source of truth for supported platforms.
- Reject missing checksums before `bump-cask-pr` attempts a download.

Fixes #23494

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
