### PR TITLE
Order reinstall package phases

### DIFF
--- a/Library/Homebrew/cask/reinstall.rb
+++ b/Library/Homebrew/cask/reinstall.rb
@@ -3,6 +3,7 @@
 
 require "utils/output"
 require "install"
+require "cask/installer"
 
 module Cask
   class Reinstall
@@ -12,8 +13,9 @@ module Cask
       params(
         casks: ::Cask::Cask, verbose: T::Boolean, force: T::Boolean, skip_cask_deps: T::Boolean, binaries: T::Boolean,
         require_sha: T::Boolean, zap: T::Boolean, skip_prefetch: T::Boolean,
-        download_queue: T.nilable(Homebrew::DownloadQueue)
-      ).void
+        download_queue: T.nilable(Homebrew::DownloadQueue),
+        cask_installers: T.nilable(T::Array[Installer])
+      ).returns(T::Array[Cask])
     }
     def self.reinstall_casks(
       *casks,
@@ -24,10 +26,9 @@ module Cask
       require_sha: false,
       zap: false,
       skip_prefetch: false,
-      download_queue: nil
+      download_queue: nil,
+      cask_installers: nil
     )
-      require "cask/installer"
-
       created_download_queue = T.let(false, T::Boolean)
       if download_queue.nil?
         if skip_prefetch
@@ -38,27 +39,29 @@ module Cask
         end
       end
 
-      cask_installers = T.let([], T::Array[Installer])
+      cask_installers = T.let(cask_installers || [], T::Array[Installer])
       begin
-        cask_installers = casks.map do |cask|
-          Installer.new(
-            cask,
-            binaries:,
-            verbose:,
-            force:,
-            skip_cask_deps:,
-            require_sha:,
-            reinstall:      true,
-            zap:,
-            download_queue:,
-            defer_fetch:    true,
-          )
+        if cask_installers.empty?
+          cask_installers = casks.map do |cask|
+            Installer.new(
+              cask,
+              binaries:,
+              verbose:,
+              force:,
+              skip_cask_deps:,
+              require_sha:,
+              reinstall:      true,
+              zap:,
+              download_queue:,
+              defer_fetch:    true,
+            )
+          end
         end
 
         unless skip_prefetch
           Homebrew::Install.enqueue_cask_installers(cask_installers, download_queue:)
           download_queue.fetch(
-            heading: Homebrew::Install.combined_fetch_downloads_heading(cask_names: casks.map(&:full_name)),
+            heading: "Fetching dependency downloads",
           )
         end
       ensure
@@ -68,12 +71,14 @@ module Cask
       # Reinstall everything that did download and report each failure as it
       # happens, rather than aborting the whole run; the failures still exit
       # nonzero at the end.
+      reinstalled_casks = T.let([], T::Array[Cask])
       cask_installers.each do |installer|
         installer.install
+        reinstalled_casks << installer.cask
       rescue => e
         ofail "#{installer.cask.full_name}: #{e}"
-        next
       end
+      reinstalled_casks
     end
   end
 end

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -9,6 +9,7 @@ require "install"
 require "reinstall"
 require "cleanup"
 require "cask/utils"
+require "cask/installer"
 require "cask/reinstall"
 require "upgrade"
 require "api"
@@ -26,7 +27,7 @@ module Homebrew
           outdated dependents and dependents with broken linkage, respectively.
 
           Unless `$HOMEBREW_NO_INSTALL_CLEANUP` is set, `brew cleanup` will then be run for the
-          reinstalled formulae or, every 30 days, for all formulae.
+          reinstalled formulae and casks or, every 30 days, for all packages.
         EOS
         switch "-d", "--debug",
                description: "If brewing fails, open an interactive debugging session with access to IRB " \
@@ -165,6 +166,8 @@ module Homebrew
         end
         shared_download_queue = T.let(nil, T.nilable(Homebrew::DownloadQueue))
         casks_prefetched = T.let(false, T::Boolean)
+        reinstalled_formulae = T.let([], T::Array[Formula])
+        prefetched_cask_installers = T.let([], T::Array[Cask::Installer])
 
         Install.ask_casks casks, action: "reinstallation", skip_cask_deps: args.skip_cask_deps? if ask
 
@@ -240,15 +243,33 @@ module Homebrew
             )
           end
 
-          valid_formula_installers = if casks.any?
-            shared_download_queue ||= Homebrew::DownloadQueue.new(pour: true)
-            download_queue = shared_download_queue
-            begin
-              valid_formula_installers = Install.enqueue_formulae(formulae_installers,
-                                                                  download_queue:)
+          dependent_formulae_installers = Upgrade.dependent_formula_installers(
+            dependants,
+            formulae,
+            flags:                      args.flags_only,
+            force_bottle:               args.force_bottle?,
+            build_from_source_formulae: args.build_from_source_formulae,
+            interactive:                args.interactive?,
+            keep_tmp:                   args.keep_tmp?,
+            debug_symbols:              args.debug_symbols?,
+            force:                      args.force?,
+            debug:                      args.debug?,
+            quiet:                      args.quiet?,
+            verbose:                    args.verbose?,
+          )
 
-              require "cask/installer"
-              fetch_cask_installers = casks.map do |cask|
+          shared_download_queue ||= Homebrew::DownloadQueue.new(pour: true)
+          download_queue = shared_download_queue
+          begin
+            all_formulae_installers = Install.enqueue_formulae(
+              (formulae_installers + dependent_formulae_installers).uniq { |fi| fi.formula.full_name },
+              download_queue:,
+            )
+            formulae_installers &= all_formulae_installers
+            dependent_formulae_installers &= all_formulae_installers
+
+            if casks.any?
+              prefetched_cask_installers = casks.map do |cask|
                 Cask::Installer.new(
                   cask,
                   binaries:       args.binaries?,
@@ -262,36 +283,28 @@ module Homebrew
                   defer_fetch:    true,
                 )
               end
-              Install.enqueue_cask_installers(fetch_cask_installers, download_queue:)
-              download_queue.fetch(heading: Install.combined_fetch_downloads_heading(
-                formula_names: valid_formula_installers.map { |fi| fi.formula.name },
-                cask_names:    casks.map(&:full_name),
-              ))
-              casks_prefetched = true
-              Install.reject_failed_downloads(valid_formula_installers, download_queue:)
-            ensure
-              download_queue.shutdown
+              Install.enqueue_cask_installers(prefetched_cask_installers, download_queue:)
             end
-          elsif shared_download_queue
-            download_queue = shared_download_queue
-            begin
-              Install.fetch_formulae(formulae_installers,
-                                     download_queue:,
-                                     shutdown_download_queue: false)
-            ensure
-              download_queue.shutdown
-            end
-          else
-            Install.fetch_formulae(formulae_installers)
+
+            download_queue.fetch(heading: Install.combined_fetch_downloads_heading(
+              formula_names: all_formulae_installers.map { |fi| fi.formula.name },
+              cask_names:    casks.map(&:full_name),
+            ))
+            casks_prefetched = casks.any?
+            all_formulae_installers = Install.reject_failed_downloads(all_formulae_installers, download_queue:)
+            formulae_installers &= all_formulae_installers
+            dependent_formulae_installers &= all_formulae_installers
+          ensure
+            download_queue.shutdown
           end
 
           # Reinstall everything that did download, rather than aborting the
           # whole run; the failures above still exit nonzero at the end.
           reinstall_contexts.each do |reinstall_context|
-            next unless valid_formula_installers.include?(reinstall_context.formula_installer)
+            next unless formulae_installers.include?(reinstall_context.formula_installer)
 
             Homebrew::Reinstall.reinstall_formula(reinstall_context)
-            Cleanup.install_formula_clean!(reinstall_context.formula)
+            reinstalled_formulae << reinstall_context.formula
           rescue BuildError
             # Reported (with analytics) by the global handler in `brew.rb`.
             raise
@@ -299,33 +312,37 @@ module Homebrew
             ofail "#{reinstall_context.formula.full_specified_name}: #{e}"
           end
 
-          Upgrade.upgrade_dependents(
+          reinstalled_formulae |= Upgrade.upgrade_dependents(
             dependants, formulae,
-            flags:                      args.flags_only,
-            force_bottle:               args.force_bottle?,
-            build_from_source_formulae: args.build_from_source_formulae,
-            interactive:                args.interactive?,
-            keep_tmp:                   args.keep_tmp?,
-            debug_symbols:              args.debug_symbols?,
-            force:                      args.force?,
-            debug:                      args.debug?,
-            quiet:                      args.quiet?,
-            verbose:                    args.verbose?
+            flags:                         args.flags_only,
+            force_bottle:                  args.force_bottle?,
+            build_from_source_formulae:    args.build_from_source_formulae,
+            interactive:                   args.interactive?,
+            keep_tmp:                      args.keep_tmp?,
+            debug_symbols:                 args.debug_symbols?,
+            force:                         args.force?,
+            debug:                         args.debug?,
+            quiet:                         args.quiet?,
+            verbose:                       args.verbose?,
+            cleanup:                       false,
+            prefetched_formula_installers: dependent_formulae_installers
           )
         end
 
+        reinstalled_casks = T.let([], T::Array[Cask::Cask])
         if casks.any?
           begin
-            Cask::Reinstall.reinstall_casks(
+            reinstalled_casks = Cask::Reinstall.reinstall_casks(
               *casks,
-              binaries:       args.binaries?,
-              verbose:        args.verbose?,
-              force:          args.force?,
-              require_sha:    args.require_sha?,
-              skip_cask_deps: args.skip_cask_deps?,
-              zap:            args.zap?,
-              skip_prefetch:  casks_prefetched,
-              download_queue: nil,
+              binaries:        args.binaries?,
+              verbose:         args.verbose?,
+              force:           args.force?,
+              require_sha:     args.require_sha?,
+              skip_cask_deps:  args.skip_cask_deps?,
+              zap:             args.zap?,
+              skip_prefetch:   casks_prefetched,
+              download_queue:  nil,
+              cask_installers: prefetched_cask_installers.presence,
             )
           rescue => e
             ofail e
@@ -334,6 +351,7 @@ module Homebrew
 
         unavailable_errors.each { |e| ofail e }
 
+        Cleanup.install_clean!(formulae: reinstalled_formulae, casks: reinstalled_casks)
         Cleanup.periodic_clean!
 
         Homebrew.messages.display_messages(display_times: args.display_times?)

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Cask::Reinstall, :cask do
     allow(failing_installer).to receive(:enqueue_dependency_downloads)
     allow(failing_installer).to receive(:install).and_raise(Cask::CaskError.new("reinstall failed"))
 
-    successful_installer = instance_double(Cask::Installer)
+    successful_installer = instance_double(Cask::Installer, cask: cask2)
     allow(successful_installer).to receive(:prelude)
     allow(successful_installer).to receive(:source_download_requires_pre_fetch?).and_return(false)
     allow(successful_installer).to receive(:enqueue_downloads)
@@ -83,9 +83,35 @@ RSpec.describe Cask::Reinstall, :cask do
       .to output(/local-caffeine: reinstall failed/).to_stderr
   end
 
+  it "returns reinstalled casks without a caveat mode option" do
+    cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+    installer = instance_double(Cask::Installer, cask:, install: nil)
+
+    expect(Cask::Installer).to receive(:new) do |new_cask, **options|
+      expect(new_cask).to eq(cask)
+      expect(options).not_to have_key(:defer_caveats)
+      installer
+    end
+
+    expect(described_class.reinstall_casks(cask, skip_prefetch: true)).to eq([cask])
+  end
+
+  it "returns the casks from supplied installers" do
+    requested_cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+    reinstalled_cask = Cask::CaskLoader.load(cask_path("local-transmission-zip"))
+    installer = Cask::Installer.allocate
+    allow(installer).to receive_messages(cask: reinstalled_cask, install: nil)
+
+    expect(described_class.reinstall_casks(
+             requested_cask,
+             skip_prefetch:   true,
+             cask_installers: [installer],
+           )).to eq([reinstalled_cask])
+  end
+
   it "reinstalls casks after an earlier failure in the same run" do
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
-    installer = instance_double(Cask::Installer, prelude: nil, enqueue_downloads: nil,
+    installer = instance_double(Cask::Installer, cask:, prelude: nil, enqueue_downloads: nil,
                                                  enqueue_dependency_downloads: nil,
                                                  source_download_requires_pre_fetch?: false)
     allow(Cask::Installer).to receive(:new).and_return(installer)

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -42,6 +42,41 @@ RSpec.describe Homebrew::Cmd::Reinstall do
       .to output(/local-caffeine is pinned\. You must unpin it to reinstall\./).to_stderr
   end
 
+  it "cleans a reinstalled cask before displaying deferred caveats" do
+    cask = Cask::Cask.new("local-caffeine")
+    allow(cask).to receive(:pinned?).and_return(false)
+    cmd = described_class.new(["--yes", "local-caffeine"])
+
+    allow(Homebrew::Trust).to receive(:trust_fully_qualified_items!)
+    allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable)
+      .with(method: :resolve)
+      .and_return([cask])
+    expect(Cask::Reinstall).to receive(:reinstall_casks)
+      .with(
+        cask,
+        binaries:        true,
+        verbose:         false,
+        force:           false,
+        require_sha:     false,
+        skip_cask_deps:  false,
+        zap:             false,
+        skip_prefetch:   false,
+        download_queue:  nil,
+        cask_installers: nil,
+      )
+      .ordered
+      .and_return([cask])
+    expect(Homebrew::Cleanup).to receive(:install_clean!)
+      .with(formulae: [], casks: [cask])
+      .ordered
+    expect(Homebrew::Cleanup).to receive(:periodic_clean!).ordered
+    expect(Homebrew.messages).to receive(:display_messages)
+      .with(display_times: false)
+      .ordered
+
+    cmd.run
+  end
+
   it "asks for casks before shared prefetch when reinstalling formulae and casks" do
     cmd = described_class.new(["testball", "local-caffeine"])
     formula = formula("testball") do
@@ -51,6 +86,7 @@ RSpec.describe Homebrew::Cmd::Reinstall do
     formula_installer = FormulaInstaller.new(formula)
     dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+    cask_installer = instance_double(Cask::Installer)
     download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil, failed_downloads: [])
     reinstall_context = Homebrew::Reinstall::InstallationContext.new(
       formula_installer:,
@@ -66,34 +102,44 @@ RSpec.describe Homebrew::Cmd::Reinstall do
     allow(Migrator).to receive(:migrate_if_needed)
     allow(Homebrew::Install).to receive(:perform_preinstall_checks_once)
     allow(Homebrew::Reinstall).to receive(:build_install_context).and_return(reinstall_context)
-    allow(Homebrew::Upgrade).to receive(:dependants).and_return(dependants)
     allow(Homebrew::Install).to receive(:ask_formulae)
     allow(Homebrew::Install).to receive(:enqueue_formulae).and_return([formula_installer])
     allow(Homebrew::Install).to receive(:enqueue_cask_installers)
-    allow(Cask::Installer).to receive(:new).and_return(instance_double(Cask::Installer))
+    allow(Cask::Installer).to receive(:new).and_return(cask_installer)
     allow(Homebrew::Reinstall).to receive(:reinstall_formula)
-    allow(Homebrew::Upgrade).to receive(:upgrade_dependents)
-    allow(Cask::Reinstall).to receive(:reinstall_casks)
-    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
+    allow(Homebrew::Upgrade).to receive_messages(dependants: dependants, upgrade_dependents: [])
+    expect(Cask::Reinstall).to receive(:reinstall_casks) do |reinstalled_cask, cask_installers:, **|
+      expect([reinstalled_cask, cask_installers]).to eq([cask, [cask_installer]])
+      [cask]
+    end
+    allow(Homebrew::Cleanup).to receive_messages(install_clean!: nil, periodic_clean!: nil)
     allow(Homebrew.messages).to receive(:display_messages)
 
     expect(Homebrew::Install).to receive(:ask_casks)
       .with([cask], action: "reinstallation", skip_cask_deps: false)
       .ordered
     expect(Homebrew::DownloadQueue).to receive(:new).ordered.and_return(download_queue)
+    expect(download_queue).to receive(:fetch)
+      .with(heading: "Fetching downloads for: testball and local-caffeine")
+      .ordered
 
     cmd.run
   end
 
   it "starts formula prelude fetches before dependant checks when not asking" do
     cmd = described_class.new(["--yes", "testball"])
-    download_queue = instance_double(Homebrew::DownloadQueue, shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil, failed_downloads: [])
     formula = formula("testball") do
       T.bind(self, T.class_of(Formula))
       url "https://brew.sh/testball-0.1.tar.gz"
     end
     formula_installer = FormulaInstaller.new(formula)
-    dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
+    dependant = formula("dependant") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/dependant-0.1.tar.gz"
+    end
+    dependant_installer = FormulaInstaller.new(dependant)
+    dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [dependant], pinned: [], skipped: [])
     reinstall_context = Homebrew::Reinstall::InstallationContext.new(
       formula_installer:,
       formula:,
@@ -109,26 +155,42 @@ RSpec.describe Homebrew::Cmd::Reinstall do
     allow(Migrator).to receive(:migrate_if_needed)
     allow(Homebrew::Install).to receive(:perform_preinstall_checks_once)
     allow(Homebrew::Reinstall).to receive(:build_install_context).and_return(reinstall_context)
-    allow(Homebrew::Reinstall).to receive(:reinstall_formula)
-    allow(Homebrew::Upgrade).to receive(:upgrade_dependents)
-    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
-    allow(Homebrew.messages).to receive(:display_messages)
     expect(Homebrew::DownloadQueue).to receive(:new).ordered.and_return(download_queue)
     expect(formula_installer).to receive(:download_queue=).with(download_queue).ordered
     expect(formula_installer).to receive(:prelude_fetch).ordered
     expect(Homebrew::Upgrade).to receive(:dependants).ordered.and_return(dependants)
-    expect(Homebrew::Install).to receive(:fetch_formulae)
-      .with([formula_installer], download_queue:, shutdown_download_queue: false)
+    expect(Homebrew::Upgrade).to receive(:dependent_formula_installers)
       .ordered
-      .and_return([formula_installer])
+      .and_return([dependant_installer])
+    expect(Homebrew::Install).to receive(:enqueue_formulae)
+      .with([formula_installer, dependant_installer], download_queue:)
+      .ordered
+      .and_return([formula_installer, dependant_installer])
+    expect(download_queue).to receive(:fetch).ordered
     expect(download_queue).to receive(:shutdown).ordered
+    expect(Homebrew::Reinstall).to receive(:reinstall_formula).with(reinstall_context).ordered
+    expect(Homebrew::Upgrade).to receive(:upgrade_dependents) do |actual_dependants, _, **options|
+      expect(actual_dependants).to eq(dependants)
+      expect(options).to include(
+        cleanup:                       false,
+        prefetched_formula_installers: [dependant_installer],
+      )
+      [dependant]
+    end.ordered
+    expect(Homebrew::Cleanup).to receive(:install_clean!)
+      .with(formulae: [formula, dependant], casks: [])
+      .ordered
+    expect(Homebrew::Cleanup).to receive(:periodic_clean!).ordered
+    expect(Homebrew.messages).to receive(:display_messages)
+      .with(display_times: false)
+      .ordered
 
     cmd.run
   end
 
   it "reinstalls the remaining formulae after one fails" do
     cmd = described_class.new(["--yes", "one", "two"])
-    download_queue = instance_double(Homebrew::DownloadQueue, shutdown: nil, failed_downloads: [])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil, failed_downloads: [])
     dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
     contexts = %w[one two].map do |name|
       formula = formula(name) do
@@ -152,10 +214,10 @@ RSpec.describe Homebrew::Cmd::Reinstall do
     allow(Homebrew::Install).to receive(:perform_preinstall_checks_once)
     allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
     allow(Homebrew::Reinstall).to receive(:build_install_context).and_return(*contexts)
-    allow(Homebrew::Install).to receive(:fetch_formulae).and_return(contexts.map(&:formula_installer))
+    allow(Homebrew::Install).to receive(:enqueue_formulae).and_return(contexts.map(&:formula_installer))
     allow(Homebrew::Reinstall).to receive(:reinstall_formula).with(contexts.fetch(0))
                                                              .and_raise("gzip decompression failed")
-    allow(Homebrew::Cleanup).to receive_messages(install_formula_clean!: nil, periodic_clean!: nil)
+    allow(Homebrew::Cleanup).to receive_messages(install_clean!: nil, periodic_clean!: nil)
     allow(Homebrew::Upgrade).to receive_messages(dependants:, upgrade_dependents: [])
     allow(Homebrew.messages).to receive(:display_messages)
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1835,7 +1835,7 @@ reinstall` will be run for outdated dependents and dependents with broken
 linkage, respectively.
 
 Unless `$HOMEBREW_NO_INSTALL_CLEANUP` is set, `brew cleanup` will then be run
-for the reinstalled formulae or, every 30 days, for all formulae.
+for the reinstalled formulae and casks or, every 30 days, for all packages.
 
 `-d`, `--debug`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1160,7 +1160,7 @@ Uninstall and then reinstall a \fIformula\fP or \fIcask\fP using the same option
 .P
 Unless \fB$HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK\fP is set, \fBbrew upgrade\fP or \fBbrew reinstall\fP will be run for outdated dependents and dependents with broken linkage, respectively\.
 .P
-Unless \fB$HOMEBREW_NO_INSTALL_CLEANUP\fP is set, \fBbrew cleanup\fP will then be run for the reinstalled formulae or, every 30 days, for all formulae\.
+Unless \fB$HOMEBREW_NO_INSTALL_CLEANUP\fP is set, \fBbrew cleanup\fP will then be run for the reinstalled formulae and casks or, every 30 days, for all packages\.
 .TP
 \fB\-d\fP, \fB\-\-debug\fP
 If brewing fails, open an interactive debugging session with access to IRB or a shell inside the temporary build directory\.


### PR DESCRIPTION
- prefetch formula and cask reinstall downloads together
- continue serial reinstalls after individual failures
- batch cleanup for successfully reinstalled packages

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 GPT Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

