### PR TITLE
cask: merge multiple `conflicts_with` stanzas

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -201,7 +201,6 @@ module Cask
       @cask = cask
       @caveats = T.let(DSL::Caveats.new(cask), DSL::Caveats)
       @conflicts_with = T.let(nil, T.nilable(DSL::ConflictsWith))
-      @conflicts_with_set_in_block = T.let(false, T::Boolean)
       @container = T.let(nil, T.nilable(DSL::Container))
       @container_set_in_block = T.let(false, T::Boolean)
       @depends_on = T.let(DSL::DependsOn.new, DSL::DependsOn)
@@ -649,11 +648,19 @@ module Cask
 
     # Declare conflicts that keep a cask from installing or working correctly.
     #
+    # NOTE: Multiple `conflicts_with` stanzas can be specified; they are merged.
+    #
     # @api public
     sig { params(kwargs: T.anything).returns(T.nilable(DSL::ConflictsWith)) }
     def conflicts_with(**kwargs)
-      # TODO: Remove this constraint and instead merge multiple `conflicts_with` stanzas
-      set_unique_stanza(:conflicts_with, kwargs.empty?) { DSL::ConflictsWith.new(**kwargs) }
+      return @conflicts_with if kwargs.empty?
+
+      new_conflicts = DSL::ConflictsWith.new(**kwargs)
+      @conflicts_with = @conflicts_with&.merge!(new_conflicts) || new_conflicts
+    rescue CaskInvalidError
+      raise
+    rescue => e
+      raise CaskInvalidError.new(cask, "'conflicts_with' stanza failed with: #{e}")
     end
 
     sig { returns(Pathname) }

--- a/Library/Homebrew/cask/dsl/conflicts_with.rb
+++ b/Library/Homebrew/cask/dsl/conflicts_with.rb
@@ -21,6 +21,12 @@ module Cask
         super(conflicts)
       end
 
+      sig { params(other: ConflictsWith).returns(T.self_type) }
+      def merge!(other)
+        other.to_h.each { |key, values| __getobj__[key] |= Set.new(values) }
+        self
+      end
+
       sig { returns(T::Hash[Symbol, T::Array[String]]) }
       def to_h
         __getobj__.transform_values(&:to_a)

--- a/Library/Homebrew/rubocops/cask/no_overrides.rb
+++ b/Library/Homebrew/rubocops/cask/no_overrides.rb
@@ -8,9 +8,9 @@ module RuboCop
         include CaskHelp
 
         # These stanzas can be overridden by `on_*` blocks, so take them into account.
-        # TODO: Update this list if new stanzas are added to `Cask::DSL` that call `set_unique_stanza`.
+        # TODO: Update this list when stanzas in `Cask::DSL` start or stop calling `set_unique_stanza`.
         OVERRIDABLE_METHODS = [
-          :appcast, :arch, :auto_updates, :conflicts_with, :container,
+          :appcast, :arch, :auto_updates, :container,
           :desc, :homepage, :os, :sha256, :url, :version
         ].freeze
 

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -738,6 +738,16 @@ RSpec.describe Cask::DSL, :cask, :no_api do
       end
     end
 
+    context "when specified multiple times" do
+      let(:token) { "with-conflicts-with-multiple" }
+
+      it "merges and deduplicates all conflicts_with stanzas" do
+        os_conflict = OS.mac? ? "macos-caffeine" : "linux-caffeine"
+        expect(cask.conflicts_with[:cask])
+          .to eq(Set.new(["local-caffeine", "with-caffeine", os_conflict]))
+      end
+    end
+
     context "with invalid conflicts_with key" do
       let(:token) { "invalid-conflicts-with-key" }
 

--- a/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
@@ -153,6 +153,19 @@ RSpec.describe RuboCop::Cop::Cask::NoOverrides, :config do
     CASK
   end
 
+  it "accepts `conflicts_with` in both top-level and `on_*` blocks" do
+    expect_no_offenses <<~CASK
+      cask "foo" do
+        version "1.2.3"
+        conflicts_with cask: "foo-beta"
+
+        on_sequoia :or_older do
+          conflicts_with cask: "foo-legacy"
+        end
+      end
+    CASK
+  end
+
   it "reports an offense when `on_*` blocks override a single upper-level stanza" do
     expect_offense <<~CASK
       cask 'foo' do

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-conflicts-with-multiple.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-conflicts-with-multiple.rb
@@ -1,0 +1,20 @@
+# typed: false
+
+cask "with-conflicts-with-multiple" do
+  version "1.2.3"
+  sha256 "8dd95f83a6cbf67dd73f003c476ea38a5aab367e3af8f56d485c0ff9017b6ee5"
+
+  on_macos do
+    conflicts_with cask: "macos-caffeine"
+  end
+  on_linux do
+    conflicts_with cask: "linux-caffeine"
+  end
+
+  url "https://brew.sh/ConflictsWith-1.2.3.dmg"
+  name "ConflictsWith"
+  homepage "https://brew.sh/"
+
+  conflicts_with cask: "local-caffeine"
+  conflicts_with cask: ["local-caffeine", "with-caffeine"]
+end


### PR DESCRIPTION
`conflicts_with` can only appear once per cask: a second top-level stanza raises, and one in an `on_*` block replaces the top-level one. So a cask can't conflict with one cask everywhere and another on one
OS only. `Cask::DSL` has a `TODO` asking to merge instead, and the Cask Cookbook already documents multiple occurrences as allowed.

Now each call merges into the previous ones as a set union, and the `NoOverrides` cop no longer flags `conflicts_with`.

No behavior change for existing casks: none of the 7,691 casks in homebrew-cask uses it more than once, and merging is idempotent so reloading gives the same result. Added a fixture cask, a DSL spec, and a `NoOverrides` cop spec.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
AI (Claude Code) assisted in writing the code and tests.
I reviewed the change and ran brew lgtm locally