### PR TITLE
cli/parser: fix help crash with `--` arguments

### DIFF
--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -31,7 +31,7 @@ module Homebrew
         @remaining = T.let([], T::Array[String])
       end
 
-      sig { params(remaining_args: T::Array[T.any(T::Array[String], String)]).void }
+      sig { params(remaining_args: T::Array[String]).void }
       def freeze_remaining_args!(remaining_args) = @remaining.replace(remaining_args).freeze
 
       sig { params(named_args: T::Array[String], cask_options: T::Boolean, without_api: T::Boolean).void }

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -527,7 +527,7 @@ module Homebrew
         remaining_args = if non_options.empty?
           remaining
         else
-          [*remaining, "--", non_options]
+          [*remaining, "--", *non_options]
         end
         @args.freeze_remaining_args!(remaining_args)
         @args.freeze_processed_options!(@processed_options)

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -84,6 +84,11 @@ RSpec.describe Homebrew::CLI::Parser do
       end
     end
 
+    it "flattens arguments after `--` into remaining" do
+      args = parser.parse(["-v", "--", "foo", "bar"])
+      expect(args.remaining).to eq ["--", "foo", "bar"]
+    end
+
     it "parses short option" do
       args = parser.parse(["-v"])
       expect(args).to be_verbose


### PR DESCRIPTION
Passing arguments after -- (e.g. `brew help developer -- foo`) to any command with subcommands crashed with `NoMethodError: undefined method 'start_with?' for an instance of Array` on help, --help, and usage-error paths.

The parser was nesting the arguments after `--` as a single array element inside `args.remaining`, so let's splat them so it stays a flat `Array[String]`, and print normal help or usage text instead.

Reproduction -

```
# Help for a command with subcommands
$ brew help developer -- foo
$ brew help services run -- foo    # subcommand-specific help

# --help flag form
$ brew analytics --help -- foo

# Usage-error paths
$ brew developer bogus -- foo      # unknown subcommand
$ brew developer state -- foo      # too many named arguments

Before (each of the above):

Error: undefined method 'start_with?' for an instance of Array /opt/homebrew/Library/Homebrew/cli/parser.rb:557:in 'block in Homebrew::CLI::Parser#generate_help_text'
...

After: each prints the expected output 
- brew help developer -- foo shows the developer help,
- brew help services run -- foo shows the run subcommand's usage, 
- invalid invocations report their actual usage error (Usage: brew developer [state]: etc.) instead of a backtrace.
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Opus 5 with manual review and testing.

-----
