### PR TITLE
Clarify outdated cask version display

### DIFF
--- a/Library/Homebrew/cask/info.rb
+++ b/Library/Homebrew/cask/info.rb
@@ -52,13 +52,20 @@ module Cask
     sig { params(cask: Cask, installed: T::Boolean).returns(String) }
     def self.title_info(cask, installed:)
       name_with_status = if installed
-        pretty_installed(cask.token)
+        pretty_install_status(cask.token, installed: true, outdated: cask.outdated?, bold: true)
       else
         pretty_uninstalled(cask.token)
       end
       title = oh1_title(name_with_status).to_s
       title += " (#{cask.name.join(", ")})" unless cask.name.empty?
-      title += ": #{cask.version}"
+
+      version = if installed && cask.outdated? && cask.installed_version.present?
+        "#{cask.installed_version} → #{cask.version}"
+      else
+        cask.version.to_s
+      end
+
+      title += ": #{version}"
       title += " (auto_updates)" if cask.auto_updates
       title
     end

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -88,6 +88,19 @@ RSpec.describe Cask::Info, :cask do
     expect { described_class.info(cask, args:) }.to not_to_output(/Metadata/).to_stdout
   end
 
+  it "shows installed and available versions when a cask is outdated" do
+    cask = Cask::CaskLoader.load("local-transmission")
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+    allow(cask).to receive_messages(installed?:        true,
+                                    installed_version: "2.60",
+                                    outdated?:         true,
+                                    version:           Cask::DSL::Version.new("2.61"),
+                                    supports_linux?:   false)
+
+    expect { described_class.info(cask, args:) }
+      .to output(/==> .*↑.*: 2\.60 → 2\.61/).to_stdout
+  end
+
   it "prints cask dependencies if the Cask has any" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
     mock_cask_installed("local-transmission-zip")
@@ -256,9 +269,8 @@ RSpec.describe Cask::Info, :cask do
         tabfile:              TEST_FIXTURE_DIR/"cask_receipt.json",
         time:,
       )
-      allow(cask).to receive(:installed?).and_return(true)
       expect(cask).to receive(:caskroom_path).and_return(caskroom)
-      expect(cask).to receive(:installed_version).and_return("2.61")
+      allow(cask).to receive_messages(installed?: true, outdated?: false, installed_version: "2.61")
       allow(Cask::Tab).to receive(:for_cask).with(cask).and_return(tab)
       allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 
@@ -291,9 +303,8 @@ RSpec.describe Cask::Info, :cask do
         tabfile:                  TEST_FIXTURE_DIR/"cask_receipt.json",
         time:,
       )
-      allow(cask).to receive(:installed?).and_return(true)
       expect(cask).to receive(:caskroom_path).and_return(caskroom)
-      expect(cask).to receive(:installed_version).and_return("2.61")
+      allow(cask).to receive_messages(installed?: true, outdated?: false, installed_version: "2.61")
       allow(Cask::Tab).to receive(:for_cask).with(cask).and_return(tab)
       allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 


### PR DESCRIPTION
Before, this should show version as 3.5.0, but it was possible to see from the install path that that was not the installed version:

```
▶ brew info font-hack-nerd-font -v
==> font-hack-nerd-font ↑ (Hack Nerd Font (Hack)): 3.4.0 → 3.5.0
https://github.com/ryanoasis/nerd-fonts
Installed (on request)
/usr/local/Caskroom/font-hack-nerd-font/3.4.0 (32.2MB)
  Installed using the internal formulae.brew.sh API on 2026-07-04 at 21:34:47
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/font/font-h/font-hack-nerd-font.rb
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

GitHub Copilot wrote it and I iterated on it and QA'd it.

-----
