### PR TITLE
Stabilise Bootsnap cache keys

### DIFF
--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -45,6 +45,21 @@ module Homebrew
           ohai "bundle install --standalone"
           run_bundle "install", "--standalone"
 
+          require "bundler"
+          definition = Bundler::Definition.build(Bundler.default_gemfile, Bundler.default_lockfile, false)
+          # Bundler ships with Ruby, outside the directory hashed by Bootsnap.
+          core_gem_names = definition.specs_for([:default])
+                                     .filter_map { |spec| spec.name if spec.name != "bundler" }
+                                     .sort
+          bootsnap_gem_names = Homebrew::Bootsnap.core_gem_names.sort
+          if core_gem_names != bootsnap_gem_names
+            raise <<~EOS
+              Bootsnap core gem list is out of date.
+              Expected: #{core_gem_names.join(", ")}
+              Actual: #{bootsnap_gem_names.join(", ")}
+            EOS
+          end
+
           if GitHub::Actions.env_set? && HOMEBREW_PREFIX.to_s == HOMEBREW_LINUX_DEFAULT_PREFIX
             ohai "chmod +t -R /home/linuxbrew/"
             system "sudo", "chmod", "+t", "-R", "/home/linuxbrew/"

--- a/Library/Homebrew/startup/bootsnap.rb
+++ b/Library/Homebrew/startup/bootsnap.rb
@@ -3,6 +3,26 @@
 
 module Homebrew
   module Bootsnap
+    # This is the default Bundler group and its transitive dependencies. Optional
+    # groups must not rotate the compile cache used by the core load graph.
+    CORE_GEM_NAMES = %w[
+      bindata
+      concurrent-ruby
+      elftools
+      logger
+      patchelf
+      plist
+      ruby-macho
+      sorbet-runtime
+    ].freeze
+    private_constant :CORE_GEM_NAMES
+
+    def self.core_gem_names = CORE_GEM_NAMES
+
+    private_class_method def self.gem_directories
+      Dir.children(File.join(Gem.paths.path, "gems")).sort
+    end
+
     def self.key
       @key ||= begin
         require "digest/sha2"
@@ -10,7 +30,9 @@ module Homebrew
         checksum = Digest::SHA256.new
         checksum << RUBY_VERSION
         checksum << RUBY_PLATFORM
-        checksum << Dir.children(File.join(Gem.paths.path, "gems")).join(",")
+        checksum << gem_directories
+                    .select { |gem| core_gem_names.any? { |name| gem.start_with?("#{name}-") } }
+                    .join(",")
 
         checksum.hexdigest
       end
@@ -21,6 +43,10 @@ module Homebrew
       raise "Needs `$HOMEBREW_CACHE` or `$HOMEBREW_DEFAULT_CACHE`!" if cache.nil? || cache.empty?
 
       File.join(cache, "bootsnap", key)
+    end
+
+    private_class_method def self.load_path_cache
+      File.join(cache_dir, "bootsnap/load-path-cache")
     end
 
     private_class_method def self.ignore_directories
@@ -46,6 +72,17 @@ module Homebrew
         return
       end
 
+      installed_gem_directories = gem_directories.join(",")
+      gem_directories_cache = File.join(cache_dir, "bootsnap/gem-directories")
+      if !File.exist?(gem_directories_cache) || File.read(gem_directories_cache) != installed_gem_directories
+        # The compile cache is shared across optional groups, but Bootsnap treats
+        # gem load paths as immutable, so invalidate their separate index.
+        require "fileutils"
+        FileUtils.rm_f load_path_cache
+        FileUtils.mkdir_p File.dirname(gem_directories_cache)
+        File.write(gem_directories_cache, installed_gem_directories)
+      end
+
       ::Bootsnap.setup(
         cache_dir:,
         ignore_directories:,
@@ -64,9 +101,12 @@ module Homebrew
       return unless enabled?
 
       ::Bootsnap.unload_cache!
+      # Gem changes invalidate resolution, but compiled files validate themselves
+      # against their source contents, so only discard the persisted load path.
+      require "fileutils"
+      FileUtils.rm_f load_path_cache
       @key = nil
 
-      # The compile cache doesn't get unloaded so we don't need to load it again!
       load!(compile_cache: false)
     end
 

--- a/Library/Homebrew/startup/bootsnap.rbi
+++ b/Library/Homebrew/startup/bootsnap.rbi
@@ -2,11 +2,20 @@
 
 module Homebrew
   module Bootsnap
+    sig { returns(T::Array[String]) }
+    def self.core_gem_names; end
+
     sig { returns(String) }
     def self.key; end
 
+    sig { returns(T::Array[String]) }
+    private_class_method def self.gem_directories; end
+
     sig { returns(String) }
     private_class_method def self.cache_dir; end
+
+    sig { returns(String) }
+    private_class_method def self.load_path_cache; end
 
     sig { returns(T::Array[String]) }
     private_class_method def self.ignore_directories; end

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -491,6 +491,21 @@ RSpec.describe Homebrew::Cleanup do
     end
   end
 
+  describe "::cleanup_bootsnap" do
+    it "removes stale keys and keeps the current key" do
+      cache = mktmpdir
+      current = cache/"bootsnap/current"
+      stale = cache/"bootsnap/stale"
+      current.mkpath
+      stale.mkpath
+      allow(Homebrew::Bootsnap).to receive(:key).and_return("current")
+
+      described_class.new(cache:).cleanup_bootsnap
+
+      expect([current.exist?, stale.exist?]).to eq([true, false])
+    end
+  end
+
   describe "::cleanup_cache" do
     it "removes legacy cask downloads during full cache cleanup", :cask do
       cask = Cask::CaskLoader.load("local-transmission")

--- a/Library/Homebrew/test/dev-cmd/install-bundler-gems_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/install-bundler-gems_spec.rb
@@ -6,4 +6,18 @@ require "dev-cmd/install-bundler-gems"
 
 RSpec.describe Homebrew::DevCmd::InstallBundlerGems do
   it_behaves_like "parseable arguments"
+
+  it "resets Bootsnap after cleaning gems" do
+    bundle = "/tmp/bundle"
+    allow(Homebrew).to receive(:setup_gem_environment!)
+    allow(Homebrew).to receive_messages(valid_gem_groups: [], user_gem_groups: [], user_vendor_version: 9)
+    allow(Homebrew).to receive(:find_in_path).with("bundle").and_return("/tmp")
+    allow(Homebrew).to receive(:`).with("#{bundle} check 2>&1").and_return("")
+    allow(Homebrew).to receive(:system).with(bundle, "clean", out: :err).and_return(true)
+    allow(Homebrew).to receive(:write_user_gem_groups)
+    expect(Homebrew::Bootsnap).to receive(:reset!)
+
+    Kernel.system("true")
+    with_env(HOMEBREW_TESTS: nil) { Homebrew.install_bundler_gems! }
+  end
 end

--- a/Library/Homebrew/test/dev-cmd/vendor-gems_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/vendor-gems_spec.rb
@@ -6,4 +6,29 @@ require "dev-cmd/vendor-gems"
 
 RSpec.describe Homebrew::DevCmd::VendorGems do
   it_behaves_like "parseable arguments"
+
+  sig { returns(Homebrew::DevCmd::VendorGems) }
+  def vendor_gems_command
+    described_class.new(["--no-commit"]).tap do |command|
+      allow(command).to receive(:run_bundle)
+      allow(command).to receive(:ohai)
+      allow(Homebrew).to receive(:setup_gem_environment!)
+      allow(Homebrew).to receive(:valid_gem_groups).and_return([])
+    end
+  end
+
+  it "rejects a stale Bootsnap core gem list" do
+    command = vendor_gems_command
+    allow(Homebrew::Bootsnap).to receive(:core_gem_names).and_return([])
+
+    expect { command.run }.to raise_error(RuntimeError, /Bootsnap core gem list is out of date/)
+  end
+
+  it "accepts reordered Bootsnap core gems" do
+    command = vendor_gems_command
+    core_gem_names = Homebrew::Bootsnap.core_gem_names.reverse
+    allow(Homebrew::Bootsnap).to receive(:core_gem_names).and_return(core_gem_names)
+
+    expect { command.run }.not_to raise_error
+  end
 end

--- a/Library/Homebrew/test/startup/bootsnap_spec.rb
+++ b/Library/Homebrew/test/startup/bootsnap_spec.rb
@@ -2,11 +2,87 @@
 # frozen_string_literal: true
 
 RSpec.describe Homebrew::Bootsnap do
+  sig { params(gem_home: Pathname).returns(String) }
+  def bootsnap_key(gem_home)
+    stdout, stderr, status = Open3.capture3(
+      { "HOMEBREW_NO_BOOTSNAP" => "1" },
+      *HOMEBREW_RUBY_EXEC_ARGS,
+      "-rrubygems", "-e", <<~RUBY, gem_home, HOMEBREW_LIBRARY_PATH/"startup/bootsnap.rb"
+        Gem.paths = { "GEM_HOME" => ARGV.fetch(0), "GEM_PATH" => ARGV.fetch(0) }
+        require ARGV.fetch(1)
+        puts Homebrew::Bootsnap.key
+      RUBY
+    )
+    raise stderr unless status.success?
+
+    stdout.chomp
+  end
+
+  describe "::key" do
+    it "ignores optional gems and changes when a core gem changes" do
+      gem_home = mktmpdir
+      gems = gem_home/"gems"
+      (gems/"sorbet-runtime-1.0").mkpath
+      original_key = bootsnap_key(gem_home)
+
+      (gems/"rspec-1.0").mkpath
+      optional_gem_key = bootsnap_key(gem_home)
+
+      (gems/"sorbet-runtime-1.0").rmdir
+      (gems/"sorbet-runtime-2.0").mkpath
+      core_gem_key = bootsnap_key(gem_home)
+
+      expect([optional_gem_key == original_key, core_gem_key == original_key]).to eq([true, false])
+    end
+  end
+
   describe "::load!" do
     it "does not error when the configured gem path is unavailable" do
       with_env(HOMEBREW_BOOTSNAP_GEM_PATH: "#{TEST_TMPDIR}/missing-bootsnap", HOMEBREW_NO_BOOTSNAP: nil) do
         expect { described_class.load! }.not_to raise_error
       end
+    end
+
+    it "invalidates stale gem load paths without removing compiled files" do
+      cache = mktmpdir
+      load_path_cache = cache/"bootsnap/load-path-cache"
+      gem_directories = cache/"bootsnap/gem-directories"
+      compile_cache = cache/"bootsnap/compile-cache-iseq/cache"
+      load_path_cache.dirname.mkpath
+      load_path_cache.write("stale")
+      gem_directories.write("old-gem-1.0")
+      compile_cache.dirname.mkpath
+      compile_cache.write("")
+      allow(described_class).to receive_messages(enabled?: true, cache_dir: cache.to_s)
+      allow(Dir).to receive(:children).with(File.join(Gem.paths.path, "gems")).and_return(["new-gem-1.0"])
+      allow(Bootsnap).to receive(:setup)
+
+      described_class.load!
+      stale_cache_removed = !load_path_cache.exist?
+      load_path_cache.write("current")
+      described_class.load!
+
+      expect([stale_cache_removed, load_path_cache.read, gem_directories.read, compile_cache.exist?])
+        .to eq([true, "current", "new-gem-1.0", true])
+    end
+  end
+
+  describe "::reset!" do
+    it "removes the load path cache and keeps the compile cache" do
+      cache = mktmpdir
+      load_path_cache = cache/"bootsnap/load-path-cache"
+      compile_cache = cache/"bootsnap/compile-cache-iseq/cache"
+      load_path_cache.dirname.mkpath
+      load_path_cache.write("")
+      compile_cache.dirname.mkpath
+      compile_cache.write("")
+      allow(described_class).to receive_messages(enabled?: true, cache_dir: cache.to_s)
+      allow(Bootsnap).to receive(:unload_cache!)
+      allow(described_class).to receive(:load!)
+
+      described_class.reset!
+
+      expect([load_path_cache.exist?, compile_cache.exist?]).to eq([false, true])
     end
   end
 

--- a/Library/Homebrew/utils/gem_setup.rb
+++ b/Library/Homebrew/utils/gem_setup.rb
@@ -274,7 +274,6 @@ module Homebrew
           exec bundle, "install", out: :err
         end)
         if $CHILD_STATUS.success?
-          Homebrew::Bootsnap.reset! if defined?(Homebrew::Bootsnap) # Gem install can run before Bootsnap loads
           true
         else
           message = <<~EOS
@@ -302,6 +301,8 @@ module Homebrew
       end
 
       if bundle_installed
+        # `bundle clean` can remove load paths just as `bundle install` can add them.
+        Homebrew::Bootsnap.reset! if defined?(Homebrew::Bootsnap) # Gem setup can run before Bootsnap loads
         write_user_gem_groups(groups)
         @bundle_installed_groups = groups
       end


### PR DESCRIPTION
- Hash only the core Bundler dependency closure so optional gem groups preserve compiled files.
- Refresh gem resolution after installs and cleans without unloading the compile cache.
- Guard the core list in `vendor-gems` and cover stale cache cleanup.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

GPT 5.6 Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----