### PR TITLE
utils/rubocop: activate installed platform Rubydex gem

### DIFF
--- a/Library/Homebrew/test/rubocop_spec.rb
+++ b/Library/Homebrew/test/rubocop_spec.rb
@@ -6,17 +6,50 @@ require "yaml"
 
 RSpec.describe "RuboCop" do
   context "when calling `rubocop` outside of the Homebrew environment" do
+    sig { returns(T::Array[String]) }
+    let(:homebrew_env_allowlist) do
+      %w[
+        HOMEBREW_TESTS
+        HOMEBREW_USE_RUBY_FROM_PATH
+        HOMEBREW_BUNDLER_VERSION
+      ]
+    end
+
     before do
       ENV.each_key do |key|
-        allowlist = %w[
-          HOMEBREW_TESTS
-          HOMEBREW_USE_RUBY_FROM_PATH
-          HOMEBREW_BUNDLER_VERSION
-        ]
-        ENV.delete(key) if key.start_with?("HOMEBREW_") && allowlist.exclude?(key)
+        ENV.delete(key) if key.start_with?("HOMEBREW_") && homebrew_env_allowlist.exclude?(key)
       end
 
       ENV["XDG_CACHE_HOME"] = (HOMEBREW_CACHE.realpath/"style").to_s
+    end
+
+    it "loads Rubydex from the installed platform gem" do
+      script = <<~RUBY
+        require ARGV.shift
+        $LOAD_PATH.reject! { |path| path.include?("/rubydex-") }
+        load ARGV.shift
+      RUBY
+      stdout, stderr, status = Bundler.with_unbundled_env do
+        ENV.delete_if do |key, _|
+          key.start_with?("HOMEBREW_") && homebrew_env_allowlist.exclude?(key)
+        end
+        ENV["XDG_CACHE_HOME"] = (HOMEBREW_CACHE.realpath/"style").to_s
+
+        Open3.capture3(
+          RUBY_PATH.to_s,
+          "-W0",
+          "-e",
+          script,
+          HOMEBREW_LIBRARY_PATH/"standalone.rb",
+          HOMEBREW_LIBRARY_PATH/"utils/rubocop.rb",
+          "-V",
+          chdir: HOMEBREW_LIBRARY_PATH,
+        )
+      end
+
+      expect(stderr).to be_empty
+      expect(status).to be_a_success
+      expect(stdout).to include("+Rubydex")
     end
 
     it "loads all Formula cops without errors" do

--- a/Library/Homebrew/utils/rubocop.rb
+++ b/Library/Homebrew/utils/rubocop.rb
@@ -5,6 +5,16 @@
 require_relative "../standalone"
 require_relative "../warnings"
 
+# The standalone bundle is generated on macOS, so activate the installed platform-specific Rubydex gem.
+rubydex_spec = begin
+  Gem::Specification.find_by_name("rubydex")
+rescue Gem::MissingSpecError
+  nil
+end
+if rubydex_spec&.full_require_paths&.none? { |path| $LOAD_PATH.include?(path) }
+  rubydex_spec.activate
+end
+
 Warnings.ignore :parser_syntax do
   require "rubocop"
 end


### PR DESCRIPTION
`Library/Homebrew/vendor/bundle/bundler/setup.rb` is committed and was generated on macOS arm64, so it hardcodes `gems/rubydex-0.3.0-arm64-darwin/lib`. Other platforms install a different build (Linux aarch64 gets `rubydex-0.3.0-aarch64-linux`), that path does not exist, and `require "rubydex"` fails. `Library/.rubocop.yml` sets `AllCops/UseProjectIndex: true`, so RuboCop skips the project index and the cops that use it fall back to file-local behavior. `brew style` is weaker off macOS arm64.

To reproduce, run `brew style` on Linux and note `AllCops/UseProjectIndex is enabled but the rubydex gem is not installed` on stderr.

This activates the installed Rubydex specification through RubyGems before RuboCop loads, and only when its require path is missing from `$LOAD_PATH`. RubyGems filters by platform, so it picks the build that is installed rather than the one baked into the standalone bundle. On macOS arm64 the guard is a no-op, and a missing gem still falls back to RuboCop's existing behavior. The new spec drops Rubydex from `$LOAD_PATH` and requires `rubocop -V` to report `+Rubydex`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new test fails without the fix and passes with it, and ran `brew lgtm` plus targeted specs.

-----
