### PR TITLE
utils/curl: request headers when body is unused

### DIFF
--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -653,6 +653,109 @@ RSpec.describe "Utils::Curl" do
     end
   end
 
+  describe "::curl_http_content_headers_and_checksum" do
+    def curl_args_for(**options)
+      args = T.let([], T::Array[String])
+      allow(self).to receive(:curl_output) do |*arguments, **_options|
+        args = arguments
+        ["", "", instance_double(Process::Status, success?: false, exitstatus: 0)]
+      end
+      curl_http_content_headers_and_checksum("https://brew.sh/", **options)
+      args
+    end
+
+    it "requests headers only when `head_only` is set" do
+      expect(curl_args_for(head_only: true)).to include("--head")
+    end
+
+    it "does not write the body to a file when `head_only` is set" do
+      expect(curl_args_for(head_only: true)).not_to include("--output")
+    end
+
+    it "does not combine `--dump-header` with `--head`" do
+      expect(curl_args_for(head_only: true)).not_to include("--dump-header")
+    end
+
+    it "downloads the body when `head_only` is not set" do
+      expect(curl_args_for(head_only: false)).to include("--output")
+    end
+  end
+
+  describe "::curl_check_http_content" do
+    let(:response) do
+      {
+        url:            "https://brew.sh/",
+        final_url:      nil,
+        exit_status:    0,
+        status_code:    "200",
+        headers:        {},
+        etag:           nil,
+        content_length: nil,
+        file:           nil,
+        file_hash:      nil,
+        responses:      [],
+      }
+    end
+
+    # Returns the recorded `head_only` of each fetch; responses are used in turn.
+    def record_head_only(*responses)
+      recorded = []
+      allow(self).to receive(:curl_http_content_headers_and_checksum) do |_url, **options|
+        recorded << options[:head_only]
+        responses[[recorded.length - 1, responses.length - 1].min]
+      end
+      recorded
+    end
+
+    it "requests headers only for an HTTPS URL" do
+      recorded = record_head_only(response)
+      curl_check_http_content("https://brew.sh/", "homepage URL")
+      expect(recorded).to eq([true])
+    end
+
+    it "downloads the body for an HTTP URL, which needs it for comparison" do
+      recorded = record_head_only(response)
+      curl_check_http_content("http://brew.sh/", "homepage URL")
+      expect(recorded).to all(be_falsey)
+    end
+
+    it "retries as a `GET` when the server rejects `HEAD`" do
+      recorded = record_head_only(response.merge(status_code: "405"), response)
+      curl_check_http_content("https://brew.sh/", "homepage URL")
+      expect(recorded).to eq([true, false])
+    end
+
+    it "reports the problem from the `GET` when the server rejects `HEAD`" do
+      record_head_only(response.merge(status_code: "405"), response.merge(status_code: "500"))
+      expect(curl_check_http_content("https://brew.sh/", "homepage URL"))
+        .to include("HTTP status code 500")
+    end
+
+    # The request may have reached the server, so `HEAD` could be why it failed.
+    test_each([28, 52, 56]) do |exit_status|
+      it "retries as a `GET` when `HEAD` failed with exit status #{exit_status}" do
+        recorded = record_head_only(response.merge(status_code: nil, exit_status:), response)
+        curl_check_http_content("https://brew.sh/", "homepage URL")
+        expect(recorded).to eq([true, false])
+      end
+    end
+
+    # These happen before the request is sent.
+    test_each([6, 7]) do |exit_status|
+      it "does not retry as a `GET` when `HEAD` failed with exit status #{exit_status}" do
+        recorded = record_head_only(response.merge(status_code: nil, exit_status:))
+        curl_check_http_content("https://brew.sh/", "homepage URL")
+        expect(recorded).to eq([true])
+      end
+    end
+
+    it "still reports an unreachable URL when the `GET` retry also fails" do
+      record_head_only(response.merge(status_code: nil, exit_status: 28))
+      expect(curl_check_http_content("https://brew.sh/", "homepage URL"))
+        .to include("is not reachable")
+    end
+  end
+
   describe "::http_status_ok?" do
     it "returns `true` when `status` is 1xx or 2xx" do
       expect(http_status_ok?("200")).to be(true)

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -24,9 +24,22 @@ module Utils
     # code that is >= 400.
     CURL_HTTP_RETURNED_ERROR_EXIT_CODE = 22
 
+    # Error returned when an operation took longer than the given timeout.
+    CURL_OPERATION_TIMEOUT_EXIT_CODE = 28
+
+    # Error returned when the server closed the connection without replying.
+    CURL_GOT_NOTHING_EXIT_CODE = 52
+
     # Error returned when curl gets an error from the lowest networking layers
     # that the receiving of data failed.
     CURL_RECV_ERROR_EXIT_CODE = 56
+
+    # Failures that can occur after the request has been sent.
+    CURL_REQUEST_SENT_EXIT_CODES = T.let([
+      CURL_OPERATION_TIMEOUT_EXIT_CODE,
+      CURL_GOT_NOTHING_EXIT_CODE,
+      CURL_RECV_ERROR_EXIT_CODE,
+    ].freeze, T::Array[Integer])
 
     # This regex is used to extract the part of an ETag within quotation marks,
     # ignoring any leading weak validator indicator (`W/`). This simplifies
@@ -51,6 +64,9 @@ module Utils
     private_constant :CURL_WEIRD_SERVER_REPLY_EXIT_CODE,
                      :CURL_HTTP_RETURNED_ERROR_EXIT_CODE,
                      :CURL_RECV_ERROR_EXIT_CODE,
+                     :CURL_OPERATION_TIMEOUT_EXIT_CODE,
+                     :CURL_GOT_NOTHING_EXIT_CODE,
+                     :CURL_REQUEST_SENT_EXIT_CODES,
                      :ETAG_VALUE_REGEX, :HTTP_RESPONSE_BODY_SEPARATOR,
                      :HTTP_STATUS_LINE_REGEX,
                      :HTTPS_REDIRECT_CURL_ARGS, :PROGRESS_BAR_REGEX
@@ -457,16 +473,32 @@ module Utils
 
       details = T.let({}, T::Hash[Symbol, T.untyped])
       attempts = 0
+      # The body is only read to compare an HTTP URL with its HTTPS counterpart.
+      head_only = T.let(url == secure_url, T::Boolean)
       user_agents.each do |user_agent|
         loop do
           details = curl_http_content_headers_and_checksum(
             url,
             specs:,
             hash_needed:,
+            head_only:,
             use_homebrew_curl:,
             user_agent:,
             referer:,
           )
+
+          # Some servers reject `HEAD` but serve `GET`.
+          # DNS and connection failures happen before the request is sent.
+          head_rejected = if (status_code = details[:status_code])
+            !http_status_ok?(status_code)
+          else
+            CURL_REQUEST_SENT_EXIT_CODES.include?(details[:exit_status])
+          end
+
+          if head_only && head_rejected
+            head_only = false
+            next
+          end
 
           # Retry on network issues
           break if details[:exit_status] != 52 && details[:exit_status] != 56
@@ -484,6 +516,9 @@ module Utils
         return if details[:responses].any? do |response|
           url_protected_by_cloudflare?(response) || url_protected_by_incapsula?(response)
         end
+
+        # TODO: `utils/shared_audits` requires this file in turn.
+        require "utils/shared_audits"
 
         # https://github.com/Homebrew/brew/issues/13789
         # If the `:homepage` of a formula is private, it will fail an `audit`
@@ -561,13 +596,14 @@ module Utils
         url:               String,
         specs:             T::Hash[Symbol, String],
         hash_needed:       T::Boolean,
+        head_only:         T::Boolean,
         use_homebrew_curl: T::Boolean,
         user_agent:        T.any(String, Symbol),
         referer:           T.nilable(String),
       ).returns(T::Hash[Symbol, T.untyped])
     }
     def curl_http_content_headers_and_checksum(
-      url, specs: {}, hash_needed: false,
+      url, specs: {}, hash_needed: false, head_only: false,
       use_homebrew_curl: false, user_agent: :default, referer: nil
     )
       file = Tempfile.new.tap(&:close)
@@ -583,8 +619,14 @@ module Utils
       end
 
       max_time = hash_needed ? 600 : 25
+      # `--head` prints the headers itself, so `--dump-header` would duplicate them.
+      output_args = if head_only
+        ["--head"]
+      else
+        ["--dump-header", "-", "--output", file.path]
+      end
       output, _, status = curl_output(
-        *specs, "--dump-header", "-", "--output", file.path, "--location", url,
+        *specs, *output_args, "--location", url,
         use_homebrew_curl:,
         connect_timeout:   15,
         max_time:,
@@ -606,7 +648,7 @@ module Utils
       etag = headers["etag"][ETAG_VALUE_REGEX, 1] if headers["etag"].present?
       content_length = headers["content-length"]
 
-      if status.success? && (file_path = file.path)
+      if !head_only && status.success? && (file_path = file.path)
         file_hash = Digest::SHA256.file(file_path).hexdigest if hash_needed
 
         # Only load file contents for text-based content comparison on small files.


### PR DESCRIPTION
Today, `curl_check_http_content` verifies that a URL is reachable, but does so with a full GET: it passes --output <tempfile> and downloads the entire resource, then discards it. For an HTTPS URL the body is never read, so this asks for the headers instead.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Opus 5 with several manual review cycles.

-----

I was investigating Cask audit and seeing where I could speed them up, and started exploring.

brew audit --online currently transfers every cask artifact twice: once by `curl_check_http_content` into a Tempfile that is unlinked on return, and once by `audit_download` into the cache. For Firefox (as an example) that is 147 MB downloaded and thrown away on every audit. Because online implies download, both always happen in the same run.

Across a sampling of Casks, speedup was anywhere from 1.5x to 45x faster, network speeds will affect individual results.

Formula were a bit different, realizing slight speedups but much less notable, and on a few smaller downloads took a small amount longer, but that could be network jitter with how small the variances are.

-----

<details>

### Hyperfine statistics

### Casks — `hyperfine --runs 3`

```
Benchmark 1: before (full GET)
  Time (mean ± σ):     187.485 s ± 15.742 s   Range: 171.562 s … 203.041 s   3 runs
Benchmark 2: after (HEAD)
  Time (mean ± σ):      14.552 s ±  1.099 s   Range:  13.316 s …  15.420 s   3 runs

Summary: after ran 12.88 ± 1.46 times faster
```

| arm | mean | σ | median | min | max | individual runs |
|---|--:|--:|--:|--:|--:|---|
| before (full GET) | 187.485 s | 15.742 s | 187.852 s | 171.562 s | 203.041 s | 187.9 / 203.0 / 171.6 |
| after (HEAD) | 14.552 s | 1.099 s | 14.919 s | 13.316 s | 15.420 s | 14.9 / 13.3 / 15.4 |

Roughly 172.9 s saved per pass.

### Formulae — `hyperfine --runs 5`

```
Benchmark 1: before (full GET)
  Time (mean ± σ):     142.368 s ±  5.629 s   Range: 138.099 s … 151.768 s   5 runs
Benchmark 2: after (HEAD)
  Time (mean ± σ):      60.892 s ± 10.368 s   Range:  52.917 s …  77.816 s   5 runs

Summary: after ran 2.34 ± 0.41 times faster
```

| arm | mean | σ | median | min | max | individual runs |
|---|--:|--:|--:|--:|--:|---|
| before (full GET) | 142.368 s | 5.629 s | 139.867 s | 138.099 s | 151.768 s | 151.8 / 143.3 / 138.8 / 139.9 / 138.1 |
| after (HEAD) | 60.892 s | 10.368 s | 56.472 s | 52.917 s | 77.816 s | 53.6 / 56.5 / 63.6 / 77.8 / 52.9 |

Roughly 81.5 s saved per pass.


-----

Times may vary based upon network

### Individual sampling results

### Casks

| cask | before (ms) | after (ms) | speedup | saved (ms) |
|---|--:|--:|--:|--:|
| `insomnia` | 15,811 | 358 | 44.1× | 15,453 |
| `inkscape` | 6,267 | 145 | 43.2× | 6,122 |
| `discord` | 7,976 | 186 | 42.9× | 7,790 |
| `obs` | 25,063 | 612 | 40.9× | 24,451 |
| `postman` | 5,901 | 153 | 38.6× | 5,748 |
| `zoom` | 7,893 | 248 | 31.9× | 7,645 |
| `tableplus` | 4,927 | 230 | 21.4× | 4,697 |
| `visual-studio-code` | 12,172 | 579 | 21.0× | 11,593 |
| `vlc` | 25,091 | 1,284 | 19.5× | 23,807 |
| `slack` | 4,991 | 308 | 16.2× | 4,683 |
| `firefox` | 6,155 | 400 | 15.4× | 5,755 |
| `spotify` | 6,539 | 432 | 15.1× | 6,107 |
| `google-chrome` | 11,011 | 768 | 14.3× | 10,243 |
| `iterm2` | 1,836 | 132 | 13.9× | 1,704 |
| `gimp` | 9,196 | 863 | 10.7× | 8,333 |
| `cyberduck` | 7,317 | 782 | 9.4× | 6,534 |
| `keka` | 1,909 | 334 | 5.7× | 1,574 |
| `sequel-ace` | 1,702 | 316 | 5.4× | 1,386 |
| `audacity` | 1,612 | 360 | 4.5× | 1,252 |
| `maccy` | 946 | 273 | 3.5× | 673 |
| `handbrake-app` | 3,245 | 1,084 | 3.0× | 2,161 |
| `stats` | 892 | 312 | 2.9× | 580 |
| `transmission` | 960 | 353 | 2.7× | 607 |
| `rectangle` | 711 | 390 | 1.8× | 320 |
| `appcleaner` | 759 | 477 | 1.6× | 282 |
| **TOTAL (25)** | **170,882** | **11,379** | **15.0×** | **159,503** |


### Formulae

### Formulae

| formula | before (ms) | after (ms) | speedup | saved (ms) |
|---|--:|--:|--:|--:|
| `cmake` | 21,413 | 2,039 | 10.5× | 19,374 |
| `go` | 16,760 | 2,947 | 5.7× | 13,812 |
| `python@3.13` | 4,094 | 1,196 | 3.4× | 2,898 |
| `git` | 24,057 | 7,343 | 3.3× | 16,714 |
| `node` | 4,653 | 1,866 | 2.5× | 2,787 |
| `postgresql@16` | 2,499 | 1,146 | 2.2× | 1,353 |
| `imagemagick` | 2,623 | 1,563 | 1.7× | 1,060 |
| `bat` | 3,090 | 1,955 | 1.6× | 1,135 |
| `neovim` | 7,493 | 4,642 | 1.6× | 2,851 |
| `redis` | 1,712 | 1,063 | 1.6× | 649 |
| `pandoc` | 3,261 | 2,092 | 1.6× | 1,169 |
| `protobuf` | 1,775 | 1,217 | 1.5× | 558 |
| `jq` | 2,589 | 1,812 | 1.4× | 777 |
| `nginx` | 1,228 | 883 | 1.4× | 345 |
| `fd` | 2,626 | 2,088 | 1.3× | 538 |
| `libgit2` | 2,386 | 1,780 | 1.3× | 606 |
| `openssl@3` | 912 | 720 | 1.3× | 192 |
| `htop` | 1,885 | 1,580 | 1.2× | 305 |
| `sqlite` | 827 | 677 | 1.2× | 150 |
| `zstd` | 1,328 | 1,140 | 1.2× | 188 |
| `tmux` | 1,753 | 1,525 | 1.1× | 228 |
| `curl` | 1,499 | 1,483 | 1.0× | 16 |
| `ffmpeg` | 19,981 | 20,569 | 0.97× | −588 |
| `ripgrep` | 2,279 | 2,432 | 0.94× | −153 |
| **TOTAL (24)** | **132,723** | **65,758** | **2.02×** | **66,965** |

</details>