### PR TITLE
os/linux/ld: prefer dynamic linkers matching the host architecture

### DIFF
--- a/Library/Homebrew/os/linux/ld.rb
+++ b/Library/Homebrew/os/linux/ld.rb
@@ -19,6 +19,16 @@ module OS
         /system/bin/linker
       ].freeze
 
+      # Preferred over `DYNAMIC_LINKERS` so that a foreign-architecture linker
+      # (e.g. x86-64 on an ARM host with multiarch) is not picked first.
+      NATIVE_DYNAMIC_LINKERS = T.let({
+        x86_64:  ["/lib64/ld-linux-x86-64.so.2"],
+        i386:    ["/lib/ld-linux.so.2"],
+        arm64:   ["/lib/ld-linux-aarch64.so.1"],
+        arm:     ["/lib/ld-linux-armhf.so.3", "/lib/ld-linux.so.3"],
+        ppc64le: ["/lib64/ld64.so.2"],
+      }.freeze, T::Hash[Symbol, T::Array[String]])
+
       class << self
         sig { params(system_ld_so: T.nilable(::Pathname)).returns(T.nilable(::Pathname)) }
         attr_writer :system_ld_so
@@ -29,7 +39,8 @@ module OS
       def self.system_ld_so
         @system_ld_so ||= T.let(nil, T.nilable(::Pathname))
         @system_ld_so ||= begin
-          linker = DYNAMIC_LINKERS.find { |s| File.executable? s }
+          candidates = NATIVE_DYNAMIC_LINKERS.fetch(::Hardware::CPU.arch, []) + DYNAMIC_LINKERS
+          linker = candidates.uniq.find { |s| File.executable? s }
           Pathname(linker) if linker
         end
       end

--- a/Library/Homebrew/test/os/linux/ld_spec.rb
+++ b/Library/Homebrew/test/os/linux/ld_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe OS::Linux::Ld do
     it "returns nil when there is no known dynamic linker" do
       expect(described_class.system_ld_so).to be_nil
     end
+
+    it "prefers the dynamic linker matching the host architecture" do
+      allow(Hardware::CPU).to receive(:arch).and_return(:arm64)
+      allow(File).to receive(:executable?).with("/lib64/ld-linux-x86-64.so.2").and_return(true)
+      allow(File).to receive(:executable?).with("/lib/ld-linux-aarch64.so.1").and_return(true)
+
+      expect(described_class.system_ld_so).to eq(Pathname("/lib/ld-linux-aarch64.so.1"))
+    end
   end
 
   describe "::sysconfdir" do


### PR DESCRIPTION
# PR draft

Title: os/linux/ld: prefer dynamic linkers matching the host architecture

Refs: https://github.com/orgs/Homebrew/discussions/6179, https://github.com/orgs/Homebrew/discussions/6680

## Problem

`OS::Linux::Ld.system_ld_so` returns the first entry of `DYNAMIC_LINKERS` that
is executable, regardless of host architecture. On hosts where a
foreign-architecture linker exists (multiarch installs such as `libc6:amd64`
on arm64, cross-toolchains, WSL, containers with emulation), the x86-64 linker
`/lib64/ld-linux-x86-64.so.2` — listed first — wins even on non-x86 hosts.
Every Homebrew binary then fails at execve with `ELIBBAD`
("Accessing a corrupted shared library"), because the kernel rejects the
wrong-architecture ELF interpreter.

Reproduction timeline on Ubuntu 24.04 aarch64:

1. `apt-get install libc6:amd64` (e.g. for qemu-user emulation) creates
   `/lib64/ld-linux-x86-64.so.2`.
2. Any subsequent `brew install/upgrade` re-runs `symlink_ld_so`, which repoints
   `<prefix>/lib/ld.so` to the x86-64 linker.
3. All dynamically linked bottles break until the next manual fix — and the
   symlink gets rewritten again by the following install.

Reported in discussions #6179 and #6680; still unfixed as of 6.0.18.

## Fix

Introduce `NATIVE_DYNAMIC_LINKERS`, keyed by `Hardware::CPU.arch`, and check
those paths first inside `system_ld_so`. The full `DYNAMIC_LINKERS` list remains
as a fallback, so behavior on unusual setups (and the existing specs) is
unchanged when no native-architecture linker matches.

Because the preference keys off `Hardware::CPU.arch` (the architecture of the
running brew/Ruby process) rather than the kernel architecture, setups where an
x86-64 Homebrew runs under emulation on ARM hardware also keep working: their
binaries genuinely need the x86-64 linker.
