### PR TITLE
vulns: close reviewed open ranges and fix historical subject lookup

### DIFF
--- a/Library/Homebrew/dev-cmd/advisory-match.rb
+++ b/Library/Homebrew/dev-cmd/advisory-match.rb
@@ -165,12 +165,13 @@ module Homebrew
       end
 
       class DirEmitter < Emitter
-        sig { params(dir: String, verbose: T::Boolean).void }
-        def initialize(dir, verbose:)
+        sig { params(dir: String, verbose: T::Boolean, close_open_ranges: T::Boolean).void }
+        def initialize(dir, verbose:, close_open_ranges:)
           super()
           FileUtils.mkdir_p(dir)
           @dir = dir
           @verbose = verbose
+          @close_open_ranges = close_open_ranges
           @written = T.let(0, Integer)
           @unchanged = T.let(0, Integer)
           @skipped_generated = T.let(0, Integer)
@@ -188,7 +189,8 @@ module Homebrew
             @skipped_generated += 1
             return
           end
-          merged = Homebrew::Vulns::OsvExport.merge_existing(path, record)
+          merged = Homebrew::Vulns::OsvExport.merge_existing(path, record,
+                                                             close_open_ranges: @close_open_ranges)
           if merged.nil?
             @unchanged += 1
             return
@@ -211,7 +213,9 @@ module Homebrew
           return true unless affected.is_a?(Array)
           return true if affected.empty?
 
-          affected.any? { |entry| !entry.is_a?(Hash) || !entry["ranges"] }
+          affected.any? do |entry|
+            !entry.is_a?(Hash) || !Homebrew::Vulns::OsvExport.ranges_terminal?(entry["ranges"])
+          end
         rescue JSON::ParserError
           true
         end
@@ -281,7 +285,7 @@ module Homebrew
       sig { returns(Emitter) }
       def build_emitter
         if (dir = args.output)
-          DirEmitter.new(dir, verbose: args.verbose?)
+          DirEmitter.new(dir, verbose: args.verbose?, close_open_ranges: !args.no_history?)
         elsif args.json?
           JsonEmitter.new
         else

--- a/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
@@ -131,6 +131,30 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
     end
   end
 
+  it "walks history and closes an existing open range with --new-history" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).to receive(:first_fixed_version).and_return("2.28.1")
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      File.write(path, JSON.generate({
+        "id"                => "BREW-requests-CVE-2024-1234",
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "1.0" }] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }))
+
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
+        .to output(/1 history walks/).to_stdout
+      expect(JSON.parse(File.read(path)).dig("affected", 0, "ranges", 0, "events"))
+        .to eq([{ "introduced" => "1.0" }, { "fixed" => "2.28.1" }])
+    end
+  end
+
   it "walks history when an existing record is malformed" do
     stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
     matcher = Homebrew::Vulns::Match.new
@@ -155,6 +179,29 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
 
     Dir.mktmpdir do |dir|
       cmd_for("requests", "--output", dir, "--no-history").run
+    end
+  end
+
+  it "does not close an existing open range with --no-history" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).not_to receive(:first_fixed_version)
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      File.write(path, JSON.generate({
+        "id"                => "BREW-requests-CVE-2024-1234",
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "1.0" }] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }))
+
+      cmd_for("requests", "--output", dir, "--no-history").run
+      expect(JSON.parse(File.read(path)).dig("affected", 0, "ranges", 0, "events"))
+        .to eq([{ "introduced" => "1.0" }])
     end
   end
 

--- a/Library/Homebrew/test/vulns/match_spec.rb
+++ b/Library/Homebrew/test/vulns/match_spec.rb
@@ -646,13 +646,13 @@ RSpec.describe Homebrew::Vulns::Match do
       revs = versions_newest_first.each_with_index.map { |_, i| ["r#{i}", "Formula/r/requests.rb"] }
       allow(fv).to receive(:rev_list) { |_, &b| revs.each { |rev, entry| b.call(rev, entry) } }
       versions_newest_first.each_with_index do |entry, i|
-        primary, res = Array(entry)
+        primary, res, resource_name = Array(entry)
         old = if primary
           formula("requests") do
             T.bind(self, T.class_of(Formula))
             url "https://files.pythonhosted.org/packages/aa/bb/cc/requests-#{primary}.tar.gz"
             if res
-              resource "certifi" do
+              resource resource_name || "certifi" do
                 url "https://files.pythonhosted.org/packages/11/22/33/certifi-#{res}.tar.gz"
               end
             end
@@ -714,6 +714,70 @@ RSpec.describe Homebrew::Vulns::Match do
     it "returns :never_affected when the formula was already past fixed at its first revision" do
       stub_history(["2.31.0"])
       expect(matcher.first_fixed_version(requests, hit_fixed_at("2.28.1"))).to eq :never_affected
+    end
+
+    it "returns :never_affected when a fixed resource was absent from earlier formula revisions" do
+      stub_history([["2.18.0", "1.2.0"], ["2.17.0", nil]])
+      current = formula("requests") do
+        T.bind(self, T.class_of(Formula))
+        url "https://files.pythonhosted.org/packages/aa/bb/cc/requests-2.18.0.tar.gz"
+        resource("certifi") do
+          url "https://files.pythonhosted.org/packages/11/22/33/certifi-1.2.0.tar.gz"
+        end
+      end
+      hit = make_hit(
+        vuln("id" => "CVE-1", "affected" => [
+          { "package" => { "ecosystem" => "PyPI", "name" => "certifi" },
+            "ranges"  => [{ "type"   => "ECOSYSTEM",
+                            "events" => [{ "introduced" => "0" }, { "fixed" => "1.0.8" }] }] },
+        ]),
+        ev(:registry, ecosystem: "PyPI", name: "certifi", subject_version: "1.2.0", resource: "certifi"),
+      )
+
+      expect(matcher.first_fixed_version(current, hit)).to eq :never_affected
+    end
+
+    it "continues past a resource-absence gap to find an older affected revision" do
+      stub_history([["3.0", "1.2.0"], ["2.0", nil], ["1.0", "1.0.7"]])
+      current = formula("requests") do
+        T.bind(self, T.class_of(Formula))
+        url "https://files.pythonhosted.org/packages/aa/bb/cc/requests-3.0.tar.gz"
+        resource("certifi") do
+          url "https://files.pythonhosted.org/packages/11/22/33/certifi-1.2.0.tar.gz"
+        end
+      end
+      hit = make_hit(
+        vuln("id" => "CVE-1", "affected" => [
+          { "package" => { "ecosystem" => "PyPI", "name" => "certifi" },
+            "ranges"  => [{ "type"   => "ECOSYSTEM",
+                            "events" => [{ "introduced" => "0" }, { "fixed" => "1.0.8" }] }] },
+        ]),
+        ev(:registry, ecosystem: "PyPI", name: "certifi", subject_version: "1.2.0", resource: "certifi"),
+      )
+
+      expect(matcher.first_fixed_version(current, hit)).to eq "2.0"
+    end
+
+    it "follows a resource package across historical resource-label changes" do
+      stub_history([["3.0", "101.0", "certifi"], ["2.0", "100.0", "certifi-python"],
+                    ["1.0", "99.0", "certifi-python"]])
+      current = formula("requests") do
+        T.bind(self, T.class_of(Formula))
+        url "https://files.pythonhosted.org/packages/aa/bb/cc/requests-3.0.tar.gz"
+        resource("certifi") do
+          url "https://files.pythonhosted.org/packages/11/22/33/certifi-101.0.tar.gz"
+        end
+      end
+      hit = make_hit(
+        vuln("id" => "CVE-1", "affected" => [
+          { "package" => { "ecosystem" => "PyPI", "name" => "certifi" },
+            "ranges"  => [{ "type"   => "ECOSYSTEM",
+                            "events" => [{ "introduced" => "0" }, { "fixed" => "100.0" }] }] },
+        ]),
+        ev(:registry, ecosystem: "PyPI", name: "certifi", subject_version: "101.0", resource: "certifi"),
+      )
+
+      expect(matcher.first_fixed_version(current, hit)).to eq "2.0"
     end
 
     it "keeps versionless (distro) evidence uncheckable at historical revisions too" do

--- a/Library/Homebrew/test/vulns/osv_export_spec.rb
+++ b/Library/Homebrew/test/vulns/osv_export_spec.rb
@@ -38,6 +38,50 @@ RSpec.describe Homebrew::Vulns::OsvExport do
     end
   end
 
+  describe ".ranges_terminal?" do
+    it "accepts every OSV terminal event and rejects open or malformed ranges" do
+      %w[fixed last_affected limit].each do |terminal|
+        ranges = [{ "events" => [{ "introduced" => "0" }, { terminal => "2.0" }] }]
+        expect(described_class.ranges_terminal?(ranges)).to be true
+      end
+
+      expect(described_class.ranges_terminal?([{ "events" => [{ "introduced" => "0" }] }])).to be false
+      expect(described_class.ranges_terminal?([])).to be false
+      expect(described_class.ranges_terminal?([{ "events" => [] }])).to be false
+    end
+  end
+
+  describe ".merge_existing" do
+    it "repairs invalid ranges individually without discarding valid reviewed ranges" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "BREW-x-CVE-1.json")
+        File.write(path, JSON.generate({
+          "id"       => "BREW-x-CVE-1",
+          "affected" => [{
+            "ranges" => [
+              { "type" => "ECOSYSTEM", "events" => [{ "introduced" => "1.0" }] },
+              { "type" => "ECOSYSTEM", "events" => [] },
+            ],
+          }],
+        }))
+        incoming = {
+          id:       "BREW-x-CVE-1",
+          affected: [{
+            ranges: [{ type: "ECOSYSTEM", events: [{ introduced: "0" }, { fixed: "2.0" }] }],
+          }],
+        }
+
+        merged = described_class.merge_existing(path, incoming, close_open_ranges: true)
+        ranges = JSON.parse(JSON.generate(merged)).dig("affected", 0, "ranges")
+
+        expect(ranges).to eq [
+          { "type" => "ECOSYSTEM", "events" => [{ "introduced" => "1.0" }, { "fixed" => "2.0" }] },
+          { "type" => "ECOSYSTEM", "events" => [{ "introduced" => "0" }, { "fixed" => "2.0" }] },
+        ]
+      end
+    end
+  end
+
   describe ".record_for" do
     it "builds a minimal record without upstream data" do
       record = described_class.record_for(nvi, "CVE-2015-2305", now:)

--- a/Library/Homebrew/vulns/match.rb
+++ b/Library/Homebrew/vulns/match.rb
@@ -619,27 +619,49 @@ module Homebrew
           # against the distro record's distro-versioned range.
           next if ev.subject_version.nil?
 
-          subject = subject_version(formula, ev.resource)&.to_s
-          evidence_range_status(ev, subject)
+          present, subject = subject_version_at(formula, ev)
+          # Absence means this formula revision did not ship the vulnerable
+          # package. Treat it as fixed for boundary walking so a temporary
+          # removal can be the fix boundary while still allowing the walk to
+          # find an older affected revision.
+          next :fixed unless present
+
+          evidence_range_status(ev, subject)&.state
         end
         return if results.empty?
-        return :affected if results.any?(&:affected?)
-        return :fixed if results.any?(&:fixed?)
+        return :affected if results.include?(:affected)
+        return :fixed if results.include?(:fixed)
 
         :not_applicable
       end
 
-      sig { params(formula: Formula, resource: T.nilable(String)).returns(T.nilable(Version)) }
-      def subject_version(formula, resource)
-        if resource
-          begin
-            formula.resource(resource)&.version
-          rescue ResourceMissingError
-            nil
-          end
-        else
-          formula.version
+      # Resolve a historical subject by upstream package identity so resource
+      # label changes do not look like removals. The boolean distinguishes a
+      # package that was absent (not affected at that revision) from one that
+      # was present but had no comparable version (uncheckable).
+      sig { params(formula: Formula, evidence: Evidence).returns([T::Boolean, T.nilable(String)]) }
+      def subject_version_at(formula, evidence)
+        return [true, formula.version.to_s] unless evidence.resource
+
+        exact_resource = formula.resources.find { |resource| resource.name == evidence.resource }
+        if exact_resource
+          exact_package = Identify.registry_package(exact_resource.url)
+          return [true, exact_resource.version&.to_s] unless exact_package
+          return [true, exact_package.version] if exact_package.ecosystem == evidence.ecosystem &&
+                                                  exact_package.name == evidence.name
         end
+
+        formula.resources.each do |resource|
+          next if resource.equal?(exact_resource)
+
+          package = Identify.registry_package(resource.url)
+          next if package.nil?
+          next if package.ecosystem != evidence.ecosystem || package.name != evidence.name
+
+          return [true, package.version]
+        end
+
+        [false, nil]
       end
     end
   end

--- a/Library/Homebrew/vulns/osv_export.rb
+++ b/Library/Homebrew/vulns/osv_export.rb
@@ -33,6 +33,8 @@ module Homebrew
       SCHEMA_VERSION = "1.7.3"
       ECOSYSTEM = "Homebrew"
       ID_PREFIX = "BREW"
+      RANGE_EVENT_KEYS = %w[introduced fixed last_affected limit].freeze
+      private_constant :RANGE_EVENT_KEYS
 
       # `annotated` is a list of `[formula, serialized_patches]` pairs. The
       # patches are passed in rather than read from the formula so callers can
@@ -80,15 +82,17 @@ module Homebrew
       end
 
       # If a record already exists at `path`, carry forward its `published`
-      # timestamp and `affected[].ranges` (so the `fixed` boundary reflects when
-      # the annotation was first observed rather than drifting to today's
-      # `pkg_version`), and skip the write entirely when nothing else has
-      # changed. Records for annotations no longer in core are simply not
-      # visited, so they persist.
+      # timestamp and `affected[].ranges` (so a terminal boundary does not
+      # drift to today's `pkg_version`), and skip the write entirely when
+      # nothing else has changed. `close_open_ranges` lets the matcher append a
+      # newly discovered `fixed` event to an existing open range while
+      # preserving its reviewed introduction events. Records for annotations
+      # no longer in core are simply not visited, so they persist.
       sig {
-        params(path: String, record: T::Hash[Symbol, T.untyped]).returns(T.nilable(T::Hash[Symbol, T.untyped]))
+        params(path: String, record: T::Hash[Symbol, T.untyped], close_open_ranges: T::Boolean)
+          .returns(T.nilable(T::Hash[Symbol, T.untyped]))
       }
-      def self.merge_existing(path, record)
+      def self.merge_existing(path, record, close_open_ranges: false)
         return record unless File.file?(path)
 
         existing = JSON.parse(File.read(path))
@@ -100,7 +104,13 @@ module Homebrew
         end
         Array(record[:affected]).each_with_index do |affected, index|
           existing_ranges = existing.dig("affected", index, "ranges")
-          affected[:ranges] = existing_ranges if existing_ranges
+          next unless existing_ranges
+
+          affected[:ranges] = if close_open_ranges
+            merge_open_ranges(existing_ranges, affected[:ranges])
+          else
+            existing_ranges
+          end
         end
 
         # Compare as parsed structures so key ordering (which JSON does not
@@ -112,6 +122,69 @@ module Homebrew
       rescue JSON::ParserError
         record
       end
+
+      # True only when every range has a terminal `fixed`, `last_affected`, or
+      # `limit` event. Invalid/empty ranges deliberately return false so the
+      # selective matcher repairs them instead of treating them as reviewed.
+      sig { params(ranges: T.untyped).returns(T::Boolean) }
+      def self.ranges_terminal?(ranges)
+        return false unless ranges.is_a?(Array)
+        return false if ranges.empty?
+
+        !!ranges.all? { |range| range_state(range) == :terminal }
+      end
+
+      sig { params(existing_ranges: T.untyped, incoming_ranges: T.untyped).returns(T.untyped) }
+      def self.merge_open_ranges(existing_ranges, incoming_ranges)
+        return incoming_ranges if !existing_ranges.is_a?(Array) || existing_ranges.empty?
+
+        incoming_ranges = Array(incoming_ranges)
+        fixed = incoming_ranges.filter_map do |range|
+          Array(range[:events] || range["events"]).rfind do |event|
+            event.is_a?(Hash) && (event.key?(:fixed) || event.key?("fixed"))
+          end
+        end.first
+        return existing_ranges unless fixed
+
+        fixed_version = fixed[:fixed] || fixed["fixed"]
+        existing_ranges.map.with_index do |range, index|
+          case range_state(range)
+          when :invalid
+            replacement = incoming_ranges[index] || incoming_ranges.first
+            next range unless replacement
+
+            if range.is_a?(Hash)
+              events = replacement[:events] || replacement["events"]
+              range.merge("events" => events)
+            else
+              replacement
+            end
+          when :open
+            range.merge("events" => [*range["events"], { "fixed" => fixed_version }])
+          else
+            range
+          end
+        end
+      end
+      private_class_method :merge_open_ranges
+
+      sig { params(range: T.untyped).returns(Symbol) }
+      def self.range_state(range)
+        return :invalid unless range.is_a?(Hash)
+
+        events = range["events"] || range[:events]
+        return :invalid if !events.is_a?(Array) || events.empty?
+
+        last = events.rfind do |event|
+          event.is_a?(Hash) && RANGE_EVENT_KEYS.any? do |key|
+            event.key?(key) || event.key?(key.to_sym)
+          end
+        end
+        return :invalid unless last
+
+        (last.key?("introduced") || last.key?(:introduced)) ? :open : :terminal
+      end
+      private_class_method :range_state
 
       sig {
         params(formula: Formula, vuln_id: String, patches: T::Array[T::Hash[String, T.untyped]],


### PR DESCRIPTION
A `BREW-*` record reviewed while its range was still open keeps that open range on rewrite, so when upstream data later moves the formula to `:fixed` the record asserts `range_state: fixed` over `{introduced: "0"}` with no `fixed` event, which reads to OSV consumers as every version being affected. Twelve records in Homebrew/advisory-database's current candidate set are in that state, and ten more are already on main.

`merge_existing` gains `close_open_ranges`, which appends the walked boundary to an open range while preserving its reviewed introduction events, and repairs an invalid range without discarding valid siblings. The matcher passes it only when a boundary was actually walked, so `--no-history` still rewrites nothing, and `history_required?` now treats a non-terminal range as needing a walk.

Separately, the history walk resolved a resource by its label, so a rename read as absence and absence ended the walk. Subjects now resolve by upstream ecosystem and name, and an absent package counts as fixed for boundary purposes so the walk reaches an older affected revision.

Verified against live OSV data: the twelve close at their real boundaries (`isponsorblocktv` 2.11.0, `mistral-vibe` 2.24.3, `torrra` 2.1.0), a `--no-history` replay leaves them untouched with zero history walks, and a false-positive `scrapy` candidate no longer appears among 35 legitimate ones.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified each new test fails without its fix and passes with it, and ran `brew lgtm` plus live replays over the affected records.

-----
