### PR TITLE
Migrate analytics to brew.sh proxy

### DIFF
--- a/Library/Homebrew/test/dev-cmd/formula-analytics_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/formula-analytics_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Homebrew::DevCmd::FormulaAnalytics do
       command.each_influx_record("SELECT 1") { |record| records << record }
 
       expect(records).to eq [{
-        "host"     => "eu-central-1-1.aws.cloud2.influxdata.com",
+        "host"     => "analytics.brew.sh",
         "org"      => Utils::Analytics::INFLUX_ORG,
         "database" => Utils::Analytics::INFLUX_BUCKET,
         "query"    => "SELECT 1",

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -11,8 +11,7 @@ module Utils
   # Helper module for fetching and reporting analytics data.
   module Analytics
     INFLUX_BUCKET = "analytics"
-    INFLUX_TOKEN = "iVdsgJ_OjvTYGAA79gOfWlA_fX0QCuj4eYUNdb-qVUTrC3tp3JTWCADVNE9HxV0kp2ZjIK9tuthy_teX4szr9A=="
-    INFLUX_HOST = "https://eu-central-1-1.aws.cloud2.influxdata.com"
+    INFLUX_HOST = "https://analytics.brew.sh"
     INFLUX_ORG = "d81a3e6d582d485f"
     WSL_SUFFIX = " [WSL]"
     ENV_CONFIG_COMMANDS = %w[config fetch install reinstall update update-report upgrade].freeze
@@ -45,7 +44,6 @@ module Utils
 
         args = [
           "--max-time", "3",
-          "--header", "Authorization: Token #{INFLUX_TOKEN}",
           "--header", "Content-Type: text/plain; charset=utf-8",
           "--header", "Accept: application/json",
           "--data-binary", "#{measurement},#{tags_string} #{fields_string} #{Time.now.to_i}"


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- []x Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
This migrates the analytics reporting to our own proxy so we have more control over it. Also makes it easier to find out for people what the traffic is. Since our proxy automatically sets a write-only token we will not need to set one anymore here.