### PR TITLE
Publish multi-platform long runner image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -425,6 +425,7 @@ jobs:
       - name: Generate AWS image name
         id: aws_image
         env:
+          ARCH: ${{ matrix.arch }}
           AWS_REGISTRY: ${{ steps.aws_registry_login.outputs.registry }}
           LONG_RUNNER_IMAGE_DIGEST: ${{ steps.runner_build.outputs.digest }}
         run: |
@@ -434,7 +435,7 @@ jobs:
             exit 1
           }
           echo "image=${AWS_REGISTRY}/runner-ecr:${digest_without_prefix}-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
-          echo "image_latest=${AWS_REGISTRY}/runner-ecr:latest" >> "$GITHUB_OUTPUT"
+          echo "image_arch=${AWS_REGISTRY}/runner-ecr:${GITHUB_SHA}-${ARCH}" >> "$GITHUB_OUTPUT"
 
       - name: Push image to AWS Elastic Container Registry
         if: fromJSON(steps.attributes.outputs.push)
@@ -447,4 +448,37 @@ jobs:
           push: true
           tags: |
             ${{ steps.aws_image.outputs.image }}
-            ${{ steps.aws_image.outputs.image_latest }}
+            ${{ steps.aws_image.outputs.image_arch }}
+
+  publish-long-runner-manifest:
+    name: Publish multi-platform runner Docker image
+    needs: [generate-tags, build-and-publish-long-runner]
+    if: github.repository_owner == 'Homebrew' && fromJSON(needs.generate-tags.outputs.push)['24.04']
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_PROJECT_ID }}:role/GithubActionsRoleECRPushBrew
+          aws-region: us-east-1
+
+      - name: AWS Elastic Container Registry Login
+        id: aws_registry_login
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Publish multi-platform manifest
+        env:
+          AWS_REGISTRY: ${{ steps.aws_registry_login.outputs.registry }}
+        run: |
+          image="${AWS_REGISTRY}/runner-ecr"
+          docker buildx imagetools create \
+            --tag "${image}:latest" \
+            "${image}:${GITHUB_SHA}-x86_64" \
+            "${image}:${GITHUB_SHA}-arm64"
+          docker buildx imagetools inspect "${image}:latest"


### PR DESCRIPTION
## What changed

Each long runner architecture now publishes under a commit-specific staging tag
(`<sha>-x86_64` and `<sha>-arm64`) instead of pushing `latest` directly. A
dependent job then creates `runner-ecr:latest` as a multi-platform manifest
containing both images.

The manifest job runs only for publishable 24.04 builds, and inspects the
resulting image after publishing it.

## Why

The architecture matrix previously pushed `runner-ecr:latest` independently from
both jobs. Each push contained only that job's platform, so whichever job
finished last replaced `latest` with a single-platform image. That is why the
arm64 image is missing from `latest` today.

Waiting for both architectures and publishing a single manifest preserves both
under `latest` and removes the race.

## Scope

An earlier revision of this PR also consolidated the long runner build into the
`build` matrix job. Following review that has been dropped, so this change is
just the multi-platform fix and the image is still copied between jobs as
before. The consolidation can be revisited separately, with the ECR push kept in
its own job so `id-token: write` stays off the build matrix.

## Reproduction

This bug is in the GitHub Actions ECR publishing workflow, so there is no local
`brew` command that reproduces it. On a publishable Docker workflow run, both
the amd64 and arm64 jobs targeted the same `runner-ecr:latest` tag
independently; inspecting that tag after the run shows only the platform from
the last push.

## Validation

- `./bin/brew style .github/workflows/docker.yml`
- `actionlint` and `zizmor` via the `workflow_syntax` job.
- Full CI is green on this commit.
- The manifest job runs `docker buildx imagetools inspect` on the tag it
  creates.

Note that every push-gated step is false on a pull request, so CI here exercises
the build path only. The ECR login and manifest creation cannot run until this
is merged.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

The reproduction checkbox is not applicable to this GitHub Actions deployment bug. No Ruby unit test was added for this workflow-only change; actionlint validates the workflow and the manifest job verifies the resulting image.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

OpenAI Codex (GPT-5.6 Sol) and Claude Opus 5 (via Claude Code) were used to audit the workflow, draft the change, and draft this PR description. I reviewed the output and the change passed the validation listed above.

-----
