### PR TITLE
dev-cmd/extract: write local patches

### DIFF
--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -143,7 +143,7 @@ module Homebrew
         path.write result
 
         patches = formula.patchlist + formula.resources.flat_map(&:patches)
-        patches.grep(LocalPatch).map { |patch| patch.file.to_s }.uniq.each do |patch_file|
+        patches.grep(LocalPatch).map { |patch| Pathname(patch.file).cleanpath }.uniq.each do |patch_file|
           patch_contents = Utils::Git.file_at_commit(repo, patch_file, rev)
           odie "Could not find #{patch_file} at revision #{rev}!" if patch_contents.blank?
 

--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -60,11 +60,11 @@ module Homebrew
         end
 
         rev = T.let(nil, T.nilable(String))
+        test_formula = T.let(nil, T.nilable(Formula))
         if args.version
           ohai "Searching repository history"
           version = args.version
           version_segments = Gem::Version.new(version).segments if Gem::Version.correct?(version)
-          test_formula = T.let(nil, T.nilable(Formula))
           result = ""
           loop do
             rev = rev.nil? ? start_rev : "#{rev}~1"
@@ -115,12 +115,14 @@ module Homebrew
             rev, (path,) = Utils::Git.last_revision_commit_of_files(repo, pattern, before_commit: start_rev)
             odie "Could not find #{name}! The formula or version may not have existed." if rev.nil?
             file = repo/T.must(path)
-            version = T.must(formula_at_revision(repo, name, file, rev)).version
+            test_formula = T.must(formula_at_revision(repo, name, file, rev))
+            version = test_formula.version
             result = Utils::Git.last_revision_of_file(repo, file)
           else
             file = files.fetch(0).realpath
-            rev = T.let("HEAD", T.nilable(String))
-            version = Formulary.factory(file).version
+            rev = "HEAD"
+            test_formula = Formulary.factory(file)
+            version = test_formula.version
             result = File.read(file)
           end
         end
@@ -157,6 +159,26 @@ module Homebrew
         ohai "Writing formula for #{name} at #{version} from revision #{rev} to:", path
         path.dirname.mkpath
         path.write result
+
+        patches = test_formula.patchlist + test_formula.resources.flat_map(&:patches)
+        patches.grep(LocalPatch).map { |patch| patch.file.to_s }.uniq.each do |patch_file|
+          patch_contents = Utils::Git.file_at_commit(repo, patch_file, rev)
+          odie "Could not find #{patch_file} at revision #{rev}!" if patch_contents.blank?
+
+          patch_path = destination_tap.path/patch_file
+          if patch_path.exist?
+            odie <<~EOS unless args.force?
+              Destination patch already exists: #{patch_path}
+              To overwrite it and continue anyways, run:
+                brew extract --force --version=#{version} #{name} #{destination_tap.name}
+            EOS
+            odebug "Overwriting existing patch at #{patch_path}"
+            patch_path.delete
+          end
+          ohai "Writing #{patch_file} from revision #{rev} to:", patch_path
+          patch_path.dirname.mkpath
+          patch_path.write patch_contents
+        end
       end
 
       private

--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -60,10 +60,10 @@ module Homebrew
         end
 
         rev = T.let(nil, T.nilable(String))
-        test_formula = T.let(nil, T.nilable(Formula))
+        formula = T.let(nil, T.nilable(Formula))
+        version = args.version
+        ohai "Searching repository history"
         if args.version
-          ohai "Searching repository history"
-          version = args.version
           version_segments = Gem::Version.new(version).segments if Gem::Version.correct?(version)
           result = ""
           loop do
@@ -75,57 +75,39 @@ module Homebrew
                 Try again after running:
                   git -C "#{source_tap.path}" fetch --unshallow
               EOS
-            elsif rev.nil?
+            elsif rev.nil? || path.nil?
               odie "Could not find #{name}! The formula or version may not have existed."
             end
 
-            file = repo/T.must(path)
+            file = repo/path
             result = Utils::Git.last_revision_of_file(repo, file, before_commit: rev)
             if result.empty?
               odebug "Skipping revision #{rev} - file is empty at this revision"
               next
             end
 
-            test_formula = formula_at_revision(repo, name, file, rev)
-            break if test_formula.nil? || test_formula.version == version
+            formula = formula_at_revision(repo, name, file, rev)
+            break if formula.nil? || formula.version == version
 
-            if version_segments && Gem::Version.correct?(test_formula.version)
-              test_formula_version_segments = Gem::Version.new(test_formula.version).segments
+            if version_segments && Gem::Version.correct?(formula.version)
+              test_formula_version_segments = Gem::Version.new(formula.version).segments
               if version_segments.length < test_formula_version_segments.length
                 odebug "Apply semantic versioning with #{test_formula_version_segments}"
                 break if version_segments == test_formula_version_segments.first(version_segments.length)
               end
             end
 
-            odebug "Trying #{test_formula.version} from revision #{rev} against desired #{version}"
+            odebug "Trying #{formula.version} from revision #{rev} against desired #{version}"
           end
-          odie "Could not find #{name}! The formula or version may not have existed." if test_formula.nil?
         else
-          # Search in the root directory of `repository` as well as recursively in all of its subdirectories.
-          files = if start_rev == "HEAD"
-            Dir[repo/"{,**/}"].filter_map do |dir|
-              Pathname.glob("#{dir}/#{name}.rb").find(&:file?)
-            end
-          else
-            []
-          end
-
-          if files.empty?
-            ohai "Searching repository history"
-            rev, (path,) = Utils::Git.last_revision_commit_of_files(repo, pattern, before_commit: start_rev)
-            odie "Could not find #{name}! The formula or version may not have existed." if rev.nil?
-            file = repo/T.must(path)
-            test_formula = T.must(formula_at_revision(repo, name, file, rev))
-            version = test_formula.version
-            result = Utils::Git.last_revision_of_file(repo, file)
-          else
-            file = files.fetch(0).realpath
-            rev = "HEAD"
-            test_formula = Formulary.factory(file)
-            version = test_formula.version
-            result = File.read(file)
-          end
+          rev, (path,) = Utils::Git.last_revision_commit_of_files(repo, pattern, before_commit: start_rev)
+          odie "Could not find #{name}! The formula or version may not have existed." if rev.nil? || path.nil?
+          file = repo/path
+          formula = formula_at_revision(repo, name, file, rev)
+          result = Utils::Git.file_at_commit(repo, file, rev)
         end
+        odie "Could not find #{name}! The formula or version may not have existed." if formula.nil?
+        version ||= formula.version
 
         # The class name has to be renamed to match the new filename,
         # e.g. Foo version 1.2.3 becomes FooAT123 and resides in Foo@1.2.3.rb.
@@ -160,13 +142,15 @@ module Homebrew
         path.dirname.mkpath
         path.write result
 
-        patches = test_formula.patchlist + test_formula.resources.flat_map(&:patches)
+        patches = formula.patchlist + formula.resources.flat_map(&:patches)
         patches.grep(LocalPatch).map { |patch| patch.file.to_s }.uniq.each do |patch_file|
           patch_contents = Utils::Git.file_at_commit(repo, patch_file, rev)
           odie "Could not find #{patch_file} at revision #{rev}!" if patch_contents.blank?
 
           patch_path = destination_tap.path/patch_file
           if patch_path.exist?
+            next if patch_path.read == patch_contents
+
             odie <<~EOS unless args.force?
               Destination patch already exists: #{patch_path}
               To overwrite it and continue anyways, run:

--- a/Library/Homebrew/test/dev-cmd/extract_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/extract_spec.rb
@@ -26,8 +26,12 @@ RSpec.describe Homebrew::DevCmd::Extract do
               cellar :any
             end
 
+            patch do
+              file "noop-a.diff"
+            end
           end
         RUBY
+        FileUtils.cp patch_fixture("noop-a"), "noop-a.diff"
         system "git", "add", "--all"
         system "git", "commit", "-m", "testball 0.1"
         # Replace with a valid formula for the next version
@@ -36,6 +40,7 @@ RSpec.describe Homebrew::DevCmd::Extract do
             url "https://brew.sh/testball-0.2.tar.gz"
           end
         RUBY
+        FileUtils.rm "noop-a.diff"
         system "git", "add", "--all"
         system "git", "commit", "-m", "testball 0.2"
       end
@@ -50,6 +55,7 @@ RSpec.describe Homebrew::DevCmd::Extract do
         .and be_a_success
       expect(path).to exist
       expect(Formulary.factory(path).version).to eq "0.2"
+      expect(target[:path]/"noop-a.diff").not_to exist
     end
 
     it "retrieves the specified version of formula" do
@@ -58,6 +64,7 @@ RSpec.describe Homebrew::DevCmd::Extract do
         .to output(/^#{path}$/).to_stdout
       expect(path).to exist
       expect(Formulary.factory(path).version).to eq "0.1"
+      expect(target[:path]/"noop-a.diff").to exist
     end
 
     it "retrieves the compatible version of formula" do
@@ -66,6 +73,7 @@ RSpec.describe Homebrew::DevCmd::Extract do
         .to output(/^#{path}$/).to_stdout
       expect(path).to exist
       expect(Formulary.factory(path).version).to eq "0.2"
+      expect(target[:path]/"noop-a.diff").not_to exist
     end
   end
 end


### PR DESCRIPTION
An issue with `brew version-install` was mentioned in user report for https://github.com/Homebrew/homebrew-core/issues/298578#issue-5138826749

> ==> Patching passlib
> Error: An exception occurred within a child process:
> ArgumentError: Patch file does not exist: Patches/ansible/passlib-1.7.4.patch

Which is due to local patch feature as the tap extracted formula will expect the patch file within user's tap.

Can reproduce same behavior with `brew version-install ansible@14.2.0` prior to PR.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
