### PR TITLE
Defer API formula inflation

### DIFF
--- a/Library/Homebrew/api/internal.rb
+++ b/Library/Homebrew/api/internal.rb
@@ -191,7 +191,8 @@ module Homebrew
         download_and_cache_data! unless data_loaded?
 
         Homebrew::API.write_names_file!("formula", regenerate:) { formula_names }
-        Homebrew::API.write_aliases_file!("formula", regenerate:) { formula_aliases }
+        # Renames resolve like aliases in lightweight formula lookups.
+        Homebrew::API.write_aliases_file!("formula", regenerate:) { formula_aliases.merge(formula_renames) }
         Homebrew::API.write_executables_file!(regenerate:, source: cached_packages_json_file_path) { formula_hashes }
       end
 

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -1134,12 +1134,35 @@ module Homebrew
         else
           :stable
         end
+        # homebrew/core formulae cannot define options, so defer their inflation until command execution.
+        install_from_api = !Homebrew::EnvConfig.no_install_from_api?
+        api_formula_cache_contents = if install_from_api && named_args.any?
+          %w[formula_names.txt formula_aliases.txt].filter_map do |file|
+            path = Homebrew::API::HOMEBREW_CACHE_API/file
+            path.read if path.file?
+          end
+        else
+          []
+        end
 
         # Only lowercase names, not paths, bottle filenames or URLs
         named_args.filter_map do |arg|
           next if arg.match?(HOMEBREW_CASK_TAP_CASK_REGEX)
 
           begin
+            api_formula_name = arg[HOMEBREW_DEFAULT_TAP_FORMULA_REGEX, :name]
+            if install_from_api && api_formula_name
+              api_formula_pattern = /^#{Regexp.escape(api_formula_name)}(?:\||$)/
+              cached_api_formula = arg != api_formula_name || api_formula_cache_contents.any? do |contents|
+                contents.match?(api_formula_pattern)
+              end
+              cached_api_formula ||= Homebrew::API::Internal.formula_hashes_cached? &&
+                                     (Homebrew::API.formula_name?(api_formula_name) ||
+                                      Homebrew::API.formula_aliases.key?(api_formula_name) ||
+                                      Homebrew::API.formula_renames.key?(api_formula_name))
+              next if cached_api_formula
+            end
+
             Formulary.factory(arg, spec, flags: argv.select { |a| a.start_with?("--") })
           rescue FormulaUnavailableError, FormulaSpecificationError
             nil

--- a/Library/Homebrew/test/api/internal_spec.rb
+++ b/Library/Homebrew/test/api/internal_spec.rb
@@ -219,6 +219,15 @@ RSpec.describe Homebrew::API::Internal do
     expect((cache_dir/"internal/executables.txt").read).to eq("foo:foo-bin food\n")
   end
 
+  it "writes formula aliases and renames as cached mappings" do
+    Homebrew::API.write_names_and_aliases
+
+    mappings = formulae_aliases.merge(formulae_renames).map { |old_name, name| "#{old_name}|#{name}" }.sort
+    expect((cache_dir/"formula_aliases.txt").read.lines(chomp: true)).to eq(
+      mappings,
+    )
+  end
+
   it "returns the expected cask hashes" do
     cask_hashes_output = described_class.cask_hashes
     expect(cask_hashes_output).to eq cask_hashes

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -399,6 +399,94 @@ RSpec.describe Homebrew::CLI::Parser do
     end
   end
 
+  describe "formula options" do
+    subject(:parser) do
+      described_class.new(Cmd) do
+        formula_options
+      end
+    end
+
+    let(:api_cache) { mktmpdir }
+
+    before do
+      stub_const("Homebrew::API::HOMEBREW_CACHE_API", api_cache)
+      allow(Homebrew::EnvConfig).to receive(:no_install_from_api?).and_return(false)
+    end
+
+    it "does not inflate API-backed formulae" do
+      (api_cache/"formula_names.txt").write("foo\n")
+
+      expect(Formulary).not_to receive(:factory)
+      parser.parse(["foo"])
+    end
+
+    it "reads API cache files once for multiple formulae" do
+      (api_cache/"formula_names.txt").write("foo\n")
+      (api_cache/"formula_aliases.txt").write("bar|foo\n")
+      reads = Hash.new(0)
+      allow_any_instance_of(Pathname).to receive(:read).and_wrap_original do |method|
+        reads[method.receiver.basename.to_s] += 1
+        method.call
+      end
+
+      expect(Formulary).not_to receive(:factory)
+      parser.parse(%w[foo bar])
+      expect(reads).to eq("formula_names.txt" => 1, "formula_aliases.txt" => 1)
+    end
+
+    it "inflates API-backed formulae when commands access them" do
+      (api_cache/"formula_names.txt").write("foo\n")
+      full_formula = formula "foo", path: api_cache/"foo.rb", tap: Tap.fetch("user/repo") do
+        url "https://brew.sh/foo-1.0.tar.gz"
+        version "1.0"
+      end
+
+      expect(Formulary).to receive(:factory).once.and_return(full_formula)
+      expect(parser.parse(["foo"]).named.to_formulae).to eq([full_formula])
+    end
+
+    it "does not inflate API-backed formula aliases or renames" do
+      (api_cache/"formula_aliases.txt").write("foo-alias|foo\nfoo-old|foo\n")
+
+      expect(Formulary).not_to receive(:factory)
+      parser.parse(%w[foo-alias foo-old])
+    end
+
+    it "uses API metadata already loaded when the cache files are missing" do
+      allow(Homebrew::API::Internal).to receive(:formula_hashes_cached?).and_return(true)
+      allow(Homebrew::API).to receive_messages(formula_name?: false, formula_aliases: { "foo-alias" => "foo" },
+                                               formula_renames: { "foo-old" => "foo" })
+      allow(Homebrew::API).to receive(:formula_name?).with("foo").and_return(true)
+
+      expect(Formulary).not_to receive(:factory)
+      parser.parse(%w[foo foo-alias foo-old])
+    end
+
+    it "does not inflate a fully qualified core formula without API caches" do
+      allow(Homebrew::API::Internal).to receive(:formula_hashes_cached?).and_return(false)
+
+      expect(Formulary).not_to receive(:factory)
+      parser.parse(["homebrew/core/foo"])
+    end
+
+    it "inflates other formulae to parse their options" do
+      allow(Homebrew::API::Internal).to receive(:formula_hashes_cached?).and_return(false)
+      option = instance_double(Option, flag: "--with-foo", description: "Build with foo")
+      formula = instance_double(Formula, name: "foo", options: [option])
+
+      expect(Formulary).to receive(:factory).and_return(formula)
+      parser.parse(%w[foo --with-foo])
+    end
+
+    it "inflates formulae when API installs are disabled" do
+      allow(Homebrew::EnvConfig).to receive(:no_install_from_api?).and_return(true)
+      formula = instance_double(Formula, name: "foo", options: [])
+
+      expect(Formulary).to receive(:factory).and_return(formula)
+      parser.parse(["foo"])
+    end
+  end
+
   describe "usage banner generation" do
     it "includes `[options]` if more than two non-global options are available" do
       parser = described_class.new(Cmd) do


### PR DESCRIPTION
- Skip option-only inflation for API-backed core formula names and mappings while retaining it for custom formulae.
- Cache renames beside aliases for lightweight command parsing.
- `brew prof --timings`: command `cli_parse` fell from 43.434 ms to 7.152 ms; inflation moved to `formula_resolution`.
- `hyperfine --warmup 3 --runs 20` on warm no-op `brew install hello`: baseline 315.0 +/- 13.0 ms, deferred 316.8 +/- 20.3 ms (1.01 +/- 0.08x, statistically neutral).
- Interleaved 20-pair wall clock was neutral: deferred minus baseline averaged +0.775 ms with a -1.522 ms median.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI GPT Sol xhigh 5.6 with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----