### PR TITLE
utils/cpan: add offline test coverage

### DIFF
--- a/Library/Homebrew/test/utils/cpan_spec.rb
+++ b/Library/Homebrew/test/utils/cpan_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "utils/cpan"
+require "utils/curl"
 
 RSpec.describe CPAN do
   let(:cpan_package_url) do
@@ -12,6 +13,11 @@ RSpec.describe CPAN do
   end
   let(:non_cpan_package_url) do
     "https://github.com/example/package/archive/v1.0.0.tar.gz"
+  end
+
+  def curl_result(stdout: "", success: true)
+    status = instance_double(Process::Status, success?: success)
+    instance_double(SystemCommand::Result, stdout:, status:)
   end
 
   describe CPAN::Package do
@@ -27,6 +33,17 @@ RSpec.describe CPAN do
       end
     end
 
+    describe ".current_version" do
+      it "returns nil for non-CPAN and unversioned archive URLs" do
+        unversioned_package = described_class.new(
+          "Example::Module",
+          "https://cpan.metacpan.org/authors/id/E/EX/EXAMPLE/Example-Module-main.tar.gz",
+        )
+
+        expect([package_from_non_cpan_url.current_version, unversioned_package.current_version]).to eq([nil, nil])
+      end
+    end
+
     describe ".valid_cpan_package?" do
       specify do
         expect(package_from_cpan_url.valid_cpan_package?).to be true
@@ -34,10 +51,201 @@ RSpec.describe CPAN do
       end
     end
 
+    describe ".latest_cpan_info" do
+      let(:latest_package_url) do
+        "https://cpan.metacpan.org/authors/id/P/PE/PEVANS/Scalar-List-Utils-1.69.tar.gz"
+      end
+      let(:latest_metadata) do
+        JSON.generate(
+          "download_url"    => latest_package_url,
+          "checksum_sha256" => "a" * 64,
+          "version"         => "1.69",
+        )
+      end
+
+      it "returns and caches release metadata" do
+        expect(Utils::Curl).to receive(:curl_output)
+          .with("https://fastapi.metacpan.org/v1/download_url/Scalar::Util", "--location", "--fail")
+          .once
+          .and_return(curl_result(stdout: latest_metadata))
+        expected = ["Scalar::Util", latest_package_url, "a" * 64, "1.69"]
+
+        expect([package_from_cpan_url.latest_cpan_info, package_from_cpan_url.latest_cpan_info])
+          .to eq([expected, expected])
+      end
+
+      it "does not query MetaCPAN for non-CPAN resources" do
+        expect(Utils::Curl).not_to receive(:curl_output)
+
+        expect(package_from_non_cpan_url.latest_cpan_info).to be_nil
+      end
+
+      it "returns nil when MetaCPAN cannot be reached" do
+        allow(Utils::Curl).to receive(:curl_output).and_return(curl_result(success: false))
+
+        expect(package_from_cpan_url.latest_cpan_info).to be_nil
+      end
+
+      it "returns nil for invalid JSON" do
+        allow(Utils::Curl).to receive(:curl_output).and_return(curl_result(stdout: "not json"))
+
+        expect(package_from_cpan_url.latest_cpan_info).to be_nil
+      end
+
+      it "returns nil when required release metadata is missing" do
+        responses = [
+          JSON.generate("checksum_sha256" => "a" * 64, "version" => "1.69"),
+          JSON.generate("download_url" => latest_package_url, "version" => "1.69"),
+        ].map { |stdout| curl_result(stdout:) }
+        allow(Utils::Curl).to receive(:curl_output).and_return(*responses)
+        packages = [
+          described_class.new("Scalar::Util", cpan_package_url),
+          described_class.new("Scalar::Util", cpan_package_url),
+        ]
+
+        expect(packages.map(&:latest_cpan_info)).to eq([nil, nil])
+      end
+    end
+
     describe ".to_s" do
       it "returns resource name" do
         expect(package_from_cpan_url.to_s).to eq "Scalar::Util"
       end
+    end
+  end
+
+  describe ".update_perl_resources!" do
+    let(:formula_path) { mktmpdir/"foo.rb" }
+    let(:formula_contents) do
+      <<~RUBY
+        class Foo < Formula
+          desc "Test formula"
+          homepage "https://example.com"
+          url "https://example.com/foo-1.0.tar.gz"
+          sha256 "#{"b" * 64}"
+
+          resource "Scalar::Util" do
+            url "#{cpan_package_url}"
+            sha256 "#{"c" * 64}"
+          end
+
+          def install
+            bin.install "foo"
+          end
+        end
+      RUBY
+    end
+    let(:test_formula) do
+      formula_path.write(formula_contents)
+      resource_url = cpan_package_url
+      formula("foo", path: formula_path) do
+        T.bind(self, T.class_of(Formula))
+        url "https://example.com/foo-1.0.tar.gz"
+        resource "Scalar::Util" do
+          url resource_url
+          sha256 "c" * 64
+        end
+      end
+    end
+    let(:latest_package_url) do
+      "https://cpan.metacpan.org/authors/id/P/PE/PEVANS/Scalar-List-Utils-1.69.tar.gz"
+    end
+    let(:latest_metadata) do
+      JSON.generate(
+        "download_url"    => latest_package_url,
+        "checksum_sha256" => "d" * 64,
+        "version"         => "1.69",
+      )
+    end
+
+    before do
+      allow(Utils::Curl).to receive(:curl_output).and_return(curl_result(stdout: latest_metadata))
+    end
+
+    it "prints updated CPAN resource blocks" do
+      expected_output = [
+        "  resource \"Scalar::Util\" do",
+        "    url \"#{latest_package_url}\"",
+        "    sha256 \"#{"d" * 64}\"",
+        "  end",
+        "",
+      ].join("\n")
+
+      expect do
+        described_class.update_perl_resources!(test_formula, print_only: true)
+      end.to output(expected_output).to_stdout
+    end
+
+    it "updates CPAN resource blocks in the formula" do
+      described_class.update_perl_resources!(test_formula, quiet: true)
+
+      expect(formula_path.read).to eq formula_contents.sub(cpan_package_url, latest_package_url)
+                                                      .sub("c" * 64, "d" * 64)
+    end
+
+    it "reports resolved resource updates" do
+      expect do
+        described_class.update_perl_resources!(test_formula)
+      end.to output(
+        /Found 1 CPAN resources.*1\.68 -> 1\.69.*Updated 1 CPAN resource/m,
+      ).to_stdout
+    end
+
+    it "reports resources that are already current" do
+      current_metadata = JSON.generate(
+        "download_url"    => cpan_package_url,
+        "checksum_sha256" => "c" * 64,
+        "version"         => "1.68",
+      )
+      allow(Utils::Curl).to receive(:curl_output).and_return(curl_result(stdout: current_metadata))
+
+      expect do
+        described_class.update_perl_resources!(test_formula)
+      end.to output(/"Scalar::Util": already up to date \(1\.68\)/).to_stdout
+    end
+
+    it "fails when the formula has no CPAN resources" do
+      non_cpan_url = non_cpan_package_url
+      test_formula = formula("foo") do
+        T.bind(self, T.class_of(Formula))
+        url "https://example.com/foo-1.0.tar.gz"
+        resource "Example" do
+          url non_cpan_url
+          sha256 "e" * 64
+        end
+      end
+
+      expect do
+        described_class.update_perl_resources!(test_formula)
+      end.to raise_error(SystemExit).and output(/"foo" has no CPAN resources to update/).to_stderr
+    end
+
+    it "fails when release metadata cannot be resolved" do
+      allow(Utils::Curl).to receive(:curl_output).and_return(curl_result(success: false))
+
+      expect do
+        described_class.update_perl_resources!(test_formula, print_only: true)
+      end.to raise_error(SystemExit).and output(/Unable to resolve "Scalar::Util"/).to_stderr
+    end
+
+    it "emits an error comment when unresolved resources are ignored" do
+      allow(Utils::Curl).to receive(:curl_output).and_return(curl_result(success: false))
+
+      expect do
+        described_class.update_perl_resources!(test_formula, print_only: true, ignore_errors: true)
+      end.to output("  # RESOURCE-ERROR: Unable to resolve \"Scalar::Util\"\n").to_stdout
+    end
+
+    it "writes error comments and marks the command failed when unresolved resources are ignored" do
+      allow(Utils::Curl).to receive(:curl_output).and_return(curl_result(success: false))
+      test_formula
+      Homebrew.failed = false
+
+      expect do
+        described_class.update_perl_resources!(test_formula, ignore_errors: true, quiet: true)
+      end.to output(/Unable to resolve some dependencies/).to_stderr
+      expect([formula_path.read.include?('  # RESOURCE-ERROR: Unable to resolve "Scalar::Util"'), Homebrew.failed?])
+        .to eq([true, true])
     end
   end
 end


### PR DESCRIPTION
`utils/cpan.rb` was almost entirely untested: the existing spec covered URL version parsing and `valid_cpan_package?`, and nothing else. Every path that talks to MetaCPAN or rewrites a formula had no coverage at all.

This adds offline coverage for `CPAN::Package#latest_cpan_info` (success, per-instance caching, non-CPAN short circuit, HTTP failure, malformed JSON, missing `download_url`, missing `checksum_sha256`) and for `CPAN.update_perl_resources!` (print-only output, in-place AST rewrite, version reporting, already-current resources, no CPAN resources, unresolvable metadata, and the `--ignore-errors` write path). `Utils::Curl.curl_output` is stubbed throughout so nothing hits the network, unlike the equivalent PyPI coverage in `pypi_spec.rb` which is gated behind `:needs_network`.

I want this in before touching `utils/cpan.rb` itself. Two production issues are already known: non-CPAN resources adjacent to CPAN ones are silently dropped during the resource-block rewrite, and a MetaCPAN response missing `version` produces an array containing `nil` despite the declared `T::Array[String]` return type. Both need behavior changes, and those are easier to review against a spec that already pins the current contract.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the tests; I reviewed the diff, verified each new example fails against a mutated implementation and passes against the real one, and ran `brew lgtm` plus targeted specs.

-----
