### PR TITLE
utils/git: only mutate describe-cache when .git is user-owned

### DIFF
--- a/Library/Homebrew/test/bash_spec.rb
+++ b/Library/Homebrew/test/bash_spec.rb
@@ -77,6 +77,66 @@ RSpec.describe "Bash" do
     end
   end
 
+  describe "set-homebrew-version-from-git" do
+    it "writes the cache when the current user owns the Git directory" do
+      Dir.mktmpdir("brew-git-cache-") do |tmpdir|
+        repository = Pathname(tmpdir)
+        revision = "0123456789abcdef0123456789abcdef01234567"
+        (repository/".git/refs/heads").mkpath
+        (repository/".git/HEAD").write "ref: refs/heads/main\n"
+        (repository/".git/refs/heads/main").write "#{revision}\n"
+
+        stdout, stderr, status = Open3.capture3(
+          { "HOMEBREW_GIT" => "git", "HOMEBREW_REPOSITORY" => repository.to_s },
+          "/bin/bash", "-c", <<~BASH, "bash", (HOMEBREW_LIBRARY_PATH/"utils/git.sh").to_s
+            source "$1"
+            git() {
+              [[ "$*" == *"describe --tags"* ]] && printf "1.2.3"
+            }
+            HOMEBREW_VERSION=
+            set-homebrew-version-from-git
+            printf "%s" "${HOMEBREW_VERSION}"
+          BASH
+        )
+
+        cache_file = repository/".git/describe-cache"/revision
+        expect([stdout, stderr, status.success?, cache_file.read]).to eq(["1.2.3", "", true, "1.2.3\n"])
+      end
+    end
+
+    it "does not mutate the cache when the current user does not own the Git directory" do
+      skip "User is root so the root directory is owned by the current user." if Process.euid.zero?
+
+      Dir.mktmpdir("brew-git-cache-") do |tmpdir|
+        repository = Pathname(tmpdir)
+        (repository/".git").make_symlink "/"
+        operations = repository/"operations"
+
+        stdout, stderr, status = Open3.capture3(
+          { "HOMEBREW_GIT" => "git", "HOMEBREW_REPOSITORY" => repository.to_s },
+          "/bin/bash", "-c", <<~'BASH', "bash", (HOMEBREW_LIBRARY_PATH/"utils/git.sh").to_s, operations.to_s
+            source "$1"
+            operations="$2"
+            git() {
+              case "$*" in
+                *"rev-parse HEAD") printf "0123456789abcdef0123456789abcdef01234567" ;;
+                *"describe --tags"*) printf "1.2.3" ;;
+                *) return 1 ;;
+              esac
+            }
+            rm() { printf "rm\n" >>"${operations}"; }
+            mkdir() { printf "mkdir\n" >>"${operations}"; }
+            HOMEBREW_VERSION=
+            set-homebrew-version-from-git
+            printf "%s" "${HOMEBREW_VERSION}"
+          BASH
+        )
+
+        expect([stdout, stderr, status.success?, operations.exist?]).to eq(["1.2.3", "", true, false])
+      end
+    end
+  end
+
   describe "every `.sh` file" do
     it "has valid Bash syntax" do
       Pathname.glob("#{HOMEBREW_LIBRARY_PATH}/**/*.sh").each do |path|

--- a/Library/Homebrew/utils/git.sh
+++ b/Library/Homebrew/utils/git.sh
@@ -110,20 +110,23 @@ read-homebrew-git-config() {
 # keyed by the HEAD revision. Leaves HOMEBREW_VERSION unchanged when the
 # revision cannot be determined e.g. in a shallow or non-Git repository.
 set-homebrew-version-from-git() {
-  local git_describe_cache="${HOMEBREW_REPOSITORY}/.git/describe-cache"
+  local git_directory="${HOMEBREW_REPOSITORY}/.git"
+  local git_describe_cache="${git_directory}/describe-cache"
+  local git_directory_owned_by_user=""
+  [[ -O "${git_directory}/." ]] && git_directory_owned_by_user="1"
 
   # Read HEAD and its ref directly rather than through `git rev-parse HEAD`
   # to avoid a fork on every invocation.
   local git_head="" git_revision="" git_ref
   local git_revision_regex="^([0-9a-f]{40}|[0-9a-f]{64})$"
-  read -r git_head 2>/dev/null <"${HOMEBREW_REPOSITORY}/.git/HEAD"
+  read -r git_head 2>/dev/null <"${git_directory}/HEAD"
   if [[ "${git_head}" == "ref: "* ]]
   then
     git_ref="${git_head#ref: }"
-    if [[ -f "${HOMEBREW_REPOSITORY}/.git/${git_ref}" ]]
+    if [[ -f "${git_directory}/${git_ref}" ]]
     then
-      read -r git_revision 2>/dev/null <"${HOMEBREW_REPOSITORY}/.git/${git_ref}"
-    elif [[ -f "${HOMEBREW_REPOSITORY}/.git/packed-refs" ]]
+      read -r git_revision 2>/dev/null <"${git_directory}/${git_ref}"
+    elif [[ -f "${git_directory}/packed-refs" ]]
     then
       local packed_revision packed_ref
       while read -r packed_revision packed_ref
@@ -133,7 +136,7 @@ set-homebrew-version-from-git() {
           git_revision="${packed_revision}"
           break
         fi
-      done <"${HOMEBREW_REPOSITORY}/.git/packed-refs"
+      done <"${git_directory}/packed-refs"
     fi
   elif [[ "${git_head}" =~ ${git_revision_regex} ]]
   then
@@ -143,14 +146,14 @@ set-homebrew-version-from-git() {
   [[ "${git_revision}" =~ ${git_revision_regex} ]] || git_revision=""
 
   # Fall back to git for anything unusual e.g. a worktree where .git is a file.
-  if [[ -z "${git_revision}" && -e "${HOMEBREW_REPOSITORY}/.git" ]]
+  if [[ -z "${git_revision}" && -e "${git_directory}" ]]
   then
     git_revision=$("${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" rev-parse HEAD 2>/dev/null)
   fi
 
   if [[ -z "${git_revision}" ]]
   then
-    if [[ -d "${git_describe_cache}" ]]
+    if [[ -n "${git_directory_owned_by_user}" && -d "${git_describe_cache}" ]]
     then
       # Don't care about permission errors here.
       rm -rf "${git_describe_cache}" 2>/dev/null
@@ -176,12 +179,15 @@ set-homebrew-version-from-git() {
   if [[ -z "${HOMEBREW_VERSION}" ]]
   then
     HOMEBREW_VERSION="$("${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" describe --tags --dirty --abbrev=7 2>/dev/null)"
-    # Don't output any permissions errors here. The user may not have write
-    # permissions to the cache but we don't care because it's an optional
-    # performance improvement.
-    rm -rf "${git_describe_cache}" 2>/dev/null
-    mkdir -p "${git_describe_cache}" 2>/dev/null
-    { echo "${HOMEBREW_VERSION}" >"${git_describe_cache_file}"; } 2>/dev/null
+    if [[ -n "${git_directory_owned_by_user}" ]]
+    then
+      # Don't output any permissions errors here. The user may not have write
+      # permissions to the cache but we don't care because it's an optional
+      # performance improvement.
+      rm -rf "${git_describe_cache}" 2>/dev/null
+      mkdir -p "${git_describe_cache}" 2>/dev/null
+      { echo "${HOMEBREW_VERSION}" >"${git_describe_cache_file}"; } 2>/dev/null
+    fi
   fi
   return 0
 }

--- a/Library/Homebrew/utils/git.sh
+++ b/Library/Homebrew/utils/git.sh
@@ -112,7 +112,7 @@ read-homebrew-git-config() {
 set-homebrew-version-from-git() {
   local git_directory="${HOMEBREW_REPOSITORY}/.git"
   local git_describe_cache="${git_directory}/describe-cache"
-  local git_directory_owned_by_user=""
+  local git_directory_owned_by_user
   [[ -O "${git_directory}/." ]] && git_directory_owned_by_user="1"
 
   # Read HEAD and its ref directly rather than through `git rev-parse HEAD`


### PR DESCRIPTION
`set-homebrew-version-from-git` deletes and recreates `.git/describe-cache` whenever it has to fall back to `git describe`. It did so unconditionally, so `brew` would `rm -rf` and `mkdir -p` inside a Git directory the invoking user does not own, e.g. an installation owned by another user or a `.git` that has been replaced by a symlink pointing elsewhere.

Only mutate the cache when `.git` is owned by the current user. Reads are unaffected, so a repository owned by someone else still uses an already populated cache and otherwise just falls back to `git describe` each run, which is all the cache was ever saving.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new ownership test fails without the fix and passes with it, and ran `brew lgtm` + targeted specs.

-----
