### PR TITLE
cache_store: make CacheStoreDatabase.use thread-safe

### DIFF
--- a/Library/Homebrew/cache_store.rb
+++ b/Library/Homebrew/cache_store.rb
@@ -13,6 +13,9 @@ class CacheStoreDatabase
   Key = type_member
   Value = type_member
 
+  # Shared by `Utils.parallel_map` during install cleanup.
+  @mutex = T.let(Thread::Mutex.new, Thread::Mutex)
+
   # Yields the cache store database.
   # Closes the database after use if it has been loaded.
   sig {
@@ -24,28 +27,37 @@ class CacheStoreDatabase
       .returns(T.type_parameter(:U))
   }
   def self.use(type, &_blk)
-    @db_type_reference_hash ||= T.let({}, T.nilable(T::Hash[T.untyped, T.untyped]))
-    @db_type_reference_hash[type] ||= {}
-    type_ref = @db_type_reference_hash[type]
+    type_ref = T.let(nil, T.untyped)
+    db = T.let(nil, T.nilable(CacheStoreDatabase[T.anything, T.anything]))
 
-    type_ref[:count] ||= 0
-    type_ref[:count]  += 1
+    @mutex.synchronize do
+      @db_type_reference_hash ||= T.let({}, T.nilable(T::Hash[T.untyped, T.untyped]))
+      @db_type_reference_hash[type] ||= {}
+      type_ref = @db_type_reference_hash[type]
 
-    type_ref[:db] ||= CacheStoreDatabase.new(type)
-
-    return_value = yield(type_ref[:db])
-    if type_ref[:count].positive?
-      type_ref[:count] -= 1
-    else
-      type_ref[:count] = 0
+      type_ref[:count] ||= 0
+      type_ref[:count] += 1
+      type_ref[:db] ||= CacheStoreDatabase.new(type)
+      db = type_ref[:db]
     end
 
-    if type_ref[:count].zero?
-      type_ref[:db].write_if_dirty!
-      type_ref.delete(:db)
-    end
+    begin
+      raise ArgumentError, "CacheStoreDatabase.use failed to allocate #{type} store" if db.nil?
 
-    return_value
+      yield(db)
+    ensure
+      # `break` from the block used to skip the decrement and leak the refcount.
+      to_write = T.let(nil, T.nilable(CacheStoreDatabase[T.anything, T.anything]))
+      @mutex.synchronize do
+        if type_ref[:count].positive?
+          type_ref[:count] -= 1
+        else
+          type_ref[:count] = 0
+        end
+        to_write = type_ref.delete(:db) if type_ref[:count].zero?
+      end
+      to_write&.write_if_dirty!
+    end
   end
 
   # Creates a CacheStoreDatabase.

--- a/Library/Homebrew/cache_store.rb
+++ b/Library/Homebrew/cache_store.rb
@@ -13,8 +13,17 @@ class CacheStoreDatabase
   Key = type_member
   Value = type_member
 
-  # Shared by `Utils.parallel_map` during install cleanup.
-  @mutex = T.let(Thread::Mutex.new, Thread::Mutex)
+  # Tracks the active users and shared database for one cache type.
+  class TypeReference < T::Struct
+    const :mutex, Thread::Mutex
+    prop :active_users, Integer, default: 0
+    prop :database, T.nilable(CacheStoreDatabase[T.anything, T.anything]), default: nil
+  end
+  private_constant :TypeReference
+
+  # Only reference creation is global; each cache type has its own lifecycle lock.
+  @type_references_mutex = T.let(Thread::Mutex.new, Thread::Mutex)
+  @type_references = T.let({}, T::Hash[Symbol, TypeReference])
 
   # Yields the cache store database.
   # Closes the database after use if it has been loaded.
@@ -27,36 +36,28 @@ class CacheStoreDatabase
       .returns(T.type_parameter(:U))
   }
   def self.use(type, &_blk)
-    type_ref = T.let(nil, T.untyped)
-    db = T.let(nil, T.nilable(CacheStoreDatabase[T.anything, T.anything]))
+    type_ref = @type_references_mutex.synchronize do
+      @type_references[type] ||= TypeReference.new(mutex: Thread::Mutex.new)
+    end
 
-    @mutex.synchronize do
-      @db_type_reference_hash ||= T.let({}, T.nilable(T::Hash[T.untyped, T.untyped]))
-      @db_type_reference_hash[type] ||= {}
-      type_ref = @db_type_reference_hash[type]
-
-      type_ref[:count] ||= 0
-      type_ref[:count] += 1
-      type_ref[:db] ||= CacheStoreDatabase.new(type)
-      db = type_ref[:db]
+    db = type_ref.mutex.synchronize do
+      type_ref.active_users += 1
+      type_ref.database ||= CacheStoreDatabase.new(type)
     end
 
     begin
-      raise ArgumentError, "CacheStoreDatabase.use failed to allocate #{type} store" if db.nil?
-
-      yield(db)
+      return_value = yield(db)
+      return_value
     ensure
       # `break` from the block used to skip the decrement and leak the refcount.
-      to_write = T.let(nil, T.nilable(CacheStoreDatabase[T.anything, T.anything]))
-      @mutex.synchronize do
-        if type_ref[:count].positive?
-          type_ref[:count] -= 1
-        else
-          type_ref[:count] = 0
+      type_ref.mutex.synchronize do
+        type_ref.active_users -= 1
+        if type_ref.active_users.zero?
+          # Prevent a replacement database from opening until the final write completes.
+          type_ref.database&.write_if_dirty!
+          type_ref.database = nil
         end
-        to_write = type_ref.delete(:db) if type_ref[:count].zero?
       end
-      to_write&.write_if_dirty!
     end
   end
 

--- a/Library/Homebrew/test/cache_store_spec.rb
+++ b/Library/Homebrew/test/cache_store_spec.rb
@@ -31,6 +31,42 @@ RSpec.describe CacheStoreDatabase do
       end
     end
 
+    it "returns the block value" do
+      expect(described_class.use(type) { :return_value }).to eq(:return_value)
+    end
+
+    it "finishes writing before opening a replacement database" do
+      events = Queue.new
+      write_started = Queue.new
+      finish_write = Queue.new
+      first_cache_store = instance_double(described_class, "first_cache_store")
+      second_cache_store = instance_double(described_class, "second_cache_store", write_if_dirty!: nil)
+      allow(first_cache_store).to receive(:write_if_dirty!) do
+        events << :write_started
+        write_started << true
+        finish_write.pop
+        events << :write_finished
+      end
+      allow(described_class).to receive(:new).with(type).and_return(first_cache_store, second_cache_store)
+
+      first_use = Thread.new { described_class.use(type) { nil } }
+      write_started.pop
+      second_use = Thread.new do
+        events << :second_use_started
+        described_class.use(type) { events << :second_database_opened }
+      end
+      Thread.pass while second_use.status == "run"
+      finish_write << true
+      [first_use, second_use].each(&:value)
+
+      expect(Array.new(4) { events.pop }).to eq([
+        :write_started,
+        :second_use_started,
+        :write_finished,
+        :second_database_opened,
+      ])
+    end
+
     it "does not raise when used concurrently, including `break`" do
       threads = Array.new(8) do |i|
         Thread.new do
@@ -44,7 +80,7 @@ RSpec.describe CacheStoreDatabase do
         end
       end
 
-      expect { threads.each(&:join) }.not_to raise_error
+      expect { threads.each(&:value) }.not_to raise_error
     end
   end
 

--- a/Library/Homebrew/test/cache_store_spec.rb
+++ b/Library/Homebrew/test/cache_store_spec.rb
@@ -17,6 +17,35 @@ RSpec.describe CacheStoreDatabase do
         # do nothing
       end
     end
+
+    it "releases the refcount when the block breaks" do
+      cache_store = instance_double(described_class, "cache_store", write_if_dirty!: nil)
+      allow(described_class).to receive(:new).with(type).and_return(cache_store)
+      expect(cache_store).to receive(:write_if_dirty!).twice
+
+      described_class.use(type) do |_db|
+        break
+      end
+      described_class.use(type) do |_db|
+        # do nothing
+      end
+    end
+
+    it "does not raise when used concurrently, including `break`" do
+      threads = Array.new(8) do |i|
+        Thread.new do
+          25.times do |n|
+            described_class.use(:concurrent_test) do |db|
+              break if n.odd?
+
+              db.delete("missing-#{i}-#{n}")
+            end
+          end
+        end
+      end
+
+      expect { threads.each(&:join) }.not_to raise_error
+    end
   end
 
   describe "#set" do


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

### Summary

`Cleanup.install_clean!` runs package cleanup through `Utils.parallel_map`, so `Keg#uninstall` can call `CacheStoreDatabase.use(:linkage)` from several threads at once.

`CacheStoreDatabase.use` kept a class-level refcount and `db` handle with no lock. One thread could `delete(:db)` while another still called `write_if_dirty!`, which raises:

```
Error: undefined method 'write_if_dirty!' for nil
/opt/homebrew/Library/Homebrew/cache_store.rb:44:in 'CacheStoreDatabase.use'
/opt/homebrew/Library/Homebrew/keg.rb:325:in 'Keg#uninstall'
/opt/homebrew/Library/Homebrew/cleanup.rb:613:in 'block in Homebrew::Cleanup#cleanup_keg'
/opt/homebrew/Library/Homebrew/cleanup.rb:363:in 'block in Homebrew::Cleanup.install_clean!'
/opt/homebrew/Library/Homebrew/utils.rb:88:in 'block (2 levels) in Utils.parallel_map'
```

`Keg#uninstall` also `break`s out of the `use` block when the linkage cache file is missing. That used to skip the decrement entirely and leak the refcount.

This PR:
- serialises the refcount/`db` lifecycle with `Thread::Mutex`
- always decrements in `ensure` so `break` cannot leak the refcount
- writes the store outside the lock when the last user drops (`to_write&.write_if_dirty!`)

Content of the linkage JSON is still last-writer-wins under concurrent mutators. That matches the existing trade-off; this only stops the crash.

### Reproduce

1. Install several formulae that have old kegs eligible for cleanup (or keep previous versions around).
2. Upgrade more than one package in one command so post-install cleanup goes through `Utils.parallel_map`:

   ```bash
   brew upgrade
   ```

   The crash is easiest to hit when many formulae have old kegs; it is a race, so it does not fire every time.

3. The stack is always `install_clean!` → `cleanup_formula` → `Keg#uninstall` → `CacheStoreDatabase.use`.

The new specs cover the two mechanisms without needing a full upgrade: `break` must still `write_if_dirty!` on the next `use`, and concurrent `use` + `break` must not raise.

### Why

A successful `brew upgrade` that then dies in cleanup leaves old kegs behind and reports a Ruby bug to the user. The package install itself already finished.