### PR TITLE
Delete node-gyp debris and strip addons when bottling

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -518,6 +518,8 @@ module Homebrew
 
           begin
             keg.delete_pyc_files!
+            keg.delete_node_gyp_debris!
+            keg.strip_node_gyp_addons!
 
             unless args.skip_relocation?
               changed_files, linkage_files = keg.replace_locations_with_placeholders

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -629,6 +629,49 @@ class Keg
   end
 
   sig { void }
+  def delete_node_gyp_debris!
+    # node-gyp compiles native addons inside the keg at install time and
+    # leaves its intermediate objects and static archives behind; they embed
+    # build paths that pin bottles and are never needed at run time (addons
+    # load the linked `.node` files, not the objects they were linked from).
+    path.find do |pn|
+      next unless pn.to_s.include?("/node_modules/")
+
+      if pn.directory? && pn.basename.to_s == "obj.target"
+        FileUtils.rm_rf pn
+        Find.prune
+      elsif %w[.o .d].include?(pn.extname) ||
+            (pn.extname == ".a" && pn.to_s.include?("/build/"))
+        pn.delete
+      end
+    end
+  end
+
+  sig { void }
+  def strip_node_gyp_addons!
+    strip = which("strip")
+    return if strip.nil?
+
+    path.find do |pn|
+      next if pn.symlink? || pn.extname != ".node" || pn.to_s.exclude?("/node_modules/")
+
+      # node-gyp addons' `N_OSO`/`N_SO` stab strings embed keg build paths,
+      # which pin bottles; stripping debug entries removes them and Apple
+      # `strip` re-signs ad hoc, so no separate codesign step is needed.
+      # Strip to a temporary file so a failure (e.g. an addon `strip` cannot
+      # parse) leaves the addon untouched.
+      stripped = Pathname("#{pn}.stripped")
+      if quiet_system(strip.to_s, "-S", "-o", stripped.to_s, pn.to_s)
+        mode = pn.stat.mode
+        FileUtils.mv stripped, pn
+        pn.chmod mode
+      else
+        FileUtils.rm_f stripped
+      end
+    end
+  end
+
+  sig { void }
   def normalize_pod2man_outputs!
     # Only process uncompressed manpages, which end in a digit
     manpages = Dir[path/"share/man/*/*.[1-9]{,p,pm}"]

--- a/Library/Homebrew/plans/relocatable-bottles.md
+++ b/Library/Homebrew/plans/relocatable-bottles.md
@@ -188,9 +188,6 @@ length limit and no new machinery.
 4. Reconcile checker divergences: pull `brew bottle --verbose` CI logs for
    the `abseil` class, fix whatever diverges, then batch re-mark provably
    clean pins `cellar :any` with no rebuild (sha256 unchanged).
-6. node-gyp debris: delete `build/**/obj.target`, `*.o` and `*.d` from
-   npm-installed trees and strip or debug-prefix-map compiled `.node`
-   addons. Flips the npm cluster.
 7. Data-driven ignore extensions where blocker diagnostics show a class is
    functionally dead.
 

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -390,6 +390,60 @@ RSpec.describe Keg do
     end
   end
 
+  describe "#delete_node_gyp_debris!" do
+    it "deletes intermediate node-gyp objects but keeps addons and other objects" do
+      keg_path = HOMEBREW_CELLAR/"foo/1.0"
+      build_dir = keg_path/"libexec/lib/node_modules/foo/build/Release"
+      (build_dir/"obj.target/foo").mkpath
+      touch build_dir/"obj.target/foo/binding.o"
+      touch build_dir/"addon.node"
+      touch build_dir/"binding.d"
+      touch build_dir/"leveldb.a"
+      (keg_path/"libexec/lib/node_modules/foo/lib").mkpath
+      touch keg_path/"libexec/lib/node_modules/foo/lib/shipped.a"
+      (keg_path/"lib").mkpath
+      touch keg_path/"lib/crt1.o"
+
+      keg.delete_node_gyp_debris!
+
+      expect(build_dir/"obj.target").not_to exist
+      expect(build_dir/"binding.d").not_to exist
+      expect(build_dir/"leveldb.a").not_to exist
+      expect(build_dir/"addon.node").to exist
+      expect(keg_path/"libexec/lib/node_modules/foo/lib/shipped.a").to exist
+      expect(keg_path/"lib/crt1.o").to exist
+    end
+  end
+
+  describe "#strip_node_gyp_addons!" do
+    let(:addon) { HOMEBREW_CELLAR/"foo/1.0/libexec/lib/node_modules/foo/build/Release/addon.node" }
+
+    before do
+      addon.dirname.mkpath
+      addon.write "unstripped"
+      allow(keg).to receive(:which).with("strip").and_return(Pathname("/usr/bin/strip"))
+    end
+
+    it "replaces addons under node_modules when strip succeeds" do
+      allow(keg).to receive(:quiet_system) do |*command|
+        File.write(command.fetch(3), "stripped")
+        true
+      end
+
+      keg.strip_node_gyp_addons!
+
+      expect(addon.read).to eq "stripped"
+    end
+
+    it "leaves addons untouched when strip fails" do
+      allow(keg).to receive(:quiet_system).and_return(false)
+
+      keg.strip_node_gyp_addons!
+
+      expect(addon.read).to eq "unstripped"
+    end
+  end
+
   describe "#homebrew_created_file?" do
     it "identifies Homebrew service files" do
       plist_file = instance_double(Pathname, extname: ".plist", basename: Pathname.new("homebrew.foo.plist"))


### PR DESCRIPTION
- node-gyp compiles native addons inside the keg at install time and
  leaves `obj.target` trees, `*.o` objects, `*.d` dependency files and
  intermediate `*.a` archives behind under `node_modules`; they embed
  build paths that pin about 33 npm formulae's bottles and are never
  needed at run time (addons load the linked `.node` files, not the
  objects they were linked from).
- `brew bottle` now deletes them alongside `*.pyc` files, scoped to
  `node_modules` trees (`*.a` further to node-gyp `build` trees) so
  legitimate shipped objects and archives are untouched.
- The linked `.node` addons themselves embed keg build paths in their
  `N_OSO`/`N_SO` stab strings, so `brew bottle` also runs
  `strip -S -o` on them, replacing each addon only when `strip`
  succeeds. Verified on `hsd`'s published `leveldown.node`: 76 keg
  paths before, 0 after, with the signature still valid because Apple
  `strip` re-signs ad hoc, so no separate codesign step is needed.

This change is part of [`plans/relocatable-bottles.md`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/plans/relocatable-bottles.md)


-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Fable 5 with local review and testing.

-----
