### PR TITLE
Record startup phases in `brew prof --timings`

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -24,8 +24,8 @@ std_trap = trap("INT") { exit! 130 } # no backtrace thanks
 require_relative "global"
 require "utils/output"
 
+require "utils/phase_timings"
 if phase_timings_output
-  require "utils/phase_timings"
   Homebrew::PhaseTimings.start!(
     output_path: phase_timings_output,
     started_at:  phase_timings_started_at,
@@ -61,8 +61,10 @@ begin
 
   ARGV.delete_at(help_cmd_index) if help_cmd_index
 
-  require "cli/parser"
-  args = Homebrew::CLI::Parser.new(Homebrew::Cmd::Brew).parse(ARGV.dup.freeze, ignore_invalid_options: true)
+  args = Homebrew::PhaseTimings.measure("cli_parse") do
+    require "cli/parser"
+    Homebrew::CLI::Parser.new(Homebrew::Cmd::Brew).parse(ARGV.dup.freeze, ignore_invalid_options: true)
+  end
   Context.current = args.context
 
   path = PATH.new(ENV.fetch("PATH"))
@@ -81,20 +83,24 @@ begin
   external_ruby_cmd_path = T.let(nil, T.nilable(Pathname))
   external_cmd_path = T.let(nil, T.nilable(Pathname))
 
-  if cmd
-    cmd = Commands::HOMEBREW_INTERNAL_COMMAND_ALIASES.fetch(cmd, cmd)
-    internal_cmd = Commands.valid_internal_cmd?(cmd) || Commands.valid_internal_dev_cmd?(cmd)
+  # `valid_internal_cmd?` requires the command's file, so this covers the
+  # command's entire `require` graph: usually the largest phase of all.
+  Homebrew::PhaseTimings.measure("command_load") do
+    if cmd
+      cmd = Commands::HOMEBREW_INTERNAL_COMMAND_ALIASES.fetch(cmd, cmd)
+      internal_cmd = Commands.valid_internal_cmd?(cmd) || Commands.valid_internal_dev_cmd?(cmd)
 
-    unless internal_cmd
-      # Add contributed commands to PATH before checking.
-      homebrew_path.append(Commands.tap_cmd_directories)
+      unless internal_cmd
+        # Add contributed commands to PATH before checking.
+        homebrew_path.append(Commands.tap_cmd_directories)
 
-      # External commands expect a normal PATH
-      ENV["PATH"] = homebrew_path.to_s
+        # External commands expect a normal PATH
+        ENV["PATH"] = homebrew_path.to_s
 
-      external_ruby_v2_cmd = !Commands.external_ruby_v2_cmd_path(cmd).nil?
-      external_ruby_cmd_path = Commands.external_ruby_cmd_path(cmd) unless external_ruby_v2_cmd
-      external_cmd_path = Commands.external_cmd_path(cmd) if !external_ruby_v2_cmd && external_ruby_cmd_path.nil?
+        external_ruby_v2_cmd = !Commands.external_ruby_v2_cmd_path(cmd).nil?
+        external_ruby_cmd_path = Commands.external_ruby_cmd_path(cmd) unless external_ruby_v2_cmd
+        external_cmd_path = Commands.external_cmd_path(cmd) if !external_ruby_v2_cmd && external_ruby_cmd_path.nil?
+      end
     end
   end
 
@@ -129,7 +135,7 @@ begin
       Homebrew::PhaseTimings.install! if phase_timings_output
       Homebrew::API.fetch_api_files! if install_from_api
 
-      command_instance = cmd_class.new
+      command_instance = Homebrew::PhaseTimings.measure("cli_parse") { cmd_class.new }
 
       require "utils/analytics"
       Utils::Analytics.report_command_run(command_instance)

--- a/Library/Homebrew/test/dev-cmd/prof_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/prof_spec.rb
@@ -108,7 +108,8 @@ RSpec.describe Homebrew::DevCmd::Prof do
       timings = JSON.parse((HOMEBREW_LIBRARY_PATH/"prof/timings.json").read)
       phases = timings.fetch("events").map { |event| event.fetch("phase") }
       expect(phases).to include(
-        "startup", "formula_resolution", "formula_inflation", "download_enqueue", "curl_body", "checksum", "symlink"
+        "startup", "cli_parse", "command_load", "formula_resolution", "formula_inflation", "download_enqueue",
+        "curl_body", "checksum", "symlink"
       )
     end
   end

--- a/Library/Homebrew/utils/phase_timings.rb
+++ b/Library/Homebrew/utils/phase_timings.rb
@@ -1,8 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "json"
-
 module Homebrew
   module PhaseTimings
     Event = T.type_alias { T::Hash[String, T.any(Integer, String)] }
@@ -38,6 +36,10 @@ module Homebrew
         .returns(T.type_parameter(:U))
     }
     def self.measure(phase, detail: nil, &_block)
+      # Recording is opt-in via `$HOMEBREW_PHASE_TIMINGS`, so callers on the
+      # startup path can measure unconditionally without paying for it.
+      return yield if @output_path.nil?
+
       started_at = monotonic_time
       begin
         yield
@@ -90,6 +92,8 @@ module Homebrew
     def self.write!
       output_path = @output_path
       return if output_path.nil?
+
+      require "json"
 
       events = @mutex.synchronize { @events.sort_by { |event| event.fetch("start") } }
       output_path.dirname.mkpath


### PR DESCRIPTION
- `startup` ended after `require "global"` and the next event was `api_metadata_load`, hiding ~130ms of a ~260ms warm no-op install
- `command_load` covers `Commands.valid_internal_cmd?`, which requires the command's file and so pays for its whole `require` graph: at ~90-135ms this is the single largest phase of `brew install`
- `cli_parse` covers both the top-level parse and `cmd_class.new`, the latter being where named args inflate formulae
- `measure` now no-ops until `start!` runs, so the startup path can measure unconditionally; `require "json"` moves into `write!`

This will help with future performance optimisation work.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Opus 5 high with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
