### PR TITLE
Suppress stderr for generated cask completions

### DIFF
--- a/Library/Homebrew/cask/artifact/generated_completion.rb
+++ b/Library/Homebrew/cask/artifact/generated_completion.rb
@@ -102,6 +102,7 @@ module Cask
             ),
             "env"             => popen_read_env,
             "output_path"     => completion_script_path(shell).to_s,
+            "print_stderr"    => false,
           }
         end
 
@@ -140,7 +141,10 @@ module Cask
         output_path.dirname.mkpath
         output_path.write(
           ::Utils::ShellCompletion.generate_completion_output(
-            completion.fetch("commands"), completion["shell_parameter"], completion.fetch("env")
+            completion.fetch("commands"),
+            completion["shell_parameter"],
+            completion.fetch("env"),
+            print_stderr: completion.fetch("print_stderr"),
           ),
         )
       rescue => e

--- a/Library/Homebrew/cask_artifact.rb
+++ b/Library/Homebrew/cask_artifact.rb
@@ -85,7 +85,10 @@ begin
       output_path.dirname.mkpath
       output_path.write(
         Utils::ShellCompletion.generate_completion_output(
-          commands, completion["shell_parameter"], completion.fetch("env")
+          commands,
+          completion["shell_parameter"],
+          completion.fetch("env"),
+          print_stderr: completion.fetch("print_stderr"),
         ),
       )
     rescue => e

--- a/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
@@ -90,6 +90,42 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
       expect(homes).to all(satisfy { |home| !home.exist? })
     end
 
+    it "suppresses completion command stderr in the sandbox" do
+      artifact = cask.artifacts.grep(described_class).first
+      captured_payload = T.let({}, T::Hash[String, T.untyped])
+
+      allow(Sandbox).to receive(:available?).and_return(true)
+      allow(Sandbox).to receive(:new) do
+        instance_double(Sandbox).tap do |sandbox|
+          allow(sandbox).to receive(:allow_read)
+          allow(sandbox).to receive(:add_install_hook_rules)
+          allow(sandbox).to receive(:allow_write_path)
+          allow(sandbox).to receive(:run) do |*args|
+            captured_payload = JSON.parse(Pathname(args.last).read)
+          end
+        end
+      end
+
+      artifact.install_phase
+
+      expect(captured_payload.fetch("completions")).to all(include("print_stderr" => false))
+    end
+
+    it "suppresses completion command stderr without the sandbox" do
+      artifact = cask.artifacts.grep(described_class).first
+
+      allow(Sandbox).to receive(:available?).and_return(false)
+      expect(Utils::ShellCompletion).to receive(:generate_completion_output).exactly(3).times do
+        |_commands, _shell_parameter, env, print_stderr:|
+        expect(print_stderr).to be false
+        "#{env.fetch("SHELL")} completion\n"
+      end
+
+      artifact.install_phase
+
+      expect((bash_dir/"foo").read).to eq("bash completion\n")
+    end
+
     context "when generation fails for one shell" do
       it "warns and continues generating other shells" do
         artifact = cask.artifacts.grep(described_class).first

--- a/Library/Homebrew/test/utils/shell_completion_spec.rb
+++ b/Library/Homebrew/test/utils/shell_completion_spec.rb
@@ -104,5 +104,22 @@ RSpec.describe Utils::ShellCompletion do
 
       described_class.generate_completion_output(["/usr/bin/foo"], nil, {})
     end
+
+    it "suppresses stderr when requested" do
+      expect(Utils).to receive(:safe_popen_read).with(
+        {}, "/usr/bin/foo"
+      ).and_return("output")
+
+      described_class.generate_completion_output(["/usr/bin/foo"], nil, {}, print_stderr: false)
+    end
+
+    it "prints stderr when HOMEBREW_STDERR is set" do
+      ENV["HOMEBREW_STDERR"] = "1"
+      expect(Utils).to receive(:safe_popen_read).with(
+        {}, "/usr/bin/foo", err: :err
+      ).and_return("output")
+
+      described_class.generate_completion_output(["/usr/bin/foo"], nil, {}, print_stderr: false)
+    end
   end
 end

--- a/Library/Homebrew/utils/shell_completion.rb
+++ b/Library/Homebrew/utils/shell_completion.rb
@@ -59,12 +59,13 @@ module Utils
         commands:        T::Array[T.any(Pathname, String)],
         shell_parameter: T.nilable(T.any(String, T::Array[String])),
         env:             T::Hash[String, String],
+        print_stderr:    T::Boolean,
       ).returns(String)
     }
-    def self.generate_completion_output(commands, shell_parameter, env)
+    def self.generate_completion_output(commands, shell_parameter, env, print_stderr: true)
       args = T.let(commands + Array(shell_parameter), T::Array[T.any(Pathname, String)])
       options = T.let({}, T::Hash[Symbol, Symbol])
-      options[:err] = :err unless ENV["HOMEBREW_STDERR"]
+      options[:err] = :err if print_stderr || ENV["HOMEBREW_STDERR"]
       Utils.safe_popen_read(env, *args, **options)
     end
   end


### PR DESCRIPTION
-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex (GPT-5) was used to investigate the regression, implement the focused change, and draft tests. I reviewed the complete diff and verified it with the commands listed below. I will answer maintainer questions and review comments myself without AI/LLM.

-----

## What

Add an explicit `print_stderr` policy to shell completion generation. Formula completions keep printing stderr by default, while both sandboxed and unsandboxed cask completion generation suppress it. Setting `HOMEBREW_STDERR` still forces stderr through.

## Why

Cask-generated completions discarded command stderr unless `HOMEBREW_STDERR` was set after https://github.com/Homebrew/brew/pull/22406. The structured cask operations change in https://github.com/Homebrew/brew/commit/f8fcbd88e037084ce18d8db6161d42d921cadf13 routed both cask paths through the shared helper, which currently forces `err: :err`.

That makes successful cask upgrades print warnings from completion generators. Codex is one visible case because it rejects helper alias creation under the temporary sandbox home; the underlying Codex behavior is tracked at https://github.com/openai/codex/issues/17473.

## Reproduction

On a Homebrew revision containing the structured cask operations change:

```console
brew install --cask codex
brew reinstall --cask codex
```

During generated completion installation, Codex prints warnings about refusing to create PATH helper aliases under the temporary cask sandbox directory even though the cask operation succeeds.

## Verification

```console
./bin/brew tests --only=utils/shell_completion
./bin/brew tests --only=cask/artifact/generated_completion
./bin/brew lgtm --online
```
