### PR TITLE
sorbet: Bump more utility tests to higher typed levels

### DIFF
--- a/Library/Homebrew/test/unpack_strategy/bazaar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/bazaar_spec.rb
@@ -4,13 +4,14 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Bazaar do
+  subject(:path) { repo }
+
   let(:repo) do
     mktmpdir.tap do |repo|
       FileUtils.touch repo/"test"
       (repo/".bzr").mkpath
     end
   end
-  let(:path) { repo }
 
   include_examples "UnpackStrategy::detect"
   include_examples "#extract", children: ["test"]

--- a/Library/Homebrew/test/unpack_strategy/bzip2_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/bzip2_spec.rb
@@ -4,7 +4,7 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Bzip2 do
-  let(:path) { TEST_FIXTURE_DIR/"cask/container.bz2" }
+  subject(:path) { TEST_FIXTURE_DIR/"cask/container.bz2" }
 
   include_examples "UnpackStrategy::detect"
   include_examples "#extract", children: ["container"]

--- a/Library/Homebrew/test/unpack_strategy/cvs_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/cvs_spec.rb
@@ -4,13 +4,14 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Cvs do
+  subject(:path) { repo }
+
   let(:repo) do
     mktmpdir.tap do |repo|
       FileUtils.touch repo/"test"
       (repo/"CVS").mkpath
     end
   end
-  let(:path) { repo }
 
   include_examples "UnpackStrategy::detect"
   include_examples "#extract", children: ["CVS", "test"]

--- a/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
@@ -5,7 +5,7 @@ require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Dmg, :needs_macos do
   describe "#mount" do
-    let(:path) { TEST_FIXTURE_DIR/"cask/container.dmg" }
+    subject(:path) { TEST_FIXTURE_DIR/"cask/container.dmg" }
 
     include_examples "UnpackStrategy::detect"
 

--- a/Library/Homebrew/test/unpack_strategy/git_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/git_spec.rb
@@ -4,6 +4,8 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Git do
+  subject(:path) { repo }
+
   let(:repo) do
     mktmpdir.tap do |repo|
       system "git", "-C", repo, "init"
@@ -13,7 +15,6 @@ RSpec.describe UnpackStrategy::Git do
       system "git", "-C", repo, "commit", "-m", "Add `test` file."
     end
   end
-  let(:path) { repo }
 
   include_examples "UnpackStrategy::detect"
   include_examples "#extract", children: [".git", "test"]

--- a/Library/Homebrew/test/unpack_strategy/gzip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/gzip_spec.rb
@@ -4,7 +4,7 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Gzip do
-  let(:path) { TEST_FIXTURE_DIR/"cask/container.gz" }
+  subject(:path) { TEST_FIXTURE_DIR/"cask/container.gz" }
 
   include_examples "UnpackStrategy::detect"
   include_examples "#extract", children: ["container"], verbose: true

--- a/Library/Homebrew/test/unpack_strategy/jar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/jar_spec.rb
@@ -4,7 +4,7 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Jar, :needs_unzip do
-  let(:path) { TEST_FIXTURE_DIR/"test.jar" }
+  subject(:path) { TEST_FIXTURE_DIR/"test.jar" }
 
   include_examples "UnpackStrategy::detect"
   include_examples "#extract", children: ["test.jar"]

--- a/Library/Homebrew/test/unpack_strategy/lha_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/lha_spec.rb
@@ -4,7 +4,7 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Lha do
-  let(:path) { TEST_FIXTURE_DIR/"test.lha" }
+  subject(:path) { TEST_FIXTURE_DIR/"test.lha" }
 
   include_examples "UnpackStrategy::detect"
 end

--- a/Library/Homebrew/test/unpack_strategy/lzip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/lzip_spec.rb
@@ -4,7 +4,7 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Lzip do
-  let(:path) { TEST_FIXTURE_DIR/"test.lz" }
+  subject(:path) { TEST_FIXTURE_DIR/"test.lz" }
 
   include_examples "UnpackStrategy::detect"
 end

--- a/Library/Homebrew/test/unpack_strategy/mercurial_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/mercurial_spec.rb
@@ -4,12 +4,13 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Mercurial do
+  subject(:path) { repo }
+
   let(:repo) do
     mktmpdir.tap do |repo|
       (repo/".hg").mkpath
     end
   end
-  let(:path) { repo }
 
   include_examples "UnpackStrategy::detect"
 end

--- a/Library/Homebrew/test/unpack_strategy/p7zip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/p7zip_spec.rb
@@ -4,7 +4,7 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::P7Zip do
-  let(:path) { TEST_FIXTURE_DIR/"cask/container.7z" }
+  subject(:path) { TEST_FIXTURE_DIR/"cask/container.7z" }
 
   include_examples "UnpackStrategy::detect"
 end

--- a/Library/Homebrew/test/unpack_strategy/rar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/rar_spec.rb
@@ -4,7 +4,7 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Rar do
-  let(:path) { TEST_FIXTURE_DIR/"cask/container.rar" }
+  subject(:path) { TEST_FIXTURE_DIR/"cask/container.rar" }
 
   include_examples "UnpackStrategy::detect"
 end

--- a/Library/Homebrew/test/unpack_strategy/shared_examples.rb
+++ b/Library/Homebrew/test/unpack_strategy/shared_examples.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "mktemp"
@@ -6,7 +6,7 @@ require "unpack_strategy"
 
 RSpec.shared_examples "UnpackStrategy::detect" do
   it "is correctly detected" do
-    expect(UnpackStrategy.detect(path)).to be_a described_class
+    expect(UnpackStrategy.detect(subject)).to be_a described_class
   end
 end
 
@@ -14,7 +14,7 @@ RSpec.shared_examples "#extract" do |children: [], verbose: false|
   specify "#extract" do
     Mktemp.new("homebrew-test-unpack").run(chdir: false) do |mktemp|
       unpack_dir = T.must(mktemp.tmpdir)
-      described_class.new(path).extract(to: unpack_dir, verbose:)
+      described_class.new(subject).extract(to: unpack_dir, verbose:)
       expect(unpack_dir.children(false).map(&:to_s)).to match_array children
     end
   end

--- a/Library/Homebrew/test/unpack_strategy/subversion_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/subversion_spec.rb
@@ -4,9 +4,10 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Subversion, :needs_svnadmin do
+  subject(:path) { working_copy }
+
   let(:repo) { mktmpdir }
   let(:working_copy) { mktmpdir }
-  let(:path) { working_copy }
 
   before do
     safe_system "svnadmin", "create", repo

--- a/Library/Homebrew/test/unpack_strategy/tar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/tar_spec.rb
@@ -4,13 +4,13 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Tar do
-  let(:path) { TEST_FIXTURE_DIR/"cask/container.tar.gz" }
+  subject(:path) { TEST_FIXTURE_DIR/"cask/container.tar.gz" }
 
   include_examples "UnpackStrategy::detect"
   include_examples "#extract", children: ["container"]
 
   context "when TAR archive is corrupted" do
-    let(:path) do
+    subject(:path) do
       (mktmpdir/"test.tar").tap do |path|
         FileUtils.touch path
       end

--- a/Library/Homebrew/test/unpack_strategy/uncompressed_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/uncompressed_spec.rb
@@ -4,7 +4,7 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Uncompressed do
-  let(:path) do
+  subject(:path) do
     (mktmpdir/"test").tap do |path|
       FileUtils.touch path
     end

--- a/Library/Homebrew/test/unpack_strategy/xar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/xar_spec.rb
@@ -4,7 +4,7 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Xar, :needs_macos do
-  let(:path) { TEST_FIXTURE_DIR/"cask/container.xar" }
+  subject(:path) { TEST_FIXTURE_DIR/"cask/container.xar" }
 
   include_examples "UnpackStrategy::detect"
   include_examples "#extract", children: ["container"]

--- a/Library/Homebrew/test/unpack_strategy/xz_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/xz_spec.rb
@@ -4,7 +4,7 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Xz do
-  let(:path) { TEST_FIXTURE_DIR/"cask/container.xz" }
+  subject(:path) { TEST_FIXTURE_DIR/"cask/container.xz" }
 
   include_examples "UnpackStrategy::detect"
 end

--- a/Library/Homebrew/test/unpack_strategy/zip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/zip_spec.rb
@@ -4,7 +4,7 @@
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Zip do
-  let(:path) { TEST_FIXTURE_DIR/"cask/MyFancyApp.zip" }
+  subject(:path) { TEST_FIXTURE_DIR/"cask/MyFancyApp.zip" }
 
   include_examples "UnpackStrategy::detect"
 
@@ -13,7 +13,7 @@ RSpec.describe UnpackStrategy::Zip do
   end
 
   context "when ZIP archive is corrupted" do
-    let(:path) do
+    subject(:path) do
       (mktmpdir/"test.zip").tap do |path|
         FileUtils.touch path
       end

--- a/Library/Homebrew/test/utils/bottles/bottles_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/bottles_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/bottles"
@@ -53,9 +53,7 @@ RSpec.describe Utils::Bottles do
 
         runtime_dependencies = described_class.load_tab(formula).runtime_dependencies
 
-        expect(runtime_dependencies).not_to be_nil
-        expect(runtime_dependencies.size).to eq(1)
-        expect(runtime_dependencies.first).to include("full_name" => "testball1")
+        expect(runtime_dependencies).to contain_exactly(a_hash_including("full_name" => "testball1"))
       end
     end
   end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Code CLI, Claude Opus 5 (High reasoning, Ultracode was too intense 🤯), with human prompting, review and tweaks.

-----

- Part of my ongoing quest to bump all the test files to at least Sorbet `typed: true`, because that's a thing we can do.
- In a 🥞 `gh stack` because I wanted to try them out on a real chain of changes.
- See the commit message body for the full description of the changes.