### PR TITLE
Add brew tests --load-only and break the install require cycle

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -236,6 +236,14 @@ jobs:
           - name: tests (macOS)
             test-flags: --coverage --profile 3
             runs-on: macos-26
+          - name: tests (load-only Linux)
+            test-flags: --load-only
+            runs-on: ubuntu-24.04
+            load_only: true
+          - name: tests (load-only macOS)
+            test-flags: --load-only
+            runs-on: macos-26
+            load_only: true
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -244,7 +252,8 @@ jobs:
           # We only test needs_homebrew_core tests on macOS because
           # homebrew/core is not available by default on GitHub-hosted Ubuntu
           # runners, and it's expensive to tap it.
-          core: ${{ runner.os == 'macOS' }}
+          # Load-only jobs never run examples, so they don't need it either.
+          core: ${{ runner.os == 'macOS' && matrix.load_only != true }}
           cask: false
 
       - name: Cache Bundler RubyGems
@@ -263,6 +272,7 @@ jobs:
         run: mkdir tests
 
       - name: Cache parallel tests log
+        if: matrix.load_only != true
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: tests
@@ -277,7 +287,7 @@ jobs:
           workflow-key: tests-tests-online
 
       - name: Install brew tests macOS dependencies
-        if: runner.os != 'Linux'
+        if: runner.os != 'Linux' && matrix.load_only != true
         uses: Homebrew/actions/cache-homebrew-prefix@8f3d1ec8a696b3b9d9a6c3696b6c73033cab69e4 # 2026.08.14.1
         with:
           install: subversion gnupg
@@ -303,6 +313,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Get RSpec JUnit XML filenames
+        if: matrix.load_only != true
         id: junit_xml
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
         run: |
@@ -311,7 +322,7 @@ jobs:
           echo "filenames=${filenames%,}" >> "$GITHUB_OUTPUT"
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: github.event_name == 'pull_request' || matrix.name != 'tests (online)'
+        if: matrix.load_only != true && (github.event_name == 'pull_request' || matrix.name != 'tests (online)')
         with:
           working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
           files: ${{ steps.junit_xml.outputs.filenames }}
@@ -320,7 +331,7 @@ jobs:
           report_type: test_results
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: github.event_name == 'pull_request' || matrix.name != 'tests (online)'
+        if: matrix.load_only != true && (github.event_name == 'pull_request' || matrix.name != 'tests (online)')
         with:
           working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
           files: Library/Homebrew/test/coverage/coverage.xml

--- a/Library/Homebrew/.rspec_parallel
+++ b/Library/Homebrew/.rspec_parallel
@@ -1,6 +1,8 @@
 --format QuietProgressFormatter
+<% unless ARGV.include?("--dry-run") %>
 --format ParallelTests::RSpec::RuntimeLogger
 --out <%= ENV["PARALLEL_RSPEC_LOG_PATH"] %>
 --format RspecJunitFormatter
 --out test/junit/rspec<%= ENV["TEST_ENV_NUMBER"] %>.xml
 <%= "--format RSpec::Github::Formatter" if ENV["GITHUB_ACTIONS"] %>
+<% end %>

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -29,6 +29,8 @@ module Homebrew
                description: "Only runs tests on files that were changed from the `main` branch."
         switch "--fail-fast",
                description: "Exit early on the first failing test."
+        switch "--load-only",
+               description: "Load each test file independently without running its examples."
         switch "--no-parallel",
                description: "Run tests serially."
         switch "--stackprof",
@@ -135,6 +137,7 @@ module Homebrew
             --require spec_helper
           ]
           bundle_args << "--fail-fast" if args.fail_fast?
+          bundle_args << "--dry-run" if args.load_only?
           bundle_args << "--profile" << args.profile if args.profile
           bundle_args << "--tag" << "~needs_arm" unless Hardware::CPU.arm?
           bundle_args << "--tag" << "~needs_intel" unless Hardware::CPU.intel?
@@ -173,6 +176,15 @@ module Homebrew
           elsif args.ruby_prof?
             ENV["TEST_RUBY_PROF"] = "call_stack"
             prof_filename = "#{test_prof}/ruby-prof-report-call_stack-wall-total.html"
+          end
+
+          if args.load_only?
+            # RSpec line selectors do not affect dry runs, and parallel_tests
+            # only accepts file paths.
+            files = files.map { |file| file.sub(/:\d+\z/, "") }.uniq
+            parallel_args += ["--test-file-limit", "1"]
+            parallel_args += ["-n", "1"] unless parallel
+            parallel = true
           end
 
           if parallel

--- a/Library/Homebrew/extend/os/mac/reinstall.rb
+++ b/Library/Homebrew/extend/os/mac/reinstall.rb
@@ -1,7 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "install"
 require "utils/output"
 
 module OS
@@ -22,6 +21,8 @@ module OS
             opoo "pkgconf would be reinstalled due to macOS version mismatch"
             return
           end
+
+          require "install"
 
           pkgconf = ::Formula["pkgconf"]
 

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/tests.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/tests.rbi
@@ -24,6 +24,9 @@ class Homebrew::DevCmd::Tests::Args < Homebrew::CLI::Args
   def generic?; end
 
   sig { returns(T::Boolean) }
+  def load_only?; end
+
+  sig { returns(T::Boolean) }
   def no_parallel?; end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "cask/installer"
-Warnings.ignore(/circular require considered harmful/) { require "install" }
+require "install"
 
 RSpec.describe Cask::Installer, :cask do
   def stub_dmg_extraction

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "cmd/install"
-Warnings.ignore(/circular require considered harmful/) { require "install" }
+require "install"
 require "cask/installer"
 require "cask/upgrade"
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/shared_examples/reinstall_pkgconf_if_needed.rb
+++ b/Library/Homebrew/test/cmd/shared_examples/reinstall_pkgconf_if_needed.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "reinstall"
+require "install"
 require "formula_installer"
 
 RSpec.shared_examples "reinstall_pkgconf_if_needed" do

--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -48,6 +48,42 @@ RSpec.describe Homebrew::DevCmd::Tests do
         expect { tests.run }.to raise_error(UsageError, /No tests are available to run on this operating system/)
       end
     end
+
+    context "when loading tests without running examples" do
+      let(:args) { ["--load-only", "--no-parallel", "--only=warnings,exceptions"] }
+
+      it "loads each selected file in a separate RSpec process" do
+        invoked_arguments = T.let([], T::Array[String])
+        allow(tests).to receive(:system) do |*arguments|
+          invoked_arguments = arguments
+          system "/usr/bin/true"
+        end
+
+        tests.run
+
+        expect(invoked_arguments)
+          .to start_with("bundle", "exec", "parallel_rspec")
+          .and array_including_cons("--test-file-limit", "1", "-n", "1", "--")
+          .and include("--dry-run")
+          .and end_with("--", "test/warnings_spec.rb", "test/exceptions_spec.rb")
+      end
+    end
+
+    context "when loading a line-qualified test" do
+      let(:args) { ["--load-only", "--only=warnings:7"] }
+
+      it "loads the entire file" do
+        invoked_arguments = T.let([], T::Array[String])
+        allow(tests).to receive(:system) do |*arguments|
+          invoked_arguments = arguments
+          system "/usr/bin/true"
+        end
+
+        tests.run
+
+        expect(invoked_arguments).to end_with("--", "test/warnings_spec.rb")
+      end
+    end
   end
 
   describe "#check_test_environment!", :needs_linux do

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -3,7 +3,7 @@
 
 require "formula"
 require "formula_installer"
-Warnings.ignore(/circular require considered harmful/) { require "install" }
+require "install"
 require "keg"
 require "sandbox"
 require "tab"

--- a/Library/Homebrew/test/os/mac/reinstall_spec.rb
+++ b/Library/Homebrew/test/os/mac/reinstall_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "reinstall"
+require "install"
 require "extend/os/mac/pkgconf"
 
 RSpec.describe Homebrew::Reinstall do

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -16,6 +16,7 @@ end
 require_relative "../standalone"
 require_relative "../warnings"
 
+Warnings.fail_on(/circular require considered harmful/)
 Warnings.ignore(/CGI library is removed from Ruby 4\.0\./) { require "cgi" }
 
 require "test-prof"

--- a/Library/Homebrew/test/warnings_spec.rb
+++ b/Library/Homebrew/test/warnings_spec.rb
@@ -4,6 +4,30 @@
 require "warnings"
 
 RSpec.describe Warnings do
+  it "raises configured fatal warnings" do
+    expect do
+      described_class.fail_on(/fatal warning/) { Warning.warn("fatal warning\n") }
+    end.to raise_error(RuntimeError, /fatal warning/)
+  end
+
+  it "allows explicitly ignored fatal warnings" do
+    expect do
+      described_class.fail_on(/explicitly ignored fatal warning/) do
+        described_class.ignore(/explicitly ignored fatal warning/) do
+          Warning.warn("explicitly ignored fatal warning\n")
+        end
+      end
+    end.not_to output.to_stderr
+  end
+
+  it "restores fatal warnings after an exception" do
+    expect do
+      described_class.fail_on(/scoped fatal warning/) { raise "failure" }
+    rescue RuntimeError
+      Warning.warn("scoped fatal warning\n")
+    end.to output("scoped fatal warning\n").to_stderr
+  end
+
   it "restores ignored warnings after an exception" do
     expect do
       described_class.ignore(/ignored warning/) { raise "failure" }

--- a/Library/Homebrew/warnings.rb
+++ b/Library/Homebrew/warnings.rb
@@ -8,6 +8,8 @@ module Warnings
     def warn(message, category: nil)
       return if Warnings.ignored?(message)
 
+      Kernel.raise message if Warnings.fatal?(message)
+
       super
     end
   end
@@ -24,11 +26,14 @@ module Warnings
   IGNORED_WARNINGS_KEY = :homebrew_ignored_warnings
   private_constant :IGNORED_WARNINGS_KEY
 
+  FATAL_WARNINGS_KEY = :homebrew_fatal_warnings
+  private_constant :FATAL_WARNINGS_KEY
+
+  @fatal_warnings = T.let([], T::Array[Regexp])
+
   sig { params(warnings: T.any(Symbol, Regexp), _block: T.proc.void).void }
   def self.ignore(*warnings, &_block)
-    warnings = warnings.flat_map do |warning|
-      warning.is_a?(Symbol) ? COMMON_WARNINGS.fetch(warning) : warning
-    end
+    warnings = expand(warnings)
 
     previous_warnings = ignored_warnings
     Thread.current.thread_variable_set(IGNORED_WARNINGS_KEY, previous_warnings + warnings)
@@ -39,16 +44,53 @@ module Warnings
     end
   end
 
+  sig { params(warnings: T.any(Symbol, Regexp), block: T.nilable(T.proc.void)).void }
+  def self.fail_on(*warnings, &block)
+    warnings = expand(warnings)
+    unless block
+      @fatal_warnings = (@fatal_warnings + warnings).uniq
+      return
+    end
+
+    previous_warnings = fatal_warnings
+    Thread.current.thread_variable_set(FATAL_WARNINGS_KEY, previous_warnings + warnings)
+    begin
+      yield
+    ensure
+      Thread.current.thread_variable_set(FATAL_WARNINGS_KEY, previous_warnings)
+    end
+  end
+
   sig { params(message: String).returns(T::Boolean) }
   def self.ignored?(message)
     ignored_warnings.any? { |warning| warning.match?(message) }
   end
+
+  sig { params(message: String).returns(T::Boolean) }
+  def self.fatal?(message)
+    @fatal_warnings.any? { |warning| warning.match?(message) } ||
+      fatal_warnings.any? { |warning| warning.match?(message) }
+  end
+
+  sig { params(warnings: T::Array[T.any(Symbol, Regexp)]).returns(T::Array[Regexp]) }
+  def self.expand(warnings)
+    warnings.flat_map do |warning|
+      warning.is_a?(Symbol) ? COMMON_WARNINGS.fetch(warning) : warning
+    end
+  end
+  private_class_method :expand
 
   sig { returns(T::Array[Regexp]) }
   def self.ignored_warnings
     Thread.current.thread_variable_get(IGNORED_WARNINGS_KEY) || []
   end
   private_class_method :ignored_warnings
+
+  sig { returns(T::Array[Regexp]) }
+  def self.fatal_warnings
+    Thread.current.thread_variable_get(FATAL_WARNINGS_KEY) || []
+  end
+  private_class_method :fatal_warnings
 
   Warning.singleton_class.prepend(Filter)
   private_constant :Filter

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -3096,6 +3096,7 @@ _brew_tests() {
       --fail-fast
       --generic
       --help
+      --load-only
       --no-parallel
       --online
       --only

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1976,6 +1976,7 @@ __fish_brew_complete_arg 'tests' -l debug -d 'Enable debugging using `ruby/debug
 __fish_brew_complete_arg 'tests' -l fail-fast -d 'Exit early on the first failing test'
 __fish_brew_complete_arg 'tests' -l generic -d 'Run only OS-agnostic tests'
 __fish_brew_complete_arg 'tests' -l help -d 'Show this message'
+__fish_brew_complete_arg 'tests' -l load-only -d 'Load each test file independently without running its examples'
 __fish_brew_complete_arg 'tests' -l no-parallel -d 'Run tests serially'
 __fish_brew_complete_arg 'tests' -l online -d 'Include tests that use the GitHub API and tests that use any of the taps for official external commands'
 __fish_brew_complete_arg 'tests' -l only -d 'Run only `test_script_spec.rb`. Appending `:line_number` will start at a specific line'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -2539,6 +2539,7 @@ _brew_tests() {
     '--fail-fast[Exit early on the first failing test]' \
     '--generic[Run only OS-agnostic tests]' \
     '--help[Show this message]' \
+    '--load-only[Load each test file independently without running its examples]' \
     '--no-parallel[Run tests serially]' \
     '--online[Include tests that use the GitHub API and tests that use any of the taps for official external commands]' \
     '(--changed)--only[Run only `test_script_spec.rb`. Appending `:line_number` will start at a specific line]' \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -3903,6 +3903,10 @@ Run Homebrew's unit and integration tests.
 
 : Exit early on the first failing test.
 
+`--load-only`
+
+: Load each test file independently without running its examples.
+
 `--no-parallel`
 
 : Run tests serially.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2467,6 +2467,9 @@ Only runs tests on files that were changed from the \fBmain\fP branch\.
 \fB\-\-fail\-fast\fP
 Exit early on the first failing test\.
 .TP
+\fB\-\-load\-only\fP
+Load each test file independently without running its examples\.
+.TP
 \fB\-\-no\-parallel\fP
 Run tests serially\.
 .TP


### PR DESCRIPTION
`brew tests` emits a Ruby 4 circular require warning while loading the specs: `loading in progress, circular require considered harmful - Library/Homebrew/install.rb`. It was suppressed with `Warnings.ignore` wrappers in four spec files, which hid the warning without removing the cycle.

The cycle is `install` -> `upgrade` -> `reinstall` -> `extend/os/reinstall` -> `extend/os/mac/reinstall` -> `install`. `Homebrew::Install` is only used on the branch that reinstalls pkgconf after a macOS SDK mismatch, so deferring the require into `reinstall_pkgconf_if_needed!` breaks the cycle and lets the four suppressions go.

`Warnings.fail_on` raises on a matching warning and `spec_helper` registers the circular-require pattern, so a new cycle fails the suite instead of scrolling past. An explicit `Warnings.ignore` still takes precedence, and `fail_on` also accepts a block for thread-scoped use.

`brew tests --load-only` loads every selected spec in its own RSpec process without running examples, which is what surfaces this class of cycle. It reuses the command's existing OS filtering and selection. The macOS and Linux jobs run it last, so a timeout can only truncate the supplemental check, and `.rspec_parallel` skips the runtime log, JUnit and GitHub formatters on dry runs.

Reproduce on `main`:

```
./bin/brew ruby -e '$VERBOSE = true; require "install"'
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the warning reproduces before the change and is absent after, and ran `brew lgtm --online` plus targeted specs on macOS and Linux.

-----
