### PR TITLE
advisory-match: add --new-history to skip reviewed records

### DIFF
--- a/Library/Homebrew/dev-cmd/advisory-match.rb
+++ b/Library/Homebrew/dev-cmd/advisory-match.rb
@@ -34,10 +34,15 @@ module Homebrew
         switch "--no-history",
                description: "Skip the `FormulaVersions` walk for the `fixed` " \
                             "boundary; use the current `pkg_version` instead."
+        switch "--new-history",
+               depends_on:  "--output=",
+               description: "Walk `FormulaVersions` only for records whose " \
+                            "reviewed ranges are not already in <directory>."
         conflicts "--all", "--index"
         conflicts "--all", "--json"
         conflicts "--index", "--json"
         conflicts "--index", "--output"
+        conflicts "--no-history", "--new-history"
 
         named_args [:formula]
 
@@ -64,7 +69,11 @@ module Homebrew
                   status, = matcher.range_status(hit)
                   next if status&.state == :not_applicable
 
-                  first_fixed = matcher.first_fixed_version(formula, hit) unless args.no_history?
+                  record_id = matcher.record_id(formula, hit)
+                  walk_history = !args.no_history? && status&.fixed?
+                  walk_history &&= emitter.history_required?(record_id) if args.new_history?
+                  emitter.record_history_walk if walk_history
+                  first_fixed = matcher.first_fixed_version(formula, hit) if walk_history
                   next if first_fixed == :never_affected
 
                   boundary = first_fixed if first_fixed.is_a?(String)
@@ -142,6 +151,12 @@ module Homebrew
       # `--output` and text mode write per-record and only accumulate counts;
       # `--json` accumulates the array (single-formula / PR-bot use, so bounded).
       class Emitter
+        sig { params(_record_id: String).returns(T::Boolean) }
+        def history_required?(_record_id) = true
+
+        sig { void }
+        def record_history_walk; end
+
         sig { params(record: T::Hash[Symbol, T.untyped]).void }
         def <<(record); end
 
@@ -159,11 +174,12 @@ module Homebrew
           @written = T.let(0, Integer)
           @unchanged = T.let(0, Integer)
           @skipped_generated = T.let(0, Integer)
+          @history_walks = T.let(0, Integer)
         end
 
         sig { override.params(record: T::Hash[Symbol, T.untyped]).void }
         def <<(record)
-          path = File.join(@dir, "#{record.fetch(:id)}.json")
+          path = record_path(record.fetch(:id))
           # A record already emitted by `generate-vulns-advisories` (a formula
           # `resolves` patch annotation) is more authoritative than a matched
           # candidate; overwriting it would drop `fix: "patch"` for a derived
@@ -182,6 +198,35 @@ module Homebrew
           @written += 1
         end
 
+        sig { override.params(record_id: String).returns(T::Boolean) }
+        def history_required?(record_id)
+          path = record_path(record_id)
+          return true unless File.file?(path)
+
+          existing = JSON.parse(File.read(path))
+          return true unless existing.is_a?(Hash)
+          return false if existing.dig("database_specific", "source") == "generated"
+
+          affected = existing["affected"]
+          return true unless affected.is_a?(Array)
+          return true if affected.empty?
+
+          affected.any? { |entry| !entry.is_a?(Hash) || !entry["ranges"] }
+        rescue JSON::ParserError
+          true
+        end
+
+        sig { override.void }
+        def record_history_walk
+          @history_walks += 1
+          puts "  #{@history_walks} history walks" if @verbose && (@history_walks % 100).zero?
+        end
+
+        sig { params(record_id: String).returns(String) }
+        def record_path(record_id)
+          File.join(@dir, "#{record_id}.json")
+        end
+
         sig { params(path: String).returns(T.nilable(String)) }
         def existing_source(path)
           JSON.parse(File.read(path)).dig("database_specific", "source")
@@ -192,7 +237,8 @@ module Homebrew
         sig { override.void }
         def finish
           Utils::Output.ohai "#{@written} records written to #{@dir} " \
-                             "(#{@unchanged} unchanged, #{@skipped_generated} generated left as-is)"
+                             "(#{@unchanged} unchanged, #{@skipped_generated} generated left as-is, " \
+                             "#{@history_walks} history walks)"
         end
       end
 

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/advisory_match.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/advisory_match.rbi
@@ -21,6 +21,9 @@ class Homebrew::DevCmd::AdvisoryMatch::Args < Homebrew::CLI::Args
   def json?; end
 
   sig { returns(T::Boolean) }
+  def new_history?; end
+
+  sig { returns(T::Boolean) }
   def no_history?; end
 
   sig { returns(T.nilable(String)) }

--- a/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
@@ -66,6 +66,110 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
     end
   end
 
+  it "only walks history for records not already present with --new-history" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      record = {
+        "schema_version"    => Homebrew::Vulns::OsvExport::SCHEMA_VERSION,
+        "id"                => "BREW-requests-CVE-2024-1234",
+        "modified"          => "2026-01-01T00:00:00Z",
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+            { "introduced" => "0" }, { "fixed" => "2.28.1" }
+          ] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }
+      File.write(path, JSON.generate(record))
+
+      matcher = Homebrew::Vulns::Match.new
+      allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+      expect(matcher).not_to receive(:first_fixed_version)
+
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
+        .to output(/0 history walks/).to_stdout
+      expect(JSON.parse(File.read(path)).dig("affected", 0, "ranges", 0, "events", 1))
+        .to eq("fixed" => "2.28.1")
+    end
+  end
+
+  it "uses the historical boundary for a new record with --new-history" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).to receive(:first_fixed_version).and_return("2.28.1")
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
+        .to output(/1 history walks/).to_stdout
+      path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      expect(JSON.parse(File.read(path)).dig("affected", 0, "ranges", 0, "events", 1))
+        .to eq("fixed" => "2.28.1")
+    end
+  end
+
+  it "walks history when an existing matched record has no ranges" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).to receive(:first_fixed_version).and_return("2.28.1")
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      File.write(path, JSON.generate({
+        "id"                => "BREW-requests-CVE-2024-1234",
+        "affected"          => [{ "package" => { "ecosystem" => "Homebrew", "name" => "requests" } }],
+        "database_specific" => { "source" => "matched" },
+      }))
+
+      cmd_for("requests", "--output", dir, "--new-history").run
+      expect(JSON.parse(File.read(path)).dig("affected", 0, "ranges", 0, "events", 1))
+        .to eq("fixed" => "2.28.1")
+    end
+  end
+
+  it "walks history when an existing record is malformed" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).to receive(:first_fixed_version).and_return("2.28.1")
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      File.write(path, "{")
+
+      cmd_for("requests", "--output", dir, "--new-history").run
+      expect(JSON.parse(File.read(path)).dig("affected", 0, "ranges", 0, "events", 1))
+        .to eq("fixed" => "2.28.1")
+    end
+  end
+
+  it "does not walk history for a new record with --no-history" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).not_to receive(:first_fixed_version)
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      cmd_for("requests", "--output", dir, "--no-history").run
+    end
+  end
+
+  it "does not count a history walk for a new record that is still affected" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.32.0")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).not_to receive(:first_fixed_version)
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
+        .to output(/0 history walks/).to_stdout
+    end
+  end
+
   it "drops :not_applicable hits instead of emitting them as open ranges" do
     allow(Homebrew::Vulns::OSV).to receive(:query_batch).and_return([[{ "id" => "CVE-2024-1234" }], []])
     allow(Homebrew::Vulns::OSV).to receive(:vulnerability).with("CVE-2024-1234").and_return(
@@ -88,7 +192,11 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
                                        "database_specific" => { "source" => "generated" },
                                        "affected"          => [{ "ecosystem_specific" => { "fix" => "patch" } }] }))
 
-      expect { cmd_for("requests", "--output", dir, "--no-history").run }
+      matcher = Homebrew::Vulns::Match.new
+      expect(matcher).not_to receive(:first_fixed_version)
+      allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
         .to output(/0 records written.*1 generated left as-is/).to_stdout
       expect(JSON.parse(File.read(path)).dig("affected", 0, "ecosystem_specific", "fix")).to eq "patch"
     end
@@ -158,6 +266,16 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
 
   it "rejects --all with --json" do
     expect { described_class.new(["--all", "--json"]) }.to raise_error(UsageError, /mutually exclusive/)
+  end
+
+  it "requires --output with --new-history" do
+    expect { described_class.new(["requests", "--new-history"]) }
+      .to raise_error(UsageError, /--new-history.*--output/)
+  end
+
+  it "rejects --new-history with --no-history" do
+    expect { described_class.new(["requests", "--output", "out", "--new-history", "--no-history"]) }
+      .to raise_error(UsageError, /mutually exclusive/)
   end
 
   it "emits the formula-identity index with --index" do

--- a/Library/Homebrew/test/vulns/match_spec.rb
+++ b/Library/Homebrew/test/vulns/match_spec.rb
@@ -562,6 +562,8 @@ RSpec.describe Homebrew::Vulns::Match do
       record = matcher.to_brew_record(requests, hit, now:)
 
       expect(record[:id]).to eq "BREW-requests-CVE-2024-1234"
+      expect(matcher.record_id(requests, hit))
+        .to eq Homebrew::Vulns::OsvExport.record_for(requests, "CVE-2024-1234", now:)[:id]
       expect(record[:upstream]).to eq ["CVE-2024-1234", "GHSA-abcd"]
       expect(record[:severity]).to eq [{ "type" => "CVSS_V3", "score" => "..." }]
       expect(record[:references]).to eq [{ "type" => "ADVISORY", "url" => "https://x" }]

--- a/Library/Homebrew/vulns/match.rb
+++ b/Library/Homebrew/vulns/match.rb
@@ -497,7 +497,7 @@ module Homebrew
 
         record = T.let({
           schema_version:    OsvExport::SCHEMA_VERSION,
-          id:                "#{OsvExport::ID_PREFIX}-#{formula.name}-#{hit.canonical_id}",
+          id:                record_id(formula, hit),
           published:         timestamp,
           modified:          timestamp,
           upstream:          vuln.identifiers,
@@ -518,6 +518,11 @@ module Homebrew
         end
 
         record
+      end
+
+      sig { params(formula: Formula, hit: Hit).returns(String) }
+      def record_id(formula, hit)
+        OsvExport.record_id(formula, hit.canonical_id)
       end
 
       sig {

--- a/Library/Homebrew/vulns/osv_export.rb
+++ b/Library/Homebrew/vulns/osv_export.rb
@@ -59,7 +59,7 @@ module Homebrew
         annotated.each do |formula, patches|
           Scanner.resolved_ids(patches).each do |vuln_id|
             upstream = upstream_cache.fetch(vuln_id) { upstream_cache[vuln_id] = fetch_upstream(vuln_id) }
-            path = File.join(dir, "#{ID_PREFIX}-#{formula.name}-#{vuln_id}.json")
+            path = File.join(dir, "#{record_id(formula, vuln_id)}.json")
             existing = File.file?(path)
             # A transient OSV outage would otherwise strip summary/severity/etc.
             # from an existing enriched record; leave it untouched instead.
@@ -123,7 +123,7 @@ module Homebrew
         timestamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
         record = T.let({
           schema_version:    SCHEMA_VERSION,
-          id:                "#{ID_PREFIX}-#{formula.name}-#{vuln_id}",
+          id:                record_id(formula, vuln_id),
           published:         timestamp,
           modified:          timestamp,
           upstream:          [vuln_id],
@@ -148,6 +148,11 @@ module Homebrew
         end
 
         record
+      end
+
+      sig { params(formula: Formula, vuln_id: String).returns(String) }
+      def self.record_id(formula, vuln_id)
+        "#{ID_PREFIX}-#{formula.name}-#{vuln_id}"
       end
 
       sig {

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -344,6 +344,7 @@ _brew_advisory_match() {
       --help
       --index
       --json
+      --new-history
       --no-history
       --output
       --quiet

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -339,6 +339,7 @@ __fish_brew_complete_arg 'advisory-match' -l debug -d 'Display any debugging inf
 __fish_brew_complete_arg 'advisory-match' -l help -d 'Show this message'
 __fish_brew_complete_arg 'advisory-match' -l index -d 'Emit the formula-identity index as JSON and exit'
 __fish_brew_complete_arg 'advisory-match' -l json -d 'Output candidate records as a JSON array'
+__fish_brew_complete_arg 'advisory-match' -l new-history -d 'Walk `FormulaVersions` only for records whose reviewed ranges are not already in directory'
 __fish_brew_complete_arg 'advisory-match' -l no-history -d 'Skip the `FormulaVersions` walk for the `fixed` boundary; use the current `pkg_version` instead'
 __fish_brew_complete_arg 'advisory-match' -l output -d 'Write each record to directory as `BREW-formula-id.json`, preserving existing `published`/`ranges` fields'
 __fish_brew_complete_arg 'advisory-match' -l quiet -d 'Make some output more quiet'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -442,7 +442,8 @@ _brew_advisory_match() {
     '--help[Show this message]' \
     '(--all --json --output)--index[Emit the formula-identity index as JSON and exit]' \
     '(--all --index)--json[Output candidate records as a JSON array]' \
-    '--no-history[Skip the `FormulaVersions` walk for the `fixed` boundary; use the current `pkg_version` instead]' \
+    '(--no-history)--new-history[Walk `FormulaVersions` only for records whose reviewed ranges are not already in directory]' \
+    '(--new-history)--no-history[Skip the `FormulaVersions` walk for the `fixed` boundary; use the current `pkg_version` instead]' \
     '(--index)--output[Write each record to directory as `BREW-formula-id.json`, preserving existing `published`/`ranges` fields]' \
     '--quiet[Make some output more quiet]' \
     '--repology[Load the formula to distro-package index from file instead of the published `data/repology.json`]' \


### PR DESCRIPTION
`brew advisory-match --output` walks homebrew-core history via `FormulaVersions` for every `:fixed` hit to find the version Homebrew first shipped a fix at. For a record already on disk that walk is wasted: `OsvExport.merge_existing` carries the existing `affected[].ranges` forward on rewrite, discarding the boundary just computed. Doing it across all of homebrew-core is what pushed Homebrew/advisory-database's Ingest onto `--no-history`, which then leaves genuinely new candidates with a `fixed` of the current `pkg_version` for reviewers to correct by hand.

`--new-history` walks only where the result can survive that merge: no record on disk, or one whose ranges `merge_existing` cannot carry forward because the file does not parse or an `affected` entry has no `ranges`. Eligibility is deliberately the same predicate `merge_existing` applies. A `source: generated` record is never rewritten, so it never walks, and the emitter reports the resulting walk count. `--no-history` is unchanged and stays an explicit escape hatch; `--json` and text mode keep their existing behavior.

Verified against live OSV over `bbot` and `summarize`: 5 history walks against 104 records left unchanged, the two `bbot` CVEs resolving to `3.0.0` and `BREW-summarize-CVE-2026-53782` to `0.17.1`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified each new test fails without the change and passes with it, and ran `brew lgtm` plus a live OSV run over `bbot` and `summarize`.

-----
