### PR TITLE
Defer package summaries until cleanup

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -115,15 +115,22 @@ module Cask
     def self.caveats(cask)
       odebug "Printing caveats"
 
-      caveats = cask.caveats
-      return if caveats.empty?
-
-      Homebrew.messages.record_caveats(cask.token, caveats)
+      caveats = record_caveats(cask)
+      return unless caveats
 
       <<~EOS
         #{ohai_title "Caveats"}
         #{caveats}
       EOS
+    end
+
+    sig { params(cask: ::Cask::Cask).returns(T.nilable(String)) }
+    def self.record_caveats(cask)
+      caveats = cask.caveats
+      return if caveats.empty?
+
+      Homebrew.messages.record_caveats(cask.token, caveats)
+      caveats
     end
 
     sig { params(quiet: T.nilable(T::Boolean), timeout: T.nilable(T.any(Integer, Float))).void }
@@ -175,7 +182,7 @@ module Cask
 
       prelude
 
-      print caveats
+      record_caveats
       fetch
       uninstall_existing_cask if reinstall?
 
@@ -553,9 +560,9 @@ on_request: true)
       [cask_installers, formula_installers]
     end
 
-    sig { returns(T.nilable(String)) }
-    def caveats
-      self.class.caveats(@cask)
+    sig { void }
+    def record_caveats
+      self.class.record_caveats(@cask)
     end
 
     sig { returns(Pathname) }

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -423,9 +423,7 @@ module Cask
         # Start new cask's installation steps
         new_cask_installer.prelude
 
-        if (caveats = new_cask_installer.caveats)
-          puts caveats
-        end
+        new_cask_installer.record_caveats
 
         new_cask_installer.fetch
 

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -11,7 +11,6 @@ require "missing_formula"
 require "formula_installer"
 require "development_tools"
 require "install"
-require "cleanup"
 require "upgrade"
 require "trust"
 
@@ -496,13 +495,12 @@ module Homebrew
           end
         end
 
-        unless args.dry_run?
-          Cleanup.install_clean!(formulae: installed_or_upgraded_formulae,
-                                 casks:    installed_or_upgraded_casks)
-        end
-        Cleanup.periodic_clean!(dry_run: args.dry_run?)
-
-        Homebrew.messages.display_messages(display_times: args.display_times?)
+        Install.finish_installation(
+          formulae:      installed_or_upgraded_formulae,
+          casks:         installed_or_upgraded_casks,
+          dry_run:       args.dry_run?,
+          display_times: args.display_times?,
+        )
       rescue FormulaUnreadableError, FormulaClassUnavailableError,
              TapFormulaUnreadableError, TapFormulaClassUnavailableError => e
         require "utils/backtrace"

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -4,10 +4,8 @@
 require "abstract_command"
 require "formula_installer"
 require "development_tools"
-require "messages"
 require "install"
 require "reinstall"
-require "cleanup"
 require "cask/utils"
 require "cask/installer"
 require "cask/reinstall"
@@ -351,10 +349,11 @@ module Homebrew
 
         unavailable_errors.each { |e| ofail e }
 
-        Cleanup.install_clean!(formulae: reinstalled_formulae, casks: reinstalled_casks)
-        Cleanup.periodic_clean!
-
-        Homebrew.messages.display_messages(display_times: args.display_times?)
+        Install.finish_installation(
+          formulae:      reinstalled_formulae,
+          casks:         reinstalled_casks,
+          display_times: args.display_times?,
+        )
       end
     end
   end

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -341,10 +341,12 @@ module Homebrew
 
         Homebrew::Reinstall.reinstall_pkgconf_if_needed!(dry_run: args.dry_run?)
 
-        Cleanup.install_clean!(formulae: @upgraded_formulae, casks: @upgraded_casks) unless args.dry_run?
-        Cleanup.periodic_clean!(dry_run: args.dry_run?)
-
-        Homebrew.messages.display_messages(display_times: args.display_times?)
+        Install.finish_installation(
+          formulae:      @upgraded_formulae,
+          casks:         @upgraded_casks,
+          dry_run:       args.dry_run?,
+          display_times: args.display_times?,
+        )
 
         show_final_upgrade_summary
       end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -961,8 +961,6 @@ on_request: installed_on_request?, options:)
     Homebrew.messages.record_completions_and_elisp(caveats.completions_and_elisp)
     return if caveats.caveats.empty?
 
-    @show_summary_heading = true
-    ohai "Caveats", caveats.to_s
     Homebrew.messages.record_caveats(formula.name, caveats)
   end
 

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -9,6 +9,8 @@ require "development_tools"
 require "upgrade"
 require "download_queue"
 require "ask"
+require "cleanup"
+require "messages"
 require "utils/output"
 require "utils/topological_hash"
 
@@ -506,6 +508,20 @@ module Homebrew
           ofail "#{cask_installer.cask}: #{e}"
         end
         downloads_succeeded
+      end
+
+      sig {
+        params(
+          formulae:      T::Array[Formula],
+          casks:         T::Array[Cask::Cask],
+          dry_run:       T::Boolean,
+          display_times: T::Boolean,
+        ).void
+      }
+      def finish_installation(formulae:, casks:, dry_run: false, display_times: false)
+        Cleanup.install_clean!(formulae:, casks:) unless dry_run
+        Cleanup.periodic_clean!(dry_run:)
+        Homebrew.messages.display_messages(force_caveats: true, display_times:)
       end
 
       sig {

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -274,12 +274,16 @@ RSpec.describe Cask::Installer, :cask do
       expect(no_checksum).to be_installed
     end
 
-    it "prints caveats if they're present" do
+    it "records caveats without printing them inline" do
       with_caveats = Cask::CaskLoader.load(cask_path("with-caveats"))
+
+      expect(Homebrew.messages).to receive(:record_caveats)
+        .with(with_caveats.token, with_caveats.caveats)
+      expect(described_class).not_to receive(:caveats)
 
       expect do
         described_class.new(with_caveats).install
-      end.to output(/Here are some things you might want to know/).to_stdout
+      end.not_to output(/Here are some things you might want to know/).to_stdout
 
       expect(with_caveats).to be_installed
     end

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -380,7 +380,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
       .ordered
     expect(Homebrew::Cleanup).to receive(:periodic_clean!).with(dry_run: false).ordered
     expect(Homebrew.messages).to receive(:display_messages)
-      .with(display_times: false)
+      .with(force_caveats: true, display_times: false)
       .ordered
 
     cmd.run
@@ -482,7 +482,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
       .ordered
     expect(Homebrew::Cleanup).to receive(:periodic_clean!).with(dry_run: false).ordered
     expect(Homebrew.messages).to receive(:display_messages)
-      .with(display_times: false)
+      .with(force_caveats: true, display_times: false)
       .ordered
 
     cmd.run

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Homebrew::Cmd::Reinstall do
       .ordered
     expect(Homebrew::Cleanup).to receive(:periodic_clean!).ordered
     expect(Homebrew.messages).to receive(:display_messages)
-      .with(display_times: false)
+      .with(force_caveats: true, display_times: false)
       .ordered
 
     cmd.run
@@ -182,7 +182,7 @@ RSpec.describe Homebrew::Cmd::Reinstall do
       .ordered
     expect(Homebrew::Cleanup).to receive(:periodic_clean!).ordered
     expect(Homebrew.messages).to receive(:display_messages)
-      .with(display_times: false)
+      .with(force_caveats: true, display_times: false)
       .ordered
 
     cmd.run

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -471,7 +471,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     expect(Homebrew::Cleanup).to receive(:install_clean!).with(formulae: [], casks: []).ordered
     expect(Homebrew::Cleanup).to receive(:periodic_clean!).with(dry_run: false).ordered
     expect(Homebrew.messages).to receive(:display_messages)
-      .with(display_times: false)
+      .with(force_caveats: true, display_times: false)
       .ordered
     expect(cmd).to receive(:show_final_upgrade_summary).with(no_args).ordered
 

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -1426,6 +1426,22 @@ RSpec.describe FormulaInstaller do
   describe "#caveats" do
     subject(:formula_installer) { described_class.new(Testball.new) }
 
+    it "records caveats without printing them inline" do
+      formula = Testball.new
+      installer = described_class.new(formula, installed_on_request: true)
+      caveats = instance_double(
+        Caveats,
+        caveats:               "Add testball to your PATH",
+        completions_and_elisp: [],
+        empty?:                false,
+      )
+
+      allow(Caveats).to receive(:new).with(formula).and_return(caveats)
+      expect(Homebrew.messages).to receive(:record_caveats).with(formula.name, caveats)
+
+      expect { installer.caveats }.not_to output.to_stdout
+    end
+
     it "shows audit problems if HOMEBREW_DEVELOPER is set" do
       ENV["HOMEBREW_DEVELOPER"] = "1"
       with_env(HOMEBREW_NO_INSTALL_FROM_API: "1") do

--- a/Library/Homebrew/test/install_spec.rb
+++ b/Library/Homebrew/test/install_spec.rb
@@ -101,6 +101,23 @@ RSpec.describe Homebrew::Install do
     end
   end
 
+  describe "::finish_installation" do
+    it "cleans packages before reporting caveats" do
+      formula = instance_double(Formula)
+      cask = instance_double(Cask::Cask)
+
+      expect(Homebrew::Cleanup).to receive(:install_clean!)
+        .with(formulae: [formula], casks: [cask])
+        .ordered
+      expect(Homebrew::Cleanup).to receive(:periodic_clean!).with(dry_run: false).ordered
+      expect(Homebrew.messages).to receive(:display_messages)
+        .with(force_caveats: true, display_times: true)
+        .ordered
+
+      described_class.finish_installation(formulae: [formula], casks: [cask], display_times: true)
+    end
+  end
+
   describe "::enqueue_cask_installers" do
     it "fetches source API downloads before enqueueing cask downloads" do
       source_download = instance_double(Homebrew::API::SourceDownload)


### PR DESCRIPTION
- collect formula and cask caveats without inline output
- share cleanup and message finalisation across commands
- print one caveat summary before the final upgrade result

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 GPT Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

