### PR TITLE
Handle empty API Cask flight blocks

### DIFF
--- a/Library/Homebrew/api/cask_struct.rb
+++ b/Library/Homebrew/api/cask_struct.rb
@@ -30,7 +30,7 @@ module Homebrew
         :homepage,
       ].freeze
 
-      EMPTY_BLOCK = T.let(-> {}.freeze, T.proc.void)
+      EMPTY_BLOCK = T.let(proc {}.freeze, T.proc.void)
       EMPTY_BLOCK_PLACEHOLDER = :empty_block
 
       ArtifactArgs = T.type_alias do
@@ -178,7 +178,7 @@ module Homebrew
       def serialize_artifact_args(artifact)
         key, args, kwargs, block = artifact
 
-        # We can't serialize Procs, so always use an empty block placeholder to be deserialized as `-> {}`.
+        # We can't serialize Procs, so always use an empty block placeholder to be deserialized as `proc {}`.
         block = EMPTY_BLOCK_PLACEHOLDER unless block.nil?
 
         [key, args, kwargs, block]

--- a/Library/Homebrew/test/cask/artifact/postflight_block_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/postflight_block_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe Cask::Artifact::PostflightBlock, :cask do
   end
 
   describe "uninstall_phase" do
+    it "accepts an empty block loaded from the API" do
+      cask = Cask::Cask.new("with-uninstall-postflight")
+      artifact = described_class.new(cask, uninstall_postflight: Homebrew::API::CaskStruct::EMPTY_BLOCK)
+
+      expect { artifact.uninstall_phase(command: NeverSudoSystemCommand, force: false) }.not_to raise_error
+    end
+
     it "calls the specified block after uninstalling, passing a Cask mini-dsl" do
       called = T.let(false, T::Boolean)
       yielded_arg = T.let(nil, T.nilable(Cask::DSL::UninstallPostflight))


### PR DESCRIPTION
- Make the `EMPTY_BLOCK` placeholder match Cask DSL block semantics.
- Cover API-loaded uninstall postflight block execution.

Fixes #23599

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

GPT 5.6 Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----