### PR TITLE
bump: retry, then skip packages on transient GitHub API errors

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -26,7 +26,7 @@ module Homebrew
         retries:         0,
       }.freeze, T::Hash[Symbol, T.untyped])
       MAX_CONSECUTIVE_GITHUB_API_ERRORS = 5
-      GITHUB_API_ERROR_RETRY_SLEEP = 5
+      MAX_GITHUB_API_RETRIES = 3
       PYPI_UNSTABLE_VERSION_REGEX = /^(?:\d+!)?\d+(?:\.\d+)*(?:a|b|rc)\d+|\.dev\d+$/i
 
       LIVECHECK_MESSAGE_REGEX = /^(?:error:|skipped|unable to get(?: throttled)? versions)/i
@@ -866,7 +866,7 @@ module Homebrew
 
           package_data = Repology.single_package_query(name, repository:) unless skip_repology?(formula_or_cask)
 
-          retried = T.let(false, T::Boolean)
+          github_api_retries = 0
           begin
             retrieve_and_display_info_and_open_pr(
               formula_or_cask,
@@ -875,14 +875,20 @@ module Homebrew
               ambiguous_cask: ambiguous_casks.include?(formula_or_cask),
             )
             consecutive_github_api_errors = 0
-          rescue GitHub::API::RateLimitExceededError, GitHub::API::AuthenticationFailedError
-            # Retrying these for the remaining packages cannot succeed, so stop now.
+          rescue GitHub::API::RateLimitExceededError => e
+            sleep_seconds = [e.reset - Time.now.to_i, 1].max
+            opoo "GitHub rate limit exceeded, sleeping for #{sleep_seconds} seconds..."
+            sleep sleep_seconds
+            retry
+          rescue GitHub::API::AuthenticationFailedError
+            # Retrying this for the remaining packages cannot succeed, so stop now.
             raise
           rescue GitHub::API::Error => e
-            unless retried
-              retried = true
-              onoe "#{name}: retrying after a GitHub API error: #{e}"
-              sleep GITHUB_API_ERROR_RETRY_SLEEP
+            github_api_retries += 1
+            if github_api_retries <= MAX_GITHUB_API_RETRIES
+              wait = 2 ** github_api_retries
+              onoe "#{name}: retrying in #{wait}s after a GitHub API error: #{e}"
+              sleep wait
               retry
             end
 

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -876,9 +876,7 @@ module Homebrew
             )
             consecutive_github_api_errors = 0
           rescue GitHub::API::RateLimitExceededError => e
-            sleep_seconds = [e.reset - Time.now.to_i, 1].max
-            opoo "GitHub rate limit exceeded, sleeping for #{sleep_seconds} seconds..."
-            sleep sleep_seconds
+            GitHub::API.sleep_for_rate_limit(e)
             retry
           rescue GitHub::API::AuthenticationFailedError
             # Retrying this for the remaining packages cannot succeed, so stop now.
@@ -886,9 +884,9 @@ module Homebrew
           rescue GitHub::API::Error => e
             github_api_retries += 1
             if github_api_retries <= MAX_GITHUB_API_RETRIES
-              wait = 2 ** github_api_retries
-              onoe "#{name}: retrying in #{wait}s after a GitHub API error: #{e}"
-              sleep wait
+              Utils.exponential_backoff_sleep(github_api_retries) do |wait|
+                onoe "#{name}: retrying in #{wait}s after a GitHub API error: #{e}"
+              end
               retry
             end
 

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -25,6 +25,8 @@ module Homebrew
         timeout:         60,
         retries:         0,
       }.freeze, T::Hash[Symbol, T.untyped])
+      MAX_CONSECUTIVE_GITHUB_API_ERRORS = 5
+      GITHUB_API_ERROR_RETRY_SLEEP = 5
       PYPI_UNSTABLE_VERSION_REGEX = /^(?:\d+!)?\d+(?:\.\d+)*(?:a|b|rc)\d+|\.dev\d+$/i
 
       LIVECHECK_MESSAGE_REGEX = /^(?:error:|skipped|unable to get(?: throttled)? versions)/i
@@ -849,6 +851,7 @@ module Homebrew
                             .flatten
         end
 
+        consecutive_github_api_errors = 0
         formulae_and_casks.each_with_index do |formula_or_cask, i|
           puts if i.positive?
           next if skip_ineligible_formulae!(formula_or_cask)
@@ -863,12 +866,33 @@ module Homebrew
 
           package_data = Repology.single_package_query(name, repository:) unless skip_repology?(formula_or_cask)
 
-          retrieve_and_display_info_and_open_pr(
-            formula_or_cask,
-            name,
-            package_data&.values&.first || [],
-            ambiguous_cask: ambiguous_casks.include?(formula_or_cask),
-          )
+          retried = T.let(false, T::Boolean)
+          begin
+            retrieve_and_display_info_and_open_pr(
+              formula_or_cask,
+              name,
+              package_data&.values&.first || [],
+              ambiguous_cask: ambiguous_casks.include?(formula_or_cask),
+            )
+            consecutive_github_api_errors = 0
+          rescue GitHub::API::RateLimitExceededError, GitHub::API::AuthenticationFailedError
+            # Retrying these for the remaining packages cannot succeed, so stop now.
+            raise
+          rescue GitHub::API::Error => e
+            unless retried
+              retried = true
+              onoe "#{name}: retrying after a GitHub API error: #{e}"
+              sleep GITHUB_API_ERROR_RETRY_SLEEP
+              retry
+            end
+
+            consecutive_github_api_errors += 1
+            if consecutive_github_api_errors >= MAX_CONSECUTIVE_GITHUB_API_ERRORS
+              odie "Aborting after #{consecutive_github_api_errors} consecutive GitHub API errors: #{e}"
+            end
+
+            onoe "#{name}: skipped after a GitHub API error: #{e}"
+          end
         end
       end
 

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -516,9 +516,7 @@ module Homebrew
         end
         results
       rescue GitHub::API::RateLimitExceededError => e
-        sleep_seconds = [e.reset - Time.now.to_i, 1].max
-        opoo "GitHub rate limit exceeded, sleeping for #{sleep_seconds} seconds..."
-        sleep sleep_seconds
+        GitHub::API.sleep_for_rate_limit(e)
         retry
       end
 

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -366,7 +366,7 @@ class GitHubPackages
       rescue ErrorDuringExecution
         retry_count += 1
         odie "Cannot perform an upload to registry after retrying multiple times!" if retry_count >= 10
-        sleep 2 ** retry_count
+        Utils.exponential_backoff_sleep(retry_count)
         retry
       end
 

--- a/Library/Homebrew/retryable_download.rb
+++ b/Library/Homebrew/retryable_download.rb
@@ -88,12 +88,12 @@ module Homebrew
       tries_remaining = @tries - @try
       raise if tries_remaining.zero?
 
-      wait = 2 ** @try
-      unless quiet
+      Utils.exponential_backoff_sleep(@try) do |wait|
+        next if quiet
+
         what = Utils.pluralize("try", tries_remaining)
         ohai "Retrying download in #{wait}s... (#{tries_remaining} #{what} left)"
       end
-      sleep wait
 
       # Preserve the partial `.incomplete` file on network errors so the next
       # attempt can resume via `--continue-at`. Clear the cache only when the

--- a/Library/Homebrew/test/utils/github/api_spec.rb
+++ b/Library/Homebrew/test/utils/github/api_spec.rb
@@ -1,0 +1,16 @@
+# typed: true
+# frozen_string_literal: true
+
+require "utils/github"
+
+RSpec.describe GitHub::API do
+  describe "::sleep_for_rate_limit" do
+    it "sleeps for at least 1 second even if the rate limit has already reset" do
+      exception = GitHub::API::RateLimitExceededError.new(
+        "API rate limit exceeded", reset: Time.now.to_i - 10, resource: "core", limit: 5000
+      )
+      expect(described_class).to receive(:sleep).with(1)
+      described_class.sleep_for_rate_limit(exception)
+    end
+  end
+end

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -157,6 +157,23 @@ RSpec.describe Utils do
     end
   end
 
+  describe ".exponential_backoff_sleep" do
+    it "sleeps for 2**try seconds" do
+      expect(described_class).to receive(:sleep).with(8)
+      described_class.exponential_backoff_sleep(3)
+    end
+
+    it "sleeps for base**try seconds when a base is given" do
+      expect(described_class).to receive(:sleep).with(27)
+      described_class.exponential_backoff_sleep(3, base: 3)
+    end
+
+    it "yields the wait time before sleeping" do
+      allow(described_class).to receive(:sleep)
+      expect { |block| described_class.exponential_backoff_sleep(2, &block) }.to yield_with_args(4)
+    end
+  end
+
   describe ".underscore" do
     # commented out entries require acronyms inflections
     let(:words) do

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -112,6 +112,15 @@ module Utils
     "#{prefix}#{stem}#{suffix}"
   end
 
+  # Sleeps for an exponentially increasing wait (`base ** try` seconds), yielding
+  # the wait time first so callers can print a message before sleeping.
+  sig { params(try: Integer, base: Integer, _blk: T.nilable(T.proc.params(wait: Integer).void)).void }
+  def self.exponential_backoff_sleep(try, base: 2, &_blk)
+    wait = base.pow(try)
+    yield wait if block_given?
+    sleep wait
+  end
+
   sig { params(author: String).returns({ email: String, name: String }) }
   def self.parse_author!(author)
     match_data = /^(?<name>[^<]+?)[ \t]*<(?<email>[^>]+?)>$/.match(author)

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -169,6 +169,14 @@ module GitHub
       JSON::ParserError,
     ].freeze
 
+    # Sleeps until the rate limit from the given exception has reset.
+    sig { params(exception: RateLimitExceededError).void }
+    def self.sleep_for_rate_limit(exception)
+      sleep_seconds = [exception.reset - Time.now.to_i, 1].max
+      opoo "GitHub rate limit exceeded, sleeping for #{sleep_seconds} seconds..."
+      sleep sleep_seconds
+    end
+
     # Gets the token from the GitHub CLI for github.com.
     sig { returns(T.nilable(String)) }
     def self.github_cli_token


### PR DESCRIPTION
**What**

`brew bump` currently aborts the entire run when a single GitHub API call fails, leaving all remaining packages unprocessed. Since packages are processed in a fixed alphabetical order, packages later in the list are starved whenever errors recur.

**Evidence**

In Homebrew/homebrew-cask, the scheduled autobump workflow died early three times in a row on `curl: (60) SSL certificate problem: self signed certificate` (a transient TLS issue affecting connections to `api.github.com`):

- https://github.com/Homebrew/homebrew-cask/actions/runs/31529589448 (Aug 11 19:47 UTC) — died at ~19% of the cask list
- https://github.com/Homebrew/homebrew-cask/actions/runs/31538866593 (Aug 11 21:39 UTC) — died at ~8%
- https://github.com/Homebrew/homebrew-cask/actions/runs/31551158644 (Aug 12 00:42 UTC) — died at ~8%

Normal runs take 58–103 min and complete the full sweep; these took 6–19 min. Because the `Bump casks` step uses `continue-on-error: true`, all three runs are displayed as "success". Meanwhile, a cask around the 13% mark (`claude`) went unprocessed for hours after its upstream feed was updated.

**How**

- Retry the same package with exponential backoff (2/4/8 seconds, up to 3 retries) via `Utils.exponential_backoff_sleep`.
- If the retries are exhausted, skip the package and continue. The existing duplicate-PR check makes re-processing a package idempotent.
- Abort after 5 consecutive package failures, so a sustained GitHub outage still stops the run quickly instead of uselessly iterating the rest of the list.
- On `RateLimitExceededError`, sleep until the rate limit resets and retry (`GitHub::API.sleep_for_rate_limit`, following the existing pattern in `dev-cmd/contributions.rb`). Re-raise `AuthenticationFailedError` immediately: retrying other packages cannot succeed in that case.

Livecheck errors (upstream/vendor hosts) are already handled per-package by the existing `rescue` in the version-retrieval path; this PR applies the same per-package containment to the GitHub API path.

`brew style`, `brew typecheck` and `brew tests` for `dev-cmd/bump`, `utils` and `utils/github/api` pass locally.

**Notes on the unticked boxes**: the failure is environmental (a transient TLS error during a bulk `brew bump --auto` run) and cannot be reproduced deterministically — see the workflow run links above for real occurrences. The changed code is the interactive run loop; exercising the new error path requires injecting `GitHub::API::Error` mid-iteration, and I am happy to add a spec if you can suggest a preferred seam for stubbing. I ran `brew style`, `brew typecheck` and `brew tests --only=dev-cmd/bump` individually (all pass) rather than the full `brew lgtm`.

-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

This PR was prepared with AI assistance (Claude Code, model Claude Fable 5): the investigation of the failed workflow runs, the initial patch, and this description draft. I reviewed the diff and the description through several revision rounds, the commit is attributed to me, and I will answer questions and review comments myself.

-----

