### PR TITLE
Cover profiler cache key stability

### DIFF
--- a/Library/Homebrew/test/startup/bootsnap_spec.rb
+++ b/Library/Homebrew/test/startup/bootsnap_spec.rb
@@ -19,20 +19,20 @@ RSpec.describe Homebrew::Bootsnap do
   end
 
   describe "::key" do
-    it "ignores optional gems and changes when a core gem changes" do
+    it "ignores profiler gems and changes when a core gem changes" do
       gem_home = mktmpdir
       gems = gem_home/"gems"
       (gems/"sorbet-runtime-1.0").mkpath
       original_key = bootsnap_key(gem_home)
 
-      (gems/"rspec-1.0").mkpath
-      optional_gem_key = bootsnap_key(gem_home)
+      (gems/"stackprof-1.0").mkpath
+      profiler_gem_key = bootsnap_key(gem_home)
 
       (gems/"sorbet-runtime-1.0").rmdir
       (gems/"sorbet-runtime-2.0").mkpath
       core_gem_key = bootsnap_key(gem_home)
 
-      expect([optional_gem_key == original_key, core_gem_key == original_key]).to eq([true, false])
+      expect([profiler_gem_key == original_key, core_gem_key == original_key]).to eq([true, false])
     end
   end
 


### PR DESCRIPTION
- Exercise the optional-gem cache key with `stackprof`.
- Tie the regression directly to `brew prof` first-run behaviour.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI GPT 5.6 Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----