### PR TITLE
Drive bottle pours from relocation metadata

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -11,16 +11,28 @@ module OS
       requires_ancestor { ::Keg }
 
       sig {
-        params(relocation: ::Keg::Relocation, with_placeholders: T::Boolean).returns(T::Array[::Pathname])
+        params(relocation: ::Keg::Relocation, with_placeholders: T::Boolean,
+               files: T.nilable(T::Array[::Pathname])).returns(T::Array[::Pathname])
       }
-      def relocate_dynamic_linkage(relocation, with_placeholders: false)
+      def relocate_dynamic_linkage(relocation, with_placeholders: false, files: nil)
         # Patching the dynamic linker of glibc breaks it.
         return [] if name.match? Version.formula_optionally_versioned_regex(:glibc)
 
         old_prefix, new_prefix = relocation.replacement_pair_for(:prefix)
 
+        candidates = if files
+          # Metadata-driven pour: only the files recorded at bottle time carry
+          # placeholdered linkage, so skip the whole-keg walk.
+          files.filter_map do |relative_path|
+            file = path/relative_path
+            ELFPathname.wrap(file) if file.file? && !file.symlink?
+          end
+        else
+          elf_files
+        end
+
         linkage_files = []
-        elf_files.each do |file|
+        candidates.each do |file|
           changed = T.let(false, T::Boolean)
           file.ensure_writable do
             changed = change_rpath!(file, old_prefix, new_prefix, with_placeholders:)

--- a/Library/Homebrew/extend/os/mac/keg.rb
+++ b/Library/Homebrew/extend/os/mac/keg.rb
@@ -39,13 +39,13 @@ module OS
         end
       end
 
-      sig { params(id: String, file: MachOShim).returns(T::Boolean) }
-      def change_dylib_id(id, file)
+      sig { params(id: String, file: MachOShim, write: T::Boolean).returns(T::Boolean) }
+      def change_dylib_id(id, file, write: true)
         return false if file.dylib_id == id
 
         require_relocation!
         odebug "Changing dylib ID of #{file}\n  from #{file.dylib_id}\n    to #{id}"
-        file.change_dylib_id(id, strict: false)
+        file.change_dylib_id(id, strict: false, write:)
         true
       rescue MachO::MachOError
         onoe <<~EOS
@@ -56,13 +56,13 @@ module OS
         raise
       end
 
-      sig { params(old: String, new: String, file: MachOShim).returns(T::Boolean) }
-      def change_install_name(old, new, file)
+      sig { params(old: String, new: String, file: MachOShim, write: T::Boolean).returns(T::Boolean) }
+      def change_install_name(old, new, file, write: true)
         return false if old == new
 
         require_relocation!
         odebug "Changing install name in #{file}\n  from #{old}\n    to #{new}"
-        file.change_install_name(old, new, strict: false)
+        file.change_install_name(old, new, strict: false, write:)
         true
       rescue MachO::MachOError
         onoe <<~EOS
@@ -73,13 +73,13 @@ module OS
         raise
       end
 
-      sig { params(old: String, new: String, file: MachOShim).returns(T::Boolean) }
-      def change_rpath(old, new, file)
+      sig { params(old: String, new: String, file: MachOShim, write: T::Boolean).returns(T::Boolean) }
+      def change_rpath(old, new, file, write: true)
         return false if old == new
 
         require_relocation!
         odebug "Changing rpath in #{file}\n  from #{old}\n    to #{new}"
-        file.change_rpath(old, new, strict: false)
+        file.change_rpath(old, new, strict: false, write:)
         true
       rescue MachO::MachOError
         onoe <<~EOS
@@ -90,10 +90,10 @@ module OS
         raise
       end
 
-      sig { params(rpath: String, file: MachOShim).returns(T::Boolean) }
-      def delete_rpath(rpath, file)
+      sig { params(rpath: String, file: MachOShim, write: T::Boolean).returns(T::Boolean) }
+      def delete_rpath(rpath, file, write: true)
         odebug "Deleting rpath #{rpath} in #{file}"
-        !file.delete_rpath(rpath, strict: false).nil?
+        !file.delete_rpath(rpath, strict: false, write:).nil?
       rescue MachO::MachOError
         onoe <<~EOS
           Failed deleting rpath #{rpath} in #{file}
@@ -154,6 +154,25 @@ module OS
           Failed applying an ad-hoc signature to #{file}:
           #{e.message}
         EOS
+      end
+
+      sig { params(files: T::Array[::Pathname]).void }
+      def codesign_patched_binaries(files)
+        return if files.empty?
+
+        # Codesigning shells out on Intel and hashes every page of the file on
+        # Apple Silicon, so parallelise it across files.
+        queue = Queue.new
+        files.each { queue << it }
+        queue.close
+        Array.new([files.length, ::Hardware::CPU.cores].min) do
+          Thread.new do
+            while (file = queue.pop)
+              # Signing rewrites the file, which may not be user-writable.
+              file.ensure_writable { codesign_patched_binary(file.to_s) }
+            end
+          end
+        end.each(&:join)
       end
 
       sig { void }

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -24,50 +24,63 @@ module OS
       end
 
       sig {
-        params(relocation: ::Keg::Relocation, with_placeholders: T::Boolean).returns(T::Array[::Pathname])
+        params(relocation: ::Keg::Relocation, with_placeholders: T::Boolean,
+               files: T.nilable(T::Array[::Pathname])).returns(T::Array[::Pathname])
       }
-      def relocate_dynamic_linkage(relocation, with_placeholders: false)
+      def relocate_dynamic_linkage(relocation, with_placeholders: false, files: nil)
+        candidates = if files
+          # Metadata-driven pour: only the files recorded at bottle time carry
+          # placeholdered linkage, so skip the whole-keg walk.
+          files.filter_map do |relative_path|
+            file = path/relative_path
+            MachOPathname.wrap(file) if file.file? && !file.symlink?
+          end
+        else
+          mach_o_files
+        end
+
         linkage_files = []
-        mach_o_files.each do |file|
+        candidates.each do |file|
           file.ensure_writable do
             modified = T.let(false, T::Boolean)
-            needs_codesigning = T.let(false, T::Boolean)
 
-            if file.dylib? && (dylib_id = file.dylib_id)
-              id = relocated_name_for(dylib_id, relocation)
-              modified = change_dylib_id(id, file) if id
-              needs_codesigning ||= modified
+            if file.dylib? && (dylib_id = file.dylib_id) && (id = relocated_name_for(dylib_id, relocation))
+              modified = change_dylib_id(id, file, write: false) || modified
             end
 
             each_linkage_for(file, :dynamically_linked_libraries) do |old_name|
               new_name = relocated_name_for(old_name, relocation)
-              modified = change_install_name(old_name, new_name, file) if new_name
-              needs_codesigning ||= modified
+              modified = change_install_name(old_name, new_name, file, write: false) || modified if new_name
             end
 
             each_linkage_for(file, :rpaths) do |old_name|
               new_name = relocated_name_for(old_name, relocation)
-              modified = change_rpath(old_name, new_name, file) if new_name
-              needs_codesigning ||= modified
+              modified = change_rpath(old_name, new_name, file, write: false) || modified if new_name
             end
 
-            # codesign the file if needed
-            linkage_files << file.relative_path_from(path) if needs_codesigning
-            codesign_patched_binary(file.to_s) if needs_codesigning
+            next unless modified
+
+            # The edits above only mutated the in-memory Mach-O, so persist
+            # them in a single write per file.
+            file.save_changes
+            linkage_files << file.relative_path_from(path)
           end
         end
+
+        # Every saved file's signature is now broken, so re-sign each exactly
+        # once, parallelised across files.
+        codesign_patched_binaries(linkage_files.map { path/it })
         linkage_files
       end
 
       sig { void }
       def fix_dynamic_linkage
+        fixed_files = []
         mach_o_files.each do |file|
           file.ensure_writable do
             modified = T.let(false, T::Boolean)
-            needs_codesigning = T.let(false, T::Boolean)
 
-            modified = change_dylib_id(dylib_id_for(file), file) if file.dylib?
-            needs_codesigning ||= modified
+            modified = change_dylib_id(dylib_id_for(file), file, write: false) if file.dylib?
 
             each_linkage_for(file, :dynamically_linked_libraries) do |bad_name|
               # Don't fix absolute paths unless they are rooted in the build directory.
@@ -77,8 +90,10 @@ module OS
                 fixed_name(file, bad_name)
               end
               loader_name = loader_name_for(file, new_name)
-              modified = change_install_name(bad_name, loader_name, file) if loader_name != bad_name
-              needs_codesigning ||= modified
+              if loader_name != bad_name
+                modified = change_install_name(bad_name, loader_name, file,
+                                               write: false) || modified
+              end
             end
 
             each_linkage_for(file, :rpaths) do |bad_name|
@@ -86,8 +101,7 @@ module OS
               loader_name = loader_name_for(file, new_name)
               next if loader_name == bad_name
 
-              modified = change_rpath(bad_name, loader_name, file)
-              needs_codesigning ||= modified
+              modified = change_rpath(bad_name, loader_name, file, write: false) || modified
             end
 
             # Strip duplicate rpaths and rpaths rooted in the build directory.
@@ -96,14 +110,21 @@ module OS
             each_linkage_for(file, :rpaths, resolve_variable_references: true) do |bad_name|
               next if !rooted_in_build_directory?(bad_name) && file.rpaths.count(bad_name) == 1
 
-              modified = delete_rpath(bad_name, file)
-              needs_codesigning ||= modified
+              modified = delete_rpath(bad_name, file, write: false) || modified
             end
 
-            # codesign the file if needed
-            codesign_patched_binary(file.to_s) if needs_codesigning
+            next unless modified
+
+            # The edits above only mutated the in-memory Mach-O, so persist
+            # them in a single write per file.
+            file.save_changes
+            fixed_files << file
           end
         end
+
+        # Every saved file's signature is now broken, so re-sign each exactly
+        # once, parallelised across files.
+        codesign_patched_binaries(fixed_files)
 
         super
       end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1639,7 +1639,7 @@ on_request: installed_on_request?, options:)
       end
       skip_linkage = false
     end
-    keg.replace_placeholders_with_locations(tab.changed_files, skip_linkage:)
+    keg.replace_placeholders_with_locations(tab.changed_files, skip_linkage:, linkage_files: tab.linkage_files)
 
     cellar = formula.bottle_specification.tag_to_cellar(Utils::Bottles.tag)
     return if BottleSpecification::RELOCATABLE_CELLARS.include?(cellar)
@@ -1649,7 +1649,7 @@ on_request: installed_on_request?, options:)
 
     return unless ENV["HOMEBREW_RELOCATE_BUILD_PREFIX"]
 
-    keg.relocate_build_prefix(keg, prefix, HOMEBREW_PREFIX)
+    keg.relocate_build_prefix(keg, prefix, HOMEBREW_PREFIX, files: tab.binary_relocation_files)
   end
 
   sig { override.params(output: T.nilable(String)).void }

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -695,6 +695,9 @@ class Keg
   sig { params(file: String).void }
   def codesign_patched_binary(file); end
 
+  sig { params(files: T::Array[Pathname]).void }
+  def codesign_patched_binaries(files); end
+
   private
 
   sig {

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -85,8 +85,11 @@ class Keg
     end
   end
 
-  sig { params(_relocation: Relocation, with_placeholders: T::Boolean).returns(T::Array[Pathname]) }
-  def relocate_dynamic_linkage(_relocation, with_placeholders: false) = []
+  sig {
+    params(_relocation: Relocation, with_placeholders: T::Boolean,
+           files: T.nilable(T::Array[Pathname])).returns(T::Array[Pathname])
+  }
+  def relocate_dynamic_linkage(_relocation, with_placeholders: false, files: nil) = []
 
   JAVA_REGEX = %r{#{HOMEBREW_PREFIX}/opt/openjdk(@\d+(\.\d+)*)?/libexec(/openjdk\.jdk/Contents/Home)?}
 
@@ -191,10 +194,13 @@ class Keg
     relocation
   end
 
-  sig { params(files: T.nilable(T::Array[Pathname]), skip_linkage: T::Boolean).void }
-  def replace_placeholders_with_locations(files, skip_linkage: false)
+  sig {
+    params(files: T.nilable(T::Array[Pathname]), skip_linkage: T::Boolean,
+           linkage_files: T.nilable(T::Array[Pathname])).void
+  }
+  def replace_placeholders_with_locations(files, skip_linkage: false, linkage_files: nil)
     relocation = prepare_relocation_to_locations.freeze
-    relocate_dynamic_linkage(relocation) unless skip_linkage
+    relocate_dynamic_linkage(relocation, files: linkage_files) unless skip_linkage
     replace_text_in_files(relocation, files:)
   end
 
@@ -246,9 +252,30 @@ class Keg
     changed_files
   end
 
-  sig { params(keg: Keg, old_prefix: T.any(String, Pathname), new_prefix: T.any(String, Pathname)).void }
-  def relocate_build_prefix(keg, old_prefix, new_prefix)
-    each_unique_file_matching(old_prefix) do |file|
+  sig {
+    params(keg: Keg, old_prefix: T.any(String, Pathname), new_prefix: T.any(String, Pathname),
+           files: T.nilable(T::Array[Pathname])).void
+  }
+  def relocate_build_prefix(keg, old_prefix, new_prefix, files: nil)
+    candidates = T.let([], T::Array[Pathname])
+    if files
+      # Metadata-driven pour: only the files recorded at bottle time carry raw
+      # prefix strings, so skip the whole-keg scan.
+      hardlinks = Set.new
+      files.each do |relative_path|
+        file = path/relative_path
+        next if !file.file? || file.symlink?
+        # Hardlinks share an inode, so patch each inode only once.
+        next unless hardlinks.add? file.stat.ino
+
+        candidates << file
+      end
+    else
+      each_unique_file_matching(old_prefix) { |file| candidates << file }
+    end
+
+    patched_files = T.let([], T::Array[Pathname])
+    candidates.each do |file|
       # Skip files which are not binary, as they do not need null padding.
       next unless keg.binary_file?(file)
 
@@ -259,9 +286,15 @@ class Keg
       # Null padding is added if the new string is too short.
       file.ensure_writable do
         binary = File.binread file
-        odebug "Replacing build prefix in: #{file}"
         binary_strings = binary.split(/#{NULL_BYTE}/o, -1)
         match_indices = binary_strings.each_index.select { |i| binary_strings.fetch(i).include?(old_prefix.to_s) }
+
+        # Bottle metadata records files pinned by any prefix, cellar or
+        # repository reference, so a recorded file may not contain this
+        # particular string and must not be rewritten or re-signed.
+        next if match_indices.empty?
+
+        odebug "Replacing build prefix in: #{file}"
 
         # Only perform substitution on strings which match prefix regex.
         match_indices.each do |i|
@@ -281,9 +314,13 @@ class Keg
         end
 
         file.atomic_write patched_binary
+        patched_files << file
       end
-      codesign_patched_binary(file.to_s)
     end
+
+    # Each patch broke the file's signature, so re-sign each patched file
+    # exactly once, parallelised across files.
+    codesign_patched_binaries(patched_files)
   end
 
   sig { params(_options: T::Hash[Symbol, T::Boolean]).returns(T::Array[Symbol]) }

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -74,8 +74,8 @@ module MachOShim
   private :mach_data
 
   # Returns the deleted rpath, or nil when there's nothing to delete.
-  sig { params(rpath: String, strict: T::Boolean).returns(T.nilable(String)) }
-  def delete_rpath(rpath, strict: true)
+  sig { params(rpath: String, strict: T::Boolean, write: T::Boolean).returns(T.nilable(String)) }
+  def delete_rpath(rpath, strict: true, write: true)
     candidates = rpaths(resolve_variable_references: false).select do |r|
       resolve_variable_name(r) == resolve_variable_name(rpath)
     end
@@ -86,25 +86,31 @@ module MachOShim
     return if rpath_to_delete.nil?
 
     macho.delete_rpath(rpath_to_delete, { last: true, strict: })
-    macho.write!
+    macho.write! if write
     rpath_to_delete
   end
 
-  sig { params(old: String, new: String, uniq: T::Boolean, last: T::Boolean, strict: T::Boolean).void }
-  def change_rpath(old, new, uniq: false, last: false, strict: true)
+  sig { params(old: String, new: String, uniq: T::Boolean, last: T::Boolean, strict: T::Boolean, write: T::Boolean).void }
+  def change_rpath(old, new, uniq: false, last: false, strict: true, write: true)
     macho.change_rpath(old, new, { uniq:, last:, strict: })
-    macho.write!
+    macho.write! if write
   end
 
-  sig { params(id: String, strict: T::Boolean).void }
-  def change_dylib_id(id, strict: true)
+  sig { params(id: String, strict: T::Boolean, write: T::Boolean).void }
+  def change_dylib_id(id, strict: true, write: true)
     macho.change_dylib_id(id, { strict: })
-    macho.write!
+    macho.write! if write
   end
 
-  sig { params(old: String, new: String, strict: T::Boolean).void }
-  def change_install_name(old, new, strict: true)
+  sig { params(old: String, new: String, strict: T::Boolean, write: T::Boolean).void }
+  def change_install_name(old, new, strict: true, write: true)
     macho.change_install_name(old, new, { strict: })
+    macho.write! if write
+  end
+
+  # Persist edits made with `write: false` in a single write per file.
+  sig { void }
+  def save_changes
     macho.write!
   end
 

--- a/Library/Homebrew/plans/relocatable-bottles.md
+++ b/Library/Homebrew/plans/relocatable-bottles.md
@@ -27,6 +27,10 @@ End each implementation commit body with this exact line:
 This change is part of [`plans/relocatable-bottles.md`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/plans/relocatable-bottles.md)
 ```
 
+Any benchmark quoted in a commit message must be the full hyperfine
+output from `brew benchmark` (using its `--exec` mode for bespoke
+workloads), never hand-summarised numbers.
+
 ## Current state (21 August 2026, formulae.brew.sh data)
 
 | Tag | `:any_skip_relocation` | `:any` | pinned |
@@ -159,14 +163,6 @@ Replaying the exact `keg_contain?` logic over the contents of 17 pinned and
     code is touched rarely and debugged under pressure.
 
 ## Plan
-
-### Phase 0: pour speed and relocation metadata (helps everyone, every prefix)
-
-3. Metadata-driven fast pour, benchmarked, with scan fallback: no keg walks,
-   only listed files touched, relocation coordinated into one write and one
-   codesign per file, codesign parallelised across files. Benefits accrue to
-   every install, default prefix included, as bottles are rebottled with
-   metadata.
 
 ### Phase 1: maximise relocatable bottles now (helps every custom prefix, any length)
 
@@ -307,7 +303,10 @@ the reason, so the exceptions list stays short, visible and countable.
   minus the named exceptions list.
 - `brew install` at any prefix up to 64 bytes never falls back to source
   because of relocation on the target platforms.
-- Default-prefix pours are measurably faster than before Phase 0.
+- Default-prefix pours are measurably faster than before the metadata-driven
+  pour (`brew benchmark` at implementation: 1.67x faster end-to-end on a
+  5,000-file synthetic keg, relocation cost itself dropping from ~320ms to
+  ~1ms), with gains accruing as bottles are rebottled with metadata.
 - CI fails when a formula regresses from relocatable-or-patchable without an
   annotation.
 

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -251,7 +251,8 @@ RSpec.describe FormulaInstaller do
     let(:downloader) { instance_double(AbstractDownloadStrategy, basename: "missing-bottle-tab", stage: nil) }
     let(:downloadable) { instance_double(Resource, downloader:) }
     let(:tab) do
-      instance_double(Tab, changed_files: nil, source: { "versions" => {} }, write: nil).as_null_object
+      instance_double(Tab, changed_files: nil, linkage_files: nil, binary_relocation_files: nil,
+                      source: { "versions" => {} }, write: nil).as_null_object
     end
     let(:keg) { instance_double(Keg) }
 
@@ -265,7 +266,7 @@ RSpec.describe FormulaInstaller do
     end
 
     it "preserves the skip-linkage decision for the default bottle domain" do
-      expect(keg).to receive(:replace_placeholders_with_locations).with(nil, skip_linkage: true)
+      expect(keg).to receive(:replace_placeholders_with_locations).with(nil, skip_linkage: true, linkage_files: nil)
 
       installer.pour
     end
@@ -273,7 +274,7 @@ RSpec.describe FormulaInstaller do
     it "relocates dynamic linkage without metadata from a bottle mirror" do
       ENV["HOMEBREW_BOTTLE_DOMAIN"] = "https://mirror.example.com"
 
-      expect(keg).to receive(:replace_placeholders_with_locations).with(nil, skip_linkage: false)
+      expect(keg).to receive(:replace_placeholders_with_locations).with(nil, skip_linkage: false, linkage_files: nil)
 
       installer.pour
     end

--- a/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
@@ -40,5 +40,24 @@ RSpec.describe Keg do
 
       expect(new_prefix_matches.size).to eq 1
     end
+
+    specify "replace prefix in recorded files without scanning the keg" do
+      setup_binary_file
+
+      expect(keg).not_to receive(:each_unique_file_matching)
+      keg.relocate_build_prefix(keg, dir, newdir, files: [Pathname("file.bin")])
+
+      null_padding = "\x00" * (dir.to_s.length - newdir.to_s.length)
+      expect(binary_file.binread).to eq "\x00#{newdir}#{null_padding}\x00\n"
+    end
+
+    specify "does not rewrite recorded files without the old prefix" do
+      binary_file.atomic_write "\x00unrelated\x00"
+      inode = binary_file.stat.ino
+
+      keg.relocate_build_prefix(keg, dir, newdir, files: [Pathname("file.bin")])
+
+      expect(binary_file.stat.ino).to eq inode
+    end
   end
 end

--- a/Library/Homebrew/test/os/linux/keg_spec.rb
+++ b/Library/Homebrew/test/os/linux/keg_spec.rb
@@ -21,4 +21,12 @@ RSpec.describe Keg, :needs_linux do
     expect(keg.relocate_dynamic_linkage(keg.prepare_relocation_to_placeholders.freeze, with_placeholders: true))
       .to eq([Pathname("bin/test")])
   end
+
+  it "relocates only recorded linkage files without walking the keg" do
+    expect(keg).not_to receive(:elf_files)
+
+    relocation = keg.prepare_relocation_to_placeholders.freeze
+    expect(keg.relocate_dynamic_linkage(relocation, with_placeholders: true, files: [Pathname("bin/test")]))
+      .to eq([Pathname("bin/test")])
+  end
 end

--- a/Library/Homebrew/test/os/mac/keg_spec.rb
+++ b/Library/Homebrew/test/os/mac/keg_spec.rb
@@ -81,25 +81,85 @@ RSpec.describe Keg do
   describe "#relocate_dynamic_linkage" do
     let(:keg_path) { HOMEBREW_CELLAR/"a/1.0" }
     let(:file) { MachOPathname.wrap(keg_path/"bin/test") }
+    let(:relocation) do
+      relocation = Keg::Relocation.new
+      relocation.add_replacement_pair(:prefix, HOMEBREW_PREFIX.to_s, Keg::PREFIX_PLACEHOLDER)
+      relocation.add_replacement_pair(:cellar, HOMEBREW_CELLAR.to_s, Keg::CELLAR_PLACEHOLDER)
+      relocation
+    end
 
     before do
       file.dirname.mkpath
       touch file
       allow(file).to receive(:ensure_writable).and_yield
+      allow(file).to receive(:save_changes)
       allow(file).to receive_messages(dylib?: false, dynamically_linked_libraries: ["#{HOMEBREW_PREFIX}/lib/foo"],
                                       rpaths: [])
       allow(keg).to receive_messages(mach_o_files: [file], change_install_name: true)
-      allow(keg).to receive(:codesign_patched_binary)
+      allow(keg).to receive(:codesign_patched_binaries)
     end
 
     after { keg.unlink }
 
     it "returns changed linkage files relative to the keg" do
-      relocation = Keg::Relocation.new
-      relocation.add_replacement_pair(:prefix, HOMEBREW_PREFIX.to_s, Keg::PREFIX_PLACEHOLDER)
-      relocation.add_replacement_pair(:cellar, HOMEBREW_CELLAR.to_s, Keg::CELLAR_PLACEHOLDER)
-
       expect(keg.relocate_dynamic_linkage(relocation)).to eq([Pathname("bin/test")])
+    end
+
+    it "saves each changed file once and codesigns changed files together" do
+      expect(file).to receive(:save_changes).once
+      expect(keg).to receive(:codesign_patched_binaries).with([keg_path/"bin/test"])
+
+      keg.relocate_dynamic_linkage(relocation)
+    end
+
+    it "relocates only recorded linkage files without walking the keg" do
+      allow(MachOPathname).to receive(:wrap).and_return(file)
+      expect(keg).not_to receive(:mach_o_files)
+
+      expect(keg.relocate_dynamic_linkage(relocation, files: [Pathname("bin/test")])).to eq([Pathname("bin/test")])
+    end
+  end
+
+  describe "#fix_dynamic_linkage" do
+    let(:keg_path) { HOMEBREW_CELLAR/"a/1.0" }
+    let(:file) { MachOPathname.wrap(keg_path/"bin/test") }
+
+    before do
+      file.dirname.mkpath
+      touch file
+      allow(file).to receive(:ensure_writable).and_yield
+      allow(file).to receive(:save_changes)
+      allow(file).to receive_messages(dylib?: false, rpaths: [],
+                                      dynamically_linked_libraries: ["#{Keg::PREFIX_PLACEHOLDER}/lib/foo"])
+      allow(keg).to receive_messages(mach_o_files: [file], change_install_name: true)
+      allow(keg).to receive(:codesign_patched_binaries)
+    end
+
+    after { keg.unlink }
+
+    it "saves each fixed file once and codesigns fixed files together" do
+      expect(file).to receive(:save_changes).once
+      expect(keg).to receive(:codesign_patched_binaries).with([file])
+
+      keg.fix_dynamic_linkage
+    end
+  end
+
+  describe "#codesign_patched_binaries" do
+    let(:keg_path) { HOMEBREW_CELLAR/"a/1.0" }
+    let(:files) { [keg_path/"bin/a", keg_path/"bin/b"] }
+
+    before do
+      (keg_path/"bin").mkpath
+      files.each { |file| touch file }
+    end
+
+    after { keg.unlink }
+
+    it "codesigns every file" do
+      files.each { |file| expect(keg).to receive(:codesign_patched_binary).with(file.to_s) }
+
+      keg.codesign_patched_binaries(files)
     end
   end
 end


### PR DESCRIPTION
- Pour-time relocation walked every file in the keg to find Mach-O/ELF
  files and `fgrep`ed the whole keg for build-prefix strings on every
  install, although bottles now record `linkage_files` and
  `binary_relocation_files` in their tabs.
- `relocate_dynamic_linkage` and `relocate_build_prefix` now accept the
  recorded file lists and touch only those files, falling back to the
  scan when a bottle carries no metadata.
- Mach-O linkage edits previously wrote the file after each individual
  change, both when relocating poured bottles and when fixing dynamic
  linkage after source builds; they now mutate the in-memory Mach-O and
  persist in a single write per file, and re-signing is parallelised
  across files.
- Skip rewriting and re-signing recorded files that do not contain the
  prefix being patched, since metadata also lists files pinned by other
  references.
- `brew benchmark --exec` over one pour's relocation of a 5,000-file
  synthetic keg (5 dylibs, 2 cellar-pinned binaries) on arm64 macOS,
  where both commands share ~450ms of constant `brew ruby` startup:
```
    Benchmark 1: pour relocation (whole-keg scan fallback)
      Time (mean ± σ):     793.2 ms ±  96.0 ms    [User: 312.9 ms, System: 391.5 ms]
      Range (min … max):   710.3 ms … 955.0 ms    10 runs

    Benchmark 2: pour relocation (bottle metadata)
      Time (mean ± σ):     474.1 ms ±  25.9 ms    [User: 216.4 ms, System: 177.1 ms]
      Range (min … max):   434.6 ms … 519.6 ms    10 runs

    Summary
      pour relocation (bottle metadata) ran
        1.67 ± 0.22 times faster than pour relocation (whole-keg scan fallback)
```

This change is part of [`plans/relocatable-bottles.md`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/plans/relocatable-bottles.md)



-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Fable 5 with local review and testing.

-----
