### PR TITLE
cask/upgrade: preserve an unquarantined app's state across upgrades

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -297,14 +297,20 @@ module Cask
         new_cask:               Cask,
         old_signing_identities: T::Hash[String, T.nilable(Quarantine::SigningIdentity)],
         old_user_approved:      T::Hash[String, T::Boolean],
+        old_unquarantined:      T::Hash[String, T::Boolean],
       ).returns(Symbol)
     }
-    def self.quarantine_release_decision(old_cask, new_cask, old_signing_identities, old_user_approved)
+    def self.quarantine_release_decision(old_cask, new_cask, old_signing_identities, old_user_approved,
+                                         old_unquarantined)
       old_app_artifacts = old_cask.artifacts.grep(Artifact::App)
       new_app_artifacts = new_cask.artifacts.grep(Artifact::App)
       return :skip if old_app_artifacts.empty? || old_app_artifacts.length != new_app_artifacts.length
       return :unapproved unless old_app_artifacts.all? do |artifact|
-        old_user_approved.fetch(artifact.target.to_s, false)
+        # An app with no quarantine attribute already launches without a Gatekeeper prompt, so carry
+        # that state forward as well: an app whose own updater replaced the bundle should not cost the
+        # user a prompt at its next upgrade. The signing identity is still checked below.
+        old_user_approved.fetch(artifact.target.to_s, false) ||
+        old_unquarantined.fetch(artifact.target.to_s, false)
       end
 
       old_app_artifacts.each_with_index do |artifact, index|
@@ -402,6 +408,7 @@ module Cask
       old_signing_identities = T.let({}, T::Hash[String, T.nilable(Quarantine::SigningIdentity)])
       old_user_approved = T.let({}, T::Hash[String, T::Boolean])
       old_approved_paths = T.let({}, T::Hash[String, T::Array[String]])
+      old_unquarantined = T.let({}, T::Hash[String, T::Boolean])
 
       begin
         oh1 "Upgrading #{Formatter.identifier(old_cask)}"
@@ -425,6 +432,11 @@ module Cask
           old_user_approved[artifact.target.to_s] = user_approved
           # Only an already approved app has approvals to pass on, so skip the scan otherwise.
           old_approved_paths[artifact.target.to_s] = Quarantine.user_approved_paths(artifact.target) if user_approved
+          old_unquarantined[artifact.target.to_s] = if artifact.target.exist?
+            Quarantine.detect(artifact.target).blank?
+          else
+            false
+          end
           old_signing_identities[artifact.target.to_s] = Quarantine.signing_identity(artifact.target)
         end
 
@@ -440,8 +452,12 @@ module Cask
         new_artifacts_installed = true
 
         if Quarantine.available?
-          case quarantine_release_decision(old_cask, new_cask, old_signing_identities, old_user_approved)
+          case quarantine_release_decision(old_cask, new_cask, old_signing_identities, old_user_approved,
+                                           old_unquarantined)
           when :release
+            if old_unquarantined.value?(true)
+              odebug "#{new_cask.token} wasn't quarantined so approving the new version to match."
+            end
             new_cask.artifacts.grep(Artifact::App).each do |artifact|
               Quarantine.inherit_user_approval!(
                 download_path:  artifact.target,

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -514,6 +514,7 @@ RSpec.describe Cask::Upgrade, :cask do
                auto_updates,
                { auto_updates_path.to_s => auto_updates_identity },
                { auto_updates_path.to_s => true },
+               { auto_updates_path.to_s => false },
              )).to eq(:release)
     end
 
@@ -526,6 +527,7 @@ RSpec.describe Cask::Upgrade, :cask do
                auto_updates,
                { auto_updates_path.to_s => auto_updates_identity },
                { auto_updates_path.to_s => true },
+               { auto_updates_path.to_s => false },
              )).to eq(:signer_changed)
     end
 
@@ -535,6 +537,7 @@ RSpec.describe Cask::Upgrade, :cask do
                auto_updates,
                { auto_updates_path.to_s => nil },
                { auto_updates_path.to_s => true },
+               { auto_updates_path.to_s => false },
              )).to eq(:signer_unverified)
     end
 
@@ -547,6 +550,7 @@ RSpec.describe Cask::Upgrade, :cask do
                auto_updates,
                { auto_updates_path.to_s => auto_updates_identity },
                { auto_updates_path.to_s => true },
+               { auto_updates_path.to_s => false },
              )).to eq(:signer_unverified)
     end
 
@@ -555,6 +559,7 @@ RSpec.describe Cask::Upgrade, :cask do
                outdated_auto_updates,
                auto_updates,
                { auto_updates_path.to_s => auto_updates_identity },
+               { auto_updates_path.to_s => false },
                { auto_updates_path.to_s => false },
              )).to eq(:unapproved)
     end
@@ -569,7 +574,34 @@ RSpec.describe Cask::Upgrade, :cask do
                local_caffeine,
                { local_caffeine_path.to_s => local_caffeine_identity },
                { local_caffeine_path.to_s => true },
+               { local_caffeine_path.to_s => false },
              )).to eq(:release)
+    end
+
+    it "releases quarantine when the old app carried no quarantine attribute at all" do
+      allow(Cask::Quarantine).to receive(:signing_identity_match)
+        .with(auto_updates_path, auto_updates_identity).and_return(true)
+
+      expect(described_class.quarantine_release_decision(
+               outdated_auto_updates,
+               auto_updates,
+               { auto_updates_path.to_s => auto_updates_identity },
+               { auto_updates_path.to_s => false },
+               { auto_updates_path.to_s => true },
+             )).to eq(:release)
+    end
+
+    it "reports a changed signer for an unquarantined old app whose identity no longer matches" do
+      allow(Cask::Quarantine).to receive(:signing_identity_match)
+        .with(auto_updates_path, auto_updates_identity).and_return(false)
+
+      expect(described_class.quarantine_release_decision(
+               outdated_auto_updates,
+               auto_updates,
+               { auto_updates_path.to_s => auto_updates_identity },
+               { auto_updates_path.to_s => false },
+               { auto_updates_path.to_s => true },
+             )).to eq(:signer_changed)
     end
 
     it "reports missing approval for casks without auto_updates when Gatekeeper was not approved" do
@@ -577,6 +609,7 @@ RSpec.describe Cask::Upgrade, :cask do
                outdated_local_caffeine,
                local_caffeine,
                { local_caffeine_path.to_s => local_caffeine_identity },
+               { local_caffeine_path.to_s => false },
                { local_caffeine_path.to_s => false },
              )).to eq(:unapproved)
     end


### PR DESCRIPTION
Following on from #23545 and #23546. This one concerns self-updating casks. When such an app updates itself it replaces a bundle the user had already approved, since nothing unapproved gets far enough to run its own updater, and the version it puts in place carries no quarantine attribute at all. Such a version launches without any Gatekeeper prompt. Upgrading it through Homebrew brings the prompt back because the new version, having no approval to inherit, is quarantined afresh.

Walking through the process: The user approves the app once, and Homebrew carries that approval onto each new version it installs. Then at some point the app's own updater replaces the bundle, potentially multiple times in a series of auto-updates, leaving no quarantine attribute at all — self-updaters do not quarantine what they install. The app keeps launching without a prompt throughout. But the very first Homebrew upgrade subsequent to a self-update quarantines the new version afresh (it has nothing to inherit from) and the app the user has been opening freely for weeks through a series of upgrades may suddenly ask whether they are sure they want to open it.

Quite simply: approved stays approved (#23060, which preserves a cask's quarantine approval across upgrades), unapproved stays unapproved, and now unquarantined-due-to-self-update graduates to approved — approved rather than left untagged, so the download's audit trail is still recorded. Approval is granted only after the existing signing-identity check passes, so this approves nothing that #23060 would not have approved had the attribute survived.

To reproduce, with any installed cask:

```
app="/Applications/AppCleaner.app"
find "$app" -print0 | xargs -0 xattr -d com.apple.quarantine   # what a self-updater leaves behind
brew upgrade --cask appcleaner
xattr -p com.apple.quarantine "$app"                           # 0381… — quarantined, unapproved
```

<details>
<summary>Details</summary>

> **Demonstrated end to end.** Stripping AppCleaner's attributes and upgrading gave `0381` on stock Homebrew, and `03c1` with this change, from the identical starting state. Both runs used a locally bumped cask version so the upgrade path ran for real rather than through the test harness.
>
> **Why not simply leave the new version unquarantined?** Because the quarantine attribute also carries the download's provenance, which #23060 (preserving quarantine approval across upgrades) deliberately kept when it replaced release-by-deletion with approval inheritance. Matching that, this keeps the attribute and sets the approved bit.
>
> **Why this is not a new trust decision.** An untagged app already runs without any Gatekeeper evaluation, so nothing is being unlocked that was locked before; the change only stops an upgrade from making the user's position worse. Anyone able to strip the attribute could equally set the approved bit directly, so no capability is added.
>
> **Reporting.** The decision is logged with `odebug` rather than at verbose level: nothing is asked of the user, and on a machine with several self-updating casks a verbose line would appear on most upgrades.

</details>

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Used Claude Code (Opus 5) to investigate and draft; I directed the investigation, and reviewed the diff and every line of this PR text.

-----
