### PR TITLE
generate-cask-ci-matrix: test lazy CaskLoader require

### DIFF
--- a/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
@@ -275,6 +275,31 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
       .and raise_error(SystemExit)
   end
 
+  it "generates a cask matrix in a clean process", :cask, :integration_test, :no_api do
+    CoreCaskTap.instance.path.cd do
+      system "git", "init", "--quiet"
+      system "git", "-c", "user.name=Homebrew Tests", "-c", "user.email=tests@brew.sh",
+             "commit", "--quiet", "--allow-empty", "-m", "initial"
+      system "git", "branch", "origin"
+
+      # Run without the Sorbet runtime so this exercises the same `require` graph as
+      # a real `brew generate-cask-ci-matrix`, which loads fewer files.
+      brew_env = {
+        "CI"                        => "1",
+        "GITHUB_OUTPUT"             => nil,
+        "GITHUB_REPOSITORY"         => "Homebrew/homebrew-cask",
+        "HOMEBREW_SORBET_RECURSIVE" => nil,
+        "HOMEBREW_SORBET_RUNTIME"   => nil,
+      }
+
+      expect do
+        expect do
+          brew "generate-cask-ci-matrix", "--cask", "local-caffeine", brew_env
+        end.to be_a_success
+      end.to output(/"token": "local-caffeine"/).to_stdout
+    end
+  end
+
   describe "::filter_runners" do
     let(:arm_linux_runner) { OS::LINUX_CI_ARM_RUNNER }
     # We simulate a macOS version older than the newest, as the method will use

--- a/Library/Homebrew/test/support/helper/cmd/brew-verify-undefined.rb
+++ b/Library/Homebrew/test/support/helper/cmd/brew-verify-undefined.rb
@@ -60,17 +60,18 @@ UNDEFINED_CONSTANTS = %w[
 ].freeze
 
 UNDEFINED_CONSTANTS_AFTER_REQUIRE = T.let({
-  "api"                           => %w[Base64 Concurrent Homebrew::DownloadQueue Plist],
-  "cask/artifact/pkg"             => %w[Plist],
-  "dev-cmd/formula-analytics"     => %w[InfluxDBClient3 PyCall],
-  "downloadable"                  => %w[Concurrent],
-  "extend/os/mac/extend/pathname" => %w[MachO],
-  "formula_cellar_checks"         => %w[Plist],
-  "keg"                           => %w[MachO],
-  "livecheck/livecheck"           => %w[Addressable],
-  "os/mac/xcode"                  => %w[Plist],
-  "service"                       => %w[Plist],
-  "services/cli"                  => %w[Plist],
+  "api"                             => %w[Base64 Concurrent Homebrew::DownloadQueue Plist],
+  "cask/artifact/pkg"               => %w[Plist],
+  "dev-cmd/formula-analytics"       => %w[InfluxDBClient3 PyCall],
+  "dev-cmd/generate-cask-ci-matrix" => %w[Cask::Cask Cask::CaskLoader],
+  "downloadable"                    => %w[Concurrent],
+  "extend/os/mac/extend/pathname"   => %w[MachO],
+  "formula_cellar_checks"           => %w[Plist],
+  "keg"                             => %w[MachO],
+  "livecheck/livecheck"             => %w[Addressable],
+  "os/mac/xcode"                    => %w[Plist],
+  "service"                         => %w[Plist],
+  "services/cli"                    => %w[Plist],
 }.freeze, T::Hash[String, T::Array[String]])
 
 module Homebrew


### PR DESCRIPTION
#23560 dropped the transitive `cask/cask_loader` require that `generate-cask-ci-matrix` relied on, which broke homebrew-cask CI with `uninitialized constant Cask::CaskLoader`. #23566 restored it as an explicit lazy require inside `generate_matrix`, but neither PR added coverage, so nothing stops the same break recurring or the require being quietly hoisted back to the top of the file.

This adds two complementary guards. The first is a clean-process integration test that runs `brew generate-cask-ci-matrix --cask` end to end against a temporary tap checkout, exercising both `Cask::CaskLoader.find_cask_in_tap` and `Cask::CaskLoader.load`. It runs with the Sorbet runtime disabled so the subprocess loads the same require graph as a real homebrew-cask CI run, since `HOMEBREW_SORBET_RUNTIME` pulls in extra files.

The second is a `dev-cmd/generate-cask-ci-matrix` entry in `UNDEFINED_CONSTANTS_AFTER_REQUIRE`, so `global_spec` fails if `Cask::Cask` or `Cask::CaskLoader` become defined merely by requiring the command file. Keeping both matters: one proves the require is present, the other proves it stays lazy, so neither should be removed as redundant.

Verified by reverting the require and confirming the integration test fails, then hoisting it to the top of the file and confirming `global_spec` fails.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the tests; I reviewed the diff, verified they fail without the lazy require and pass with it, and ran `brew lgtm` + targeted specs.

-----
