### PR TITLE
Run privileged cask install steps in the parent process

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_artifact.rb
+++ b/Library/Homebrew/cask/artifact/abstract_artifact.rb
@@ -214,11 +214,13 @@ module Cask
 
       sig {
         params(
-          sandbox: Sandbox,
-          payload: T::Hash[String, T.untyped],
+          sandbox:               Sandbox,
+          payload:               T::Hash[String, T.untyped],
+          passthrough_stdin:     T::Boolean,
+          child_message_handler: T.nilable(T.proc.params(message: String).returns(T.nilable(String))),
         ).void
       }
-      def run_cask_sandbox(sandbox, payload)
+      def run_cask_sandbox(sandbox, payload, passthrough_stdin: true, child_message_handler: nil)
         # Formulae sandbox the complete `postinstall.rb` process. Do the same
         # for cask operations so Ruby file changes and every command share one
         # profile, instead of forwarding command input and output through files.
@@ -242,7 +244,9 @@ module Cask
               "-I", $LOAD_PATH.join(File::PATH_SEPARATOR),
               "--",
               HOMEBREW_LIBRARY_PATH/"cask_artifact.rb",
-              payload_path
+              payload_path,
+              passthrough_stdin:,
+              child_message_handler:
             )
           end
         end

--- a/Library/Homebrew/cask/artifact/install_steps.rb
+++ b/Library/Homebrew/cask/artifact/install_steps.rb
@@ -68,74 +68,71 @@ module Cask
           return
         end
 
-        normalised_steps = Homebrew::InstallSteps::DSL.normalise_steps(steps)
-        parent_error = T.let(nil, T.nilable(Exception))
         last_privileged_index = T.let(-1, Integer)
         # macOS caches sudo credentials per terminal or session, so privileged
         # steps must run in this parent process to reuse its ticket instead of
-        # prompting once per sandbox child PTY. The child only nominates
-        # predeclared steps by index; each request is fully validated here
-        # because the sandboxed child is untrusted while running cask code.
+        # prompting once per sandbox child PTY.
         child_message_handler = proc do |message|
-          response = Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_FAILED
-          begin
-            request = begin
-              JSON.parse(message)
-            rescue JSON::ParserError
-              nil
-            end
-            # Child error reports arrive on the same pipe; leave them for
-            # `Utils.safe_fork` to raise.
-            next if request.is_a?(Hash) && request.key?("json_class")
-            next response if parent_error
+          index = run_privileged_step_request(message, runner:, phase:, last_privileged_index:)
+          next if index.nil?
 
-            if !request.is_a?(Hash) ||
-               request["type"] != Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_REQUEST
-              raise ArgumentError, "Invalid privileged cask child message."
-            end
-
-            index = request.fetch("index")
-            unless index.is_a?(Integer)
-              raise ArgumentError,
-                    "Invalid privileged cask install step index: #{index.inspect}"
-            end
-            if index <= last_privileged_index
-              raise ArgumentError, "Privileged cask install steps must be requested in order."
-            end
-
-            step = normalised_steps.fetch(index)
-            unless runner.sudo_required?([step])
-              raise ArgumentError, "Cask install step #{index} is not privileged."
-            end
-
-            # Guards are re-evaluated here instead of trusting the child, and
-            # guard results persist across requests so multi-step guard blocks
-            # keep the snapshot semantics of a single uninterrupted run.
-            runner.run([step], phase:, reset_guard_results: false)
-            last_privileged_index = index
-            response = Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_SUCCEEDED
-          rescue Interrupt, StandardError => e
-            parent_error ||= e
-          end
-          response
+          last_privileged_index = index
+          Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_SUCCEEDED
         end
 
-        sandbox_error = T.let(nil, T.nilable(Exception))
-        begin
-          # Keep the parent terminal free for the sudo prompt: forwarded
-          # sandbox stdin would otherwise compete for the password input.
-          run_cask_sandbox(
-            sandbox,
-            payload,
-            passthrough_stdin:     false,
-            child_message_handler:,
-          )
-        rescue Interrupt, StandardError => e
-          sandbox_error = e
+        # Keep the parent terminal free for the sudo prompt: forwarded
+        # sandbox stdin would otherwise compete for the password input.
+        run_cask_sandbox(
+          sandbox,
+          payload,
+          passthrough_stdin:     false,
+          child_message_handler:,
+        )
+      end
+
+      sig {
+        params(
+          message:               String,
+          runner:                Homebrew::InstallSteps::Runner,
+          phase:                 Symbol,
+          last_privileged_index: Integer,
+        ).returns(T.nilable(Integer))
+      }
+      def run_privileged_step_request(message, runner:, phase:, last_privileged_index:)
+        request = begin
+          JSON.parse(message)
+        rescue JSON::ParserError
+          nil
+        end
+        # Child error reports arrive on the same pipe; leave them for
+        # `Utils.safe_fork` to raise.
+        return if request.is_a?(Hash) && request.key?("json_class")
+
+        # The sandboxed child is untrusted and may only nominate a predeclared
+        # privileged step by index.
+        if !request.is_a?(Hash) ||
+           request["type"] != Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_REQUEST
+          raise ArgumentError, "Invalid privileged cask child message."
         end
 
-        raise parent_error if parent_error
-        raise sandbox_error if sandbox_error
+        index = request.fetch("index")
+        unless index.is_a?(Integer)
+          raise ArgumentError,
+                "Invalid privileged cask install step index: #{index.inspect}"
+        end
+        if index <= last_privileged_index
+          raise ArgumentError, "Privileged cask install steps must be requested in order."
+        end
+
+        step = steps.fetch(index)
+        unless runner.sudo_required?([step])
+          raise ArgumentError, "Cask install step #{index} is not privileged."
+        end
+
+        # Re-evaluate guards in the parent instead of trusting the child, while
+        # preserving snapshots across requests from the same step plan.
+        runner.run([step], phase:, reset_guard_results: false)
+        index
       end
     end
 

--- a/Library/Homebrew/cask/artifact/install_steps.rb
+++ b/Library/Homebrew/cask/artifact/install_steps.rb
@@ -43,30 +43,99 @@ module Cask
 
         sandbox.allow_write_path cask.caskroom_path
         sandbox.allow_write_path cask.config.appdir
-        sandbox.allow_process_exec "/usr/bin/sudo", no_sandbox: true if runner.sudo_required?(steps)
         Keg.keg_link_directories.each { |directory| sandbox.allow_write_path HOMEBREW_PREFIX/directory }
         original_home = Pathname(Dir.home).expand_path
         runner.sandbox_write_paths(steps, phase:).each do |path|
           sandbox.allow_write_path path
           sandbox.allow_read(path:, type: :subpath) if path.expand_path.ascend.include?(original_home)
         end
-        run_cask_sandbox(
-          sandbox,
-          {
-            "action"  => "install_steps",
-            "context" => {
-              "name"          => cask.name,
-              "token"         => cask.token,
-              "version"       => cask.version.to_s,
-              "staged_path"   => cask.staged_path.to_s,
-              "caskroom_path" => cask.caskroom_path.to_s,
-              "home"          => Dir.home,
-              "config"        => cask.config.to_json,
-            },
-            "phase"   => phase.to_s,
-            "steps"   => steps,
+        payload = {
+          "action"  => "install_steps",
+          "context" => {
+            "name"          => cask.name,
+            "token"         => cask.token,
+            "version"       => cask.version.to_s,
+            "staged_path"   => cask.staged_path.to_s,
+            "caskroom_path" => cask.caskroom_path.to_s,
+            "home"          => Dir.home,
+            "config"        => cask.config.to_json,
           },
-        )
+          "phase"   => phase.to_s,
+          "steps"   => steps,
+        }
+        unless runner.sudo_required?(steps)
+          run_cask_sandbox(sandbox, payload)
+          return
+        end
+
+        normalised_steps = Homebrew::InstallSteps::DSL.normalise_steps(steps)
+        parent_error = T.let(nil, T.nilable(Exception))
+        last_privileged_index = T.let(-1, Integer)
+        # macOS caches sudo credentials per terminal or session, so privileged
+        # steps must run in this parent process to reuse its ticket instead of
+        # prompting once per sandbox child PTY. The child only nominates
+        # predeclared steps by index; each request is fully validated here
+        # because the sandboxed child is untrusted while running cask code.
+        child_message_handler = proc do |message|
+          response = Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_FAILED
+          begin
+            request = begin
+              JSON.parse(message)
+            rescue JSON::ParserError
+              nil
+            end
+            # Child error reports arrive on the same pipe; leave them for
+            # `Utils.safe_fork` to raise.
+            next if request.is_a?(Hash) && request.key?("json_class")
+            next response if parent_error
+
+            if !request.is_a?(Hash) ||
+               request["type"] != Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_REQUEST
+              raise ArgumentError, "Invalid privileged cask child message."
+            end
+
+            index = request.fetch("index")
+            unless index.is_a?(Integer)
+              raise ArgumentError,
+                    "Invalid privileged cask install step index: #{index.inspect}"
+            end
+            if index <= last_privileged_index
+              raise ArgumentError, "Privileged cask install steps must be requested in order."
+            end
+
+            step = normalised_steps.fetch(index)
+            unless runner.sudo_required?([step])
+              raise ArgumentError, "Cask install step #{index} is not privileged."
+            end
+
+            # Guards are re-evaluated here instead of trusting the child, and
+            # guard results persist across requests so multi-step guard blocks
+            # keep the snapshot semantics of a single uninterrupted run.
+            runner.run([step], phase:, reset_guard_results: false)
+            last_privileged_index = index
+            response = Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_SUCCEEDED
+          rescue Interrupt, StandardError => e
+            parent_error ||= e
+          end
+          response
+        end
+
+        sandbox_error = T.let(nil, T.nilable(Exception))
+        begin
+          # Keep the parent terminal free for the sudo prompt: forwarded
+          # sandbox stdin would otherwise compete for the password input.
+          run_cask_sandbox(
+            sandbox,
+            payload,
+            passthrough_stdin:     false,
+            child_message_handler:,
+          )
+        rescue Interrupt, StandardError => e
+          sandbox_error = e
+        end
+
+        raise parent_error if parent_error
+        raise sandbox_error if sandbox_error
       end
     end
 

--- a/Library/Homebrew/cask_artifact.rb
+++ b/Library/Homebrew/cask_artifact.rb
@@ -55,7 +55,11 @@ module Cask
 end
 
 begin
-  error_pipe = Utils.forked_child_error_pipe
+  error_pipe = if ENV.delete("HOMEBREW_CHILD_MESSAGE_CHANNEL")
+    Utils.forked_child_channel
+  else
+    Utils.forked_child_error_pipe
+  end
 
   trap("INT", old_trap)
 
@@ -76,7 +80,27 @@ begin
     context = Cask::InstallStepsContext.new(payload.fetch("context"))
     steps = payload.fetch("steps")
     phase = payload.fetch("phase").to_sym
-    Homebrew::InstallSteps::Runner.new(context:).run(steps, phase:)
+    # Privileged steps execute in the parent process to reuse its sudo ticket
+    # (see Cask::Artifact::AbstractInstallSteps#run_steps). Request each step
+    # by index and wait for the outcome so ordering is preserved.
+    privileged_step_handler = if error_pipe.is_a?(Utils::ForkedChildChannel)
+      proc do |index|
+        error_pipe.puts JSON.generate(
+          "type"  => Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_REQUEST,
+          "index" => index,
+        )
+        error_pipe.flush
+        response = error_pipe.gets&.chomp
+        next if response == Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_SUCCEEDED
+
+        raise "The parent process failed to run privileged cask install step #{index}."
+      end
+    else
+      proc do |index|
+        raise "Privileged cask install step #{index} requires a parent message channel."
+      end
+    end
+    Homebrew::InstallSteps::Runner.new(context:).run(steps, phase:, privileged_step_handler:)
   when "generated_completions"
     errors = []
     payload.fetch("completions").each do |completion|

--- a/Library/Homebrew/extend/os/linux/sandbox.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox.rb
@@ -75,8 +75,14 @@ module OS
         end
       end
 
-      sig { params(args: T.any(String, ::Pathname)).void }
-      def run(*args)
+      sig {
+        params(
+          args:                  T.any(String, ::Pathname),
+          passthrough_stdin:     T::Boolean,
+          child_message_handler: T.nilable(T.proc.params(message: String).returns(T.nilable(String))),
+        ).void
+      }
+      def run(*args, passthrough_stdin: true, child_message_handler: nil)
         landlock.run { super }
       end
 

--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -870,6 +870,10 @@ module Homebrew
       include SystemCommand::Mixin
       include ::Utils::Output::Mixin
 
+      PRIVILEGED_STEP_REQUEST = "homebrew_cask_privileged_step"
+      PRIVILEGED_STEP_SUCCEEDED = "homebrew_cask_privileged_step_succeeded"
+      PRIVILEGED_STEP_FAILED = "homebrew_cask_privileged_step_failed"
+
       # Path tokens reuse the step base resolution; formula metadata tokens are
       # resolved separately. Anything else is left verbatim so literal braces in
       # templates are never rewritten.
@@ -887,14 +891,35 @@ module Homebrew
         @guard_results = T.let({}, T::Hash[PathSpec, T::Boolean])
       end
 
-      sig { params(steps: Steps, phase: Symbol).void }
-      def run(steps, phase: :install)
-        @guard_results.clear
-        DSL.normalise_steps(steps).each do |step|
+      # `privileged_step_handler` delegates steps that may need `sudo` to the
+      # caller (the parent process broker for sandboxed cask steps), and
+      # `reset_guard_results: false` lets that broker run steps one at a time
+      # while keeping guard snapshots from earlier steps in the same plan.
+      sig {
+        params(
+          steps:                   Steps,
+          phase:                   Symbol,
+          privileged_step_handler: T.nilable(T.proc.params(index: Integer).void),
+          reset_guard_results:     T::Boolean,
+        ).void
+      }
+      def run(steps, phase: :install, privileged_step_handler: nil, reset_guard_results: true)
+        @guard_results.clear if reset_guard_results
+        DSL.normalise_steps(steps).each_with_index do |step, index|
           if phase == :uninstall
-            run_uninstall_step(step)
+            if privileged_step_handler && sudo_required?([step])
+              privileged_step_handler.call(index)
+            else
+              run_uninstall_step(step)
+            end
           else
-            run_install_step(step)
+            next unless step_guards_match?(step)
+
+            if privileged_step_handler && sudo_required?([step])
+              privileged_step_handler.call(index)
+            else
+              run_install_step(step)
+            end
           end
         end
       end
@@ -952,8 +977,6 @@ module Homebrew
 
       sig { params(step: Step).void }
       def run_install_step(step)
-        return unless step_guards_match?(step)
-
         case step.fetch("type")
         when "mkdir"
           resolve_path(step_path(step, "path")).mkdir

--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -872,7 +872,6 @@ module Homebrew
 
       PRIVILEGED_STEP_REQUEST = "homebrew_cask_privileged_step"
       PRIVILEGED_STEP_SUCCEEDED = "homebrew_cask_privileged_step_succeeded"
-      PRIVILEGED_STEP_FAILED = "homebrew_cask_privileged_step_failed"
 
       # Path tokens reuse the step base resolution; formula metadata tokens are
       # resolved separately. Anything else is left verbatim so literal braces in
@@ -906,20 +905,14 @@ module Homebrew
       def run(steps, phase: :install, privileged_step_handler: nil, reset_guard_results: true)
         @guard_results.clear if reset_guard_results
         DSL.normalise_steps(steps).each_with_index do |step, index|
-          if phase == :uninstall
-            if privileged_step_handler && sudo_required?([step])
-              privileged_step_handler.call(index)
-            else
-              run_uninstall_step(step)
-            end
-          else
-            next unless step_guards_match?(step)
+          next if phase != :uninstall && !step_guards_match?(step)
 
-            if privileged_step_handler && sudo_required?([step])
-              privileged_step_handler.call(index)
-            else
-              run_install_step(step)
-            end
+          if privileged_step_handler && sudo_required?([step])
+            privileged_step_handler.call(index)
+          elsif phase == :uninstall
+            run_uninstall_step(step)
+          else
+            run_install_step(step)
           end
         end
       end

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -548,8 +548,14 @@ class Sandbox
     add_rule allow: false, operation: "network*"
   end
 
-  sig { params(args: T.any(String, Pathname)).void }
-  def run(*args)
+  sig {
+    params(
+      args:                  T.any(String, Pathname),
+      passthrough_stdin:     T::Boolean,
+      child_message_handler: T.nilable(T.proc.params(message: String).returns(T.nilable(String))),
+    ).void
+  }
+  def run(*args, passthrough_stdin: true, child_message_handler: nil)
     Dir.mktmpdir("homebrew-sandbox", HOMEBREW_TEMP) do |tmpdir|
       allow_network path: File.join(tmpdir, "socket"), type: :literal if allow_network_for_error_pipe?
       @start = T.let(Time.now, T.nilable(Time))
@@ -579,17 +585,19 @@ class Sandbox
             old_winch = trap(:WINCH, &winch)
             winch.call(nil)
 
-            stdin_thread = Thread.new do
-              IO.copy_stream($stdin, controller)
-            rescue Errno::EIO
-              # stdin is unavailable - move on.
+            if passthrough_stdin
+              stdin_thread = Thread.new do
+                IO.copy_stream($stdin, controller)
+              rescue Errno::EIO
+                # stdin is unavailable - move on.
+              end
             end
 
             stdout_thread = Thread.new do
               copy_pty_output(controller)
             end
 
-            Utils.safe_fork(directory: tmpdir, yield_parent: true) do |error_pipe|
+            Utils.safe_fork(directory: tmpdir, yield_parent: true, child_message_handler:) do |error_pipe|
               if error_pipe
                 # Child side
                 Process.setsid
@@ -620,7 +628,7 @@ class Sandbox
             trap(:WINCH, old_winch)
           end
 
-          if $stdin.tty?
+          if $stdin.tty? && passthrough_stdin
             # If stdin is a TTY, set it to a raw, passthrough mode while we
             # copy the input/output of the process spawned in the PTY, then
             # restore its original state afterwards. Keep `opost` set, unlike

--- a/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/generated_completion_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
           allow(sandbox).to receive(:allow_read)
           allow(sandbox).to receive(:add_install_hook_rules)
           allow(sandbox).to receive(:allow_write_path)
-          allow(sandbox).to receive(:run) do |*args|
+          allow(sandbox).to receive(:run) do |*args, **|
             run_sandboxed_payload.call(args)
           end
         end
@@ -73,7 +73,7 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
             calls << :add_install_hook_rules
           end
           allow(sandbox).to receive(:allow_write_path)
-          allow(sandbox).to receive(:run) do |*args|
+          allow(sandbox).to receive(:run) do |*args, **|
             calls << :run
             homes << Pathname(args.grep(/^HOME=/).first.delete_prefix("HOME="))
             run_sandboxed_payload.call(args)
@@ -100,7 +100,7 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
           allow(sandbox).to receive(:allow_read)
           allow(sandbox).to receive(:add_install_hook_rules)
           allow(sandbox).to receive(:allow_write_path)
-          allow(sandbox).to receive(:run) do |*args|
+          allow(sandbox).to receive(:run) do |*args, **|
             captured_payload = JSON.parse(Pathname(args.last).read)
           end
         end
@@ -141,7 +141,7 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
             allow(sandbox).to receive(:allow_read)
             allow(sandbox).to receive(:add_install_hook_rules)
             allow(sandbox).to receive(:allow_write_path)
-            allow(sandbox).to receive(:run) do |*args|
+            allow(sandbox).to receive(:run) do |*args, **|
               run_sandboxed_payload.call(args)
             end
           end
@@ -195,7 +195,7 @@ RSpec.describe Cask::Artifact::GeneratedCompletion, :cask do
           allow(sandbox).to receive(:allow_read)
           allow(sandbox).to receive(:add_install_hook_rules)
           allow(sandbox).to receive(:allow_write_path)
-          allow(sandbox).to receive(:run) do |*args|
+          allow(sandbox).to receive(:run) do |*args, **|
             captured_payload = JSON.parse(Pathname(args.last).read)
             run_sandboxed_payload.call(args)
           end

--- a/Library/Homebrew/test/cask/artifact/install_steps_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/install_steps_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Cask::Artifact::AbstractInstallSteps, :cask do
     expect(sandbox).to receive(:allow_write_path).with(original_home/"Library/Application Support")
     expect(sandbox).to receive(:allow_read)
       .with(path: original_home/"Library/Application Support", type: :subpath)
-    expect(sandbox).to receive(:run).once do |*args|
+    expect(sandbox).to receive(:run).once do |*args, **|
       expect(args).to include(HOMEBREW_LIBRARY_PATH/"cask_artifact.rb")
 
       payload = JSON.parse(Pathname(args.last).read)
@@ -142,13 +142,338 @@ RSpec.describe Cask::Artifact::AbstractInstallSteps, :cask do
   end
 
   context "when install steps may require sudo" do
+    it "runs privileged steps from separate sandbox phases in the parent process" do
+      cask = Cask::Cask.new("with-parent-privileged-install-steps") do
+        version "1.2.3"
+        sha256 :no_check
+        url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
+
+        preflight_steps do
+          run "/usr/bin/true", sudo: true
+        end
+
+        postflight_steps do
+          run "/usr/bin/true", sudo: true
+        end
+      end
+      sandbox = instance_double(Sandbox).as_null_object
+      command = class_double(SystemCommand)
+      parent_pid = Process.pid
+      cask.staged_path.mkpath
+      cask.config_path.dirname.mkpath
+
+      allow(Sandbox).to receive_messages(available?: true, new: sandbox)
+      allow(sandbox).to receive(:allow_write_path)
+      allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
+      allow(sandbox).to receive(:run) do |*args, passthrough_stdin:, child_message_handler:|
+        expect(passthrough_stdin).to be(false)
+        Utils.safe_fork(child_message_handler:) { exec(*args.map(&:to_s)) }
+      end
+      expect(command).to receive(:run).twice do |_, sudo:, **|
+        expect(sudo).to be(true)
+        expect(Process.pid).to eq(parent_pid)
+      end
+
+      Cask::Installer.new(cask, command:).install_artifacts
+    end
+
+    it "rejects requests for steps that are not privileged" do
+      cask = Cask::Cask.new("with-invalid-parent-step-request") do
+        version "1.2.3"
+        sha256 :no_check
+        url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
+
+        postflight_steps do
+          touch "unprivileged"
+          run "/usr/bin/true", sudo: true
+        end
+      end
+      sandbox = instance_double(Sandbox).as_null_object
+      cask.staged_path.mkpath
+      cask.config_path.dirname.mkpath
+
+      allow(Sandbox).to receive_messages(available?: true, new: sandbox)
+      allow(sandbox).to receive(:allow_write_path)
+      allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
+      allow(sandbox).to receive(:run) do |*_, child_message_handler:, **|
+        response = child_message_handler.call(
+          JSON.generate(
+            "type"  => Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_REQUEST,
+            "index" => 0,
+          ),
+        )
+        expect(response).to eq(Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_FAILED)
+      end
+
+      expect do
+        Cask::Installer.new(cask, command: NeverSudoSystemCommand).install_artifacts
+      end.to raise_error(ArgumentError, "Cask install step 0 is not privileged.")
+    end
+
+    it "rejects child messages that are not privileged step requests" do
+      cask = Cask::Cask.new("with-non-request-child-messages") do
+        version "1.2.3"
+        sha256 :no_check
+        url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
+
+        postflight_steps do
+          run "/usr/bin/true", sudo: true
+        end
+      end
+      sandbox = instance_double(Sandbox).as_null_object
+      cask.staged_path.mkpath
+      cask.config_path.dirname.mkpath
+
+      allow(Sandbox).to receive_messages(available?: true, new: sandbox)
+      allow(sandbox).to receive(:allow_write_path)
+      allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
+      allow(sandbox).to receive(:run) do |*_, child_message_handler:, **|
+        messages = ["not JSON", "null", "5", "[1]", "true", "{}", '{"type":"other"}']
+        messages.each do |message|
+          expect(child_message_handler.call(message))
+            .to eq(Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_FAILED)
+        end
+      end
+
+      expect do
+        Cask::Installer.new(cask, command: NeverSudoSystemCommand).install_artifacts
+      end.to raise_error(ArgumentError, "Invalid privileged cask child message.")
+    end
+
+    it "rejects invalid privileged step indices" do
+      cask = Cask::Cask.new("with-invalid-parent-step-index") do
+        version "1.2.3"
+        sha256 :no_check
+        url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
+
+        postflight_steps do
+          run "/usr/bin/true", sudo: true
+        end
+      end
+      sandbox = instance_double(Sandbox).as_null_object
+      cask.staged_path.mkpath
+      cask.config_path.dirname.mkpath
+
+      allow(Sandbox).to receive_messages(available?: true, new: sandbox)
+      allow(sandbox).to receive(:allow_write_path)
+      allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
+      allow(sandbox).to receive(:run) do |*_, child_message_handler:, **|
+        response = child_message_handler.call(
+          JSON.generate(
+            "type"  => Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_REQUEST,
+            "index" => "0",
+          ),
+        )
+        expect(response).to eq(Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_FAILED)
+      end
+
+      expect do
+        Cask::Installer.new(cask, command: NeverSudoSystemCommand).install_artifacts
+      end.to raise_error(ArgumentError, 'Invalid privileged cask install step index: "0"')
+    end
+
+    it "rejects out-of-range privileged step indices" do
+      cask = Cask::Cask.new("with-out-of-range-parent-step-index") do
+        version "1.2.3"
+        sha256 :no_check
+        url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
+
+        postflight_steps do
+          run "/usr/bin/true", sudo: true
+        end
+      end
+      sandbox = instance_double(Sandbox).as_null_object
+      cask.staged_path.mkpath
+      cask.config_path.dirname.mkpath
+
+      allow(Sandbox).to receive_messages(available?: true, new: sandbox)
+      allow(sandbox).to receive(:allow_write_path)
+      allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
+      allow(sandbox).to receive(:run) do |*_, child_message_handler:, **|
+        response = child_message_handler.call(
+          JSON.generate(
+            "type"  => Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_REQUEST,
+            "index" => 99,
+          ),
+        )
+        expect(response).to eq(Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_FAILED)
+      end
+
+      expect do
+        Cask::Installer.new(cask, command: NeverSudoSystemCommand).install_artifacts
+      end.to raise_error(IndexError)
+    end
+
+    it "rejects replayed privileged step requests" do
+      cask = Cask::Cask.new("with-replayed-parent-step-request") do
+        version "1.2.3"
+        sha256 :no_check
+        url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
+
+        postflight_steps do
+          run "/usr/bin/true", sudo: true
+        end
+      end
+      sandbox = instance_double(Sandbox).as_null_object
+      command = class_double(SystemCommand)
+      cask.staged_path.mkpath
+      cask.config_path.dirname.mkpath
+
+      allow(Sandbox).to receive_messages(available?: true, new: sandbox)
+      allow(sandbox).to receive(:allow_write_path)
+      allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
+      allow(sandbox).to receive(:run) do |*_, child_message_handler:, **|
+        request = JSON.generate(
+          "type"  => Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_REQUEST,
+          "index" => 0,
+        )
+        expect(child_message_handler.call(request))
+          .to eq(Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_SUCCEEDED)
+        expect(child_message_handler.call(request))
+          .to eq(Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_FAILED)
+      end
+      expect(command).to receive(:run).once
+
+      expect do
+        Cask::Installer.new(cask, command:).install_artifacts
+      end.to raise_error(ArgumentError, "Privileged cask install steps must be requested in order.")
+    end
+
+    it "re-evaluates privileged step guards in the parent" do
+      cask = Cask::Cask.new("with-guarded-parent-step-request") do
+        version "1.2.3"
+        sha256 :no_check
+        url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
+
+        postflight_steps do
+          if_path_exists "missing" do
+            run "/usr/bin/true", sudo: true
+          end
+        end
+      end
+      sandbox = instance_double(Sandbox).as_null_object
+      command = class_double(SystemCommand)
+      cask.staged_path.mkpath
+      cask.config_path.dirname.mkpath
+
+      allow(Sandbox).to receive_messages(available?: true, new: sandbox)
+      allow(sandbox).to receive(:allow_write_path)
+      allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
+      allow(sandbox).to receive(:run) do |*_, child_message_handler:, **|
+        response = child_message_handler.call(
+          JSON.generate(
+            "type"  => Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_REQUEST,
+            "index" => 0,
+          ),
+        )
+        expect(response).to eq(Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_SUCCEEDED)
+      end
+      expect(command).not_to receive(:run)
+
+      Cask::Installer.new(cask, command:).install_artifacts
+    end
+
+    it "preserves parent guard snapshots across privileged step requests" do
+      guard_path = mktmpdir/"guard"
+      cask = Cask::Cask.new("with-shared-guard-parent-step-requests") do
+        version "1.2.3"
+        sha256 :no_check
+        url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
+
+        postflight_steps do
+          unless_path_exists guard_path do
+            run "/usr/bin/true", sudo: true
+            run "/usr/bin/true", sudo: true
+          end
+        end
+      end
+      sandbox = instance_double(Sandbox).as_null_object
+      command = class_double(SystemCommand)
+      cask.staged_path.mkpath
+      cask.config_path.dirname.mkpath
+
+      allow(Sandbox).to receive_messages(available?: true, new: sandbox)
+      allow(sandbox).to receive(:allow_write_path)
+      allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
+      allow(sandbox).to receive(:run) do |*_, child_message_handler:, **|
+        2.times do |index|
+          response = child_message_handler.call(
+            JSON.generate(
+              "type"  => Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_REQUEST,
+              "index" => index,
+            ),
+          )
+          expect(response).to eq(Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_SUCCEEDED)
+        end
+      end
+      expect(command).to receive(:run).twice do
+        guard_path.mkpath
+      end
+
+      Cask::Installer.new(cask, command:).install_artifacts
+    end
+
+    it "fails clearly when a privileged step has no parent message channel" do
+      cask = Cask::Cask.new("without-parent-message-channel") do
+        version "1.2.3"
+        sha256 :no_check
+        url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
+
+        postflight_steps do
+          run "/usr/bin/true", sudo: true
+        end
+      end
+      sandbox = instance_double(Sandbox).as_null_object
+      cask.staged_path.mkpath
+      cask.config_path.dirname.mkpath
+
+      allow(Sandbox).to receive_messages(available?: true, new: sandbox)
+      allow(sandbox).to receive(:allow_write_path)
+      allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
+      allow(sandbox).to receive(:run) do |*args, **|
+        Utils.safe_fork { exec(*args.map(&:to_s)) }
+      end
+
+      expect do
+        Cask::Installer.new(cask, command: NeverSudoSystemCommand).install_artifacts
+      end.to raise_error(RuntimeError, /Privileged cask install step 0 requires a parent message channel/)
+    end
+
+    it "preserves errors raised by a parent-side privileged step" do
+      cask = Cask::Cask.new("with-failing-parent-privileged-install-step") do
+        version "1.2.3"
+        sha256 :no_check
+        url "file://#{TEST_FIXTURE_DIR}/cask/container.zip"
+
+        postflight_steps do
+          run "/usr/bin/false", sudo: true
+        end
+      end
+      sandbox = instance_double(Sandbox).as_null_object
+      command = class_double(SystemCommand)
+      cask.staged_path.mkpath
+      cask.config_path.dirname.mkpath
+
+      allow(Sandbox).to receive_messages(available?: true, new: sandbox)
+      allow(sandbox).to receive(:allow_write_path)
+      allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
+      allow(sandbox).to receive(:run) do |*args, child_message_handler:, **|
+        Utils.safe_fork(child_message_handler:) { exec(*args.map(&:to_s)) }
+      end
+      allow(command).to receive(:run).and_raise("parent privileged step failed")
+
+      expect do
+        Cask::Installer.new(cask, command:).install_artifacts
+      end.to raise_error(RuntimeError, "parent privileged step failed")
+    end
+
     {
       "an explicitly privileged command" => proc { run "/usr/bin/true", sudo: true },
       "a conditionally privileged step"  => proc { remove "/usr/local/example", sudo: :if_needed },
       "an ownership step"                => proc { set_ownership "/usr/local/example" },
       "a keychain certificate step"      => proc { delete_keychain_certificates "Example" },
     }.each do |description, step|
-      it "allows #{description} to run sudo outside the sandbox" do
+      it "routes #{description} to the parent process" do
         cask = Cask::Cask.new("with-sandboxed-sudo-install-steps") do
           version "1.2.3"
           sha256 :no_check
@@ -163,8 +488,11 @@ RSpec.describe Cask::Artifact::AbstractInstallSteps, :cask do
         allow(Sandbox).to receive_messages(available?: true, new: sandbox)
         allow(sandbox).to receive(:allow_write_path)
         allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
-        expect(sandbox).to receive(:allow_process_exec).with("/usr/bin/sudo", no_sandbox: true)
-        expect(sandbox).to receive(:run)
+        expect(sandbox).not_to receive(:allow_process_exec)
+        expect(sandbox).to receive(:run) do |*_, passthrough_stdin:, child_message_handler:|
+          expect(passthrough_stdin).to be(false)
+          expect(child_message_handler).to be_a(Proc)
+        end
 
         Cask::Installer.new(cask, command: NeverSudoSystemCommand).install_artifacts
       end

--- a/Library/Homebrew/test/cask/artifact/install_steps_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/install_steps_spec.rb
@@ -196,13 +196,12 @@ RSpec.describe Cask::Artifact::AbstractInstallSteps, :cask do
       allow(sandbox).to receive(:allow_write_path)
       allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
       allow(sandbox).to receive(:run) do |*_, child_message_handler:, **|
-        response = child_message_handler.call(
+        child_message_handler.call(
           JSON.generate(
             "type"  => Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_REQUEST,
             "index" => 0,
           ),
         )
-        expect(response).to eq(Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_FAILED)
       end
 
       expect do
@@ -230,14 +229,12 @@ RSpec.describe Cask::Artifact::AbstractInstallSteps, :cask do
       allow(sandbox).to receive(:run) do |*_, child_message_handler:, **|
         messages = ["not JSON", "null", "5", "[1]", "true", "{}", '{"type":"other"}']
         messages.each do |message|
-          expect(child_message_handler.call(message))
-            .to eq(Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_FAILED)
+          expect { child_message_handler.call(message) }
+            .to raise_error(ArgumentError, "Invalid privileged cask child message.")
         end
       end
 
-      expect do
-        Cask::Installer.new(cask, command: NeverSudoSystemCommand).install_artifacts
-      end.to raise_error(ArgumentError, "Invalid privileged cask child message.")
+      Cask::Installer.new(cask, command: NeverSudoSystemCommand).install_artifacts
     end
 
     it "rejects invalid privileged step indices" do
@@ -258,13 +255,12 @@ RSpec.describe Cask::Artifact::AbstractInstallSteps, :cask do
       allow(sandbox).to receive(:allow_write_path)
       allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
       allow(sandbox).to receive(:run) do |*_, child_message_handler:, **|
-        response = child_message_handler.call(
+        child_message_handler.call(
           JSON.generate(
             "type"  => Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_REQUEST,
             "index" => "0",
           ),
         )
-        expect(response).to eq(Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_FAILED)
       end
 
       expect do
@@ -290,13 +286,12 @@ RSpec.describe Cask::Artifact::AbstractInstallSteps, :cask do
       allow(sandbox).to receive(:allow_write_path)
       allow(Sandbox).to receive(:with_preserved_brew_file).and_yield
       allow(sandbox).to receive(:run) do |*_, child_message_handler:, **|
-        response = child_message_handler.call(
+        child_message_handler.call(
           JSON.generate(
             "type"  => Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_REQUEST,
             "index" => 99,
           ),
         )
-        expect(response).to eq(Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_FAILED)
       end
 
       expect do
@@ -329,8 +324,7 @@ RSpec.describe Cask::Artifact::AbstractInstallSteps, :cask do
         )
         expect(child_message_handler.call(request))
           .to eq(Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_SUCCEEDED)
-        expect(child_message_handler.call(request))
-          .to eq(Homebrew::InstallSteps::Runner::PRIVILEGED_STEP_FAILED)
+        child_message_handler.call(request)
       end
       expect(command).to receive(:run).once
 

--- a/Library/Homebrew/test/sandbox_linux_spec.rb
+++ b/Library/Homebrew/test/sandbox_linux_spec.rb
@@ -42,6 +42,28 @@ RSpec.describe Sandbox, :needs_linux do
       end.not_to raise_error
     end
 
+    it "forwards child message handling options" do
+      messages = []
+      handler = proc do |message|
+        messages << message.chomp
+        "acknowledged"
+      end
+      script = <<~'RUBY'
+        UNIXSocket.open(ENV.fetch("HOMEBREW_ERROR_PIPE")) do |socket|
+          request_pipe = socket.recv_io
+          response_pipe = socket.recv_io
+          request_pipe.puts "privileged step"
+          request_pipe.flush
+          raise "parent did not acknowledge child message" if response_pipe.gets != "acknowledged\n"
+        end
+      RUBY
+
+      sandbox.run RUBY_PATH, "-rsocket", "-e", script,
+                  passthrough_stdin: false, child_message_handler: handler
+
+      expect(messages).to eq(["privileged step"])
+    end
+
     it "prevents listing a denied read hierarchy" do
       denied_dir = mktmpdir
       FileUtils.touch denied_dir/"secret"

--- a/Library/Homebrew/test/utils/fork_spec.rb
+++ b/Library/Homebrew/test/utils/fork_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "utils/fork"
+require "timeout"
 
 RSpec.describe Utils do
   describe "::child_error_hash" do
@@ -15,6 +16,64 @@ RSpec.describe Utils do
   end
 
   describe "#safe_fork" do
+    it "responds to messages from the forked child" do
+      messages = []
+      handler = proc do |message|
+        messages << message.chomp
+        "acknowledged"
+      end
+
+      described_class.safe_fork(child_message_handler: handler) do
+        channel = described_class.forked_child_channel
+        channel.puts "privileged step"
+        channel.flush
+        raise "parent did not acknowledge child message" if channel.gets != "acknowledged\n"
+
+        channel.close
+      end
+
+      expect(messages).to eq(["privileged step"])
+    end
+
+    it "interrupts a child waiting for a parent response without deadlocking" do
+      expect do
+        Timeout.timeout(2) do
+          handler = proc do |_message|
+            raise Interrupt
+          end
+          described_class.safe_fork(child_message_handler: handler) do
+            channel = described_class.forked_child_channel
+            channel.puts "privileged step"
+            channel.flush
+            channel.gets
+            channel.close
+          end
+        end
+      end.to raise_error(Interrupt)
+    end
+
+    it "reaps the child when a parent message handler raises" do
+      child_pid = T.let(nil, T.nilable(Integer))
+      handler = proc do |message|
+        child_pid = message.to_i
+        raise "parent message handler failed"
+      end
+
+      expect do
+        described_class.safe_fork(child_message_handler: handler) do
+          channel = described_class.forked_child_channel
+          channel.puts Process.pid.to_s
+          channel.flush
+          channel.close
+        end
+      end.to raise_error(RuntimeError, "parent message handler failed")
+
+      pid = child_pid
+      raise "child did not send its process ID" unless pid
+
+      expect { Process.waitpid(pid) }.to raise_error(Errno::ECHILD)
+    end
+
     it "raises a RuntimeError on an error that isn't ErrorDuringExecution" do
       expect do
         described_class.safe_fork do

--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -5,10 +5,51 @@ require "fcntl"
 require "utils/socket"
 
 module Utils
+  # Bidirectional channel handed to a forked child whose parent passed
+  # `child_message_handler` to `safe_fork`: request lines are written to the
+  # error pipe and each response is read back from a second pipe.
+  class ForkedChildChannel
+    sig { params(error_pipe: IO, response_pipe: IO).void }
+    def initialize(error_pipe, response_pipe)
+      @error_pipe = error_pipe
+      @response_pipe = response_pipe
+      @error_pipe.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+      @response_pipe.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+    end
+
+    sig { params(message: String).void }
+    def puts(message)
+      @error_pipe.puts message
+    end
+
+    sig { void }
+    def flush
+      @error_pipe.flush
+    end
+
+    sig { returns(T.nilable(String)) }
+    def gets
+      @response_pipe.gets
+    end
+
+    sig { void }
+    def close
+      @error_pipe.close unless @error_pipe.closed?
+      @response_pipe.close unless @response_pipe.closed?
+    end
+  end
+
   sig { returns(IO) }
   def self.forked_child_error_pipe
     UNIXSocketExt.open(ENV.fetch("HOMEBREW_ERROR_PIPE"), &:recv_io).tap do |error_pipe|
       error_pipe.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+    end
+  end
+
+  sig { returns(ForkedChildChannel) }
+  def self.forked_child_channel
+    UNIXSocketExt.open(ENV.fetch("HOMEBREW_ERROR_PIPE")) do |socket|
+      ForkedChildChannel.new(socket.recv_io, socket.recv_io)
     end
   end
 
@@ -37,7 +78,7 @@ module Utils
     error_hash
   end
 
-  sig { params(error_pipe: T.nilable(IO), error: Exception).void }
+  sig { params(error_pipe: T.nilable(T.any(IO, ForkedChildChannel)), error: Exception).void }
   def self.report_forked_child_error(error_pipe, error)
     error_pipe&.puts child_error_hash(error).to_json
     error_pipe&.close
@@ -77,34 +118,46 @@ module Utils
   # See `man fork` for more information.
   sig {
     params(directory: T.nilable(String), yield_parent: T::Boolean,
+           child_message_handler: T.nilable(T.proc.params(message: String).returns(T.nilable(String))),
            _blk: T.proc.params(arg0: T.nilable(String)).void).void
   }
-  def self.safe_fork(directory: nil, yield_parent: false, &_blk)
+  def self.safe_fork(directory: nil, yield_parent: false, child_message_handler: nil, &_blk)
     block = proc do |tmpdir|
       UNIXServerExt.open("#{tmpdir}/socket") do |server|
-        read, write = IO.pipe
+        error_read, error_write = IO.pipe
+        response_read = T.let(nil, T.nilable(IO))
+        response_write = T.let(nil, T.nilable(IO))
+        response_read, response_write = IO.pipe if child_message_handler
 
         pid = fork do
           # bootsnap doesn't like these forked processes
           ENV["HOMEBREW_NO_BOOTSNAP"] = "1"
           error_pipe = server.path
           ENV["HOMEBREW_ERROR_PIPE"] = error_pipe
+          if child_message_handler
+            ENV["HOMEBREW_CHILD_MESSAGE_CHANNEL"] = "1"
+          else
+            ENV.delete("HOMEBREW_CHILD_MESSAGE_CHANNEL")
+          end
           server.close
-          read.close
-          write.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+          error_read.close
+          response_write&.close
+          error_write.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+          response_read&.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
 
           Process::UID.change_privilege(Process.euid) if Process.euid != Process.uid
 
           yield(error_pipe)
         # This could be any type of exception, so rescue them all.
         rescue Exception => e # rubocop:disable Lint/RescueException
-          report_forked_child_error(write, e)
+          report_forked_child_error(error_write, e)
 
           exit!
         else
           exit!(true)
         end
 
+        child_reaped = T.let(false, T::Boolean)
         begin
           yield(nil) if yield_parent
 
@@ -112,16 +165,43 @@ module Utils
             socket = server.accept_nonblock
           rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::ECONNABORTED, Errno::EPROTO, Errno::EINTR
             retry unless Process.waitpid(pid, Process::WNOHANG)
+
+            child_reaped = true
           else
-            socket.send_io(write)
+            socket.send_io(error_write)
+            socket.send_io(response_read) if response_read
             socket.close
           end
-          write.close
-          data = read.read
-          read.close
-          Process.waitpid(pid) unless socket.nil?
-        rescue Interrupt
-          Process.waitpid(pid)
+          error_write.close
+          response_read&.close
+          data = +""
+          # Lines the handler answers are responded to on the response pipe;
+          # anything else (e.g. a child error report) stays error data.
+          error_read.each_line do |line|
+            if child_message_handler && response_write && (response = child_message_handler.call(line))
+              response_write.puts response
+              response_write.flush
+            else
+              data << line
+            end
+          end
+          error_read.close
+          response_write&.close
+          unless socket.nil?
+            Process.waitpid(pid)
+            child_reaped = true
+          end
+        ensure
+          # Close the pipes before reaping: a child blocked waiting for a
+          # response must see EOF and exit or `waitpid` would deadlock.
+          [error_read, error_write, response_read, response_write].compact.each do |pipe|
+            pipe.close unless pipe.closed?
+          end
+          begin
+            Process.waitpid(pid) unless child_reaped
+          rescue Errno::ECHILD
+            nil
+          end
         end
 
         # 130 is the exit status for a process interrupted via Ctrl-C.

--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -13,8 +13,6 @@ module Utils
     def initialize(error_pipe, response_pipe)
       @error_pipe = error_pipe
       @response_pipe = response_pipe
-      @error_pipe.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
-      @response_pipe.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
     end
 
     sig { params(message: String).void }
@@ -41,15 +39,22 @@ module Utils
 
   sig { returns(IO) }
   def self.forked_child_error_pipe
-    UNIXSocketExt.open(ENV.fetch("HOMEBREW_ERROR_PIPE"), &:recv_io).tap do |error_pipe|
-      error_pipe.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+    UNIXSocketExt.open(ENV.fetch("HOMEBREW_ERROR_PIPE")) do |socket|
+      receive_forked_child_pipe(socket)
     end
   end
 
   sig { returns(ForkedChildChannel) }
   def self.forked_child_channel
     UNIXSocketExt.open(ENV.fetch("HOMEBREW_ERROR_PIPE")) do |socket|
-      ForkedChildChannel.new(socket.recv_io, socket.recv_io)
+      ForkedChildChannel.new(receive_forked_child_pipe(socket), receive_forked_child_pipe(socket))
+    end
+  end
+
+  sig { params(socket: UNIXSocket).returns(IO) }
+  private_class_method def self.receive_forked_child_pipe(socket)
+    socket.recv_io.tap do |pipe|
+      pipe.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
     end
   end
 


### PR DESCRIPTION
`brew upgrade` can prompt for the macOS password several times in one run because each sandboxed cask operation acquires its own sudo timestamp on its own PTY instead of reusing the original terminal's ticket. Reproduce with `brew reinstall --cask docker-desktop`, which prompts more than once before this change and at most once after.

Privileged structured steps (`sudo: true`, `sudo: :if_needed`, ownership changes, keychain certificate deletion) now run in the parent process, where the sudo ticket applies. The sandbox child requests each step by its normalized plan index over a new bidirectional `Utils.safe_fork` channel; the parent validates the request (shape, integer index, strictly increasing order, plan membership, `sudo_required?`), re-evaluates guards itself, and runs the exact predeclared step. The `allow_process_exec "/usr/bin/sudo", no_sandbox: true` escape is removed, and stdin passthrough is disabled for brokered runs so the sandbox PTY cannot compete with the sudo prompt. Nonprivileged operations are unchanged.

New tests cover parent-side execution, protocol validation, guard snapshots, interrupt handling, child reaping, and Linux keyword forwarding.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5) drafted the implementation and tests; I reviewed the diff, verified the regression tests fail without the fixes and pass with them, and ran `brew lgtm --online` plus the focused fork, sandbox, and cask install step suites.

-----
