### PR TITLE
livecheck/livecheck: rename some params to formula_or_cask

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -1143,19 +1143,19 @@ module Homebrew
       !throttle_days.nil? && throttle_interval_elapsed?(formula_or_cask, throttle_days)
     end
 
-    sig { params(package_or_resource: T.any(Formula, Cask::Cask)).returns(T.nilable(Integer)) }
-    def self.formula_or_cask_last_updated_timestamp(package_or_resource)
-      tap = package_or_resource.tap
+    sig { params(formula_or_cask: T.any(Formula, Cask::Cask)).returns(T.nilable(Integer)) }
+    def self.formula_or_cask_last_updated_timestamp(formula_or_cask)
+      tap = formula_or_cask.tap
       return if tap.nil?
       return unless tap.git?
       return unless Utils::Git.available?
 
-      if package_or_resource.is_a?(Formula)
-        timestamp = formula_last_version_update_timestamp(package_or_resource, tap:)
+      if formula_or_cask.is_a?(Formula)
+        timestamp = formula_last_version_update_timestamp(formula_or_cask, tap:)
         return timestamp if timestamp.present?
       end
 
-      formula_or_cask_last_commit_timestamp(package_or_resource, tap)
+      formula_or_cask_last_commit_timestamp(formula_or_cask, tap)
     end
 
     sig { params(formula: Formula, tap: Tap).returns(T.nilable(Integer)) }
@@ -1218,14 +1218,14 @@ module Homebrew
     end
 
     sig {
-      params(package_or_resource: T.any(Formula, Cask::Cask), tap: Tap).returns(T.nilable(Integer))
+      params(formula_or_cask: T.any(Formula, Cask::Cask), tap: Tap).returns(T.nilable(Integer))
     }
-    private_class_method def self.formula_or_cask_last_commit_timestamp(package_or_resource, tap)
-      sourcefile = case package_or_resource
+    private_class_method def self.formula_or_cask_last_commit_timestamp(formula_or_cask, tap)
+      sourcefile = case formula_or_cask
       when Formula
-        package_or_resource.path
+        formula_or_cask.path
       when Cask::Cask
-        package_or_resource.sourcefile_path
+        formula_or_cask.sourcefile_path
       end
       return if sourcefile.nil?
 
@@ -1287,11 +1287,11 @@ module Homebrew
       nil
     end
 
-    sig { params(package_or_resource: T.any(Formula, Cask::Cask), days: Integer).returns(T::Boolean) }
-    def self.throttle_interval_elapsed?(package_or_resource, days)
+    sig { params(formula_or_cask: T.any(Formula, Cask::Cask), days: Integer).returns(T::Boolean) }
+    def self.throttle_interval_elapsed?(formula_or_cask, days)
       return false if days <= 0
 
-      last_updated_timestamp = formula_or_cask_last_updated_timestamp(package_or_resource)
+      last_updated_timestamp = formula_or_cask_last_updated_timestamp(formula_or_cask)
       return false if last_updated_timestamp.nil?
 
       elapsed_seconds = Time.now.to_i - last_updated_timestamp


### PR DESCRIPTION
`package_or_resource` is used in other methods for `T.any(Formula, Cask::Cask, Resource)`.

The usage modified here are only `T.any(Formula, Cask::Cask)` and changing to `formula_or_cask` keeps same style in module.

Was working on some other changes and extracting minor touchups to separate PR to minimize diff.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
