### PR TITLE
Normalize hyphenated HOMEBREW_CASK_OPTS option names

### DIFF
--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -133,10 +133,9 @@ module Cask
       @zsh_completion = T.let(nil, T.nilable(Pathname))
       @fish_completion = T.let(nil, T.nilable(Pathname))
 
-      if ignore_invalid_keys
-        if (unknown_keys = ((Array(@env&.keys) + @explicit.keys).uniq - self.class.defaults.keys).presence)
-          opoo "Ignoring unknown cask configuration keys: #{unknown_keys.inspect}"
-        end
+      if ignore_invalid_keys &&
+         (unknown_keys = ((Array(@env&.keys) + @explicit.keys).uniq - self.class.defaults.keys).presence)
+        opoo "Ignoring unknown cask configuration keys: #{unknown_keys.inspect}"
 
         @env&.delete_if { |key, _| unknown_keys.include?(key) }
         @explicit.delete_if { |key, _| unknown_keys.include?(key) }

--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -153,7 +153,8 @@ module Cask
           .select { |arg| arg.include?("=") }
           .map { |arg| T.cast(arg.split("=", 2), [String, String]) }
           .to_h do |(flag, value)|
-            key = flag.sub(/^--/, "")
+            # command-line flags are hyphenated (e.g. --input-methoddir) but config keys use underscores
+            key = flag.sub(/^--/, "").tr("-", "_")
             # converts --language flag to :languages config key
             if key == "language"
               key = "languages"

--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -6,12 +6,15 @@ require "json"
 require "lazy_object"
 require "locale"
 require "extend/hash/keys"
+require "utils/output"
 
 module Cask
   # Configuration for installing casks.
   #
   # @api internal
   class Config
+    include ::Utils::Output::Mixin
+
     ConfigHash = T.type_alias { T::Hash[Symbol, T.any(LazyObject, String, Pathname, T::Array[String])] }
     DEFAULT_DIRS = T.let(
       {
@@ -131,8 +134,11 @@ module Cask
       @fish_completion = T.let(nil, T.nilable(Pathname))
 
       if ignore_invalid_keys
-        @env&.delete_if { |key, _| self.class.defaults.keys.exclude?(key) }
-        @explicit.delete_if { |key, _| self.class.defaults.keys.exclude?(key) }
+        unknown_keys = ((@env&.keys || []) + @explicit.keys).uniq - self.class.defaults.keys
+        opoo "Ignoring unknown cask configuration keys: #{unknown_keys.inspect}" unless unknown_keys.empty?
+
+        @env&.delete_if { |key, _| unknown_keys.include?(key) }
+        @explicit.delete_if { |key, _| unknown_keys.include?(key) }
         return
       end
 

--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -134,8 +134,9 @@ module Cask
       @fish_completion = T.let(nil, T.nilable(Pathname))
 
       if ignore_invalid_keys
-        unknown_keys = ((@env&.keys || []) + @explicit.keys).uniq - self.class.defaults.keys
-        opoo "Ignoring unknown cask configuration keys: #{unknown_keys.inspect}" unless unknown_keys.empty?
+        if (unknown_keys = ((Array(@env&.keys) + @explicit.keys).uniq - self.class.defaults.keys).presence)
+          opoo "Ignoring unknown cask configuration keys: #{unknown_keys.inspect}"
+        end
 
         @env&.delete_if { |key, _| unknown_keys.include?(key) }
         @explicit.delete_if { |key, _| unknown_keys.include?(key) }

--- a/Library/Homebrew/cask_artifact.rb
+++ b/Library/Homebrew/cask_artifact.rb
@@ -46,7 +46,7 @@ module Cask
       @staged_path = T.let(Pathname(context.fetch("staged_path")), Pathname)
       @caskroom_path = T.let(Pathname(context.fetch("caskroom_path")), Pathname)
       @home = T.let(Pathname(context.fetch("home")), Pathname)
-      @config = T.let(Config.from_json(context.fetch("config")), Config)
+      @config = T.let(Config.from_json(context.fetch("config"), ignore_invalid_keys: true), Config)
     end
 
     sig { returns(String) }

--- a/Library/Homebrew/test/cask/config_spec.rb
+++ b/Library/Homebrew/test/cask/config_spec.rb
@@ -37,6 +37,22 @@ RSpec.describe Cask::Config, :cask do
       EOS
       expect(config.appdir).to eq(Pathname("/path/to/apps"))
     end
+
+    it "ignores invalid keys when requested" do
+      json = <<~EOS
+        {
+          "default": {},
+          "env": {
+            "appdir": "/path/to/apps",
+            "invaliddir": "/path/to/invalid"
+          },
+          "explicit": {}
+        }
+      EOS
+      config = described_class.from_json(json, ignore_invalid_keys: true)
+
+      expect(config.env).to eq(appdir: Pathname("/path/to/apps"))
+    end
   end
 
   describe "#default" do
@@ -76,6 +92,33 @@ RSpec.describe Cask::Config, :cask do
       ENV["HOMEBREW_CASK_OPTS"] = "--appdir=/path/to/apps"
 
       expect(config.env).to eq(appdir: Pathname("/path/to/apps"))
+    end
+
+    it "normalizes hyphenated option names to underscored keys" do
+      ENV["HOMEBREW_CASK_OPTS"] = "--input-methoddir=/path/to/input/methods"
+
+      expect(config.env).to eq(input_methoddir: Pathname("/path/to/input/methods"))
+      expect(config.input_methoddir).to eq(Pathname("/path/to/input/methods"))
+    end
+
+    it "accepts underscored option names" do
+      ENV["HOMEBREW_CASK_OPTS"] = "--input_methoddir=/path/to/input/methods"
+
+      expect(config.env).to eq(input_methoddir: Pathname("/path/to/input/methods"))
+    end
+
+    it "normalizes option names but not their values" do
+      ENV["HOMEBREW_CASK_OPTS"] = "--language=zh-TW,en-GB"
+
+      expect(config.env).to eq(languages: ["zh-TW", "en-GB"])
+    end
+
+    it "survives a JSON round-trip" do
+      ENV["HOMEBREW_CASK_OPTS"] = "--input-methoddir=/path/to/input/methods"
+
+      round_tripped = described_class.from_json(config.to_json)
+
+      expect(round_tripped.input_methoddir).to eq(Pathname("/path/to/input/methods"))
     end
   end
 

--- a/Library/Homebrew/test/cask/config_spec.rb
+++ b/Library/Homebrew/test/cask/config_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe Cask::Config, :cask do
   end
 
   describe "::from_json" do
+    let(:invalid_keys_json) do
+      <<~EOS
+        {
+          "default": {},
+          "env": {
+            "appdir": "/path/to/apps",
+            "invaliddir": "/path/to/invalid"
+          },
+          "explicit": {}
+        }
+      EOS
+    end
+
     it "deserializes a configuration in JSON format" do
       config = described_class.from_json <<~EOS
         {
@@ -39,19 +52,21 @@ RSpec.describe Cask::Config, :cask do
     end
 
     it "ignores invalid keys when requested" do
-      json = <<~EOS
-        {
-          "default": {},
-          "env": {
-            "appdir": "/path/to/apps",
-            "invaliddir": "/path/to/invalid"
-          },
-          "explicit": {}
-        }
-      EOS
-      config = described_class.from_json(json, ignore_invalid_keys: true)
+      config = described_class.from_json(invalid_keys_json, ignore_invalid_keys: true)
 
       expect(config.env).to eq(appdir: Pathname("/path/to/apps"))
+    end
+
+    it "warns about ignored invalid keys" do
+      expect { described_class.from_json(invalid_keys_json, ignore_invalid_keys: true) }
+        .to output(/Ignoring unknown cask configuration keys: \[:invaliddir\]/).to_stderr
+    end
+
+    it "does not warn when all keys are valid" do
+      valid_json = { default: {}, env: { appdir: "/path/to/apps" }, explicit: {} }.to_json
+
+      expect { described_class.from_json(valid_json, ignore_invalid_keys: true) }
+        .not_to output.to_stderr
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Fable xhigh with manual review and testing.

-----

Before this, doing

```
HOMEBREW_CASK_OPTS="--input-methoddir=/some/path" brew install gcloud-cli
```

would error out with

```
Error: An exception occurred within a child process:

  ArgumentError: Unknown key: :"input-methoddir". Valid keys are: :languages, :appdir, :appimagedir, :keyboard_layoutdir, :colorpickerdir, :prefpanedir, :qlplugindir, :mdimporterdir, :dictionarydir, :fontdir, :servicedir, :input_methoddir, :internet_plugindir, :audio_unit_plugindir, :vst_plugindir, :vst3_plugindir, :screen_saverdir
```

Let's fix that by normalising the option name appropriately.

Let's also avoid invalid keys from failing Cask installs with `ignore_invalid_keys: true`, which was the behaviour until recently.
