### PR TITLE
sorbet: Bump more core tests to higher typed levels

### DIFF
--- a/Library/Homebrew/test/bash_spec.rb
+++ b/Library/Homebrew/test/bash_spec.rb
@@ -1,10 +1,11 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "open3"
 
 RSpec.describe "Bash" do
   matcher :have_valid_bash_syntax do
+    T.bind(self, T.class_of(RSpec::Matchers::DSL::Matcher))
     match do |file|
       stdout, stderr, status = Open3.capture3("/bin/bash", "-n", file)
 

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "extend/ENV"
@@ -20,6 +20,8 @@ RSpec.describe Requirement do
 
   describe "#tags" do
     subject(:req) { klass.new(tags) }
+
+    let(:tags) { [] }
 
     context "with a single tag" do
       let(:tags) { ["bar"] }
@@ -50,6 +52,7 @@ RSpec.describe Requirement do
     describe "#fatal true is specified" do
       let(:klass) do
         Class.new(described_class) do
+          T.bind(self, T.class_of(Requirement))
           fatal true
         end
       end

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "version"
@@ -433,8 +433,9 @@ RSpec.describe Version do
 
   describe "::detect" do
     matcher :be_detected_from do |url, **specs|
+      T.bind(self, T.class_of(RSpec::Matchers::DSL::Matcher))
       match do |expected|
-        @detected = described_class.detect(url, **specs)
+        @detected = Version.detect(url, **specs)
         @detected == expected
       end
 


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Code CLI, Claude Opus 5 (High reasoning, Ultracode was too intense 🤯), with human prompting, review and tweaks.

-----

- Part of my ongoing quest to bump all the test files to at least Sorbet `typed: true`, because that's a thing we can do.
- In a 🥞 `gh stack` because I wanted to try them out on a real chain of changes.
- See the commit message body for the full description of the changes.