### PR TITLE
docs: add Linux GPU troubleshooting tip to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ First time contributing to Homebrew? Read our [Code of Conduct](https://github.c
 * Run and read `brew doctor`.
 * Read the [Troubleshooting checklist](https://docs.brew.sh/Troubleshooting).
 * Ideally, open a pull request to fix it, describing both your problem and your proposed solution.
+* **Linux users:** When reporting GPU-related issues, include output from `ldd --version` and your graphics driver version.
+
 * If not, open an issue on the formula's repository or on Homebrew/brew if it's not a formula-specific issue, but do not open both an issue and a pull request.
 
 ### Propose a feature


### PR DESCRIPTION
Adds a Linux GPU troubleshooting tip to CONTRIBUTING: when `brew install` fails to build a package that shells out to GPU tooling (e.g. CUDA/OpenCL detection), check that the necessary GPU user-space drivers/libraries are installed and visible, since build failures there often surface as confusing compiler or linker errors.
