### PR TITLE
Make network access allowances exclusive

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3994,7 +3994,8 @@ class Formula
 
     # The phases for which network access is allowed. By default, network
     # access is allowed for all phases. Valid phases are `:build`, `:test`,
-    # and `:postinstall`. When no argument is passed, network access will be
+    # and `:postinstall`. When phases are passed, network access will be denied
+    # for all other phases. When no argument is passed, network access will be
     # allowed for all phases.
     #
     # ### Examples
@@ -4020,9 +4021,9 @@ class Formula
       else
         phases_array.each do |phase|
           raise ArgumentError, "Unknown phase: #{phase}" unless SUPPORTED_NETWORK_ACCESS_PHASES.include?(phase)
-
-          network_access_allowed[phase] = true
         end
+        network_access_allowed.transform_values! { false }
+        phases_array.each { |phase| network_access_allowed[phase] = true }
       end
     end
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -3034,6 +3034,22 @@ RSpec.describe Formula do
         end
       end
     end
+
+    it "denies network access for phases not explicitly allowed" do
+      f = Class.new(Testball) do
+        allow_network_access! [:build, :test]
+      end
+
+      expect(PHASES.to_h { |phase| [phase, f.network_access_allowed?(phase)] })
+        .to eq(build: true, postinstall: false, test: true)
+    end
+
+    it "does not change network access when allowing an invalid phase" do
+      f = Class.new(Testball)
+
+      expect { f.allow_network_access! [:build, :foo] }.to raise_error(ArgumentError)
+      expect(PHASES).to all(satisfy { |phase| f.network_access_allowed?(phase) })
+    end
   end
 
   describe "#network_access_allowed?" do


### PR DESCRIPTION
- Treat explicit phases as an allow-list so formulae can name only the phases requiring network access.
- Preserve no-argument behaviour and scalar or array inputs.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 sol high with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----