### PR TITLE
context: replace T.nilable(T::Boolean)

### DIFF
--- a/Library/Homebrew/context.rb
+++ b/Library/Homebrew/context.rb
@@ -11,13 +11,13 @@ module Context
   class ContextStruct
     sig {
       params(
-        debug:                          T.nilable(T::Boolean),
-        quiet:                          T.nilable(T::Boolean),
-        verbose:                        T.nilable(T::Boolean),
-        deferred_environment_expansion: T.nilable(T::Boolean),
+        debug:                          T::Boolean,
+        quiet:                          T::Boolean,
+        verbose:                        T::Boolean,
+        deferred_environment_expansion: T::Boolean,
       ).void
     }
-    def initialize(debug: nil, quiet: nil, verbose: nil, deferred_environment_expansion: nil)
+    def initialize(debug: false, quiet: false, verbose: false, deferred_environment_expansion: false)
       @debug = debug
       @quiet = quiet
       @verbose = verbose
@@ -89,10 +89,10 @@ module Context
 
   sig {
     params(
-      debug:                          T.nilable(T::Boolean),
-      quiet:                          T.nilable(T::Boolean),
-      verbose:                        T.nilable(T::Boolean),
-      deferred_environment_expansion: T.nilable(T::Boolean),
+      debug:                          T::Boolean,
+      quiet:                          T::Boolean,
+      verbose:                        T::Boolean,
+      deferred_environment_expansion: T::Boolean,
       _block:                         T.proc.void,
     ).returns(T.untyped)
   }


### PR DESCRIPTION
This pull request addresses issue #23350 in Homebrew/brew by replacing T.nilable(T::Boolean) with T::Boolean for the affected boolean configuration values in Library/Homebrew/context.rb. The affected values are initialized to false, ensuring that they consistently behave as booleans rather than allowing nil. This simplifies the type definitions, improves type safety, and aligns the implementation with how these values are used throughout the codebase. The changes were verified using brew style and brew typecheck.
