### PR TITLE
Suppress no-op cleanup output

### DIFF
--- a/Library/Homebrew/bundle/subcommand/cleanup.rb
+++ b/Library/Homebrew/bundle/subcommand/cleanup.rb
@@ -213,7 +213,7 @@ module Homebrew
               would_uninstall = true
             end
 
-            would_cleanup = Cleanup.printed_dry_run_output?(Cleanup.dry_run_output)
+            would_cleanup = Cleanup.printed_dry_run_output?(Cleanup.dry_run_output(quiet: true))
             would_change = would_uninstall || would_cleanup
 
             # `Ask.confirm?` only prints a prompt on a TTY; when it does, don't

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -310,17 +310,17 @@ module Homebrew
       true
     end
 
-    sig { params(args: String, formulae: T::Array[Formula]).returns(String) }
-    def self.dry_run_output(*args, formulae: [])
+    sig { params(args: String, formulae: T::Array[Formula], quiet: T::Boolean).returns(String) }
+    def self.dry_run_output(*args, formulae: [], quiet: false)
       output = StringIO.new
       old_stdout = $stdout
       begin
         $stdout = output
         cleanup = Cleanup.new(*args, dry_run: true)
         if formulae.empty?
-          cleanup.clean!
+          cleanup.clean!(quiet:)
         else
-          formulae.each { |formula| cleanup.cleanup_formula(formula) }
+          formulae.each { |formula| cleanup.cleanup_formula(formula, quiet:) }
         end
       ensure
         $stdout = old_stdout
@@ -341,9 +341,13 @@ module Homebrew
     def self.install_formula_clean!(formula)
       return if install_cleanup_formulae([formula]).blank?
 
+      output = StringIO.new
+      Cleanup.new(output:).cleanup_formula(formula, quiet: true)
+      return if output.string.empty?
+
       ohai "Running `brew cleanup #{formula}`..."
       puts_no_install_cleanup_disable_message_if_not_already!
-      Cleanup.new.cleanup_formula(formula)
+      print output.string
     end
 
     sig { params(formulae: T::Array[Formula], casks: T::Array[Cask::Cask]).void }
@@ -373,6 +377,9 @@ module Homebrew
 
       Cleanup.new.cleanup_cache_db if formulae.present?
       Cleanup.new.cleanup_unreferenced_downloads
+
+      cleanup_output.reject! { |_, output| output.empty? }
+      return if cleanup_output.empty?
 
       oh1 "Cleanup"
       cleanup_output.each do |name, output|

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -27,8 +27,41 @@ RSpec.describe Homebrew::Cleanup do
     FileUtils.rm_rf HOMEBREW_LIBRARY/"Homebrew"
   end
 
+  describe "::install_formula_clean!" do
+    it "does not report a formula when nothing was cleaned" do
+      formula = Testball.new
+
+      allow(described_class).to receive(:install_cleanup_formulae).with([formula]).and_return([formula])
+      expect_any_instance_of(described_class).to receive(:cleanup_formula).with(formula, quiet: true)
+
+      with_env(HOMEBREW_NO_ENV_HINTS: "1") do
+        expect { described_class.install_formula_clean!(formula) }.not_to output.to_stdout
+      end
+    end
+
+    it "reports a formula when it was cleaned" do
+      formula = Testball.new
+      stale_path = mktmpdir/"testball--0.0"
+      stale_path.write "stale"
+
+      allow(described_class).to receive(:install_cleanup_formulae).with([formula]).and_return([formula])
+      expect_any_instance_of(described_class).to receive(:cleanup_formula)
+        .with(formula, quiet: true) do |cleanup, package, **|
+        expect(package).to be(formula)
+        cleanup.cleanup_path(stale_path) { stale_path.unlink }
+      end
+
+      with_env(HOMEBREW_NO_ENV_HINTS: "1") do
+        expect { described_class.install_formula_clean!(formula) }.to output(<<~EOS).to_stdout
+          ==> Running `brew cleanup testball`...
+          Removing: #{stale_path}... (#{stale_path.abv})
+        EOS
+      end
+    end
+  end
+
   describe "::install_clean!" do
-    it "cleans formulae and casks in parallel before reporting them", :cask do
+    it "does not report formulae and casks when nothing was cleaned", :cask do
       formula = Testball.new
       cask = Cask::Cask.new("local-caffeine")
 
@@ -42,10 +75,31 @@ RSpec.describe Homebrew::Cleanup do
       expect_any_instance_of(described_class).to receive(:cleanup_unreferenced_downloads).with(no_args)
 
       with_env(HOMEBREW_NO_ENV_HINTS: "1") do
+        expect { described_class.install_clean!(formulae: [formula], casks: [cask]) }.not_to output.to_stdout
+      end
+    end
+
+    it "only reports packages that were cleaned", :cask do
+      formula = Testball.new
+      cask = Cask::Cask.new("local-caffeine")
+      stale_path = mktmpdir/"testball--0.0"
+      stale_path.write "stale"
+
+      allow(described_class).to receive(:install_cleanup_formulae).with([formula]).and_return([formula])
+      expect_any_instance_of(described_class).to receive(:cleanup_formula) do |cleanup, package, **|
+        expect(package).to be(formula)
+        cleanup.cleanup_path(stale_path) { stale_path.unlink }
+      end
+      expect_any_instance_of(described_class).to receive(:cleanup_cask)
+        .with(cask, cleanup_unreferenced: false)
+      expect_any_instance_of(described_class).to receive(:cleanup_cache_db).with(no_args)
+      expect_any_instance_of(described_class).to receive(:cleanup_unreferenced_downloads).with(no_args)
+
+      with_env(HOMEBREW_NO_ENV_HINTS: "1") do
         expect { described_class.install_clean!(formulae: [formula], casks: [cask]) }.to output(<<~EOS).to_stdout
           ==> Cleanup
           ==> testball
-          ==> local-caffeine
+          Removing: #{stale_path}... (#{stale_path.abv})
         EOS
       end
     end

--- a/Library/Homebrew/test/cmd/bundle/cleanup_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/cleanup_subcommand_spec.rb
@@ -515,7 +515,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
     it "lists casks, formulae and taps" do
       expect(Formatter).to receive(:columns).with(%w[a b]).exactly(5).times.and_return("a b")
       expect(Kernel).not_to receive(:system)
-      expect(Homebrew::Cleanup).to receive(:dry_run_output).and_return("")
+      expect(Homebrew::Cleanup).to receive(:dry_run_output).with(quiet: true).and_return("")
       output_pattern = Regexp.new(
         "Would uninstall casks:.*Would uninstall formulae:.*Would untap:.*" \
         "Would uninstall VSCode extensions:.*Would uninstall flatpaks:",
@@ -536,7 +536,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
       expect(Kernel).to receive(:system).with(HOMEBREW_BREW_FILE, "uninstall", "--cask", "--force", "a", "b")
       expect(Kernel).to receive(:system).with(HOMEBREW_BREW_FILE, "uninstall", "--formula", "--force", "a", "b")
       expect(Kernel).to receive(:system).with(HOMEBREW_BREW_FILE, "untap", "a", "b")
-      expect(Homebrew::Cleanup).to receive(:dry_run_output).and_return("")
+      expect(Homebrew::Cleanup).to receive(:dry_run_output).with(quiet: true).and_return("")
 
       expect { described_class.cleanup(ask: true) }.not_to output(/Run .brew bundle cleanup --force/).to_stdout
     end
@@ -554,7 +554,7 @@ RSpec.describe Homebrew::Cmd::Bundle::CleanupSubcommand do
 
     define_method(:sane?) do
       expect(described_class).not_to receive(:system_output_no_stderr)
-      expect(Homebrew::Cleanup).to receive(:dry_run_output).and_return("cleaned")
+      expect(Homebrew::Cleanup).to receive(:dry_run_output).with(quiet: true).and_return("cleaned")
     end
 
     context "with --force" do


### PR DESCRIPTION
- Only report automatic cleanup headings and package names when files are actually removed, avoiding misleading no-op output.
- Quiet Bundle cleanup previews because missing latest formula versions do not affect which Brewfile entries will be removed.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex GPT 5.6 Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----