### PR TITLE
untap: require CaskLoader

### DIFF
--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -125,6 +125,7 @@ module Homebrew
       # All installed casks currently available in a tap by cask full name.
       sig { params(tap: Tap).returns(T::Array[Cask::Cask]) }
       def installed_casks_for(tap:)
+        require "cask/cask_loader"
         tap.cask_tokens.filter_map do |cask_token|
           next unless installed_cask_tokens.include?(Utils.name_from_full_name(cask_token))
 

--- a/Library/Homebrew/test/cmd/untap_spec.rb
+++ b/Library/Homebrew/test/cmd/untap_spec.rb
@@ -9,12 +9,28 @@ RSpec.describe Homebrew::Cmd::Untap do
 
   it_behaves_like "parseable arguments"
 
-  it "untaps a given Tap", :integration_test do
+  it "untaps a given Tap with an installed cask", :cask, :integration_test do
     setup_test_tap
+    tap = Tap.fetch("homebrew", "foo")
 
-    expect { brew "untap", "homebrew/foo" }
+    cask_source = <<~RUBY
+      cask "testcask" do
+        version "1.2.3"
+        sha256 :no_check
+        url "https://brew.sh/"
+      end
+    RUBY
+
+    cask_path = tap.cask_dir/"testcask.rb"
+    cask_path.dirname.mkpath
+    cask_path.write(cask_source)
+    tap.clear_cache
+
+    cask = Cask::CaskLoader::FromContentLoader.new(cask_source, tap:).load(config: nil)
+    InstallHelper.install_with_caskfile(cask)
+
+    expect { brew "untap", "--force", "homebrew/foo" }
       .to output(/Untapped/).to_stderr
-      .and not_to_output.to_stdout
       .and be_a_success
   end
 


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

While trying to remove `kegworks-app/kegworks`, I found that `brew untap` fails when the tap has an installed cask.

### Reproduction

On the current `main` branch:

```console
brew tap kegworks-app/kegworks
brew install --cask kegworks-app/kegworks/sikarugir
brew untap kegworks-app/kegworks
```

The final command fails with:

```text
Error: uninitialized constant Cask::CaskLoader
/opt/homebrew/Library/Homebrew/cmd/untap.rb:132:in 'block in Homebrew::Cmd::Untap#installed_casks_for'
/opt/homebrew/Library/Homebrew/cmd/untap.rb:128:in 'Array#each'
/opt/homebrew/Library/Homebrew/cmd/untap.rb:128:in 'Enumerable#filter_map'
/opt/homebrew/Library/Homebrew/cmd/untap.rb:128:in 'Homebrew::Cmd::Untap#installed_casks_for'
```

From what I can tell, `installed_casks_for` calls `Cask::CaskLoader.load(...)` while checking installed casks, but does not load `cask/cask_loader` before using it.

This change loads `cask/cask_loader` inside `installed_casks_for`, where `Cask::CaskLoader` is used, and updates the existing `untap` integration test. The test now installs a cask from the test tap and uses `brew untap --force` in a fresh process to exercise the same installed-cask path without requiring interactive confirmation.

This may be related to the recent Cask lazy-loading changes in #23560. Similar `Cask::CaskLoader` loading regressions were addressed in #23566 and #23587.

### Testing

I verified the regression with a red/green test cycle:

- without `require "cask/cask_loader"`, the integration test fails with `uninitialized constant Cask::CaskLoader`;
- with the require restored, the test passes.

I also ran:

```console
./bin/brew tests --only=cmd/untap
./bin/brew lgtm --online
```

Both completed successfully.

### AI/LLM disclosure

ChatGPT (GPT-5.6 Sol) was used to assist with investigating the failure, reviewing related Homebrew changes, understanding the contribution process, and developing the regression test. I reviewed the code and prose myself and reproduced and tested the changes locally.
