### PR TITLE
keg: create share/pwsh as a real directory when linking

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -519,6 +519,7 @@ class Keg
            %r{^icons/}, # all icons subfolders should also mkpath
            /^zsh/,
            /^fish/,
+           /^pwsh/,
            %r{^lua/}, #  Lua, Lua51, Lua53 all need the same handling.
            %r{^guile/},
            /^postgresql@\d+/,

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -181,6 +181,14 @@ RSpec.describe Keg do
       expect(link.lstat).to be_a_directory
     end
 
+    specify "share/pwsh directory is created" do
+      link = HOMEBREW_PREFIX/"share"/"pwsh"
+      (keg/"share"/"pwsh"/"completions").mkpath
+      FileUtils.touch keg/"share"/"pwsh"/"completions"/"_test.ps1"
+      keg.link
+      expect(link.lstat).to be_a_directory
+    end
+
     specify "symlinks are linked directly" do
       link = HOMEBREW_PREFIX/"lib"/"pkgconfig"
 


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude is used to investigate and write a commit, but this PR is opened by me. 

-----

Add pwsh to the share/ paths that get :mkpath treatment, like zsh and fish already do. Without this the first formula that ships PowerShell completions has its whole share/pwsh directory symlinked into the prefix, so anything writing to share/pwsh/completions afterwards lands inside that formula's keg.

Will fix
- https://github.com/Homebrew/homebrew-core/issues/298829