### PR TITLE
bundle: fail Flatpak entries when flatpak is not installed

### DIFF
--- a/Library/Homebrew/bundle/extensions/flatpak.rb
+++ b/Library/Homebrew/bundle/extensions/flatpak.rb
@@ -176,7 +176,7 @@ module Homebrew
           _ = no_upgrade
           _ = url
 
-          return false unless package_manager_installed?
+          return true unless package_manager_installed?
 
           # Check if package is installed at all (regardless of remote)
           if package_installed?(name)
@@ -206,10 +206,14 @@ module Homebrew
           _ = no_upgrade
           _ = force
 
-          return true unless package_manager_installed?
           return true unless preinstall
 
-          flatpak = package_manager_executable!.to_s
+          flatpak = package_manager_executable
+          if flatpak.nil?
+            $stderr.puts "flatpak is not installed. Install it with your distribution's package manager."
+            return false
+          end
+          flatpak = flatpak.to_s
 
           # 3-tier remote handling:
           # - Tier 1: no URL → use named remote (default: flathub)

--- a/Library/Homebrew/test/bundle/flatpak_spec.rb
+++ b/Library/Homebrew/test/bundle/flatpak_spec.rb
@@ -230,16 +230,17 @@ RSpec.describe Homebrew::Bundle::Flatpak do
   end
 
   describe "installing" do
-    context "when Flatpak is not installed", :needs_linux do
+    context "when Flatpak is not installed" do
       before do
         described_class.reset!
         allow(described_class).to receive(:package_manager_executable).and_return(nil)
       end
 
-      it "returns false without attempting installation" do
+      it "fails with installation guidance without attempting installation" do
         expect(Homebrew::Bundle).not_to receive(:system)
-        expect(described_class.preinstall!("org.gnome.Calculator")).to be(false)
-        expect(described_class.install!("org.gnome.Calculator")).to be(true)
+        expect(described_class.preinstall!("org.gnome.Calculator")).to be(true)
+        expect { expect(described_class.install!("org.gnome.Calculator")).to be(false) }
+          .to output(/flatpak is not installed.*distribution's package manager/).to_stderr
       end
     end
 

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe Homebrew::Bundle::Installer do
   let(:second_formula_entry) { Homebrew::Bundle::Dsl::Entry.new(:brew, "redis") }
   let(:cask_options) { { args: {}, full_name: "homebrew/cask/google-chrome" } }
   let(:cask_entry) { Homebrew::Bundle::Dsl::Entry.new(:cask, "google-chrome", cask_options) }
+  let(:flatpak_entry) do
+    Homebrew::Bundle::Dsl::Entry.new(:flatpak, "org.gnome.Calculator", { remote: "flathub" })
+  end
 
   before do
     described_class.reset!
@@ -67,6 +70,25 @@ RSpec.describe Homebrew::Bundle::Installer do
     expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
 
     described_class.install!([formula_entry], no_upgrade: true, quiet: true)
+  end
+
+  it "fails a missing Flatpak entry without skipping following entries or claiming success" do
+    tap_entry = Homebrew::Bundle::Dsl::Entry.new(:tap, "example/tap")
+    allow(Homebrew::Bundle::Flatpak).to receive(:package_manager_executable).and_return(nil)
+    expect(Homebrew::Bundle::Tap).to receive(:preinstall!)
+      .with("example/tap", no_upgrade: false, verbose: false)
+      .and_return(true)
+    expect(Homebrew::Bundle::Tap).to receive(:install!)
+      .with("example/tap", preinstall: true, no_upgrade: false, verbose: false, force: false)
+      .and_return(true)
+
+    result = T.let(nil, T.nilable(T::Boolean))
+    expect do
+      result = described_class.install!([flatpak_entry, tap_entry], quiet: false)
+    end.to output(
+      /flatpak is not installed.*Installing org\.gnome\.Calculator has failed!.*`brew bundle` failed!/m,
+    ).to_stderr.and not_to_output(/Using org\.gnome\.Calculator/).to_stdout
+    expect(result).to be(false)
   end
 
   it "skips fetching formulae from untapped taps" do


### PR DESCRIPTION
On Linux without `flatpak` installed, `brew bundle` printed `Using <flatpak>` for every Flatpak entry and then claimed all dependencies were installed, reported in https://github.com/orgs/Homebrew/discussions/7031. `Flatpak.preinstall!` returned `false` when the package manager was missing, which the installer reads as "already installed", and `Flatpak.install!` returned `true` on the same condition and incremented the success count.

Unlike the other extensions there is no `flatpak` formula to bootstrap, so a missing executable now fails that entry with guidance to install it from the distribution's package manager. Later Brewfile entries still install, and the run ends with the usual failure summary and a nonzero exit rather than aborting or reporting success. New tests cover the class methods directly and the behavior through `Installer.install!`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the fix and pass with it, and ran `brew lgtm` + targeted specs.

-----
