### PR TITLE
advisory-match: add --repology to load a local index

### DIFF
--- a/Library/Homebrew/dev-cmd/advisory-match.rb
+++ b/Library/Homebrew/dev-cmd/advisory-match.rb
@@ -28,6 +28,9 @@ module Homebrew
                description: "Write each record to <directory> as " \
                             "`BREW-<formula>-<id>.json`, preserving existing " \
                             "`published`/`ranges` fields."
+        flag   "--repology=",
+               description: "Load the formula to distro-package index from " \
+                            "<file> instead of the published `data/repology.json`."
         switch "--no-history",
                description: "Skip the `FormulaVersions` walk for the `fixed` " \
                             "boundary; use the current `pkg_version` instead."
@@ -47,7 +50,7 @@ module Homebrew
         Homebrew.with_no_api_env do
           latest_macos = MacOSVersion.new((HOMEBREW_MACOS_NEWEST_UNSUPPORTED.to_i - 1).to_s).to_sym
           Homebrew::SimulateSystem.with(os: latest_macos, arch: :arm) do
-            matcher = Homebrew::Vulns::Match.new(bulk: args.all? || args.index?)
+            matcher = Homebrew::Vulns::Match.new(repology: local_repology, bulk: args.all? || args.index?)
             next emit_index(matcher) if args.index?
 
             emitter = build_emitter
@@ -75,6 +78,15 @@ module Homebrew
             emitter.finish
           end
         end
+      end
+
+      # A CI run that has just built the index locally (advisory-database's
+      # Ingest) reads it directly instead of fetching the published copy.
+      sig { returns(T.nilable(Homebrew::Vulns::Repology)) }
+      def local_repology
+        return unless (path = args.repology)
+
+        Homebrew::Vulns::Repology.from_file(Pathname(path))
       end
 
       sig { returns(T::Enumerator[Formula]) }

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/advisory_match.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/advisory_match.rbi
@@ -25,4 +25,7 @@ class Homebrew::DevCmd::AdvisoryMatch::Args < Homebrew::CLI::Args
 
   sig { returns(T.nilable(String)) }
   def output; end
+
+  sig { returns(T.nilable(String)) }
+  def repology; end
 end

--- a/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
@@ -110,6 +110,26 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
       .to_stdout
   end
 
+  it "loads the Repology index from --repology=<file> instead of the published feed" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "repology.json")
+      File.write(path, JSON.generate({ "meta" => {}, "formulae" => {} }))
+      expect(Homebrew::Vulns::Repology).not_to receive(:load)
+
+      records = JSON.parse(capture_stdout do
+        cmd_for("requests", "--json", "--no-history", "--repology", path).run
+      end)
+      expect(records.first["id"]).to eq "BREW-requests-CVE-2024-1234"
+    end
+  end
+
+  it "raises on an unreadable --repology file" do
+    expect { cmd_for("requests", "--json", "--repology", "/nonexistent/repology.json").run }
+      .to raise_error(Errno::ENOENT)
+  end
+
   it "reports an OSV outage and finishes the emitter without raising" do
     allow(Homebrew::Vulns::OSV).to receive(:query_batch)
       .and_raise(Homebrew::Vulns::OSV::ApiError, "503")

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -347,6 +347,7 @@ _brew_advisory_match() {
       --no-history
       --output
       --quiet
+      --repology
       --verbose
       "
       return

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -342,6 +342,7 @@ __fish_brew_complete_arg 'advisory-match' -l json -d 'Output candidate records a
 __fish_brew_complete_arg 'advisory-match' -l no-history -d 'Skip the `FormulaVersions` walk for the `fixed` boundary; use the current `pkg_version` instead'
 __fish_brew_complete_arg 'advisory-match' -l output -d 'Write each record to directory as `BREW-formula-id.json`, preserving existing `published`/`ranges` fields'
 __fish_brew_complete_arg 'advisory-match' -l quiet -d 'Make some output more quiet'
+__fish_brew_complete_arg 'advisory-match' -l repology -d 'Load the formula to distro-package index from file instead of the published `data/repology.json`'
 __fish_brew_complete_arg 'advisory-match' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'advisory-match' -a '(__fish_brew_suggest_formulae_all)'
 

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -443,6 +443,7 @@ _brew_advisory_match() {
     '--no-history[Skip the `FormulaVersions` walk for the `fixed` boundary; use the current `pkg_version` instead]' \
     '(--index)--output[Write each record to directory as `BREW-formula-id.json`, preserving existing `published`/`ranges` fields]' \
     '--quiet[Make some output more quiet]' \
+    '--repology[Load the formula to distro-package index from file instead of the published `data/repology.json`]' \
     '--verbose[Make some output more verbose]' \
     - formula \
     '*:formula:__brew_formulae'


### PR DESCRIPTION
`brew advisory-match` gains a `--repology=<file>` flag that loads the formula → distro-package index from a local file, using the existing `CachedFeed.from_file` parsing and validation and skipping the published-URL fetch entirely.

The index only exists to feed `advisory-match`: advisory-database's Regenerate workflow crawls Repology daily and routes the result through a pull request to its own repository purely so the matcher's raw-URL fetch of `main` sees a fresh copy. With this flag, that repository's Ingest workflow can build the index at the start of each run and read it directly, retiring the daily index-churn PRs; local `advisory-match` runs keep the published-URL behaviour unless the flag is given.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI disclosure: drafted with Claude Code (Claude Fable 5) under my direction. I reviewed the diff and verified it locally with `brew style`, `brew typecheck` and `brew lgtm`; commits are authored and signed off by me with no AI attribution, and review responses will be my own.

-----