### PR TITLE
Keep one failure from aborting a batch install

### DIFF
--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -158,6 +158,34 @@ class Bottle
     downloader.bottle_blob_sha256 == resource_checksum.hexdigest
   end
 
+  # A cached immutable blob is trusted without rehashing it (see
+  # `downloaded_and_valid?`), so a locally corrupted bottle would fail to
+  # extract on every run: verify it after a failed extraction and, when it was
+  # indeed corrupt, discard it and retry with a freshly downloaded one.
+  sig { params(quiet: T::Boolean, _block: T.proc.void).void }
+  def with_corrupt_download_retry(quiet: false, &_block)
+    yield
+  rescue
+    discard_corrupt_cached_download
+    raise if cached_download.exist?
+
+    downloading!
+    fetch(quiet:)
+    extracting!
+    yield
+  end
+
+  sig { void }
+  def discard_corrupt_cached_download
+    expected_checksum = resource.checksum
+    return if expected_checksum.nil?
+    return unless cached_download.file?
+    return if cached_download.sha256 == expected_checksum.hexdigest
+
+    opoo "Removing corrupt cached download: #{cached_download.basename}"
+    clear_cache
+  end
+
   sig { override.returns(T.nilable(Integer)) }
   def total_size
     bottle_size || super
@@ -184,7 +212,7 @@ class Bottle
   end
 
   sig { void }
-  def stage = downloader.stage
+  def stage = with_corrupt_download_retry { downloader.stage }
 
   sig { params(timeout: T.nilable(T.any(Integer, Float)), quiet: T::Boolean).void }
   def fetch_tab(timeout: nil, quiet: false)
@@ -269,10 +297,12 @@ class Bottle
     bottle_tmp_keg = staged_path_from_download_queue
     bottle_poured_file = staged_path_from_download_queue_marker
 
-    begin
+    # Stay quiet on the retry: the download queue is redrawing its own
+    # progress lines while this runs in a worker thread.
+    with_corrupt_download_retry(quiet: true) do
       HOMEBREW_TEMP_CELLAR.mkpath
 
-      return if bottle_poured_file.exist?
+      next if bottle_poured_file.exist?
 
       FileUtils.rm(bottle_poured_file) if bottle_poured_file.symlink?
       FileUtils.rm_r(bottle_tmp_keg) if bottle_tmp_keg.directory?

--- a/Library/Homebrew/cask/reinstall.rb
+++ b/Library/Homebrew/cask/reinstall.rb
@@ -65,22 +65,15 @@ module Cask
         download_queue.shutdown if created_download_queue
       end
 
-      exit 1 if Homebrew.failed?
-
-      caught_exceptions = []
-
+      # Reinstall everything that did download and report each failure as it
+      # happens, rather than aborting the whole run; the failures still exit
+      # nonzero at the end.
       cask_installers.each do |installer|
         installer.install
       rescue => e
-        caught_exceptions << e
+        ofail "#{installer.cask.full_name}: #{e}"
         next
       end
-
-      return if caught_exceptions.empty?
-
-      raise MultipleCaskErrors, caught_exceptions if caught_exceptions.count > 1
-
-      raise caught_exceptions.fetch(0)
     end
   end
 end

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -212,8 +212,10 @@ module Cask
 
       return false if upgradable_casks.empty?
 
-      caught_exceptions = []
-      caught_exceptions.concat(prefetched_errors) if prefetched_errors
+      # Report each failure as it happens and carry on with the other casks,
+      # rather than aborting the run; `ofail` still exits nonzero at the end.
+      prefetched_errors&.each { |error| ofail error }
+      failed = T.let(prefetched_errors.present?, T::Boolean)
 
       created_download_queue = T.let(false, T::Boolean)
       download_queue ||= if !dry_run && !skip_prefetch
@@ -236,7 +238,8 @@ module Cask
             begin
               installer.check_requirements
             rescue CaskError => e
-              caught_exceptions << e
+              ofail e
+              failed = true
               next false
             end
 
@@ -257,7 +260,7 @@ module Cask
         end
       end
 
-      return false if upgradable_casks.empty? && caught_exceptions.empty?
+      return false if upgradable_casks.empty? && !failed
 
       cask_upgrades = upgradable_casks.map do |(old_cask, new_cask)|
         "#{new_cask.full_name} #{old_cask.version} -> #{new_cask.version}"
@@ -280,18 +283,12 @@ module Cask
         )
         summary_upgrades&.push(cask_upgrades.fetch(index))
       rescue => e
-        new_exception = e.exception("#{new_cask.full_name}: #{e}")
-        new_exception.set_backtrace(e.backtrace)
-        caught_exceptions << new_exception
+        ofail "#{new_cask.full_name}: #{e}"
+        failed = true
         next
       end
 
-      return true if caught_exceptions.empty?
-
-      raise MultipleCaskErrors, caught_exceptions if caught_exceptions.count > 1
-      raise caught_exceptions.fetch(0) if caught_exceptions.one?
-
-      false
+      !failed
     end
 
     sig {

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -391,13 +391,14 @@ module Homebrew
               formula_names: formulae_installer.map { |fi| fi.formula.name },
               cask_names:    fetch_casks.map(&:full_name),
             ))
+            # Install everything that did download, rather than aborting the
+            # whole run; the failures above still exit nonzero at the end.
+            formulae_installer = Install.reject_failed_downloads(formulae_installer, download_queue:)
           ensure
             download_queue.shutdown
           end
         end
         shared_download_queue&.shutdown
-
-        exit 1 if Homebrew.failed?
 
         Install.install_formulae(formulae_installer,
                                  dry_run: args.dry_run?,
@@ -419,22 +420,20 @@ module Homebrew
         )
 
         if casks.any?
-          begin
-            new_casks.each do |cask|
-              Cask::Installer.new(
-                cask,
-                adopt:          args.adopt?,
-                binaries:       args.binaries?,
-                defer_fetch:    fetch_casks.include?(cask),
-                force:          args.force?,
-                quiet:          args.quiet?,
-                require_sha:    args.require_sha?,
-                skip_cask_deps: args.skip_cask_deps?,
-                verbose:        args.verbose?,
-              ).install
-            end
+          new_casks.each do |cask|
+            Cask::Installer.new(
+              cask,
+              adopt:          args.adopt?,
+              binaries:       args.binaries?,
+              defer_fetch:    fetch_casks.include?(cask),
+              force:          args.force?,
+              quiet:          args.quiet?,
+              require_sha:    args.require_sha?,
+              skip_cask_deps: args.skip_cask_deps?,
+              verbose:        args.verbose?,
+            ).install
           rescue => e
-            ofail e
+            ofail "#{cask.full_name}: #{e}"
           end
 
           if !Homebrew::EnvConfig.no_install_upgrade? && installed_casks.any?

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -268,7 +268,7 @@ module Homebrew
                 cask_names:    casks.map(&:full_name),
               ))
               casks_prefetched = true
-              valid_formula_installers
+              Install.reject_failed_downloads(valid_formula_installers, download_queue:)
             ensure
               download_queue.shutdown
             end
@@ -285,13 +285,18 @@ module Homebrew
             Install.fetch_formulae(formulae_installers)
           end
 
-          exit 1 if Homebrew.failed?
-
+          # Reinstall everything that did download, rather than aborting the
+          # whole run; the failures above still exit nonzero at the end.
           reinstall_contexts.each do |reinstall_context|
             next unless valid_formula_installers.include?(reinstall_context.formula_installer)
 
             Homebrew::Reinstall.reinstall_formula(reinstall_context)
             Cleanup.install_formula_clean!(reinstall_context.formula)
+          rescue BuildError
+            # Reported (with analytics) by the global handler in `brew.rb`.
+            raise
+          rescue => e
+            ofail "#{reinstall_context.formula.full_specified_name}: #{e}"
           end
 
           Upgrade.upgrade_dependents(

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -5,6 +5,7 @@ require "abstract_command"
 require "formula_installer"
 require "install"
 require "upgrade"
+require "cask/download"
 require "cask/utils"
 require "cask/upgrade"
 require "api"
@@ -287,10 +288,13 @@ module Homebrew
               formula_names: prefetched_formulae_names,
               cask_names:    prefetched_cask_names,
             ))
-            if shared_download_queue.fetch_failed
-              formulae_prefetched = false
-              prefetched_casks = false
-            end
+            # Only redo the slower unprefetched fetch for the kind of package
+            # that actually failed, so e.g. one bad bottle does not also
+            # re-verify every already downloaded cask.
+            failed_cask_downloads, failed_formula_downloads =
+              shared_download_queue.failed_downloads.partition { |download| download.is_a?(Cask::Download) }
+            formulae_prefetched = false if failed_formula_downloads.any?
+            prefetched_casks = false if failed_cask_downloads.any?
           ensure
             shared_download_queue.shutdown
           end
@@ -790,9 +794,8 @@ module Homebrew
         return false if minimum_version.present? && casks.empty?
 
         if skip_prefetch && casks.empty? && prefetched_cask_errors.present?
-          raise Cask::MultipleCaskErrors, prefetched_cask_errors if prefetched_cask_errors.count > 1
-
-          raise prefetched_cask_errors.fetch(0)
+          prefetched_cask_errors.each { |error| ofail error }
+          return false
         end
 
         Cask::Upgrade.upgrade_casks!(

--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -34,7 +34,7 @@ module Homebrew
       @downloads_by_location = T.let({}, T::Hash[Pathname, Concurrent::Promises::Future])
       @cancelled = T.let(Concurrent::AtomicBoolean.new(false), Concurrent::AtomicBoolean)
       @active_threads = T.let(Concurrent::Set.new, Concurrent::Set)
-      @fetch_failed = T.let(false, T::Boolean)
+      @failed_downloads = T.let([], T::Array[Downloadable])
       @deferred_failure_messages = T.let([], T::Array[T.proc.void])
     end
 
@@ -117,7 +117,7 @@ module Homebrew
              allow_failures: T::Boolean).void
     }
     def fetch(only: nil, heading: nil, allow_failures: false)
-      @fetch_failed = false
+      @failed_downloads = []
       @deferred_failure_messages = []
       context_before_fetch = Context.current
       fetchable_downloads = if only
@@ -151,7 +151,7 @@ module Homebrew
             next
           end
 
-          @fetch_failed = true
+          @failed_downloads << downloadable
           ofail "#{downloadable.download_queue_type} reports different checksum: #{e.expected}"
         rescue
           raise unless allow_failures
@@ -191,7 +191,7 @@ module Homebrew
               unlink_cached_download(downloadable) if exception.is_a?(ChecksumMismatchError)
             elsif future.rejected?
               if exception.is_a?(ChecksumMismatchError)
-                @fetch_failed = true
+                @failed_downloads << downloadable
                 actual = Digest::SHA256.file(downloadable.cached_download).hexdigest
                 actual_message, expected_message = align_checksum_mismatch_message(downloadable.download_queue_type)
 
@@ -218,7 +218,7 @@ module Homebrew
                 else
                   future.reason.to_s
                 end
-                @fetch_failed = true
+                @failed_downloads << downloadable
                 report_or_defer_failure { ofail failure_message }
               end
             end
@@ -308,8 +308,10 @@ module Homebrew
       end
     end
 
-    sig { returns(T::Boolean) }
-    attr_reader :fetch_failed
+    # The downloadables that failed in the last `fetch`, so callers can retry
+    # or skip only the packages that were actually affected.
+    sig { returns(T::Array[Downloadable]) }
+    attr_reader :failed_downloads
 
     sig { params(message: String).void }
     def stdout_print_and_flush_if_tty(message)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1596,6 +1596,9 @@ on_request: installed_on_request?, options:)
         FileUtils.rm(bottle_poured_file)
         FileUtils.mv(bottle_tmp_keg, formula.prefix)
         bottle_tmp_keg.parent.rmdir_if_possible
+      elsif downloadable_object.is_a?(Bottle)
+        # Retries with a fresh download if the cached bottle turns out corrupt.
+        downloadable_object.stage
       else
         downloadable_object.downloader.stage
       end

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -367,6 +367,7 @@ module Homebrew
                 combined_fetch_downloads_heading(formula_names: valid_formula_installers.map { |fi| fi.formula.name })
               end
               download_queue.fetch(heading:)
+              valid_formula_installers = reject_failed_downloads(valid_formula_installers, download_queue:)
             end
           end
         ensure
@@ -374,6 +375,25 @@ module Homebrew
         end
 
         valid_formula_installers
+      end
+
+      # A failed download has already been reported, so skip installing its
+      # formula rather than failing a second time on the missing or known-bad
+      # download, while still installing everything else.
+      sig {
+        params(formula_installers: T::Array[FormulaInstaller],
+               download_queue:     Homebrew::DownloadQueue).returns(T::Array[FormulaInstaller])
+      }
+      def reject_failed_downloads(formula_installers, download_queue:)
+        failed_names = download_queue.failed_downloads.filter_map do |downloadable|
+          case downloadable
+          when Bottle then downloadable.name
+          when Resource then downloadable.owner&.name
+          end
+        end
+        return formula_installers if failed_names.empty?
+
+        formula_installers.reject { |fi| failed_names.include?(fi.formula.name) }
       end
 
       sig {
@@ -520,6 +540,13 @@ module Homebrew
           upgrade = formula.linked? && formula.outdated? && !formula.head? && !Homebrew::EnvConfig.no_install_upgrade?
           install_formula(fi, upgrade:)
           Cleanup.install_formula_clean!(formula)
+        rescue BuildError
+          # Reported (with analytics) by the global handler in `brew.rb`.
+          raise
+        rescue => e
+          # Keep a single failed install (e.g. a bottle that fails to extract)
+          # from aborting the rest of the batch while still failing the run.
+          ofail "#{fi.formula.full_specified_name}: #{e}"
         end
       end
 

--- a/Library/Homebrew/test/bottle_spec.rb
+++ b/Library/Homebrew/test/bottle_spec.rb
@@ -37,6 +37,51 @@ RSpec.describe Bottle do
     end
   end
 
+  describe "#stage_from_download_queue" do
+    sig { params(checksum: String, content: String).returns(Bottle) }
+    def cached_bottle(checksum, content)
+      bottle_spec = BottleSpecification.new
+      bottle_spec.root_url(HOMEBREW_BOTTLE_DEFAULT_DOMAIN)
+      bottle_spec.sha256(cellar: :any_skip_relocation, arm64_big_sur: checksum)
+      bottle = described_class.new(nil, bottle_spec, Utils::Bottles::Tag.from_symbol(:arm64_big_sur),
+                                   name: "foo", pkg_version: PkgVersion.new(Version.new("1.2.3"), 0))
+      bottle.cached_download.dirname.mkpath
+      bottle.cached_download.write(content)
+      bottle
+    end
+
+    it "downloads a corrupt cached bottle again and extracts it", :aggregate_failures do
+      bottle = cached_bottle("d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97", "corrupt")
+      unpack_strategy = instance_double(UnpackStrategy::Tar)
+      allow(unpack_strategy).to receive(:extract_nestedly) { bottle.staged_path_from_download_queue.mkpath }
+      extractions = 0
+      allow(UnpackStrategy).to receive(:detect) do
+        extractions += 1
+        raise "gzip decompression failed" if extractions == 1
+
+        unpack_strategy
+      end
+
+      expect(bottle).to receive(:fetch) { bottle.cached_download.write("valid") }
+
+      expect { bottle.stage_from_download_queue(bottle.cached_download, pour: true) }
+        .to output(/Removing corrupt cached download/).to_stderr
+      expect(extractions).to eq(2)
+    end
+
+    it "keeps a cached bottle matching its checksum that fails to extract", :aggregate_failures do
+      content = "valid but unextractable"
+      bottle = cached_bottle(Digest::SHA256.hexdigest(content), content)
+      allow(UnpackStrategy).to receive(:detect).and_raise("gzip decompression failed")
+
+      expect(bottle).not_to receive(:fetch)
+
+      expect { bottle.stage_from_download_queue(bottle.cached_download, pour: true) }
+        .to raise_error(RuntimeError, "gzip decompression failed")
+      expect(bottle.cached_download).to exist
+    end
+  end
+
   describe "#github_packages_manifest_resource" do
     sig { returns(String) }
     def bottle_domain = "https://mirror.example.com/homebrew-bottles"

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Cask::Reinstall, :cask do
     Cask::Installer.new(cask1).install
     Cask::Installer.new(cask2).install
 
-    failing_installer = instance_double(Cask::Installer)
+    failing_installer = instance_double(Cask::Installer, cask: cask1)
     allow(failing_installer).to receive(:prelude)
     allow(failing_installer).to receive(:source_download_requires_pre_fetch?).and_return(false)
     allow(failing_installer).to receive(:enqueue_downloads)
@@ -77,7 +77,22 @@ RSpec.describe Cask::Reinstall, :cask do
     allow(Cask::Installer).to receive(:new).and_return(failing_installer, successful_installer)
 
     expect(successful_installer).to receive(:install)
-    expect { described_class.reinstall_casks(cask1, cask2) }.to raise_error(Cask::CaskError, "reinstall failed")
+    expect { described_class.reinstall_casks(cask1, cask2) }
+      .to output(/local-caffeine: reinstall failed/).to_stderr
+  end
+
+  it "reinstalls casks after an earlier failure in the same run" do
+    cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+    installer = instance_double(Cask::Installer, prelude: nil, enqueue_downloads: nil,
+                                                 source_download_requires_pre_fetch?: false)
+    allow(Cask::Installer).to receive(:new).and_return(installer)
+    # A failure earlier in the run (e.g. a formula in the same `brew reinstall`)
+    # must not stop the casks that are ready from being reinstalled.
+    Homebrew.failed = true
+
+    expect(installer).to receive(:install)
+
+    described_class.reinstall_casks(cask)
   end
 
   it "allows reinstalling a non installed Cask" do

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -749,7 +749,7 @@ RSpec.describe Cask::Upgrade, :cask do
 
       expect do
         described_class.upgrade_casks!(local_caffeine, args:)
-      end.to raise_error(Cask::CaskError)
+      end.to output(/local-caffeine: finalize failed/).to_stderr
 
       expect(JSON.parse(receipt_path.read).dig("source", "version")).to eq("1.2.2")
     end
@@ -783,7 +783,7 @@ RSpec.describe Cask::Upgrade, :cask do
 
       expect do
         described_class.upgrade_casks!(will_fail_if_upgraded, args:)
-      end.to raise_error(Cask::CaskError).and output(output_reverted).to_stderr
+      end.to output(output_reverted).to_stderr
 
       expect(will_fail_if_upgraded).to be_installed
       expect(will_fail_if_upgraded_path).to be_a_file
@@ -801,7 +801,7 @@ RSpec.describe Cask::Upgrade, :cask do
 
       expect do
         described_class.upgrade_casks!(bad_checksum, args:)
-      end.to raise_error(ChecksumMismatchError).and(not_to_output(output_reverted).to_stderr)
+      end.to output(/bad-checksum: SHA-256 mismatch/).to_stderr.and(not_to_output(output_reverted).to_stderr)
 
       expect(bad_checksum).to be_installed
       expect(bad_checksum_path).to be_a_directory
@@ -809,13 +809,13 @@ RSpec.describe Cask::Upgrade, :cask do
       expect(bad_checksum.staged_path).not_to exist
     end
 
-    it "raises the original upgrade error, not a failure that occurs while rolling back" do
+    it "reports the original upgrade error, not a failure that occurs while rolling back" do
       will_fail_if_upgraded = Cask::CaskLoader.load("will-fail-if-upgraded")
       allow_any_instance_of(Cask::Installer).to receive(:revert_upgrade).and_raise("rollback failed")
 
       expect do
         described_class.upgrade_casks!(will_fail_if_upgraded, args:)
-      end.to raise_error(Cask::CaskError)
+      end.to output(/Error: will-fail-if-upgraded: /).to_stderr
     end
   end
 
@@ -865,7 +865,7 @@ RSpec.describe Cask::Upgrade, :cask do
 
       expect do
         described_class.upgrade_casks!(args:, skip_prefetch: true, summary_upgrades:)
-      end.to raise_error(Cask::MultipleCaskErrors)
+      end.to output(/bad-checksum: failed.*bad-checksum2: failed/m).to_stderr
 
       expect(upgraded_tokens).to contain_exactly("bad-checksum", "bad-checksum2", "local-transmission-zip")
       expect(summary_upgrades).to contain_exactly("local-transmission-zip 2.60 -> 2.61")
@@ -919,16 +919,13 @@ RSpec.describe Cask::Upgrade, :cask do
           summary_upgrades:,
           args:
         )
-      end.to raise_error(
-        Cask::CaskError,
-        "local-caffeine: This cask does not run on macOS versions older than Tahoe.",
-      )
+      end.to output(/local-caffeine: This cask does not run on macOS versions older than Tahoe\./).to_stderr
 
       expect(upgraded_tokens).to eq(["local-transmission-zip"])
       expect(summary_upgrades).to eq(["local-transmission-zip 2.60 -> 2.61"])
     end
 
-    it "raises prefetched requirement errors after compatible casks" do
+    it "reports prefetched requirement errors alongside compatible casks" do
       summary_upgrades = []
       upgraded_tokens = []
       cask_error = Cask::CaskError.new(
@@ -948,7 +945,7 @@ RSpec.describe Cask::Upgrade, :cask do
           prefetched_errors:    [cask_error],
           args:,
         )
-      end.to raise_error(Cask::CaskError, cask_error.message)
+      end.to output(/#{Regexp.escape(cask_error.message)}/).to_stderr
 
       expect(upgraded_tokens).to eq(["local-transmission-zip"])
       expect(summary_upgrades).to eq(["local-transmission-zip 2.60 -> 2.61"])

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
 
   it "starts formula prelude fetches before dependant checks when not asking" do
     cmd = described_class.new(["--yes", "testball"])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil, failed_downloads: [])
     formula = formula("testball") do
       T.bind(self, T.class_of(Formula))
       url "https://brew.sh/testball-0.1.tar.gz"
@@ -363,10 +363,64 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     cmd.run
   end
 
+  it "installs what did download after an earlier failure" do
+    cmd = described_class.new(["--yes", "testball"])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil, failed_downloads: [])
+    formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/testball-0.1.tar.gz"
+    end
+    formula_installer = instance_double(FormulaInstaller, formula:, download_queue: nil, prelude_fetch: nil)
+    dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
+
+    allow(Tap).to receive_messages(with_formula_name: nil, with_cask_token: nil)
+    allow(Homebrew::Trust).to receive(:trust_fully_qualified_items!)
+    allow(cmd.args.named).to receive(:to_formulae_and_casks).with(warn: false).and_return([formula])
+    allow(Homebrew::Install).to receive(:perform_preinstall_checks_once)
+    allow(Homebrew::Install).to receive(:check_cc_argv)
+    allow(Homebrew::Install).to receive_messages(install_formula?: true, formula_installers: [formula_installer],
+                                                 enqueue_formulae: [formula_installer])
+    allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
+    allow(formula_installer).to receive(:download_queue=)
+    allow(Homebrew::Upgrade).to receive_messages(dependants:, upgrade_dependents: [])
+    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
+    allow(Homebrew.messages).to receive(:display_messages)
+    # A failure earlier in the run (e.g. one download of many) must not stop
+    # the packages that are ready from being installed.
+    Homebrew.failed = true
+
+    expect(Homebrew::Install).to receive(:install_formulae).with([formula_installer], dry_run: false, verbose: false)
+
+    cmd.run
+  end
+
+  it "names the cask that failed to install", :cask do
+    cmd = described_class.new(["--yes", "local-caffeine"])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil, failed_downloads: [])
+    cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+    installer = instance_double(Cask::Installer, enqueue_downloads: nil, source_download_requires_pre_fetch?: false)
+    dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
+
+    allow(Tap).to receive_messages(with_formula_name: nil, with_cask_token: nil)
+    allow(Homebrew::Trust).to receive(:trust_fully_qualified_items!)
+    allow(cmd.args.named).to receive(:to_formulae_and_casks).with(warn: false).and_return([cask])
+    allow(Cask::Upgrade).to receive(:outdated_casks).and_return([])
+    allow(Cask::Installer).to receive(:new).and_return(installer)
+    allow(installer).to receive(:install).and_raise("uh-oh")
+    allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
+    allow(Homebrew::Install).to receive(:perform_preinstall_checks_once)
+    allow(Homebrew::Install).to receive(:check_cc_argv)
+    allow(Homebrew::Upgrade).to receive_messages(dependants:, upgrade_dependents: [])
+    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
+    allow(Homebrew.messages).to receive(:display_messages)
+
+    expect { cmd.run }.to output(/local-caffeine: uh-oh/).to_stderr
+  end
+
   it "drains metadata-only prelude fetches before the dry-run plan when asking" do
     cmd = described_class.new(["testball"])
-    download_queue = instance_double(Homebrew::DownloadQueue, shutdown:  nil,
-                                                              downloads: { instance_double(Downloadable) => nil })
+    downloads = { instance_double(Downloadable) => nil }
+    download_queue = instance_double(Homebrew::DownloadQueue, shutdown: nil, failed_downloads: [], downloads:)
     formula = formula("testball") do
       T.bind(self, T.class_of(Formula))
       url "https://brew.sh/testball-0.1.tar.gz"
@@ -498,7 +552,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
 
   it "prints a shared fetch heading and correct upgrade count", :cask do
     cmd = described_class.new(["--yes", "codex"])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil, failed_downloads: [])
     formula = formula("testball_bottle") do
       T.bind(self, T.class_of(Formula))
       url "https://brew.sh/testball_bottle-0.1.tar.gz"

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Homebrew::Cmd::Reinstall do
     formula_installer = FormulaInstaller.new(formula)
     dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil, failed_downloads: [])
     reinstall_context = Homebrew::Reinstall::InstallationContext.new(
       formula_installer:,
       formula:,
@@ -124,6 +124,44 @@ RSpec.describe Homebrew::Cmd::Reinstall do
     expect(download_queue).to receive(:shutdown).ordered
 
     cmd.run
+  end
+
+  it "reinstalls the remaining formulae after one fails" do
+    cmd = described_class.new(["--yes", "one", "two"])
+    download_queue = instance_double(Homebrew::DownloadQueue, shutdown: nil, failed_downloads: [])
+    dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
+    contexts = %w[one two].map do |name|
+      formula = formula(name) do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/#{name}-0.1.tar.gz"
+      end
+      allow(formula).to receive_messages(latest_formula: formula, pinned?: false)
+      Homebrew::Reinstall::InstallationContext.new(
+        formula_installer: FormulaInstaller.new(formula),
+        formula:,
+        keg:               nil,
+        options:           Options.create([]),
+      )
+    end
+
+    allow(Homebrew::Trust).to receive(:trust_fully_qualified_items!)
+    allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable)
+      .with(method: :resolve)
+      .and_return(contexts.map(&:formula))
+    allow(Migrator).to receive(:migrate_if_needed)
+    allow(Homebrew::Install).to receive(:perform_preinstall_checks_once)
+    allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
+    allow(Homebrew::Reinstall).to receive(:build_install_context).and_return(*contexts)
+    allow(Homebrew::Install).to receive(:fetch_formulae).and_return(contexts.map(&:formula_installer))
+    allow(Homebrew::Reinstall).to receive(:reinstall_formula).with(contexts.fetch(0))
+                                                             .and_raise("gzip decompression failed")
+    allow(Homebrew::Cleanup).to receive_messages(install_formula_clean!: nil, periodic_clean!: nil)
+    allow(Homebrew::Upgrade).to receive_messages(dependants:, upgrade_dependents: [])
+    allow(Homebrew.messages).to receive(:display_messages)
+
+    expect(Homebrew::Reinstall).to receive(:reinstall_formula).with(contexts.fetch(1))
+
+    expect { cmd.run }.to output(/Error: one: gzip decompression failed/).to_stderr
   end
 
   it "reinstalls a Formula", :integration_test do

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -404,7 +404,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   # upgrades with asking for user prompts
   it "prints formula and cask ask plans before upgrading" do
     cmd = described_class.new([])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, fetch_failed: false, shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil)
 
     expect(cmd).to receive(:upgrade_outdated_formulae!)
       .with([], dry_run: true, show_upgrade_summary: false)
@@ -739,7 +739,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
   it "prints a combined upgrade summary before fetching combined downloads" do
     cmd = described_class.new(["-y"])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, fetch_failed: false, shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil)
     cask = instance_double(
       Cask::Cask,
       artifacts:         [],
@@ -787,7 +787,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
   it "asks before fetching formulae and casks in the same download queue" do
     cmd = described_class.new([])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, fetch_failed: false, shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil)
     cask = instance_double(
       Cask::Cask,
       artifacts:         [],
@@ -837,7 +837,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
   it "uses prefetched compatible casks and carries requirement errors into upgrade" do
     cmd = described_class.new(["--yes"])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, fetch_failed: false, shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil)
     cask = instance_double(Cask::Cask)
     cask_error = Cask::CaskError.new("bad-cask: This cask requires Linux.")
 
@@ -870,7 +870,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
   it "prefetches language cask files before fetching combined downloads" do
     cmd = described_class.new(["--yes"])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch_failed: false, shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [], shutdown: nil)
     cask = instance_double(
       Cask::Cask,
       artifacts:         [],
@@ -974,7 +974,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
   it "omits the cask file heading for cached language cask files" do
     cmd = described_class.new(["-y"])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch_failed: false, shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [], shutdown: nil)
     cask = instance_double(
       Cask::Cask,
       artifacts:         [],
@@ -1043,9 +1043,22 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     Homebrew::Upgrade.formula_installers([formula], flags: [])
   end
 
-  it "does not trust failed shared prefetches" do
+  it "only distrusts the formula half of a shared prefetch whose bottle download failed" do
+    expect(run_upgrade_with_failed_shared_prefetch(instance_double(Bottle)))
+      .to eq(use_prefetched: false, skip_prefetch: true)
+  end
+
+  it "only distrusts the cask half of a shared prefetch whose cask download failed" do
+    expect(run_upgrade_with_failed_shared_prefetch(Cask::Download.new(Cask::Cask.new("codex"))))
+      .to eq(use_prefetched: true, skip_prefetch: false)
+  end
+
+  def run_upgrade_with_failed_shared_prefetch(failed_download)
+    upgraded = {}
     cmd = described_class.new([])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, fetch_failed: true, shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch:            nil,
+                                                              failed_downloads: [failed_download],
+                                                              shutdown:         nil)
     cask = instance_double(
       Cask::Cask,
       artifacts:         [],
@@ -1061,15 +1074,13 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
                                                               use_prefetched: false,
                                                               prefetch_names: nil,
                                                               prefetch_upgrades: nil,
-                                                              show_upgrade_summary: true,
+                                                              dry_run: false,
                                                               **|
       if prefetch_only
-        expect(show_upgrade_summary).to be(false)
         prefetch_names&.replace(["deno"])
         prefetch_upgrades&.replace(["deno 2.7.10 -> 2.7.11"])
-      else
-        expect(use_prefetched).to be(false)
-        expect(show_upgrade_summary).to be(false)
+      elsif !dry_run
+        upgraded[:use_prefetched] = use_prefetched
       end
 
       true
@@ -1077,8 +1088,12 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     allow(Cask::Upgrade).to receive(:outdated_casks).and_return([cask])
     allow(Cask::Installer).to receive(:new).and_return(installer)
     allow(Cask::Upgrade).to receive(:upgrade_casks!) do |*_, **kwargs|
-      expect(kwargs[:skip_prefetch]).to be(false)
-      expect(kwargs[:show_upgrade_summary]).to be(false)
+      if kwargs[:dry_run]
+        # Plan an upgrade in the `--ask` preview so the shared prefetch runs.
+        kwargs[:summary_upgrades]&.push("codex 0.117.0 -> 0.118.0")
+      else
+        upgraded[:skip_prefetch] = kwargs[:skip_prefetch]
+      end
 
       true
     end
@@ -1087,6 +1102,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     allow(Homebrew.messages).to receive(:display_messages)
 
     cmd.run
+    upgraded
   end
 
   it "does not print removed caveats method errors for installed casks", :cask do

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Homebrew::DownloadQueue do
 
     expect { download_queue.fetch }.to output(/network blew up/).to_stderr
 
-    expect(download_queue.fetch_failed).to be(true)
+    expect(download_queue.failed_downloads).to eq([downloadable])
     expect(Homebrew).to have_failed
   end
 
@@ -108,7 +108,7 @@ RSpec.describe Homebrew::DownloadQueue do
     download_queue.enqueue(downloadable)
 
     expect { download_queue.fetch(allow_failures: true) }.to output(/✘/).to_stderr
-    expect(download_queue.fetch_failed).to be false
+    expect(download_queue.failed_downloads).to be_empty
     expect(Homebrew).not_to have_failed
   end
 

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -102,6 +102,35 @@ RSpec.describe FormulaInstaller do
     end
   end
 
+  specify "bottle install with a corrupt cached download", :aggregate_failures do
+    allow(DevelopmentTools).to receive(:installed?).and_return(false)
+    formula = TestballBottle.new
+    bottle = formula.bottle
+    stub_formula_loader formula
+
+    # Simulate a GitHub Packages bottle blob, which is trusted without being
+    # rehashed, so this corrupt download is only noticed when it fails to
+    # extract and must then be discarded and downloaded again.
+    bottle.cached_download.dirname.mkpath
+    bottle.cached_download.write("corrupt" * 1000)
+    allow(bottle).to receive(:downloaded_and_valid?).and_return(true)
+
+    formula_installer = described_class.new(formula)
+    begin
+      expect do
+        Homebrew::Install.fetch_formulae([formula_installer])
+        formula_installer.install
+      end.to output(/Removing corrupt cached download/).to_stderr
+
+      expect(formula).to be_latest_version_installed
+      expect(Homebrew).not_to have_failed
+    ensure
+      Keg.new(formula.prefix).uninstall if formula.prefix.directory?
+      formula.clear_cache
+      bottle.clear_cache
+    end
+  end
+
   specify "build tools error" do
     allow(DevelopmentTools).to receive(:installed?).and_return(false)
 

--- a/Library/Homebrew/test/install_spec.rb
+++ b/Library/Homebrew/test/install_spec.rb
@@ -48,6 +48,46 @@ RSpec.describe Homebrew::Install do
     end
   end
 
+  describe "::reject_failed_downloads" do
+    it "skips the formula whose download failed and keeps the rest" do
+      bottle_spec = BottleSpecification.new
+      bottle_spec.sha256(arm64_big_sur: "deadbeef" * 8)
+      failed_bottle = Bottle.new(nil, bottle_spec, Utils::Bottles::Tag.from_symbol(:arm64_big_sur),
+                                 name: "bad-bottle", pkg_version: PkgVersion.new(Version.new("1.0"), 0))
+      bad_fi = instance_double(FormulaInstaller, formula: formula("bad-bottle") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end)
+      good_fi = instance_double(FormulaInstaller, formula: formula("good-bottle") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end)
+      download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [failed_bottle])
+
+      expect(described_class.reject_failed_downloads([bad_fi, good_fi], download_queue:)).to eq([good_fi])
+    end
+  end
+
+  describe "::install_formulae" do
+    it "skips a formula whose install raises and continues with the rest" do
+      bad_fi = instance_double(FormulaInstaller, formula: formula("bad-bottle") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end)
+      good_fi = instance_double(FormulaInstaller, formula: formula("good-bottle") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end)
+      allow(Homebrew::Cleanup).to receive(:install_formula_clean!)
+      allow(described_class).to receive(:install_formula).with(bad_fi, upgrade: false)
+                                                         .and_raise("gzip decompression failed")
+      expect(described_class).to receive(:install_formula).with(good_fi, upgrade: false)
+
+      expect { described_class.install_formulae([bad_fi, good_fi]) }
+        .to output(/Error: bad-bottle: gzip decompression failed/).to_stderr
+    end
+  end
+
   describe "::enqueue_cask_installers" do
     it "skips casks whose enqueue raises and continues with the rest" do
       bad_cask = instance_double(Cask::Cask, to_s: "bad-cask")

--- a/Library/Homebrew/test/upgrade_spec.rb
+++ b/Library/Homebrew/test/upgrade_spec.rb
@@ -69,6 +69,15 @@ RSpec.describe Homebrew::Upgrade do
       expect { described_class.upgrade_formula(formula_installer, dry_run: true) }
         .to output(/Would upgrade.*python@3.14 3.7.1 -> 3.14.6/m).to_stdout
     end
+
+    it "reports a failed upgrade instead of aborting the rest of the batch" do
+      formula_installer = instance_double(FormulaInstaller, formula: Testball.new)
+      allow(Homebrew::Install).to receive(:install_formula).and_raise("gzip decompression failed")
+
+      expect do
+        expect(described_class.upgrade_formula(formula_installer)).to be(false)
+      end.to output(/Error: testball: gzip decompression failed/).to_stderr
+    end
   end
 
   describe "::formula_installers" do

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -449,12 +449,12 @@ module Homebrew
           # We already attempted to reinstall f as part of the dependency tree of
           # another formula. In that case, don't generate an error, just move on.
           nil
-        rescue CannotInstallFormulaError, DownloadError => e
-          ofail e
         rescue BuildError => e
           e.dump(verbose:)
           puts
           Homebrew.failed = true
+        rescue => e
+          ofail e
         end
         upgraded_formulae
       end
@@ -490,6 +490,11 @@ module Homebrew
         e.dump(verbose:)
         puts
         Homebrew.failed = true
+        false
+      rescue => e
+        # Keep a single failed upgrade (e.g. a bottle that fails to extract)
+        # from aborting the rest of the batch while still failing the run.
+        ofail "#{formula_installer.formula.full_specified_name}: #{e}"
         false
       end
 


### PR DESCRIPTION
- A bottle that fails to extract aborted the whole `brew upgrade` (or multi-formula `brew install`) run, so every remaining formula and cask was skipped: report the failure and carry on with the rest instead, still exiting nonzero.
- `Bottle#downloaded_and_valid?` trusts an immutable GitHub Packages blob without rehashing it, so a corrupt cached bottle failed to extract on every run. Verify it after a failed extraction, then discard it and retry the extraction with a fresh download.
- `brew install` and `brew reinstall` exited as soon as anything had failed, before installing anything at all: install what did download instead, skipping only the packages whose downloads failed.
- Isolate each cask in `brew install` and each formula in `brew reinstall`, and widen the errors tolerated per package, so one failure no longer skips everything after it.
- Track which downloads failed in `DownloadQueue` so a failed bottle only distrusts the shared formula prefetch, rather than also making every already downloaded cask be fetched and verified again.

Fixes https://github.com/Homebrew/brew/issues/23519.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Opus 5 high with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
