### PR TITLE
tests: speed up slow tests

### DIFF
--- a/Library/Homebrew/test/cask/migrator_spec.rb
+++ b/Library/Homebrew/test/cask/migrator_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Cask::Migrator do
 
   describe ".migrate_if_needed", :cask do
     let(:old_cask) { Cask::CaskLoader.load(cask_path("local-caffeine")) }
-    let(:new_cask) { Cask::CaskLoader.load(cask_path("local-transmission")) }
+    let(:new_cask) { Cask::CaskLoader.load(cask_path("local-transmission-zip")) }
     let(:old_caskroom_path) { Cask::Caskroom.path/"local-caffeine" }
     let(:appdir) { Pathname(new_cask.config.appdir) }
 
@@ -81,7 +81,7 @@ RSpec.describe Cask::Migrator do
     context "when the new token is an alias symlink pointing at the old directory" do
       it "moves the old cask to the new token without copying it into itself" do
         InstallHelper.stub_cask_installation(old_cask)
-        FileUtils.ln_s "local-caffeine", Cask::Caskroom.path/"local-transmission"
+        FileUtils.ln_s "local-caffeine", Cask::Caskroom.path/"local-transmission-zip"
         rename_old_cask_to_new_cask
 
         described_class.migrate_if_needed(new_cask)
@@ -89,7 +89,7 @@ RSpec.describe Cask::Migrator do
         expect([
           old_caskroom_path.symlink?,
           new_cask.installed_version,
-          (Cask::Caskroom.path/"local-transmission/local-caffeine").exist?,
+          (Cask::Caskroom.path/"local-transmission-zip/local-caffeine").exist?,
         ]).to eq([true, old_cask.version.to_s, false])
       end
     end
@@ -115,7 +115,7 @@ RSpec.describe Cask::Migrator do
 
       it "does not uninstall the old cask in a dry run" do
         expect { described_class.migrate_if_needed(new_cask, dry_run: true) }
-          .to output(/local-transmission is already installed, so local-caffeine would be uninstalled/)
+          .to output(/local-transmission-zip is already installed, so local-caffeine would be uninstalled/)
           .to_stdout
 
         expect([old_caskroom_path.directory?, (appdir/"Caffeine.app").exist?]).to eq([true, true])

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -202,6 +202,10 @@ RSpec.configure do |config|
     ERROR
   end
 
+  config.before do
+    allow(Utils).to receive(:sleep)
+  end
+
   config.before(:each, :no_api) do
     ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
   end

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -397,7 +397,7 @@ RSpec.describe Tab do
 
       f = formula do
         T.bind(self, T.class_of(Formula))
-        url "foo-1.0"
+        url "file:///foo-1.0"
         depends_on "bar"
         depends_on "user/repo/from_tap"
         depends_on "baz" => :build
@@ -444,7 +444,7 @@ RSpec.describe Tab do
       alias_path = CoreTap.instance.alias_dir/"bar"
       f = formula(alias_path:) do
         T.bind(self, T.class_of(Formula))
-        url "foo-1.0"
+        url "file:///foo-1.0"
       end
       compiler = DevelopmentTools.default_compiler
       stdlib = :libcxx


### PR DESCRIPTION
This PR optimises some of the slowest tests in the suite, without undermining their accuracy.

1. Migrator Spec - use `zip` fixture instead of `dmg` - avoids the need to mount the image.

<details><summary>Benchmark</summary>
<p>
Benchmark 1: before
  Time (mean ± σ):     10.638 s ±  1.252 s    [User: 1.239 s, System: 1.053 s]
  Range (min … max):    7.639 s … 12.059 s    10 runs

Benchmark 2: after
  Time (mean ± σ):      2.560 s ±  0.094 s    [User: 1.172 s, System: 0.933 s]
  Range (min … max):    2.497 s …  2.743 s    10 runs

Summary
  after ran
    4.16 ± 0.51 times faster than before
</p>
</details> 


2. Tab Spec - use a `file://` url, to prevent the spec from trying to use `curl`.

<details><summary>Benchmark</summary>
<p>
Benchmark 1: before
  Time (mean ± σ):     19.561 s ±  0.207 s    [User: 4.323 s, System: 0.955 s]
  Range (min … max):   19.326 s … 19.981 s    10 runs

Benchmark 2: after
  Time (mean ± σ):      5.413 s ±  0.108 s    [User: 4.274 s, System: 0.895 s]
  Range (min … max):    5.308 s …  5.647 s    10 runs

Summary
  after ran
    3.61 ± 0.08 times faster than before
</p>
</details> 

3. `spec_helper` - stub the timeout so there isn't any unnecessary sleep during the test run.

<details><summary>Benchmark</summary>
<p>
Benchmark 1: before
  Time (mean ± σ):      4.052 s ±  0.046 s    [User: 1.168 s, System: 0.613 s]
  Range (min … max):    3.986 s …  4.125 s    10 runs

Benchmark 2: after
  Time (mean ± σ):      1.933 s ±  0.019 s    [User: 1.128 s, System: 0.557 s]
  Range (min … max):    1.908 s …  1.964 s    10 runs

Summary
  after ran
    2.10 ± 0.03 times faster than before
</p>
</details> 

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

I used `claude-code` with Opus 5 to find the slowest tests, and speed them up. I verified the performance improvement and the changes that were made.