### PR TITLE
keg: skip linking some symlinks that point to other kegs

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -808,12 +808,18 @@ class Keg
     root.find do |src|
       next if src == root
 
-      dst = HOMEBREW_PREFIX + src.relative_path_from(path)
+      relative_src = src.relative_path_from(path)
+      dst = HOMEBREW_PREFIX + relative_src
       dst.extend ObserverPathnameExtension
 
       if src.symlink? || src.file?
         Find.prune if File.basename(src) == ".DS_Store"
-        Find.prune if src.resolved_path == dst
+        resolved_src = src.resolved_path
+        Find.prune if resolved_src == dst
+        # Skip symlinks where the source is located in another keg at the same
+        # relative path. Split formulae (e.g. llvm + flang) can use these when
+        # their binaries need to find files at a specific relative path.
+        Find.prune if resolved_src.fnmatch?("#{HOMEBREW_PREFIX}/opt/*/#{relative_src}", File::FNM_PATHNAME)
         # Don't link pyc or pyo files because Python overwrites these
         # cached object files and next time brew wants to link, the
         # file is in the way.

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe Keg do
 
   include FileUtils
 
-  def setup_test_keg(name, version)
+  def setup_test_keg(name, version, suffix: nil)
     path = HOMEBREW_CELLAR/name/version
     (path/"bin").mkpath
 
     %w[hiworld helloworld goodbye_cruel_world].each do |file|
-      touch path/"bin"/file
+      touch path/"bin"/"#{file}#{suffix}"
     end
 
     keg = Keg.new(path)
@@ -198,6 +198,36 @@ RSpec.describe Keg do
 
       expect(link.resolved_path).to be_a_symlink
       expect(link.lstat).to be_a_symlink
+    end
+
+    context "when keg symlinks to another keg" do
+      let(:other_keg) { setup_test_keg("bar", "1.0", suffix: "-bar") }
+      let(:filename) { "libtest.dylib" }
+      let(:file) { other_keg/"lib"/filename }
+
+      before do
+        file.dirname.mkpath
+        touch file
+        other_keg.link
+      end
+
+      it "ignores symlinks that have same relative path" do
+        (keg/"lib"/filename).make_relative_symlink other_keg.opt_record/"lib"/filename
+        keg.link
+        expect((HOMEBREW_PREFIX/"lib"/filename).resolved_path).to eq file
+      end
+
+      it "links symlinks that have different relative path" do
+        filename2 = "libtest2.dylib"
+        (keg/"lib"/filename2).make_relative_symlink other_keg.opt_record/"lib"/filename
+        keg.link
+        expect((HOMEBREW_PREFIX/"lib"/filename2).resolved_path).to eq keg/"lib"/filename2
+      end
+
+      it "fails linking symlinks that use Cellar path" do
+        (keg/"lib"/filename).make_relative_symlink other_keg/"lib"/filename
+        expect { keg.link }.to raise_error(Keg::ConflictError)
+      end
     end
   end
 


### PR DESCRIPTION
Specifically symlinks that point to another keg via the opt path using the same relative path. These would have previously been a conflict linking the same file.

This can be used by split formulae to help resolve the path of relative files, e.g. Flang expecting LLVM's LTO library at `../lib/<libname>`.

We've used other workarounds before like reversing the symlink so we resolve the path via Homebrew prefix; however, this is less ideal as the wrong file can be found if a user runs brew unlink/link. Also has lower security as an unrelated formula could inject something into the same location unlike our sandboxed kegs.

This change does not allow symlink to Cellar path as it is fragile and should never be used in formulae.

---

Mainly want this for the LLVM case as I've been working on LLVM 23 update and am trying to fix up some LLVM <-> Flang interaction.
* On macOS, we use a toolchain file that sets `-lto_library`. This works, but can't remove the default arg so there is always going to be a warning on invalid path
* On Linux, we use reversed symlink `Flang keg --> Homebrew prefix --> LLVM keg`. The problem here is `brew unlink llvm` will break it and even worse is `brew unlink llvm && brew link llvm@20` would cause wrong LTO library to be found as path is unversioned.

There are other scenarios like improving `qt` formula layout to work even when user `brew unlink`s Qt6 formulae.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
