### PR TITLE
Handle unknown user in trust file

### DIFF
--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -213,6 +213,15 @@ RSpec.describe Homebrew::Trust, :trust_store do
     end
   end
 
+  it "falls back to the current home when USER cannot be looked up" do
+    home = Pathname(TEST_TMPDIR)/"home"
+
+    with_env(USER: "nonexistent_user_zzz", HOME: home, HOMEBREW_USER_CONFIG_HOME: home/".homebrew") do
+      expect { expect(described_class.trust_file).to eq(home/".homebrew/trust.json") }
+        .to output(/Could not determine home directory for `\$USER` \(nonexistent_user_zzz\)/).to_stderr
+    end
+  end
+
   it "trusts a GitHub SSH-remote tap by its name" do
     tap = Tap.fetch("thirdparty", "foo")
     tap.path.mkpath

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -23,10 +23,19 @@ module Homebrew
     }.freeze, T::Hash[Symbol, Symbol])
     private_constant :SETTING_KEYS
 
-    sig { params(home: T.any(String, Pathname)).returns(Pathname) }
-    def self.trust_file(home: Dir.home(ENV.fetch("USER")))
+    sig { params(home: T.nilable(T.any(String, Pathname))).returns(Pathname) }
+    def self.trust_file(home: nil)
+      user = ENV.fetch("USER")
+      user_home = Pathname.new begin
+        Dir.home(user)
+      rescue ArgumentError
+        fallback_home = Dir.home
+        opoo "Could not determine home directory for `$USER` (#{user}); falling back to #{fallback_home}."
+        fallback_home
+      end
+      home ||= user_home
       user_config_home = Pathname.new(ENV.fetch("HOMEBREW_USER_CONFIG_HOME"))
-      if user_config_home == Pathname.new(Dir.home(ENV.fetch("USER")))/".homebrew"
+      if user_config_home == user_home/".homebrew"
         Pathname.new(home.to_s)/".homebrew/trust.json"
       else
         user_config_home/"trust.json"


### PR DESCRIPTION
An unresolvable `$USER` made `Dir.home` abort every command that read the tap trust store.

- Warn and fall back to the current home resolution.
- Cover a stale `$USER` with a regression test.

Fixes #23592

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 Sol medium with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----