### PR TITLE
Handle disappearing Landlock paths

### DIFF
--- a/Library/Homebrew/extend/os/linux/sandbox/landlock.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox/landlock.rb
@@ -354,6 +354,8 @@ class Sandbox
         @readable_paths.each do |path|
           allowed_access = File.directory?(path) ? READ_ACCESS_FS : FILE_READ_ACCESS_FS
           add_path_rule(ruleset_fd, path, allowed_access)
+        rescue Errno::ENOENT
+          nil
         end
         @writable_paths.each do |path|
           allowed_access = if File.directory?(path)

--- a/Library/Homebrew/test/sandbox_landlock_spec.rb
+++ b/Library/Homebrew/test/sandbox_landlock_spec.rb
@@ -210,6 +210,24 @@ RSpec.describe Sandbox::Landlock do
       ])
     end
 
+    it "skips readable paths removed after command setup" do
+      readable_dir = mktmpdir
+      denied_dir = mktmpdir
+      sandbox.deny_read_path denied_dir
+      allow(landlock).to receive(:readable_paths).with([denied_dir]).and_return([readable_dir.to_s])
+      landlock.command(["true"], tmpdir.to_s)
+      readable_dir.rmdir
+
+      allow(described_class).to receive_messages(abi_version: 10, landlock_create_ruleset: 17,
+                                                 landlock_add_rule: 0, set_no_new_privileges: 0,
+                                                 landlock_restrict_self: 0)
+      allow(landlock).to receive(:open_path).and_return(18)
+      expect(landlock).to receive(:open_path).with(readable_dir.to_s).and_raise(Errno::ENOENT)
+      allow(landlock).to receive(:close_file_descriptor)
+
+      expect { landlock.apply! }.not_to raise_error
+    end
+
     it "allows pseudo-terminal device access" do
       landlock.command(["true"], tmpdir.to_s)
 


### PR DESCRIPTION
- Ignore `ENOENT` when derived readable paths vanish during setup.
- Cover the race between command setup and Landlock application.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 Sol xhigh with local review and (unit) testing (as on macOS).

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----