### PR TITLE
Load cask loader when reading Caskroom

### DIFF
--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -70,6 +70,8 @@ module Cask
 
     sig { params(caskfile: Pathname).void }
     def self.migrate_caskfile_to_json(caskfile)
+      require "cask/cask_loader"
+
       # Parse regular installed JSON so current files can be skipped and useful URL data can survive repairs.
       token = CaskLoader.token_from_path(caskfile)
       installed_json_caskfile = CaskLoader.installed_json_caskfile?(caskfile)
@@ -225,6 +227,8 @@ module Cask
     # @api internal
     sig { params(config: T.nilable(Config)).returns(T::Array[Cask]) }
     def self.casks(config: nil)
+      require "cask/cask_loader"
+
       tokens.sort.filter_map do |token|
         # This is nested so that the rescue can catch errors from both branches
         begin

--- a/Library/Homebrew/test/cmd/bundle/check_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/check_subcommand_spec.rb
@@ -33,6 +33,32 @@ RSpec.describe Homebrew::Cmd::Bundle::CheckSubcommand, :no_api do
                                                            taps_to_tap:         nothing)
       expect { do_check }.not_to raise_error
     end
+
+    it "recognises installed casks alongside formulae", :cask, :integration_test do
+      allow(Formulary).to receive(:loader_for).and_call_original
+      setup_test_formula "testball", tab_attributes: { installed_on_request: true }
+
+      installed_caskfile = Cask::Caskroom.path/
+                           "local-caffeine/.metadata/1.2.3/20250101000000.000/Casks/local-caffeine.rb"
+      installed_caskfile.dirname.mkpath
+      FileUtils.cp cask_path("local-caffeine"), installed_caskfile
+
+      brewfile = mktmpdir/"Brewfile"
+      brewfile.write <<~RUBY
+        brew "testball", link: false
+        cask "local-caffeine"
+      RUBY
+
+      brew_env = {
+        "HOMEBREW_SORBET_RECURSIVE" => nil,
+        "HOMEBREW_SORBET_RUNTIME"   => nil,
+      }
+
+      expect { brew "bundle", "check", "--no-upgrade", "--verbose", "--file=#{brewfile}", brew_env }
+        .to output("The Brewfile's dependencies are satisfied.\n").to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+    end
   end
 
   context "when no dependencies are specified" do


### PR DESCRIPTION
- Prevent swallowed loader errors from hiding installed casks.
- Cover mixed formula and cask Brewfiles in a clean process.

Fixes https://github.com/Homebrew/brew/issues/23567
Fixes https://github.com/Homebrew/brew/issues/23569

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----