### PR TITLE
ask: acknowledge a confirmed prompt

### DIFF
--- a/Library/Homebrew/ask.rb
+++ b/Library/Homebrew/ask.rb
@@ -23,6 +23,7 @@ module Homebrew
 
         result = result.chomp.strip.downcase
         if result == "y"
+          ohai "Proceeding..."
           return true
         # N, Escape, Ctrl-C and Ctrl-D.
         elsif ["n", "\e", "\u0003", "\u0004"].include?(result)

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -180,7 +180,10 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
 
       expect do
         Homebrew::Install.ask(action: "upgrade")
-      end.to output("==> Do you want to proceed with the upgrade? [y/n]\n").to_stdout
+      end.to output(<<~EOS).to_stdout
+        ==> Do you want to proceed with the upgrade? [y/n]
+        ==> Proceeding...
+      EOS
     end
   end
 


### PR DESCRIPTION
This PR adds a simple line of output that acknowledges the user's response to `==> Do you want to proceed with the upgrade? [y/n]`. Before this PR, when the action that followed the input was expensive, it was not obvious that the response (`y`) succeeded. This makes it clear that the input has succeeded and progressed to the next stage.

This is something that I run into regularly when using `brew upgrade`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
