### PR TITLE
Drop legacy option names when deserializing cask config

### DIFF
--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -79,16 +79,19 @@ module Cask
       new(
         default:             reject_legacy_keys(config.fetch(:default,  {})),
         env:                 reject_legacy_keys(config.fetch(:env,      {})),
-        explicit:            reject_legacy_keys(config.fetch(:explicit, {})),
+        explicit:            reject_legacy_keys(config.fetch(:explicit, {})) || {},
         ignore_invalid_keys:,
       )
     end
 
-    # saved configs can contain hyphenated option names that were never honored when read back,
-    # so drop them instead of warning about them or retroactively making them take effect
-    sig { params(config: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+    # Saved configs can contain hyphenated option names that were never honored when read back,
+    # so drop them instead of warning about them or retroactively making them take effect.
+    sig { params(config: T.nilable(ConfigHash)).returns(T.nilable(ConfigHash)) }
     def self.reject_legacy_keys(config)
-      config.reject { |key, _| key.to_s.include?("-") && defaults.key?(key.to_s.tr("-", "_").to_sym) }
+      return if config.nil?
+
+      valid_keys = defaults
+      config.reject { |key, _| key.to_s.include?("-") && valid_keys.key?(key.to_s.tr("-", "_").to_sym) }
     end
 
     # runtime recursive evaluation forces the LazyObject to be evaluated

--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -77,11 +77,18 @@ module Cask
       config = JSON.parse(json, symbolize_names: true)
 
       new(
-        default:             config.fetch(:default,  {}),
-        env:                 config.fetch(:env,      {}),
-        explicit:            config.fetch(:explicit, {}),
+        default:             reject_legacy_keys(config.fetch(:default,  {})),
+        env:                 reject_legacy_keys(config.fetch(:env,      {})),
+        explicit:            reject_legacy_keys(config.fetch(:explicit, {})),
         ignore_invalid_keys:,
       )
+    end
+
+    # saved configs can contain hyphenated option names that were never honored when read back,
+    # so drop them instead of warning about them or retroactively making them take effect
+    sig { params(config: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+    def self.reject_legacy_keys(config)
+      config.reject { |key, _| key.to_s.include?("-") && defaults.key?(key.to_s.tr("-", "_").to_sym) }
     end
 
     # runtime recursive evaluation forces the LazyObject to be evaluated

--- a/Library/Homebrew/test/cask/config_spec.rb
+++ b/Library/Homebrew/test/cask/config_spec.rb
@@ -38,6 +38,19 @@ RSpec.describe Cask::Config, :cask do
       EOS
     end
 
+    let(:legacy_keys_json) do
+      <<~EOS
+        {
+          "default": {},
+          "env": {
+            "appdir": "/path/to/apps",
+            "input-methoddir": "/path/to/input/methods"
+          },
+          "explicit": {}
+        }
+      EOS
+    end
+
     it "deserializes a configuration in JSON format" do
       config = described_class.from_json <<~EOS
         {
@@ -67,6 +80,36 @@ RSpec.describe Cask::Config, :cask do
 
       expect { described_class.from_json(valid_json, ignore_invalid_keys: true) }
         .not_to output.to_stderr
+    end
+
+    it "raises for unknown keys" do
+      expect { described_class.from_json(invalid_keys_json) }
+        .to raise_error(ArgumentError, /Unknown key: :invaliddir/)
+    end
+
+    it "drops legacy hyphenated keys" do
+      config = described_class.from_json(legacy_keys_json, ignore_invalid_keys: true)
+
+      expect(config.env).to eq(appdir: Pathname("/path/to/apps"))
+      expect(config.input_methoddir).to eq(Pathname(TEST_TMPDIR).join("cask-input_methoddir"))
+    end
+
+    it "does not warn about legacy hyphenated keys" do
+      expect { described_class.from_json(legacy_keys_json, ignore_invalid_keys: true) }
+        .not_to output.to_stderr
+    end
+
+    it "accepts legacy hyphenated keys without ignoring invalid keys" do
+      config = described_class.from_json(legacy_keys_json)
+
+      expect(config.input_methoddir).to eq(Pathname(TEST_TMPDIR).join("cask-input_methoddir"))
+    end
+
+    it "warns about unknown hyphenated keys" do
+      unknown_json = { default: {}, env: { "bogus-typodir": "/path/to/bogus" }, explicit: {} }.to_json
+
+      expect { described_class.from_json(unknown_json, ignore_invalid_keys: true) }
+        .to output(/Ignoring unknown cask configuration keys: \[:"bogus-typodir"\]/).to_stderr
     end
   end
 

--- a/Library/Homebrew/test/cask/config_spec.rb
+++ b/Library/Homebrew/test/cask/config_spec.rb
@@ -111,6 +111,13 @@ RSpec.describe Cask::Config, :cask do
       expect { described_class.from_json(unknown_json, ignore_invalid_keys: true) }
         .to output(/Ignoring unknown cask configuration keys: \[:"bogus-typodir"\]/).to_stderr
     end
+
+    it "tolerates null configuration sections" do
+      null_sections_json = '{"default": null, "env": null, "explicit": null}'
+
+      expect { described_class.from_json(null_sections_json, ignore_invalid_keys: true) }
+        .not_to raise_error
+    end
   end
 
   describe "#default" do


### PR DESCRIPTION
- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Fable xhigh with manual review and testing

-----

After #23505, cask configuration stored in the metadata directory can throw dozens of warnings like

```
Warning: Ignoring unknown cask configuration keys: [:"input-methoddir", :"internet-plugindir", :"audio-unit-plugindir", :"vst-plugindir", :"vst3-plugindir", :"screen-saverdir"]
```

Let's fix that by just ignoring them. We never honoured them before, and they're not actionable for the user.

Closes #23507.
