### PR TITLE
Normalize option names when deserializing cask config

### DIFF
--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -77,11 +77,17 @@ module Cask
       config = JSON.parse(json, symbolize_names: true)
 
       new(
-        default:             config.fetch(:default,  {}),
-        env:                 config.fetch(:env,      {}),
-        explicit:            config.fetch(:explicit, {}),
+        default:             normalize_keys(config.fetch(:default,  {})),
+        env:                 normalize_keys(config.fetch(:env,      {})),
+        explicit:            normalize_keys(config.fetch(:explicit, {})),
         ignore_invalid_keys:,
       )
+    end
+
+    # saved configs can contain hyphenated option names written before these were normalized
+    sig { params(config: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+    def self.normalize_keys(config)
+      config.transform_keys { |key| key.to_s.tr("-", "_").to_sym }
     end
 
     # runtime recursive evaluation forces the LazyObject to be evaluated

--- a/Library/Homebrew/test/cask/config_spec.rb
+++ b/Library/Homebrew/test/cask/config_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe Cask::Config, :cask do
       EOS
     end
 
+    let(:legacy_keys_json) do
+      <<~EOS
+        {
+          "default": {},
+          "env": {
+            "input-methoddir": "/path/to/input/methods"
+          },
+          "explicit": {}
+        }
+      EOS
+    end
+
     it "deserializes a configuration in JSON format" do
       config = described_class.from_json <<~EOS
         {
@@ -67,6 +79,24 @@ RSpec.describe Cask::Config, :cask do
 
       expect { described_class.from_json(valid_json, ignore_invalid_keys: true) }
         .not_to output.to_stderr
+    end
+
+    it "normalizes hyphenated keys from a saved configuration" do
+      config = described_class.from_json(legacy_keys_json, ignore_invalid_keys: true)
+
+      expect(config.env).to eq(input_methoddir: Pathname("/path/to/input/methods"))
+      expect(config.input_methoddir).to eq(Pathname("/path/to/input/methods"))
+    end
+
+    it "does not warn about hyphenated keys from a saved configuration" do
+      expect { described_class.from_json(legacy_keys_json, ignore_invalid_keys: true) }
+        .not_to output.to_stderr
+    end
+
+    it "accepts hyphenated keys from a saved configuration without ignoring invalid keys" do
+      config = described_class.from_json(legacy_keys_json)
+
+      expect(config.input_methoddir).to eq(Pathname("/path/to/input/methods"))
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Fable xhigh with manual review and testing

-----

Before #23505, the cask configuration stored in its metadata directory would contain invalid keys that were silently ignored. Now, they can show dozens of warnings like

```
Warning: Ignoring unknown cask configuration keys: [:"input-methoddir", :"internet-plugindir", :"audio-unit-plugindir", :"vst-plugindir", :"vst3-plugindir", :"screen-saverdir"]
```

on every `brew update`. Let's fix that by normalising these too.

One drawback: these configs will now be respected at uninstall-time even if they weren't used at install-time. I don't have a good solution for that at the moment, but I'm looking into it.

**Edit:** Opened #23508 as an alternative without the drawback.