### PR TITLE
cask/upgrade: mirror per-file quarantine approval across upgrades

### DIFF
--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -69,18 +69,47 @@ module Cask
                      print_stderr: false).stdout.rstrip
     end
 
-    sig { params(file: T.any(String, Pathname)).returns(T::Boolean) }
-    def self.user_approved?(file)
-      return false if xattr.nil?
-
-      quarantine_status = status(file)
+    sig { params(quarantine_status: String).returns(T::Boolean) }
+    def self.user_approved_status?(quarantine_status)
       return false if quarantine_status.empty?
 
       quarantine_status.split(";").fetch(0).to_i(16).anybits?(USER_APPROVED_FLAG)
     end
+    private_class_method :user_approved_status?
 
-    sig { params(download_path: T.nilable(Pathname)).void }
-    def self.inherit_user_approval!(download_path: nil)
+    sig { params(file: T.any(String, Pathname)).returns(T::Boolean) }
+    def self.user_approved?(file)
+      return false if xattr.nil?
+
+      user_approved_status?(status(file))
+    end
+
+    # The paths inside `directory` that Gatekeeper has approved, relative to it. macOS records approval on
+    # each file as it is first evaluated, so a bundle accumulates approvals for the components that have
+    # actually run rather than carrying one bundle-wide state.
+    sig { params(directory: T.any(String, Pathname)).returns(T::Array[String]) }
+    def self.user_approved_paths(directory)
+      directory = Pathname(directory)
+      xattr = self.xattr
+      return [] if xattr.nil? || !directory.directory?
+
+      # Read the whole tree in one pass: `xattr -r` prefixes each line with `path: `, and exits non-zero
+      # for the paths without the attribute, which is the normal case, so don't use `system_command!`.
+      system_command(xattr,
+                     args:         ["-p", "-r", QUARANTINE_ATTRIBUTE, directory],
+                     print_stderr: false).stdout.lines.filter_map do |line|
+        path, _, quarantine_status = line.rstrip.partition(": ")
+        next unless user_approved_status?(quarantine_status)
+
+        path = Pathname(path)
+        next if path == directory || path.symlink?
+
+        path.relative_path_from(directory).to_s
+      end
+    end
+
+    sig { params(download_path: T.nilable(Pathname), approved_paths: T::Array[String]).void }
+    def self.inherit_user_approval!(download_path: nil, approved_paths: [])
       return if !download_path || !detect(download_path)
 
       # Preserve quarantine provenance so Gatekeeper still checks the upgraded app while carrying forward
@@ -91,15 +120,23 @@ module Cask
       xattr = self.xattr
       raise "unexpected nil xattr" if xattr.nil?
 
-      quarantiner = system_command(xattr,
+      # Mirror the approvals the previous version had accumulated onto the paths it shared with this one;
+      # anything new to this version has never run, so it stays unapproved.
+      inherited_paths = approved_paths.map { |path| download_path/path }
+                                      .select { |path| path.exist? && !path.symlink? }
+
+      quarantiner = system_command("/usr/bin/xargs",
                                    args:         [
+                                     "-0",
+                                     "--",
+                                     xattr,
                                      "-w",
                                      QUARANTINE_ATTRIBUTE,
                                      status(download_path).sub(/\A[0-9a-f]+/i) do |flags|
                                        (flags.to_i(16) | USER_APPROVED_FLAG).to_s(16).rjust(flags.length, "0")
                                      end,
-                                     download_path,
                                    ],
+                                   input:        [download_path, *inherited_paths].join("\0"),
                                    print_stderr: false)
 
       return if quarantiner.success?

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -401,6 +401,7 @@ module Cask
       new_artifacts_installed = false
       old_signing_identities = T.let({}, T::Hash[String, T.nilable(Quarantine::SigningIdentity)])
       old_user_approved = T.let({}, T::Hash[String, T::Boolean])
+      old_approved_paths = T.let({}, T::Hash[String, T::Array[String]])
 
       begin
         oh1 "Upgrading #{Formatter.identifier(old_cask)}"
@@ -416,12 +417,14 @@ module Cask
         new_cask_installer.fetch
 
         old_cask.artifacts.grep(Artifact::App).each do |artifact|
-          old_user_approved[artifact.target.to_s] =
-            if artifact.target.exist?
-              Quarantine.user_approved?(artifact.target)
-            else
-              false
-            end
+          user_approved = if artifact.target.exist?
+            Quarantine.user_approved?(artifact.target)
+          else
+            false
+          end
+          old_user_approved[artifact.target.to_s] = user_approved
+          # Only an already approved app has approvals to pass on, so skip the scan otherwise.
+          old_approved_paths[artifact.target.to_s] = Quarantine.user_approved_paths(artifact.target) if user_approved
           old_signing_identities[artifact.target.to_s] = Quarantine.signing_identity(artifact.target)
         end
 
@@ -440,7 +443,10 @@ module Cask
           case quarantine_release_decision(old_cask, new_cask, old_signing_identities, old_user_approved)
           when :release
             new_cask.artifacts.grep(Artifact::App).each do |artifact|
-              Quarantine.inherit_user_approval!(download_path: artifact.target)
+              Quarantine.inherit_user_approval!(
+                download_path:  artifact.target,
+                approved_paths: old_approved_paths.fetch(artifact.target.to_s, []),
+              )
             rescue CaskQuarantineReleaseError => e
               odebug e
               opoo "Homebrew couldn't inherit #{new_cask.token}'s quarantine approval so macOS may prompt at " \

--- a/Library/Homebrew/test/cask/quarantine_spec.rb
+++ b/Library/Homebrew/test/cask/quarantine_spec.rb
@@ -203,17 +203,73 @@ RSpec.describe Cask::Quarantine do
         xattr:,
       )
       expect(klass).to receive(:system_command).with(
-        xattr,
+        "/usr/bin/xargs",
         args:         [
+          "-0",
+          "--",
+          xattr,
           "-w",
           Cask::Quarantine::QUARANTINE_ATTRIBUTE,
           "03c1;6a51855d;;3C86362A-29CA-4D55-90E7-A6621B9CC78D",
-          file,
         ],
+        input:        file.to_s,
         print_stderr: false,
       ).and_return(instance_double(SystemCommand::Result, success?: true))
 
       klass.inherit_user_approval!(download_path: file)
+    end
+
+    it "mirrors approval onto shared paths and skips paths this version does not have" do
+      mktmpdir do |tmpdir|
+        app = tmpdir/"Test.app"
+        (app/"Contents/MacOS").mkpath
+        FileUtils.touch app/"Contents/MacOS/Test"
+
+        allow(klass).to receive_messages(
+          detect: true,
+          status: "0381;6a51855d;;3C86362A-29CA-4D55-90E7-A6621B9CC78D",
+          xattr:,
+        )
+        expect(klass).to receive(:system_command).with(
+          "/usr/bin/xargs",
+          args:         [
+            "-0",
+            "--",
+            xattr,
+            "-w",
+            Cask::Quarantine::QUARANTINE_ATTRIBUTE,
+            "03c1;6a51855d;;3C86362A-29CA-4D55-90E7-A6621B9CC78D",
+          ],
+          input:        [app, app/"Contents/MacOS/Test"].join("\0"),
+          print_stderr: false,
+        ).and_return(instance_double(SystemCommand::Result, success?: true))
+
+        klass.inherit_user_approval!(download_path:  app,
+                                     approved_paths: ["Contents/MacOS/Test", "Contents/MacOS/Removed"])
+      end
+    end
+  end
+
+  describe ".user_approved_paths" do
+    let(:xattr) { Pathname("/usr/bin/xattr") }
+
+    it "returns only the approved paths, relative to the directory" do
+      mktmpdir do |tmpdir|
+        app = tmpdir/"Test.app"
+        (app/"Contents").mkpath
+        FileUtils.touch app/"Contents/approved"
+        FileUtils.touch app/"Contents/unapproved"
+
+        allow(klass).to receive_messages(xattr: xattr, system_command: instance_double(
+          SystemCommand::Result,
+          stdout: "#{app}: 03c1;6a51855d;;uuid\n" \
+                  "#{app}/Contents: 0381;6a51855d;;uuid\n" \
+                  "#{app}/Contents/approved: 03c1;6a51855d;;uuid\n" \
+                  "#{app}/Contents/unapproved: 0381;6a51855d;;uuid\n",
+        ))
+
+        expect(klass.user_approved_paths(app)).to eq(["Contents/approved"])
+      end
     end
   end
 

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -596,7 +596,8 @@ RSpec.describe Cask::Upgrade, :cask do
         signing_identity_match: true,
       )
 
-      expect(Cask::Quarantine).to receive(:inherit_user_approval!).with(download_path: local_caffeine_path)
+      expect(Cask::Quarantine).to receive(:inherit_user_approval!)
+        .with(download_path: local_caffeine_path, approved_paths: [])
 
       described_class.upgrade_casks!(local_caffeine, args:)
     end


### PR DESCRIPTION
Continuing from #23545 and my daily monitoring of cask upgrades: quarantine is applied to every file in an installed bundle, but approval is inherited on the bundle root alone, so an upgrade returns components the user had already run to the unapproved state.

`Quarantine.propagate` globs `to/"**/*"` and writes the attribute to every path, while `inherit_user_approval!` writes the approved status to `download_path` only. macOS records approval per file as each component is first evaluated, so a bundle accumulates approvals for the parts that have actually run — on this machine, JetBrains Toolbox carries 838 approved paths while Calendr, which only ever runs its own binary, carries just its root. After an upgrade that inherits approval, all of those revert to unapproved while the root alone is approved.

To see the state on any Mac with a cask that has been in use for a while:

```
app="/Applications/JetBrains Toolbox.app"
xattr -p com.apple.quarantine "$app"                                                    # 03c1… — approved
find "$app" -print0 | xargs -0 xattr -p com.apple.quarantine 2>/dev/null | grep -c 03c1 # 838 approved paths
```

After an upgrade that inherits approval, only the first of those is approved again: `inherit_user_approval!` writes one path, while the new bundle's remaining files carry the uniform unapproved status `propagate` gave them.

Demonstrated end to end with `appcleaner`: with the root and `Contents/MacOS/AppCleaner` both approved before the upgrade, `brew upgrade --cask appcleaner` left the root at `03c1` and returned the executable to `0381`. With this change, the same starting state (root plus two nested paths) came through the upgrade with all three still approved.

Each lost approval also means a fresh Gatekeeper evaluation the next time that component runs — for the JetBrains Toolbox install above, up to 837 of them.

This carries the previous version's approved paths over to the paths it shares with the new one. Paths the new version does not have are dropped, and paths new to it stay unapproved, since they have never run. Approval is still granted only after the existing signing-identity check passes, so nothing is approved that #23060 would not already have approved at the root.

<details>
<summary>Details</summary>

> **Cost.** The scan is skipped entirely unless the old bundle's root is approved, which is the case where the upgrade would do nothing with the result anyway. When it does run it is a single `xattr -r -p` pass: 0.26s for Claude.app's 3,018 paths on an M1, against the full-tree write `propagate` already performs at install. The worst case I could find locally, an Xcode installation at 156,994 paths, took 13.4s — for an app of that file count, against a download measured in gigabytes, and on a machine several generations old. The approvals are then written in a single `xargs` pass, replacing the previous single-file write.
>
> **Reading and writing are deliberately asymmetric.** The read uses `-r` because enumerating grants nothing; the write stays path-by-path so approval cannot spread to components that never ran. `system_command` is used rather than `system_command!` because `xattr -p` exits non-zero whenever a path simply lacks the attribute, which is the normal case.
>
> **Verified against real bundles** via `brew ruby`: JetBrains Toolbox 837 paths beneath its root, Calendr and BetterDisplay none.
>
</details>

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Used Claude Code (Opus 5) to investigate and draft; I directed the investigation, and reviewed the diff and every line of this PR text.

-----
