### PR TITLE
cask/audit: anchor sha256 check to string

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -411,7 +411,7 @@ module Cask
 
       odebug "Auditing sha256 string is a legal SHA-256 digest"
       return unless cask.sha256.is_a?(Checksum)
-      return if cask.sha256[/\A[0-9a-f]{64}\z/i]
+      return if cask.sha256.to_s.match?(/\A[0-9a-f]{64}\z/i)
 
       add_error "sha256 string must be of 64 hexadecimal characters"
     end

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -411,7 +411,7 @@ module Cask
 
       odebug "Auditing sha256 string is a legal SHA-256 digest"
       return unless cask.sha256.is_a?(Checksum)
-      return if cask.sha256.length == 64 && cask.sha256[/^[0-9a-f]+$/i]
+      return if cask.sha256[/\A[0-9a-f]{64}\z/i]
 
       add_error "sha256 string must be of 64 hexadecimal characters"
     end

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -978,6 +978,20 @@ RSpec.describe Cask::Audit, :cask do
         it { is_expected.to error_with("sha256 string must be of 64 hexadecimal characters") }
       end
 
+      context "when sha256 is 64 characters but contains a newline" do
+        let(:only) { ["sha256_actually_256"] }
+        let(:cask_token) { "invalid-sha256-newline" }
+
+        it { is_expected.to error_with("sha256 string must be of 64 hexadecimal characters") }
+      end
+
+      context "when sha256 is 64 characters but only one of them is hexadecimal" do
+        let(:only) { ["sha256_actually_256"] }
+        let(:cask_token) { "invalid-sha256-hex-fragment" }
+
+        it { is_expected.to error_with("sha256 string must be of 64 hexadecimal characters") }
+      end
+
       context "when sha256 is sha256 for empty string" do
         let(:only) { ["sha256_invalid"] }
         let(:cask_token) { "sha256-for-empty-string" }

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid-sha256-hex-fragment.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid-sha256-hex-fragment.rb
@@ -1,0 +1,13 @@
+# typed: false
+
+cask "invalid-sha256-hex-fragment" do
+  version "1.2.3"
+  sha256 "a\nZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  name "Caffeine"
+  desc "Cask for testing a sha256 whose hexadecimal run is far shorter than 64"
+  homepage "https://brew.sh/"
+
+  app "Caffeine.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid-sha256-newline.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid-sha256-newline.rb
@@ -1,0 +1,13 @@
+# typed: false
+
+cask "invalid-sha256-newline" do
+  version "1.2.3"
+  sha256 "0123456789abcdef0123456789abcde\n0123456789abcdef0123456789abcdef"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  name "Caffeine"
+  desc "Cask for testing a sha256 that is the right length but not hexadecimal"
+  homepage "https://brew.sh/"
+
+  app "Caffeine.app"
+end


### PR DESCRIPTION
This hardens the valid `sha256` check, removing some edge cases such as - 

- a checksum that contains 1 valid hexadecimal character would still pass if a valid length
- a checksum with newline characters embedded of the correct length would pass

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Opus 5 with manual review.