### PR TITLE
Report progress when uploading bottles

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -75,13 +75,16 @@ class GitHubPackages
 
     # We intentionally iterate over `bottles_hash` twice to
     # avoid erroring out in the middle of uploading bottles.
-    # rubocop:disable Style/CombinableLoops
-    bottles_hash.each do |formula_full_name, bottle_hash|
+    bottle_count = bottles_hash.count
+    bottles_hash.each_with_index do |(formula_full_name, bottle_hash), index|
       # Next, upload the bottles after checking them all.
       upload_bottle(user, token, skopeo, formula_full_name, bottle_hash,
                     keep_old:, dry_run:, warn_on_error:)
+      next if bottle_count < 3
+
+      uploaded_count = index + 1
+      ohai "Upload progress: #{uploaded_count} formula(e) uploaded, #{bottle_count - uploaded_count} remaining"
     end
-    # rubocop:enable Style/CombinableLoops
   end
 
   sig { params(version: Version, rebuild: Integer, bottle_tag: T.nilable(String)).returns(String) }

--- a/Library/Homebrew/github_releases.rb
+++ b/Library/Homebrew/github_releases.rb
@@ -14,7 +14,8 @@ class GitHubReleases
 
   sig { params(bottles_hash: T::Hash[String, T.untyped]).void }
   def upload_bottles(bottles_hash)
-    bottles_hash.each_value do |bottle_hash|
+    bottle_count = bottles_hash.count
+    bottles_hash.each_value.with_index do |bottle_hash, index|
       root_url = bottle_hash["bottle"]["root_url"]
       url_match = root_url.match URL_REGEX
       _, user, repo, tag = *url_match
@@ -36,6 +37,11 @@ class GitHubReleases
         odebug "Uploading #{remote_file}"
         GitHub.upload_release_asset user, repo, release["id"], local_file:, remote_file:
       end
+
+      next if bottle_count < 3
+
+      uploaded_count = index + 1
+      ohai "Upload progress: #{uploaded_count} formula(e) uploaded, #{bottle_count - uploaded_count} remaining"
     end
   end
 end

--- a/Library/Homebrew/test/github_packages_spec.rb
+++ b/Library/Homebrew/test/github_packages_spec.rb
@@ -4,6 +4,94 @@
 require "github_packages"
 
 RSpec.describe GitHubPackages do
+  describe "#upload_bottles" do
+    it "reports progress when uploading many bottles" do
+      github_packages = described_class.new
+      events = []
+      bottles_hash = {
+        "foo" => {},
+        "bar" => {},
+        "baz" => {},
+      }
+
+      allow(Homebrew::EnvConfig).to receive_messages(
+        github_packages_user:  "brewtest",
+        github_packages_token: "ghp_test",
+      )
+      allow(github_packages).to receive(:load_schemas!)
+      allow(github_packages).to receive(:preupload_check)
+      allow(github_packages).to receive(:ensure_executable!).and_return(Pathname("skopeo"))
+      allow(github_packages).to receive(:upload_bottle) do |_, _, _, formula_full_name, *_args, **_options|
+        events << "Uploaded #{formula_full_name}"
+      end
+      allow(github_packages).to receive(:ohai) { |message| events << message }
+
+      github_packages.upload_bottles(bottles_hash, keep_old: false, dry_run: false, warn_on_error: false)
+
+      expect(events).to eq([
+        "Uploaded foo",
+        "Upload progress: 1 formula(e) uploaded, 2 remaining",
+        "Uploaded bar",
+        "Upload progress: 2 formula(e) uploaded, 1 remaining",
+        "Uploaded baz",
+        "Upload progress: 3 formula(e) uploaded, 0 remaining",
+      ])
+    end
+
+    it "does not report progress when uploading fewer than three bottles" do
+      github_packages = described_class.new
+      events = []
+      bottles_hash = {
+        "foo" => {},
+        "bar" => {},
+      }
+
+      allow(Homebrew::EnvConfig).to receive_messages(
+        github_packages_user:  "brewtest",
+        github_packages_token: "ghp_test",
+      )
+      allow(github_packages).to receive(:load_schemas!)
+      allow(github_packages).to receive(:preupload_check)
+      allow(github_packages).to receive(:ensure_executable!).and_return(Pathname("skopeo"))
+      allow(github_packages).to receive(:upload_bottle) do |_, _, _, formula_full_name, *_args, **_options|
+        events << "Uploaded #{formula_full_name}"
+      end
+      allow(github_packages).to receive(:ohai) { |message| events << message }
+
+      github_packages.upload_bottles(bottles_hash, keep_old: false, dry_run: false, warn_on_error: false)
+
+      expect(events).to eq([
+        "Uploaded foo",
+        "Uploaded bar",
+      ])
+    end
+
+    it "includes skipped bottles in progress" do
+      github_packages = described_class.new
+      bottles_hash = {
+        "foo" => {},
+        "bar" => {},
+        "baz" => {},
+      }
+
+      allow(Homebrew::EnvConfig).to receive_messages(
+        github_packages_user:  "brewtest",
+        github_packages_token: "ghp_test",
+      )
+      allow(github_packages).to receive(:ensure_executable!).and_return(Pathname("skopeo"))
+      allow(github_packages).to receive(:load_schemas!)
+      allow(github_packages).to receive(:preupload_check)
+
+      expect do
+        github_packages.upload_bottles(bottles_hash, keep_old: false, dry_run: false, warn_on_error: true)
+      end.to output(<<~EOS).to_stdout
+        ==> Upload progress: 1 formula(e) uploaded, 2 remaining
+        ==> Upload progress: 2 formula(e) uploaded, 1 remaining
+        ==> Upload progress: 3 formula(e) uploaded, 0 remaining
+      EOS
+    end
+  end
+
   describe "#upload_bottle" do
     it "omits platform metadata from image index descriptors for all bottles" do
       mktmpdir.cd do

--- a/Library/Homebrew/test/github_releases_spec.rb
+++ b/Library/Homebrew/test/github_releases_spec.rb
@@ -1,0 +1,79 @@
+# typed: true
+# frozen_string_literal: true
+
+require "github_releases"
+
+RSpec.describe GitHubReleases do
+  describe "#upload_bottles" do
+    it "reports progress when uploading many bottles" do
+      events = []
+      bottles_hash = %w[foo bar baz].to_h do |formula_name|
+        [formula_name, {
+          "bottle" => {
+            "root_url" => "https://github.com/homebrew/homebrew-core/releases/download/test",
+            "tags"     => {
+              "arm64"  => {
+                "filename"       => "#{formula_name}-arm64.bottle.tar.gz",
+                "local_filename" => "#{formula_name}-arm64.local.bottle.tar.gz",
+              },
+              "x86_64" => {
+                "filename"       => "#{formula_name}-x86_64.bottle.tar.gz",
+                "local_filename" => "#{formula_name}-x86_64.local.bottle.tar.gz",
+              },
+            },
+          },
+        }]
+      end
+      allow(GitHub).to receive(:get_release).and_return({ "id" => 123 })
+      allow(GitHub).to receive(:upload_release_asset) do |_, _, _, local_file:, remote_file:|
+        events << "Uploaded #{remote_file} from #{local_file}"
+      end
+      github_releases = described_class.new
+      allow(github_releases).to receive(:ohai) { |message| events << message }
+
+      github_releases.upload_bottles(bottles_hash)
+
+      expect(events).to eq([
+        "Uploaded foo-arm64.bottle.tar.gz from foo-arm64.local.bottle.tar.gz",
+        "Uploaded foo-x86_64.bottle.tar.gz from foo-x86_64.local.bottle.tar.gz",
+        "Upload progress: 1 formula(e) uploaded, 2 remaining",
+        "Uploaded bar-arm64.bottle.tar.gz from bar-arm64.local.bottle.tar.gz",
+        "Uploaded bar-x86_64.bottle.tar.gz from bar-x86_64.local.bottle.tar.gz",
+        "Upload progress: 2 formula(e) uploaded, 1 remaining",
+        "Uploaded baz-arm64.bottle.tar.gz from baz-arm64.local.bottle.tar.gz",
+        "Uploaded baz-x86_64.bottle.tar.gz from baz-x86_64.local.bottle.tar.gz",
+        "Upload progress: 3 formula(e) uploaded, 0 remaining",
+      ])
+    end
+
+    it "does not report progress when uploading fewer than three bottles" do
+      events = []
+      bottles_hash = %w[foo bar].to_h do |formula_name|
+        [formula_name, {
+          "bottle" => {
+            "root_url" => "https://github.com/homebrew/homebrew-core/releases/download/test",
+            "tags"     => {
+              "arm64" => {
+                "filename"       => "#{formula_name}-arm64.bottle.tar.gz",
+                "local_filename" => "#{formula_name}-arm64.local.bottle.tar.gz",
+              },
+            },
+          },
+        }]
+      end
+      allow(GitHub).to receive(:get_release).and_return({ "id" => 123 })
+      allow(GitHub).to receive(:upload_release_asset) do |_, _, _, local_file:, remote_file:|
+        events << "Uploaded #{remote_file} from #{local_file}"
+      end
+      github_releases = described_class.new
+      allow(github_releases).to receive(:ohai) { |message| events << message }
+
+      github_releases.upload_bottles(bottles_hash)
+
+      expect(events).to eq([
+        "Uploaded foo-arm64.bottle.tar.gz from foo-arm64.local.bottle.tar.gz",
+        "Uploaded bar-arm64.bottle.tar.gz from bar-arm64.local.bottle.tar.gz",
+      ])
+    end
+  end
+end


### PR DESCRIPTION
`brew pr-upload` prints nothing between formulae, so a large bottle upload can run for many minutes with no sign of how far along it is or whether it is stuck.

This adds formula-level progress to both upload backends, matching what the test jobs already print in `Library/Homebrew/test_bot/formulae.rb`:

```
==> Upload progress: 3 formula(e) uploaded, 0 remaining
```

It prints after each formula finishes and only when there are at least three formulae, so one and two formula uploads stay quiet. As in the test jobs, the count tracks formulae processed rather than bottles published, so a formula skipped under `--warn-on-upload-failure` still counts and its `opoo` line reports the skip.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new ordering tests fail when progress is printed before the upload and pass when restored, and ran `brew lgtm` + targeted specs.

-----
