### PR TITLE
audit: resolve untapped core dependencies

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -246,6 +246,12 @@ module Homebrew
               # don't unnecessarily require a full Homebrew/core clone.
               fa = if f.core_formula?
                 Homebrew.with_no_api_env(&audit_proc)
+              elsif Homebrew::EnvConfig.automatically_set_no_install_from_api?
+                with_env(
+                  HOMEBREW_NO_INSTALL_FROM_API:                   nil,
+                  HOMEBREW_AUTOMATICALLY_SET_NO_INSTALL_FROM_API: nil,
+                  &audit_proc
+                )
               else
                 audit_proc.call
               end

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -84,5 +84,31 @@ RSpec.describe Homebrew::DevCmd::Audit do
         expect { audit.run }.not_to output.to_stdout
       end
     end
+
+    it "enables API access when auditing external formulae after it was automatically disabled" do
+      formula_file = tap_path/"Formula/example.rb"
+      formula_file.dirname.mkpath
+      formula_file.write <<~RUBY
+        class Example < Formula
+          desc "Example"
+          homepage "https://example.com"
+          url "https://example.com/example-1.0.tar.gz"
+          sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+
+          depends_on "dependency"
+        end
+      RUBY
+      allow(tap).to receive_messages(formula_files: [formula_file], cask_files: [])
+      formula_auditor = instance_double(Homebrew::FormulaAuditor, audit: nil, problems: [], new_formula_problems: [])
+
+      with_env(HOMEBREW_NO_INSTALL_FROM_API: "1", HOMEBREW_AUTOMATICALLY_SET_NO_INSTALL_FROM_API: "1") do
+        expect(Homebrew::FormulaAuditor).to receive(:new) do
+          expect(Homebrew::EnvConfig.no_install_from_api?).to be(false)
+          formula_auditor
+        end
+
+        audit.run
+      end
+    end
   end
 end


### PR DESCRIPTION
- Restore API access for external formula audits when a parent command
  automatically disabled it.
- Preserve an explicitly disabled API setting.

Fixes #23539 

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----