### PR TITLE
Invalidate bottle cache for local patches

### DIFF
--- a/Library/Homebrew/test/test_bot/test_formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/test_formulae_spec.rb
@@ -9,6 +9,43 @@ RSpec.describe Homebrew::TestBot::TestFormulae do
     described_class.new(tap: nil, git: nil, dry_run: false, fail_fast: false, verbose: false)
   end
 
+  describe "#artifact_cache_valid?" do
+    it "rejects a bottle when a local patch has changed" do
+      Dir.mktmpdir do |tmpdir|
+        repository = Pathname(tmpdir)
+        formula_path = repository/"foo.rb"
+        patch_path = repository/"patches/foo.diff"
+        patch_path.dirname.mkpath
+        formula_path.write "formula\n"
+        patch_path.write "old patch\n"
+        system "git", "-C", repository.to_s, "init", "--quiet"
+        system "git", "-C", repository.to_s, "add", "."
+        system "git", "-C", repository.to_s, "commit", "--quiet", "-m", "initial"
+        revision = Utils.safe_popen_read("git", "-C", repository, "rev-parse", "HEAD").chomp
+        patch_path.write "new patch\n"
+
+        f = formula("foo", path: formula_path) do
+          T.bind(self, T.class_of(Formula))
+          url "foo-1.0"
+          patch do
+            file "patches/foo.diff"
+          end
+        end
+        test_formulae = Class.new(described_class) do
+          T.bind(self, T.class_of(Homebrew::TestBot::TestFormulae))
+          public :artifact_cache_valid?
+        end.new(
+          tap: instance_double(Tap, path: repository), git: "git", dry_run: true, fail_fast: false, verbose: false,
+        )
+        allow(test_formulae).to receive(:local_bottle_hash).and_return(
+          "foo" => { "formula" => { "tap_git_revision" => revision } },
+        )
+
+        expect(test_formulae.artifact_cache_valid?(f)).to be(false)
+      end
+    end
+  end
+
   describe "#download_artifacts_from_previous_run!" do
     it "does not raise KeyError when accessing downloaded_artifacts for a new SHA" do
       # Regression test: @downloaded_artifacts uses a hash with a default block, so we must use

--- a/Library/Homebrew/test_bot/test_formulae.rb
+++ b/Library/Homebrew/test_bot/test_formulae.rb
@@ -233,9 +233,10 @@ module Homebrew
           @fetched_refs << git_ref if steps.fetch(-1).passed?
         end
 
-        relative_formula_path = formula.path.relative_path_from(repository)
+        relative_paths = [formula.path.relative_path_from(repository).to_s]
+        relative_paths.concat(formula.patchlist.grep(LocalPatch).map { |patch| patch.file.to_s })
         !!system(git.to_s, "-C", repository.to_s, "diff", "--no-ext-diff", "--quiet", git_ref, "--",
-                 relative_formula_path.to_s)
+                 *relative_paths)
       end
 
       sig { params(formula: String, bottle_dir: Pathname).returns(T.nilable(T::Hash[String, T.untyped])) }


### PR DESCRIPTION
- Include local patch paths when checking formula changes.
- Prevent stale bottles when a patch changes without its formula.
- Cover the cache decision with a regression test.

Fixes https://github.com/Homebrew/brew/issues/23588

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 Sol xhigh with local review and (unit) testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----