### PR TITLE
upgrade: print the fetch heading before prefetching

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -229,6 +229,7 @@ module Homebrew
         formulae_prefetched = T.let(false, T::Boolean)
         prefetched_casks = T.let(false, T::Boolean)
         ask_upgrade_planned = T.let(false, T::Boolean)
+        planned_fetch_names = T.let([], T::Array[String])
         shared_download_queue = T.let(nil, T.nilable(Homebrew::DownloadQueue))
         if ask
           unless only_upgrade_casks
@@ -249,9 +250,9 @@ module Homebrew
           end
 
           show_final_upgrade_summary(dry_run: true)
+          planned_fetch_names = final_upgrade_summary.version_changes.map { |change| change.split.fetch(0) }
           if Install.ask_prompt_needed?(
-            planned_names:   final_upgrade_summary.version_changes.map do |version_change|
-              planned_name = version_change.split.fetch(0)
+            planned_names:   planned_fetch_names.map do |planned_name|
               formulae.find { |formula| formula.full_specified_name == planned_name }&.full_name || planned_name
             end,
             requested_names: args.named,
@@ -267,6 +268,10 @@ module Homebrew
 
         if !args.dry_run? && (!ask || ask_upgrade_planned) && !(only_upgrade_formulae && only_upgrade_casks)
           shared_download_queue = Homebrew::DownloadQueue.new(pour: true)
+          # The preview shown before the prompt already knows what will be
+          # upgraded, so print the heading before the prefetch works it out again.
+          early_fetch_heading = Install.combined_fetch_downloads_heading(formula_names: planned_fetch_names)
+          shared_download_queue.print_heading(early_fetch_heading) if early_fetch_heading
           begin
             unless only_upgrade_casks
               formulae_prefetched = upgrade_outdated_formulae!(
@@ -295,10 +300,13 @@ module Homebrew
                 dry_run: args.dry_run?,
               )
             end
-            shared_download_queue.fetch(heading: Install.combined_fetch_downloads_heading(
-              formula_names: prefetched_formulae_names,
-              cask_names:    prefetched_cask_names,
-            ) || "Fetching dependency downloads")
+            unless early_fetch_heading
+              fetch_heading = Install.combined_fetch_downloads_heading(
+                formula_names: prefetched_formulae_names,
+                cask_names:    prefetched_cask_names,
+              ) || "Fetching dependency downloads"
+            end
+            shared_download_queue.fetch(heading: fetch_heading)
             # Only redo the slower unprefetched fetch for the kind of package
             # that actually failed, so e.g. one bad bottle does not also
             # re-verify every already downloaded cask.

--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -109,6 +109,18 @@ module Homebrew
       end
     end
 
+    sig { params(heading: String).void }
+    def print_heading(heading)
+      if tty
+        oh1 heading, truncate: false
+        $stdout.flush
+      else
+        # Keep the heading off parsed stdout (e.g. `brew info --json | jq`)
+        # and on the same stream as the non-TTY report lines below.
+        $stderr.puts oh1_title(heading, truncate: false)
+      end
+    end
+
     # Waits for and reports queued downloads. With `only:`, limits that to
     # downloadables of the given class, leaving the rest enqueued and
     # unreported for a later fetch, e.g. so dependency resolution can wait
@@ -136,16 +148,7 @@ module Homebrew
       end
       return if fetchable_downloads.empty?
 
-      if heading
-        if tty
-          oh1 heading, truncate: false
-          $stdout.flush
-        else
-          # Keep the heading off parsed stdout (e.g. `brew info --json | jq`)
-          # and on the same stream as the non-TTY report lines below.
-          $stderr.puts oh1_title(heading, truncate: false)
-        end
-      end
+      print_heading(heading) if heading
 
       if concurrency == 1
         fetchable_downloads.each do |downloadable, promise|

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -416,7 +416,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   # upgrades with asking for user prompts
   it "prints formula and cask ask plans before upgrading" do
     cmd = described_class.new([])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil,
+                                     print_heading: nil)
 
     expect(cmd).to receive(:upgrade_outdated_formulae!)
       .with([], dry_run: true, show_upgrade_summary: false)
@@ -537,7 +538,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       url "https://brew.sh/testball-0.2"
     end
     cmd = described_class.new(["oldtestball"])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil,
+                                     print_heading: nil)
     allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable)
       .with(method: :resolve)
       .and_return([formula])
@@ -782,7 +784,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
   it "prints a combined upgrade summary before fetching combined downloads" do
     cmd = described_class.new(["-y"])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil,
+                                     print_heading: nil)
     cask = instance_double(
       Cask::Cask,
       artifacts:         [],
@@ -839,7 +842,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       url "https://brew.sh/testball-0.2"
     end
     cmd = described_class.new(["--formula", "testball", "--yes"])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil,
+                                     print_heading: nil)
 
     allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable)
       .with(method: :resolve)
@@ -869,7 +873,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     installer = Cask::Installer.allocate
     allow(installer).to receive(:enqueue_dependency_downloads)
     cmd = described_class.new(["--cask", "codex", "--yes"])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil,
+                                     print_heading: nil)
 
     allow(cmd.args.named).to receive(:to_formulae_and_casks_and_unavailable)
       .with(method: :resolve)
@@ -954,7 +959,8 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
   it "asks before fetching formulae and casks in the same download queue" do
     cmd = described_class.new([])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil,
+                                     print_heading: nil)
     cask = instance_double(
       Cask::Cask,
       artifacts:         [],
@@ -1003,9 +1009,40 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     cmd.run
   end
 
+  it "heads the downloads before prefetching them" do
+    cmd = described_class.new([])
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil,
+                                     print_heading: nil)
+    sequence = []
+
+    allow(download_queue).to receive(:print_heading) { |heading| sequence << heading }
+    allow(cmd).to receive(:upgrade_outdated_formulae!) do |_, dry_run: false, prefetch_only: false,
+                                                              prefetch_names: nil, **|
+      if dry_run
+        cmd.final_upgrade_summary.version_changes << "deno 2.7.10 -> 2.7.11"
+      elsif prefetch_only
+        sequence << "prefetch"
+        prefetch_names&.replace(["deno"])
+      end
+
+      true
+    end
+    allow(cmd).to receive_messages(upgrade_outdated_casks!: false, prefetch_outdated_casks!: false)
+    allow(Homebrew::Cleanup).to receive(:periodic_clean!)
+    allow(Homebrew::Reinstall).to receive(:reinstall_pkgconf_if_needed!)
+    allow(Homebrew.messages).to receive(:display_messages)
+    allow(Homebrew::Install).to receive(:ask)
+    allow(Homebrew::DownloadQueue).to receive(:new).and_return(download_queue)
+
+    cmd.run
+
+    expect(sequence).to eq(["Fetching downloads for: deno", "prefetch"])
+  end
+
   it "uses prefetched compatible casks and carries requirement errors into upgrade" do
     cmd = described_class.new(["--yes"])
-    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil)
+    download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, failed_downloads: [], shutdown: nil,
+                                     print_heading: nil)
     cask = instance_double(Cask::Cask)
     cask_error = Cask::CaskError.new("bad-cask: This cask requires Linux.")
 
@@ -1163,6 +1200,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     cmd = described_class.new([])
     download_queue = instance_double(Homebrew::DownloadQueue, fetch:            nil,
                                                               failed_downloads: [failed_download],
+                                                              print_heading:    nil,
                                                               shutdown:         nil)
     cask = instance_double(
       Cask::Cask,


### PR DESCRIPTION
Alternative to #23638.

- Print the `==> Fetching downloads for:` heading immediately after the upgrade prompt, using the names the ask preview has already worked out, so confirming with `y` prints something straight away rather than after the prefetch that currently supplies them.
- Extract the `print_heading` logic to a method so we can call it from the other site.
- Skip the heading in `fetch` when it has already been printed, leaving the non-ask path and its `Fetching dependency downloads` fallback unchanged.
- Two drawbacks with this implentation: the heading now names what the preview planned, so a package filtered out during prefetch can be named in a heading it isn't fetched under, and `==> Downloading bottle manifests` now outputs under the heading rather than preceding it.


-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

I used `claude-code` with Opus 5, to implement the change.