### PR TITLE
generate-cask-ci-matrix: require Cask::CaskLoader

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
@@ -270,6 +270,7 @@ module Homebrew
           odie "Found Ruby files in wrong directory:\n#{ruby_files_in_wrong_directory.join("\n")}"
         end
 
+        require "cask/cask_loader"
         cask_files_to_check = if cask_names.any?
           cask_names.map do |cask_name|
             Cask::CaskLoader.find_cask_in_tap(cask_name, tap).relative_path_from(tap.path)


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`brew generate-cask-ci-matrix` is failing in the homebrew-cask repository with an `uninitialized constant Cask::CaskLoader` error, so this adds a `require` where `Cask::CaskLoader` is used in the command. This only started occurring in the most recent autobump run, so it may be related to the Cask-related changes that were merged a couple of hours ago (e.g., https://github.com/Homebrew/brew/pull/23560).

To be clear, homebrew-cask CI is currently failing for every PR due to this error and I've prioritized trying to get this merged quickly. I was unable to replicate the error locally, so I can't confirm whether there will be other `require`s needed but I can create follow-up PRs if CI continues to fail after merging.