### PR TITLE
Support JSON data in POST downloads

### DIFF
--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -19,6 +19,9 @@ module Cask
     sig { returns(T.nilable(T::Hash[String, String])) }
     attr_reader :cookies, :data
 
+    sig { returns(T.nilable(T::Hash[Symbol, T.anything])) }
+    attr_reader :json
+
     sig { returns(T.nilable(T::Array[String])) }
     attr_reader :header
 
@@ -59,13 +62,14 @@ module Cask
         header:          T.nilable(T.any(String, T::Array[String])),
         user_agent:      T.nilable(T.any(Symbol, String)),
         data:            T.nilable(T::Hash[String, String]),
+        json:            T.nilable(T::Hash[Symbol, T.anything]),
         only_path:       T.nilable(String),
         caller_location: Thread::Backtrace::Location,
       ).void
     }
     def initialize(
       uri, verified: nil, using: nil, tag: nil, branch: nil, revisions: nil, revision: nil, trust_cert: nil,
-      cookies: nil, referer: nil, header: nil, user_agent: nil, data: nil, only_path: nil,
+      cookies: nil, referer: nil, header: nil, user_agent: nil, data: nil, json: nil, only_path: nil,
       caller_location: caller_locations.fetch(0)
     )
       @uri = T.let(URI(uri), URI::Generic)
@@ -86,6 +90,7 @@ module Cask
       specs[:headers]    = @header     = T.let(header, T.nilable(T::Array[String]))
       specs[:user_agent] = @user_agent = T.let(user_agent || :default, T.nilable(T.any(Symbol, String)))
       specs[:data]       = @data       = T.let(data, T.nilable(T::Hash[String, String]))
+      specs[:json]       = @json       = T.let(json, T.nilable(T::Hash[Symbol, T.anything]))
       specs[:only_path]  = @only_path  = T.let(only_path, T.nilable(String))
 
       @specs = T.let(specs.compact, T::Hash[Symbol, T.untyped])

--- a/Library/Homebrew/download_strategy/curl_post_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/curl_post_download_strategy.rb
@@ -3,6 +3,7 @@
 
 # Strategy for downloading via an HTTP POST request using `curl`.
 # Query parameters on the URL are converted into POST parameters.
+# `data` hashes are form encoded and `json` hashes are JSON encoded.
 #
 # @api public
 class CurlPostDownloadStrategy < CurlDownloadStrategy
@@ -13,11 +14,16 @@ class CurlPostDownloadStrategy < CurlDownloadStrategy
             .returns(T.nilable(SystemCommand::Result))
   }
   def _fetch(url:, resolved_url:, timeout:)
+    raise ArgumentError, "Only use `data` or `json`, not both" if meta.key?(:data) && meta.key?(:json)
+
     ensure_no_insecure_redirect!(url:, resolved_url:)
 
     args = if meta.key?(:data)
       escape_data = ->(d) { ["-d", URI.encode_www_form([d])] }
       [url, *meta[:data].flat_map(&escape_data)]
+    elsif meta.key?(:json)
+      [url, "--data", JSON.generate(meta[:json]),
+       "--header", "Content-Type: application/json", "--header", "Accept: application/json"]
     else
       url, query = url.split("?", 2)
       query.nil? ? [url, "-X", "POST"] : [url, "-d", query]

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -413,6 +413,14 @@ RSpec.describe Cask::DSL, :cask, :no_api do
     it "prevents defining multiple urls" do
       expect { cask }.to raise_error(Cask::CaskInvalidError, /'url' stanza may only appear once/)
     end
+
+    it "allows JSON data for POST requests" do
+      cask = Cask::Cask.new("post-json") do
+        url "https://example.com/download", using: :post, json: { query: "a + b = c" }
+      end
+
+      expect(cask.url.specs).to include(json: { query: "a + b = c" })
+    end
   end
 
   describe "homepage stanza" do

--- a/Library/Homebrew/test/download_strategies/curl_post_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_post_spec.rb
@@ -62,6 +62,51 @@ RSpec.describe CurlPostDownloadStrategy do
       end
     end
 
+    context "with :using and :json specified" do
+      let(:specs) do
+        {
+          using: :post,
+          json:  {
+            query: "a + b = c",
+          },
+        }
+      end
+
+      before do
+        allow(strategy).to receive(:curl_version).and_return(Version.new("7.41.0"))
+      end
+
+      it "adds the appropriate curl args" do
+        expect(strategy).to receive(:system_command)
+          .with(
+            /curl/,
+            hash_including(args: array_including_cons("--data", '{"query":"a + b = c"}')
+                                 .and(array_including_cons("--header", "Content-Type: application/json"))
+                                 .and(array_including_cons("--header", "Accept: application/json"))),
+          )
+          .at_least(:once)
+          .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "", assert_success!: nil))
+
+        strategy.fetch
+      end
+    end
+
+    context "with both :data and :json specified" do
+      let(:specs) do
+        {
+          using: :post,
+          data:  { form: "data" },
+          json:  { query: "value" },
+        }
+      end
+
+      it "raises an error" do
+        allow(strategy).to receive(:curl_download)
+
+        expect { strategy.fetch }.to raise_error(ArgumentError, "Only use `data` or `json`, not both")
+      end
+    end
+
     context "with :using but no :data" do
       let(:specs) { { using: :post } }
 

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -1194,6 +1194,7 @@ When a plain URL string is insufficient to fetch a file, additional information 
 | `header:`          | string or array of strings holding the header(s) to set for the download request (Example: [pull-6545](https://github.com/Homebrew/brew/pull/6545#issue-503302353), [issue-15590](https://github.com/Homebrew/brew/issues/15590#issue-1774825542)) |
 | `user_agent:`      | string holding the user agent to set for the download request. Can also be set to the symbol `:fake`, which will use a generic browser-like user agent string. We prefer `:fake` when the server does not require a specific user agent. |
 | `data:`            | hash of parameters to be set for a POST request (Example: [segger-jlink.rb](https://github.com/Homebrew/homebrew-cask/blob/38ac55614f146d68ae317594f0c119e9acbd7c9e/Casks/s/segger-jlink.rb#L6-L11)) |
+| `json:`            | hash of parameters to be JSON encoded for a POST request |
 
 #### Difficulty finding a URL
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -805,7 +805,7 @@ Homebrew offers these anonymous download strategies.
 | `:hg`            | fetch from Mercurial repository  | `hg` installed |
 | `:homebrew_curl` | download using brewed `curl`     | `curl` installed |
 | `:nounzip`       | download without decompressing   | |
-| `:post`          | download using `curl` via POST   | `data:` [hash of parameters](Cask-Cookbook.md#additional-url-parameters) |
+| `:post`          | download using `curl` via POST   | `data:` or `json:` [hash of parameters](Cask-Cookbook.md#additional-url-parameters) |
 | `:svn`           | fetch from Subversion repository | `svn` installed |
 
 If you need more control over the way files are downloaded and staged, you can create a custom download strategy and specify it with the `:using` option:


### PR DESCRIPTION
- Serialise `json:` URL hashes with curl's `--json`
- Expose and document the option for casks and formulae

Fixes #23564

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Codex 5.6 Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----