### PR TITLE
Report unavailable cask platforms accurately

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -62,9 +62,13 @@ module Cask
             next false
           end
 
-          if cask.outdated?(greedy: true)
+          version = cask.version
+          if version.nil?
+            opoo "Not upgrading #{cask.token}, no version is available for the current platform" unless quiet
+            false
+          elsif cask.outdated?(greedy: true)
             true
-          elsif cask.version&.latest?
+          elsif version.latest?
             opoo "Not upgrading #{cask.token}, the downloaded artifact has not changed" unless quiet
             false
           else

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Cask::Upgrade, :cask do
     allow(Homebrew::EnvConfig).to receive(:upgrade_auto_updates_casks?).and_return(true)
   end
 
-  it "excludes casks with no version for the current OS" do
+  it "warns and excludes casks with no version for the current platform" do
     cask = Homebrew::SimulateSystem.with(os: :linux) do
       Cask::Cask.new("macos-only") do
         on_macos do
@@ -56,7 +56,9 @@ RSpec.describe Cask::Upgrade, :cask do
       end
     end
 
-    expect(described_class.outdated_casks([cask], args:, force: true, quiet: true)).to be_empty
+    expect do
+      expect(described_class.outdated_casks([cask], args:, force: true, quiet: false)).to be_empty
+    end.to output(/Not upgrading macos-only, no version is available for the current platform/).to_stderr
   end
 
   context "when the upgrade is a dry run" do


### PR DESCRIPTION
- `outdated_casks` treated a missing `version` as non-latest but then reported that the latest version was already installed.
- Handle the missing version explicitly and reuse the narrowed value so non-quiet output identifies the unavailable current platform.
- Strengthen the regression coverage for the warning path.

Follow-up based on https://github.com/Homebrew/brew/pull/23499#discussion_r3760794177

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex Sol 5.6 xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
