### PR TITLE
sorbet: Bump more RuboCop tests to higher typed levels

### DIFF
--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/urls"
@@ -322,10 +322,9 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
   end
 
   context "when auditing Apache URLs" do
-    let(:expected_url) { "https://www.apache.org/dyn/closer.lua?path=apr/apr-1.7.6.tar.bz2" }
-
     shared_examples "offense" do |url|
       it "registers an offense and corrects" do
+        expected_url = "https://www.apache.org/dyn/closer.lua?path=apr/apr-1.7.6.tar.bz2"
         message = "FormulaAudit/Urls: #{url} should be: #{expected_url}"
 
         expect_offense(<<~RUBY, url:, message:)


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Code CLI, Claude Opus 5 (High reasoning, Ultracode was too intense 🤯), with human prompting, review and tweaks.

-----

- Part of my ongoing quest to bump all the test files to at least Sorbet `typed: true`, because that's a thing we can do.
- In a 🥞 `gh stack` because I wanted to try them out on a real chain of changes.
- See the commit message body for the full description of the changes.