### PR TITLE
Skip warm GHCR manifest cache discovery

### DIFF
--- a/Library/Homebrew/download_strategy/curl_github_packages_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/curl_github_packages_download_strategy.rb
@@ -27,12 +27,14 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
 
   sig { override.returns(Pathname) }
   def cached_location
-    return super unless immutable_bottle_blob?
-
     cached_location = @cached_location
     return cached_location unless cached_location.nil?
+    return super if @resolved_basename.blank?
 
-    @cached_location = HOMEBREW_CACHE/"downloads/#{Digest::SHA256.hexdigest(url)}--#{Utils.safe_filename(@resolved_basename.to_s)}"
+    cached_location = HOMEBREW_CACHE/"downloads/#{Digest::SHA256.hexdigest(url)}--#{Utils.safe_filename(@resolved_basename.to_s)}"
+    return super if !immutable_bottle_blob? && (!mirrors.empty? || !cached_location.exist?)
+
+    @cached_location = cached_location
   end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
@@ -88,6 +88,52 @@ RSpec.describe CurlGitHubPackagesDownloadStrategy do
         .to eq(HOMEBREW_CACHE/"downloads/#{Digest::SHA256.hexdigest(url)}--foo--1.2.3.arm64_ventura.bottle.tar.gz")
     end
 
+    context "with an existing resolved cache location" do
+      let(:url) { "https://#{GitHubPackages::URL_DOMAIN}/v2/homebrew/core/foo/manifests/1.2.3" }
+      let(:specs) { {} }
+
+      it "uses it without discovering cache files" do
+        strategy.resolved_basename = "foo-1.2.3.bottle_manifest.json"
+        cached_location = HOMEBREW_CACHE/"downloads/#{Digest::SHA256.hexdigest(url)}--foo-1.2.3.bottle_manifest.json"
+        cached_location.dirname.mkpath
+        cached_location.write("cached")
+
+        expect(Pathname).not_to receive(:glob)
+
+        expect(strategy.cached_location).to eq(cached_location)
+      end
+
+      it "does not discover cache files for 100 cached manifests" do
+        strategies = (1..100).map do |index|
+          url = "https://#{GitHubPackages::URL_DOMAIN}/v2/homebrew/core/foo#{index}/manifests/1.2.3"
+          strategy = described_class.new(url, "foo#{index}", version, **specs)
+          strategy.resolved_basename = "foo#{index}-1.2.3.bottle_manifest.json"
+          cached_location = HOMEBREW_CACHE/"downloads/#{Digest::SHA256.hexdigest(url)}--foo#{index}-1.2.3.bottle_manifest.json"
+          cached_location.dirname.mkpath
+          cached_location.write("cached")
+          strategy
+        end
+
+        expect(Pathname).not_to receive(:glob)
+
+        strategies.each(&:cached_location)
+      end
+    end
+
+    context "with a cached download using another basename" do
+      let(:url) { "https://#{GitHubPackages::URL_DOMAIN}/v2/homebrew/core/foo/manifests/1.2.4" }
+      let(:specs) { {} }
+
+      it "uses generic cache discovery" do
+        strategy.resolved_basename = "foo-1.2.4.bottle_manifest.json"
+        cached_location = HOMEBREW_CACHE/"downloads/#{Digest::SHA256.hexdigest(url)}--server-filename.json"
+        cached_location.dirname.mkpath
+        cached_location.write("cached")
+
+        expect(strategy.cached_location).to eq(cached_location)
+      end
+    end
+
     context "with a custom cache" do
       let(:cache) { HOMEBREW_CACHE/"custom-cache" }
       let(:specs) { { bottle: true, cache: } }
@@ -107,7 +153,9 @@ RSpec.describe CurlGitHubPackagesDownloadStrategy do
       it "uses generic cache discovery" do
         strategy.resolved_basename = "foo--1.2.3.arm64_ventura.bottle.tar.gz"
 
-        expect(strategy.immutable_bottle_blob?).to be false
+        expect(Pathname).to receive(:glob).and_call_original
+
+        strategy.cached_location
       end
     end
   end


### PR DESCRIPTION
- Avoid globbing when an API-resolved manifest cache path exists.
- Retain generic discovery for mirrors and alternate filenames.

Mild performance improvement. Would use `hyperfine` to demonstrate this but just ran out of tokens so: take my word for it 😅 

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

GPT 5.6 Sol and Terra xhigh with local review and testing.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----