### PR TITLE
keg_relocate: skip running patchelf on bun binaries

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -10,8 +10,8 @@ module OS
 
       requires_ancestor { ::Keg }
 
-      sig { params(relocation: ::Keg::Relocation, skip_protodesc_cold: T::Boolean).void }
-      def relocate_dynamic_linkage(relocation, skip_protodesc_cold: false)
+      sig { params(relocation: ::Keg::Relocation, with_placeholders: T::Boolean).void }
+      def relocate_dynamic_linkage(relocation, with_placeholders: false)
         # Patching the dynamic linker of glibc breaks it.
         return if name.match? Version.formula_optionally_versioned_regex(:glibc)
 
@@ -19,22 +19,23 @@ module OS
 
         elf_files.each do |file|
           file.ensure_writable do
-            change_rpath!(file, old_prefix, new_prefix, skip_protodesc_cold:)
+            change_rpath!(file, old_prefix, new_prefix, with_placeholders:)
           end
         end
       end
 
       sig {
         params(file: ELFShim, old_prefix: T.any(String, Regexp), new_prefix: String,
-               skip_protodesc_cold: T::Boolean).returns(T::Boolean)
+               with_placeholders: T::Boolean).returns(T::Boolean)
       }
-      def change_rpath!(file, old_prefix, new_prefix, skip_protodesc_cold: false)
+      def change_rpath!(file, old_prefix, new_prefix, with_placeholders: false)
         return false if !file.elf? || !file.dynamic_elf?
 
         # Skip relocation of files with `protodesc_cold` sections because patchelf.rb seems to break them,
         # but only when bottling (as we don't want to break existing bottles that require relocation).
         # https://github.com/Homebrew/homebrew-core/pull/232490#issuecomment-3161362452
-        return false if skip_protodesc_cold && file.section_names.include?("protodesc_cold")
+        # Also skip relocation of files with `.bun` sections
+        return false if with_placeholders && file.section_names.intersect?(["protodesc_cold", ".bun"])
 
         updated = {}
         old_rpath = file.rpath

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -23,8 +23,8 @@ module OS
         end
       end
 
-      sig { params(relocation: ::Keg::Relocation, skip_protodesc_cold: T::Boolean).void }
-      def relocate_dynamic_linkage(relocation, skip_protodesc_cold: false)
+      sig { params(relocation: ::Keg::Relocation, with_placeholders: T::Boolean).void }
+      def relocate_dynamic_linkage(relocation, with_placeholders: false)
         mach_o_files.each do |file|
           file.ensure_writable do
             modified = T.let(false, T::Boolean)

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -85,8 +85,8 @@ class Keg
     end
   end
 
-  sig { params(_relocation: Relocation, skip_protodesc_cold: T::Boolean).void }
-  def relocate_dynamic_linkage(_relocation, skip_protodesc_cold: false); end
+  sig { params(_relocation: Relocation, with_placeholders: T::Boolean).void }
+  def relocate_dynamic_linkage(_relocation, with_placeholders: false); end
 
   JAVA_REGEX = %r{#{HOMEBREW_PREFIX}/opt/openjdk(@\d+(\.\d+)*)?/libexec(/openjdk\.jdk/Contents/Home)?}
 
@@ -172,7 +172,7 @@ class Keg
   sig { returns(T::Array[Pathname]) }
   def replace_locations_with_placeholders
     relocation = prepare_relocation_to_placeholders.freeze
-    relocate_dynamic_linkage(relocation, skip_protodesc_cold: true)
+    relocate_dynamic_linkage(relocation, with_placeholders: true)
     replace_text_in_files(relocation)
   end
 


### PR DESCRIPTION
The `.bun` section needs to occur at a specific location. Upstream does support relocating interpreter (at least via NixOS/patchelf) but either patchelf.rb or RUNPATH relocation results in broken binary.

Was originally going to handle with
- https://github.com/Homebrew/brew/pull/22442

As wanted to check if newer bun helped, but looks like relocation doesn't work in 1.4.0 even after
- https://github.com/oven-sh/bun/pull/31024
- https://github.com/Homebrew/homebrew-core/actions/runs/32392766548/job/96504251147?pr=299808#step:4:71

Should still be easy to check locally in future if a patchelf.rb upgrade helps by undoing this skip and running `brew install bun && brew bottle bun && brew test bun`.

Also want to get this in before `bun` dependents start propagating gzip hack.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
