### PR TITLE
Improve and cleanup cask downloads

### DIFF
--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -3,7 +3,6 @@
 
 require "cachable"
 require "api"
-require "api/source_download"
 require "api/cask/cask_struct_generator"
 
 module Homebrew
@@ -35,53 +34,6 @@ module Homebrew
 
         cache["cask_json"] ||= {}
         cache["cask_json"][name] = json_cask
-      end
-
-      sig {
-        params(
-          cask:           ::Cask::Cask,
-          download_queue: DownloadQueueType,
-          enqueue:        T::Boolean,
-        ).returns(Homebrew::API::SourceDownload)
-      }
-      def self.source_download(cask, download_queue: nil, enqueue: false)
-        download = source_download_for(cask)
-
-        if enqueue
-          require "download_queue"
-          download_queue ||= Homebrew.default_download_queue
-          download_queue.enqueue(download)
-        elsif !download.symlink_location.exist?
-          download.fetch
-        end
-
-        download
-      end
-
-      sig { params(cask: ::Cask::Cask).returns(Homebrew::API::SourceDownload) }
-      def self.source_download_for(cask)
-        path = cask.ruby_source_path.to_s
-        sha256 = cask.ruby_source_checksum[:sha256]
-        checksum = Checksum.new(sha256) if sha256
-        git_head = cask.tap_git_head || "HEAD"
-        tap = cask.tap&.full_name || "Homebrew/homebrew-cask"
-
-        Homebrew::API::SourceDownload.new(
-          "https://raw.githubusercontent.com/#{tap}/#{git_head}/#{path}",
-          checksum,
-          mirrors: [
-            "#{HOMEBREW_API_DEFAULT_DOMAIN}/cask-source/#{File.basename(path)}",
-          ],
-          cache:   HOMEBREW_CACHE_API_SOURCE/"#{tap}/#{git_head}/Cask",
-        )
-      end
-
-      sig { params(cask: ::Cask::Cask).returns(::Cask::Cask) }
-      def self.source_download_cask(cask)
-        download = source_download(cask)
-
-        ::Cask::CaskLoader::FromPathLoader.new(download.symlink_location)
-                                          .load(config: cask.config)
       end
 
       sig { returns(Pathname) }

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -112,7 +112,6 @@ module Cask
       @loaded_from_api = loaded_from_api
       @loaded_from_internal_api = loaded_from_internal_api
       @api_source = api_source
-      @language_variations_available = T.let(false, T::Boolean)
       @language_evaluator = T.let(nil, T.nilable(T.proc.params(languages: T::Array[String]).returns(T.nilable(String))))
       @loader = loader
       # Sorbet has trouble with bound procs assigned to instance variables:
@@ -273,13 +272,6 @@ module Cask
     sig { returns(T::Boolean) }
     def supports_macos?
       !depends_on.requires_linux?
-    end
-
-    # The caskfile is needed during installation when there are legacy
-    # `*flight` blocks or language variations missing from API data.
-    sig { returns(T::Boolean) }
-    def caskfile_only?
-      (languages.any? && !@language_variations_available) || artifacts.any?(Artifact::AbstractFlightBlock)
     end
 
     sig { returns(T::Boolean) }
@@ -521,7 +513,6 @@ module Cask
       raise ArgumentError, "Expected cask to be loaded from the API" unless loaded_from_api?
 
       @languages = cask_struct.languages
-      @language_variations_available = cask_struct.language_variations.any?
       @language_evaluator = ->(languages) { cask_struct.language(languages) }
       @tap_git_head = tap_git_head
       @ruby_source_path = cask_struct.ruby_source_path

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -158,7 +158,7 @@ module Cask
 
         @token = T.let(CaskLoader.token_from_path(path), String)
         @path = T.let(path, Pathname)
-        @tap = T.let(Tap.from_path(path) || Homebrew::API.tap_from_source_download(path), T.nilable(Tap))
+        @tap = T.let(Tap.from_path(path), T.nilable(Tap))
         @from_installed_caskfile = T.let(false, T::Boolean)
         @api_fallback = T.let(true, T::Boolean)
       end

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -58,11 +58,9 @@ module Cask
       @quiet = quiet
       @download_queue = download_queue
       @defer_fetch = defer_fetch
-      @source_download = T.let(nil, T.nilable(Homebrew::API::SourceDownload))
       # Restricts what `#uninstall` removes, for artifacts that are shared with a cask
       # which must be kept installed.
       @default_uninstall_artifacts = default_uninstall_artifacts
-      @ran_prelude_fetch = T.let(false, T::Boolean)
       @ran_prelude = T.let(false, T::Boolean)
       @cask_and_formula_dependencies = T.let(nil, T.nilable(T::Array[T.any(Formula, ::Cask::Cask)]))
       @dependency_cask_installers = T.let(nil, T.nilable(T::Array[Installer]))
@@ -86,6 +84,9 @@ module Cask
 
     sig { void }
     def download_failed! = @download_failed = true
+
+    sig { returns(T::Array[Installer]) }
+    def dependency_cask_installers = @dependency_cask_installers || []
 
     sig { returns(T::Boolean) }
     def installed_on_request? = @installed_on_request
@@ -275,7 +276,7 @@ on_request: true)
     sig { returns(Download) }
     def downloader
       @downloader ||= T.let(
-        (if @cask.loaded_from_internal_api? && !@cask.caskfile_only?
+        (if @cask.loaded_from_internal_api?
            Homebrew::API::CaskDownload.download(
              token:       @cask.token,
              cask_struct: Homebrew::API::Internal.cask_struct(@cask.token),
@@ -460,12 +461,11 @@ on_request: true)
 
     sig { void }
     def enqueue_dependency_downloads
-      return unless installed_on_request?
+      return if download_failed? || !installed_on_request?
 
       cask_installers, formula_installers = dependency_installers(defer_fetch: true)
       if cask_installers.any?
-        Homebrew::Install.enqueue_cask_installers(cask_installers,
-                                                  download_queue: @download_queue)
+        Homebrew::Install.enqueue_cask_installers(cask_installers)
       end
       if formula_installers.any?
         @dependency_formula_installers = Homebrew::Install.enqueue_formulae(formula_installers,
@@ -834,8 +834,8 @@ on_request: true)
       remove_broken_caskroom_symlinks
     end
 
-    sig { params(cask_only: T::Boolean).void }
-    def forbidden_tap_check(cask_only: false)
+    sig { void }
+    def forbidden_tap_check
       return if Tap.allowed_taps.blank? && Tap.forbidden_taps.blank?
 
       owner = Homebrew::EnvConfig.forbidden_owner
@@ -857,7 +857,6 @@ on_request: true)
         raise CaskCannotBeInstalledError.new(@cask, cask_error_message)
       end
 
-      return if cask_only
       return if skip_cask_deps?
 
       cask_and_formula_dependencies.each do |cask_or_formula|
@@ -876,8 +875,8 @@ on_request: true)
       end
     end
 
-    sig { params(cask_only: T::Boolean).void }
-    def forbidden_cask_and_formula_check(cask_only: false)
+    sig { void }
+    def forbidden_cask_and_formula_check
       forbid_casks = Homebrew::EnvConfig.forbid_casks?
       forbidden_formulae = Set.new(Homebrew::EnvConfig.forbidden_formulae.to_s.split)
       forbidden_casks = Set.new(Homebrew::EnvConfig.forbidden_casks.to_s.split)
@@ -901,7 +900,6 @@ on_request: true)
         )
       end
 
-      return if cask_only
       return if skip_cask_deps?
 
       cask_and_formula_dependencies.each do |dep_cask_or_formula|
@@ -965,8 +963,9 @@ on_request: true)
     def prelude
       return if @ran_prelude
 
-      check_prelude_requirements unless @ran_prelude_fetch
-      load_cask_from_source_api! if cask_from_source_api?
+      check_deprecate_disable
+      check_conflicts
+      check_requirements
       forbidden_tap_check
       forbidden_cask_and_formula_check
       forbidden_cask_artifacts_check
@@ -974,51 +973,10 @@ on_request: true)
       @ran_prelude = true
     end
 
-    sig { returns(T::Boolean) }
-    def source_download_requires_pre_fetch?
-      cask_from_source_api? && @cask.languages.any?
-    end
-
-    sig { params(download_queue: Homebrew::DownloadQueue).void }
-    def prelude_fetch(download_queue: @download_queue)
-      return unless (download = prelude_fetch_download)
-
-      download_queue.enqueue(download)
-    end
-
-    sig { returns(T.nilable(Homebrew::API::SourceDownload)) }
-    def prelude_fetch_download
-      return if @ran_prelude_fetch
-
-      check_prelude_requirements
-      @ran_prelude_fetch = true
-      return unless source_download_requires_pre_fetch?
-
-      if source_download.downloaded?
-        source_download.verify_download_integrity(source_download.cached_download)
-        source_download.downloader.create_symlink_to_cached_download(source_download.cached_download)
-        return
-      end
-
-      source_download
-    end
-
     sig { void }
     def enqueue_downloads
-      download_queue = @download_queue
-      prelude_fetch(download_queue:) unless @ran_prelude_fetch
-
-      if source_download_requires_pre_fetch?
-        load_cask_from_source_api!
-      elsif cask_from_source_api?
-        Homebrew::API::Cask.source_download(@cask, download_queue:, enqueue: true)
-      end
-
-      forbidden_tap_check
-      forbidden_cask_and_formula_check
-      forbidden_cask_artifacts_check
-
-      download_queue.enqueue(downloader)
+      prelude
+      @download_queue.enqueue(downloader)
     end
 
     # load the same cask file that was used for installation, if possible
@@ -1030,62 +988,57 @@ on_request: true)
       @installed_uninstall_artifacts_missing = installed_caskfile.is_a?(Pathname) &&
                                                installed_uninstall_artifacts_missing?(installed_caskfile)
 
-      if installed_caskfile&.exist?
-        tab = CaskLoader.load_installed_tab(@cask)
-        tap = tab.tap
-        tap ||= @cask.tap
-        if installed_caskfile.extname == ".rb" &&
-           Homebrew::EnvConfig.require_tap_trust? &&
-           tap &&
-           !Homebrew::Trust.trusted?(:cask, "#{tap.name}/#{@cask.token}")
-          opoo "Skipping loading untrusted Cask #{tap.name}/#{@cask.token}; uninstalling recorded artifacts only."
+      return unless installed_caskfile&.exist?
 
-          dsl = DSL.new(@cask)
-          default_uninstall_artifact_keys = DSL::ACTIVATABLE_ARTIFACT_CLASSES.filter_map do |klass|
-            next if [Artifact::Uninstall, Artifact::Zap].include?(klass)
-            next if !klass.method_defined?(:uninstall_phase) && !klass.method_defined?(:post_uninstall_phase)
+      tab = CaskLoader.load_installed_tab(@cask)
+      tap = tab.tap
+      tap ||= @cask.tap
+      if installed_caskfile.extname == ".rb" &&
+         Homebrew::EnvConfig.require_tap_trust? &&
+         tap &&
+         !Homebrew::Trust.trusted?(:cask, "#{tap.name}/#{@cask.token}")
+        opoo "Skipping loading untrusted Cask #{tap.name}/#{@cask.token}; uninstalling recorded artifacts only."
 
-            klass.dsl_key
-          end.to_set
-          Array(tab.uninstall_artifacts).each do |artifact_entry|
-            next unless artifact_entry.is_a?(Hash)
+        dsl = DSL.new(@cask)
+        default_uninstall_artifact_keys = DSL::ACTIVATABLE_ARTIFACT_CLASSES.filter_map do |klass|
+          next if [Artifact::Uninstall, Artifact::Zap].include?(klass)
+          next if !klass.method_defined?(:uninstall_phase) && !klass.method_defined?(:post_uninstall_phase)
 
-            artifact_entry.each do |raw_key, raw_args|
-              dsl_key = raw_key.to_sym
-              next unless default_uninstall_artifact_keys.include?(dsl_key)
+          klass.dsl_key
+        end.to_set
+        Array(tab.uninstall_artifacts).each do |artifact_entry|
+          next unless artifact_entry.is_a?(Hash)
 
-              args = Array(raw_args)
-              if args.last.is_a?(Hash)
-                dsl.public_send(
-                  dsl_key,
-                  *args[...-1],
-                  **T.cast(args.last, T::Hash[T.any(Symbol, String), T.anything]).transform_keys(&:to_sym),
-                )
-              else
-                dsl.public_send(dsl_key, *args)
-              end
+          artifact_entry.each do |raw_key, raw_args|
+            dsl_key = raw_key.to_sym
+            next unless default_uninstall_artifact_keys.include?(dsl_key)
+
+            args = Array(raw_args)
+            if args.last.is_a?(Hash)
+              dsl.public_send(
+                dsl_key,
+                *args[...-1],
+                **T.cast(args.last, T::Hash[T.any(Symbol, String), T.anything]).transform_keys(&:to_sym),
+              )
+            else
+              dsl.public_send(dsl_key, *args)
             end
           end
-          @default_uninstall_artifacts ||= dsl.artifacts
-          return
         end
-
-        begin
-          @cask = CaskLoader.load_from_installed_caskfile(installed_caskfile)
-          return
-        rescue CaskInvalidError, CaskUnavailableError, MethodDeprecatedError
-          # could be caused by trying to load outdated or deleted caskfile
-        end
-
-        recovered_cask = CaskLoader.recover_from_installed_caskfile(installed_caskfile, tab:, fallback_cask: @cask)
-        if recovered_cask
-          @cask = recovered_cask
-          return
-        end
+        @default_uninstall_artifacts ||= dsl.artifacts
+        return
       end
 
-      load_cask_from_source_api! if cask_from_source_api?
+      begin
+        @cask = CaskLoader.load_from_installed_caskfile(installed_caskfile)
+        return
+      rescue CaskInvalidError, CaskUnavailableError, MethodDeprecatedError
+        # could be caused by trying to load outdated or deleted caskfile
+      end
+
+      recovered_cask = CaskLoader.recover_from_installed_caskfile(installed_caskfile, tab:, fallback_cask: @cask)
       # otherwise we default to the current cask
+      @cask = recovered_cask if recovered_cask
     end
 
     private
@@ -1112,32 +1065,6 @@ on_request: true)
       return false if installed_json.nil? || installed_json.key?("artifacts")
 
       CaskLoader.load_installed_tab(@cask).uninstall_artifacts.blank?
-    end
-
-    sig { void }
-    def check_prelude_requirements
-      check_deprecate_disable
-      check_conflicts
-      check_requirements
-      # Run the cask-self forbidden checks before loading the caskfile from the
-      # Source API so a forbidden cask never triggers a network fetch.
-      forbidden_tap_check(cask_only: true)
-      forbidden_cask_and_formula_check(cask_only: true)
-    end
-
-    sig { returns(Homebrew::API::SourceDownload) }
-    def source_download
-      @source_download ||= Homebrew::API::Cask.source_download_for(@cask)
-    end
-
-    sig { void }
-    def load_cask_from_source_api!
-      @cask = Homebrew::API::Cask.source_download_cask(@cask)
-    end
-
-    sig { returns(T::Boolean) }
-    def cask_from_source_api?
-      @cask.loaded_from_api? && @cask.caskfile_only?
     end
   end
 end

--- a/Library/Homebrew/cask/reinstall.rb
+++ b/Library/Homebrew/cask/reinstall.rb
@@ -59,10 +59,11 @@ module Cask
         end
 
         unless skip_prefetch
-          Homebrew::Install.enqueue_cask_installers(cask_installers, download_queue:)
-          download_queue.fetch(
-            heading: "Fetching dependency downloads",
-          )
+          cask_installers = Homebrew::Install.enqueue_cask_installers(cask_installers)
+          download_queue.fetch(heading: Homebrew::Install.combined_fetch_downloads_heading(
+            cask_names: cask_installers.map { |installer| installer.cask.full_name },
+          ))
+          Homebrew::Install.fetch_cask_dependencies(cask_installers, download_queue:)
         end
       ensure
         download_queue.shutdown if created_download_queue

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -254,11 +254,12 @@ module Cask
             true
           end
 
-          Homebrew::Install.enqueue_cask_installers(prefetched_cask_installers,
+          prefetched_cask_installers.replace(Homebrew::Install.enqueue_cask_installers(prefetched_cask_installers))
+          prefetch_download_queue.fetch(heading: Homebrew::Install.combined_fetch_downloads_heading(
+            cask_names: prefetched_cask_installers.map { |installer| installer.cask.full_name },
+          ))
+          Homebrew::Install.fetch_cask_dependencies(prefetched_cask_installers,
                                                     download_queue: prefetch_download_queue)
-          prefetch_download_queue.fetch(
-            heading: "Fetching dependency downloads",
-          )
         ensure
           prefetch_download_queue.shutdown if created_download_queue
         end

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -112,26 +112,13 @@ module Homebrew
         type = relative_path_parts.fetch(3)
         basename = relative_path_parts.fetch(-1)
         return false unless basename.end_with?(".rb")
+        # Cask sources are no longer downloaded, so any cached ones are stale.
+        return true if type == "Cask"
+        return false if type != "Formula"
 
-        name = "#{org}/#{repo}/#{File.basename(basename, ".rb")}"
-        package = case type
-        when "Cask"
-          begin
-            Cask::CaskLoader.load(name)
-          rescue Cask::CaskError
-            nil
-          end
-        when "Formula"
-          begin
-            Formulary.factory(name)
-          rescue FormulaUnavailableError
-            nil
-          end
-        end
-        return false if package.nil? && %w[Cask Formula].exclude?(type)
-        return true if package.nil?
-
-        package.tap_git_head != git_head
+        Formulary.factory("#{org}/#{repo}/#{File.basename(basename, ".rb")}").tap_git_head != git_head
+      rescue FormulaUnavailableError
+        true
       end
 
       sig { params(formula: Formula).returns(T::Set[String]) }

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -411,12 +411,16 @@ module Homebrew
                 )
               end
 
-              Install.enqueue_cask_installers(prefetched_cask_installers, download_queue:)
+              prefetched_cask_installers = Install.enqueue_cask_installers(prefetched_cask_installers)
             end
 
             download_queue.fetch(heading: Install.combined_fetch_downloads_heading(
               formula_names: all_formulae_installer.map { |fi| fi.formula.name },
+              cask_names:    fetch_casks.map(&:full_name),
             ) || "Fetching dependency downloads")
+            if prefetched_cask_installers
+              Install.fetch_cask_dependencies(prefetched_cask_installers, download_queue:)
+            end
             # Install everything that did download, rather than aborting the
             # whole run; the failures above still exit nonzero at the end.
             all_formulae_installer = Install.reject_failed_downloads(all_formulae_installer, download_queue:)

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -281,13 +281,14 @@ module Homebrew
                   defer_fetch:    true,
                 )
               end
-              Install.enqueue_cask_installers(prefetched_cask_installers, download_queue:)
+              prefetched_cask_installers = Install.enqueue_cask_installers(prefetched_cask_installers)
             end
 
             download_queue.fetch(heading: Install.combined_fetch_downloads_heading(
               formula_names: all_formulae_installers.map { |fi| fi.formula.name },
               cask_names:    casks.map(&:full_name),
             ))
+            Install.fetch_cask_dependencies(prefetched_cask_installers, download_queue:)
             casks_prefetched = casks.any?
             all_formulae_installers = Install.reject_failed_downloads(all_formulae_installers, download_queue:)
             formulae_installers &= all_formulae_installers

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -297,6 +297,7 @@ module Homebrew
             end
             shared_download_queue.fetch(heading: Install.combined_fetch_downloads_heading(
               formula_names: prefetched_formulae_names,
+              cask_names:    prefetched_cask_names,
             ) || "Fetching dependency downloads")
             # Only redo the slower unprefetched fetch for the kind of package
             # that actually failed, so e.g. one bad bottle does not also
@@ -305,6 +306,9 @@ module Homebrew
               shared_download_queue.failed_downloads.partition { |download| download.is_a?(Cask::Download) }
             formulae_prefetched = false if failed_formula_downloads.any?
             prefetched_casks = false if failed_cask_downloads.any?
+            if prefetched_casks
+              Install.fetch_cask_dependencies(prefetched_cask_installers, download_queue: shared_download_queue)
+            end
           ensure
             shared_download_queue.shutdown
           end
@@ -818,17 +822,17 @@ module Homebrew
           fetchable_cask_installers << installer
           true
         end
-        prefetch_casks&.replace(outdated_casks)
         return prefetch_errors.present? if outdated_casks.empty?
 
-        cask_names = outdated_casks.map(&:full_name)
-        cask_downloads_succeeded = Install.enqueue_cask_installers(fetchable_cask_installers, download_queue:)
-        prefetch_installers&.replace(fetchable_cask_installers)
-        prefetch_names&.replace(cask_names)
+        valid_cask_installers = Install.enqueue_cask_installers(fetchable_cask_installers)
+        valid_casks = valid_cask_installers.map(&:cask)
+        prefetch_installers&.replace(valid_cask_installers)
+        prefetch_casks&.replace(valid_casks)
+        prefetch_names&.replace(valid_casks.map(&:full_name))
         prefetch_upgrades&.replace(
-          outdated_casks.map { |cask| "#{cask.full_name} #{cask.installed_version} -> #{cask.version}" },
+          valid_casks.map { |cask| "#{cask.full_name} #{cask.installed_version} -> #{cask.version}" },
         )
-        cask_downloads_succeeded != false
+        true
       rescue => e
         ofail e
         false

--- a/Library/Homebrew/dev-cmd/generate-cask-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-api.rb
@@ -35,8 +35,9 @@ module Homebrew
         raise TapUnavailableError, tap.name unless tap.installed?
 
         unless args.dry_run?
-          directories = ["_data/cask", "api/cask", "api/cask-source", "cask", "api/internal"].freeze
-          FileUtils.rm_rf directories
+          directories = ["_data/cask", "api/cask", "cask", "api/internal"].freeze
+          # `api/cask-source` is no longer generated but may remain from earlier runs.
+          FileUtils.rm_rf directories + ["api/cask-source"]
           FileUtils.mkdir_p directories
         end
 
@@ -54,13 +55,11 @@ module Homebrew
               name = cask.token
               all_casks[name] = cask.to_hash_with_variations
               json = JSON.pretty_generate(all_casks[name])
-              cask_source = path.read
               html_template_name = html_template(name)
 
               unless args.dry_run?
                 File.write("_data/cask/#{name.tr("+", "_")}.json", "#{json}\n")
                 File.write("api/cask/#{name}.json", CASK_JSON_TEMPLATE)
-                File.write("api/cask-source/#{name}.rb", cask_source)
                 File.write("cask/#{name}.html", html_template_name)
               end
             rescue

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -271,54 +271,49 @@ module Homebrew
         "Fetching downloads for: #{combined_fetch_targets.to_sentence}"
       end
 
-      sig {
-        params(cask_installers: T::Array[Cask::Installer], download_queue: Homebrew::DownloadQueue)
-          .returns(T::Boolean)
-      }
-      def enqueue_cask_installers(cask_installers, download_queue:)
-        source_download_installers = {}
-        valid_cask_installers = cask_installers.select do |cask_installer|
-          if cask_installer.source_download_requires_pre_fetch? &&
-             (source_download = cask_installer.prelude_fetch_download)
-            source_download_installers[source_download] = cask_installer
-          end
-          true
-        rescue => e
-          ofail "#{cask_installer.cask}: #{e}"
-          false
-        end
-
-        if source_download_installers.any?
-          source_download_installers.each_key { |source_download| download_queue.enqueue(source_download) }
-          download_queue.fetch(only: Homebrew::API::SourceDownload, heading: "Downloading Cask files")
-        end
-
-        failed_source_downloads = download_queue.failed_downloads.grep(Homebrew::API::SourceDownload)
-        failed_source_installers = failed_source_downloads.map do |download|
-          source_download_installers.fetch(download).tap(&:download_failed!)
-        end
-
-        valid_cask_installers.select! do |cask_installer|
-          next false if failed_source_installers.include?(cask_installer)
-
+      # Leave the cask downloads queued so the caller fetches them alongside
+      # any formula bottles under one heading instead of draining them first.
+      sig { params(cask_installers: T::Array[Cask::Installer]).returns(T::Array[Cask::Installer]) }
+      def enqueue_cask_installers(cask_installers)
+        cask_installers.select do |cask_installer|
           cask_installer.enqueue_downloads
           true
         rescue => e
           ofail "#{cask_installer.cask}: #{e}"
           false
         end
+      end
 
-        download_queue.fetch(only: Cask::Download, heading: "Downloading Cask files")
-        downloads_succeeded = failed_source_downloads.empty? && download_queue.failed_downloads.none?(Cask::Download)
-        valid_cask_installers.each do |cask_installer|
-          if !downloads_succeeded && download_queue.failed_downloads.include?(cask_installer.downloader)
-            cask_installer.download_failed!
-          end
+      # Cask dependencies are resolved from the downloaded container, so they
+      # can only be queued once the cask downloads above have been fetched.
+      sig { params(cask_installers: T::Array[Cask::Installer], download_queue: Homebrew::DownloadQueue).void }
+      def fetch_cask_dependencies(cask_installers, download_queue:)
+        return if cask_installers.empty?
+
+        mark_failed_cask_downloads(cask_installers, download_queue:)
+        cask_installers.each do |cask_installer|
           cask_installer.enqueue_dependency_downloads
         rescue => e
           ofail "#{cask_installer.cask}: #{e}"
         end
-        downloads_succeeded
+        download_queue.fetch(heading: "Fetching dependency downloads")
+        mark_failed_cask_downloads(cask_installers, download_queue:)
+      end
+
+      sig { params(cask_installers: T::Array[Cask::Installer], download_queue: Homebrew::DownloadQueue).void }
+      def mark_failed_cask_downloads(cask_installers, download_queue:)
+        failed_downloads = download_queue.failed_downloads
+        return if failed_downloads.empty?
+
+        cask_installers.each do |cask_installer|
+          next if cask_installer.download_failed?
+
+          if failed_downloads.include?(cask_installer.downloader)
+            cask_installer.download_failed!
+          else
+            mark_failed_cask_downloads(cask_installer.dependency_cask_installers, download_queue:)
+          end
+        end
       end
 
       sig {

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -44,41 +44,4 @@ RSpec.describe Homebrew::API::Cask do
       expect(casks_output).to eq casks_hash
     end
   end
-
-  describe "::source_download", :needs_macos do
-    let(:cask) do
-      cask = Cask::CaskLoader::FromAPILoader.new(
-        "everything",
-        from_json: JSON.parse((TEST_FIXTURE_DIR/"cask/everything.json").read.strip),
-      ).load(config: nil)
-      cask
-    end
-
-    before do
-      allow(Homebrew::API).to receive(:fetch_json_api_file).and_return([{
-        "formulae"               => {},
-        "casks"                  => {},
-        "formula_aliases"        => {},
-        "formula_renames"        => {},
-        "cask_renames"           => {},
-        "formula_tap_git_head"   => "",
-        "cask_tap_git_head"      => "",
-        "formula_tap_migrations" => {},
-        "cask_tap_migrations"    => {},
-      }, true])
-      allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:fetch)
-      allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:symlink_location).and_return(
-        TEST_FIXTURE_DIR/"cask/Casks/everything.rb",
-      )
-    end
-
-    it "specifies the correct URL and sha256" do
-      expect(Homebrew::API::SourceDownload).to receive(:new).with(
-        "https://raw.githubusercontent.com/Homebrew/homebrew-cask/abcdef1234567890abcdef1234567890abcdef12/Casks/everything.rb",
-        Checksum.new("00ae1ae330365f3d6e4387776f67a9c4b096da3d4546bd0827b5dcafa985234e"),
-        any_args,
-      ).and_call_original
-      described_class.source_download(cask)
-    end
-  end
 end

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
       expect(cask.artifacts_list(uninstall_only: true)).to eq([{ app: ["Self-contained.app"] }])
     end
 
-    shared_examples "loads from API" do |cask_token, caskfile_only:|
+    shared_examples "loads from API" do |cask_token|
       include_context "with API setup", cask_token
       include_context "with internal API setup", cask_token
       let(:cask_from_api) { api_loader.load(config: nil) }
@@ -252,7 +252,6 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
         expect(cask_from_api.token).to eq(api_token)
         expect(cask_from_api.loaded_from_api?).to be(true)
         expect(cask_from_api.loaded_from_internal_api?).to be(false)
-        expect(cask_from_api.caskfile_only?).to be(caskfile_only)
         expect(cask_from_api.sourcefile_path).to eq(Homebrew::API::Cask.cached_json_file_path)
       end
 
@@ -261,41 +260,40 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
         expect(cask_from_internal_api.token).to eq(internal_api_token)
         expect(cask_from_internal_api.loaded_from_api?).to be(true)
         expect(cask_from_internal_api.loaded_from_internal_api?).to be(true)
-        expect(cask_from_internal_api.caskfile_only?).to be(caskfile_only)
         expect(cask_from_internal_api.sourcefile_path).to eq(Homebrew::API::Internal.cached_packages_json_file_path)
       end
     end
 
     context "with a binary stanza" do
-      include_examples "loads from API", "with-binary", caskfile_only: false
+      include_examples "loads from API", "with-binary"
     end
 
     context "with cask dependencies" do
-      include_examples "loads from API", "with-depends-on-cask-multiple", caskfile_only: false
+      include_examples "loads from API", "with-depends-on-cask-multiple"
     end
 
     context "with formula dependencies" do
-      include_examples "loads from API", "with-depends-on-formula-multiple", caskfile_only: false
+      include_examples "loads from API", "with-depends-on-formula-multiple"
     end
 
     context "with macos dependencies" do
-      include_examples "loads from API", "with-depends-on-macos-array", caskfile_only: false
+      include_examples "loads from API", "with-depends-on-macos-array"
     end
 
     context "with an installer stanza" do
-      include_examples "loads from API", "with-installer-script", caskfile_only: false
+      include_examples "loads from API", "with-installer-script"
     end
 
     context "with uninstall stanzas" do
-      include_examples "loads from API", "with-uninstall-multi", caskfile_only: false
+      include_examples "loads from API", "with-uninstall-multi"
     end
 
     context "with a zap stanza" do
-      include_examples "loads from API", "with-zap", caskfile_only: false
+      include_examples "loads from API", "with-zap"
     end
 
     context "with install step stanzas" do
-      include_examples "loads from API", "with-install-steps", caskfile_only: false
+      include_examples "loads from API", "with-install-steps"
 
       context "when running install steps loaded from internal JSON API" do
         include_context "with internal API setup", "with-install-steps"
@@ -318,23 +316,23 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
     end
 
     context "with a preflight stanza" do
-      include_examples "loads from API", "with-preflight", caskfile_only: true
+      include_examples "loads from API", "with-preflight"
     end
 
     context "with an uninstall-preflight stanza" do
-      include_examples "loads from API", "with-uninstall-preflight", caskfile_only: true
+      include_examples "loads from API", "with-uninstall-preflight"
     end
 
     context "with a postflight stanza" do
-      include_examples "loads from API", "with-postflight", caskfile_only: true
+      include_examples "loads from API", "with-postflight"
     end
 
     context "with an uninstall-postflight stanza" do
-      include_examples "loads from API", "with-uninstall-postflight", caskfile_only: true
+      include_examples "loads from API", "with-uninstall-postflight"
     end
 
     context "with a language stanza" do
-      include_examples "loads from API", "with-languages", caskfile_only: false
+      include_examples "loads from API", "with-languages"
 
       it "loads the selected language variation from both APIs" do
         config = Cask::Config.new(explicit: { languages: ["zh"] })
@@ -348,12 +346,6 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
           "fab685fabf73d5a9382581ce8698fce9408f5feaa49fa10d9bc6c510493300f5",
           ["Container.app"],
         ]))
-      end
-
-      it "keeps the source fallback for old API data" do
-        cask = described_class.new(api_token, from_json: cask_json.except("language_variations")).load(config: nil)
-
-        expect(cask).to be_caskfile_only
       end
     end
   end

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -682,7 +682,6 @@ RSpec.describe Cask::Cask, :cask do
 
     context "when loaded from json file" do
       it "returns expected hash" do
-        expect(Homebrew::API::Cask).not_to receive(:source_download)
         hash = Cask::CaskLoader::FromAPILoader.new(
           "everything", from_json: JSON.parse(expected_json)
         ).load(config: nil).to_h
@@ -1215,7 +1214,6 @@ RSpec.describe Cask::Cask, :cask do
       end
 
       it "returns expected hash with variations" do
-        expect(Homebrew::API::Cask).not_to receive(:source_download)
         cask = Cask::CaskLoader::FromAPILoader.new("everything-with-variations", from_json: JSON.parse(expected_json))
                                               .load(config: nil)
 

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -145,12 +145,12 @@ RSpec.describe Cask::Installer, :cask do
         call_order << :languages
         ["en-US"]
       end
-      allow(installer).to receive(:check_prelude_requirements) { call_order << :prelude_requirements }
+      allow(installer).to receive(:check_requirements) { call_order << :requirements }
 
       installer.prelude
 
       expect(call_order.first).to eq(:languages)
-      expect(call_order).to include(:prelude_requirements)
+      expect(call_order).to include(:requirements)
     end
   end
 
@@ -472,23 +472,6 @@ RSpec.describe Cask::Installer, :cask do
       expect(latest_cask.download_sha_path).to be_a_file
     end
 
-    context "when loaded from the api and caskfile is required" do
-      let(:path) { cask_path("local-caffeine") }
-      let(:content) { File.read(path) }
-
-      it "installs cask" do
-        source_caffeine = Cask::CaskLoader.load(path)
-        expect(Homebrew::API::Cask).to receive(:source_download_cask).once.and_return(source_caffeine)
-
-        caffeine = Cask::CaskLoader.load(path)
-        allow(caffeine).to receive(:loaded_from_api?).and_return(true)
-        expect(caffeine).to receive(:caskfile_only?).once.and_return(true)
-
-        described_class.new(caffeine).install
-        expect(Cask::CaskLoader.load(path)).to be_installed
-      end
-    end
-
     context "when loaded from the api with unsupported requirements" do
       let(:cask) { Cask::CaskLoader.load(cask_path("with-preflight")) }
       let(:download_queue) { instance_double(Homebrew::DownloadQueue, enqueue: nil) }
@@ -501,16 +484,12 @@ RSpec.describe Cask::Installer, :cask do
       end
 
       it "checks requirements before enqueueing downloads" do
-        expect(Homebrew::API::Cask).not_to receive(:source_download)
-
         expect do
           described_class.new(cask, download_queue:).enqueue_downloads
         end.to raise_error(Cask::CaskError, "with-preflight: macOS is required")
       end
 
-      it "checks requirements before loading the source cask during fetch" do
-        expect(Homebrew::API::Cask).not_to receive(:source_download_cask)
-
+      it "checks requirements before downloading during fetch" do
         expect do
           described_class.new(cask).fetch
         end.to raise_error(Cask::CaskError, "with-preflight: macOS is required")
@@ -591,32 +570,6 @@ RSpec.describe Cask::Installer, :cask do
       expect(Cask::Caskroom.path.join("local-caffeine", caffeine.version)).not_to be_a_directory
       expect(Cask::Caskroom.path.join("local-caffeine", mutated_version)).not_to be_a_directory
       expect(Cask::Caskroom.path.join("local-caffeine")).not_to be_a_directory
-    end
-
-    context "when loaded from the api, caskfile is required and installed caskfile is invalid" do
-      let(:path) { cask_path("local-caffeine") }
-      let(:content) { File.read(path) }
-      let(:invalid_path) { instance_double(Pathname) }
-
-      before do
-        allow(invalid_path).to receive(:exist?).and_return(false)
-      end
-
-      it "uninstalls cask" do
-        source_caffeine = Cask::CaskLoader.load(path)
-        expect(Homebrew::API::Cask).to receive(:source_download_cask).twice.and_return(source_caffeine)
-
-        caffeine = Cask::CaskLoader.load(path)
-        allow(caffeine).to receive(:loaded_from_api?).and_return(true)
-        expect(caffeine).to receive(:caskfile_only?).twice.and_return(true)
-        expect(caffeine).to receive(:installed_caskfile).once.and_return(invalid_path)
-
-        described_class.new(caffeine).install
-        expect(Cask::CaskLoader.load(path)).to be_installed
-
-        described_class.new(caffeine).uninstall
-        expect(Cask::CaskLoader.load(path)).not_to be_installed
-      end
     end
   end
 
@@ -785,23 +738,21 @@ RSpec.describe Cask::Installer, :cask do
   end
 
   describe "#prelude" do
-    it "raises on forbidden cask before fetching the caskfile from the Source API" do
+    it "raises on forbidden cask before downloading" do
       ENV["HOMEBREW_FORBIDDEN_CASKS"] = cask_name = "homebrew-forbidden-cask"
       cask = Cask::Cask.new(cask_name) do
         url "file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz"
         app "Fake.app"
       end
-      allow(cask).to receive_messages(loaded_from_api?: true, caskfile_only?: true)
       installer = described_class.new(cask)
 
-      expect(Homebrew::API::Cask).not_to receive(:source_download_cask)
       expect(installer).not_to receive(:download)
 
       expect { installer.prelude }.to raise_error(Cask::CaskCannotBeInstalledError, /forbidden for installation/)
     end
   end
 
-  describe "#prelude_fetch" do
+  describe "#enqueue_downloads" do
     it "uses API cask metadata for API-loaded cask downloads" do
       cask = Cask::Cask.new("api-cask", loaded_from_api: true, loaded_from_internal_api: true) do
         url "https://example.com/source-cask.zip"
@@ -818,7 +769,6 @@ RSpec.describe Cask::Installer, :cask do
       installer = described_class.new(cask, download_queue:)
 
       allow(Homebrew::API::Internal).to receive(:cask_struct).with("api-cask").and_return(cask_struct)
-      expect(Homebrew::API::Cask).not_to receive(:source_download)
       expect(download_queue).to receive(:enqueue) do |download|
         expect(download).to be_a(Cask::Download)
         expect(download.url.to_s).to eq("https://example.com/api-cask.zip")
@@ -842,44 +792,9 @@ RSpec.describe Cask::Installer, :cask do
       installer = described_class.new(cask, download_queue:)
 
       allow(Homebrew::API::Internal).to receive(:cask_struct).with("language-api-cask").and_return(cask_struct)
-      expect(Homebrew::API::Cask).not_to receive(:source_download)
       expect(download_queue).to receive(:enqueue) do |download|
         expect(download.url.to_s).to eq("file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz")
       end
-
-      installer.enqueue_downloads
-    end
-
-    it "enqueues source API caskfiles before the main cask download" do
-      cask = Cask::Cask.new("source-api-cask") do
-        url "file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz"
-        app "Fake.app"
-      end
-      allow(cask).to receive_messages(loaded_from_api?: true, caskfile_only?: true, languages: ["en"])
-      download_queue = instance_double(Homebrew::DownloadQueue)
-      installer = described_class.new(cask, download_queue:)
-      source_download = instance_double(Homebrew::API::SourceDownload, downloaded?: false)
-
-      expect(Homebrew::API::Cask).to receive(:source_download_for).with(cask).and_return(source_download)
-      expect(download_queue).to receive(:enqueue).with(source_download)
-      expect(Homebrew::API::Cask).not_to receive(:source_download_cask)
-      expect(installer).not_to receive(:download)
-
-      installer.prelude_fetch
-    end
-
-    it "leaves source API caskfiles in the main queue when their URL is known" do
-      cask = Cask::Cask.new("source-api-cask") do
-        url "file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz"
-        app "Fake.app"
-      end
-      allow(cask).to receive_messages(loaded_from_api?: true, caskfile_only?: true, languages: [])
-      download_queue = instance_double(Homebrew::DownloadQueue)
-      installer = described_class.new(cask, download_queue:)
-
-      expect(Homebrew::API::Cask).to receive(:source_download).with(cask, download_queue:, enqueue: true)
-      expect(Homebrew::API::Cask).not_to receive(:source_download_cask)
-      expect(download_queue).to receive(:enqueue).with(instance_of(Cask::Download))
 
       installer.enqueue_downloads
     end
@@ -972,6 +887,16 @@ RSpec.describe Cask::Installer, :cask do
   end
 
   describe "#enqueue_dependency_downloads" do
+    it "skips dependency resolution when the cask download failed" do
+      cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+      installer = described_class.new(cask, download_queue: instance_double(Homebrew::DownloadQueue))
+      installer.download_failed!
+
+      expect(installer).not_to receive(:cask_and_formula_dependencies)
+
+      installer.enqueue_dependency_downloads
+    end
+
     it "reuses formula dependencies fetched before installation" do
       cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
       dependency = formula("cask-dependency") do

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Cask::Reinstall, :cask do
 
     expect do
       described_class.reinstall_casks(Cask::CaskLoader.load("local-caffeine"))
-    end.to output(output).to_stdout.and output(/==> Downloading Cask files/).to_stderr
+    end.to output(output).to_stdout.and output(/==> Fetching downloads for: local-caffeine/).to_stderr
   end
 
   it "displays the reinstallation progress with zapping" do
@@ -44,7 +44,7 @@ RSpec.describe Cask::Reinstall, :cask do
 
     expect do
       described_class.reinstall_casks(Cask::CaskLoader.load("local-caffeine"), zap: true)
-    end.to output(output).to_stdout.and output(/==> Downloading Cask files/).to_stderr
+    end.to output(output).to_stdout.and output(/==> Fetching downloads for: local-caffeine/).to_stderr
   end
 
   it "allows reinstalling a Cask" do
@@ -65,14 +65,12 @@ RSpec.describe Cask::Reinstall, :cask do
 
     failing_installer = instance_double(Cask::Installer, cask: cask1)
     allow(failing_installer).to receive(:prelude)
-    allow(failing_installer).to receive(:source_download_requires_pre_fetch?).and_return(false)
     allow(failing_installer).to receive(:enqueue_downloads)
     allow(failing_installer).to receive(:enqueue_dependency_downloads)
     allow(failing_installer).to receive(:install).and_raise(Cask::CaskError.new("reinstall failed"))
 
     successful_installer = instance_double(Cask::Installer, cask: cask2)
     allow(successful_installer).to receive(:prelude)
-    allow(successful_installer).to receive(:source_download_requires_pre_fetch?).and_return(false)
     allow(successful_installer).to receive(:enqueue_downloads)
     allow(successful_installer).to receive(:enqueue_dependency_downloads)
 
@@ -112,8 +110,7 @@ RSpec.describe Cask::Reinstall, :cask do
   it "reinstalls casks after an earlier failure in the same run" do
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
     installer = instance_double(Cask::Installer, cask:, prelude: nil, enqueue_downloads: nil,
-                                                 enqueue_dependency_downloads: nil,
-                                                 source_download_requires_pre_fetch?: false)
+                                                 enqueue_dependency_downloads: nil)
     allow(Cask::Installer).to receive(:new).and_return(installer)
     # A failure earlier in the run (e.g. a formula in the same `brew reinstall`)
     # must not stop the casks that are ready from being reinstalled.

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -512,8 +512,7 @@ RSpec.describe Cask::Upgrade, :cask do
 
     it 'prefetches "auto_updates true" casks with quarantine until signed identity is checked' do
       installer = instance_double(Cask::Installer, cask: auto_updates, check_requirements: nil,
-                                                   enqueue_downloads: nil, enqueue_dependency_downloads: nil,
-                                                   source_download_requires_pre_fetch?: false)
+                                                   enqueue_downloads: nil, enqueue_dependency_downloads: nil)
 
       expect(Cask::Installer).to receive(:new) do |cask, **|
         expect(cask).to eq(auto_updates)
@@ -529,11 +528,11 @@ RSpec.describe Cask::Upgrade, :cask do
     it "retains installers in a caller-supplied prefetch collection" do
       installer = Cask::Installer.allocate
       prefetched_cask_installers = []
-      download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil)
+      download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [])
 
       allow(installer).to receive_messages(cask: auto_updates, check_requirements: nil)
       allow(Cask::Installer).to receive(:new).and_return(installer)
-      allow(Homebrew::Install).to receive(:enqueue_cask_installers)
+      allow(Homebrew::Install).to receive(:enqueue_cask_installers).and_return([installer])
       allow(described_class).to receive(:upgrade_cask)
 
       described_class.upgrade_casks!(
@@ -891,7 +890,7 @@ RSpec.describe Cask::Upgrade, :cask do
 
       expect do
         described_class.upgrade_casks!(bad_checksum, args:)
-      end.to output(/bad-checksum: SHA-256 mismatch/).to_stderr.and(not_to_output(output_reverted).to_stderr)
+      end.to output(/bad-checksum: Download failed/).to_stderr.and(not_to_output(output_reverted).to_stderr)
 
       expect(bad_checksum).to be_installed
       expect(bad_checksum_path).to be_a_directory
@@ -989,10 +988,9 @@ RSpec.describe Cask::Upgrade, :cask do
     it "continues upgrading compatible casks" do
       summary_upgrades = []
       upgraded_tokens = []
-      incompatible_installer = instance_double(Cask::Installer, source_download_requires_pre_fetch?: false)
-      compatible_installer = instance_double(Cask::Installer, cask:                                local_transmission,
-                                                              enqueue_dependency_downloads:        nil,
-                                                              source_download_requires_pre_fetch?: false)
+      incompatible_installer = instance_double(Cask::Installer)
+      compatible_installer = instance_double(Cask::Installer, cask:                         local_transmission,
+                                                              enqueue_dependency_downloads: nil)
 
       allow(incompatible_installer).to receive(:check_requirements)
         .and_raise(Cask::CaskError, "local-caffeine: This cask does not run on macOS versions older than Tahoe.")

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -792,6 +792,16 @@ RSpec.describe Homebrew::Cleanup do
       expect([source_file.exist?, nested_source_file.exist?]).to eq([true, true])
     end
 
+    it "removes cached API cask source paths" do
+      source_file = HOMEBREW_CACHE/"api-source/Homebrew/homebrew-cask/abc123/Cask/testball.rb"
+      source_file.dirname.mkpath
+      FileUtils.touch source_file
+
+      cleanup.cleanup_cache([{ path: source_file, type: :api_source }])
+
+      expect(source_file).not_to exist
+    end
+
     context "when cleaning old files in HOMEBREW_CACHE" do
       let(:bottle) { HOMEBREW_CACHE/"testball--0.0.1.tag.bottle.tar.gz" }
       let(:testball) { HOMEBREW_CACHE/"testball--0.0.1" }

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -441,8 +441,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil, failed_downloads: [])
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
     installer = instance_double(Cask::Installer, cask:, enqueue_downloads: nil,
-                                                  enqueue_dependency_downloads: nil,
-                                                  source_download_requires_pre_fetch?: false)
+                                                  enqueue_dependency_downloads: nil)
     dependants = Homebrew::Upgrade::Dependents.new(upgradeable: [], pinned: [], skipped: [])
 
     allow(Tap).to receive_messages(with_formula_name: nil, with_cask_token: nil)
@@ -466,8 +465,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil, failed_downloads: [])
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
     installer = instance_double(Cask::Installer, cask:, install: nil, enqueue_downloads: nil,
-                                                  enqueue_dependency_downloads: nil,
-                                                  source_download_requires_pre_fetch?: false)
+                                                  enqueue_dependency_downloads: nil)
 
     allow(Tap).to receive_messages(with_formula_name: nil, with_cask_token: nil)
     allow(Homebrew::Trust).to receive(:trust_fully_qualified_items!)
@@ -488,7 +486,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     allow(Cask::Installer).to receive(:new).and_return(installer)
 
     expect(download_queue).to receive(:fetch)
-      .with(only: Cask::Download, heading: "Downloading Cask files")
+      .with(heading: "Fetching downloads for: local-caffeine")
       .ordered
     expect(download_queue).to receive(:fetch)
       .with(heading: "Fetching dependency downloads")
@@ -648,8 +646,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     formula_installer = instance_double(FormulaInstaller, formula:)
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
     installer = instance_double(Cask::Installer, cask:, enqueue_downloads: nil,
-                                                  enqueue_dependency_downloads: nil,
-                                                  source_download_requires_pre_fetch?: false)
+                                                  enqueue_dependency_downloads: nil)
 
     allow(Tap).to receive_messages(with_formula_name: nil, with_cask_token: nil)
     allow(cmd.args.named).to receive(:to_formulae_and_casks).with(warn: false).and_return([formula, cask])
@@ -688,10 +685,10 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
       true
     end
     expect(download_queue).to receive(:fetch)
-      .with(only: Cask::Download, heading: "Downloading Cask files")
+      .with(heading: "Fetching downloads for: testball_bottle and codex")
       .ordered
     expect(download_queue).to receive(:fetch)
-      .with(heading: "Fetching downloads for: testball_bottle")
+      .with(heading: "Fetching dependency downloads")
       .ordered
 
     expect { cmd.run }.to output(<<~EOS).to_stdout

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -103,8 +103,9 @@ RSpec.describe Homebrew::Cmd::Reinstall do
     allow(Homebrew::Install).to receive(:perform_preinstall_checks_once)
     allow(Homebrew::Reinstall).to receive(:build_install_context).and_return(reinstall_context)
     allow(Homebrew::Install).to receive(:ask_formulae)
-    allow(Homebrew::Install).to receive(:enqueue_formulae).and_return([formula_installer])
-    allow(Homebrew::Install).to receive(:enqueue_cask_installers)
+    allow(Homebrew::Install).to receive_messages(enqueue_formulae:        [formula_installer],
+                                                 enqueue_cask_installers: [cask_installer])
+    allow(Homebrew::Install).to receive(:fetch_cask_dependencies)
     allow(Cask::Installer).to receive(:new).and_return(cask_installer)
     allow(Homebrew::Reinstall).to receive(:reinstall_formula)
     allow(Homebrew::Upgrade).to receive_messages(dependants: dependants, upgrade_dependents: [])

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -791,9 +791,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       version:           "0.118.0",
     )
     installer = Cask::Installer.allocate
-    allow(installer).to receive_messages(check_requirements: nil, enqueue_downloads: nil,
-                                         enqueue_dependency_downloads: nil,
-                                         source_download_requires_pre_fetch?: false)
+    allow(installer).to receive_messages(cask:, check_requirements: nil, enqueue_downloads: nil,
+                                         enqueue_dependency_downloads: nil)
 
     expect(Homebrew::DownloadQueue).to receive(:new).once.and_return(download_queue)
     allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, prefetch_only: false,
@@ -821,10 +820,10 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
     allow(Homebrew.messages).to receive(:display_messages)
     expect(download_queue).to receive(:fetch)
-      .with(only: Cask::Download, heading: "Downloading Cask files")
+      .with(heading: "Fetching downloads for: deno and codex")
       .ordered
     expect(download_queue).to receive(:fetch)
-      .with(heading: "Fetching downloads for: deno")
+      .with(heading: "Fetching dependency downloads")
       .ordered
 
     expect { cmd.run }.to output(<<~EOS).to_stdout
@@ -868,6 +867,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   it "prefetches a named cask-only upgrade before installing" do
     cask = Cask::Cask.new("codex")
     installer = Cask::Installer.allocate
+    allow(installer).to receive(:enqueue_dependency_downloads)
     cmd = described_class.new(["--cask", "codex", "--yes"])
     download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil)
 
@@ -886,7 +886,10 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       prefetch_installers.replace([installer])
       true
     end
-    expect(download_queue).to receive(:fetch).with(heading: "Fetching dependency downloads")
+    expect(download_queue).to receive(:fetch).with(heading: "Fetching downloads for: codex").ordered
+    expect(download_queue).to receive(:fetch)
+      .with(heading: "Fetching dependency downloads")
+      .ordered
     expect(cmd).to receive(:upgrade_outdated_casks!)
       .with(
         [cask],
@@ -960,9 +963,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       version:           "0.118.0",
     )
     installer = Cask::Installer.allocate
-    allow(installer).to receive_messages(check_requirements: nil, enqueue_downloads: nil,
-                                         enqueue_dependency_downloads: nil,
-                                         source_download_requires_pre_fetch?: false)
+    allow(installer).to receive_messages(cask:, check_requirements: nil, enqueue_downloads: nil,
+                                         enqueue_dependency_downloads: nil)
 
     allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, dry_run: false, prefetch_only: false,
                                                               use_prefetched: false, prefetch_names: nil,
@@ -995,7 +997,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
     expect(Homebrew::Install).to receive(:ask).with(action: "upgrade").ordered
     expect(Homebrew::DownloadQueue).to receive(:new).ordered.and_return(download_queue)
-    expect(Homebrew::Install).to receive(:enqueue_cask_installers).ordered
+    expect(Homebrew::Install).to receive(:enqueue_cask_installers).ordered.and_return([])
     expect(download_queue).to receive(:fetch).ordered
 
     cmd.run
@@ -1035,63 +1037,6 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     cmd.run
   end
 
-  it "prefetches language cask files before fetching combined downloads" do
-    cmd = described_class.new(["--yes"])
-    download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [], shutdown: nil)
-    cask = instance_double(
-      Cask::Cask,
-      artifacts:         [],
-      full_name:         "codex",
-      installed_version: "0.117.0",
-      version:           "0.118.0",
-    )
-    installer = Cask::Installer.allocate
-    allow(installer).to receive_messages(
-      check_requirements:                  nil,
-      enqueue_downloads:                   nil,
-      enqueue_dependency_downloads:        nil,
-      source_download_requires_pre_fetch?: true,
-    )
-    source_download = instance_double(Homebrew::API::SourceDownload)
-
-    expect(Homebrew::DownloadQueue).to receive(:new).once.and_return(download_queue)
-    allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, prefetch_only: false,
-                                                              prefetch_names: nil,
-                                                              prefetch_upgrades: nil,
-                                                              show_upgrade_summary: true,
-                                                              **|
-      if prefetch_only
-        expect(show_upgrade_summary).to be(false)
-        prefetch_names&.replace(["deno"])
-        prefetch_upgrades&.replace(["deno 2.7.10 -> 2.7.11"])
-      end
-
-      true
-    end
-    allow(Cask::Installer).to receive(:new).and_return(installer)
-    expect(installer).to receive(:prelude_fetch_download).and_return(source_download)
-    expect(download_queue).to receive(:enqueue).with(source_download).ordered
-    expect(download_queue).to receive(:fetch)
-      .with(only: Homebrew::API::SourceDownload, heading: "Downloading Cask files")
-      .ordered
-    expect(download_queue).to receive(:fetch)
-      .with(only: Cask::Download, heading: "Downloading Cask files")
-      .ordered
-    expect(download_queue).to receive(:fetch)
-      .with(heading: "Fetching downloads for: deno")
-      .ordered
-    allow(Cask::Upgrade).to receive_messages(outdated_casks: [cask], upgrade_casks!: true)
-    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
-    allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
-    allow(Homebrew.messages).to receive(:display_messages)
-
-    expect { cmd.run }.to output(<<~EOS).to_stdout
-      ==> Upgrading 2 outdated packages:
-      deno   2.7.10  -> 2.7.11
-      codex  0.117.0 -> 0.118.0
-    EOS
-  end
-
   it "skips incompatible casks during combined prefetch" do
     cmd = described_class.new(["--yes"])
     download_queue = instance_double(Homebrew::DownloadQueue)
@@ -1113,7 +1058,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     )
     incompatible_installer = Cask::Installer.allocate
     compatible_installer = Cask::Installer.allocate
-    allow(compatible_installer).to receive(:check_requirements)
+    allow(compatible_installer).to receive_messages(check_requirements: nil, cask: compatible_cask)
     prefetch_names = []
     prefetch_upgrades = []
     prefetch_casks = []
@@ -1125,7 +1070,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     allow(Cask::Installer).to receive(:new) do |cask, **|
       (cask == incompatible_cask) ? incompatible_installer : compatible_installer
     end
-    expect(Homebrew::Install).to receive(:enqueue_cask_installers).with([compatible_installer], download_queue:)
+    expect(Homebrew::Install).to receive(:enqueue_cask_installers).with([compatible_installer])
+                                                                  .and_return([compatible_installer])
     expect(cmd).not_to receive(:ofail)
 
     expect(
@@ -1144,56 +1090,39 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     expect(prefetch_errors.map(&:to_s)).to eq(["bad-cask: This cask requires Linux."])
   end
 
-  it "omits the cask file heading for cached language cask files" do
-    cmd = described_class.new(["-y"])
-    download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [], shutdown: nil)
+  it "drops casks whose downloads could not be enqueued from the prefetch" do
+    cmd = described_class.new(["--yes"])
+    download_queue = instance_double(Homebrew::DownloadQueue)
     cask = instance_double(
       Cask::Cask,
       artifacts:         [],
       full_name:         "codex",
       installed_version: "0.117.0",
+      token:             "codex",
       version:           "0.118.0",
     )
     installer = Cask::Installer.allocate
-    allow(installer).to receive_messages(
-      check_requirements:                  nil,
-      enqueue_downloads:                   nil,
-      enqueue_dependency_downloads:        nil,
-      source_download_requires_pre_fetch?: true,
-    )
+    allow(installer).to receive(:check_requirements)
+    prefetch_names = []
+    prefetch_upgrades = []
+    prefetch_casks = []
+    prefetch_installers = []
 
-    expect(Homebrew::DownloadQueue).to receive(:new).once.and_return(download_queue)
-    allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, prefetch_only: false,
-                                                              prefetch_names: nil,
-                                                              prefetch_upgrades: nil,
-                                                              show_upgrade_summary: true,
-                                                              **|
-      if prefetch_only
-        expect(show_upgrade_summary).to be(false)
-        prefetch_names&.replace(["deno"])
-        prefetch_upgrades&.replace(["deno 2.7.10 -> 2.7.11"])
-      end
-
-      true
-    end
+    allow(Cask::Upgrade).to receive(:outdated_casks).and_return([cask])
     allow(Cask::Installer).to receive(:new).and_return(installer)
-    expect(installer).to receive(:prelude_fetch_download).and_return(nil)
-    expect(download_queue).to receive(:fetch)
-      .with(only: Cask::Download, heading: "Downloading Cask files")
-      .ordered
-    expect(download_queue).to receive(:fetch)
-      .with(heading: "Fetching downloads for: deno")
-      .ordered
-    allow(Cask::Upgrade).to receive_messages(outdated_casks: [cask], upgrade_casks!: true)
-    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
-    allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
-    allow(Homebrew.messages).to receive(:display_messages)
+    expect(Homebrew::Install).to receive(:enqueue_cask_installers).with([installer]).and_return([])
 
-    expect { cmd.run }.to output(<<~EOS).to_stdout
-      ==> Upgrading 2 outdated packages:
-      deno   2.7.10  -> 2.7.11
-      codex  0.117.0 -> 0.118.0
-    EOS
+    expect(
+      cmd.prefetch_outdated_casks!(
+        [],
+        download_queue:,
+        prefetch_names:,
+        prefetch_upgrades:,
+        prefetch_casks:,
+        prefetch_installers:,
+      ),
+    ).to be(true)
+    expect([prefetch_names, prefetch_upgrades, prefetch_casks, prefetch_installers]).to all(be_empty)
   end
 
   it "passes a bottle manifest heading to the tab prefetch queue" do
@@ -1243,10 +1172,9 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       version:           "0.118.0",
     )
     installer = Cask::Installer.allocate
-    allow(installer).to receive_messages(check_requirements: nil, downloader: failed_download,
-                                         download_failed!: nil, enqueue_downloads: nil,
-                                         enqueue_dependency_downloads: nil,
-                                         source_download_requires_pre_fetch?: false)
+    allow(installer).to receive_messages(cask:, check_requirements: nil, downloader: failed_download,
+                                         download_failed!: nil, download_failed?: false, enqueue_downloads: nil,
+                                         enqueue_dependency_downloads: nil)
 
     allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
     allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, prefetch_only: false,

--- a/Library/Homebrew/test/install_spec.rb
+++ b/Library/Homebrew/test/install_spec.rb
@@ -119,79 +119,86 @@ RSpec.describe Homebrew::Install do
   end
 
   describe "::enqueue_cask_installers" do
-    it "fetches source API downloads before enqueueing cask downloads" do
-      source_download = instance_double(Homebrew::API::SourceDownload)
-      installer = instance_double(
-        Cask::Installer,
-        cask:                                instance_double(Cask::Cask),
-        enqueue_dependency_downloads:        nil,
-        enqueue_downloads:                   nil,
-        prelude_fetch_download:              source_download,
-        source_download_requires_pre_fetch?: true,
-      )
-      download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [])
+    it "returns the installers whose downloads were enqueued" do
+      installer = instance_double(Cask::Installer)
 
-      expect(download_queue).to receive(:enqueue).with(source_download).ordered
-      expect(download_queue).to receive(:fetch)
-        .with(only: Homebrew::API::SourceDownload, heading: "Downloading Cask files")
-        .ordered
-      expect(installer).to receive(:enqueue_downloads).ordered
-      expect(download_queue).to receive(:fetch)
-        .with(only: Cask::Download, heading: "Downloading Cask files")
-        .ordered
+      expect(installer).to receive(:enqueue_downloads)
 
-      described_class.enqueue_cask_installers([installer], download_queue:)
-    end
-
-    it "marks a cask whose source API download fails" do
-      source_download = Homebrew::API::SourceDownload.new("https://brew.sh/cask.rb", nil)
-      installer = instance_double(
-        Cask::Installer,
-        cask:                                instance_double(Cask::Cask),
-        prelude_fetch_download:              source_download,
-        source_download_requires_pre_fetch?: true,
-      )
-      download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [source_download])
-
-      allow(download_queue).to receive(:enqueue)
-      allow(download_queue).to receive(:fetch)
-      expect(installer).to receive(:download_failed!)
-      expect(installer).not_to receive(:enqueue_downloads)
-
-      expect(described_class.enqueue_cask_installers([installer], download_queue:)).to be(false)
-    end
-
-    it "enqueues dependencies after fetching primary cask downloads" do
-      cask = instance_double(Cask::Cask, to_s: "dependent-cask")
-      installer = instance_double(Cask::Installer, cask:, source_download_requires_pre_fetch?: false)
-      download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [])
-
-      expect(installer).to receive(:enqueue_downloads).ordered
-      expect(download_queue).to receive(:fetch)
-        .with(only: Cask::Download, heading: "Downloading Cask files")
-        .ordered
-      expect(installer).to receive(:enqueue_dependency_downloads).ordered
-
-      described_class.enqueue_cask_installers([installer], download_queue:)
+      expect(described_class.enqueue_cask_installers([installer])).to eq([installer])
     end
 
     it "skips casks whose enqueue raises and continues with the rest" do
-      bad_cask = instance_double(Cask::Cask, to_s: "bad-cask")
-      bad_installer = instance_double(Cask::Installer, cask:                                bad_cask,
-                                                       source_download_requires_pre_fetch?: false)
+      bad_installer = instance_double(Cask::Installer, cask: instance_double(Cask::Cask, to_s: "bad-cask"))
       allow(bad_installer).to receive(:enqueue_downloads)
         .and_raise(URI::InvalidURIError, 'bad URI (is not URI?): "https://example.com/bad -cask.dmg"')
-      good_installer = instance_double(Cask::Installer, source_download_requires_pre_fetch?: false,
-                                                        enqueue_dependency_downloads:        nil)
-      expect(good_installer).to receive(:enqueue_downloads)
+      good_installer = instance_double(Cask::Installer, enqueue_downloads: nil)
 
-      download_queue = Homebrew::DownloadQueue.new(pour: true)
-      begin
-        expect { described_class.enqueue_cask_installers([bad_installer, good_installer], download_queue:) }
-          .to output(/Error: bad-cask: bad URI/).to_stderr
-      ensure
-        download_queue.shutdown
-      end
+      expect do
+        expect(described_class.enqueue_cask_installers([bad_installer, good_installer])).to eq([good_installer])
+      end.to output(/Error: bad-cask: bad URI/).to_stderr
+    end
+  end
+
+  describe "::fetch_cask_dependencies" do
+    it "enqueues dependency downloads once the cask downloads have been fetched" do
+      installer = instance_double(Cask::Installer)
+      download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [])
+
+      expect(installer).to receive(:enqueue_dependency_downloads).ordered
+      expect(download_queue).to receive(:fetch).with(heading: "Fetching dependency downloads").ordered
+
+      described_class.fetch_cask_dependencies([installer], download_queue:)
+    end
+
+    it "marks casks whose downloads failed before resolving dependencies" do
+      downloader = instance_double(Cask::Download)
+      installer = instance_double(Cask::Installer, downloader:, enqueue_dependency_downloads: nil)
+      download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [downloader], fetch: nil)
+
+      allow(installer).to receive(:download_failed?).and_return(false, true)
+      expect(installer).to receive(:download_failed!).ordered
+      expect(installer).to receive(:enqueue_dependency_downloads).ordered
+
+      described_class.fetch_cask_dependencies([installer], download_queue:)
+    end
+
+    it "skips casks whose dependency resolution raises and continues with the rest" do
+      bad_installer = instance_double(Cask::Installer, cask: instance_double(Cask::Cask, to_s: "bad-cask"))
+      allow(bad_installer).to receive(:enqueue_dependency_downloads).and_raise("unexpected nil primary_container")
+      good_installer = instance_double(Cask::Installer)
+      download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [], fetch: nil)
+
+      expect(good_installer).to receive(:enqueue_dependency_downloads)
+
+      expect { described_class.fetch_cask_dependencies([bad_installer, good_installer], download_queue:) }
+        .to output(/Error: bad-cask: unexpected nil primary_container/).to_stderr
+    end
+  end
+
+  describe "::mark_failed_cask_downloads" do
+    it "marks cask installers whose downloads failed" do
+      downloader = instance_double(Cask::Download)
+      installer = instance_double(Cask::Installer, downloader:, download_failed?: false)
+      download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [downloader])
+
+      expect(installer).to receive(:download_failed!)
+
+      described_class.mark_failed_cask_downloads([installer], download_queue:)
+    end
+
+    it "marks dependency cask installers whose downloads failed" do
+      dependency_downloader = instance_double(Cask::Download)
+      dependency_installer = instance_double(Cask::Installer, downloader:       dependency_downloader,
+                                                              download_failed?: false)
+      installer = instance_double(Cask::Installer, downloader:                 instance_double(Cask::Download),
+                                                   download_failed?:           false,
+                                                   dependency_cask_installers: [dependency_installer])
+      download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [dependency_downloader])
+
+      expect(installer).not_to receive(:download_failed!)
+      expect(dependency_installer).to receive(:download_failed!)
+
+      described_class.mark_failed_cask_downloads([installer], download_queue:)
     end
   end
 


### PR DESCRIPTION
- `Install.enqueue_cask_installers` drained cask downloads under a separate `Downloading Cask files` heading before the shared queue fetched formula bottles, serialising the two and splitting the output.
- Leave cask and dependency downloads queued so every command fetches them concurrently with bottles under one `Fetching downloads for:` heading, marking failed cask downloads afterwards.
- Drop the cask source file fallback: language variations and structured install steps live in the API, so `caskfile_only?` and `Homebrew::API::Cask.source_download*` never fired for official casks.
- Stop publishing `api/cask-source/*.rb` and treat cached cask sources as stale so existing caches are cleaned up.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Fable 5 high with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----