### PR TITLE
Record bottle relocation metadata

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -232,9 +232,13 @@ module Homebrew
 
       sig {
         params(string: String, keg: Keg, ignores: T::Array[Regexp],
-               formula_and_runtime_deps_names: T.nilable(T::Array[String])).returns(T::Boolean)
+               formula_and_runtime_deps_names: T.nilable(T::Array[String]),
+               binary_relocation_files: T::Array[Pathname],
+               binary_relocation_diagnostics: T::Array[T::Hash[String, T.any(String, Integer)]])
+          .returns(T::Boolean)
       }
-      def keg_contain?(string, keg, ignores, formula_and_runtime_deps_names = nil)
+      def keg_contain?(string, keg, ignores, formula_and_runtime_deps_names = nil,
+                       binary_relocation_files: [], binary_relocation_diagnostics: [])
         @put_string_exists_header, @put_filenames = nil
 
         print_filename = lambda do |str, filename|
@@ -269,6 +273,21 @@ module Homebrew
           text_matches = Keg.text_matches_in_file(file, string, ignores, linked_libraries,
                                                   formula_and_runtime_deps_names)
           result = true if text_matches.any?
+
+          if text_matches.present? && keg.binary_file?(file)
+            relative_path = file.relative_path_from(keg.to_path)
+            binary_relocation_files << relative_path unless binary_relocation_files.include?(relative_path)
+            text_matches.each do |match, offset|
+              break if binary_relocation_diagnostics.size >= MAXIMUM_STRING_MATCHES
+
+              diagnostic = {
+                "path"   => relative_path.to_s,
+                "string" => match,
+                "offset" => offset.to_i(16),
+              }
+              binary_relocation_diagnostics << diagnostic unless binary_relocation_diagnostics.include?(diagnostic)
+            end
+          end
 
           next if !args.verbose? || text_matches.empty?
 
@@ -487,16 +506,22 @@ module Homebrew
         ohai "Bottling #{local_filename}..."
 
         formula_and_runtime_deps_names = [formula.name] + formula.runtime_dependencies.map(&:name)
+        binary_relocation_files = T.let([], T::Array[Pathname])
+        # Detailed blockers stay in CI JSON while the client-facing tab contains only compact file paths.
+        binary_relocation_diagnostics = T.let([], T::Array[T::Hash[String, T.any(String, Integer)]])
 
         # this will be nil when using a local bottle
         keg&.lock do
           original_tab = nil
-          changed_files = nil
+          changed_files = T.let(nil, T.nilable(T::Array[Pathname]))
+          linkage_files = T.let(nil, T.nilable(T::Array[Pathname]))
 
           begin
             keg.delete_pyc_files!
 
-            changed_files = keg.replace_locations_with_placeholders unless args.skip_relocation?
+            unless args.skip_relocation?
+              changed_files, linkage_files = keg.replace_locations_with_placeholders
+            end
 
             Formula.clear_cache
             Keg.clear_cache
@@ -508,7 +533,72 @@ module Homebrew
             original_tab = tab.dup
             tab.poured_from_bottle = false
             tab.time = nil
-            tab.changed_files = changed_files.dup
+            tab.changed_files = changed_files&.dup
+            tab.linkage_files = linkage_files&.sort
+
+            ohai "Detecting if #{local_filename} is relocatable..." if keg.disk_usage > 1 * 1024 * 1024
+
+            is_usr_local_prefix = prefix == "/usr/local"
+            prefix_check = if is_usr_local_prefix
+              "#{prefix}/opt"
+            else
+              prefix
+            end
+
+            # Ignore matches to source code, which is not required at run time.
+            # These matches may be caused by debugging symbols.
+            ignores = [%r{/include/|\.(c|cc|cpp|h|hpp)$}]
+
+            # Add additional workarounds to ignore
+            ignores += formula_ignores(formula)
+
+            repository_reference = if HOMEBREW_PREFIX == HOMEBREW_REPOSITORY
+              HOMEBREW_LIBRARY
+            else
+              HOMEBREW_REPOSITORY
+            end.to_s
+            if keg_contain?(repository_reference, keg, ignores + ALLOWABLE_HOMEBREW_REPOSITORY_LINKS)
+              odie "Bottle contains non-relocatable reference to #{repository_reference}!"
+            end
+
+            relocatable = true
+            if args.skip_relocation?
+              skip_relocation = true
+            else
+              relocatable = false if keg_contain?(
+                prefix_check, keg, ignores, formula_and_runtime_deps_names,
+                binary_relocation_files:, binary_relocation_diagnostics:
+              )
+              relocatable = false if keg_contain?(
+                cellar, keg, ignores, formula_and_runtime_deps_names,
+                binary_relocation_files:, binary_relocation_diagnostics:
+              )
+              relocatable = false if keg_contain?(
+                HOMEBREW_LIBRARY.to_s, keg, ignores, formula_and_runtime_deps_names,
+                binary_relocation_files:, binary_relocation_diagnostics:
+              )
+              if is_usr_local_prefix
+                relocatable = false if keg_contain_absolute_symlink_starting_with?(prefix, keg)
+                if tap.disabled_new_usr_local_relocation_formulae.exclude?(formula.name)
+                  keg.new_usr_local_replacement_pairs.each_value do |value|
+                    relocatable = false if keg_contain?(
+                      value.fetch(:old), keg, ignores,
+                      binary_relocation_files:, binary_relocation_diagnostics:
+                    )
+                  end
+                else
+                  ["#{prefix}/etc", "#{prefix}/var", "#{prefix}/share/vim"].each do |path|
+                    relocatable = false if keg_contain?(
+                      path, keg, ignores,
+                      binary_relocation_files:, binary_relocation_diagnostics:
+                    )
+                  end
+                end
+              end
+              skip_relocation = relocatable && !keg.require_relocation?
+            end
+            tab.binary_relocation_files = args.skip_relocation? ? nil : binary_relocation_files.sort
+
             if args.only_json_tab?
               tab.changed_files&.delete(Pathname.new(AbstractTab::FILENAME))
               tab.tabfile&.unlink
@@ -546,52 +636,6 @@ module Homebrew
               sudo_purge
             end
 
-            ohai "Detecting if #{local_filename} is relocatable..." if bottle_path.size > 1 * 1024 * 1024
-
-            is_usr_local_prefix = prefix == "/usr/local"
-            prefix_check = if is_usr_local_prefix
-              "#{prefix}/opt"
-            else
-              prefix
-            end
-
-            # Ignore matches to source code, which is not required at run time.
-            # These matches may be caused by debugging symbols.
-            ignores = [%r{/include/|\.(c|cc|cpp|h|hpp)$}]
-
-            # Add additional workarounds to ignore
-            ignores += formula_ignores(formula)
-
-            repository_reference = if HOMEBREW_PREFIX == HOMEBREW_REPOSITORY
-              HOMEBREW_LIBRARY
-            else
-              HOMEBREW_REPOSITORY
-            end.to_s
-            if keg_contain?(repository_reference, keg, ignores + ALLOWABLE_HOMEBREW_REPOSITORY_LINKS)
-              odie "Bottle contains non-relocatable reference to #{repository_reference}!"
-            end
-
-            relocatable = true
-            if args.skip_relocation?
-              skip_relocation = true
-            else
-              relocatable = false if keg_contain?(prefix_check, keg, ignores, formula_and_runtime_deps_names)
-              relocatable = false if keg_contain?(cellar, keg, ignores, formula_and_runtime_deps_names)
-              relocatable = false if keg_contain?(HOMEBREW_LIBRARY.to_s, keg, ignores, formula_and_runtime_deps_names)
-              if is_usr_local_prefix
-                relocatable = false if keg_contain_absolute_symlink_starting_with?(prefix, keg)
-                if tap.disabled_new_usr_local_relocation_formulae.exclude?(formula.name)
-                  keg.new_usr_local_replacement_pairs.each_value do |value|
-                    relocatable = false if keg_contain?(value.fetch(:old), keg, ignores)
-                  end
-                else
-                  relocatable = false if keg_contain?("#{prefix}/etc", keg, ignores)
-                  relocatable = false if keg_contain?("#{prefix}/var", keg, ignores)
-                  relocatable = false if keg_contain?("#{prefix}/share/vim", keg, ignores)
-                end
-              end
-              skip_relocation = relocatable && !keg.require_relocation?
-            end
             puts if !relocatable && args.verbose?
           rescue Interrupt
             ignore_interrupts { bottle_path.unlink if bottle_path.exist? }
@@ -599,7 +643,7 @@ module Homebrew
           ensure
             ignore_interrupts do
               original_tab&.write
-              keg.replace_placeholders_with_locations(changed_files) if changed_files && !args.skip_relocation?
+              keg.replace_placeholders_with_locations(changed_files) if changed_files
             end
           end
         end
@@ -689,14 +733,15 @@ module Homebrew
               "date"     => Pathname(filename.to_s).mtime.utc.iso8601,
               "tags"     => {
                 bottle_tag.to_s => {
-                  "filename"        => filename.url_encode,
-                  "local_filename"  => filename.to_s,
-                  "sha256"          => sha256,
-                  "tab"             => bottle_tab.to_bottle_hash,
-                  "sbom"            => SBOM.create(formula, bottle_tab).to_spdx_supplement,
-                  "path_exec_files" => path_exec_files,
-                  "all_files"       => all_files,
-                  "installed_size"  => installed_size,
+                  "filename"                      => filename.url_encode,
+                  "local_filename"                => filename.to_s,
+                  "sha256"                        => sha256,
+                  "tab"                           => bottle_tab.to_bottle_hash,
+                  "binary_relocation_diagnostics" => binary_relocation_diagnostics,
+                  "sbom"                          => SBOM.create(formula, bottle_tab).to_spdx_supplement,
+                  "path_exec_files"               => path_exec_files,
+                  "all_files"                     => all_files,
+                  "installed_size"                => installed_size,
                 },
               },
             },

--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -10,18 +10,24 @@ module OS
 
       requires_ancestor { ::Keg }
 
-      sig { params(relocation: ::Keg::Relocation, with_placeholders: T::Boolean).void }
+      sig {
+        params(relocation: ::Keg::Relocation, with_placeholders: T::Boolean).returns(T::Array[::Pathname])
+      }
       def relocate_dynamic_linkage(relocation, with_placeholders: false)
         # Patching the dynamic linker of glibc breaks it.
-        return if name.match? Version.formula_optionally_versioned_regex(:glibc)
+        return [] if name.match? Version.formula_optionally_versioned_regex(:glibc)
 
         old_prefix, new_prefix = relocation.replacement_pair_for(:prefix)
 
+        linkage_files = []
         elf_files.each do |file|
+          changed = T.let(false, T::Boolean)
           file.ensure_writable do
-            change_rpath!(file, old_prefix, new_prefix, with_placeholders:)
+            changed = change_rpath!(file, old_prefix, new_prefix, with_placeholders:)
           end
+          linkage_files << file.relative_path_from(path) if changed
         end
+        linkage_files
       end
 
       sig {

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -23,8 +23,11 @@ module OS
         end
       end
 
-      sig { params(relocation: ::Keg::Relocation, with_placeholders: T::Boolean).void }
+      sig {
+        params(relocation: ::Keg::Relocation, with_placeholders: T::Boolean).returns(T::Array[::Pathname])
+      }
       def relocate_dynamic_linkage(relocation, with_placeholders: false)
+        linkage_files = []
         mach_o_files.each do |file|
           file.ensure_writable do
             modified = T.let(false, T::Boolean)
@@ -49,9 +52,11 @@ module OS
             end
 
             # codesign the file if needed
+            linkage_files << file.relative_path_from(path) if needs_codesigning
             codesign_patched_binary(file.to_s) if needs_codesigning
           end
         end
+        linkage_files
       end
 
       sig { void }

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -85,8 +85,8 @@ class Keg
     end
   end
 
-  sig { params(_relocation: Relocation, with_placeholders: T::Boolean).void }
-  def relocate_dynamic_linkage(_relocation, with_placeholders: false); end
+  sig { params(_relocation: Relocation, with_placeholders: T::Boolean).returns(T::Array[Pathname]) }
+  def relocate_dynamic_linkage(_relocation, with_placeholders: false) = []
 
   JAVA_REGEX = %r{#{HOMEBREW_PREFIX}/opt/openjdk(@\d+(\.\d+)*)?/libexec(/openjdk\.jdk/Contents/Home)?}
 
@@ -169,11 +169,11 @@ class Keg
     relocation
   end
 
-  sig { returns(T::Array[Pathname]) }
+  sig { returns([T::Array[Pathname], T::Array[Pathname]]) }
   def replace_locations_with_placeholders
     relocation = prepare_relocation_to_placeholders.freeze
-    relocate_dynamic_linkage(relocation, with_placeholders: true)
-    replace_text_in_files(relocation)
+    linkage_files = relocate_dynamic_linkage(relocation, with_placeholders: true)
+    [replace_text_in_files(relocation), linkage_files]
   end
 
   sig { returns(Relocation) }

--- a/Library/Homebrew/plans/relocatable-bottles.md
+++ b/Library/Homebrew/plans/relocatable-bottles.md
@@ -21,6 +21,12 @@ Every Homebrew/core bottle pours at every prefix under 65 characters long.
 This is a living document: edit or remove steps as they are implemented so
 it always describes the remaining work.
 
+End each implementation commit body with this exact line:
+
+```text
+This change is part of [`plans/relocatable-bottles.md`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/plans/relocatable-bottles.md)
+```
+
 ## Current state (21 August 2026, formulae.brew.sh data)
 
 | Tag | `:any_skip_relocation` | `:any` | pinned |
@@ -156,15 +162,6 @@ Replaying the exact `keg_contain?` logic over the contents of 17 pinned and
 
 ### Phase 0: pour speed and relocation metadata (helps everyone, every prefix)
 
-1. Tab gains `built_prefix` as the literal prefix string, only when the
-   build prefix is not the tag's default. Ships pre-download via the
-   `sh.brew.tab` manifest annotation, like the rest of the tab since
-   `--only-json-tab`.
-2. Tab gains per-bottle file lists for every bottle: `changed_files`
-   (exists), `linkage_files` (Mach-O/ELF placeholder carriers) and
-   `binary_relocation_files` (raw-string blockers). Measured cost is about
-   40 to 600 bytes against today's 2.2 to 9.5 KB tabs. Full string/offset
-   diagnostics stay CI-side in the `brew bottle --json` output, capped.
 3. Metadata-driven fast pour, benchmarked, with scan fallback: no keg walks,
    only listed files touched, relocation coordinated into one write and one
    codesign per file, codesign parallelised across files. Benefits accrue to

--- a/Library/Homebrew/tab/tab.rb
+++ b/Library/Homebrew/tab/tab.rb
@@ -13,6 +13,9 @@ class Tab < AbstractTab
   sig { returns(T.nilable(T::Boolean)) }
   attr_accessor :built_as_bottle
 
+  sig { returns(T.nilable(String)) }
+  attr_accessor :built_prefix
+
   sig { returns(T.nilable(T.any(String, Symbol))) }
   attr_accessor :stdlib
 
@@ -37,25 +40,40 @@ class Tab < AbstractTab
   sig { returns(T.nilable(T::Array[Pathname])) }
   attr_accessor :changed_files
 
+  sig { returns(T.nilable(T::Array[Pathname])) }
+  attr_accessor :linkage_files
+
+  sig { returns(T.nilable(T::Array[Pathname])) }
+  attr_accessor :binary_relocation_files
+
   sig {
-    params(poured_from_bottle:   T.nilable(T::Boolean),
-           built_as_bottle:      T.nilable(T::Boolean),
-           changed_files:        T.nilable(T::Array[T.any(Pathname, String)]),
-           stdlib:               T.nilable(T.any(String, Symbol)),
-           aliases:              T.nilable(T::Array[String]),
-           used_options:         T.nilable(T::Array[String]),
-           unused_options:       T.nilable(T::Array[String]),
-           compiler:             T.nilable(T.any(String, Symbol)),
-           source_modified_time: T.nilable(Integer),
-           tapped_from:          T.nilable(String),
-           rest:                 T.untyped).void
+    params(poured_from_bottle:      T.nilable(T::Boolean),
+           built_as_bottle:         T.nilable(T::Boolean),
+           built_prefix:            T.nilable(String),
+           changed_files:           T.nilable(T::Array[T.any(Pathname, String)]),
+           linkage_files:           T.nilable(T::Array[T.any(Pathname, String)]),
+           binary_relocation_files: T.nilable(T::Array[T.any(Pathname, String)]),
+           stdlib:                  T.nilable(T.any(String, Symbol)),
+           aliases:                 T.nilable(T::Array[String]),
+           used_options:            T.nilable(T::Array[String]),
+           unused_options:          T.nilable(T::Array[String]),
+           compiler:                T.nilable(T.any(String, Symbol)),
+           source_modified_time:    T.nilable(Integer),
+           tapped_from:             T.nilable(String),
+           rest:                    T.untyped).void
   }
-  def initialize(poured_from_bottle: nil, built_as_bottle: nil, changed_files: nil, stdlib: nil, aliases: nil,
-                 used_options: nil, unused_options: nil, compiler: nil, source_modified_time: nil,
-                 tapped_from: nil, **rest)
+  def initialize(poured_from_bottle: nil, built_as_bottle: nil, built_prefix: nil, changed_files: nil,
+                 linkage_files: nil, binary_relocation_files: nil, stdlib: nil, aliases: nil, used_options: nil,
+                 unused_options: nil, compiler: nil, source_modified_time: nil, tapped_from: nil, **rest)
     @poured_from_bottle = poured_from_bottle
     @built_as_bottle = built_as_bottle
+    @built_prefix = built_prefix
     @changed_files = T.let(changed_files&.map { |f| Pathname(f) }, T.nilable(T::Array[Pathname]))
+    @linkage_files = T.let(linkage_files&.map { |f| Pathname(f) }, T.nilable(T::Array[Pathname]))
+    @binary_relocation_files = T.let(
+      binary_relocation_files&.map { |f| Pathname(f) },
+      T.nilable(T::Array[Pathname]),
+    )
     @stdlib = stdlib
     @aliases = aliases
     @used_options = used_options
@@ -83,6 +101,7 @@ class Tab < AbstractTab
     tab.unused_options = build.unused_options.as_flags
     tab.tabfile = formula.prefix/FILENAME
     tab.built_as_bottle = build.bottle?
+    tab.built_prefix = HOMEBREW_PREFIX.to_s if build.bottle? && !Homebrew.default_prefix?
     tab.poured_from_bottle = false
     tab.source_modified_time = formula.source_modified_time.to_i
     tab.compiler = compiler
@@ -371,11 +390,14 @@ class Tab < AbstractTab
       "used_options"             => used_options.as_flags,
       "unused_options"           => unused_options.as_flags,
       "built_as_bottle"          => built_as_bottle,
+      "built_prefix"             => built_prefix,
       "poured_from_bottle"       => poured_from_bottle,
       "loaded_from_api"          => loaded_from_api,
       "loaded_from_internal_api" => loaded_from_internal_api,
       "installed_on_request"     => installed_on_request,
       "changed_files"            => changed_files&.map(&:to_s),
+      "linkage_files"            => linkage_files&.map(&:to_s),
+      "binary_relocation_files"  => binary_relocation_files&.map(&:to_s),
       "time"                     => time,
       "source_modified_time"     => source_modified_time.to_i,
       "stdlib"                   => stdlib&.to_s,
@@ -387,6 +409,9 @@ class Tab < AbstractTab
       "built_on"                 => built_on,
     }
     attributes.delete("stdlib") if attributes["stdlib"].blank?
+    attributes.delete("built_prefix") if attributes["built_prefix"].nil?
+    attributes.delete("linkage_files") if attributes["linkage_files"].nil?
+    attributes.delete("binary_relocation_files") if attributes["binary_relocation_files"].nil?
 
     JSON.pretty_generate(attributes, options)
   end
@@ -395,17 +420,23 @@ class Tab < AbstractTab
   sig { returns(T::Hash[String, T.untyped]) }
   def to_bottle_hash
     attributes = {
-      "homebrew_version"     => homebrew_version,
-      "changed_files"        => changed_files&.map(&:to_s),
-      "source_modified_time" => source_modified_time.to_i,
-      "stdlib"               => stdlib&.to_s,
-      "compiler"             => compiler.to_s,
-      "runtime_dependencies" => runtime_dependencies,
-      "source"               => source.slice("scm_revision").compact.presence,
-      "arch"                 => arch,
-      "built_on"             => built_on,
+      "homebrew_version"        => homebrew_version,
+      "built_prefix"            => built_prefix,
+      "changed_files"           => changed_files&.map(&:to_s),
+      "linkage_files"           => linkage_files&.map(&:to_s),
+      "binary_relocation_files" => binary_relocation_files&.map(&:to_s),
+      "source_modified_time"    => source_modified_time.to_i,
+      "stdlib"                  => stdlib&.to_s,
+      "compiler"                => compiler.to_s,
+      "runtime_dependencies"    => runtime_dependencies,
+      "source"                  => source.slice("scm_revision").compact.presence,
+      "arch"                    => arch,
+      "built_on"                => built_on,
     }
     attributes.delete("stdlib") if attributes["stdlib"].blank?
+    attributes.delete("built_prefix") if attributes["built_prefix"].nil?
+    attributes.delete("linkage_files") if attributes["linkage_files"].nil?
+    attributes.delete("binary_relocation_files") if attributes["binary_relocation_files"].nil?
     attributes.delete("source") if attributes["source"].blank?
     attributes
   end

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -34,23 +34,81 @@ RSpec.describe Homebrew::DevCmd::Bottle do
 
   it_behaves_like "parseable arguments"
 
-  it "builds a bottle for the given Formula", :integration_test, :needs_network do
-    install_test_formula "testball", build_bottle: true
+  it "does not restore locations when placeholdering fails" do
+    formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/testball-1.0.tar.gz"
+    end
+    tap = instance_double(
+      Tap,
+      installed?: true,
+      path:       HOMEBREW_REPOSITORY,
+      git_head:   "HEAD",
+      remote:     "https://github.com/Homebrew/homebrew-core",
+    )
+    keg = instance_double(Keg)
+    bottle = described_class.new(["--no-rebuild", formula.name])
+
+    allow(Homebrew).to receive(:install_bundler_gems!)
+    allow(bottle.args.named).to receive(:to_resolved_formulae).with(uniq: false).and_return([formula])
+    allow(formula).to receive_messages(latest_version_installed?: true, tap:, runtime_dependencies: [])
+    allow(Utils::Bottles).to receive(:built_as?).with(formula).and_return(true)
+    allow(Keg).to receive(:new).with(formula.prefix).and_return(keg)
+    allow(keg).to receive(:lock).and_yield
+    allow(keg).to receive(:delete_pyc_files!).and_raise("placeholdering failed")
+    allow(keg).to receive(:replace_placeholders_with_locations).and_raise("restoration ran")
+
+    expect { bottle.run }.to raise_error(RuntimeError, "placeholdering failed")
+  end
+
+  it "builds a bottle for the given Formula", :integration_test do
+    setup_test_formula "testball", tab_attributes: { built_as_bottle: true }
+    formula = Formula["testball"]
 
     # `brew bottle` should not fail with dead symlink
     # https://github.com/Homebrew/legacy-homebrew/issues/49007
-    (HOMEBREW_CELLAR/"testball/0.1").cd do
+    formula.prefix.cd do
       FileUtils.ln_s "not-exist", "symlink"
     end
+    formula.libexec.mkpath
+    (formula.libexec/"raw-prefix").binwrite(
+      "\0#{Array.new(Homebrew::DevCmd::Bottle::MAXIMUM_STRING_MATCHES + 1, formula.libexec.to_s).join("\0")}\0",
+    )
 
     begin
-      expect { brew "bottle", "--no-rebuild", "testball" }
+      expect { brew "bottle", "--no-rebuild", "--json", "testball" }
         .to output(/testball--0\.1.*\.bottle\.tar\.gz/).to_stdout
         .and not_to_output.to_stderr
         .and be_a_success
       expect(HOMEBREW_CELLAR/"testball-bottle.tar").not_to exist
+
+      tag = JSON.parse(Pathname(Dir["testball--0.1*.bottle.json"].fetch(0)).read)
+                .dig("testball", "bottle", "tags").values.fetch(0)
+      expect(tag.fetch("tab")).to include(
+        "changed_files"           => be_an(Array),
+        "linkage_files"           => be_an(Array),
+        "binary_relocation_files" => include("libexec/raw-prefix"),
+      )
+      binary_relocation_diagnostics = tag.fetch("binary_relocation_diagnostics")
+      expect(binary_relocation_diagnostics.size).to eq(Homebrew::DevCmd::Bottle::MAXIMUM_STRING_MATCHES)
+      expect(binary_relocation_diagnostics).to include(
+        include(
+          "path"   => "libexec/raw-prefix",
+          "string" => formula.libexec.to_s,
+          "offset" => be_an(Integer),
+        ),
+      )
+
+      expect { brew "bottle", "--no-rebuild", "--json", "--skip-relocation", "testball" }
+        .to be_a_success
+      skipped_tag = JSON.parse(Pathname(Dir["testball--0.1*.bottle.json"].fetch(0)).read)
+                        .dig("testball", "bottle", "tags").values.fetch(0)
+      expect(skipped_tag.fetch("tab").values_at(
+               "changed_files", "linkage_files", "binary_relocation_files"
+             )).to eq([nil, nil, nil])
     ensure
       FileUtils.rm_f Dir.glob("testball--0.1*.bottle.tar.gz")
+      FileUtils.rm_f Dir.glob("testball--0.1*.bottle.json")
     end
   end
 

--- a/Library/Homebrew/test/github_packages_spec.rb
+++ b/Library/Homebrew/test/github_packages_spec.rb
@@ -140,8 +140,11 @@ RSpec.describe GitHubPackages do
                                               "arm64_sonoma" => {
                                                 "local_filename" => bottle.to_s,
                                                 "tab"            => {
-                                                  "arch"     => "arm64",
-                                                  "built_on" => {
+                                                  "arch"                    => "arm64",
+                                                  "built_prefix"            => "/custom/prefix",
+                                                  "linkage_files"           => ["bin/foo"],
+                                                  "binary_relocation_files" => ["libexec/foo"],
+                                                  "built_on"                => {
                                                     "os"         => "Macintosh",
                                                     "os_version" => "macOS 14",
                                                   },
@@ -180,7 +183,13 @@ RSpec.describe GitHubPackages do
         expect(manifests_by_tag.fetch("1.0.arm64_sonoma"))
           .to include("platform" => include("architecture" => "arm64", "os" => "darwin"))
         expect(JSON.parse(manifests_by_tag.fetch("1.0.arm64_sonoma").fetch("annotations").fetch("sh.brew.tab")))
-          .to include("arch" => "arm64", "built_on" => include("os" => "Macintosh"))
+          .to include(
+            "arch"                    => "arm64",
+            "built_prefix"            => "/custom/prefix",
+            "linkage_files"           => ["bin/foo"],
+            "binary_relocation_files" => ["libexec/foo"],
+            "built_on"                => include("os" => "Macintosh"),
+          )
       end
     end
   end

--- a/Library/Homebrew/test/keg_relocate/text_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/text_spec.rb
@@ -80,4 +80,12 @@ RSpec.describe Keg do
       EOS
     end
   end
+
+  specify "#replace_locations_with_placeholders returns its file lists" do
+    linkage_files = [Pathname("bin/foo")]
+    changed_files = [Pathname("share/foo")]
+    allow(keg).to receive_messages(relocate_dynamic_linkage: linkage_files, replace_text_in_files: changed_files)
+
+    expect(keg.replace_locations_with_placeholders).to eq([changed_files, linkage_files])
+  end
 end

--- a/Library/Homebrew/test/os/linux/keg_spec.rb
+++ b/Library/Homebrew/test/os/linux/keg_spec.rb
@@ -1,0 +1,24 @@
+# typed: true
+# frozen_string_literal: true
+
+require "keg"
+
+RSpec.describe Keg, :needs_linux do
+  subject(:keg) { described_class.new(keg_path) }
+
+  let(:keg_path) { HOMEBREW_CELLAR/"a/1.0" }
+  let(:file) { ELFPathname.wrap(keg_path/"bin/test") }
+
+  before do
+    file.dirname.mkpath
+    FileUtils.cp(TEST_FIXTURE_DIR/"elf/c.elf", file)
+    file.patch!(interpreter: "#{HOMEBREW_PREFIX}/lib/ld.so", rpath: "#{HOMEBREW_PREFIX}/lib")
+  end
+
+  after { keg.unlink }
+
+  it "returns changed linkage files relative to the keg" do
+    expect(keg.relocate_dynamic_linkage(keg.prepare_relocation_to_placeholders.freeze, with_placeholders: true))
+      .to eq([Pathname("bin/test")])
+  end
+end

--- a/Library/Homebrew/test/os/mac/keg_spec.rb
+++ b/Library/Homebrew/test/os/mac/keg_spec.rb
@@ -77,4 +77,29 @@ RSpec.describe Keg do
       keg.codesign_patched_binary(file)
     end
   end
+
+  describe "#relocate_dynamic_linkage" do
+    let(:keg_path) { HOMEBREW_CELLAR/"a/1.0" }
+    let(:file) { MachOPathname.wrap(keg_path/"bin/test") }
+
+    before do
+      file.dirname.mkpath
+      touch file
+      allow(file).to receive(:ensure_writable).and_yield
+      allow(file).to receive_messages(dylib?: false, dynamically_linked_libraries: ["#{HOMEBREW_PREFIX}/lib/foo"],
+                                      rpaths: [])
+      allow(keg).to receive_messages(mach_o_files: [file], change_install_name: true)
+      allow(keg).to receive(:codesign_patched_binary)
+    end
+
+    after { keg.unlink }
+
+    it "returns changed linkage files relative to the keg" do
+      relocation = Keg::Relocation.new
+      relocation.add_replacement_pair(:prefix, HOMEBREW_PREFIX.to_s, Keg::PREFIX_PLACEHOLDER)
+      relocation.add_replacement_pair(:cellar, HOMEBREW_CELLAR.to_s, Keg::CELLAR_PLACEHOLDER)
+
+      expect(keg.relocate_dynamic_linkage(relocation)).to eq([Pathname("bin/test")])
+    end
+  end
 end

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -7,19 +7,21 @@ require "formula"
 RSpec.describe Tab do
   subject(:tab) do
     described_class.new(
-      homebrew_version:     HOMEBREW_VERSION,
-      used_options:         used_options.as_flags,
-      unused_options:       unused_options.as_flags,
-      built_as_bottle:      false,
-      poured_from_bottle:   true,
-      installed_on_request: true,
-      changed_files:        [],
+      homebrew_version:        HOMEBREW_VERSION,
+      used_options:            used_options.as_flags,
+      unused_options:          unused_options.as_flags,
+      built_as_bottle:         false,
+      poured_from_bottle:      true,
+      installed_on_request:    true,
+      changed_files:           [],
+      linkage_files:           ["bin/foo"],
+      binary_relocation_files: ["libexec/foo"],
       time:,
-      source_modified_time: 0,
-      compiler:             "clang",
-      stdlib:               "libcxx",
-      runtime_dependencies: [],
-      source:               {
+      source_modified_time:    0,
+      compiler:                "clang",
+      stdlib:                  "libcxx",
+      runtime_dependencies:    [],
+      source:                  {
         "tap"          => CoreTap.instance.to_s,
         "path"         => CoreTap.instance.path.to_s,
         "spec"         => "stable",
@@ -29,8 +31,8 @@ RSpec.describe Tab do
           "head"   => "HEAD-1111111",
         },
       },
-      arch:                 Hardware::CPU.arch,
-      built_on:             DevelopmentTools.build_system_info,
+      arch:                    Hardware::CPU.arch,
+      built_on:                DevelopmentTools.build_system_info,
     )
   end
 
@@ -108,6 +110,8 @@ RSpec.describe Tab do
     expect(tab.unused_options).to be_empty
     expect(tab.used_options).to be_empty
     expect(tab.changed_files).to be_nil
+    expect(tab.linkage_files).to be_nil
+    expect(tab.binary_relocation_files).to be_nil
     expect(tab).not_to be_built_as_bottle
     expect(tab).not_to be_poured_from_bottle
     expect(tab).not_to be_installed_on_request
@@ -440,6 +444,23 @@ RSpec.describe Tab do
       expect(tab.source["scm_revision"]).to be_nil
     end
 
+    it "records a non-default bottle build prefix" do
+      f.build = BuildOptions.new(Options.create(["--build-bottle"]), f.options)
+      allow(Homebrew).to receive(:default_prefix?).and_return(false)
+      stub_const("HOMEBREW_PREFIX", Pathname("/custom/prefix"))
+
+      expect(described_class.create(f, DevelopmentTools.default_compiler, :libcxx).built_prefix)
+        .to eq("/custom/prefix")
+    end
+
+    it "omits the default bottle build prefix" do
+      f.build = BuildOptions.new(Options.create(["--build-bottle"]), f.options)
+      allow(Homebrew).to receive(:default_prefix?).and_return(true)
+
+      expect(described_class.create(f, DevelopmentTools.default_compiler, :libcxx).to_bottle_hash)
+        .not_to have_key("built_prefix")
+    end
+
     it "can create a formula Tab from an alias" do
       alias_path = CoreTap.instance.alias_dir/"bar"
       f = formula(alias_path:) do
@@ -555,6 +576,7 @@ RSpec.describe Tab do
   end
 
   specify "#to_json" do
+    tab.built_prefix = "/custom/prefix"
     json_tab = described_class.new(**JSON.parse(tab.to_json).transform_keys(&:to_sym))
     expect(json_tab.homebrew_version).to eq(tab.homebrew_version)
     expect(json_tab.used_options.sort).to eq(tab.used_options.sort)
@@ -562,6 +584,9 @@ RSpec.describe Tab do
     expect(json_tab.built_as_bottle).to eq(tab.built_as_bottle)
     expect(json_tab.poured_from_bottle).to eq(tab.poured_from_bottle)
     expect(json_tab.changed_files).to eq(tab.changed_files)
+    expect(json_tab.linkage_files).to eq(tab.linkage_files)
+    expect(json_tab.binary_relocation_files).to eq(tab.binary_relocation_files)
+    expect(json_tab.built_prefix).to eq(tab.built_prefix)
     expect(json_tab.tap).to eq(tab.tap)
     expect(json_tab.spec).to eq(tab.spec)
     expect(json_tab.time).to eq(tab.time)
@@ -577,9 +602,13 @@ RSpec.describe Tab do
   end
 
   specify "#to_bottle_hash" do
+    tab.built_prefix = "/custom/prefix"
     json_tab = described_class.new(**JSON.parse(tab.to_bottle_hash.to_json).transform_keys(&:to_sym))
     expect(json_tab.homebrew_version).to eq(tab.homebrew_version)
     expect(json_tab.changed_files).to eq(tab.changed_files)
+    expect(json_tab.linkage_files).to eq(tab.linkage_files)
+    expect(json_tab.binary_relocation_files).to eq(tab.binary_relocation_files)
+    expect(json_tab.built_prefix).to eq(tab.built_prefix)
     expect(json_tab.source_modified_time).to eq(tab.source_modified_time)
     expect(json_tab.stdlib).to eq(tab.stdlib)
     expect(json_tab.compiler).to eq(tab.compiler)


### PR DESCRIPTION
Pour-time relocation currently discovers work by walking every keg. It also cannot identify the prefix used to build a pinned bottle when that prefix differs from the tag default. Moving discovery to bottle time performs the work once in CI instead of repeating it on every user's machine.

- Record a literal non-default build prefix as `built_prefix`. Omit the field at tag defaults so default builds do not gain it. A literal prefix also avoids coupling readers to a versioned prefix-name mapping.
- Record `changed_files` for text placeholder replacements, `linkage_files` for Mach-O or ELF placeholder carriers and `binary_relocation_files` for residual raw C-string blockers.
- Make Mach-O and ELF relocation return the relative files they changed while placeholdering. This avoids a second binary scan just to build the metadata.
- Collect raw blocker paths during the existing relocatability scan. Keep capped path, string and offset diagnostics in `brew bottle --json` for CI, while putting only compact path lists in the tab.
- Publish the fields in the pre-download `sh.brew.tab` OCI annotation. This lets `--only-json-tab` determine future relocation work before fetching a bottle.

The file lists should cost about 40 to 600 bytes per tab. Existing tabs are roughly 2.2 to 9.5 KB. Old bottles and mirrors may omit every field, so the planned pour path will retain a full-scan fallback and avoid version coupling.

This does not change pour behaviour yet. As bottles are rebuilt, we can use the lists to touch only known files, combine edits into one write and one signing operation per binary and parallelise signing. Default-prefix and custom-prefix installs both benefit.

`built_prefix` and `binary_relocation_files` also prepare raw patching of pinned bottles. Initially, legacy bottles can only be patched into prefixes no longer than their default build prefix: 13 bytes on arm64 macOS and 26 on Linux. A later canonical 64-byte build prefix gives every embedded C string 64 bytes of patchable material, while `built_prefix` supplies the exact literal that clients must replace.

Relocatable `:any` and `:any_skip_relocation` bottles continue to pour unchanged. Only pinned bottles eventually need raw-string patching, normally in one or two files, followed by re-signing. Existing bottles remain supported through the scan fallback throughout the rollout.

This change is part of [`plans/relocatable-bottles.md`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/plans/relocatable-bottles.md)

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex GPT 5.6 Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----