### PR TITLE
Faster ``brew cleanup`` with many installed packages

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -402,6 +402,8 @@ module Homebrew
                .sort_by(&:name)
                .reject { |f| Cleanup.skip_clean_formula?(f) }
                .each do |formula|
+          # Don't `cleanup_unreferenced` here for each formula.
+          # Instead, let it be run once `cleanup_cache` below.
           cleanup_formula(formula, quiet:, ds_store: false, cache_db: false, cleanup_unreferenced: false)
         end
 

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -401,7 +401,7 @@ module Homebrew
                .sort_by(&:name)
                .reject { |f| Cleanup.skip_clean_formula?(f) }
                .each do |formula|
-          cleanup_formula(formula, quiet:, ds_store: false, cache_db: false)
+          cleanup_formula(formula, quiet:, ds_store: false, cache_db: false, cleanup_unreferenced: false)
         end
 
         if ENV["HOMEBREW_AUTOREMOVE"].present?
@@ -479,11 +479,17 @@ module Homebrew
       cleanup_cache(cache_entries(paths, type:), cleanup_unreferenced:)
     end
 
-    sig { params(formula: Formula, quiet: T::Boolean, ds_store: T::Boolean, cache_db: T::Boolean).void }
-    def cleanup_formula(formula, quiet: false, ds_store: true, cache_db: true)
+    sig {
+      params(formula: Formula, quiet: T::Boolean, ds_store: T::Boolean, cache_db: T::Boolean,
+             cleanup_unreferenced: T::Boolean).void
+    }
+    def cleanup_formula(formula, quiet: false, ds_store: true, cache_db: true, cleanup_unreferenced: true)
       formula.eligible_kegs_for_cleanup(quiet:)
              .each { |keg| cleanup_keg(keg) }
-      cleanup_cache_entries(Pathname.glob(cache/"#{formula.name}{_bottle_manifest,}--*"), type: nil)
+      cleanup_cache_entries(
+        Pathname.glob(cache/"#{formula.name}{_bottle_manifest,}--*"),
+        type: nil, cleanup_unreferenced:,
+      )
       rm_ds_store([formula.rack]) if ds_store
       cleanup_cache_db(formula.rack) if cache_db
       cleanup_lockfiles(FormulaLock.new(formula.name).path)

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -480,19 +480,22 @@ module Homebrew
       cleanup_cache(cache_entries(paths, type:), cleanup_unreferenced:)
     end
 
+    # Returns the cached `<formula>--<version>` and
+    # `<formula>_bottle_manifest--<version>` downloads for a formula. Globbing
+    # these per formula rescans the entire cache each time, which is quadratic
+    # for `brew cleanup`, so index the cache by name prefix once instead.
     sig { params(formula: Formula).returns(T::Array[Pathname]) }
     def formula_cache_paths(formula)
-      index = @formula_cache_paths ||= begin
-        children = cache.directory? ? cache.children : []
-        children.each_with_object({}) do |path, hash|
-          prefix, separator, = path.basename.to_s.partition("--")
-          next if separator.empty? || prefix.start_with?(".")
+      return [] unless cache.directory?
 
-          (hash[prefix] ||= []) << path
-        end
+      index = @formula_cache_paths ||= cache.children.each_with_object({}) do |path, hash|
+        prefix, separator, = path.basename.to_s.partition("--")
+        next if prefix.start_with?(".") || separator.empty?
+
+        (hash[prefix] ||= []) << path
       end
 
-      (index.fetch(formula.name, []) + index.fetch("#{formula.name}_bottle_manifest", [])).sort
+      [*index.fetch(formula.name, []), *index.fetch("#{formula.name}_bottle_manifest", [])].sort
     end
 
     sig {

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -277,6 +277,7 @@ module Homebrew
       @days = T.let(days || Homebrew::EnvConfig.cleanup_max_age_days.to_i, Integer)
       @cache = cache
       @cleaned_up_paths = T.let(Set.new, T::Set[Pathname])
+      @formula_cache_paths = T.let(nil, T.nilable(T::Hash[String, T::Array[Pathname]]))
     end
 
     sig { returns(T::Boolean) }
@@ -479,6 +480,21 @@ module Homebrew
       cleanup_cache(cache_entries(paths, type:), cleanup_unreferenced:)
     end
 
+    sig { params(formula: Formula).returns(T::Array[Pathname]) }
+    def formula_cache_paths(formula)
+      index = @formula_cache_paths ||= begin
+        children = cache.directory? ? cache.children : []
+        children.each_with_object({}) do |path, hash|
+          prefix, separator, = path.basename.to_s.partition("--")
+          next if separator.empty? || prefix.start_with?(".")
+
+          (hash[prefix] ||= []) << path
+        end
+      end
+
+      (index.fetch(formula.name, []) + index.fetch("#{formula.name}_bottle_manifest", [])).sort
+    end
+
     sig {
       params(formula: Formula, quiet: T::Boolean, ds_store: T::Boolean, cache_db: T::Boolean,
              cleanup_unreferenced: T::Boolean).void
@@ -486,10 +502,7 @@ module Homebrew
     def cleanup_formula(formula, quiet: false, ds_store: true, cache_db: true, cleanup_unreferenced: true)
       formula.eligible_kegs_for_cleanup(quiet:)
              .each { |keg| cleanup_keg(keg) }
-      cleanup_cache_entries(
-        Pathname.glob(cache/"#{formula.name}{_bottle_manifest,}--*"),
-        type: nil, cleanup_unreferenced:,
-      )
+      cleanup_cache_entries(formula_cache_paths(formula), type: nil, cleanup_unreferenced:)
       rm_ds_store([formula.rack]) if ds_store
       cleanup_cache_db(formula.rack) if cache_db
       cleanup_lockfiles(FormulaLock.new(formula.name).path)

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -77,6 +77,18 @@ RSpec.describe Homebrew::Cleanup do
       expect(lock_file).to exist
     end
 
+    it "cleans up unreferenced downloads once, however many formulae are installed" do
+      ENV["HOMEBREW_NO_AUTOREMOVE"] = "1"
+      installed = ["foo", "bar", "baz"].map do |name|
+        instance_double(Formula, name:, eligible_kegs_for_cleanup: [])
+      end
+      allow(Formula).to receive(:installed).and_return(installed)
+
+      expect(cleanup).to receive(:cleanup_unreferenced_downloads).once.and_call_original
+
+      cleanup.clean!
+    end
+
     it "doesn't load untrusted installed formulae while cleaning the cache" do
       cache_file = HOMEBREW_CACHE/"untrusted--1.0"
       cache_file.write "cached"
@@ -268,6 +280,41 @@ RSpec.describe Homebrew::Cleanup do
     expect(f2).not_to be_latest_version_installed
     expect(f3).to be_latest_version_installed
     expect(f4).to be_latest_version_installed
+  end
+
+  describe "#formula_cache_paths" do
+    let(:cache) { mktmpdir/"cache" }
+    let(:testball) { instance_double(Formula, name: "testball") }
+
+    before do
+      cache.mkpath
+    end
+
+    it "returns only the formula's own downloads and bottle manifests" do
+      matching = [
+        cache/"testball--1.0.tar.gz",
+        cache/"testball--rsrc--1.0.txt",
+        cache/"testball_bottle_manifest--1.0.bottle_manifest.json",
+      ]
+      non_matching = [
+        cache/".testball--1.0.tar.gz",
+        cache/"testball-foo--1.0.tar.gz",
+        cache/"testball_bottle_manifest",
+        cache/"testballs--1.0.tar.gz",
+      ]
+      (matching + non_matching).each { |path| FileUtils.touch path }
+
+      expect(described_class.new(cache:).formula_cache_paths(testball)).to eq(matching)
+    end
+
+    it "reads the cache directory only once for multiple formulae" do
+      cleanup = described_class.new(cache:)
+
+      expect(cache).to receive(:children).once.and_return([cache/"testball--1.0.tar.gz"])
+
+      cleanup.formula_cache_paths(testball)
+      cleanup.formula_cache_paths(instance_double(Formula, name: "other"))
+    end
   end
 
   describe "#cleanup_cask", :cask do


### PR DESCRIPTION
I have a brew installation with thousands of packages and noticed that ``brew cleanup`` was slow.

This was on a busy machine because I'm also working on other things, and this took forever to run, but...

Before:

```
$ hyperfine "brew cleanup"
Benchmark 1: brew cleanup
  Time (mean ± σ):     1364.028 s ± 224.121 s    [User: 843.672 s, System: 452.171 s]
  Range (min … max):   1210.127 s … 1900.369 s    10 runs
```

In the process of figuring out why that was, I made this first change:

`brew cleanup` with no arguments loops over every installed formula calling `cleanup_formula`, which reached `cleanup_cache` with `cleanup_unreferenced` defaulting to true. That ran `cleanup_unreferenced_downloads` once per formula, and each run walks the whole cache to rebuild the referenced-download set. 

We now instead pass `cleanup_unreferenced: false` from the loop instead. `clean!` already calls `cleanup_cache` immediately afterwards, which prunes unreferenced downloads once against the final on-disk state.

After this first patch:

```
$ hyperfine "brew cleanup"
Benchmark 1: brew cleanup
  Time (mean ± σ):     197.364 s ± 30.493 s    [User: 88.488 s, System: 81.864 s]
  Range (min … max):   162.264 s … 244.500 s    10 runs
```

And then I made a second patch that caches the formula paths to reduce directory traversal compared to the glob approach that was in it before.

After this second patch:

```
$ hyperfine "brew cleanup"
Benchmark 1: brew cleanup
  Time (mean ± σ):     53.382 s ±  1.327 s    [User: 17.148 s, System: 18.608 s]
  Range (min … max):   50.729 s … 55.329 s    10 runs
```

The remaining cost is largely ``rm_ds_store``, but I did not do anything with that yet except make the observation.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I asked Claude Opus 5 to explain the current brew cleanup tests and help me understand the current tests and where to slot in regression tests that would cover this.

-----
