### PR TITLE
sorbet: Bump more command tests to higher typed levels

### DIFF
--- a/Library/Homebrew/test/abstract_command_spec.rb
+++ b/Library/Homebrew/test/abstract_command_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -23,7 +23,7 @@ RSpec.describe Homebrew::AbstractCommand do
       end
 
       it "allows access to args" do
-        expect(TestCat.new(["--bar", "baz"]).args.bar).to eq("baz")
+        expect(TestCat.new(["--bar", "baz"]).args).to have_attributes(bar: "baz")
       end
 
       it "raises on invalid args" do
@@ -68,7 +68,9 @@ RSpec.describe Homebrew::AbstractCommand do
           filename = File.basename(file, ".rb")
           require(file)
           command = described_class.command(filename)
-          expect(Pathname(File.join(__dir__, "../#{dir}/#{command.command_name}.rb"))).to exist
+          expect(command).not_to be_nil, "No command found for #{filename}"
+
+          expect(Pathname(File.join(__dir__, "../#{dir}/#{command&.command_name}.rb"))).to exist
         end
       end
     end

--- a/Library/Homebrew/test/bundle_version_spec.rb
+++ b/Library/Homebrew/test/bundle_version_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "bundle_version"
@@ -41,7 +41,7 @@ RSpec.describe Homebrew::BundleVersion do
       ["2.5.2(3329)", "3329"] => "2.5.2,3329",
     }
 
-    expected_mappings.each do |(short_version, version), expected_version|
+    test_each_hash(expected_mappings) do |(short_version, version), expected_version|
       it "maps (#{short_version.inspect}, #{version.inspect}) to #{expected_version.inspect}" do
         expect(described_class.new(short_version, version).nice_version)
           .to eq expected_version

--- a/Library/Homebrew/test/dev-cmd/generate-vulns-advisories_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-vulns-advisories_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"
@@ -19,7 +19,10 @@ RSpec.describe Homebrew::DevCmd::GenerateVulnsAdvisories do
         resolves "CVE-2015-2305"
       end
     end
-    plain = formula("plain") { url "https://example.com/plain-1.0.tar.gz" }
+    plain = formula("plain") do
+      T.bind(self, T.class_of(Formula))
+      url "https://example.com/plain-1.0.tar.gz"
+    end
     [nvi, plain].each do |f|
       allow(f).to receive(:to_hash_with_variations)
         .and_return({ "patches" => f.serialized_patches, "variations" => {} })
@@ -104,7 +107,12 @@ RSpec.describe Homebrew::DevCmd::GenerateVulnsAdvisories do
   describe "#first_fixed_version" do
     subject(:cmd) { described_class.new(["out"]) }
 
-    let(:current) { formula("x") { url "https://example.com/x-1.2.tar.gz" } }
+    let(:current) do
+      formula("x") do
+        T.bind(self, T.class_of(Formula))
+        url "https://example.com/x-1.2.tar.gz"
+      end
+    end
 
     def with_history(revisions)
       fv = instance_double(FormulaVersions)


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Code CLI, Claude Opus 5 (High reasoning, Ultracode was too intense 🤯), with human prompting, review and tweaks.

-----

- Part of my ongoing quest to bump all the test files to at least Sorbet `typed: true`, because that's a thing we can do.
- In a 🥞 `gh stack` because I wanted to try them out on a real chain of changes.
- See the commit message body for the full description of the changes.