### PR TITLE
rubocops/uses_from_macos: add `lldb` to provided by macOS

### DIFF
--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -35,6 +35,7 @@ module RuboCop
           libxcrypt
           libxml2
           libxslt
+          lldb
           llvm
           lsof
           m4


### PR DESCRIPTION
Planning to split out LLDB in LLVM 23 so adding separate provided by macOS entry so we can annotate formula correctly (i.e. macOS has `/usr/bin/lldb` provided by CLT/Xcode.app).

- https://github.com/Homebrew/homebrew-core/pull/299464

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
