### PR TITLE
Prepare batched package installation

### DIFF
--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -274,7 +274,7 @@ class Bottle
   sig { returns(Filename) }
   def filename = Filename.new(@name, @pkg_version, @tag, @spec.rebuild)
 
-  sig { returns(Pathname) }
+  sig { override.returns(Pathname) }
   def staged_path_from_download_queue
     bottle_filename = filename
     HOMEBREW_TEMP_CELLAR/bottle_filename.name/bottle_filename.version.to_s

--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -140,7 +140,7 @@ module Cask
       end
     end
 
-    sig { returns(Pathname) }
+    sig { override.returns(Pathname) }
     def staged_path_from_download_queue
       HOMEBREW_PREFIX/"var/homebrew/tmp/.caskroom"/cask.staged_path.relative_path_from(Caskroom.path)
     end

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -65,6 +65,10 @@ module Cask
       @ran_prelude_fetch = T.let(false, T::Boolean)
       @ran_prelude = T.let(false, T::Boolean)
       @cask_and_formula_dependencies = T.let(nil, T.nilable(T::Array[T.any(Formula, ::Cask::Cask)]))
+      @dependency_cask_installers = T.let(nil, T.nilable(T::Array[Installer]))
+      @dependency_formula_installers = T.let(nil, T.nilable(T::Array[FormulaInstaller]))
+      @dependencies_enqueued = T.let(false, T::Boolean)
+      @download_failed = T.let(false, T::Boolean)
       @installed_uninstall_artifacts_missing = T.let(false, T::Boolean)
     end
 
@@ -76,6 +80,12 @@ module Cask
 
     sig { returns(T::Boolean) }
     def force? = @force
+
+    sig { returns(T::Boolean) }
+    def download_failed? = @download_failed
+
+    sig { void }
+    def download_failed! = @download_failed = true
 
     sig { returns(T::Boolean) }
     def installed_on_request? = @installed_on_request
@@ -153,6 +163,8 @@ module Cask
 
     sig { void }
     def install
+      raise CaskError, "Download failed for #{@cask}." if download_failed?
+
       start_time = Time.now
       odebug "Cask::Installer#install"
 
@@ -393,7 +405,7 @@ on_request: true)
     def check_arch_requirements
       return if @cask.depends_on.arch.nil?
 
-      @current_arch = T.let(@current_arch, T.nilable(T::Hash[Symbol, T.untyped]))
+      @current_arch = T.let(@current_arch, T.nilable(T::Hash[Symbol, T.nilable(T.any(Symbol, Integer))]))
       @current_arch ||= { type: Hardware::CPU.type, bits: Hardware::CPU.bits }
       return if @cask.depends_on.arch.any? do |arch|
         arch[:type] == @current_arch[:type] &&
@@ -438,6 +450,22 @@ on_request: true)
     end
 
     sig { void }
+    def enqueue_dependency_downloads
+      return unless installed_on_request?
+
+      cask_installers, formula_installers = dependency_installers(defer_fetch: true)
+      if cask_installers.any?
+        Homebrew::Install.enqueue_cask_installers(cask_installers,
+                                                  download_queue: @download_queue)
+      end
+      if formula_installers.any?
+        @dependency_formula_installers = Homebrew::Install.enqueue_formulae(formula_installers,
+                                                                            download_queue: @download_queue)
+      end
+      @dependencies_enqueued = true
+    end
+
+    sig { void }
     def satisfy_cask_and_formula_dependencies
       return unless installed_on_request?
 
@@ -453,15 +481,48 @@ on_request: true)
       end
 
       ohai "Installing dependencies: #{missing_formulae_and_casks.join(", ")}"
+      if skip_cask_deps?
+        missing_formulae_and_casks.grep(Cask).each do |dependency|
+          opoo "`--skip-cask-deps` is set; skipping installation of #{dependency}."
+        end
+      end
+
+      cask_installers, formula_installers = dependency_installers
+      if (failed_installer = cask_installers.find(&:download_failed?))
+        raise CaskError, "Dependency download failed for #{failed_installer.cask}."
+      end
+
+      cask_installers.reject { |installer| installer.cask.installed? }.each(&:install)
+      return if formula_installers.blank?
+
+      Homebrew::Install.perform_preinstall_checks_once
+      valid_formula_installers = if @dependencies_enqueued
+        Homebrew::Install.reject_failed_downloads(formula_installers, download_queue: @download_queue)
+      else
+        Homebrew::Install.fetch_formulae(formula_installers)
+      end
+      valid_formula_installers.each do |formula_installer|
+        next if formula_installer.formula.any_version_installed? && formula_installer.formula.optlinked?
+
+        formula_installer.install
+        formula_installer.finish
+      end
+    end
+
+    sig {
+      params(defer_fetch: T::Boolean)
+        .returns([T::Array[Installer], T::Array[FormulaInstaller]])
+    }
+    def dependency_installers(defer_fetch: false)
+      if @dependency_cask_installers && @dependency_formula_installers
+        return [@dependency_cask_installers, @dependency_formula_installers]
+      end
+
       cask_installers = T.let([], T::Array[Installer])
       formula_installers = T.let([], T::Array[FormulaInstaller])
-
-      missing_formulae_and_casks.each do |cask_or_formula|
+      missing_cask_and_formula_dependencies.each do |cask_or_formula|
         if cask_or_formula.is_a?(Cask)
-          if skip_cask_deps?
-            opoo "`--skip-cask-deps` is set; skipping installation of #{cask_or_formula}."
-            next
-          end
+          next if skip_cask_deps?
 
           cask_installers << Installer.new(
             cask_or_formula,
@@ -472,6 +533,8 @@ on_request: true)
             quiet:                quiet?,
             require_sha:          require_sha?,
             verbose:              verbose?,
+            download_queue:       @download_queue,
+            defer_fetch:,
           )
         else
           formula_installers << FormulaInstaller.new(
@@ -485,15 +548,9 @@ on_request: true)
         end
       end
 
-      cask_installers.each(&:install)
-      return if formula_installers.blank?
-
-      Homebrew::Install.perform_preinstall_checks_once
-      valid_formula_installers = Homebrew::Install.fetch_formulae(formula_installers)
-      valid_formula_installers.each do |formula_installer|
-        formula_installer.install
-        formula_installer.finish
-      end
+      @dependency_cask_installers = cask_installers
+      @dependency_formula_installers = formula_installers
+      [cask_installers, formula_installers]
     end
 
     sig { returns(T.nilable(String)) }

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -266,9 +266,16 @@ module Homebrew
     attr_reader :disk_cleanup_size
 
     sig {
-      params(args: String, dry_run: T::Boolean, scrub: T::Boolean, days: T.nilable(Integer), cache: Pathname).void
+      params(
+        args:    String,
+        dry_run: T::Boolean,
+        scrub:   T::Boolean,
+        days:    T.nilable(Integer),
+        cache:   Pathname,
+        output:  T.any(IO, StringIO),
+      ).void
     }
-    def initialize(*args, dry_run: false, scrub: false, days: nil, cache: HOMEBREW_CACHE)
+    def initialize(*args, dry_run: false, scrub: false, days: nil, cache: HOMEBREW_CACHE, output: $stdout)
       @disk_cleanup_size = T.let(0, Integer)
       @args = args
       @dry_run = dry_run
@@ -276,6 +283,7 @@ module Homebrew
       @prune = T.let(days.present?, T::Boolean)
       @days = T.let(days || Homebrew::EnvConfig.cleanup_max_age_days.to_i, Integer)
       @cache = cache
+      @output = output
       @cleaned_up_paths = T.let(Set.new, T::Set[Pathname])
       @formula_cache_paths = T.let(nil, T.nilable(T::Hash[String, T::Array[Pathname]]))
     end
@@ -337,6 +345,42 @@ module Homebrew
       ohai "Running `brew cleanup #{formula}`..."
       puts_no_install_cleanup_disable_message_if_not_already!
       Cleanup.new.cleanup_formula(formula)
+    end
+
+    sig { params(formulae: T::Array[Formula], casks: T::Array[Cask::Cask]).void }
+    def self.install_clean!(formulae: [], casks: [])
+      return if Homebrew::EnvConfig.no_install_cleanup?
+
+      formulae = install_cleanup_formulae(formulae).uniq(&:full_name)
+      casks = casks.uniq(&:full_name)
+      packages = T.let(formulae + casks, T::Array[T.any(Formula, Cask::Cask)])
+      return if packages.empty?
+
+      cleanup_output = Utils.parallel_map(packages) do |package|
+        output = StringIO.new
+        cleanup = Cleanup.new(output:)
+        name = case package
+        when Formula
+          cleanup.cleanup_formula(package, quiet: true, cache_db: false, cleanup_unreferenced: false)
+          package.full_specified_name
+        when Cask::Cask
+          cleanup.cleanup_cask(package, cleanup_unreferenced: false)
+          package.full_name
+        else
+          T.absurd(package)
+        end
+        [name, output.string]
+      end
+
+      Cleanup.new.cleanup_cache_db if formulae.present?
+      Cleanup.new.cleanup_unreferenced_downloads
+
+      oh1 "Cleanup"
+      cleanup_output.each do |name, output|
+        ohai name
+        print output
+      end
+      puts_no_install_cleanup_disable_message_if_not_already!
     end
 
     sig { void }
@@ -405,6 +449,12 @@ module Homebrew
           # Don't `cleanup_unreferenced` here for each formula.
           # Instead, let it be run once `cleanup_cache` below.
           cleanup_formula(formula, quiet:, ds_store: false, cache_db: false, cleanup_unreferenced: false)
+        end
+
+        if periodic
+          Cask::Caskroom.casks.sort_by(&:full_name).each do |cask|
+            cleanup_cask(cask, ds_store: false, cleanup_legacy_downloads: false, cleanup_unreferenced: false)
+          end
         end
 
         if ENV["HOMEBREW_AUTOREMOVE"].present?
@@ -513,11 +563,18 @@ module Homebrew
       cleanup_lockfiles(FormulaLock.new(formula.name).path)
     end
 
-    sig { params(cask: Cask::Cask, ds_store: T::Boolean).void }
-    def cleanup_cask(cask, ds_store: true)
+    sig {
+      params(
+        cask:                     Cask::Cask,
+        ds_store:                 T::Boolean,
+        cleanup_legacy_downloads: T::Boolean,
+        cleanup_unreferenced:     T::Boolean,
+      ).void
+    }
+    def cleanup_cask(cask, ds_store: true, cleanup_legacy_downloads: true, cleanup_unreferenced: true)
       cleanup_cache_entries(Pathname.glob(cache/"Cask/#{cask.token}--*"), type: :cask, cleanup_unreferenced: false)
-      cleanup_legacy_cask_downloads([cask])
-      cleanup_unreferenced_downloads
+      cleanup_legacy_cask_downloads([cask]) if cleanup_legacy_downloads
+      cleanup_unreferenced_downloads if cleanup_unreferenced
 
       rm_ds_store([cask.caskroom_path]) if ds_store
       cleanup_lockfiles(CaskLock.new(cask.token).path)
@@ -700,9 +757,9 @@ module Homebrew
       @disk_cleanup_size += path.disk_usage
 
       if dry_run?
-        puts "Would remove: #{path} (#{path.abv})"
+        @output.puts "Would remove: #{path} (#{path.abv})"
       else
-        puts "Removing: #{path}... (#{path.abv})"
+        @output.puts "Removing: #{path}... (#{path.abv})"
         yield
       end
     end

--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -32,6 +32,7 @@ module Homebrew
       @spinner = T.let(nil, T.nilable(Spinner))
       @symlink_targets = T.let({}, T::Hash[Pathname, T::Set[Downloadable]])
       @downloads_by_location = T.let({}, T::Hash[Pathname, Concurrent::Promises::Future])
+      @staged_downloads_by_location = T.let({}, T::Hash[Pathname, Concurrent::Promises::Future])
       @cancelled = T.let(Concurrent::AtomicBoolean.new(false), Concurrent::AtomicBoolean)
       @active_threads = T.let(Concurrent::Set.new, Concurrent::Set)
       @failed_downloads = T.let([], T::Array[Downloadable])
@@ -81,19 +82,27 @@ module Homebrew
       end
 
       downloads[downloadable] = if stage
-        download.then_on(
-          pool, downloadable, pour, @cancelled
-        ) do |downloaded_path, queued_downloadable, queue_pour, cancelled|
-          with_active_thread do
-            raise CancelledDownloadError if cancelled.true?
+        stage_download = lambda do
+          download.then_on(
+            pool, downloadable, pour, @cancelled
+          ) do |downloaded_path, queued_downloadable, queue_pour, cancelled|
+            with_active_thread do
+              raise CancelledDownloadError if cancelled.true?
 
-            if queued_downloadable.stage_from_download_queue?(downloaded_path, pour: queue_pour)
-              queued_downloadable.extracting!
-              queued_downloadable.stage_from_download_queue(downloaded_path, pour: queue_pour)
-              queued_downloadable.downloaded!
+              if queued_downloadable.stage_from_download_queue?(downloaded_path, pour: queue_pour)
+                queued_downloadable.extracting!
+                queued_downloadable.stage_from_download_queue(downloaded_path, pour: queue_pour)
+                queued_downloadable.downloaded!
+              end
+              downloaded_path
             end
-            downloaded_path
           end
+        end
+
+        if (staged_location = downloadable.staged_path_from_download_queue)
+          @staged_downloads_by_location[staged_location] ||= stage_download.call
+        else
+          stage_download.call
         end
       else
         download
@@ -301,9 +310,12 @@ module Homebrew
         # Keep unfetched downloads (and their location dedup entries) queued
         # for the next fetch.
         fetchable_downloads.each_key { |downloadable| downloads.delete(downloadable) }
+        fetched_staging = fetchable_downloads.each_value.to_set
+        @staged_downloads_by_location.delete_if { |_, future| fetched_staging.include?(future) }
       else
         downloads.clear
         @downloads_by_location.clear
+        @staged_downloads_by_location.clear
         @symlink_targets.clear
       end
     end

--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -227,6 +227,9 @@ module Downloadable
     false
   end
 
+  sig { overridable.returns(T.nilable(Pathname)) }
+  def staged_path_from_download_queue; end
+
   sig { overridable.params(_download: Pathname, pour: T::Boolean).void }
   def stage_from_download_queue(_download, pour:); end
 

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -458,13 +458,16 @@ module Homebrew
         "Fetching downloads for: #{combined_fetch_targets.to_sentence}"
       end
 
-      sig { params(cask_installers: T::Array[T.untyped], download_queue: Homebrew::DownloadQueue).void }
+      sig {
+        params(cask_installers: T::Array[Cask::Installer], download_queue: Homebrew::DownloadQueue)
+          .returns(T::Boolean)
+      }
       def enqueue_cask_installers(cask_installers, download_queue:)
-        source_downloads = []
+        source_download_installers = {}
         valid_cask_installers = cask_installers.select do |cask_installer|
           if cask_installer.source_download_requires_pre_fetch? &&
              (source_download = cask_installer.prelude_fetch_download)
-            source_downloads << source_download
+            source_download_installers[source_download] = cask_installer
           end
           true
         rescue => e
@@ -472,16 +475,37 @@ module Homebrew
           false
         end
 
-        if source_downloads.any?
-          source_downloads.each { |source_download| download_queue.enqueue(source_download) }
-          download_queue.fetch(only: Cask::Download, heading: "Downloading Cask files")
+        if source_download_installers.any?
+          source_download_installers.each_key { |source_download| download_queue.enqueue(source_download) }
+          download_queue.fetch(only: Homebrew::API::SourceDownload, heading: "Downloading Cask files")
         end
 
-        valid_cask_installers.each do |cask_installer|
+        failed_source_downloads = download_queue.failed_downloads.grep(Homebrew::API::SourceDownload)
+        failed_source_installers = failed_source_downloads.map do |download|
+          source_download_installers.fetch(download).tap(&:download_failed!)
+        end
+
+        valid_cask_installers.select! do |cask_installer|
+          next false if failed_source_installers.include?(cask_installer)
+
           cask_installer.enqueue_downloads
+          true
+        rescue => e
+          ofail "#{cask_installer.cask}: #{e}"
+          false
+        end
+
+        download_queue.fetch(only: Cask::Download, heading: "Downloading Cask files")
+        downloads_succeeded = failed_source_downloads.empty? && download_queue.failed_downloads.none?(Cask::Download)
+        valid_cask_installers.each do |cask_installer|
+          if !downloads_succeeded && download_queue.failed_downloads.include?(cask_installer.downloader)
+            cask_installer.download_failed!
+          end
+          cask_installer.enqueue_dependency_downloads
         rescue => e
           ofail "#{cask_installer.cask}: #{e}"
         end
+        downloads_succeeded
       end
 
       sig {
@@ -492,7 +516,8 @@ module Homebrew
                cc: T.nilable(String), git: T::Boolean, interactive: T::Boolean, keep_tmp: T::Boolean,
                debug_symbols: T::Boolean, force: T::Boolean, overwrite: T::Boolean, debug: T::Boolean,
                quiet: T::Boolean, verbose: T::Boolean, dry_run: T::Boolean,
-               dry_run_action: String, skip_post_install: T::Boolean, skip_link: T::Boolean).void
+               dry_run_action: String, skip_post_install: T::Boolean, skip_link: T::Boolean,
+               cleanup: T::Boolean).returns(T::Array[Formula])
       }
       def install_formulae(
         formula_installers,
@@ -517,10 +542,11 @@ module Homebrew
         dry_run: false,
         dry_run_action: "install",
         skip_post_install: false,
-        skip_link: false
+        skip_link: false,
+        cleanup: true
       )
         formulae_names_to_install = formula_installers.map { |fi| fi.formula.name }
-        return if formulae_names_to_install.empty?
+        return [] if formulae_names_to_install.empty?
 
         if dry_run
           ohai "Would #{dry_run_action} #{Utils.pluralize("formula", formulae_names_to_install.count,
@@ -532,14 +558,16 @@ module Homebrew
 
             print_dry_run_dependencies(fi.formula, fi.compute_dependencies, &:name)
           end
-          return
+          return []
         end
 
+        installed_formulae = T.let([], T::Array[Formula])
         formula_installers.each do |fi|
           formula = fi.formula
           upgrade = formula.linked? && formula.outdated? && !formula.head? && !Homebrew::EnvConfig.no_install_upgrade?
           install_formula(fi, upgrade:)
-          Cleanup.install_formula_clean!(formula)
+          Cleanup.install_formula_clean!(formula) if cleanup
+          installed_formulae << formula
         rescue BuildError
           # Reported (with analytics) by the global handler in `brew.rb`.
           raise
@@ -548,6 +576,7 @@ module Homebrew
           # from aborting the rest of the batch while still failing the run.
           ofail "#{fi.formula.full_specified_name}: #{e}"
         end
+        installed_formulae
       end
 
       sig {

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -910,6 +910,39 @@ RSpec.describe Cask::Installer, :cask do
     end
   end
 
+  describe "#enqueue_dependency_downloads" do
+    it "reuses formula dependencies fetched before installation" do
+      cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+      dependency = formula("cask-dependency") do
+        url "https://brew.sh/cask-dependency-1.0.tar.gz"
+      end
+      queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [])
+      installer = described_class.new(cask, download_queue: queue)
+      allow(installer).to receive_messages(cask_and_formula_dependencies:         [dependency],
+                                           missing_cask_and_formula_dependencies: [dependency])
+      allow(dependency).to receive_messages(any_version_installed?: false, optlinked?: false)
+      formula_installers = nil
+
+      expect(Homebrew::Install).to receive(:enqueue_formulae) do |installers, download_queue:|
+        expect(download_queue).to equal(queue)
+        formula_installers = installers
+        installers
+      end
+      installer.enqueue_dependency_downloads
+      formula_installers&.each do |formula_installer|
+        allow(formula_installer).to receive(:install)
+        allow(formula_installer).to receive(:finish)
+      end
+      allow(Homebrew::Install).to receive(:perform_preinstall_checks_once)
+      expect(Homebrew::Install).not_to receive(:fetch_formulae)
+      expect(Homebrew::Install).to receive(:reject_failed_downloads)
+        .with(formula_installers, download_queue: queue)
+        .and_return(formula_installers)
+
+      installer.satisfy_cask_and_formula_dependencies
+    end
+  end
+
   describe "#load_installed_caskfile!" do
     it "uses recovered installed metadata before falling back to the current cask" do
       cask = Cask::CaskLoader.load(cask_path("local-caffeine"))

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Cask::Reinstall, :cask do
 
     expect do
       described_class.reinstall_casks(Cask::CaskLoader.load("local-caffeine"))
-    end.to output(output).to_stdout.and output(/==> Fetching downloads for:.*caffeine/).to_stderr
+    end.to output(output).to_stdout.and output(/==> Downloading Cask files/).to_stderr
   end
 
   it "displays the reinstallation progress with zapping" do
@@ -44,7 +44,7 @@ RSpec.describe Cask::Reinstall, :cask do
 
     expect do
       described_class.reinstall_casks(Cask::CaskLoader.load("local-caffeine"), zap: true)
-    end.to output(output).to_stdout.and output(/==> Fetching downloads for:.*caffeine/).to_stderr
+    end.to output(output).to_stdout.and output(/==> Downloading Cask files/).to_stderr
   end
 
   it "allows reinstalling a Cask" do
@@ -67,12 +67,14 @@ RSpec.describe Cask::Reinstall, :cask do
     allow(failing_installer).to receive(:prelude)
     allow(failing_installer).to receive(:source_download_requires_pre_fetch?).and_return(false)
     allow(failing_installer).to receive(:enqueue_downloads)
+    allow(failing_installer).to receive(:enqueue_dependency_downloads)
     allow(failing_installer).to receive(:install).and_raise(Cask::CaskError.new("reinstall failed"))
 
     successful_installer = instance_double(Cask::Installer)
     allow(successful_installer).to receive(:prelude)
     allow(successful_installer).to receive(:source_download_requires_pre_fetch?).and_return(false)
     allow(successful_installer).to receive(:enqueue_downloads)
+    allow(successful_installer).to receive(:enqueue_dependency_downloads)
 
     allow(Cask::Installer).to receive(:new).and_return(failing_installer, successful_installer)
 
@@ -84,6 +86,7 @@ RSpec.describe Cask::Reinstall, :cask do
   it "reinstalls casks after an earlier failure in the same run" do
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
     installer = instance_double(Cask::Installer, prelude: nil, enqueue_downloads: nil,
+                                                 enqueue_dependency_downloads: nil,
                                                  source_download_requires_pre_fetch?: false)
     allow(Cask::Installer).to receive(:new).and_return(installer)
     # A failure earlier in the run (e.g. a formula in the same `brew reinstall`)

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -494,6 +494,7 @@ RSpec.describe Cask::Upgrade, :cask do
 
     it 'prefetches "auto_updates true" casks with quarantine until signed identity is checked' do
       installer = instance_double(Cask::Installer, check_requirements: nil, enqueue_downloads: nil,
+                                                   enqueue_dependency_downloads: nil,
                                                    source_download_requires_pre_fetch?: false)
 
       expect(Cask::Installer).to receive(:new) do |cask, **|
@@ -934,7 +935,8 @@ RSpec.describe Cask::Upgrade, :cask do
       summary_upgrades = []
       upgraded_tokens = []
       incompatible_installer = instance_double(Cask::Installer, source_download_requires_pre_fetch?: false)
-      compatible_installer = instance_double(Cask::Installer, source_download_requires_pre_fetch?: false)
+      compatible_installer = instance_double(Cask::Installer, source_download_requires_pre_fetch?: false,
+                                                              enqueue_dependency_downloads:        nil)
 
       allow(incompatible_installer).to receive(:check_requirements)
         .and_raise(Cask::CaskError, "local-caffeine: This cask does not run on macOS versions older than Tahoe.")

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -27,6 +27,30 @@ RSpec.describe Homebrew::Cleanup do
     FileUtils.rm_rf HOMEBREW_LIBRARY/"Homebrew"
   end
 
+  describe "::install_clean!" do
+    it "cleans formulae and casks in parallel before reporting them", :cask do
+      formula = Testball.new
+      cask = Cask::Cask.new("local-caffeine")
+
+      allow(described_class).to receive(:install_cleanup_formulae).with([formula]).and_return([formula])
+      expect(Utils).to receive(:parallel_map).with([formula, cask]).and_call_original
+      expect_any_instance_of(described_class).to receive(:cleanup_formula)
+        .with(formula, quiet: true, cache_db: false, cleanup_unreferenced: false)
+      expect_any_instance_of(described_class).to receive(:cleanup_cask)
+        .with(cask, cleanup_unreferenced: false)
+      expect_any_instance_of(described_class).to receive(:cleanup_cache_db).with(no_args)
+      expect_any_instance_of(described_class).to receive(:cleanup_unreferenced_downloads).with(no_args)
+
+      with_env(HOMEBREW_NO_ENV_HINTS: "1") do
+        expect { described_class.install_clean!(formulae: [formula], casks: [cask]) }.to output(<<~EOS).to_stdout
+          ==> Cleanup
+          ==> testball
+          ==> local-caffeine
+        EOS
+      end
+    end
+  end
+
   describe "::prune?" do
     subject(:path) { HOMEBREW_CACHE/"foo" }
 
@@ -46,6 +70,18 @@ RSpec.describe Homebrew::Cleanup do
   end
 
   describe "::cleanup" do
+    it "cleans installed casks during periodic cleanup", :cask do
+      cask = Cask::Cask.new("local-caffeine")
+      ENV["HOMEBREW_NO_AUTOREMOVE"] = "1"
+      allow(Formula).to receive(:installed).and_return([])
+      allow(Cask::Caskroom).to receive(:casks).and_return([cask])
+
+      expect(cleanup).to receive(:cleanup_cask)
+        .with(cask, ds_store: false, cleanup_legacy_downloads: false, cleanup_unreferenced: false)
+
+      cleanup.clean!(periodic: true)
+    end
+
     it "removes .DS_Store and lock files" do
       cleanup.clean!
 

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -398,7 +398,8 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     cmd = described_class.new(["--yes", "local-caffeine"])
     download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil, failed_downloads: [])
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
-    installer = instance_double(Cask::Installer, enqueue_downloads: nil, source_download_requires_pre_fetch?: false)
+    installer = instance_double(Cask::Installer, enqueue_downloads: nil, enqueue_dependency_downloads: nil,
+                                                  source_download_requires_pre_fetch?: false)
     dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
 
     allow(Tap).to receive_messages(with_formula_name: nil, with_cask_token: nil)
@@ -559,7 +560,8 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     end
     formula_installer = instance_double(FormulaInstaller, formula:)
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
-    installer = instance_double(Cask::Installer, enqueue_downloads: nil, source_download_requires_pre_fetch?: false)
+    installer = instance_double(Cask::Installer, enqueue_downloads: nil, enqueue_dependency_downloads: nil,
+                                                  source_download_requires_pre_fetch?: false)
 
     allow(Tap).to receive_messages(with_formula_name: nil, with_cask_token: nil)
     allow(cmd.args.named).to receive(:to_formulae_and_casks).with(warn: false).and_return([formula, cask])

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -748,6 +748,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       version:           "0.118.0",
     )
     installer = instance_double(Cask::Installer, check_requirements: nil, enqueue_downloads: nil,
+                                                 enqueue_dependency_downloads: nil,
                                                  source_download_requires_pre_fetch?: false)
 
     expect(Homebrew::DownloadQueue).to receive(:new).once.and_return(download_queue)
@@ -882,6 +883,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       Cask::Installer,
       check_requirements:                  nil,
       enqueue_downloads:                   nil,
+      enqueue_dependency_downloads:        nil,
       source_download_requires_pre_fetch?: true,
     )
     source_download = instance_double(Homebrew::API::SourceDownload)
@@ -903,6 +905,9 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     allow(Cask::Installer).to receive(:new).and_return(installer)
     expect(installer).to receive(:prelude_fetch_download).and_return(source_download)
     expect(download_queue).to receive(:enqueue).with(source_download).ordered
+    expect(download_queue).to receive(:fetch)
+      .with(only: Homebrew::API::SourceDownload, heading: "Downloading Cask files")
+      .ordered
     expect(download_queue).to receive(:fetch)
       .with(only: Cask::Download, heading: "Downloading Cask files")
       .ordered
@@ -986,6 +991,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       Cask::Installer,
       check_requirements:                  nil,
       enqueue_downloads:                   nil,
+      enqueue_dependency_downloads:        nil,
       source_download_requires_pre_fetch?: true,
     )
 
@@ -1006,8 +1012,11 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     allow(Cask::Installer).to receive(:new).and_return(installer)
     expect(installer).to receive(:prelude_fetch_download).and_return(nil)
     expect(download_queue).to receive(:fetch)
+      .with(only: Cask::Download, heading: "Downloading Cask files")
+      .ordered
+    expect(download_queue).to receive(:fetch)
       .with(heading: "Fetching downloads for: deno and codex")
-      .once
+      .ordered
     allow(Cask::Upgrade).to receive_messages(outdated_casks: [cask], upgrade_casks!: true)
     allow(Homebrew::Cleanup).to receive(:periodic_clean!)
     allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
@@ -1066,7 +1075,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       installed_version: "0.117.0",
       version:           "0.118.0",
     )
-    installer = instance_double(Cask::Installer, check_requirements: nil, enqueue_downloads: nil,
+    installer = instance_double(Cask::Installer, check_requirements: nil, downloader: nil,
+                                                 enqueue_downloads: nil, enqueue_dependency_downloads: nil,
                                                  source_download_requires_pre_fetch?: false)
 
     allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -11,12 +11,13 @@ RSpec.describe Homebrew::DownloadQueue do
     instance_double(
       Downloadable,
       cached_download:,
-      checksum:               nil,
-      downloaded_and_valid?:  false,
-      downloader:             nil,
-      download_queue_message: "Bottle testball",
-      download_queue_name:    "testball",
-      download_queue_type:    "Bottle",
+      checksum:                        nil,
+      downloaded_and_valid?:           false,
+      downloader:                      nil,
+      download_queue_message:          "Bottle testball",
+      download_queue_name:             "testball",
+      download_queue_type:             "Bottle",
+      staged_path_from_download_queue: nil,
     )
   end
   let(:download_error) { DownloadError.new(downloadable, RuntimeError.new("network blew up")) }
@@ -341,6 +342,35 @@ RSpec.describe Homebrew::DownloadQueue do
 
     download_queue.enqueue(downloadable)
     download_queue.enqueue(downloadable, stage: true)
+    download_queue.fetch
+  end
+
+  it "stages duplicate downloads with the same destination once" do
+    staged_path = HOMEBREW_TEMP_CELLAR/"testball/0.1"
+    bottles = Array.new(2) do
+      instance_double(
+        Bottle,
+        cached_download:,
+        downloaded_and_valid?:           false,
+        downloader:                      nil,
+        download_queue_message:          "Bottle testball",
+        download_queue_name:             "testball",
+        download_queue_type:             "Bottle",
+        staged_path_from_download_queue: staged_path,
+      )
+    end
+    bottles.each do |bottle|
+      allow(bottle).to receive_messages(
+        downloaded!:                nil,
+        extracting!:                nil,
+        stage_from_download_queue?: true,
+      )
+    end
+    expect(retryable_download).to receive(:fetch).once.and_return(cached_download)
+    expect(bottles.first).to receive(:stage_from_download_queue).once
+    expect(bottles.second).not_to receive(:stage_from_download_queue)
+
+    bottles.each { |bottle| download_queue.enqueue(bottle, stage: true) }
     download_queue.fetch
   end
 

--- a/Library/Homebrew/test/install_spec.rb
+++ b/Library/Homebrew/test/install_spec.rb
@@ -69,6 +69,19 @@ RSpec.describe Homebrew::Install do
   end
 
   describe "::install_formulae" do
+    it "returns installed formulae without cleaning them inline when cleanup is deferred" do
+      formula = formula("good-bottle") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      formula_installer = instance_double(FormulaInstaller, formula:)
+
+      expect(described_class).to receive(:install_formula).with(formula_installer, upgrade: false)
+      expect(Homebrew::Cleanup).not_to receive(:install_formula_clean!)
+
+      expect(described_class.install_formulae([formula_installer], cleanup: false)).to eq([formula])
+    end
+
     it "skips a formula whose install raises and continues with the rest" do
       bad_fi = instance_double(FormulaInstaller, formula: formula("bad-bottle") do
         T.bind(self, T.class_of(Formula))
@@ -89,13 +102,70 @@ RSpec.describe Homebrew::Install do
   end
 
   describe "::enqueue_cask_installers" do
+    it "fetches source API downloads before enqueueing cask downloads" do
+      source_download = instance_double(Homebrew::API::SourceDownload)
+      installer = instance_double(
+        Cask::Installer,
+        cask:                                instance_double(Cask::Cask),
+        enqueue_dependency_downloads:        nil,
+        enqueue_downloads:                   nil,
+        prelude_fetch_download:              source_download,
+        source_download_requires_pre_fetch?: true,
+      )
+      download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [])
+
+      expect(download_queue).to receive(:enqueue).with(source_download).ordered
+      expect(download_queue).to receive(:fetch)
+        .with(only: Homebrew::API::SourceDownload, heading: "Downloading Cask files")
+        .ordered
+      expect(installer).to receive(:enqueue_downloads).ordered
+      expect(download_queue).to receive(:fetch)
+        .with(only: Cask::Download, heading: "Downloading Cask files")
+        .ordered
+
+      described_class.enqueue_cask_installers([installer], download_queue:)
+    end
+
+    it "marks a cask whose source API download fails" do
+      source_download = Homebrew::API::SourceDownload.new("https://brew.sh/cask.rb", nil)
+      installer = instance_double(
+        Cask::Installer,
+        cask:                                instance_double(Cask::Cask),
+        prelude_fetch_download:              source_download,
+        source_download_requires_pre_fetch?: true,
+      )
+      download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [source_download])
+
+      allow(download_queue).to receive(:enqueue)
+      allow(download_queue).to receive(:fetch)
+      expect(installer).to receive(:download_failed!)
+      expect(installer).not_to receive(:enqueue_downloads)
+
+      expect(described_class.enqueue_cask_installers([installer], download_queue:)).to be(false)
+    end
+
+    it "enqueues dependencies after fetching primary cask downloads" do
+      cask = instance_double(Cask::Cask, to_s: "dependent-cask")
+      installer = instance_double(Cask::Installer, cask:, source_download_requires_pre_fetch?: false)
+      download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [])
+
+      expect(installer).to receive(:enqueue_downloads).ordered
+      expect(download_queue).to receive(:fetch)
+        .with(only: Cask::Download, heading: "Downloading Cask files")
+        .ordered
+      expect(installer).to receive(:enqueue_dependency_downloads).ordered
+
+      described_class.enqueue_cask_installers([installer], download_queue:)
+    end
+
     it "skips casks whose enqueue raises and continues with the rest" do
       bad_cask = instance_double(Cask::Cask, to_s: "bad-cask")
       bad_installer = instance_double(Cask::Installer, cask:                                bad_cask,
                                                        source_download_requires_pre_fetch?: false)
       allow(bad_installer).to receive(:enqueue_downloads)
         .and_raise(URI::InvalidURIError, 'bad URI (is not URI?): "https://example.com/bad -cask.dmg"')
-      good_installer = instance_double(Cask::Installer, source_download_requires_pre_fetch?: false)
+      good_installer = instance_double(Cask::Installer, source_download_requires_pre_fetch?: false,
+                                                        enqueue_dependency_downloads:        nil)
       expect(good_installer).to receive(:enqueue_downloads)
 
       download_queue = Homebrew::DownloadQueue.new(pour: true)


### PR DESCRIPTION
- prefetch cask dependencies before serial installation
- collect successful formula installs for deferred cleanup
- clean formulae and casks concurrently with ordered output

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 GPT Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----


