### PR TITLE
Order upgrade package phases

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -6,6 +6,7 @@ require "formula_installer"
 require "install"
 require "upgrade"
 require "cask/download"
+require "cask/installer"
 require "cask/utils"
 require "cask/upgrade"
 require "api"
@@ -21,6 +22,7 @@ module Homebrew
         const :formulae_installer, T::Array[FormulaInstaller]
         const :dependants, Homebrew::Upgrade::Dependents
         const :pinned_formulae, T::Array[Formula], default: []
+        const :dependent_formulae_installer, T::Array[FormulaInstaller], default: []
       end
 
       class FinalUpgradeSummary < T::Struct
@@ -42,7 +44,7 @@ module Homebrew
           outdated dependents and dependents with broken linkage, respectively.
 
           Unless `$HOMEBREW_NO_INSTALL_CLEANUP` is set, `brew cleanup` will then be run for the
-          upgraded formulae or, every 30 days, for all formulae.
+          upgraded formulae and casks or, every 30 days, for all packages.
         EOS
         switch "-d", "--debug",
                description: "If brewing fails, open an interactive debugging session with access to IRB " \
@@ -161,6 +163,8 @@ module Homebrew
       def initialize(argv = ARGV.freeze)
         super
         @ask_prompt_required = T.let(false, T::Boolean)
+        @upgraded_formulae = T.let([], T::Array[Formula])
+        @upgraded_casks = T.let([], T::Array[Cask::Cask])
       end
 
       sig { override.void }
@@ -183,9 +187,12 @@ module Homebrew
         prefetched_cask_names = T.let([], T::Array[String])
         prefetched_cask_upgrades = T.let([], T::Array[String])
         prefetched_cask_upgrade_casks = T.let([], T::Array[Cask::Cask])
+        prefetched_cask_installers = T.let([], T::Array[Cask::Installer])
         prefetched_cask_errors = T.let([], T::Array[StandardError])
         @final_upgrade_summary = T.let(FinalUpgradeSummary.new, T.nilable(FinalUpgradeSummary))
         @ask_prompt_required = false
+        @upgraded_formulae.clear
+        @upgraded_casks.clear
         ask = !args.no_ask? && !args.dry_run?
         skip_upgrades_after_failed_ask_preview = T.let(false, T::Boolean)
 
@@ -252,32 +259,36 @@ module Homebrew
             named:           args.named.present?,
           )
             Install.ask(action: "upgrade")
-            Cask::Upgrade.show_upgrade_summary(final_upgrade_summary.version_changes)
           end
           ask_upgrade_planned = final_upgrade_summary.version_changes.present?
           skip_upgrades_after_failed_ask_preview = Homebrew.failed? && !ask_upgrade_planned
           @final_upgrade_summary = FinalUpgradeSummary.new
         end
 
-        if !args.dry_run? && (!ask || ask_upgrade_planned) && !only_upgrade_formulae && !only_upgrade_casks
+        if !args.dry_run? && (!ask || ask_upgrade_planned) && !(only_upgrade_formulae && only_upgrade_casks)
           shared_download_queue = Homebrew::DownloadQueue.new(pour: true)
           begin
-            formulae_prefetched = upgrade_outdated_formulae!(
-              formulae,
-              prefetch_only:        true,
-              download_queue:       shared_download_queue,
-              prefetch_names:       prefetched_formulae_names,
-              prefetch_upgrades:    prefetched_formulae_upgrades,
-              show_upgrade_summary: false,
-            )
-            prefetched_casks = prefetch_outdated_casks!(
-              casks,
-              download_queue:    shared_download_queue,
-              prefetch_names:    prefetched_cask_names,
-              prefetch_upgrades: prefetched_cask_upgrades,
-              prefetch_casks:    prefetched_cask_upgrade_casks,
-              prefetch_errors:   prefetched_cask_errors,
-            )
+            unless only_upgrade_casks
+              formulae_prefetched = upgrade_outdated_formulae!(
+                formulae,
+                prefetch_only:        true,
+                download_queue:       shared_download_queue,
+                prefetch_names:       prefetched_formulae_names,
+                prefetch_upgrades:    prefetched_formulae_upgrades,
+                show_upgrade_summary: false,
+              )
+            end
+            unless only_upgrade_formulae
+              prefetched_casks = prefetch_outdated_casks!(
+                casks,
+                download_queue:      shared_download_queue,
+                prefetch_names:      prefetched_cask_names,
+                prefetch_upgrades:   prefetched_cask_upgrades,
+                prefetch_casks:      prefetched_cask_upgrade_casks,
+                prefetch_installers: prefetched_cask_installers,
+                prefetch_errors:     prefetched_cask_errors,
+              )
+            end
             unless ask
               Cask::Upgrade.show_upgrade_summary(
                 prefetched_formulae_upgrades + prefetched_cask_upgrades,
@@ -286,8 +297,7 @@ module Homebrew
             end
             shared_download_queue.fetch(heading: Install.combined_fetch_downloads_heading(
               formula_names: prefetched_formulae_names,
-              cask_names:    prefetched_cask_names,
-            ))
+            ) || "Fetching dependency downloads")
             # Only redo the slower unprefetched fetch for the kind of package
             # that actually failed, so e.g. one bad bottle does not also
             # re-verify every already downloaded cask.
@@ -311,10 +321,11 @@ module Homebrew
           if prefetched_casks
             upgrade_outdated_casks!(
               prefetched_cask_upgrade_casks,
-              skip_prefetch:          true,
-              show_upgrade_summary:   prefetched_cask_upgrades.blank? && !args.dry_run? && !ask,
-              download_queue:         nil,
-              prefetched_cask_errors: prefetched_cask_errors,
+              skip_prefetch:              true,
+              show_upgrade_summary:       prefetched_cask_upgrades.blank? && !args.dry_run? && !ask,
+              download_queue:             nil,
+              prefetched_cask_errors:     prefetched_cask_errors,
+              prefetched_cask_installers:,
             )
           else
             upgrade_outdated_casks!(
@@ -328,9 +339,10 @@ module Homebrew
 
         unavailable_errors.each { |e| ofail e }
 
-        Cleanup.periodic_clean!(dry_run: args.dry_run?)
-
         Homebrew::Reinstall.reinstall_pkgconf_if_needed!(dry_run: args.dry_run?)
+
+        Cleanup.install_clean!(formulae: @upgraded_formulae, casks: @upgraded_casks) unless args.dry_run?
+        Cleanup.periodic_clean!(dry_run: args.dry_run?)
 
         Homebrew.messages.display_messages(display_times: args.display_times?)
 
@@ -621,21 +633,53 @@ module Homebrew
         else
           formulae_upgrade_context(formulae, show_upgrade_summary:, dry_run:)
         end
-        return false if context.blank?
+        if context.blank?
+          if prefetch_only
+            @prefetched_formulae_upgrade_context = FormulaeUpgradeContext.new(
+              formulae_to_install: [],
+              formulae_installer:  [],
+              dependants:          Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: []),
+            )
+            return true
+          end
+          return false
+        end
 
         if prefetch_only
           prefetch_download_queue = download_queue || Homebrew.default_download_queue
-          valid_formula_installers = Install.enqueue_formulae(context.formulae_installer,
+          dependent_formulae_installer = Upgrade.dependent_formula_installers(
+            context.dependants,
+            context.formulae_installer.map(&:formula),
+            flags:                      args.flags_only,
+            force_bottle:               args.force_bottle?,
+            build_from_source_formulae: args.build_from_source_formulae,
+            interactive:                args.interactive?,
+            keep_tmp:                   args.keep_tmp?,
+            debug_symbols:              args.debug_symbols?,
+            force:                      args.force?,
+            debug:                      args.debug?,
+            quiet:                      args.quiet?,
+            verbose:                    args.verbose?,
+          )
+          valid_formula_installers = Install.enqueue_formulae((context.formulae_installer +
+                                                               dependent_formulae_installer)
+                                                                .uniq { |fi| fi.formula.full_name },
                                                               download_queue: prefetch_download_queue)
           prefetch_names&.replace(valid_formula_installers.map { |fi| fi.formula.name })
           prefetch_upgrades&.replace(formula_upgrade_descriptions(valid_formula_installers.map(&:formula)))
+          valid_dependent_formulae_installer = valid_formula_installers & dependent_formulae_installer
           @prefetched_formulae_upgrade_context = FormulaeUpgradeContext.new(
-            formulae_to_install: context.formulae_to_install,
-            formulae_installer:  valid_formula_installers,
-            dependants:          context.dependants,
-            pinned_formulae:     context.pinned_formulae,
+            formulae_to_install:          context.formulae_to_install,
+            formulae_installer:           valid_formula_installers & context.formulae_installer,
+            dependants:                   Upgrade::Dependents.new(
+              upgradeable: valid_dependent_formulae_installer.map(&:formula),
+              pinned:      context.dependants.pinned,
+              skipped:     context.dependants.skipped,
+            ),
+            pinned_formulae:              context.pinned_formulae,
+            dependent_formulae_installer: valid_dependent_formulae_installer,
           )
-          return valid_formula_installers.present?
+          return true
         end
 
         formula_version_changes = formula_upgrade_descriptions(context.formulae_installer.map(&:formula),
@@ -665,26 +709,34 @@ module Homebrew
           dry_run:,
           verbose:            args.verbose?,
           fetch:              !use_prefetched_context,
+          cleanup:            false,
           skip_formula_names:,
         )
 
+        prefetched_dependent_formulae_installer = if use_prefetched_context
+          context.dependent_formulae_installer
+        end
         upgraded_dependent_formulae = Upgrade.upgrade_dependents(
           context.dependants, context.formulae_to_install,
-          flags:                      args.flags_only,
+          flags:                         args.flags_only,
           dry_run:,
-          force_bottle:               args.force_bottle?,
-          build_from_source_formulae: args.build_from_source_formulae,
-          interactive:                args.interactive?,
-          keep_tmp:                   args.keep_tmp?,
-          debug_symbols:              args.debug_symbols?,
-          force:                      args.force?,
-          debug:                      args.debug?,
-          quiet:                      args.quiet?,
-          verbose:                    args.verbose?,
+          force_bottle:                  args.force_bottle?,
+          build_from_source_formulae:    args.build_from_source_formulae,
+          interactive:                   args.interactive?,
+          keep_tmp:                      args.keep_tmp?,
+          debug_symbols:                 args.debug_symbols?,
+          force:                         args.force?,
+          debug:                         args.debug?,
+          quiet:                         args.quiet?,
+          verbose:                       args.verbose?,
+          cleanup:                       false,
+          prefetched_formula_installers: prefetched_dependent_formulae_installer,
           skip_formula_names:
         )
 
         unless dry_run
+          @upgraded_formulae.concat(upgraded_formula_installers.map(&:formula) + upgraded_dependent_formulae)
+                            .uniq!(&:full_name)
           upgraded_formulae_by_identity = T.let({}.compare_by_identity, T::Hash[Formula, T::Boolean])
           (upgraded_formula_installers.map(&:formula) + upgraded_dependent_formulae).each do |formula|
             upgraded_formulae_by_identity[formula] = true
@@ -709,11 +761,13 @@ module Homebrew
                prefetch_names: T.nilable(T::Array[String]),
                prefetch_upgrades: T.nilable(T::Array[String]),
                prefetch_casks: T.nilable(T::Array[Cask::Cask]),
+               prefetch_installers: T.nilable(T::Array[Cask::Installer]),
                prefetch_errors: T.nilable(T::Array[StandardError]))
           .returns(T::Boolean)
       }
       def prefetch_outdated_casks!(casks, download_queue:, prefetch_names: nil,
-                                   prefetch_upgrades: nil, prefetch_casks: nil, prefetch_errors: nil)
+                                   prefetch_upgrades: nil, prefetch_casks: nil, prefetch_installers: nil,
+                                   prefetch_errors: nil)
         return false if args.formula?
 
         casks = minimum_version_casks(casks, quiet: true)
@@ -766,12 +820,13 @@ module Homebrew
         return prefetch_errors.present? if outdated_casks.empty?
 
         cask_names = outdated_casks.map(&:full_name)
-        Install.enqueue_cask_installers(fetchable_cask_installers, download_queue:)
+        cask_downloads_succeeded = Install.enqueue_cask_installers(fetchable_cask_installers, download_queue:)
+        prefetch_installers&.replace(fetchable_cask_installers)
         prefetch_names&.replace(cask_names)
         prefetch_upgrades&.replace(
           outdated_casks.map { |cask| "#{cask.full_name} #{cask.installed_version} -> #{cask.version}" },
         )
-        true
+        cask_downloads_succeeded != false
       rescue => e
         ofail e
         false
@@ -781,12 +836,14 @@ module Homebrew
         params(casks: T::Array[Cask::Cask], skip_prefetch: T::Boolean, show_upgrade_summary: T::Boolean,
                dry_run: T::Boolean,
                download_queue: T.nilable(Homebrew::DownloadQueue),
-               prefetched_cask_errors: T.nilable(T::Array[StandardError]))
+               prefetched_cask_errors: T.nilable(T::Array[StandardError]),
+               prefetched_cask_installers: T.nilable(T::Array[Cask::Installer]))
           .returns(T::Boolean)
       }
       def upgrade_outdated_casks!(casks, skip_prefetch: false, show_upgrade_summary: true,
                                   dry_run: args.dry_run?,
-                                  download_queue: nil, prefetched_cask_errors: nil)
+                                  download_queue: nil, prefetched_cask_errors: nil,
+                                  prefetched_cask_installers: nil)
         return false if args.formula?
 
         quiet = args.quiet? || (dry_run && !args.dry_run?)
@@ -800,25 +857,27 @@ module Homebrew
 
         Cask::Upgrade.upgrade_casks!(
           *casks,
-          force:                args.force?,
-          greedy:               args.greedy?,
-          greedy_latest:        args.greedy_latest?,
-          greedy_auto_updates:  args.greedy_auto_updates?,
+          force:                      args.force?,
+          greedy:                     args.greedy?,
+          greedy_latest:              args.greedy_latest?,
+          greedy_auto_updates:        args.greedy_auto_updates?,
           dry_run:,
-          binaries:             args.binaries?,
-          require_sha:          args.require_sha?,
-          skip_cask_deps:       args.skip_cask_deps?,
-          quit:                 !args.no_quit?,
-          verbose:              args.verbose?,
+          binaries:                   args.binaries?,
+          require_sha:                args.require_sha?,
+          skip_cask_deps:             args.skip_cask_deps?,
+          quit:                       !args.no_quit?,
+          verbose:                    args.verbose?,
           quiet:,
           skip_prefetch:,
           show_upgrade_summary:,
           download_queue:,
-          summary_upgrades:     final_upgrade_summary.version_changes,
-          summary_pinned:       final_upgrade_summary.pinned_casks,
-          summary_deprecated:   final_upgrade_summary.deprecated,
-          summary_disabled:     final_upgrade_summary.disabled,
-          prefetched_errors:    prefetched_cask_errors,
+          summary_upgrades:           final_upgrade_summary.version_changes,
+          summary_pinned:             final_upgrade_summary.pinned_casks,
+          summary_deprecated:         final_upgrade_summary.deprecated,
+          summary_disabled:           final_upgrade_summary.disabled,
+          prefetched_errors:          prefetched_cask_errors,
+          upgraded_casks:             @upgraded_casks,
+          prefetched_cask_installers:,
           args:,
         )
       rescue => e

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -86,6 +86,14 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     install_formula_version "needs-pinned-dep", "1.0", optlinked: true
   end
 
+  def stub_formula_upgrade_installers
+    allow(Homebrew::Upgrade).to receive(:formula_installers) do |formulae, **|
+      formulae.map { |formula| FormulaInstaller.new(formula) }
+    end
+    allow(Homebrew::Install).to receive(:enqueue_formulae) { |formulae_installer, **| formulae_installer }
+    allow(Homebrew::Upgrade).to receive_messages(upgrade_formulae: [], upgrade_dependents: [])
+  end
+
   it "upgrades a Formula and Cask", :cask, :integration_test do
     formula_name = "testball_bottle"
     formula_rack = HOMEBREW_CELLAR/formula_name
@@ -110,6 +118,9 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       RUBY
       CoreCaskTap.instance.clear_cache
       InstallHelper.stub_cask_installation(Cask::CaskLoader.load(dir/"local-upgrade-test.rb"))
+      old_cask_download = HOMEBREW_CACHE/"Cask/local-upgrade-test--1.0"
+      old_cask_download.dirname.mkpath
+      old_cask_download.write("cached")
 
       (formula_rack/"0.0.1/foo").mkpath
 
@@ -120,6 +131,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       expect(formula_rack/"0.1").to be_a_directory
       expect(formula_rack/"0.0.1").not_to exist
       expect(Cask::CaskLoader.load("local-upgrade-test").installed_version).to eq("2.0")
+      expect(old_cask_download).not_to exist
     end
   end
 
@@ -182,7 +194,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     RUBY
     install_formula_version "gh", "2.93.0", optlinked: true
     install_formula_version "visual-studio-code", "1.111.0", optlinked: true
-    allow(Homebrew::Upgrade).to receive(:formula_installers).and_return([])
+    stub_formula_upgrade_installers
     allow(Homebrew::Cleanup).to receive(:periodic_clean!)
     allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
     allow(Homebrew.messages).to receive(:display_messages)
@@ -200,7 +212,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
   it "describes unresolved HEAD formula upgrades as latest HEAD", :no_api do
     install_head_formula_version "head-formula", "1234567"
-    allow(Homebrew::Upgrade).to receive(:formula_installers).and_return([])
+    stub_formula_upgrade_installers
     allow(Homebrew::Cleanup).to receive(:periodic_clean!)
     allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
     allow(Homebrew.messages).to receive(:display_messages)
@@ -219,7 +231,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     install_head_formula_version "head-formula", "1234567"
     allow_any_instance_of(Formula).to receive(:latest_head_pkg_version)
       .and_return(PkgVersion.parse("HEAD-7654321"))
-    allow(Homebrew::Upgrade).to receive(:formula_installers).and_return([])
+    stub_formula_upgrade_installers
     allow(Homebrew::Cleanup).to receive(:periodic_clean!)
     allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
     allow(Homebrew.messages).to receive(:display_messages)
@@ -420,9 +432,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     expect(cmd).to receive(:show_final_upgrade_summary).with(dry_run: true).ordered
     expect(Homebrew::Install).to receive(:ask).with(action: "upgrade")
                                               .ordered
-    expect(Cask::Upgrade).to receive(:show_upgrade_summary)
-      .with(["testball 0.1 -> 0.2"])
-      .ordered
+    expect(Cask::Upgrade).not_to receive(:show_upgrade_summary)
     expect(Homebrew::DownloadQueue).to receive(:new).ordered.and_return(download_queue)
     expect(cmd).to receive(:upgrade_outdated_formulae!)
       .with(
@@ -439,10 +449,11 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       .with(
         [],
         download_queue:,
-        prefetch_names:    [],
-        prefetch_upgrades: [],
-        prefetch_casks:    [],
-        prefetch_errors:   [],
+        prefetch_names:      [],
+        prefetch_upgrades:   [],
+        prefetch_casks:      [],
+        prefetch_installers: [],
+        prefetch_errors:     [],
       )
       .ordered
       .and_return(true)
@@ -453,12 +464,16 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       .and_return(true)
     expect(cmd).to receive(:upgrade_outdated_casks!)
       .with([], skip_prefetch: true, show_upgrade_summary: false, download_queue: nil,
-                prefetched_cask_errors: [])
+                prefetched_cask_errors: [], prefetched_cask_installers: [])
       .ordered
       .and_return(true)
-    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
-    allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
-    allow(Homebrew.messages).to receive(:display_messages)
+    expect(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!).with(dry_run: false).ordered
+    expect(Homebrew::Cleanup).to receive(:install_clean!).with(formulae: [], casks: []).ordered
+    expect(Homebrew::Cleanup).to receive(:periodic_clean!).with(dry_run: false).ordered
+    expect(Homebrew.messages).to receive(:display_messages)
+      .with(display_times: false)
+      .ordered
+    expect(cmd).to receive(:show_final_upgrade_summary).with(no_args).ordered
 
     cmd.run
   end
@@ -522,6 +537,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       url "https://brew.sh/testball-0.2"
     end
     cmd = described_class.new(["oldtestball"])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil)
     allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable)
       .with(method: :resolve)
       .and_return([formula])
@@ -535,8 +551,21 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     allow(cmd).to receive(:show_final_upgrade_summary).and_call_original
     expect(cmd).to receive(:show_final_upgrade_summary).with(dry_run: true).ordered
     expect(Homebrew::Install).to receive(:ask).with(action: "upgrade").ordered
+    expect(Homebrew::DownloadQueue).to receive(:new).ordered.and_return(download_queue)
     expect(cmd).to receive(:upgrade_outdated_formulae!)
-      .with([formula], use_prefetched: false, show_upgrade_summary: false)
+      .with(
+        [formula],
+        prefetch_only:        true,
+        download_queue:,
+        prefetch_names:       [],
+        prefetch_upgrades:    [],
+        show_upgrade_summary: false,
+      )
+      .ordered
+      .and_return(true)
+    expect(download_queue).to receive(:fetch).ordered
+    expect(cmd).to receive(:upgrade_outdated_formulae!)
+      .with([formula], use_prefetched: true, show_upgrade_summary: false)
       .ordered
       .and_return(true)
     allow(Homebrew::Cleanup).to receive(:periodic_clean!)
@@ -721,6 +750,20 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     EOS
   end
 
+  it "deduplicates the execution upgrade summary" do
+    expect do
+      Cask::Upgrade.show_upgrade_summary([
+        "testball 0.1 -> 0.2",
+        "testball 0.1 -> 0.2",
+        "codex 1.0 -> 2.0",
+      ])
+    end.to output(<<~EOS).to_stdout
+      ==> Upgrading 2 outdated packages:
+      testball  0.1 -> 0.2
+      codex     1.0 -> 2.0
+    EOS
+  end
+
   it "uses the final summary for dry-run upgrade lists" do
     cmd = described_class.new(["--dry-run", "--yes"])
 
@@ -747,9 +790,10 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       installed_version: "0.117.0",
       version:           "0.118.0",
     )
-    installer = instance_double(Cask::Installer, check_requirements: nil, enqueue_downloads: nil,
-                                                 enqueue_dependency_downloads: nil,
-                                                 source_download_requires_pre_fetch?: false)
+    installer = Cask::Installer.allocate
+    allow(installer).to receive_messages(check_requirements: nil, enqueue_downloads: nil,
+                                         enqueue_dependency_downloads: nil,
+                                         source_download_requires_pre_fetch?: false)
 
     expect(Homebrew::DownloadQueue).to receive(:new).once.and_return(download_queue)
     allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, prefetch_only: false,
@@ -777,13 +821,132 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
     allow(Homebrew.messages).to receive(:display_messages)
     expect(download_queue).to receive(:fetch)
-      .with(heading: "Fetching downloads for: deno and codex")
+      .with(only: Cask::Download, heading: "Downloading Cask files")
+      .ordered
+    expect(download_queue).to receive(:fetch)
+      .with(heading: "Fetching downloads for: deno")
+      .ordered
 
     expect { cmd.run }.to output(<<~EOS).to_stdout
       ==> Upgrading 2 outdated packages:
       deno   2.7.10  -> 2.7.11
       codex  0.117.0 -> 0.118.0
     EOS
+  end
+
+  it "prefetches a named formula-only upgrade before installing" do
+    formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/testball-0.2"
+    end
+    cmd = described_class.new(["--formula", "testball", "--yes"])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil)
+
+    allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable)
+      .with(method: :resolve)
+      .and_return([formula])
+    allow(Homebrew::Trust).to receive(:trust_fully_qualified_items!)
+    expect(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
+    expect(cmd).to receive(:upgrade_outdated_formulae!) do |formulae, prefetch_only: false, prefetch_names: nil,
+                                                                prefetch_upgrades: nil, **|
+      expect(formulae).to eq([formula])
+      if prefetch_only
+        prefetch_names&.replace(["testball"])
+        prefetch_upgrades&.replace(["testball 0.1 -> 0.2"])
+      end
+      true
+    end.twice
+    expect(cmd).not_to receive(:prefetch_outdated_casks!)
+    expect(download_queue).to receive(:fetch).with(heading: "Fetching downloads for: testball")
+    allow(Homebrew::Cleanup).to receive_messages(install_clean!: nil, periodic_clean!: nil)
+    allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
+    allow(Homebrew.messages).to receive(:display_messages)
+
+    cmd.run
+  end
+
+  it "prefetches a named cask-only upgrade before installing" do
+    cask = Cask::Cask.new("codex")
+    installer = Cask::Installer.allocate
+    cmd = described_class.new(["--cask", "codex", "--yes"])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil)
+
+    allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable)
+      .with(method: :resolve)
+      .and_return([cask])
+    allow(Homebrew::Trust).to receive(:trust_fully_qualified_items!)
+    expect(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
+    expect(cmd).not_to receive(:upgrade_outdated_formulae!)
+    expect(cmd).to receive(:prefetch_outdated_casks!) do |casks, prefetch_names:, prefetch_upgrades:,
+                                                          prefetch_casks:, prefetch_installers:, **|
+      expect(casks).to eq([cask])
+      prefetch_names.replace(["codex"])
+      prefetch_upgrades.replace(["codex 1.0 -> 2.0"])
+      prefetch_casks.replace([cask])
+      prefetch_installers.replace([installer])
+      true
+    end
+    expect(download_queue).to receive(:fetch).with(heading: "Fetching dependency downloads")
+    expect(cmd).to receive(:upgrade_outdated_casks!)
+      .with(
+        [cask],
+        skip_prefetch:              true,
+        show_upgrade_summary:       false,
+        download_queue:             nil,
+        prefetched_cask_errors:     [],
+        prefetched_cask_installers: [installer],
+      )
+      .and_return(true)
+    allow(Homebrew::Cleanup).to receive_messages(install_clean!: nil, periodic_clean!: nil)
+    allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
+    allow(Homebrew.messages).to receive(:display_messages)
+
+    cmd.run
+  end
+
+  it "prefetches discovered dependants with primary formulae" do
+    primary = formula("primary") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/primary-2.0"
+    end
+    dependant = formula("dependant") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/dependant-2.0"
+    end
+    primary_installer = FormulaInstaller.new(primary)
+    dependant_installer = FormulaInstaller.new(dependant)
+    download_queue = instance_double(Homebrew::DownloadQueue)
+    cmd = described_class.new(["--yes"])
+
+    allow(cmd).to receive(:formulae_upgrade_context).and_return(
+      Homebrew::Cmd::UpgradeCmd::FormulaeUpgradeContext.new(
+        formulae_to_install: [primary],
+        formulae_installer:  [primary_installer],
+        dependants:          Homebrew::Upgrade::Dependents.new(
+          upgradeable: [dependant], pinned: [], skipped: [],
+        ),
+      ),
+    )
+    expect(Homebrew::Upgrade).to receive(:dependent_formula_installers) do |dependants, formulae, **options|
+      expect(dependants.upgradeable).to eq([dependant])
+      expect(formulae).to eq([primary])
+      expect(options).not_to have_key(:defer_caveats)
+      [dependant_installer]
+    end
+    expect(Homebrew::Install).to receive(:enqueue_formulae)
+      .with([primary_installer, dependant_installer], download_queue:)
+      .and_return([primary_installer, dependant_installer])
+
+    prefetch_names = []
+    prefetch_upgrades = []
+    expect(cmd.upgrade_outdated_formulae!(
+             [],
+             prefetch_only:     true,
+             download_queue:,
+             prefetch_names:,
+             prefetch_upgrades:,
+           )).to be(true)
+    expect(prefetch_names).to eq(%w[primary dependant])
   end
 
   it "asks before fetching formulae and casks in the same download queue" do
@@ -796,8 +959,10 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       installed_version: "0.117.0",
       version:           "0.118.0",
     )
-    installer = instance_double(Cask::Installer, check_requirements: nil, enqueue_downloads: nil,
-                                                 source_download_requires_pre_fetch?: false)
+    installer = Cask::Installer.allocate
+    allow(installer).to receive_messages(check_requirements: nil, enqueue_downloads: nil,
+                                         enqueue_dependency_downloads: nil,
+                                         source_download_requires_pre_fetch?: false)
 
     allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, dry_run: false, prefetch_only: false,
                                                               use_prefetched: false, prefetch_names: nil,
@@ -856,10 +1021,11 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     expect(cmd).to receive(:upgrade_outdated_casks!)
       .with(
         [cask],
-        skip_prefetch:          true,
-        show_upgrade_summary:   false,
-        download_queue:         nil,
-        prefetched_cask_errors: [cask_error],
+        skip_prefetch:              true,
+        show_upgrade_summary:       false,
+        download_queue:             nil,
+        prefetched_cask_errors:     [cask_error],
+        prefetched_cask_installers: [],
       )
       .and_return(true)
     allow(Homebrew::Cleanup).to receive(:periodic_clean!)
@@ -879,8 +1045,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       installed_version: "0.117.0",
       version:           "0.118.0",
     )
-    installer = instance_double(
-      Cask::Installer,
+    installer = Cask::Installer.allocate
+    allow(installer).to receive_messages(
       check_requirements:                  nil,
       enqueue_downloads:                   nil,
       enqueue_dependency_downloads:        nil,
@@ -912,7 +1078,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       .with(only: Cask::Download, heading: "Downloading Cask files")
       .ordered
     expect(download_queue).to receive(:fetch)
-      .with(heading: "Fetching downloads for: deno and codex")
+      .with(heading: "Fetching downloads for: deno")
       .ordered
     allow(Cask::Upgrade).to receive_messages(outdated_casks: [cask], upgrade_casks!: true)
     allow(Homebrew::Cleanup).to receive(:periodic_clean!)
@@ -945,8 +1111,9 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       token:             "codex",
       version:           "0.118.0",
     )
-    incompatible_installer = instance_double(Cask::Installer)
-    compatible_installer = instance_double(Cask::Installer, check_requirements: nil)
+    incompatible_installer = Cask::Installer.allocate
+    compatible_installer = Cask::Installer.allocate
+    allow(compatible_installer).to receive(:check_requirements)
     prefetch_names = []
     prefetch_upgrades = []
     prefetch_casks = []
@@ -987,8 +1154,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       installed_version: "0.117.0",
       version:           "0.118.0",
     )
-    installer = instance_double(
-      Cask::Installer,
+    installer = Cask::Installer.allocate
+    allow(installer).to receive_messages(
       check_requirements:                  nil,
       enqueue_downloads:                   nil,
       enqueue_dependency_downloads:        nil,
@@ -1015,7 +1182,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       .with(only: Cask::Download, heading: "Downloading Cask files")
       .ordered
     expect(download_queue).to receive(:fetch)
-      .with(heading: "Fetching downloads for: deno and codex")
+      .with(heading: "Fetching downloads for: deno")
       .ordered
     allow(Cask::Upgrade).to receive_messages(outdated_casks: [cask], upgrade_casks!: true)
     allow(Homebrew::Cleanup).to receive(:periodic_clean!)
@@ -1075,9 +1242,11 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       installed_version: "0.117.0",
       version:           "0.118.0",
     )
-    installer = instance_double(Cask::Installer, check_requirements: nil, downloader: nil,
-                                                 enqueue_downloads: nil, enqueue_dependency_downloads: nil,
-                                                 source_download_requires_pre_fetch?: false)
+    installer = Cask::Installer.allocate
+    allow(installer).to receive_messages(check_requirements: nil, downloader: failed_download,
+                                         download_failed!: nil, enqueue_downloads: nil,
+                                         enqueue_dependency_downloads: nil,
+                                         source_download_requires_pre_fetch?: false)
 
     allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
     allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, prefetch_only: false,

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2370,7 +2370,7 @@ reinstall` will be run for outdated dependents and dependents with broken
 linkage, respectively.
 
 Unless `$HOMEBREW_NO_INSTALL_CLEANUP` is set, `brew cleanup` will then be run
-for the upgraded formulae or, every 30 days, for all formulae.
+for the upgraded formulae and casks or, every 30 days, for all packages.
 
 `-d`, `--debug`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1492,7 +1492,7 @@ Upgrade outdated, unpinned packages using the same options they were originally 
 .P
 Unless \fB$HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK\fP is set, \fBbrew upgrade\fP or \fBbrew reinstall\fP will be run for outdated dependents and dependents with broken linkage, respectively\.
 .P
-Unless \fB$HOMEBREW_NO_INSTALL_CLEANUP\fP is set, \fBbrew cleanup\fP will then be run for the upgraded formulae or, every 30 days, for all formulae\.
+Unless \fB$HOMEBREW_NO_INSTALL_CLEANUP\fP is set, \fBbrew cleanup\fP will then be run for the upgraded formulae and casks or, every 30 days, for all packages\.
 .TP
 \fB\-d\fP, \fB\-\-debug\fP
 If brewing fails, open an interactive debugging session with access to IRB or a shell inside the temporary build directory\.


### PR DESCRIPTION
- derive one stable formula and cask upgrade plan
- prefetch all selected packages before serial upgrades
- report only successful upgrades in the final summary

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 GPT Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

