### PR TITLE
missing_formula: defer cask/info require

### DIFF
--- a/Library/Homebrew/extend/os/mac/missing_formula.rb
+++ b/Library/Homebrew/extend/os/mac/missing_formula.rb
@@ -1,7 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "cask/info"
 require "cask/cask_loader"
 require "cask/caskroom"
 
@@ -42,6 +41,8 @@ module OS
             cask = ::Cask::Caskroom.casks.find { |installed_cask| installed_cask.to_s == name }
             Kernel.raise ::Cask::CaskUnavailableError, name if cask.nil?
           when "info"
+            Kernel.require "cask/info"
+
             cask = ::Cask::CaskLoader.load(name)
             suggestion = <<~EOS
               Found a cask named "#{name}" instead.


### PR DESCRIPTION
Commands that load `missing_formula` emit a Ruby 4 circular require warning under `HOMEBREW_DEVELOPER`: `loading in progress, circular require considered harmful - Library/Homebrew/missing_formula.rb`.

The cycle is `missing_formula` -> `extend/os/mac/missing_formula` -> `cask/info` -> `cmd/info` -> `missing_formula`. `Cask::Info` is only used by the `"info"` branch of `suggest_command`, so requiring it at load time pulled all of `cmd/info` into every `missing_formula` consumer just to loop back on itself.

Defer the require into that branch. This matches the existing lazy `require "cask/info"` in `cmd/info.rb` and the lazy `require "missing_formula"` calls in `cli/named_args.rb`, and it keeps `cmd/info` off the `brew search` and `brew install` load paths.

Reproduce on `main`:

```
./bin/brew ruby -e '$VERBOSE = true; require "cmd/search"'
```

`Cask::CaskUnavailableError` still resolves through `cask/cask_loader`, and the `show_info: true` example in `test/missing_formula_spec.rb` already exercises the deferred require from a cold load, so no new test is added.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation; I reviewed the diff, verified the warning reproduces before the change and is absent after, and ran `brew lgtm` plus targeted specs.

-----
