### PR TITLE
cask/artifact: don't copy xattrs when quarantine is unavailable

### DIFF
--- a/Library/Homebrew/cask/artifact/moved.rb
+++ b/Library/Homebrew/cask/artifact/moved.rb
@@ -157,7 +157,7 @@ module Cask
             command.run!("/bin/cp", args: ["-pR", *source.children, target],
                                     sudo: true)
           end
-          Quarantine.copy_xattrs(source, target, command:)
+          Quarantine.copy_xattrs(source, target, command:) if Quarantine.available?
           FileUtils.rm_r(source)
         elsif target.dirname.writable?
           FileUtils.move(source, target)

--- a/Library/Homebrew/test/cask/artifact/app_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/app_spec.rb
@@ -392,6 +392,18 @@ RSpec.describe Cask::Artifact::App, :cask do
       expect(contents_path).to exist
     end
 
+    describe "when quarantine support is unavailable" do
+      it "reinstalls into the reused directory without copying xattrs" do
+        allow(Cask::Quarantine).to receive(:available?).and_return(false)
+        expect(Cask::Quarantine).not_to receive(:copy_xattrs)
+
+        app.uninstall_phase(command:, force:, successor: cask)
+        app.install_phase(command:, adopt:, force:, predecessor: cask)
+
+        expect(target_path.join("Contents/Info.plist")).to exist
+      end
+    end
+
     describe "when the system blocks modifying apps" do
       it "uninstalls and reinstalls the app" do
         target_contents_path = target_path.join("Contents")


### PR DESCRIPTION
Following on from #23608, which fixed a defect I had recently introduced in #23556 by failing to guard a call to `Quarantine.detect`. Upon discovering my mistake, I checked every other call site of the Quarantine methods that raise where there is no quarantine support, and found one existing instance of the same defect: two call sites in `download.rb` and one in `audit.rb` were already guarded (#23229), two in `upgrade.rb` were guarded by #23608, but one in `moved.rb` was unguarded. This PR addresses that defect.

When an install or upgrade reuses an existing target directory — the adopt/overwrite path, and ordinary upgrades, which keep the app directory in place — `Moved#move` copies the source's extended attributes with `Quarantine.copy_xattrs`. That method is implemented in the macOS extension only; the base module raises `NotImplementedError`, so on Linux the install dies mid-move. The fix guards the call with `Quarantine.available?`, as the module's other call sites do. As with #23608, I have not seen this reported — reaching it needs a cask installed on Linux — so this is closing a latent hole rather than fixing a live crash.

To reproduce, on a system without quarantine support, with any installed app cask:

```
brew upgrade --cask <token>
Error: <token>: NotImplementedError
```

<details>
<summary>Details</summary>

> **What does the test assert?** That the reused-directory reinstall completes without `Quarantine.copy_xattrs` being called when `Quarantine.available?` is false. Verified red before the change (the unguarded call fires) and green after. Same shape as the regression tests in #23229 and #23608.
>
> **Why `Quarantine.available?` rather than an OS check?** It is the guard the module's other call sites use, and it also covers the macOS degenerate case of a broken `xattr`, where the rest of the quarantine machinery (propagation, the upgrade snapshot) is already skipped — copying quarantine xattrs for an install that was never quarantined would do nothing useful.

</details>

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include [Hyperfine](https://github.com/sharkdp/hyperfine) benchmarks.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Used Claude Code (Fable 5) to investigate and draft; I directed the investigation, and reviewed the diff and every line of this PR text.

-----
