### PR TITLE
Fix cask extract integrity

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -308,6 +308,8 @@ on_request: true)
 
     sig { params(to: Pathname).void }
     def extract_primary_container(to: @cask.staged_path)
+      download(quiet: true) if @cask.download.nil?
+
       downloader.extract_primary_container(to:, verbose: verbose?)
     end
 

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -1,6 +1,8 @@
 # typed: false
 # frozen_string_literal: true
 
+Warnings.ignore(/circular require considered harmful/) { require "install" }
+
 RSpec.describe Cask::Installer, :cask do
   def stub_dmg_extraction
     allow(UnpackStrategy::Dmg).to receive(:can_extract?).and_return(true)

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -10,6 +10,25 @@ RSpec.describe Cask::Installer, :cask do
     end
   end
 
+  describe "#extract_primary_container" do
+    it "respects the installer's download integrity setting" do
+      cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+      installer = described_class.new(cask, verify_download_integrity: false)
+      download = instance_double(Cask::Download)
+      downloaded_path = Pathname("/path/to/downloaded/cask")
+
+      allow(installer).to receive(:downloader).and_return(download)
+      expect(download).to receive(:fetch)
+        .with(quiet: true, verify_download_integrity: false, timeout: nil)
+        .and_return(downloaded_path)
+      expect(download).to receive(:extract_primary_container).with(to: cask.staged_path, verbose: false)
+
+      installer.extract_primary_container
+
+      expect(cask.download).to eq(downloaded_path)
+    end
+  end
+
   describe "#save_caskfile" do
     it "stores casks loaded from Ruby source as JSON metadata" do
       cask = Cask::CaskLoader.load(cask_path("local-caffeine"))

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -1,8 +1,7 @@
 # typed: false
 # frozen_string_literal: true
 
-Warnings.ignore(/circular require considered harmful/) { require "install" }
-
+require "cask/installer"
 RSpec.describe Cask::Installer, :cask do
   def stub_dmg_extraction
     allow(UnpackStrategy::Dmg).to receive(:can_extract?).and_return(true)


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Used Codex (GPT-5.6) to investigate and I reviewed manually

-----

`brew audit --cask --online` can fail with a SHA-256 mismatch when an `:extract_plist` livecheck uses a URL different from the cask artifact URL.

```sh
HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --cask --online speedify
```
This fails while checking the unversioned livecheck artifact:

```console
Expected: 6fddd9d517fc622e870412fb215be4891fbffb9fd25f902b071d5f6bd605c136
Actual: d05574631c810a4fc3f7fc3b68a9a3a58f4050c757e2f93d0199b178ffaa7b9d
File: ...--SpeedifyInstaller.dmg
```

The versioned cask artifact still matches its declared checksum. The mismatch occurs because the livecheck URL points to a different artifact.

## Cause

UnversionedCaskChecker creates its installer with download integrity verification disabled:

```
Cask::Installer.new(cask, verify_download_integrity: false)
```

This is necessary for :extract_plist livechecks that replace the cask URL with an unversioned livecheck URL.

After #23033 moved container extraction from Cask::Installer to Cask::Download, Cask::Installer#extract_primary_container delegated directly to the downloader without first calling Cask::Installer#download.

As a result, the downloader fetched the livecheck artifact using the default:

verify_download_integrity: true

This applied the original cask checksum to the artifact from the livecheck URL.

## Change

Download the artifact through Cask::Installer#download before delegating container extraction:

download(quiet: true) if @cask.download.nil?

This forwards the installer's configured verify_download_integrity value to Cask::Download#fetch and stores the downloaded path on the cask.

Normal cask installations continue to verify checksums. Callers such as UnversionedCaskChecker that explicitly disable integrity verification now retain that behavior during container extraction.