### PR TITLE
Clean up stale versioned opt aliases

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -827,9 +827,8 @@ module Formulary
       keg_directory = HOMEBREW_PREFIX/"opt/#{ref}"
       return unless keg_directory.directory?
 
-      # The formula file in `.brew` will use the canonical name, whereas `ref` can be an alias.
-      # Use `Keg#name` to get the canonical name.
       keg = Keg.new(keg_directory)
+      return if ref != keg.name
       return unless (keg_formula = keg_directory/".brew/#{keg.name}.rb").file?
 
       new(keg.name, keg_formula, tap: keg.tab.tap)

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -285,14 +285,7 @@ class Keg
     opt = opt_record.parent
     linkedkegs = linked_keg_record.parent
 
-    tap = begin
-      to_formula.tap
-    rescue
-      # If the formula can't be found, just ignore aliases for now.
-      nil
-    end
-
-    if tap
+    if (tap = tab.tap)
       bad_tap_opt = opt/tap.user
       FileUtils.rm_rf bad_tap_opt if !bad_tap_opt.symlink? && bad_tap_opt.directory?
     end
@@ -309,8 +302,8 @@ class Keg
       a = a.basename.to_s
       next if aliases.include?(a)
 
-      remove_alias_symlink(opt/a, rack)
-      remove_alias_symlink(linkedkegs/a, rack)
+      remove_alias_symlink(opt/a, rack, match_parent: true)
+      remove_alias_symlink(linkedkegs/a, rack, match_parent: true)
     end
   end
 
@@ -614,6 +607,7 @@ class Keg
 
   sig { params(verbose: T::Boolean, dry_run: T::Boolean, overwrite: T::Boolean).void }
   def optlink(verbose: false, dry_run: false, overwrite: false)
+    remove_old_aliases
     opt_record.delete if opt_record.symlink? || opt_record.exist?
     make_relative_symlink(opt_record, path, verbose:, dry_run:, overwrite:)
     aliases.each do |a|
@@ -780,10 +774,12 @@ class Keg
     raise LinkError.new(self, src.relative_path_from(path), dst, e)
   end
 
-  sig { params(alias_symlink: Pathname, alias_match_path: Pathname).void }
-  def remove_alias_symlink(alias_symlink, alias_match_path)
+  sig { params(alias_symlink: Pathname, alias_match_path: Pathname, match_parent: T::Boolean).void }
+  def remove_alias_symlink(alias_symlink, alias_match_path, match_parent: false)
     if alias_symlink.symlink? && alias_symlink.exist?
-      alias_symlink.delete if alias_match_path.exist? && alias_symlink.realpath == alias_match_path.realpath
+      alias_path = alias_symlink.realpath
+      alias_path = alias_path.parent if match_parent
+      alias_symlink.delete if alias_match_path.exist? && alias_path == alias_match_path.realpath
     elsif alias_symlink.symlink? || alias_symlink.exist?
       alias_symlink.delete
     end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -317,6 +317,21 @@ RSpec.describe Formulary do
           f = described_class.from_keg(keg)
           expect(f).to be_a(Formula)
         end
+
+        it "does not load a Formula using a removed alias" do
+          keg_path = HOMEBREW_CELLAR/formula_name/"0.1"
+          (keg_path/".brew/#{formula_name}.rb").tap do |keg_formula|
+            keg_formula.dirname.mkpath
+            keg_formula.write(formula_content)
+          end
+          tab = Tab.empty
+          tab.tabfile = keg_path/AbstractTab::FILENAME
+          tab.write
+          (HOMEBREW_PREFIX/"opt/removed-alias").make_relative_symlink(keg_path)
+          described_class.clear_cache
+
+          expect { described_class.factory("removed-alias") }.to raise_error(FormulaUnavailableError)
+        end
       end
 
       context "when migrating from a Tap" do

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -339,6 +339,25 @@ RSpec.describe Keg do
   end
 
   describe "#optlink" do
+    it "removes a stale versioned alias link" do
+      setup_test_keg("foo", "0.9")
+      stale_alias = HOMEBREW_PREFIX/"opt/foo@0"
+      stale_alias.make_relative_symlink(HOMEBREW_CELLAR/"foo/0.9")
+
+      keg.optlink
+
+      expect(stale_alias).not_to exist
+    end
+
+    it "preserves the opt link for a versioned Formula" do
+      versioned_keg = setup_test_keg("foo@1", "1.0")
+      versioned_keg.optlink
+
+      keg.optlink
+
+      expect(versioned_keg).to be_optlinked
+    end
+
     it "creates an opt link" do
       oldname_opt_record = HOMEBREW_PREFIX/"opt/oldfoo"
       oldname_opt_record.make_relative_symlink(HOMEBREW_CELLAR/"foo/1.0")


### PR DESCRIPTION
- Clean obsolete aliases when opt-linking an upgraded keg
- Ignore removed aliases during installed-keg fallback resolution
- Preserve links belonging to real versioned formulae

Fixes #23631

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----