### PR TITLE
vulns: read the advisory index from formulae.brew.sh

### DIFF
--- a/Library/Homebrew/vulns/advisory_database.rb
+++ b/Library/Homebrew/vulns/advisory_database.rb
@@ -6,16 +6,15 @@ require "vulns/vulnerability"
 
 module Homebrew
   module Vulns
-    # Reader for the concatenated `BREW-*` OSV corpus published by
-    # Homebrew/advisory-database at `data/advisories.json` (built by that
-    # repository's `AdvisoryIndex` via `rake advisories:concat`).
+    # Reader for the concatenated `BREW-*` OSV corpus generated from
+    # Homebrew/advisory-database and published by formulae.brew.sh at
+    # `/api/advisories.json`.
     #
     # Consumed by `brew generate-formula-api` to attach a `vulnerabilities`
     # field to each formula's API JSON, and by `brew vulns` (Phase 4) as the
     # local `ecosystem: Homebrew` range source until osv.dev ingests the feed.
     class AdvisoryDatabase < CachedFeed
-      DATA_URL = "https://raw.githubusercontent.com/Homebrew/advisory-database/" \
-                 "main/data/advisories.json"
+      DATA_URL = "https://formulae.brew.sh/api/advisories.json"
 
       sig { override.returns(String) }
       def self.data_url = DATA_URL

--- a/Library/Homebrew/vulns/cached_feed.rb
+++ b/Library/Homebrew/vulns/cached_feed.rb
@@ -55,7 +55,7 @@ module Homebrew
         Tempfile.create([cache_filename, ".download"], cache_file.dirname.to_s) do |tmp|
           tmp.close
           path = Pathname(tmp.path)
-          Utils::Curl.curl_download("--fail", "--silent", data_url, to: path)
+          Utils::Curl.curl_download("--fail", "--silent", "--compressed", data_url, to: path)
           loaded = from_file(path)
           File.rename(path, cache_file)
           return loaded


### PR DESCRIPTION
`brew vulns` now reads the advisory index from https://formulae.brew.sh/api/advisories.json, which the site build generates from Homebrew/advisory-database's reviewed main. The published file is byte-identical to the committed `data/advisories.json` it replaces (SHA-256 verified), so this is a URL change only.

Feed downloads also request compressed transfer: the index is 67 MB raw and 14 MB gzip-encoded, and curl falls back to identity for hosts that do not compress.

Once this reaches a stable tag, Homebrew/advisory-database stops committing the generated index; the raw URL keeps working until then.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
