### PR TITLE
formatter: fix comma placement for negative numbers

### DIFF
--- a/Library/Homebrew/test/formatter_spec.rb
+++ b/Library/Homebrew/test/formatter_spec.rb
@@ -171,6 +171,7 @@ RSpec.describe Formatter do
       expect(described_class.number_readable(1)).to eq("1")
       expect(described_class.number_readable(1_000)).to eq("1,000")
       expect(described_class.number_readable(1_000_000)).to eq("1,000,000")
+      expect(described_class.number_readable(-123_456)).to eq("-123,456")
     end
   end
 

--- a/Library/Homebrew/utils/formatter.rb
+++ b/Library/Homebrew/utils/formatter.rb
@@ -207,9 +207,7 @@ module Formatter
 
   sig { params(number: Integer).returns(String) }
   def self.number_readable(number)
-    numstr = number.to_i.to_s
-    (numstr.size - 3).step(1, -3) { |i| numstr.insert(i.to_i, ",") }
-    numstr
+    number.to_i.to_s.gsub(/(\d)(?=(\d{3})+\z)/, "\\1,")
   end
 
   sig { params(input: String, secrets: T::Array[String]).returns(String) }


### PR DESCRIPTION
`Formatter.number_readable` inserted a comma immediately after the minus sign for negatives whose digit count is a multiple of three.

Replaced with a lookahead gsub that can only insert between digits.

We currently don't use negative numbers anywhere so a bit of an edge finding.

n.b. I've been fuzzing various parts of the codebase to identify small correctness bugs like this.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [ ] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [ ] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [ ] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Ox Alpha + Opus 5 for reverification, manual testing + verification, brew lgtm --online.

-----
