### PR TITLE
Select the native architecture's dynamic linker on Linux

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -143,6 +143,14 @@ module Homebrew
 
           bundle_args = os_bundle_args(bundle_args)
           files = os_files(files)
+          if files.blank?
+            if args.changed?
+              opoo "No tests are available to run on this operating system."
+              return
+            end
+
+            raise UsageError, "No tests are available to run on this operating system."
+          end
 
           puts "Randomized with seed #{seed}"
 

--- a/Library/Homebrew/os/linux/ld.rb
+++ b/Library/Homebrew/os/linux/ld.rb
@@ -1,23 +1,40 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "hardware"
+
 module OS
   module Linux
     # Helper functions for querying `ld` information.
     module Ld
-      # This is a list of known paths to the host dynamic linker on Linux if
-      # the host glibc is new enough. Brew will fail to create a symlink for
-      # ld.so if the host linker cannot be found in this list.
-      DYNAMIC_LINKERS = %w[
-        /lib64/ld-linux-x86-64.so.2
-        /lib64/ld64.so.2
-        /lib/ld-linux.so.3
-        /lib/ld-linux.so.2
-        /lib/ld-linux-aarch64.so.1
-        /lib/ld-linux-armhf.so.3
-        /system/bin/linker64
-        /system/bin/linker
-      ].freeze
+      # These are known paths to the host dynamic linker on Linux if the host
+      # glibc is new enough. Brew will fail to create a symlink for ld.so if
+      # the host architecture's linker cannot be found in this list.
+      DYNAMIC_LINKERS = T.let({
+        arm:     %w[
+          /lib/ld-linux.so.3
+          /lib/ld-linux-armhf.so.3
+          /system/bin/linker
+        ].freeze,
+        arm64:   %w[
+          /lib/ld-linux-aarch64.so.1
+          /system/bin/linker64
+        ].freeze,
+        i386:    %w[
+          /lib/ld-linux.so.2
+          /system/bin/linker
+        ].freeze,
+        ppc64:   %w[
+          /lib64/ld64.so.2
+        ].freeze,
+        ppc64le: %w[
+          /lib64/ld64.so.2
+        ].freeze,
+        x86_64:  %w[
+          /lib64/ld-linux-x86-64.so.2
+          /system/bin/linker64
+        ].freeze,
+      }.freeze, T::Hash[Symbol, T::Array[String]])
 
       class << self
         sig { params(system_ld_so: T.nilable(::Pathname)).returns(T.nilable(::Pathname)) }
@@ -29,7 +46,7 @@ module OS
       def self.system_ld_so
         @system_ld_so ||= T.let(nil, T.nilable(::Pathname))
         @system_ld_so ||= begin
-          linker = DYNAMIC_LINKERS.find { |s| File.executable? s }
+          linker = DYNAMIC_LINKERS.fetch(::Hardware::CPU.arch, []).find { |s| File.executable? s }
           Pathname(linker) if linker
         end
       end

--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -7,6 +7,49 @@ require "dev-cmd/tests"
 RSpec.describe Homebrew::DevCmd::Tests do
   it_behaves_like "parseable arguments"
 
+  describe "#run" do
+    subject(:tests) { described_class.new(args) }
+
+    let(:args) { [] }
+
+    before do
+      allow(Homebrew).to receive_messages(valid_gem_groups: [], install_bundler_gems!: nil)
+      allow(tests).to receive_messages(setup_environment!: nil, check_test_environment!: nil)
+    end
+
+    context "when changed tests only run on another OS" do
+      let(:args) { ["--changed"] }
+      let(:changed_file) do
+        if OS.linux?
+          "Library/Homebrew/cask/cask.rb"
+        else
+          "Library/Homebrew/os/linux/ld.rb"
+        end
+      end
+
+      before do
+        allow(Utils::Git).to receive(:changed_files).and_return([changed_file])
+      end
+
+      it "does not invoke RSpec" do
+        expect(tests).not_to receive(:system)
+
+        expect { tests.run }.to output(/No tests are available to run on this operating system/).to_stderr
+      end
+    end
+
+    context "when an explicit test only runs on another OS" do
+      let(:args) { ["--only=#{test_name}"] }
+      let(:test_name) { OS.linux? ? "cask/cask" : "os/linux/ld" }
+
+      it "fails instead of reporting success without running the test" do
+        expect(tests).not_to receive(:system)
+
+        expect { tests.run }.to raise_error(UsageError, /No tests are available to run on this operating system/)
+      end
+    end
+  end
+
   describe "#check_test_environment!", :needs_linux do
     subject(:tests) { described_class.new([]) }
 

--- a/Library/Homebrew/test/os/linux/ld_spec.rb
+++ b/Library/Homebrew/test/os/linux/ld_spec.rb
@@ -15,16 +15,29 @@ RSpec.describe OS::Linux::Ld do
   end
 
   describe "::system_ld_so" do
-    let(:ld_so) { "/lib/ld-linux.so.3" }
+    let(:ld_so) { "/lib64/ld-linux-x86-64.so.2" }
 
     before do
+      allow(Hardware::CPU).to receive(:arch).and_return(:x86_64)
       allow(File).to receive(:executable?).and_return(false)
+      described_class.system_ld_so = nil
+    end
+
+    after do
       described_class.system_ld_so = nil
     end
 
     it "returns the path to a known dynamic linker" do
       allow(File).to receive(:executable?).with(ld_so).and_return(true)
       expect(described_class.system_ld_so).to eq(Pathname(ld_so))
+    end
+
+    it "prefers the native dynamic linker when a foreign architecture linker is installed" do
+      allow(Hardware::CPU).to receive(:arch).and_return(:arm64)
+      allow(File).to receive(:executable?).with("/lib64/ld-linux-x86-64.so.2").and_return(true)
+      allow(File).to receive(:executable?).with("/lib/ld-linux-aarch64.so.1").and_return(true)
+
+      expect(described_class.system_ld_so).to eq(Pathname("/lib/ld-linux-aarch64.so.1"))
     end
 
     it "returns nil when there is no known dynamic linker" do


### PR DESCRIPTION
On ARM64 Linux with amd64 multi-arch libc installed, `OS::Linux::Ld.system_ld_so` returned the first executable path from a flat, cross-architecture list, so `$HOMEBREW_PREFIX/lib/ld.so` was symlinked to `/lib64/ld-linux-x86-64.so.2` and ARM binaries stopped running. Reported in [discussion #6179](https://github.com/orgs/Homebrew/discussions/6179#discussioncomment-18117019).

`DYNAMIC_LINKERS` is now keyed by `Hardware::CPU.arch` and only the native architecture's candidates are searched, so a foreign loader can no longer be selected when the native one is missing.

The second commit fixes something that surfaced while testing the first. `brew tests --changed` could select a spec that OS filtering then removed, leaving RSpec invoked with an empty file list and failing `brew lgtm` on macOS. `--changed` now warns and returns, while every other invocation fails, including an explicit `--only` for a spec the current OS filters out, rather than exiting green without running anything.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the fix and pass with it, and ran `brew lgtm --online` plus targeted specs.

-----
