### PR TITLE
Check ELF relocatability by structure when bottling

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -454,41 +454,193 @@ class Keg
   def self.text_matches_in_file(file, string, ignores, linked_libraries, formula_and_runtime_deps_names)
     text_matches = []
     path_regex = Relocation.path_to_regex(string)
-    Utils.popen_read("strings", "-t", "x", "-", file.to_s) do |io|
-      until io.eof?
-        str = io.readline.chomp
-        next if ignores.any? { |i| str.match?(i) }
-        next unless str.match? path_regex
+    each_candidate_string(file, string) do |(offset, match)|
+      next if ignores.any? { |i| match.match?(i) }
+      next unless match.match? path_regex
 
-        offset, match = str.split(" ", 2)
-        odie "Failed to parse strings output: #{str.inspect}" unless match
+      # Some binaries contain strings with lists of files
+      # e.g. `/usr/local/lib/foo:/usr/local/share/foo:/usr/lib/foo`
+      # Each item in the list should be checked separately
+      match.split(":").each do |sub_match|
+        # Not all items in the list may be matches
+        next unless sub_match.match? path_regex
+        next if linked_libraries.include? sub_match # Don't bother reporting a string if it was found by otool
 
-        # Some binaries contain strings with lists of files
-        # e.g. `/usr/local/lib/foo:/usr/local/share/foo:/usr/lib/foo`
-        # Each item in the list should be checked separately
-        match.split(":").each do |sub_match|
-          # Not all items in the list may be matches
-          next unless sub_match.match? path_regex
-          next if linked_libraries.include? sub_match # Don't bother reporting a string if it was found by otool
+        # Do not report matches to files that do not exist.
+        next unless File.exist? sub_match
 
-          # Do not report matches to files that do not exist.
-          next unless File.exist? sub_match
-
-          # Do not report matches to build dependencies.
-          if formula_and_runtime_deps_names.present?
-            begin
-              keg_name = Keg.for(Pathname.new(sub_match)).name
-              next unless formula_and_runtime_deps_names.include? keg_name
-            rescue NotAKegError
-              nil
-            end
+        # Do not report matches to build dependencies.
+        if formula_and_runtime_deps_names.present?
+          begin
+            keg_name = Keg.for(Pathname.new(sub_match)).name
+            next unless formula_and_runtime_deps_names.include? keg_name
+          rescue NotAKegError
+            nil
           end
-
-          text_matches << [match, offset] unless text_matches.any? { |text| text.last == offset }
         end
+
+        text_matches << [match, offset] unless text_matches.any? { |text| text.last == offset }
       end
     end
     text_matches
+  end
+
+  # Yields each printable string in the file with its hexadecimal offset, as
+  # `strings -t x` reports them. ELF files yield only the strings the loader
+  # or the program can reach, see `elf_relocation_strings`.
+  sig { params(file: Pathname, string: String, block: T.proc.params(candidate: [String, String]).void).void }
+  def self.each_candidate_string(file, string, &block)
+    if (elf_strings = elf_relocation_strings(file, string))
+      elf_strings.each(&block)
+      return
+    end
+
+    Utils.popen_read("strings", "-t", "x", "-", file.to_s) do |io|
+      until io.eof?
+        line = io.readline.chomp
+        offset, match = line.split(" ", 2)
+        odie "Failed to parse strings output: #{line.inspect}" if offset.nil? || match.nil?
+
+        yield [offset, match]
+      end
+    end
+  end
+
+  # Runs of at least four printable bytes, as `strings` reports by default.
+  PRINTABLE_RUN_REGEX = /[\t\x20-\x7e]{4,}/n
+  private_constant :PRINTABLE_RUN_REGEX
+
+  # Build tools leave dead prefix strings in ELF files: Meson's install-time
+  # RPATH fixer overwrites the build RPATH with the shorter install RPATH
+  # without clearing the rest of the old string, and patchelf moves the
+  # dynamic string table or interpreter when growing them, leaving the old
+  # copy behind. A whole-file `strings` scan still finds those bytes and
+  # wrongly pins bottles whose live linkage is fully placeholdered. ELF files
+  # are therefore scanned by structure rather than as a whole: the interpreter the
+  # loader uses, the dynamic strings the loader references and the contents of
+  # the remaining sections. Bytes outside every section and unreferenced
+  # entries in loader-owned string tables are never candidates.
+  #
+  # This deliberately errs towards relocatability (design decision 11 in
+  # `plans/relocatable-bottles.md`): a wrongly pinned bottle forces source
+  # builds for every non-default-prefix user, whereas a wrongly accepted one
+  # surfaces as a per-formula bug report and fix.
+  #
+  # Returns nil, so that the whole file is scanned instead, for files that are
+  # not ELF, cannot name their sections or whose tables are truncated.
+  sig { params(file: Pathname, string: String).returns(T.nilable(T::Array[[String, String]])) }
+  def self.elf_relocation_strings(file, string)
+    require "os/linux/elf"
+    return unless T.cast(Pathname.new(file.to_s).extend(ELFShim), ELFShim).elf?
+
+    require "elftools"
+    require "strscan"
+
+    stream = file.open("rb")
+    begin
+      elf = ELFTools::ELFFile.new(stream)
+      # A file may legally keep section headers while `e_shstrndx` is
+      # `SHN_UNDEF` (no section-name table); sections cannot be told apart
+      # without names.
+      return unless elf.strtab_section.is_a?(ELFTools::Sections::StrTabSection)
+
+      strings = T.let([], T::Array[[Integer, String]])
+
+      if (interp = elf.segment_by_type(:interp))
+        strings << [interp.header.p_offset.to_i, interp.interp_name]
+      end
+
+      string_table_range = T.let(nil, T.nilable(T::Range[Integer]))
+      if (dynamic = elf.segment_by_type(:dynamic))
+        # Dynamic tags whose value is an offset into the dynamic string
+        # table, i.e. the strings the loader can actually see.
+        string_tags = [
+          ELFTools::Constants::DT::DT_NEEDED,
+          ELFTools::Constants::DT::DT_SONAME,
+          ELFTools::Constants::DT::DT_RPATH,
+          ELFTools::Constants::DT::DT_RUNPATH,
+          ELFTools::Constants::DT::DT_AUXILIARY,
+          # elftools 1.3.1 mislabels `DT_USED` (0x7ffffffe) as `DT_FILTER`;
+          # both hold string-table offsets, so keep the mislabelled value
+          # and add the ELF ABI's real `DT_FILTER`.
+          ELFTools::Constants::DT::DT_FILTER,
+          0x7fffffff, # DT_FILTER
+          ELFTools::Constants::DT::DT_AUDIT,
+          ELFTools::Constants::DT::DT_DEPAUDIT,
+          ELFTools::Constants::DT::DT_CONFIG,
+        ]
+        string_table_vaddr = T.let(nil, T.nilable(Integer))
+        string_table_size = T.let(nil, T.nilable(Integer))
+        string_offsets = []
+        dynamic.tags.each do |tag|
+          case tag.header.d_tag.to_i
+          when ELFTools::Constants::DT::DT_STRTAB then string_table_vaddr = tag.header.d_val.to_i
+          when ELFTools::Constants::DT::DT_STRSZ then string_table_size = tag.header.d_val.to_i
+          when *string_tags then string_offsets << tag.header.d_val.to_i
+          end
+        end
+        if string_table_vaddr && (string_table_offset = elf.offset_from_vma(string_table_vaddr))
+          string_table_range = string_table_offset...(string_table_offset + string_table_size) if string_table_size
+
+          # Dynamic symbol names are loader-visible strings in the same
+          # table, referenced by `.dynsym` `st_name` rather than by dynamic
+          # tags. Version table strings also index the table but hold
+          # version names, never paths, so they are not collected.
+          elf.sections_by_type(ELFTools::Constants::SHT::SHT_DYNSYM).each do |section|
+            section.symbols.each do |symbol|
+              name_offset = symbol.header.st_name.to_i
+              string_offsets << name_offset unless name_offset.zero?
+            end
+          end
+
+          # A referenced string runs from its offset to the terminating NUL,
+          # so a suffix-merged reference to the interior `libfoo.so` of
+          # `/old/prefix/libfoo.so` never yields the dead prefix before it.
+          string_offsets.uniq.each do |offset|
+            stream.pos = string_table_offset + offset
+            referenced = stream.gets("\0")&.delete_suffix("\0")
+            strings << [string_table_offset + offset, referenced] if referenced
+          end
+        end
+      end
+
+      # Everything else the program itself can reach: the contents of the
+      # remaining sections. Loader-owned string regions are covered above and
+      # bytes outside every section are deliberately excluded from relocation.
+      elf.sections.each do |section|
+        header = section.header
+        # SHT_NOBITS sections (e.g. `.bss`) occupy no file bytes.
+        next if header.sh_type.to_i == ELFTools::Constants::SHT::SHT_NOBITS
+        next if header.sh_size.to_i.zero?
+        next if [".dynstr", ".interp"].include?(section.name)
+
+        section_start = header.sh_offset.to_i
+        next if string_table_range&.cover?(section_start)
+
+        data = section.data
+        # Cheap pre-check before extracting every printable run.
+        next unless data.include?(string)
+
+        scanner = StringScanner.new(data)
+        while scanner.skip_until(PRINTABLE_RUN_REGEX)
+          run = scanner.matched
+          strings << [section_start + scanner.pos - run.bytesize, run]
+        end
+      end
+
+      strings.filter_map do |offset, match|
+        next unless match.ascii_only?
+
+        [offset.to_s(16), match.force_encoding(Encoding::UTF_8)]
+      end
+    ensure
+      stream.close
+    end
+  rescue ELFTools::ELFError, IOError, SystemCallError
+    # Not valid ELF, or program, section or dynamic tables truncated or
+    # pointing outside the file mid-parse (Linux raises `Errno::EINVAL`
+    # for the resulting seek where macOS returns EOF).
+    nil
   end
 
   sig { params(_file: Pathname, _string: String).returns(T::Array[String]) }

--- a/Library/Homebrew/plans/relocatable-bottles.md
+++ b/Library/Homebrew/plans/relocatable-bottles.md
@@ -106,11 +106,14 @@ Replaying the exact `keg_contain?` logic over the contents of 17 pinned and
 - 12/17: compiled-in own-keg or prefix C strings (sysconfdir, datadir,
   localedir, plugin directories), e.g. `wget2`'s localedir, `graphviz`'s
   plugin directory, `python@3.x`'s framework prefix.
-- 2/17: stale ELF `.dynstr` bytes: patchelf.rb writes a placeholdered RUNPATH
-  but leaves the old string dead in the binary and the checker counts the
-  corpse (`harfbuzz`, `shared-mime-info`; the 224-formula glib/gobject
+- 2/17: stale ELF `.dynstr` bytes: Meson's install-time RPATH rewrite
+  overwrites the build RPATH without clearing the rest of the old string
+  (intentional upstream; Nix carries a patch), and patchelf leaves the old
+  table behind when growing one, so the checker counts the corpse
+  (`harfbuzz`, `shared-mime-info`; the 224-formula glib/gobject
   introspection cluster on Linux looks identical). Functionally these are
-  false positives.
+  false positives, since addressed by scanning ELF files by structure
+  (design decision 11).
 - 1/17: node-gyp build debris: native addons compiled inside the keg embed
   keg paths in debug info and ship stray `.o` artefacts (about 29 npm
   formulae).
@@ -161,6 +164,19 @@ Replaying the exact `keg_contain?` logic over the contents of 17 pinned and
 10. Non-intuitive logic must always be commented, especially relocation edge
     cases (NUL padding, string-table subtleties, codesign behaviour): this
     code is touched rarely and debugged under pressure.
+11. The relocatability checker deliberately errs towards classifying
+    bottles as relocatable rather than pinned. This is a rebalancing of the
+    original `strings`-based checker, which counted every prefix byte
+    sequence in a file as a pin: a wrongly pinned bottle forces source
+    builds for every non-default-prefix user and poisons its whole
+    dependent subtree, whereas a wrongly relocatable one surfaces as a
+    per-formula bug report with a trivial fix and is caught by the Phase 2
+    validation sweep and the test-bot relocated-pour test. Concretely, ELF
+    files are scanned by structure rather than as a whole: only the
+    interpreter the loader uses, the dynamic strings the loader references
+    and the contents of ordinary sections count; bytes outside every
+    section and unreferenced entries in loader-owned string tables never
+    do. Other file types keep the whole-file scan.
 
 ## Plan
 
@@ -172,10 +188,6 @@ length limit and no new machinery.
 4. Reconcile checker divergences: pull `brew bottle --verbose` CI logs for
    the `abseil` class, fix whatever diverges, then batch re-mark provably
    clean pins `cellar :any` with no rebuild (sha256 unchanged).
-5. ELF-aware checker: map string offsets to sections (elftools is already
-   vendored via patchelf.rb) and stop counting stale `.dynstr` corpses.
-   Flips the glib/gobject-introspection cluster and much of the Linux-only
-   pinned set on their next rebottle.
 6. node-gyp debris: delete `build/**/obj.target`, `*.o` and `*.d` from
    npm-installed trees and strip or debug-prefix-map compiled `.node`
    addons. Flips the npm cluster.

--- a/Library/Homebrew/test/keg_relocate/elf_checker_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/elf_checker_spec.rb
@@ -1,0 +1,136 @@
+# typed: true
+# frozen_string_literal: true
+
+require "keg_relocate"
+require "patchelf"
+require "elftools"
+
+RSpec.describe Keg do
+  let(:dir) { HOMEBREW_CELLAR/"foo/1.0.0" }
+  let(:file) { dir/"bin/program" }
+  let(:baked_rpath) { "#{dir}/lib/#{"deep/" * 10}end" }
+
+  def patch_rpath(rpath)
+    patcher = PatchELF::Patcher.new(file.to_s, on_error: :silent)
+    patcher.rpath = rpath
+    patcher.save(patchelf_compatible: true)
+  end
+
+  def patch_interpreter(interpreter)
+    patcher = PatchELF::Patcher.new(file.to_s, on_error: :silent)
+    patcher.interpreter = interpreter
+    patcher.save(patchelf_compatible: true)
+  end
+
+  before do
+    Pathname(baked_rpath).mkpath
+    file.dirname.mkpath
+    FileUtils.cp TEST_FIXTURE_DIR/"elf/hello", file
+    patch_rpath baked_rpath
+  end
+
+  describe "::text_matches_in_file" do
+    it "keeps prefix strings the dynamic loader still references" do
+      expect(described_class.text_matches_in_file(file, dir.to_s, [], [], nil).size).to eq 1
+    end
+
+    it "drops dead loader strings nothing references any more" do
+      # Shrinking the RPATH leaves an in-place `X` run inside `.dynstr`;
+      # writing a prefix string over it recreates the dead bytes a moved or
+      # rewritten string table leaves behind.
+      patch_rpath "#{Keg::PREFIX_PLACEHOLDER}/lib"
+      corpse_offset = File.binread(file).index("X" * (dir.to_s.length + 2))
+      raise "no X padding run found" if corpse_offset.nil?
+
+      File.open(file, "r+b") do |f|
+        f.seek(corpse_offset)
+        f.write("#{dir}\x00")
+      end
+
+      expect(described_class.text_matches_in_file(file, dir.to_s, [], [], nil)).to be_empty
+    end
+
+    it "drops prefix strings outside every section" do
+      patch_rpath "#{Keg::PREFIX_PLACEHOLDER}/lib"
+      file.open("ab") { |f| f.write("\x00#{dir}\x00") }
+
+      expect(described_class.text_matches_in_file(file, dir.to_s, [], [], nil)).to be_empty
+    end
+
+    it "drops prefixes before the substring a dynamic tag references" do
+      # Point DT_RPATH into the interior of the baked string, as a linker
+      # does for tail-merged entries: the prefix bytes before the
+      # referenced substring are then dead.
+      value_offset = file.open("rb") do |stream|
+        dynamic = ELFTools::ELFFile.new(stream).segment_by_type(:dynamic)
+        index = dynamic.tags.find_index do |tag|
+          [ELFTools::Constants::DT::DT_RPATH, ELFTools::Constants::DT::DT_RUNPATH].include?(tag.header.d_tag.to_i)
+        end
+        dynamic.header.p_offset.to_i + (index * 16) + 8
+      end
+      referenced = File.binread(file, 8, value_offset).unpack1("Q<")
+      File.open(file, "r+b") do |f|
+        f.seek(value_offset)
+        f.write([referenced + dir.to_s.length + 1].pack("Q<"))
+      end
+
+      expect(described_class.text_matches_in_file(file, dir.to_s, [], [], nil)).to be_empty
+    end
+
+    it "keeps matches when the section-name table is unavailable" do
+      # `e_shstrndx` may legally be `SHN_UNDEF`, leaving sections unnameable.
+      File.open(file, "r+b") do |f|
+        f.seek(62)
+        f.write("\x00\x00")
+      end
+
+      expect(described_class.text_matches_in_file(file, dir.to_s, [], [], nil).size).to eq 1
+    end
+
+    it "keeps the interpreter the loader still uses" do
+      interpreter = "#{dir}/ld.so"
+      FileUtils.touch interpreter
+      patch_rpath "#{Keg::PREFIX_PLACEHOLDER}/lib"
+      patch_interpreter interpreter
+
+      expect(described_class.text_matches_in_file(file, dir.to_s, [], [], nil).size).to eq 1
+    end
+
+    it "drops old interpreter bytes the loader no longer uses" do
+      patch_rpath "#{Keg::PREFIX_PLACEHOLDER}/lib"
+      # Growing the interpreter moves it; shrinking it back leaves an
+      # in-place padding run where dead interpreter bytes can survive.
+      patch_interpreter "#{dir}/#{"deep/" * 10}ld.so"
+      patch_interpreter "#{Keg::PREFIX_PLACEHOLDER}/lib/ld.so"
+      anchor = "#{Keg::PREFIX_PLACEHOLDER}/lib/ld.so\x00"
+      corpse_offset = File.binread(file).index(anchor)
+      raise "no placeholdered interpreter found" if corpse_offset.nil?
+
+      File.open(file, "r+b") do |f|
+        f.seek(corpse_offset + anchor.bytesize)
+        f.write("#{dir}\x00")
+      end
+
+      expect(described_class.text_matches_in_file(file, dir.to_s, [], [], nil)).to be_empty
+    end
+
+    it "keeps matches in files whose ELF tables are truncated" do
+      file.binwrite "\x7fELF\x02\x01\x01#{"\x00" * 9}\x00#{dir}\x00"
+
+      expect(described_class.text_matches_in_file(file, dir.to_s, [], [], nil).size).to eq 1
+    end
+
+    it "keeps prefix strings compiled into ordinary sections" do
+      patch_rpath "#{Keg::PREFIX_PLACEHOLDER}/lib"
+      text_offset = file.open("rb") do |stream|
+        ELFTools::ELFFile.new(stream).section_by_name(".text").header.sh_offset.to_i
+      end
+      File.open(file, "r+b") do |f|
+        f.seek(text_offset)
+        f.write("\x00#{dir}\x00")
+      end
+
+      expect(described_class.text_matches_in_file(file, dir.to_s, [], [], nil).size).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
This PR deliberately rebalances the bottle relocatability checker towards classifying bottles as relocatable rather than pinned, now documented as design decision 11 in `plans/relocatable-bottles.md`.

The original `strings`-based checker treats every prefix byte sequence in a file as a pin. For ELF files that counts bytes the program can never reach: Meson's install-time RPATH fixer overwrites the build RPATH with the shorter install RPATH without clearing the rest of the old string (intentional upstream; Nix patches it out), and patchelf leaves the old dynamic string table or interpreter behind when growing them. A wrongly pinned bottle forces source builds for every non-default-prefix user and poisons its whole dependent subtree, whereas a wrongly relocatable one surfaces as a per-formula bug report with a trivial fix and is caught by the planned validation sweep and test-bot relocated-pour test.

Concretely, ELF files are no longer `strings`-scanned as a whole. `Keg.text_matches_in_file` now takes its candidates from the ELF structures themselves, using the vendored elftools:

- the interpreter the loader uses (`PT_INTERP`);
- the dynamic strings the loader references: dynamic tags (including the ELF ABI's real `DT_FILTER`, which elftools 1.3.1 mislabels) and `.dynsym` names, read from their offset to the NUL so a suffix-merged reference never yields the dead prefix in front of it;
- the printable contents of the remaining sections.

Bytes outside every section and unreferenced entries in loader-owned string tables are never candidates. Files that are not ELF, cannot name their sections (`e_shstrndx` of `SHN_UNDEF`) or whose tables are truncated mid-parse keep the whole-file scan, so nothing is dropped where the structure cannot be read. Other file types are unchanged.

Affected formulae flip to `cellar :any` on their next rebottle.

This change is part of [`plans/relocatable-bottles.md`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/plans/relocatable-bottles.md)

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Fable 5 with local review and testing.

-----
