### PR TITLE
test/cmd/which-formula_spec: avoid modifications outside test dir

### DIFF
--- a/Library/Homebrew/test/cmd/which-formula_spec.rb
+++ b/Library/Homebrew/test/cmd/which-formula_spec.rb
@@ -10,13 +10,7 @@ RSpec.describe Homebrew::Cmd::WhichFormula do
   it_behaves_like "parseable arguments"
 
   describe "which_formula" do
-    let(:shell_cellar) do
-      if (HOMEBREW_LIBRARY_PATH.parent.parent/"Cellar").directory?
-        HOMEBREW_LIBRARY_PATH.parent.parent/"Cellar"
-      else
-        HOMEBREW_CELLAR
-      end
-    end
+    let(:shell_cellar) { HOMEBREW_CELLAR }
 
     before do
       # Write the database where `brew which-formula` (a Bash command) reads it:


### PR DESCRIPTION
`HOMEBREW_LIBRARY_PATH` is the non-mocked path so setting `shell_cellar` based on this means modifications are done outside of test environment and instead in user's installation.

Can see this happen by adding a `sleep 10` in test case and then checking cellar path.
* Before test
  ```console
  ❯ /bin/ls /opt/homebrew/Cellar/foo
  ls: /opt/homebrew/Cellar/foo: No such file or directory
  ```
* During test
  ```console
  ❯ /bin/ls /opt/homebrew/Cellar/foo
  1.0.0
  ```

Not sure why this isn't sandboxed. Maybe to avoid nested usage or some particular integration scenarios?

Instead, `HOMEBREW_CELLAR` is within our temporary test path.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
