### PR TITLE
pathname/disk_usage_extension: fix double path traversal

### DIFF
--- a/Library/Homebrew/extend/pathname/disk_usage_extension.rb
+++ b/Library/Homebrew/extend/pathname/disk_usage_extension.rb
@@ -29,9 +29,8 @@ module DiskUsageExtension
   sig { returns(String) }
   def abv
     out = +""
-    @file_count, @disk_usage = compute_disk_usage
-    out << "#{Formatter.number_readable(@file_count)} files, " if @file_count > 1
-    out << Formatter.disk_usage_readable(@disk_usage).to_s
+    out << "#{Formatter.number_readable(file_count)} files, " if file_count > 1
+    out << Formatter.disk_usage_readable(disk_usage).to_s
     out.freeze
   end
 


### PR DESCRIPTION
`abv` called the private `compute_disk_usage` directly instead of the disk_usage/file_count readers, which cache the same result so it walked the whole tree twice.

This should recognize ~35% speed improvement.

```
Benchmark 1: before (abv recomputes)
  Time (mean ± σ):     12.301 s ±  0.131 s    [User: 3.830 s, System: 8.225 s]
  Range (min … max):   12.167 s … 12.501 s    5 runs

Benchmark 2: after (abv reuses memo)
  Time (mean ± σ):      7.738 s ±  0.472 s    [User: 2.150 s, System: 5.175 s]
  Range (min … max):    7.407 s …  8.545 s    5 runs
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Ox Alpha + Opus 5, manual verification.

-----
