### PR TITLE
sorbet: Bump more Cask tests to higher typed levels

### DIFF
--- a/Library/Homebrew/sorbet/rbi/dsl/cask/dsl.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/cask/dsl.rbi
@@ -63,6 +63,12 @@ class Cask::DSL
   sig { params(args: T.anything, kwargs: T.anything).void }
   def mdimporter(*args, **kwargs); end
 
+  sig { params(block: T.proc.bind(Cask::DSL).returns(T.anything)).returns(T.anything) }
+  def on_arm(&block); end
+
+  sig { params(block: T.proc.bind(Cask::DSL).returns(T.anything)).returns(T.anything) }
+  def on_intel(&block); end
+
   sig { params(args: T.anything, kwargs: T.anything).void }
   def pkg(*args, **kwargs); end
 

--- a/Library/Homebrew/sorbet/tapioca/compilers/cask/dsl.rb
+++ b/Library/Homebrew/sorbet/tapioca/compilers/cask/dsl.rb
@@ -48,6 +48,16 @@ module Tapioca
               return_type: "void",
             )
           end
+
+          OnSystem::ARCH_OPTIONS.each do |arch|
+            klass.create_method(
+              "on_#{arch}",
+              parameters:  [
+                create_block_param("block", type: "T.proc.bind(Cask::DSL).returns(T.anything)"),
+              ],
+              return_type: "T.anything",
+            )
+          end
         end
       end
 

--- a/Library/Homebrew/test/cask/download_spec.rb
+++ b/Library/Homebrew/test/cask/download_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 RSpec.describe Cask::Download, :cask do
@@ -9,11 +9,10 @@ RSpec.describe Cask::Download, :cask do
     let(:full_token) { token }
     let(:url) { instance_double(URL, to_s: url_to_s, specs: {}) }
     let(:url_to_s) { "https://example.com/app.dmg" }
+    let(:version) { nil }
     let(:cask) { instance_double(Cask::Cask, token:, full_token:, version:, url:) }
 
     context "when cask has no version" do
-      let(:version) { nil }
-
       it "returns the cask token" do
         expect(download_name).to eq "example-cask"
       end
@@ -133,6 +132,7 @@ RSpec.describe Cask::Download, :cask do
     subject(:verification) { described_class.new(cask).verify_download_integrity(downloaded_path) }
 
     let(:tap) { nil }
+    let(:expected_sha256) { nil }
     let(:cask) { instance_double(Cask::Cask, token: "cask", sha256: expected_sha256, tap:) }
     let(:cafebabe) { "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe" }
     let(:deadbeef) { "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" }
@@ -168,8 +168,6 @@ RSpec.describe Cask::Download, :cask do
     end
 
     context "when the expected checksum is nil" do
-      let(:expected_sha256) { nil }
-
       it "outputs an error" do
         expect { verification }.to output(/sha256 "#{computed_sha256}"/).to_stderr
       end

--- a/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Code CLI, Claude Opus 5 (High reasoning, Ultracode was too intense 🤯), with human prompting, review and tweaks.

-----

- Part of my ongoing quest to bump all the test files to at least Sorbet `typed: true`, because that's a thing we can do.
- In a 🥞 `gh stack` because I wanted to try them out on a real chain of changes.
- See the commit message body for the full description of the changes.