### PR TITLE
cask/upgrade: claim macOS may prompt rather than will

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -443,16 +443,16 @@ module Cask
               Quarantine.inherit_user_approval!(download_path: artifact.target)
             rescue CaskQuarantineReleaseError => e
               odebug e
-              opoo "Homebrew couldn't inherit #{new_cask.token}'s quarantine approval so macOS will prompt at " \
+              opoo "Homebrew couldn't inherit #{new_cask.token}'s quarantine approval so macOS may prompt at " \
                    "next launch."
             end
           when :signer_changed
-            opoo "#{new_cask.token}'s signer changed so macOS will prompt at next launch."
+            opoo "#{new_cask.token}'s signer changed so macOS may prompt at next launch."
           when :signer_unverified
-            opoo "Homebrew couldn't verify #{new_cask.token}'s signer so macOS will prompt at next launch."
+            opoo "Homebrew couldn't verify #{new_cask.token}'s signer so macOS may prompt at next launch."
           when :unapproved
             message = "#{new_cask.token} wasn't quarantine approved so not approving now. " \
-                      "macOS will prompt at next launch."
+                      "macOS may prompt at next launch."
             if verbose
               ohai message
             else

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -613,7 +613,7 @@ RSpec.describe Cask::Upgrade, :cask do
 
       expect do
         described_class.upgrade_casks!(local_caffeine, args:)
-      end.to output(/couldn't inherit local-caffeine's quarantine approval so macOS will prompt/).to_stderr
+      end.to output(/couldn't inherit local-caffeine's quarantine approval so macOS may prompt/).to_stderr
     end
 
     it "reports the skipped quarantine release under --verbose when approval is missing" do
@@ -635,7 +635,7 @@ RSpec.describe Cask::Upgrade, :cask do
 
       expect do
         described_class.upgrade_casks!(local_caffeine, args:)
-      end.to output(/local-caffeine's signer changed so macOS will prompt/).to_stderr
+      end.to output(/local-caffeine's signer changed so macOS may prompt/).to_stderr
     end
 
     it "reports an unverified signer by default so the returning Gatekeeper prompt is explained" do


### PR DESCRIPTION
In the context of increased concern about security, I've been monitoring the output of my daily `brew upgrade` runs for a couple of months, and that record establishes a minor inaccuracy in one of the claims the output makes.

**This PR changes "will" to "may" in the four messages and updates the two spec expectations to match.** Wording only; no behaviour change.

The four quarantine messages in cask upgrades state that "macOS will prompt at next launch". However, macOS often doesn't. I, for one, was consternated by this, thinking an application that needed my approval had managed to run without it when I was not prompted. In fact, after studying the situation, I have established that nothing bad is happening. The issue is just that Homebrew cannot know. Whether a prompt appears is decided by macOS's identity-level approval state (the ExecPolicy database, keyed to signer and bundle identity), which Homebrew has no way to read. The quarantine xattr Homebrew manages is only part of the story.

Both outcomes occur in practice after the identical message. In one `brew upgrade` run on my machine, `betterdisplay` and `whatsapp` each got the `:unapproved` message minutes apart; `betterdisplay` launched moments later (via upgrade's reopen) with no prompt and remains unapproved days later, while `whatsapp` prompted at its first launch five hours after. Again: when the claim is wrong, a user who was told to expect a prompt sees none and may reasonably conclude something else went wrong — or reads the warning as noise, which costs the messages their credibility for the times they are right.

To see the message: `brew reinstall --cask` anything whose installed app is not quarantine-approved (for example because its own updater replaced the bundle) prints the `:unapproved` variant. Whether macOS then prompts at the next launch is the part Homebrew cannot predict, as above — which is why there is no deterministic repro for the claim being wrong, only for the claim being made.

<details>
<summary>Details</summary>

**What Homebrew can and cannot know about the prompt**

| Quarantine xattr on the app | Prompt at next launch |
|---|---|
| absent | no — nothing triggers a Gatekeeper evaluation |
| present, not approved | either — macOS's identity-level approval state decides |
| present, approved | usually no, but not guaranteed — macOS updates have produced prompts for previously known apps |

Gatekeeper's first-launch prompt is triggered by the quarantine attribute's presence, so an untagged app is the one state Homebrew could truthfully promise about: no tag, no evaluation, no prompt (which is what `--no-quarantine` buys, and why bundles replaced by an app's own updater never prompt). For any tagged state the outcome is decided by approval records Homebrew cannot read. The four messages changed here all describe tagged-but-unapproved outcomes — squarely in the unknowable zone — while the one state that permits a confident claim is one where Homebrew prints nothing at all.

</details>


- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Used Claude Code (Fable 5) to investigate and draft; I directed the investigation, and reviewed the diff and every line of this PR text.

-----

