### PR TITLE
utils/cpan: fail closed on non-CPAN and livecheck resources

### DIFF
--- a/Library/Homebrew/test/utils/cpan_spec.rb
+++ b/Library/Homebrew/test/utils/cpan_spec.rb
@@ -135,6 +135,30 @@ RSpec.describe CPAN do
         end
       RUBY
     end
+    let(:mixed_formula_contents) do
+      formula_contents.sub(
+        "  def install",
+        [
+          '  resource "vendored-blob" do',
+          "    url \"#{non_cpan_package_url}\"",
+          "    sha256 \"#{"e" * 64}\"",
+          "  end",
+          "",
+          "  def install",
+        ].join("\n"),
+      )
+    end
+    let(:livecheck_formula_contents) do
+      formula_contents.sub(
+        "    sha256 \"#{"c" * 64}\"",
+        [
+          "    sha256 \"#{"c" * 64}\"",
+          "    livecheck do",
+          "      regex(/Scalar-List-Utils[._-]v?(\\d+(?:\\.\\d+)+)\\.t/i)",
+          "    end",
+        ].join("\n"),
+      )
+    end
     let(:test_formula) do
       formula_path.write(formula_contents)
       resource_url = cpan_package_url
@@ -144,6 +168,38 @@ RSpec.describe CPAN do
         resource "Scalar::Util" do
           url resource_url
           sha256 "c" * 64
+        end
+      end
+    end
+    let(:mixed_formula) do
+      formula_path.write(mixed_formula_contents)
+      resource_url = cpan_package_url
+      non_cpan_url = non_cpan_package_url
+      formula("foo", path: formula_path) do
+        T.bind(self, T.class_of(Formula))
+        url "https://example.com/foo-1.0.tar.gz"
+        resource "Scalar::Util" do
+          url resource_url
+          sha256 "c" * 64
+        end
+        resource "vendored-blob" do
+          url non_cpan_url
+          sha256 "e" * 64
+        end
+      end
+    end
+    let(:livecheck_formula) do
+      formula_path.write(livecheck_formula_contents)
+      resource_url = cpan_package_url
+      formula("foo", path: formula_path) do
+        T.bind(self, T.class_of(Formula))
+        url "https://example.com/foo-1.0.tar.gz"
+        resource "Scalar::Util" do
+          url resource_url
+          sha256 "c" * 64
+          livecheck do
+            regex(/Scalar-List-Utils[._-]v?(\d+(?:\.\d+)+)\.t/i)
+          end
         end
       end
     end
@@ -157,23 +213,24 @@ RSpec.describe CPAN do
         "version"         => "1.69",
       )
     end
-
-    before do
-      allow(Utils::Curl).to receive(:curl_output).and_return(curl_result(stdout: latest_metadata))
-    end
-
-    it "prints updated CPAN resource blocks" do
-      expected_output = [
+    let(:updated_resource_output) do
+      [
         "  resource \"Scalar::Util\" do",
         "    url \"#{latest_package_url}\"",
         "    sha256 \"#{"d" * 64}\"",
         "  end",
         "",
       ].join("\n")
+    end
 
+    before do
+      allow(Utils::Curl).to receive(:curl_output).and_return(curl_result(stdout: latest_metadata))
+    end
+
+    it "prints updated CPAN resource blocks" do
       expect do
         described_class.update_perl_resources!(test_formula, print_only: true)
-      end.to output(expected_output).to_stdout
+      end.to output(updated_resource_output).to_stdout
     end
 
     it "updates CPAN resource blocks in the formula" do
@@ -181,6 +238,40 @@ RSpec.describe CPAN do
 
       expect(formula_path.read).to eq formula_contents.sub(cpan_package_url, latest_package_url)
                                                       .sub("c" * 64, "d" * 64)
+    end
+
+    it "fails without modifying formulas containing non-CPAN resources" do
+      expect(Utils::Curl).not_to receive(:curl_output)
+
+      expect do
+        described_class.update_perl_resources!(mixed_formula, quiet: true)
+      end.to raise_error(SystemExit).and output(
+        /"foo" contains non-CPAN resources: vendored-blob.*Please update the resources manually/m,
+      ).to_stderr
+      expect(formula_path.read).to eq mixed_formula_contents
+    end
+
+    it "prints CPAN resource blocks for formulas containing non-CPAN resources" do
+      expect do
+        described_class.update_perl_resources!(mixed_formula, print_only: true)
+      end.to output(updated_resource_output).to_stdout
+    end
+
+    it "fails without modifying formulas containing CPAN resource livecheck blocks" do
+      expect(Utils::Curl).not_to receive(:curl_output)
+
+      expect do
+        described_class.update_perl_resources!(livecheck_formula, quiet: true)
+      end.to raise_error(SystemExit).and output(
+        /"foo" contains CPAN resources with livecheck blocks: Scalar::Util.*Please update the resources manually/m,
+      ).to_stderr
+      expect(formula_path.read).to eq livecheck_formula_contents
+    end
+
+    it "prints CPAN resource blocks for formulas containing CPAN resource livecheck blocks" do
+      expect do
+        described_class.update_perl_resources!(livecheck_formula, print_only: true)
+      end.to output(updated_resource_output).to_stdout
     end
 
     it "reports resolved resource updates" do

--- a/Library/Homebrew/utils/cpan.rb
+++ b/Library/Homebrew/utils/cpan.rb
@@ -95,10 +95,26 @@ module CPAN
 
     odie "\"#{formula.name}\" has no CPAN resources to update." if cpan_resources.empty?
 
+    non_cpan_resource_names = formula.resources.filter_map do |resource|
+      resource.name unless resource.url.start_with?(METACPAN_URL_PREFIX)
+    end
+    livecheck_resource_names = cpan_resources.filter_map do |resource|
+      resource.name if resource.livecheck_defined?
+    end
+
+    unless print_only
+      odie <<~EOS unless non_cpan_resource_names.empty?
+        "#{formula.name}" contains non-CPAN resources: #{non_cpan_resource_names.sort.join(", ")}
+        Please update the resources manually.
+      EOS
+      odie <<~EOS unless livecheck_resource_names.empty?
+        "#{formula.name}" contains CPAN resources with livecheck blocks: #{livecheck_resource_names.sort.join(", ")}
+        Please update the resources manually.
+      EOS
+    end
+
     show_info = !print_only && !quiet
 
-    non_cpan_resources = formula.resources.reject { |resource| resource.url.start_with?(METACPAN_URL_PREFIX) }
-    ohai "Skipping #{non_cpan_resources.length} non-CPAN resources" if non_cpan_resources.any? && show_info
     ohai "Found #{cpan_resources.length} CPAN resources to update" if show_info
 
     new_resource_blocks = ""


### PR DESCRIPTION
`CPAN.update_perl_resources!` replaces the entire resource stanza group with the blocks it generates for MetaCPAN resources, so anything else living in that group is deleted. That means non-CPAN resources, and `livecheck` blocks inside CPAN resources, were silently discarded by an in-place update.

Eight homebrew-core formulae are affected. `git` loses its `html` and `man` resources, `texlive` makes 45 MetaCPAN requests and then drops 4 non-CPAN resources, and `libbi` drops 1. `argus-clients`, `amtterm`, `help2man`, `exim`, and `lanraragi` each lose the `livecheck` block on a CPAN resource.

To reproduce:

```
brew update-perl-resources git
git -C "$(brew --repository homebrew/core)" diff Formula/g/git.rb
git -C "$(brew --repository homebrew/core)" checkout Formula/g/git.rb
```

The diff shows the `html` and `man` resource blocks removed.

This adds two guards that fail closed before any MetaCPAN request or disk write, following the non-PyPI resource guard in `utils/pypi.rb`. `--print-only` is unaffected and still prints the CPAN blocks it would generate. Note this is a user-visible change: the command now refuses on those eight formulae, where it previously succeeded destructively. Teaching it to skip and preserve those resources the way `utils/pypi.rb` does is a follow-up; refusing is the safe intermediate state.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified each new test fails without the guards and passes with them, and ran `brew lgtm` plus targeted specs.

-----
