### PR TITLE
Load cask loader for cask search

### DIFF
--- a/Library/Homebrew/search.rb
+++ b/Library/Homebrew/search.rb
@@ -158,6 +158,8 @@ module Homebrew
 
     sig { params(string_or_regex: T.any(Regexp, String)).returns(T::Array[String]) }
     def self.search_casks(string_or_regex)
+      require "cask/cask_loader"
+
       if string_or_regex.is_a?(String) && string_or_regex.match?(HOMEBREW_TAP_CASK_REGEX)
         return begin
           matched_cask = Cask::CaskLoader.load(string_or_regex)

--- a/Library/Homebrew/test/search_spec.rb
+++ b/Library/Homebrew/test/search_spec.rb
@@ -149,6 +149,13 @@ RSpec.describe Homebrew::Search do
       expect(described_class.search_casks(/testball/))
         .to eq([described_class.pretty_installed("testball")])
     end
+
+    it "loads the cask loader itself" do
+      script = 'require "global"; require "search"; ' \
+               'print Homebrew::Search.search_casks("homebrew/cask/nonexistent-cask").inspect'
+      expect(Utils.popen_read({ "HOMEBREW_NO_INSTALL_FROM_API" => "1" },
+                              RUBY_PATH, "-I", HOMEBREW_LIBRARY_PATH.to_s, "-e", script, err: :out)).to eq("[]")
+    end
   end
 
   describe "#search_descriptions" do


### PR DESCRIPTION
- Fix `brew search` erroring on Linux when a cask matches.
- macOS only loaded it via `extend/os/mac/missing_formula`.
- Cover `search_casks` requiring the cask loader itself.

Fixes #23609

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Opus 5 xhigh iwth local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----