### PR TITLE
Check raw linkage names when bottling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ When running Ruby directly (e.g. `ruby -e ...`, `gem`, profiling tools), never u
 
 Do not use conventional commit prefixes such as `feat:`, `fix:`, `chore:`, `refactor:`, `perf:` or `ci:`; the `Commit Style` GitHub Actions workflow rejects them.
 
+When opening pull requests, always fill in the pull request template from `.github/PULL_REQUEST_TEMPLATE.md`; do not bypass it with e.g. `gh pr create --fill`.
+
 ## Code Standards
 
 ### Required Before Each Commit

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -15,8 +15,13 @@ module OS
 
           # Check dynamic library linkage. Importantly, do not perform for static
           # libraries, which will falsely report "linkage" to themselves.
+          # Only the raw load-command names matter: resolving `@rpath` or
+          # `@loader_path` references against the live keg turns
+          # relocatable-by-construction linkage into absolute build-prefix
+          # paths and wrongly pins bottles, while genuinely unplaceholdered
+          # names contain the prefix in their raw form already.
           if file.mach_o_executable? || file.dylib? || file.mach_o_bundle?
-            file.dynamically_linked_libraries.select { |lib| lib.include? string }
+            file.dynamically_linked_libraries(resolve_variable_references: false).select { |lib| lib.include? string }
           else
             []
           end

--- a/Library/Homebrew/plans/relocatable-bottles.md
+++ b/Library/Homebrew/plans/relocatable-bottles.md
@@ -31,6 +31,10 @@ Any benchmark quoted in a commit message must be the full hyperfine
 output from `brew benchmark` (using its `--exec` mode for bespoke
 workloads), never hand-summarised numbers.
 
+Pull requests must always fill in the repository's pull request
+template (`.github/PULL_REQUEST_TEMPLATE.md`), never bypass it
+(e.g. with `gh pr create --fill`).
+
 ## Current state (21 August 2026, formulae.brew.sh data)
 
 | Tag | `:any_skip_relocation` | `:any` | pinned |

--- a/Library/Homebrew/plans/relocatable-bottles.md
+++ b/Library/Homebrew/plans/relocatable-bottles.md
@@ -118,9 +118,10 @@ Replaying the exact `keg_contain?` logic over the contents of 17 pinned and
   keg paths in debug info and ship stray `.o` artefacts (about 29 npm
   formulae).
 - 1/17: `abseil` replays clean under the current checker yet CI pinned it:
-  some pins are stale or wrong. A bottle's cellar lives in the formula, not
-  the tarball, so provably clean bottles can be re-marked `cellar :any`
-  without rebuilding.
+  since explained and fixed (phantom resolved-linkage matches, Phase 1
+  item 4). A bottle's cellar lives in the formula, not the tarball, so
+  provably clean bottles can be re-marked `cellar :any` without
+  rebuilding.
 
 ## Design decisions
 
@@ -185,9 +186,19 @@ Replaying the exact `keg_contain?` logic over the contents of 17 pinned and
 Each pinned bottle flipped to `cellar :any` pours at any prefix with no
 length limit and no new machinery.
 
-4. Reconcile checker divergences: pull `brew bottle --verbose` CI logs for
-   the `abseil` class, fix whatever diverges, then batch re-mark provably
-   clean pins `cellar :any` with no rebuild (sha256 unchanged).
+4. Reconcile checker divergences: resolved. The `abseil` class was pinned
+   by `file_linked_libraries` resolving `@rpath`/`@loader_path` load
+   commands against the live keg at bottle time, turning relocatable
+   linkage into absolute build-prefix paths; the checker now reads raw
+   load-command names. Text matches never recorded it because googletest
+   include-path strings hit the `ignores` filters, which also explains
+   why only arm64 macOS pinned: `/usr/local/include/...` never byte-matched
+   Intel's `/usr/local/opt` and `/usr/local/Cellar` search strings and
+   Linux has no linkage check. Remaining: once the fix is deployed to CI,
+   batch re-mark provably clean pins `cellar :any` with no rebuild
+   (sha256 unchanged) in homebrew/core, starting from the 127 formulae
+   pinned on all arm64 macOS tags yet `:any` on `x86_64_linux` (e.g.
+   `abseil`, `boost`, `binutils`, `aws-sdk-cpp`).
 7. Data-driven ignore extensions where blocker diagnostics show a class is
    functionally dead.
 
@@ -321,9 +332,6 @@ the reason, so the exceptions list stays short, visible and countable.
 
 ## Open questions
 
-- The `abseil`-class anomaly: why did CI pin bottles whose contents pass the
-  current checker? Needs a `brew bottle --verbose` CI log to reconcile
-  before trusting the checker's output as blocker metadata.
 - Symbolic cellar spelling and JSON API versioning for third-party
   consumers.
 - How many formulae fail to build at all at a 64-byte prefix

--- a/Library/Homebrew/test/os/mac/keg_spec.rb
+++ b/Library/Homebrew/test/os/mac/keg_spec.rb
@@ -34,6 +34,26 @@ RSpec.describe Keg do
     end
   end
 
+  describe "::file_linked_libraries" do
+    let(:file) { MachOPathname.wrap(keg_path/"lib/a.dylib") }
+
+    before do
+      file.dirname.mkpath
+      touch file
+      allow(MachOPathname).to receive(:wrap).and_return(file)
+      allow(file).to receive_messages(dylib?: true, mach_o_executable?: false, mach_o_bundle?: false)
+    end
+
+    it "checks raw load-command names without resolving variable references" do
+      expect(file).to receive(:dynamically_linked_libraries)
+        .with(resolve_variable_references: false)
+        .and_return(["@rpath/liba.dylib", "#{HOMEBREW_PREFIX}/lib/libb.dylib"])
+
+      expect(described_class.file_linked_libraries(file, HOMEBREW_PREFIX.to_s))
+        .to eq(["#{HOMEBREW_PREFIX}/lib/libb.dylib"])
+    end
+  end
+
   describe "#codesign_patched_binary" do
     let(:keg_path) { HOMEBREW_CELLAR/"a/1.0" }
     let(:file) { "#{keg_path}/bin/test" }


### PR DESCRIPTION
- `brew bottle`'s relocatability checker resolved `@rpath` and
  `@loader_path` load commands against the live keg, so
  relocatable-by-construction linkage read back as absolute
  build-prefix paths and wrongly pinned bottles to their build cellar.
- Verified against the fresh `abseil` rebuild: its googletest helper
  dylibs carry `/opt/homebrew/include/gtest/...` assertion strings
  that select the files for checking (while the `ignores` filters
  drop every text match, leaving `binary_relocation_files` empty),
  after which their `@rpath/libabsl_*.dylib` load commands resolved
  through `LC_RPATH @loader_path` to the keg's absolute path and
  pinned the bottle. Only arm64 macOS was affected:
  `/usr/local/include/...` never byte-matches Intel's
  `/usr/local/opt` and `/usr/local/Cellar` search strings and Linux
  performs no linkage check.
- The checker now reads raw load-command names. Raw names lose no
  true positives: a genuinely unplaceholdered name or RPATH contains
  the prefix in its raw bytes and is already caught.
- 127 formulae are pinned on all arm64 macOS tags yet `cellar :any`
  on `x86_64_linux` (e.g. `abseil`, `boost`, `binutils`,
  `aws-sdk-cpp`); once this fix reaches CI they can be re-marked or
  will flip on rebottle.

This change is part of [`plans/relocatable-bottles.md`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/plans/relocatable-bottles.md)


-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Fable 5 with local review and testing.

-----
