### PR TITLE
utils/clang: allow Version type for kernel_version

### DIFF
--- a/Library/Homebrew/test/utils/clang_spec.rb
+++ b/Library/Homebrew/test/utils/clang_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Utils::Clang, :needs_macos do
     described_class.write_system_config_files(
       config_dir:,
       macos_version:,
-      kernel_version: 23,
+      kernel_version: Version.new("23"),
       arch:           :arm64,
     )
 

--- a/Library/Homebrew/utils/clang.rb
+++ b/Library/Homebrew/utils/clang.rb
@@ -7,7 +7,7 @@ module Utils
       params(
         config_dir:     Pathname,
         macos_version:  T.any(String, MacOSVersion),
-        kernel_version: T.any(String, Integer),
+        kernel_version: T.any(String, Version),
         arch:           Symbol,
       ).void
     }


### PR DESCRIPTION
Fixes type error in LLVM formulae:
```
TypeError: Parameter 'kernel_version': Expected type
T.any(Integer, String), got type Version with value #<Version 27>
```

As `MacOSVersion.kernel_major_version` returns a `Version` which all LLVM formulae currently use during build.

Seen in
- https://github.com/Homebrew/homebrew-core/pull/299027

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
