### PR TITLE
generate-zap: resolve apps from package receipts

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-zap.rb
+++ b/Library/Homebrew/dev-cmd/generate-zap.rb
@@ -3,7 +3,6 @@
 
 require "abstract_command"
 require "cask"
-require "cask/pkg"
 require "system_command"
 
 module Homebrew

--- a/Library/Homebrew/dev-cmd/generate-zap.rb
+++ b/Library/Homebrew/dev-cmd/generate-zap.rb
@@ -137,7 +137,29 @@ module Homebrew
         end
 
         token_pattern = cask.token.tr("-", " ").split.map(&:capitalize).join(" ")
-        pkg_app_paths = installed_pkg_app_paths(cask)
+        pkgutil_receipt_patterns = T.let([], T::Array[String])
+        cask.artifacts.each do |artifact|
+          next unless artifact.is_a?(Cask::Artifact::AbstractUninstall)
+
+          pkgutil = artifact.directives[:pkgutil]
+          if pkgutil.is_a?(String)
+            pkgutil_receipt_patterns << pkgutil
+          elsif pkgutil.is_a?(Array)
+            pkgutil.each { |pattern| pkgutil_receipt_patterns << pattern if pattern.is_a?(String) }
+          end
+        end
+
+        pkg_app_paths = pkgutil_receipt_patterns.uniq.flat_map do |receipt_pattern|
+          Cask::Pkg.all_matching(receipt_pattern, SystemCommand).flat_map do |pkg|
+            pkg.pkgutil_bom_all.filter_map do |path|
+              match = path.to_s.match(%r{\A(?<app_path>.*?\.app)(?:/|\z)}i)
+              next if match.nil?
+
+              Pathname.new(match[:app_path])
+            end
+          end
+        end.uniq.select(&:directory?)
+
         unless pkg_app_paths.empty?
           ohai "No app artifact found in cask \"#{cask.token}\"; using installed package receipts."
           patterns = patterns_from_app_paths(pkg_app_paths)
@@ -152,55 +174,15 @@ module Homebrew
       sig { params(app_paths: T::Array[Pathname]).returns(T::Array[String]) }
       def patterns_from_app_paths(app_paths)
         app_paths.flat_map do |app_path|
-          [app_path.basename(".app").to_s, *bundle_identifiers(app_path)]
+          patterns = [app_path.basename(".app").to_s]
+          info_plist = app_path/"Contents/Info.plist"
+          next patterns if !info_plist.exist? || !info_plist.readable?
+
+          plist = system_command!("plutil", args: ["-convert", "xml1", "-o", "-", info_plist]).plist
+          bundle_identifier = plist["CFBundleIdentifier"]
+          patterns << bundle_identifier if bundle_identifier.is_a?(String)
+          patterns
         end.uniq
-      end
-
-      sig { params(cask: Cask::Cask).returns(T::Array[Pathname]) }
-      def installed_pkg_app_paths(cask)
-        pkgutil_receipt_patterns(cask).flat_map do |receipt_pattern|
-          Cask::Pkg.all_matching(receipt_pattern, SystemCommand).flat_map do |pkg|
-            pkg.pkgutil_bom_all.filter_map { |path| top_level_app_path(path) }
-          end
-        end.uniq.select(&:directory?)
-      end
-
-      sig { params(cask: Cask::Cask).returns(T::Array[String]) }
-      def pkgutil_receipt_patterns(cask)
-        patterns = T.let([], T::Array[String])
-
-        cask.artifacts.each do |artifact|
-          next unless artifact.is_a?(Cask::Artifact::AbstractUninstall)
-
-          pkgutil = artifact.directives[:pkgutil]
-          if pkgutil.is_a?(String)
-            patterns << pkgutil
-          elsif pkgutil.is_a?(Array)
-            pkgutil.each { |pattern| patterns << pattern if pattern.is_a?(String) }
-          end
-        end
-
-        patterns.uniq
-      end
-
-      sig { params(path: Pathname).returns(T.nilable(Pathname)) }
-      def top_level_app_path(path)
-        match = path.to_s.match(%r{\A(?<app_path>.*?\.app)(?:/|\z)}i)
-        return if match.nil?
-
-        Pathname.new(match[:app_path])
-      end
-
-      sig { params(app_path: Pathname).returns(T::Array[String]) }
-      def bundle_identifiers(app_path)
-        info_plist = app_path/"Contents/Info.plist"
-        return [] if !info_plist.exist? || !info_plist.readable?
-
-        plist = system_command!("plutil", args: ["-convert", "xml1", "-o", "-", info_plist]).plist
-        bundle_identifier = plist["CFBundleIdentifier"]
-        return [] unless bundle_identifier.is_a?(String)
-
-        [bundle_identifier]
       end
 
       sig {

--- a/Library/Homebrew/dev-cmd/generate-zap.rb
+++ b/Library/Homebrew/dev-cmd/generate-zap.rb
@@ -3,6 +3,7 @@
 
 require "abstract_command"
 require "cask"
+require "cask/pkg"
 require "system_command"
 
 module Homebrew
@@ -133,18 +134,67 @@ module Homebrew
       def resolve_patterns_from_cask(cask)
         app_artifact = cask.artifacts.find { |a| a.is_a?(Cask::Artifact::App) }
         if app_artifact
-          patterns = [app_artifact.target.basename(".app").to_s]
-          patterns.concat(bundle_identifiers(app_artifact))
-          patterns.uniq
-        else
-          ohai "No app artifact found in cask \"#{cask.token}\"; using token as app name."
-          [cask.token.tr("-", " ").split.map(&:capitalize).join(" ")]
+          return patterns_from_app_paths([app_artifact.target])
         end
+
+        token_pattern = cask.token.tr("-", " ").split.map(&:capitalize).join(" ")
+        pkg_app_paths = installed_pkg_app_paths(cask)
+        unless pkg_app_paths.empty?
+          ohai "No app artifact found in cask \"#{cask.token}\"; using installed package receipts."
+          patterns = patterns_from_app_paths(pkg_app_paths)
+          patterns << token_pattern unless patterns.any? { |pattern| pattern.casecmp?(token_pattern) }
+          return patterns
+        end
+
+        ohai "No app artifact or installed package app found in cask \"#{cask.token}\"; using token as app name."
+        [token_pattern]
       end
 
-      sig { params(app_artifact: Cask::Artifact::App).returns(T::Array[String]) }
-      def bundle_identifiers(app_artifact)
-        info_plist = app_artifact.target/"Contents/Info.plist"
+      sig { params(app_paths: T::Array[Pathname]).returns(T::Array[String]) }
+      def patterns_from_app_paths(app_paths)
+        app_paths.flat_map do |app_path|
+          [app_path.basename(".app").to_s, *bundle_identifiers(app_path)]
+        end.uniq
+      end
+
+      sig { params(cask: Cask::Cask).returns(T::Array[Pathname]) }
+      def installed_pkg_app_paths(cask)
+        pkgutil_receipt_patterns(cask).flat_map do |receipt_pattern|
+          Cask::Pkg.all_matching(receipt_pattern, SystemCommand).flat_map do |pkg|
+            pkg.pkgutil_bom_all.filter_map { |path| top_level_app_path(path) }
+          end
+        end.uniq.select(&:directory?)
+      end
+
+      sig { params(cask: Cask::Cask).returns(T::Array[String]) }
+      def pkgutil_receipt_patterns(cask)
+        patterns = T.let([], T::Array[String])
+
+        cask.artifacts.each do |artifact|
+          next unless artifact.is_a?(Cask::Artifact::AbstractUninstall)
+
+          pkgutil = artifact.directives[:pkgutil]
+          if pkgutil.is_a?(String)
+            patterns << pkgutil
+          elsif pkgutil.is_a?(Array)
+            pkgutil.each { |pattern| patterns << pattern if pattern.is_a?(String) }
+          end
+        end
+
+        patterns.uniq
+      end
+
+      sig { params(path: Pathname).returns(T.nilable(Pathname)) }
+      def top_level_app_path(path)
+        match = path.to_s.match(%r{\A(?<app_path>.*?\.app)(?:/|\z)}i)
+        return if match.nil?
+
+        Pathname.new(match[:app_path])
+      end
+
+      sig { params(app_path: Pathname).returns(T::Array[String]) }
+      def bundle_identifiers(app_path)
+        info_plist = app_path/"Contents/Info.plist"
         return [] if !info_plist.exist? || !info_plist.readable?
 
         plist = system_command!("plutil", args: ["-convert", "xml1", "-o", "-", info_plist]).plist

--- a/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
@@ -187,21 +187,21 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
     end
   end
 
-  describe "#bundle_identifiers" do
-    it "returns empty array when Info.plist is missing" do
-      expect(generate_zap.bundle_identifiers(Pathname.new("TestCask.app"))).to eq([])
+  describe "#patterns_from_app_paths" do
+    it "returns only the app name when Info.plist is missing" do
+      expect(generate_zap.patterns_from_app_paths([Pathname.new("TestCask.app")])).to eq(["TestCask"])
     end
 
-    it "returns empty array when Info.plist is unreadable" do
+    it "returns only the app name when Info.plist is unreadable" do
       info_plist = instance_double(Pathname, exist?: true, readable?: false)
-      app_path = instance_double(Pathname)
+      app_path = instance_double(Pathname, basename: Pathname.new("TestCask"))
 
       allow(app_path).to receive(:/).with("Contents/Info.plist").and_return(info_plist)
 
-      expect(generate_zap.bundle_identifiers(app_path)).to eq([])
+      expect(generate_zap.patterns_from_app_paths([app_path])).to eq(["TestCask"])
     end
 
-    it "returns empty array when CFBundleIdentifier is not a string" do
+    it "returns only the app name when CFBundleIdentifier is not a string" do
       Dir.mktmpdir do |tmpdir|
         app_path = Pathname.new("#{tmpdir}/TestCask.app")
         info_plist = app_path/"Contents/Info.plist"
@@ -214,7 +214,7 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
           .with("plutil", args: ["-convert", "xml1", "-o", "-", info_plist])
           .and_return(result)
 
-        expect(generate_zap.bundle_identifiers(app_path)).to eq([])
+        expect(generate_zap.patterns_from_app_paths([app_path])).to eq(["TestCask"])
       end
     end
   end

--- a/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
@@ -57,6 +57,53 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
       end
     end
 
+    it "resolves an installed app and bundle identifier from a package receipt" do
+      Dir.mktmpdir do |tmpdir|
+        app_path = Pathname.new("#{tmpdir}/TestPkg.app")
+        info_plist = app_path/"Contents/Info.plist"
+        info_plist.dirname.mkpath
+        info_plist.write("")
+
+        cask = Cask::Cask.new("test-pkg") do
+          uninstall pkgutil: "com.example.test-pkg"
+        end
+        pkg = instance_double(
+          Cask::Pkg,
+          pkgutil_bom_all: [
+            app_path/"Contents/MacOS/TestPkg",
+            app_path/"Contents/Frameworks/TestPkg Helper.app/Contents/MacOS/TestPkg Helper",
+          ],
+        )
+        result = instance_double(SystemCommand::Result, plist: { "CFBundleIdentifier" => "com.example.testpkg" })
+
+        allow(Cask::Pkg).to receive(:all_matching)
+          .with("com.example.test-pkg", SystemCommand)
+          .and_return([pkg])
+        allow(generate_zap).to receive(:system_command!)
+          .with("plutil", args: ["-convert", "xml1", "-o", "-", info_plist])
+          .and_return(result)
+
+        expect(generate_zap.resolve_patterns_from_cask(cask))
+          .to eq(["TestPkg", "com.example.testpkg", "Test Pkg"])
+      end
+    end
+
+    it "ignores stale package receipts" do
+      cask = Cask::Cask.new("test-pkg") do
+        uninstall pkgutil: "com.example.test-pkg"
+      end
+      pkg = instance_double(
+        Cask::Pkg,
+        pkgutil_bom_all: [Pathname.new("/Applications/TestPkg.app/Contents/MacOS/TestPkg")],
+      )
+
+      allow(Cask::Pkg).to receive(:all_matching)
+        .with("com.example.test-pkg", SystemCommand)
+        .and_return([pkg])
+
+      expect(generate_zap.resolve_patterns_from_cask(cask)).to eq(["Test Pkg"])
+    end
+
     it "falls back to title-cased token when no app artifact exists" do
       cask = Cask::Cask.new("test-cask")
 
@@ -142,19 +189,16 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
 
   describe "#bundle_identifiers" do
     it "returns empty array when Info.plist is missing" do
-      app = instance_double(Cask::Artifact::App, target: Pathname.new("TestCask.app"))
-
-      expect(generate_zap.bundle_identifiers(app)).to eq([])
+      expect(generate_zap.bundle_identifiers(Pathname.new("TestCask.app"))).to eq([])
     end
 
     it "returns empty array when Info.plist is unreadable" do
       info_plist = instance_double(Pathname, exist?: true, readable?: false)
       app_path = instance_double(Pathname)
-      app = instance_double(Cask::Artifact::App, target: app_path)
 
       allow(app_path).to receive(:/).with("Contents/Info.plist").and_return(info_plist)
 
-      expect(generate_zap.bundle_identifiers(app)).to eq([])
+      expect(generate_zap.bundle_identifiers(app_path)).to eq([])
     end
 
     it "returns empty array when CFBundleIdentifier is not a string" do
@@ -164,14 +208,13 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
         info_plist.dirname.mkpath
         info_plist.write("")
 
-        app = instance_double(Cask::Artifact::App, target: app_path)
         result = instance_double(SystemCommand::Result, plist: { "CFBundleIdentifier" => [] })
 
         allow(generate_zap).to receive(:system_command!)
           .with("plutil", args: ["-convert", "xml1", "-o", "-", info_plist])
           .and_return(result)
 
-        expect(generate_zap.bundle_identifiers(app)).to eq([])
+        expect(generate_zap.bundle_identifiers(app_path)).to eq([])
       end
     end
   end


### PR DESCRIPTION
-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

GitHub Copilot CLI using GPT-5.6 Sol helped investigate the issue, implement the change, and write tests. I reviewed the resulting diff, tested it against Cloudflare WARP, Google Drive, and Zoom package receipts, and ran `brew lgtm --online`.

-----

`brew generate-zap` resolves search patterns from an `app` artifact's name and bundle identifier. Casks installed through a `pkg` artifact do not expose an `app` artifact, even when the package installs an application. The command therefore falls back to the title-cased token and can incorrectly report that no zap stanza is required.

For example:

```console
$ brew install --cask cloudflare-warp
$ open "/Applications/Cloudflare WARP.app"
$ brew generate-zap cloudflare-warp
Warning: No files found matching "Cloudflare Warp".
# No zap stanza required
```

This change uses `pkgutil` directives from uninstall and zap artifacts to find installed package receipts. It derives top-level application bundles from each receipt, excluding nested helper apps and stale receipt paths, then scans using their application names and bundle identifiers. The existing token-derived pattern remains as a fallback so broader matches such as Zoom updater files are preserved.

Package receipts are the local source of truth for package-installed applications and avoid downloading or expanding installers. This lets package-based casks use the same bundle-aware zap generation as casks with explicit `app` artifacts.