### PR TITLE
cask/upgrade: don't read quarantine metadata when quarantine is unavailable

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -427,21 +427,27 @@ module Cask
 
         new_cask_installer.fetch
 
-        old_cask.artifacts.grep(Artifact::App).each do |artifact|
-          user_approved = if artifact.target.exist?
-            Quarantine.user_approved?(artifact.target)
-          else
-            false
+        # This snapshot reads quarantine metadata, so it needs the same guard as the code below that uses it.
+        if Quarantine.available?
+          old_cask.artifacts.grep(Artifact::App).each do |artifact|
+            user_approved = if artifact.target.exist?
+              Quarantine.user_approved?(artifact.target)
+            else
+              false
+            end
+            old_user_approved[artifact.target.to_s] = user_approved
+            # Only an already approved app has approvals to pass on, so skip the scan otherwise.
+            if user_approved
+              old_approved_paths[artifact.target.to_s] =
+                Quarantine.user_approved_paths(artifact.target)
+            end
+            old_unquarantined[artifact.target.to_s] = if artifact.target.exist?
+              Quarantine.detect(artifact.target).blank?
+            else
+              false
+            end
+            old_signing_identities[artifact.target.to_s] = Quarantine.signing_identity(artifact.target)
           end
-          old_user_approved[artifact.target.to_s] = user_approved
-          # Only an already approved app has approvals to pass on, so skip the scan otherwise.
-          old_approved_paths[artifact.target.to_s] = Quarantine.user_approved_paths(artifact.target) if user_approved
-          old_unquarantined[artifact.target.to_s] = if artifact.target.exist?
-            Quarantine.detect(artifact.target).blank?
-          else
-            false
-          end
-          old_signing_identities[artifact.target.to_s] = Quarantine.signing_identity(artifact.target)
         end
 
         # Move the old cask's artifacts back to staging

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -768,6 +768,20 @@ RSpec.describe Cask::Upgrade, :cask do
     end
   end
 
+  context "when quarantine support is unavailable" do
+    before do
+      Cask::Installer.new(Cask::CaskLoader.load(cask_path("outdated/local-caffeine"))).install
+    end
+
+    it "upgrades without reading quarantine metadata" do
+      allow(Cask::Quarantine).to receive(:available?).and_return(false)
+      expect(Cask::Quarantine).not_to receive(:detect)
+
+      expect { described_class.upgrade_casks!(local_caffeine, args:) }
+        .to change(local_caffeine, :installed_version).from("1.2.2").to("1.2.3")
+    end
+  end
+
   context "when upgrading after a forced upgrade without a cask receipt" do
     before do
       InstallHelper.stub_cask_installation(Cask::CaskLoader.load(cask_path("outdated/local-caffeine")))


### PR DESCRIPTION
`Cask::Upgrade` snapshots each app's quarantine state before swapping in the new version. One of the calls it makes, `Quarantine.detect`, raises `unexpected nil xattr` when there is no `xattr` binary to run, which is the normal state on Linux. Everything the snapshot collects is used only inside the `Quarantine.available?` branch below it, so the snapshot can carry the same guard.

I introduced this in #23556, which added the `Quarantine.detect` call without the guard its neighbours in that block already have: `user_approved?` and `user_approved_paths` both return early when there is no `xattr`, and `signing_identity` is a stub off macOS, so `detect` is the only one of the four that raises.

Homebrew's own CI cannot catch this. The `Homebrew Cask` shared context is declared `:needs_macos`, and `shared_context_metadata_behavior` is `:apply_to_host_groups`, so every `:cask` spec inherits that tag and is skipped on Linux. That is also why the same class of bug in `brew audit` (#23226, fixed in #23229) surfaced in homebrew-cask's CI rather than here. It is why the test below simulates an unsupported system instead of being tagged `:needs_linux`, which would skip on every platform.

To reproduce, on Linux or anywhere else with no `xattr` on the path, with an outdated cask that installs an app:

```
brew upgrade --cask <token>
Error: <token>: unexpected nil xattr
```

I have not seen this reported, and I would expect very few people to reach it, since it needs a cask actually installed on Linux. #23226 was the same defect in `brew audit`, which Linux does reach routinely because homebrew-cask audits every cask on Linux CI. This is the upgrade-path sibling of that bug, so it is worth closing even though the path is quieter.

<details>
<summary>Details</summary>

> **How was this demonstrated?** I have no Linux box to hand, so I reproduced the condition on macOS by making `Quarantine.xattr` return `nil`, which is exactly what `DevelopmentTools.locate("xattr")` returns when the binary is absent. `Quarantine.detect` then raises, and an otherwise passing upgrade spec fails with the cask left at its old version. The new spec was verified red before the change and green after.
>
> **Why guard the whole snapshot rather than the one call?** Guarding only `detect` would fix the crash, but the block as a whole exists to read quarantine metadata and its output is consumed only when quarantine is available, so the condition belongs to the block. It also keeps the next probe added there from reintroducing the same bug.
>
> **What does the test assert?** That an upgrade completes without `Quarantine.detect` being called when `Quarantine.available?` is false. This mirrors the regression test added in #23229 for the audit path.

</details>

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Used Claude Code (Fable 5) to investigate and draft; I directed the investigation, and reviewed the diff and every line of this PR text.

-----
