### PR TITLE
Order install package phases

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -27,7 +27,7 @@ module Homebrew
           outdated dependents and dependents with broken linkage, respectively.
 
           Unless `$HOMEBREW_NO_INSTALL_CLEANUP` is set, `brew cleanup` will then be run for
-          the installed formulae or, every 30 days, for all formulae.
+          the installed formulae and casks or, every 30 days, for all packages.
 
           Unless `$HOMEBREW_NO_INSTALL_UPGRADE` is set, `brew install` <formula> will upgrade <formula> if it
           is already installed but outdated.
@@ -222,6 +222,7 @@ module Homebrew
         new_casks = T.let([], T::Array[Cask::Cask])
         upgrade_casks = T.let([], T::Array[Cask::Cask])
         fetch_casks = T.let([], T::Array[Cask::Cask])
+        prefetched_cask_installers = T.let([], T::Array[Cask::Installer])
         if casks.any?
           if args.dry_run?
             Install.print_dry_run_casks(casks, skip_cask_deps: args.skip_cask_deps?, include_installed: false)
@@ -357,81 +358,117 @@ module Homebrew
           raise
         end
 
-        if !args.dry_run? && (formulae_installer.any? || fetch_casks.any?)
+        dependent_formulae_installer = if args.dry_run?
+          []
+        else
+          Upgrade.dependent_formula_installers(
+            dependants,
+            installed_formulae,
+            flags:                      args.flags_only,
+            force_bottle:               args.force_bottle?,
+            build_from_source_formulae: args.build_from_source_formulae,
+            interactive:                args.interactive?,
+            keep_tmp:                   args.keep_tmp?,
+            debug_symbols:              args.debug_symbols?,
+            force:                      args.force?,
+            debug:                      args.debug?,
+            quiet:                      args.quiet?,
+            verbose:                    args.verbose?,
+          )
+        end
+
+        if !args.dry_run? && (formulae_installer.any? || dependent_formulae_installer.any? || fetch_casks.any?)
           download_queue = T.let(shared_download_queue || Homebrew::DownloadQueue.new(pour: true),
                                  Homebrew::DownloadQueue)
           shared_download_queue = nil
           begin
-            Cask::Upgrade.show_upgrade_summary(
-              upgrade_casks.map { |cask| "#{cask.full_name} #{cask.installed_version} -> #{cask.version}" },
-            )
+            unless ask
+              Cask::Upgrade.show_upgrade_summary(
+                upgrade_casks.map { |cask| "#{cask.full_name} #{cask.installed_version} -> #{cask.version}" },
+              )
+            end
 
-            formulae_installer = Install.enqueue_formulae(formulae_installer, download_queue:)
+            all_formulae_installer = Install.enqueue_formulae(
+              (formulae_installer + dependent_formulae_installer).uniq { |fi| fi.formula.full_name },
+              download_queue:,
+            )
+            formulae_installer &= all_formulae_installer
+            dependent_formulae_installer &= all_formulae_installer
 
             if fetch_casks.any?
-              fetch_cask_installers = fetch_casks.map do |cask|
+              prefetched_cask_installers = fetch_casks.map do |cask|
                 Cask::Installer.new(
                   cask,
-                  reinstall:      true,
+                  adopt:          args.adopt?,
                   binaries:       args.binaries?,
                   verbose:        args.verbose?,
                   force:          args.force?,
+                  quiet:          args.quiet?,
                   skip_cask_deps: args.skip_cask_deps?,
                   require_sha:    args.require_sha?,
-                  zap:            args.zap?,
+                  upgrade:        upgrade_casks.include?(cask),
                   download_queue:,
                   defer_fetch:    true,
                 )
               end
 
-              Install.enqueue_cask_installers(fetch_cask_installers, download_queue:)
+              Install.enqueue_cask_installers(prefetched_cask_installers, download_queue:)
             end
 
             download_queue.fetch(heading: Install.combined_fetch_downloads_heading(
-              formula_names: formulae_installer.map { |fi| fi.formula.name },
-              cask_names:    fetch_casks.map(&:full_name),
-            ))
+              formula_names: all_formulae_installer.map { |fi| fi.formula.name },
+            ) || "Fetching dependency downloads")
             # Install everything that did download, rather than aborting the
             # whole run; the failures above still exit nonzero at the end.
-            formulae_installer = Install.reject_failed_downloads(formulae_installer, download_queue:)
+            all_formulae_installer = Install.reject_failed_downloads(all_formulae_installer, download_queue:)
+            formulae_installer &= all_formulae_installer
+            dependent_formulae_installer &= all_formulae_installer
           ensure
             download_queue.shutdown
           end
         end
         shared_download_queue&.shutdown
 
-        Install.install_formulae(formulae_installer,
-                                 dry_run: args.dry_run?,
-                                 verbose: args.verbose?)
-
-        Upgrade.upgrade_dependents(
-          dependants, installed_formulae,
-          flags:                      args.flags_only,
-          dry_run:                    args.dry_run?,
-          force_bottle:               args.force_bottle?,
-          build_from_source_formulae: args.build_from_source_formulae,
-          interactive:                args.interactive?,
-          keep_tmp:                   args.keep_tmp?,
-          debug_symbols:              args.debug_symbols?,
-          force:                      args.force?,
-          debug:                      args.debug?,
-          quiet:                      args.quiet?,
-          verbose:                    args.verbose?
+        installed_or_upgraded_formulae = Install.install_formulae(
+          formulae_installer,
+          dry_run: args.dry_run?,
+          verbose: args.verbose?,
+          cleanup: false,
         )
 
+        installed_or_upgraded_formulae |= Upgrade.upgrade_dependents(
+          dependants, installed_formulae,
+          flags:                         args.flags_only,
+          dry_run:                       args.dry_run?,
+          force_bottle:                  args.force_bottle?,
+          build_from_source_formulae:    args.build_from_source_formulae,
+          interactive:                   args.interactive?,
+          keep_tmp:                      args.keep_tmp?,
+          debug_symbols:                 args.debug_symbols?,
+          force:                         args.force?,
+          debug:                         args.debug?,
+          quiet:                         args.quiet?,
+          verbose:                       args.verbose?,
+          cleanup:                       false,
+          prefetched_formula_installers: dependent_formulae_installer
+        )
+
+        installed_or_upgraded_casks = T.let([], T::Array[Cask::Cask])
         if casks.any?
           new_casks.each do |cask|
-            Cask::Installer.new(
+            installer = prefetched_cask_installers.find { |candidate| candidate.cask.equal?(cask) }
+            installer ||= Cask::Installer.new(
               cask,
               adopt:          args.adopt?,
               binaries:       args.binaries?,
-              defer_fetch:    fetch_casks.include?(cask),
               force:          args.force?,
               quiet:          args.quiet?,
               require_sha:    args.require_sha?,
               skip_cask_deps: args.skip_cask_deps?,
               verbose:        args.verbose?,
-            ).install
+            )
+            installer.install
+            installed_or_upgraded_casks << cask
           rescue => e
             ofail "#{cask.full_name}: #{e}"
           end
@@ -440,15 +477,17 @@ module Homebrew
             begin
               Cask::Upgrade.upgrade_casks!(
                 *installed_casks,
-                force:                args.force?,
-                dry_run:              args.dry_run?,
-                binaries:             args.binaries?,
-                require_sha:          args.require_sha?,
-                skip_cask_deps:       args.skip_cask_deps?,
-                verbose:              args.verbose?,
-                quiet:                args.quiet?,
-                skip_prefetch:        true,
-                show_upgrade_summary: false,
+                force:                      args.force?,
+                dry_run:                    args.dry_run?,
+                binaries:                   args.binaries?,
+                require_sha:                args.require_sha?,
+                skip_cask_deps:             args.skip_cask_deps?,
+                verbose:                    args.verbose?,
+                quiet:                      args.quiet?,
+                skip_prefetch:              true,
+                show_upgrade_summary:       false,
+                upgraded_casks:             installed_or_upgraded_casks,
+                prefetched_cask_installers:,
                 args:,
               )
             rescue => e
@@ -457,6 +496,10 @@ module Homebrew
           end
         end
 
+        unless args.dry_run?
+          Cleanup.install_clean!(formulae: installed_or_upgraded_formulae,
+                                 casks:    installed_or_upgraded_casks)
+        end
         Cleanup.periodic_clean!(dry_run: args.dry_run?)
 
         Homebrew.messages.display_messages(display_times: args.display_times?)

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -337,7 +337,12 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
       url "https://brew.sh/testball-0.1.tar.gz"
     end
     formula_installer = instance_double(FormulaInstaller, formula:)
-    dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
+    dependant = formula("dependant") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/dependant-0.1.tar.gz"
+    end
+    dependant_installer = instance_double(FormulaInstaller, formula: dependant)
+    dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [dependant], pinned: [], skipped: [])
 
     allow(Tap).to receive_messages(with_formula_name: nil, with_cask_token: nil)
     allow(Homebrew::Trust).to receive(:trust_fully_qualified_items!)
@@ -345,20 +350,38 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     allow(Homebrew::Install).to receive(:perform_preinstall_checks_once)
     allow(Homebrew::Install).to receive(:check_cc_argv)
     allow(Homebrew::Install).to receive_messages(install_formula?: true, formula_installers: [formula_installer])
-    allow(Homebrew::Install).to receive(:install_formulae)
-    allow(Homebrew::Upgrade).to receive(:upgrade_dependents)
-    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
-    allow(Homebrew.messages).to receive(:display_messages)
     expect(Homebrew::DownloadQueue).to receive(:new).ordered.and_return(download_queue)
     expect(formula_installer).to receive(:download_queue=).with(download_queue).ordered
     expect(formula_installer).to receive(:prelude_fetch).with(no_args).ordered
     expect(Homebrew::Upgrade).to receive(:dependants).ordered.and_return(dependants)
-    expect(Homebrew::Install).to receive(:enqueue_formulae)
-      .with([formula_installer], download_queue:)
+    expect(Homebrew::Upgrade).to receive(:dependent_formula_installers)
       .ordered
-      .and_return([formula_installer])
+      .and_return([dependant_installer])
+    expect(Homebrew::Install).to receive(:enqueue_formulae)
+      .with([formula_installer, dependant_installer], download_queue:)
+      .ordered
+      .and_return([formula_installer, dependant_installer])
     expect(download_queue).to receive(:fetch).ordered
     expect(download_queue).to receive(:shutdown).ordered
+    expect(Homebrew::Install).to receive(:install_formulae)
+      .with([formula_installer], dry_run: false, verbose: false, cleanup: false)
+      .ordered
+      .and_return([formula])
+    expect(Homebrew::Upgrade).to receive(:upgrade_dependents) do |actual_dependants, _, **options|
+      expect(actual_dependants).to eq(dependants)
+      expect(options).to include(
+        cleanup:                       false,
+        prefetched_formula_installers: [dependant_installer],
+      )
+      [dependant]
+    end.ordered
+    expect(Homebrew::Cleanup).to receive(:install_clean!)
+      .with(formulae: [formula, dependant], casks: [])
+      .ordered
+    expect(Homebrew::Cleanup).to receive(:periodic_clean!).with(dry_run: false).ordered
+    expect(Homebrew.messages).to receive(:display_messages)
+      .with(display_times: false)
+      .ordered
 
     cmd.run
   end
@@ -389,7 +412,9 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     # the packages that are ready from being installed.
     Homebrew.failed = true
 
-    expect(Homebrew::Install).to receive(:install_formulae).with([formula_installer], dry_run: false, verbose: false)
+    expect(Homebrew::Install).to receive(:install_formulae)
+      .with([formula_installer], dry_run: false, verbose: false, cleanup: false)
+      .and_return([formula])
 
     cmd.run
   end
@@ -398,7 +423,8 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     cmd = described_class.new(["--yes", "local-caffeine"])
     download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil, failed_downloads: [])
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
-    installer = instance_double(Cask::Installer, enqueue_downloads: nil, enqueue_dependency_downloads: nil,
+    installer = instance_double(Cask::Installer, cask:, enqueue_downloads: nil,
+                                                  enqueue_dependency_downloads: nil,
                                                   source_download_requires_pre_fetch?: false)
     dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
 
@@ -418,6 +444,50 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     expect { cmd.run }.to output(/local-caffeine: uh-oh/).to_stderr
   end
 
+  it "cleans an installed cask before displaying deferred caveats", :cask do
+    cmd = described_class.new(["--yes", "local-caffeine"])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil, failed_downloads: [])
+    cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+    installer = instance_double(Cask::Installer, cask:, install: nil, enqueue_downloads: nil,
+                                                  enqueue_dependency_downloads: nil,
+                                                  source_download_requires_pre_fetch?: false)
+
+    allow(Tap).to receive_messages(with_formula_name: nil, with_cask_token: nil)
+    allow(Homebrew::Trust).to receive(:trust_fully_qualified_items!)
+    allow(cmd.args.named).to receive(:to_formulae_and_casks).with(warn: false).and_return([cask])
+    allow(Cask::Upgrade).to receive(:outdated_casks).and_return([])
+    allow(Homebrew::Install).to receive(:perform_preinstall_checks_once)
+    allow(Homebrew::Install).to receive(:check_cc_argv)
+    allow(Homebrew::Upgrade).to receive_messages(
+      dependants:                   Homebrew::Upgrade::Dependents.new(
+        upgradeable: [],
+        pinned:      [],
+        skipped:     [],
+      ),
+      dependent_formula_installers: [],
+      upgrade_dependents:           [],
+    )
+    allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
+    allow(Cask::Installer).to receive(:new).and_return(installer)
+
+    expect(download_queue).to receive(:fetch)
+      .with(only: Cask::Download, heading: "Downloading Cask files")
+      .ordered
+    expect(download_queue).to receive(:fetch)
+      .with(heading: "Fetching dependency downloads")
+      .ordered
+    expect(installer).to receive(:install).ordered
+    expect(Homebrew::Cleanup).to receive(:install_clean!)
+      .with(formulae: [], casks: [cask])
+      .ordered
+    expect(Homebrew::Cleanup).to receive(:periodic_clean!).with(dry_run: false).ordered
+    expect(Homebrew.messages).to receive(:display_messages)
+      .with(display_times: false)
+      .ordered
+
+    cmd.run
+  end
+
   it "drains metadata-only prelude fetches before the dry-run plan when asking" do
     cmd = described_class.new(["testball"])
     downloads = { instance_double(Downloadable) => nil }
@@ -435,8 +505,8 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     allow(Homebrew::Install).to receive(:perform_preinstall_checks_once)
     allow(Homebrew::Install).to receive(:check_cc_argv)
     allow(Homebrew::Install).to receive_messages(install_formula?: true, formula_installers: [formula_installer])
-    allow(Homebrew::Install).to receive(:install_formulae)
-    allow(Homebrew::Upgrade).to receive(:upgrade_dependents)
+    allow(Homebrew::Install).to receive(:install_formulae).and_return([])
+    allow(Homebrew::Upgrade).to receive(:upgrade_dependents).and_return([])
     allow(Homebrew::Cleanup).to receive(:periodic_clean!)
     allow(Homebrew.messages).to receive(:display_messages)
     expect(Homebrew::DownloadQueue).to receive(:new).ordered.and_return(download_queue)
@@ -560,7 +630,8 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     end
     formula_installer = instance_double(FormulaInstaller, formula:)
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
-    installer = instance_double(Cask::Installer, enqueue_downloads: nil, enqueue_dependency_downloads: nil,
+    installer = instance_double(Cask::Installer, cask:, enqueue_downloads: nil,
+                                                  enqueue_dependency_downloads: nil,
                                                   source_download_requires_pre_fetch?: false)
 
     allow(Tap).to receive_messages(with_formula_name: nil, with_cask_token: nil)
@@ -573,14 +644,8 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     )
     allow(Cask::Upgrade).to receive(:outdated_casks).and_return([cask])
     allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
-    allow(Homebrew::Install).to receive(:install_formula?).and_return(true)
     allow(Homebrew::Install).to receive(:perform_preinstall_checks_once)
     allow(Homebrew::Install).to receive(:check_cc_argv)
-    allow(Homebrew::Upgrade).to receive(:dependants).and_return(Homebrew::Upgrade::Dependents.new(
-                                                                  upgradeable: [],
-                                                                  pinned:      [],
-                                                                  skipped:     [],
-                                                                ))
     allow(Homebrew::Install).to receive_messages(
       formula_installers: [formula_installer],
       enqueue_formulae:   [formula_installer],
@@ -588,8 +653,15 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     allow(formula_installer).to receive(:download_queue=)
     allow(formula_installer).to receive(:prelude_fetch)
     allow(Cask::Installer).to receive(:new).and_return(installer)
-    allow(Homebrew::Install).to receive(:install_formulae)
-    allow(Homebrew::Upgrade).to receive(:upgrade_dependents)
+    allow(Homebrew::Install).to receive_messages(install_formula?: true, install_formulae: [])
+    allow(Homebrew::Upgrade).to receive_messages(
+      dependants:         Homebrew::Upgrade::Dependents.new(
+        upgradeable: [],
+        pinned:      [],
+        skipped:     [],
+      ),
+      upgrade_dependents: [],
+    )
     allow(Homebrew::Cleanup).to receive(:periodic_clean!)
     allow(Homebrew.messages).to receive(:display_messages)
     allow(Cask::Upgrade).to receive(:upgrade_casks!) do |*_, **kwargs|
@@ -599,7 +671,11 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
       true
     end
     expect(download_queue).to receive(:fetch)
-      .with(heading: "Fetching downloads for: testball_bottle and codex")
+      .with(only: Cask::Download, heading: "Downloading Cask files")
+      .ordered
+    expect(download_queue).to receive(:fetch)
+      .with(heading: "Fetching downloads for: testball_bottle")
+      .ordered
 
     expect { cmd.run }.to output(<<~EOS).to_stdout
       ==> Upgrading 1 outdated package:

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1346,7 +1346,7 @@ reinstall` will be run for outdated dependents and dependents with broken
 linkage, respectively.
 
 Unless `$HOMEBREW_NO_INSTALL_CLEANUP` is set, `brew cleanup` will then be run
-for the installed formulae or, every 30 days, for all formulae.
+for the installed formulae and casks or, every 30 days, for all packages.
 
 Unless `$HOMEBREW_NO_INSTALL_UPGRADE` is set, `brew install` *`formula`* will
 upgrade *`formula`* if it is already installed but outdated.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -862,7 +862,7 @@ Install a \fIformula\fP or \fIcask\fP\&\. Additional options specific to a \fIfo
 .P
 Unless \fB$HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK\fP is set, \fBbrew upgrade\fP or \fBbrew reinstall\fP will be run for outdated dependents and dependents with broken linkage, respectively\.
 .P
-Unless \fB$HOMEBREW_NO_INSTALL_CLEANUP\fP is set, \fBbrew cleanup\fP will then be run for the installed formulae or, every 30 days, for all formulae\.
+Unless \fB$HOMEBREW_NO_INSTALL_CLEANUP\fP is set, \fBbrew cleanup\fP will then be run for the installed formulae and casks or, every 30 days, for all packages\.
 .P
 Unless \fB$HOMEBREW_NO_INSTALL_UPGRADE\fP is set, \fBbrew install\fP \fIformula\fP will upgrade \fIformula\fP if it is already installed but outdated\.
 .TP


### PR DESCRIPTION
- share one download queue across formulae and casks
- fetch all dependencies before serial package installation
- defer successful package cleanup until installation completes

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 GPT Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----


