### PR TITLE
dev-cmd/bump: skip if there is an open bump PR

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -52,7 +52,7 @@ module Homebrew
         const :newer_than_upstream, T::Hash[Symbol, T::Boolean], default: {}
         const :cooldown_skipped_versions, T::Hash[Symbol, Version], default: {}
         const :duplicate_pull_requests, T.nilable(T.any(T::Array[String], String))
-        const :maybe_duplicate_pull_requests, T.nilable(T.any(T::Array[String], String))
+        const :open_bump_pull_requests, T.nilable(T.any(T::Array[String], String))
       end
 
       cmd_args do
@@ -380,8 +380,8 @@ module Homebrew
               version: pull_request_version,
             )
 
-            maybe_duplicate_pull_requests = if duplicate_pull_requests.nil?
-              retrieve_pull_requests(formula_or_cask, name)
+            open_bump_pull_requests = if duplicate_pull_requests.nil?
+              retrieve_pull_requests(formula_or_cask, name, state: "open")
             end
           end
         end
@@ -398,7 +398,7 @@ module Homebrew
           newer_than_upstream:,
           cooldown_skipped_versions:,
           duplicate_pull_requests:,
-          maybe_duplicate_pull_requests:,
+          open_bump_pull_requests:,
         )
       end
 
@@ -423,7 +423,7 @@ module Homebrew
         newer_than_upstream = version_info.newer_than_upstream
         cooldown_skipped_version = version_info.cooldown_skipped_versions.values.max
         duplicate_pull_requests = version_info.duplicate_pull_requests
-        maybe_duplicate_pull_requests = version_info.maybe_duplicate_pull_requests
+        open_bump_pull_requests = version_info.open_bump_pull_requests
 
         versions_equal = (new_version == current_version)
         all_newer_than_upstream = newer_than_upstream.all? { |_k, v| v == true }
@@ -509,18 +509,16 @@ module Homebrew
            !all_newer_than_upstream
           if duplicate_pull_requests
             duplicate_pull_requests_text = duplicate_pull_requests
-          elsif maybe_duplicate_pull_requests
+          elsif open_bump_pull_requests
             duplicate_pull_requests_text = "none"
-            maybe_duplicate_pull_requests_text = maybe_duplicate_pull_requests
+            open_bump_pull_requests_text = open_bump_pull_requests
           else
             duplicate_pull_requests_text = "none"
-            maybe_duplicate_pull_requests_text = "none"
+            open_bump_pull_requests_text = "none"
           end
 
           puts "Duplicate pull requests:  #{duplicate_pull_requests_text}"
-          if maybe_duplicate_pull_requests_text
-            puts "Maybe duplicate pull requests: #{maybe_duplicate_pull_requests_text}"
-          end
+          puts "Open bump pull requests:  #{open_bump_pull_requests_text}" if open_bump_pull_requests_text
         end
 
         if !args.open_pr? ||
@@ -544,7 +542,7 @@ module Homebrew
           return
         end
 
-        return if duplicate_pull_requests.present?
+        return if duplicate_pull_requests.present? || open_bump_pull_requests.present?
 
         version_args = version_args_for_bump(current_version:, new_version:, multiple_versions:, name:)
         return if version_args.blank?
@@ -818,6 +816,41 @@ module Homebrew
         end
       end
 
+      sig {
+        params(
+          formula_or_cask: T.any(Formula, Cask::Cask),
+          name:            String,
+          state:           T.nilable(String),
+          version:         T.nilable(String),
+        ).returns T.nilable(T.any(T::Array[String], String))
+      }
+      def retrieve_pull_requests(formula_or_cask, name, state: nil, version: nil)
+        tap_remote_repo = formula_or_cask.tap&.remote_repository || formula_or_cask.tap&.full_name
+        odie "unexpected nil tap remote repository" if tap_remote_repo.nil?
+
+        pull_requests = begin
+          GitHub.fetch_pull_requests(name, tap_remote_repo, state:, version:)
+        rescue GitHub::API::ValidationFailedError => e
+          odebug "Error fetching pull requests for #{formula_or_cask} #{name}: #{e}"
+          nil
+        end
+        return if pull_requests.blank?
+
+        # If a version is provided, we keep all matches in case a contributor has
+        # opened a PR with a non-standard title, e.g. "<name>: update to <version>".
+        # Otherwise, filter results to reduce false positives. The filter is still
+        # loose enough to allow synced formulae, e.g. "<name> <n2> ... <version>",
+        # and titles with parentheses, e.g. "<name> <version> (<extra-message>)"
+        if version.blank?
+          pull_requests.select! do |pr|
+            (title = pr["title"]) && title.start_with?("#{name} ") && title.exclude?(": ")
+          end
+          return if pull_requests.blank?
+        end
+
+        pull_requests.map { |pr| "#{pr["title"]} (#{Formatter.url(pr["html_url"])})" }.join(", ")
+      end
+
       private
 
       sig { params(formula_or_cask: T.any(Formula, Cask::Cask)).returns(T::Boolean) }
@@ -961,28 +994,6 @@ module Homebrew
         end
       rescue => e
         ["error: #{e}", nil]
-      end
-
-      sig {
-        params(
-          formula_or_cask: T.any(Formula, Cask::Cask),
-          name:            String,
-          version:         T.nilable(String),
-        ).returns T.nilable(T.any(T::Array[String], String))
-      }
-      def retrieve_pull_requests(formula_or_cask, name, version: nil)
-        tap_remote_repo = formula_or_cask.tap&.remote_repository || formula_or_cask.tap&.full_name
-        odie "unexpected nil tap remote repository" if tap_remote_repo.nil?
-
-        pull_requests = begin
-          GitHub.fetch_pull_requests(name, tap_remote_repo, version:)
-        rescue GitHub::API::ValidationFailedError => e
-          odebug "Error fetching pull requests for #{formula_or_cask} #{name}: #{e}"
-          nil
-        end
-        return if pull_requests.blank?
-
-        pull_requests.map { |pr| "#{pr["title"]} (#{Formatter.url(pr["html_url"])})" }.join(", ")
       end
 
       sig {

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -163,19 +163,19 @@ RSpec.describe Homebrew::DevCmd::Bump do
 
     it "passes arch-specific version arguments when a cask moves from one version to arch-specific versions" do
       version_info = Homebrew::DevCmd::Bump::VersionBumpInfo.new(
-        type:                          :cask,
-        deprecated:                    { general: false },
-        multiple_versions:             { current: false, new: true },
-        version_name:                  "cask version:   ",
-        current_version:               Homebrew::BumpVersionParser.new(general: Version.new("1.2.3")),
-        new_version:                   Homebrew::BumpVersionParser.new(
+        type:                    :cask,
+        deprecated:              { general: false },
+        multiple_versions:       { current: false, new: true },
+        version_name:            "cask version:   ",
+        current_version:         Homebrew::BumpVersionParser.new(general: Version.new("1.2.3")),
+        new_version:             Homebrew::BumpVersionParser.new(
           arm:   Version.new("1.2.5"),
           intel: Version.new("1.2.4"),
         ),
-        repology_latest:               "not found",
-        newer_than_upstream:           { general: false },
-        duplicate_pull_requests:       nil,
-        maybe_duplicate_pull_requests: nil,
+        repology_latest:         "not found",
+        newer_than_upstream:     { general: false },
+        duplicate_pull_requests: nil,
+        open_bump_pull_requests: nil,
       )
       allow(bump).to receive(:retrieve_versions_by_arch).and_return(version_info)
 
@@ -194,19 +194,19 @@ RSpec.describe Homebrew::DevCmd::Bump do
 
     it "passes arch-specific version arguments when an arch-specific cask moves to one version" do
       version_info = Homebrew::DevCmd::Bump::VersionBumpInfo.new(
-        type:                          :cask,
-        deprecated:                    { arm: false, intel: false },
-        multiple_versions:             { current: true, new: false },
-        version_name:                  "cask version:   ",
-        current_version:               Homebrew::BumpVersionParser.new(
+        type:                    :cask,
+        deprecated:              { arm: false, intel: false },
+        multiple_versions:       { current: true, new: false },
+        version_name:            "cask version:   ",
+        current_version:         Homebrew::BumpVersionParser.new(
           arm:   Version.new("1.2.3"),
           intel: Version.new("1.2.2"),
         ),
-        new_version:                   Homebrew::BumpVersionParser.new(general: Version.new("1.2.4")),
-        repology_latest:               "not found",
-        newer_than_upstream:           { arm: false, intel: false },
-        duplicate_pull_requests:       nil,
-        maybe_duplicate_pull_requests: nil,
+        new_version:             Homebrew::BumpVersionParser.new(general: Version.new("1.2.4")),
+        repology_latest:         "not found",
+        newer_than_upstream:     { arm: false, intel: false },
+        duplicate_pull_requests: nil,
+        open_bump_pull_requests: nil,
       )
       allow(bump).to receive(:retrieve_versions_by_arch).and_return(version_info)
 
@@ -225,17 +225,17 @@ RSpec.describe Homebrew::DevCmd::Bump do
 
     it "notes when a newer upstream version was skipped due to release cooldown" do
       version_info = Homebrew::DevCmd::Bump::VersionBumpInfo.new(
-        type:                          :formula,
-        deprecated:                    { general: false },
-        multiple_versions:             { current: false, new: false },
-        version_name:                  "formula version:",
-        current_version:               Homebrew::BumpVersionParser.new(general: Version.new("1.2.3")),
-        new_version:                   Homebrew::BumpVersionParser.new(general: Version.new("1.2.3")),
-        repology_latest:               "not found",
-        newer_than_upstream:           { general: false },
-        cooldown_skipped_versions:     { general: Version.new("1.2.4") },
-        duplicate_pull_requests:       nil,
-        maybe_duplicate_pull_requests: nil,
+        type:                      :formula,
+        deprecated:                { general: false },
+        multiple_versions:         { current: false, new: false },
+        version_name:              "formula version:",
+        current_version:           Homebrew::BumpVersionParser.new(general: Version.new("1.2.3")),
+        new_version:               Homebrew::BumpVersionParser.new(general: Version.new("1.2.3")),
+        repology_latest:           "not found",
+        newer_than_upstream:       { general: false },
+        cooldown_skipped_versions: { general: Version.new("1.2.4") },
+        duplicate_pull_requests:   nil,
+        open_bump_pull_requests:   nil,
       )
       allow(bump).to receive(:retrieve_versions_by_arch).and_return(version_info)
 
@@ -561,6 +561,44 @@ RSpec.describe Homebrew::DevCmd::Bump do
         .and_return([content, "", instance_double(Process::Status, success?: true)])
 
       expect(bump.version_with_cooldown(version_info, Version.new("1.2.2"))).to eq(Version.new("1.2.3"))
+    end
+  end
+
+  describe "::retrieve_pull_requests" do
+    let(:name) { "basic_formula" }
+    let(:tap_name) { "homebrew/tap" }
+    let(:version) { "1.2.3" }
+    let(:title) { "#{name} #{version}" }
+    let(:pull_url) { "https://github.com/Homebrew/homebrew-tap/pull" }
+    let(:pull_requests) { [] }
+
+    before do
+      allow(f_basic).to receive(:tap).and_return(Tap.fetch(tap_name))
+      allow(GitHub).to receive(:fetch_pull_requests).and_return(pull_requests)
+      add_pull_request(title, 100)
+    end
+
+    def add_pull_request(title, number)
+      pull_requests.append({
+        "number"   => number,
+        "title"    => title,
+        "state"    => "open",
+        "html_url" => "#{pull_url}/#{number}",
+      })
+    end
+
+    it "outputs all pull requests API returned when given a version" do
+      title_2 = "#{name}: update to #{version}"
+      add_pull_request(title_2, 101)
+      expect(bump.retrieve_pull_requests(f_basic, name, version:)).to eq(
+        "#{title} (#{pull_url}/100), #{title_2} (#{pull_url}/101)",
+      )
+    end
+
+    it "filters pull requests when not given a version" do
+      add_pull_request("#{name}: fix an issue with formula", 101)
+      add_pull_request("some other PR with #{name} #{version}", 102)
+      expect(bump.retrieve_pull_requests(f_basic, name)).to eq("#{title} (#{pull_url}/100)")
     end
   end
 end


### PR DESCRIPTION
Finding open PRs that follow standard bump title makes it possible to avoid multiple PRs for same formula/cask. Back-to-back PRs can lead to unwanted resetting of cooldowns that lead to delaying bumps and closing PRs that were actively being worked on with more progress than newly created PRs.

This replaces prior `maybe_duplicate_pull_requests` as keeping both will increase GitHub API usage which can lead to rate limits. The old query wasn't very useful as it would find every single PR with the name which could be 100+ resulting in excessively large list.

- https://github.com/Homebrew/homebrew-core/actions/runs/32753872611/job/97516824300#step:6:71

---

Main goal is to help with applying days throttle globally across repository. Right now, time-based throttle increases maintainer burden as once the throttle time passes, autobump is able to create back-to-back PRs if initial ones are not merged fast enough (and these end up causing more problems when combined with cooldown).

With change, if a new bump is wanted, then can either update existing PR, wait for stale close or manually close.

In general case, the pattern match should work. There may be some false positives/negatives though mainly if a non-standard PR title is used. Can review autobump output in future to see if needs to be improved.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
