### PR TITLE
sandbox: keep terminal output translation on during PTY passthrough

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -612,14 +612,30 @@ class Sandbox
           end
 
           if $stdin.tty?
-            # If stdin is a TTY, use io.raw to set stdin to a raw, passthrough
-            # mode while we copy the input/output of the process spawned in the
-            # PTY. After we've finished copying to/from the PTY process, io.raw
-            # will restore the stdin TTY to its original state.
+            # If stdin is a TTY, set it to a raw, passthrough mode while we
+            # copy the input/output of the process spawned in the PTY, then
+            # restore its original state afterwards. Keep `opost` set, unlike
+            # `IO#raw`: clearing it stops LF -> CRLF translation for the whole
+            # terminal, so anything written outside the PTY meanwhile (e.g.
+            # our own `$stdout` when piped) renders staircased — and set the
+            # mode in one `stty` call so there is no window where `opost` is
+            # clear.
             begin
               # Ignore SIGTTOU as setting raw mode will hang if the process is in the background.
               old_ttou = trap(:TTOU, "IGNORE")
-              $stdin.raw(&write_to_pty)
+              saved_stty = Utils.popen_read("stty", "-g").chomp
+              if saved_stty.empty?
+                # Cannot save the terminal state, so don't change it either.
+                write_to_pty.call
+              else
+                begin
+                  # `-echo` matches `IO#raw`; `stty raw` alone leaves echo on.
+                  system("stty", "raw", "-echo", "opost")
+                  write_to_pty.call
+                ensure
+                  system("stty", saved_stty)
+                end
+              end
             ensure
               trap(:TTOU, old_ttou)
             end

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -275,10 +275,8 @@ class Sandbox
   # capture it once per process. `nil` when it cannot be captured.
   sig { returns(T.nilable(String)) }
   def self.tty_state
-    return @tty_state if defined?(@tty_state)
-
-    state = Utils.popen_read("stty", "-g").chomp
-    @tty_state = T.let(state.empty? ? nil : state, T.nilable(String))
+    @tty_state ||= T.let(Utils.popen_read("stty", "-g").chomp, T.nilable(String))
+    @tty_state.presence
   end
 
   sig { void }

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -270,6 +270,17 @@ class Sandbox
     raise NotImplementedError, "Sandbox is not implemented for this OS."
   end
 
+  # The terminal state to restore after a PTY passthrough. It cannot change
+  # in the background while `brew` runs (each passthrough restores it), so
+  # capture it once per process. `nil` when it cannot be captured.
+  sig { returns(T.nilable(String)) }
+  def self.tty_state
+    return @tty_state if defined?(@tty_state)
+
+    state = Utils.popen_read("stty", "-g").chomp
+    @tty_state = T.let(state.empty? ? nil : state, T.nilable(String))
+  end
+
   sig { void }
   def initialize
     @profile = T.let(SandboxProfile.new, SandboxProfile)
@@ -623,17 +634,17 @@ class Sandbox
             begin
               # Ignore SIGTTOU as setting raw mode will hang if the process is in the background.
               old_ttou = trap(:TTOU, "IGNORE")
-              saved_stty = Utils.popen_read("stty", "-g").chomp
-              if saved_stty.empty?
+              saved_stty = Sandbox.tty_state
+              if saved_stty.nil?
                 # Cannot save the terminal state, so don't change it either.
                 write_to_pty.call
               else
                 begin
                   # `-echo` matches `IO#raw`; `stty raw` alone leaves echo on.
-                  system("stty", "raw", "-echo", "opost")
+                  Utils.popen_read("stty", "raw", "-echo", "opost")
                   write_to_pty.call
                 ensure
-                  system("stty", saved_stty)
+                  Utils.popen_read("stty", saved_stty)
                 end
               end
             ensure

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -634,17 +634,17 @@ class Sandbox
             begin
               # Ignore SIGTTOU as setting raw mode will hang if the process is in the background.
               old_ttou = trap(:TTOU, "IGNORE")
-              saved_stty = Sandbox.tty_state
-              if saved_stty.nil?
-                # Cannot save the terminal state, so don't change it either.
-                write_to_pty.call
-              else
+              if (tty_state = Sandbox.tty_state)
                 begin
                   # `-echo` matches `IO#raw`; `stty raw` alone leaves echo on.
                   Utils.popen_read("stty", "raw", "-echo", "opost")
                   write_to_pty.call
                 ensure
-                  Utils.popen_read("stty", saved_stty)
+                  Utils.popen_read("stty", tty_state)
+                end
+              else
+                # Cannot get the terminal state, so don't change it either.
+                write_to_pty.call
                 end
               end
             ensure

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -643,7 +643,6 @@ class Sandbox
               else
                 # Cannot get the terminal state, so don't change it either.
                 write_to_pty.call
-                end
               end
             ensure
               trap(:TTOU, old_ttou)


### PR DESCRIPTION
When a piped install (`brew reinstall --verbose python@3.14 2>&1 | tee
log.txt`) runs a sandboxed step, any buffered output that flushes while that
step is running renders staircased, like this:

```
ln -s …/Python.framework/Headers Headers
                                        ln -s …/Python.framework/Python Python
                                                                              ln -s …/Python.framework/Resources Resources
```

This change makes it render properly, like this:

```
ln -s …/Python.framework/Headers Headers
ln -s …/Python.framework/Python Python
ln -s …/Python.framework/Resources Resources
```

In plain English: ending a terminal line takes both a line feed and a
carriage return, and Unix programs only write the line feed; the terminal
driver quietly adds the carriage return. While a sandboxed step runs, brew
wires the user's keyboard through to it, which requires putting the real
terminal into raw mode ("stop helping — pass every byte through untouched")
for the child's lifetime. But raw is a package deal that also switches off
the carriage-return courtesy, so any buffered output delivered during that
window steps down the screen without ever returning to the margin. In this
repro that delivery happens at the start of the window: launching the child
flushes the tail of the link listing, which is what staircases.

In termios terms: the passthrough uses `IO#raw`, which clears `OPOST`; the
fix sets the terminal mode itself — raw, no echo, `opost` kept on — in a
single `stty` call.

<details>
<summary>Details</summary>

The sandbox's PTY passthrough uses `IO#raw`, which also clears `OPOST` —
disabling LF -> CRLF translation for the whole terminal — so brew's own
piped stdout renders staircased whenever a buffered chunk flushes while the
passthrough is active.

That is what the excerpt above shows: python@3.14's postinstall runs
sandboxed, the tail of the verbose keg-link listing is still sitting in the
stdout buffer when the passthrough opens, and it flushes just as the window
opens — a couple of dozen lines staircase, then the margin returns at the
install's summary line.

Only input needs to be raw, so set the mode with `opost` kept on instead.
The whole mode is applied in a single `stty` call. When I tried setting raw
first and repairing `opost` afterwards, it still staircased, because the
flush landed in the milliseconds between the two calls.

Reproduced with the command above: the staircase starts at the same line
every run (a stdout buffer boundary — Ruby block-buffers piped stdout, which
also makes the boundary deterministic) and recovers exactly at the end of
the sandboxed step. The capture file contains plain `\n` text throughout, so
the corruption is display-only. Polling the terminal's termios during the
run shows a single raw-mode window whose open and close line up with the
staircase's start and end, with only brew's Ruby process (plus the shell and
`tee`) holding the tty; inside the window `stty -a` reports `-opost`.
`IO#raw` on a fresh PTY confirms `opost -> -opost` in isolation.

`-echo` is included because
`stty raw`, unlike `IO#raw`, leaves echo enabled. If the terminal state
cannot be saved, the mode is left untouched rather than changed
unrestorably.

Verified on macOS 26.6.1 / Terminal.app: before the change the repro
staircases every run; after it, the same command renders every line at the
margin.

</details>

No new tests: exercising this needs a controlling terminal whose mode the
test can flip and observe, which the CI environment does not provide; the
existing sandbox specs cover the surrounding code and pass.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Used Claude Code (Fable 5) to investigate and draft; I directed the
investigation, and reviewed the diff and every line of this PR text.

-----
