### PR TITLE
Prepare combined upgrade planning

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -8,6 +8,7 @@ require "deprecate_disable"
 require "install"
 require "upgrade"
 require "utils/output"
+require "cask/installer"
 
 module Cask
   class Upgrade
@@ -93,6 +94,7 @@ module Cask
 
     sig { params(cask_upgrades: T::Array[String], dry_run: T.nilable(T::Boolean)).void }
     def self.show_upgrade_summary(cask_upgrades, dry_run: false)
+      cask_upgrades = cask_upgrades.uniq
       return if cask_upgrades.empty?
 
       verb = dry_run ? "Would upgrade" : "Upgrading"
@@ -102,27 +104,29 @@ module Cask
 
     sig {
       params(
-        casks:                Cask,
-        args:                 Homebrew::CLI::Args,
-        force:                T.nilable(T::Boolean),
-        greedy:               T.nilable(T::Boolean),
-        greedy_latest:        T.nilable(T::Boolean),
-        greedy_auto_updates:  T.nilable(T::Boolean),
-        dry_run:              T.nilable(T::Boolean),
-        skip_cask_deps:       T.nilable(T::Boolean),
-        verbose:              T.nilable(T::Boolean),
-        quiet:                T.nilable(T::Boolean),
-        binaries:             T.nilable(T::Boolean),
-        require_sha:          T.nilable(T::Boolean),
-        quit:                 T::Boolean,
-        skip_prefetch:        T::Boolean,
-        show_upgrade_summary: T::Boolean,
-        download_queue:       T.nilable(Homebrew::DownloadQueue),
-        summary_upgrades:     T.nilable(T::Array[String]),
-        summary_pinned:       T.nilable(T::Array[String]),
-        summary_deprecated:   T.nilable(T::Array[String]),
-        summary_disabled:     T.nilable(T::Array[String]),
-        prefetched_errors:    T.nilable(T::Array[StandardError]),
+        casks:                      Cask,
+        args:                       Homebrew::CLI::Args,
+        force:                      T.nilable(T::Boolean),
+        greedy:                     T.nilable(T::Boolean),
+        greedy_latest:              T.nilable(T::Boolean),
+        greedy_auto_updates:        T.nilable(T::Boolean),
+        dry_run:                    T.nilable(T::Boolean),
+        skip_cask_deps:             T.nilable(T::Boolean),
+        verbose:                    T.nilable(T::Boolean),
+        quiet:                      T.nilable(T::Boolean),
+        binaries:                   T.nilable(T::Boolean),
+        require_sha:                T.nilable(T::Boolean),
+        quit:                       T::Boolean,
+        skip_prefetch:              T::Boolean,
+        show_upgrade_summary:       T::Boolean,
+        download_queue:             T.nilable(Homebrew::DownloadQueue),
+        summary_upgrades:           T.nilable(T::Array[String]),
+        summary_pinned:             T.nilable(T::Array[String]),
+        summary_deprecated:         T.nilable(T::Array[String]),
+        summary_disabled:           T.nilable(T::Array[String]),
+        prefetched_errors:          T.nilable(T::Array[StandardError]),
+        upgraded_casks:             T.nilable(T::Array[Cask]),
+        prefetched_cask_installers: T.nilable(T::Array[Installer]),
       ).returns(T::Boolean)
     }
     def self.upgrade_casks!(
@@ -146,7 +150,9 @@ module Cask
       summary_pinned: nil,
       summary_deprecated: nil,
       summary_disabled: nil,
-      prefetched_errors: nil
+      prefetched_errors: nil,
+      upgraded_casks: nil,
+      prefetched_cask_installers: nil
     )
       outdated_casks =
         self.outdated_casks(casks, args:, greedy:, greedy_latest:, greedy_auto_updates:, force:, quiet:,
@@ -222,11 +228,12 @@ module Cask
         created_download_queue = true
         Homebrew::DownloadQueue.new(pour: true)
       end
+      prefetched_cask_installers ||= []
 
       if !dry_run && !skip_prefetch
         prefetch_download_queue = download_queue || Homebrew.default_download_queue
         begin
-          fetchable_cask_installers = []
+          prefetched_cask_installers.clear
           upgradable_casks.select! do |(_, cask)|
             # This is significantly easier given the weird difference in Sorbet signatures here.
             # rubocop:disable Style/DoubleNegation
@@ -243,17 +250,14 @@ module Cask
               next false
             end
 
-            fetchable_cask_installers << installer
+            prefetched_cask_installers << installer
             true
           end
 
-          fetchable_casks = upgradable_casks.map(&:last)
-          Homebrew::Install.enqueue_cask_installers(fetchable_cask_installers,
+          Homebrew::Install.enqueue_cask_installers(prefetched_cask_installers,
                                                     download_queue: prefetch_download_queue)
           prefetch_download_queue.fetch(
-            heading: Homebrew::Install.combined_fetch_downloads_heading(
-              cask_names: fetchable_casks.map(&:full_name),
-            ),
+            heading: "Fetching dependency downloads",
           )
         ensure
           prefetch_download_queue.shutdown if created_download_queue
@@ -276,12 +280,14 @@ module Cask
       download_queue ||= Homebrew.default_download_queue
 
       upgradable_casks.each_with_index do |(old_cask, new_cask), index|
+        new_cask_installer = prefetched_cask_installers.find { |installer| installer.cask.equal?(new_cask) }
         upgrade_cask(
           old_cask, new_cask,
           binaries:, force:, skip_cask_deps:, verbose:,
-          require_sha:, quit:, download_queue:
+          require_sha:, quit:, download_queue:, new_cask_installer:
         )
         summary_upgrades&.push(cask_upgrades.fetch(index))
+        upgraded_casks&.push(new_cask)
       rescue => e
         ofail "#{new_cask.full_name}: #{e}"
         failed = true
@@ -356,23 +362,23 @@ module Cask
 
     sig {
       params(
-        old_cask:       Cask,
-        new_cask:       Cask,
-        binaries:       T.nilable(T::Boolean),
-        force:          T.nilable(T::Boolean),
-        require_sha:    T.nilable(T::Boolean),
-        quit:           T::Boolean,
-        skip_cask_deps: T.nilable(T::Boolean),
-        verbose:        T.nilable(T::Boolean),
-        download_queue: Homebrew::DownloadQueue,
+        old_cask:           Cask,
+        new_cask:           Cask,
+        binaries:           T.nilable(T::Boolean),
+        force:              T.nilable(T::Boolean),
+        require_sha:        T.nilable(T::Boolean),
+        quit:               T::Boolean,
+        skip_cask_deps:     T.nilable(T::Boolean),
+        verbose:            T.nilable(T::Boolean),
+        download_queue:     Homebrew::DownloadQueue,
+        new_cask_installer: T.nilable(Installer),
       ).void
     }
     def self.upgrade_cask(
       old_cask, new_cask,
-      binaries:, force:, require_sha:, quit:, skip_cask_deps:, verbose:, download_queue:
+      binaries:, force:, require_sha:, quit:, skip_cask_deps:, verbose:, download_queue:,
+      new_cask_installer: nil
     )
-      require "cask/installer"
-
       start_time = Time.now
       odebug "Started upgrade process for Cask #{old_cask}"
       old_config = old_cask.config
@@ -400,8 +406,8 @@ module Cask
         download_queue:,
       }.compact
 
-      new_cask_installer =
-        Installer.new(new_cask, **new_options, defer_fetch: true)
+      new_cask_installer ||= Installer.new(new_cask, **new_options, defer_fetch: true)
+      raise CaskError, "Download failed for #{new_cask}." if new_cask_installer.download_failed?
 
       started_upgrade = false
       new_artifacts_installed = false

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -215,6 +215,24 @@ RSpec.describe Cask::Upgrade, :cask do
         )
       end
 
+      it "records upgraded casks without a caveat mode option" do
+        upgraded_casks = []
+
+        expect(described_class).to receive(:upgrade_cask) do |_, _, **options|
+          expect(options).not_to have_key(:defer_caveats)
+        end
+
+        described_class.upgrade_casks!(
+          local_caffeine,
+          upgraded_casks:,
+          skip_prefetch:        true,
+          show_upgrade_summary: false,
+          args:,
+        )
+
+        expect(upgraded_casks).to eq([local_caffeine])
+      end
+
       it "excludes pinned Casks" do
         local_caffeine.pin
         summary_pinned = []
@@ -493,17 +511,40 @@ RSpec.describe Cask::Upgrade, :cask do
     end
 
     it 'prefetches "auto_updates true" casks with quarantine until signed identity is checked' do
-      installer = instance_double(Cask::Installer, check_requirements: nil, enqueue_downloads: nil,
-                                                   enqueue_dependency_downloads: nil,
+      installer = instance_double(Cask::Installer, cask: auto_updates, check_requirements: nil,
+                                                   enqueue_downloads: nil, enqueue_dependency_downloads: nil,
                                                    source_download_requires_pre_fetch?: false)
 
       expect(Cask::Installer).to receive(:new) do |cask, **|
         expect(cask).to eq(auto_updates)
         installer
       end
-      expect(described_class).to receive(:upgrade_cask)
+      expect(described_class).to receive(:upgrade_cask) do |_, _, new_cask_installer:, **|
+        expect(new_cask_installer).to equal(installer)
+      end
 
       described_class.upgrade_casks!(auto_updates, show_upgrade_summary: false, args:)
+    end
+
+    it "retains installers in a caller-supplied prefetch collection" do
+      installer = Cask::Installer.allocate
+      prefetched_cask_installers = []
+      download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil)
+
+      allow(installer).to receive_messages(cask: auto_updates, check_requirements: nil)
+      allow(Cask::Installer).to receive(:new).and_return(installer)
+      allow(Homebrew::Install).to receive(:enqueue_cask_installers)
+      allow(described_class).to receive(:upgrade_cask)
+
+      described_class.upgrade_casks!(
+        auto_updates,
+        download_queue:,
+        prefetched_cask_installers:,
+        show_upgrade_summary:       false,
+        args:,
+      )
+
+      expect(prefetched_cask_installers).to eq([installer])
     end
 
     it "releases quarantine when Gatekeeper was already approved and identity matches" do
@@ -935,12 +976,14 @@ RSpec.describe Cask::Upgrade, :cask do
       summary_upgrades = []
       upgraded_tokens = []
       incompatible_installer = instance_double(Cask::Installer, source_download_requires_pre_fetch?: false)
-      compatible_installer = instance_double(Cask::Installer, source_download_requires_pre_fetch?: false,
-                                                              enqueue_dependency_downloads:        nil)
+      compatible_installer = instance_double(Cask::Installer, cask:                                local_transmission,
+                                                              enqueue_dependency_downloads:        nil,
+                                                              source_download_requires_pre_fetch?: false)
 
       allow(incompatible_installer).to receive(:check_requirements)
         .and_raise(Cask::CaskError, "local-caffeine: This cask does not run on macOS versions older than Tahoe.")
-      allow(compatible_installer).to receive_messages(check_requirements: nil, enqueue_downloads: nil)
+      allow(compatible_installer).to receive_messages(check_requirements: nil, enqueue_downloads: nil,
+                                                      enqueue_dependency_downloads: nil)
       allow(Cask::Installer).to receive(:new) do |cask, **|
         (cask.token == "local-caffeine") ? incompatible_installer : compatible_installer
       end

--- a/Library/Homebrew/test/upgrade_spec.rb
+++ b/Library/Homebrew/test/upgrade_spec.rb
@@ -80,6 +80,23 @@ RSpec.describe Homebrew::Upgrade do
     end
   end
 
+  describe "::upgrade_formulae" do
+    it "can defer cleanup until the batch has finished installing" do
+      formula_installer = instance_double(FormulaInstaller, formula: Testball.new)
+
+      allow(described_class).to receive(:upgrade_formula).with(
+        formula_installer,
+        dry_run:            false,
+        verbose:            false,
+        skip_formula_names: [],
+      ).and_return(true)
+      expect(Homebrew::Cleanup).not_to receive(:install_formula_clean!)
+
+      expect(described_class.upgrade_formulae([formula_installer], fetch: false, cleanup: false))
+        .to eq([formula_installer])
+    end
+  end
+
   describe "::formula_installers" do
     it "explains when installed dependencies satisfy the bottle metadata" do
       dependent = formula("dependent") do
@@ -112,6 +129,33 @@ RSpec.describe Homebrew::Upgrade do
     end
   end
 
+  describe "::dependent_formula_installers" do
+    it "excludes primary formulae without a caveat mode option" do
+      primary = Testball.new
+      dependant = formula("dependant") do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/dependant-2.0"
+      end
+      formula_installer = FormulaInstaller.new(dependant)
+      dependants = Homebrew::Upgrade::Dependents.new(
+        upgradeable: [primary, dependant], pinned: [], skipped: [],
+      )
+
+      expect(described_class).to receive(:formula_installers) do |formulae, **options|
+        expect(formulae).to eq([dependant])
+        expect(options).to include(flags: [], dependents: true)
+        expect(options).not_to have_key(:defer_caveats)
+        [formula_installer]
+      end
+
+      expect(described_class.dependent_formula_installers(
+               dependants,
+               [primary],
+               flags: [],
+             )).to eq([formula_installer])
+    end
+  end
+
   describe "::upgrade_dependents" do
     it "returns installed dependents unless they are primary formulae" do
       installed_dependent = formula("installed-dependent") do
@@ -129,6 +173,51 @@ RSpec.describe Homebrew::Upgrade do
 
       expect(described_class.upgrade_dependents(dependants, [primary_formula], flags: []))
         .to contain_exactly(installed_dependent)
+    end
+
+    it "installs prefetched dependants without fetching again" do
+      dependant = formula("dependant") do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/dependant-2.0"
+      end
+      formula_installer = FormulaInstaller.new(dependant)
+      dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [dependant], pinned: [], skipped: [])
+
+      allow(FormulaInstaller).to receive(:installed).and_return(Set.new)
+      expect(described_class).not_to receive(:formula_installers)
+      expect(described_class).to receive(:filter_dependent_formula_installers)
+        .with([formula_installer])
+        .and_return([formula_installer])
+      expect(described_class).to receive(:upgrade_formulae)
+        .with([formula_installer], verbose: false, cleanup: false, fetch: false)
+        .and_return([formula_installer])
+
+      expect(described_class.upgrade_dependents(
+               dependants,
+               [],
+               flags:                         [],
+               cleanup:                       false,
+               prefetched_formula_installers: [formula_installer],
+             )).to eq([dependant])
+    end
+
+    it "rechecks prefetched dependants after primary formulae are installed" do
+      dependant = Testball.new
+      formula_installer = FormulaInstaller.new(dependant)
+      dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [dependant], pinned: [], skipped: [])
+
+      allow(FormulaInstaller).to receive(:installed).and_return(Set.new)
+      expect(described_class).to receive(:filter_dependent_formula_installers)
+        .with([formula_installer])
+        .and_return([])
+      expect(described_class).not_to receive(:upgrade_formulae)
+
+      expect(described_class.upgrade_dependents(
+               dependants,
+               [],
+               flags:                         [],
+               prefetched_formula_installers: [formula_installer],
+             )).to be_empty
     end
   end
 end

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -140,23 +140,8 @@ module Homebrew
           download_queue.shutdown
         end
 
-        installers.filter_map do |fi|
+        installers = installers.filter_map do |fi|
           fi.determine_bottle_tab_attributes
-
-          if !dry_run && dependents
-            all_runtime_deps_installed = fi.bottle_tab_runtime_dependencies.presence&.all? do |dependency, hash|
-              minimum_version = if (version = hash["version"])
-                Version.new(version)
-              end
-              Dependency.new(dependency).installed?(minimum_version:, minimum_revision: hash["revision"].to_i)
-            end
-
-            if all_runtime_deps_installed
-              ohai "Not upgrading #{fi.formula.full_specified_name}: " \
-                   "installed runtime dependencies satisfy bottle metadata"
-              next
-            end
-          end
 
           if dry_run
             begin
@@ -169,13 +154,75 @@ module Homebrew
 
           fi
         end
+        return installers if dry_run || !dependents
+
+        filter_dependent_formula_installers(installers)
+      end
+
+      sig { params(formula_installers: T::Array[FormulaInstaller]).returns(T::Array[FormulaInstaller]) }
+      def filter_dependent_formula_installers(formula_installers)
+        formula_installers.reject do |fi|
+          all_runtime_deps_installed = fi.bottle_tab_runtime_dependencies.presence&.all? do |dependency, hash|
+            minimum_version = if (version = hash["version"])
+              Version.new(version)
+            end
+            Dependency.new(dependency).installed?(minimum_version:, minimum_revision: hash["revision"].to_i)
+          end
+
+          next false unless all_runtime_deps_installed
+
+          ohai "Not upgrading #{fi.formula.full_specified_name}: " \
+               "installed runtime dependencies satisfy bottle metadata"
+          true
+        end
+      end
+
+      sig {
+        params(
+          deps: Dependents, formulae: T::Array[Formula], flags: T::Array[String],
+          force_bottle: T::Boolean, build_from_source_formulae: T::Array[String],
+          interactive: T::Boolean, keep_tmp: T::Boolean, debug_symbols: T::Boolean,
+          force: T::Boolean, debug: T::Boolean, quiet: T::Boolean, verbose: T::Boolean
+        ).returns(T::Array[FormulaInstaller])
+      }
+      def dependent_formula_installers(
+        deps,
+        formulae,
+        flags:,
+        force_bottle: false,
+        build_from_source_formulae: [],
+        interactive: false,
+        keep_tmp: false,
+        debug_symbols: false,
+        force: false,
+        debug: false,
+        quiet: false,
+        verbose: false
+      )
+        formula_names = formulae.map(&:full_name)
+        formula_installers(
+          deps.upgradeable.reject { |formula| formula_names.include?(formula.full_name) },
+          flags:,
+          force_bottle:,
+          build_from_source_formulae:,
+          dependents:                 true,
+          interactive:,
+          keep_tmp:,
+          debug_symbols:,
+          force:,
+          debug:,
+          quiet:,
+          verbose:,
+        )
       end
 
       sig {
         params(formula_installers: T::Array[FormulaInstaller], dry_run: T::Boolean, verbose: T::Boolean,
-               fetch: T::Boolean, skip_formula_names: T::Array[String]).returns(T::Array[FormulaInstaller])
+               fetch: T::Boolean, cleanup: T::Boolean,
+               skip_formula_names: T::Array[String]).returns(T::Array[FormulaInstaller])
       }
-      def upgrade_formulae(formula_installers, dry_run: false, verbose: false, fetch: true, skip_formula_names: [])
+      def upgrade_formulae(formula_installers, dry_run: false, verbose: false, fetch: true, cleanup: true,
+                           skip_formula_names: [])
         valid_formula_installers = if dry_run || !fetch
           formula_installers
         else
@@ -184,7 +231,7 @@ module Homebrew
 
         upgraded_formula_installers = valid_formula_installers.select do |fi|
           upgraded = upgrade_formula(fi, dry_run:, verbose:, skip_formula_names:)
-          Cleanup.install_formula_clean!(fi.formula) if upgraded && !dry_run
+          Cleanup.install_formula_clean!(fi.formula) if upgraded && !dry_run && cleanup
           upgraded
         end
         return upgraded_formula_installers unless dry_run
@@ -278,7 +325,8 @@ module Homebrew
                dry_run: T::Boolean, installed_on_request: T::Boolean, force_bottle: T::Boolean,
                build_from_source_formulae: T::Array[String], interactive: T::Boolean, keep_tmp: T::Boolean,
                debug_symbols: T::Boolean, force: T::Boolean, debug: T::Boolean, quiet: T::Boolean,
-               verbose: T::Boolean, skip_formula_names: T::Array[String]).returns(T::Array[Formula])
+               verbose: T::Boolean, skip_formula_names: T::Array[String], cleanup: T::Boolean,
+               prefetched_formula_installers: T.nilable(T::Array[FormulaInstaller])).returns(T::Array[Formula])
       }
       def upgrade_dependents(deps, formulae,
                              flags:,
@@ -293,10 +341,12 @@ module Homebrew
                              debug: false,
                              quiet: false,
                              verbose: false,
-                             skip_formula_names: [])
+                             skip_formula_names: [],
+                             cleanup: true,
+                             prefetched_formula_installers: nil)
         return [] if deps.blank?
 
-        upgradeable = deps.upgradeable
+        upgradeable = deps.upgradeable.dup
         pinned      = deps.pinned
         skipped     = deps.skipped
         if pinned.present?
@@ -331,20 +381,27 @@ module Homebrew
 
         dependent_installers = T.let([], T::Array[FormulaInstaller])
         unless dry_run
-          dependent_installers = formula_installers(
-            upgradeable.dup,
-            flags:,
-            force_bottle:,
-            build_from_source_formulae:,
-            dependents:                 true,
-            interactive:,
-            keep_tmp:,
-            debug_symbols:,
-            force:,
-            debug:,
-            quiet:,
-            verbose:,
-          )
+          dependent_installers = if prefetched_formula_installers
+            upgradeable_names = upgradeable.map(&:full_name)
+            filter_dependent_formula_installers(
+              prefetched_formula_installers.select { |fi| upgradeable_names.include?(fi.formula.full_name) },
+            )
+          else
+            formula_installers(
+              upgradeable.dup,
+              flags:,
+              force_bottle:,
+              build_from_source_formulae:,
+              dependents:                 true,
+              interactive:,
+              keep_tmp:,
+              debug_symbols:,
+              force:,
+              debug:,
+              quiet:,
+              verbose:,
+            )
+          end
           upgradeable = dependent_installers.map(&:formula)
         end
 
@@ -367,7 +424,16 @@ module Homebrew
           puts format_upgrade_summary(formulae_upgrades).join("\n")
         end
 
-        upgraded_formulae.concat(upgrade_formulae(dependent_installers, verbose:).map(&:formula)) unless dry_run
+        if !dry_run && dependent_installers.present?
+          upgraded_formulae.concat(
+            upgrade_formulae(
+              dependent_installers,
+              verbose:,
+              cleanup:,
+              fetch:   prefetched_formula_installers.nil?,
+            ).map(&:formula),
+          )
+        end
 
         # Update non-core installed formulae for linkage checks after upgrading
         # Don't need to check core formulae because we do so at CI time.
@@ -534,7 +600,8 @@ module Homebrew
                force_bottle: T::Boolean,
                build_from_source_formulae: T::Array[String], interactive: T::Boolean,
                keep_tmp: T::Boolean, debug_symbols: T::Boolean, force: T::Boolean,
-               overwrite: T::Boolean, debug: T::Boolean, quiet: T::Boolean, verbose: T::Boolean).returns(FormulaInstaller)
+               overwrite: T::Boolean, debug: T::Boolean, quiet: T::Boolean,
+               verbose: T::Boolean).returns(FormulaInstaller)
       }
       def create_formula_installer(
         formula,


### PR DESCRIPTION
- return successful formula and cask upgrades to callers
- retain prefetched installers and dependant download plans
- deduplicate package summaries before execution

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 GPT Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----


