### PR TITLE
cc shim: compare by canonicalizing both sides, fixing issues with symlinked HOMEs

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -50,8 +50,11 @@ class Cmd
     @deps = Set.new(ENV.fetch("HOMEBREW_DEPENDENCIES", "").split(","))
     @formula_prefix = ENV["HOMEBREW_FORMULA_PREFIX"]
     @formula_buildpath = ENV["HOMEBREW_FORMULA_BUILDPATH"]
+    @self_dir = "#{canonical_path(formula_prefix)}/" if formula_prefix
+    @keg_dirs = [opt, cellar].map { canonical_path(it) }
+    @prefix_dirs = [prefix, cachedir, tmpdir].map { canonical_path(it) if it }
     # matches opt or Cellar prefix and formula name
-    @keg_regex = %r{(#{Regexp.escape(opt)}|#{Regexp.escape(cellar)})/([\w+-.@]+)}
+    @keg_regex = %r{(#{@keg_dirs.map { Regexp.escape(it) }.join("|")})/([\w+-.@]+)}
   end
 
   def split_args_at_double_dash(args)
@@ -157,8 +160,8 @@ class Cmd
   end
 
   def refurbished_args
-    @lset = Set.new(library_paths + system_library_paths)
-    @iset = Set.new(isystem_paths + include_paths)
+    @lset = Set.new((library_paths + system_library_paths).map { canonical_path(it) })
+    @iset = Set.new((isystem_paths + include_paths).map { canonical_path(it) })
 
     args = []
     enum = @args.each
@@ -272,14 +275,14 @@ class Cmd
 
   def keep?(path)
     # Allow references to self
-    if formula_prefix && path.start_with?("#{formula_prefix}/")
+    if @self_dir && path.start_with?(@self_dir)
       true
     # first two paths: reject references to Cellar or opt paths
     # for unspecified dependencies
-    elsif path.start_with?(cellar, opt)
+    elsif path.start_with?(*@keg_dirs)
       dep = path[keg_regex, 2]
       dep && @deps.include?(dep)
-    elsif path.start_with?(prefix, cachedir, tmpdir)
+    elsif path.start_with?(*@prefix_dirs)
       true
     elsif path.start_with?("/opt/local", "/opt/boxen/homebrew", "/opt/X11", "/sw", "/usr/X11")
       # ignore MacPorts, Boxen's Homebrew, X11, fink
@@ -403,7 +406,7 @@ class Cmd
   end
 
   def system_library_paths
-    paths = [canonical_path("#{sysroot}/usr/lib")]
+    paths = ["#{sysroot}/usr/lib"]
     paths << "/usr/local/lib" if !sysroot && !ENV["SDKROOT"]
     paths
   end
@@ -488,10 +491,14 @@ class Cmd
     (fuse_ld_arg == "ld") || fuse_ld_arg.end_with?("/usr/bin/ld")
   end
 
+  # A realpath that doesn't require the full path to exist. It canonicalizes the path
+  # components that exist and leaves the rest alone, like GNU realpath -m.
   def canonical_path(path)
     path = Pathname.new(path)
-    path = path.realpath if path.exist?
-    path.to_s
+    existing = path.ascend.find(&:exist?)
+    return path.to_s if existing.nil?
+
+    existing.realpath.join(path.relative_path_from(existing)).to_s
   end
 
   def path_flags(prefix, paths)

--- a/Library/Homebrew/test/shims/super/cc_spec.rb
+++ b/Library/Homebrew/test/shims/super/cc_spec.rb
@@ -1,0 +1,146 @@
+# typed: true
+# frozen_string_literal: true
+
+require "fileutils"
+
+cc_shim = HOMEBREW_SHIMS_PATH/"super/cc"
+cc_source = cc_shim.read
+cc_ruby_offset = cc_source.index("#!/usr/bin/env ruby")
+raise "no Ruby shebang found in #{cc_shim}" if cc_ruby_offset.nil?
+
+module CcShim; end
+CcShim.module_eval(cc_source[cc_ruby_offset..], cc_shim.to_s, cc_source[...cc_ruby_offset].count("\n") + 1)
+CcShim::Cmd.include(CcShim)
+
+RSpec.describe CcShim::Cmd do
+  let(:root) { mktmpdir }
+  let(:real_prefix) { "#{root}/real/brew" }
+  let(:cellar) { "Cellar" }
+  let(:opt) { "opt" }
+
+  before do
+    FileUtils.mkdir_p([
+      "#{real_prefix}/include",
+      "#{real_prefix}/lib/ocaml/caml",
+      "#{real_prefix}/#{cellar}/ocaml/5.5.0/lib/ocaml",
+      "#{real_prefix}/#{cellar}/undeclared/1.0/include",
+      "#{real_prefix}/#{cellar}/testball/1.0/include",
+      "#{real_prefix}/#{opt}",
+      "#{root}/temp/build",
+    ])
+    FileUtils.ln_s("#{real_prefix}/#{cellar}/ocaml/5.5.0", "#{real_prefix}/#{opt}/ocaml")
+    FileUtils.ln_s("#{real_prefix}/#{cellar}/undeclared/1.0", "#{real_prefix}/#{opt}/undeclared")
+    FileUtils.ln_s("#{root}/real", "#{root}/link")
+    FileUtils.ln_s(real_prefix, "#{root}/alias")
+  end
+
+  def setup_env(prefix)
+    ENV["HOMEBREW_PREFIX"] = prefix
+    ENV["HOMEBREW_CELLAR"] = "#{prefix}/#{cellar}"
+    ENV["HOMEBREW_OPT"] = "#{prefix}/#{opt}"
+    ENV["HOMEBREW_CACHE"] = "#{prefix}/cache"
+    ENV["HOMEBREW_TEMP"] = "#{root}/temp"
+    ENV["HOMEBREW_CCCFG"] = "O"
+    ENV["HOMEBREW_OPTIMIZATION_LEVEL"] = "O2"
+    ENV["HOMEBREW_DEPENDENCIES"] = "ocaml"
+    ENV["HOMEBREW_FORMULA_PREFIX"] = "#{prefix}/#{cellar}/testball/1.0"
+    ENV["HOMEBREW_OPTFLAGS"] = ""
+    ENV["HOMEBREW_ISYSTEM_PATHS"] = "#{prefix}/include"
+    ENV["HOMEBREW_INCLUDE_PATHS"] = ""
+    ENV["HOMEBREW_LIBRARY_PATHS"] = "#{prefix}/lib"
+    ENV["HOMEBREW_RPATH_PATHS"] = "#{prefix}/lib"
+    ENV.delete("HOMEBREW_SDKROOT")
+  end
+
+  def include_flags(prefix)
+    setup_env(prefix)
+
+    argv = [
+      "-c",
+      "-I#{prefix}/include",
+      "-I#{prefix}/lib/ocaml",
+      "-I#{prefix}/#{opt}/ocaml/lib/ocaml",
+      "-I#{prefix}/#{cellar}/testball/1.0/include",
+      "-I#{root}/temp/build",
+      "-I#{prefix}/#{cellar}/ocaml/5.5.0/lib/ocaml/notyet",
+      "-I#{root}/alias/#{cellar}/ocaml/5.5.0/lib/ocaml/alsonotyet",
+      "-I#{prefix}/#{opt}/undeclared/include",
+      "-I#{prefix}/#{cellar}/undeclared/1.0/include",
+      "test.c",
+    ]
+
+    described_class.new("gcc", argv).args.grep(/^-I/)
+  end
+
+  def link_flags(prefix)
+    setup_env(prefix)
+
+    argv = ["-o", "prog", "-L#{prefix}/#{cellar}/ocaml/5.5.0/lib", "prog.o"]
+
+    described_class.new("gcc", argv).args
+  end
+
+  context "when no path component of the prefix is a symlink" do
+    it "keeps the prefix, declared dependencies and references to self" do
+      expect(include_flags(real_prefix)).to include(
+        "-I#{real_prefix}/lib/ocaml",
+        "-I#{real_prefix}/#{opt}/ocaml/lib/ocaml",
+        "-I#{real_prefix}/#{cellar}/testball/1.0/include",
+        "-I#{root}/temp/build",
+      )
+    end
+
+    it "keeps directories that do not exist yet, however they are spelled" do
+      expect(include_flags(real_prefix)).to include(
+        "-I#{real_prefix}/#{cellar}/ocaml/5.5.0/lib/ocaml/notyet",
+        "-I#{root}/alias/#{cellar}/ocaml/5.5.0/lib/ocaml/alsonotyet",
+      )
+    end
+
+    it "drops paths superenv provides itself" do
+      expect(include_flags(real_prefix)).not_to include("-I#{real_prefix}/include")
+    end
+
+    it "rejects undeclared dependencies" do
+      expect(include_flags(real_prefix)).not_to include(
+        "-I#{real_prefix}/#{opt}/undeclared/include",
+        "-I#{real_prefix}/#{cellar}/undeclared/1.0/include",
+      )
+    end
+  end
+
+  context "when a path component of the prefix is a symlink" do
+    let(:linked_prefix) { "#{root}/link/brew" }
+
+    it "keeps the prefix, declared dependencies and references to self" do
+      expect(include_flags(linked_prefix)).to include(
+        "-I#{linked_prefix}/lib/ocaml",
+        "-I#{linked_prefix}/#{opt}/ocaml/lib/ocaml",
+        "-I#{linked_prefix}/#{cellar}/testball/1.0/include",
+        "-I#{root}/temp/build",
+      )
+    end
+
+    it "keeps directories that do not exist yet, however they are spelled" do
+      expect(include_flags(linked_prefix)).to include(
+        "-I#{linked_prefix}/#{cellar}/ocaml/5.5.0/lib/ocaml/notyet",
+        "-I#{root}/alias/#{cellar}/ocaml/5.5.0/lib/ocaml/alsonotyet",
+      )
+    end
+
+    it "drops paths superenv provides itself" do
+      expect(include_flags(linked_prefix)).not_to include("-I#{linked_prefix}/include")
+    end
+
+    it "never emits a path with its symlinks resolved" do
+      expect(link_flags(linked_prefix).join(" ")).not_to include("#{root}/real")
+    end
+
+    it "rejects undeclared dependencies" do
+      expect(include_flags(linked_prefix)).not_to include(
+        "-I#{linked_prefix}/#{opt}/undeclared/include",
+        "-I#{linked_prefix}/#{cellar}/undeclared/1.0/include",
+      )
+    end
+  end
+end

--- a/Library/Homebrew/test/shims/super/cc_spec.rbi
+++ b/Library/Homebrew/test/shims/super/cc_spec.rbi
@@ -1,0 +1,11 @@
+# typed: strict
+
+module CcShim
+  class Cmd
+    sig { params(arg0: String, args: T::Array[String]).void }
+    def initialize(arg0, args); end
+
+    sig { returns(T::Array[String]) }
+    def args; end
+  end
+end


### PR DESCRIPTION
The main thing this does is fix the cc shim on Linux distros with
symlinked homes like Fedora Silverblue.

Previously, `keep?` decided whether a -I or -L flag is passed through
to the compiler by comparing its path against `HOMEBREW_FORMULA_PREFIX`,
`HOMEBREW_OPT`, `HOMEBREW_CELLAR`, `HOMEBREW_PREFIX`, `HOMEBREW_CACHE` and
`HOMEBREW_TEMP`. The path it was handed had been through `canonical_path`,
which resolves symlinks, but the values compared against were used
exactly as they appear in the environment.

When any component of those paths was a symlink the two spellings never
matched, so every flag pointing inside the prefix fell through to the
last branch of `keep?`, which dropped it on Linux and kept it on macOS.
On a system where `/home` is a symlink to `/var/home` (Fedora Silverblue,
Bazzite) with Homebrew installed in `/home/linuxbrew/.linuxbrew`, a Linux
build lost every -I and -L under the prefix, including ones
naming a declared dependency or the formula's own keg.

The bug surfaced for me when I tried to compile cpdf. In that build,
`ocamlc` compiled C stubs with `-I$(ocamlc -where)`, the OCaml stdlib
directory, so `cpdf` failed to build with `fatal error: caml/alloc.h:
No such file or directory`.

The solution is to canonicalize the paths that `keep?` compares against,
so both sides of every comparison are in the same form. However, since
`canonical_path` gives up when the path does not exist and just returns
its input, this would still fail to keep paths when the flag
contains a reference to a directory that does not exist yet. Fix by
making `canonical_path` a total function.

Also, canonicalize iset and lset, the sets that deduplicate the -I and
-L paths since those are compared against paths that have already been
canoncalized. This generalizes the fix in b0d7de289c7d.

The second commit adds some tests. They build a miniature prefix in a
temporary directory and run the same expectations against the plain path
and the symlink.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Opus 5 inside Pi was used to write all code, including the bug fix and tests. The PR description is mine