### PR TITLE
utils/curl: fix curl_version memoization

### DIFF
--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -570,6 +570,14 @@ RSpec.describe "Utils::Curl" do
     it "returns a curl version string" do
       expect(curl_version).to match(/^v?(\d+(?:\.\d+)+)$/)
     end
+
+    it "only runs the curl subprocess on the first call" do
+      allow(self).to receive(:curl_path).and_return("/usr/bin/curl")
+      expect(self).to receive(:curl_output).once.and_return(
+        instance_double(SystemCommand::Result, stdout: "curl 8.7.1 (x86_64-apple-darwin)"),
+      )
+      2.times { expect(curl_version).to eq(Version.new("8.7.1")) }
+    end
   end
 
   describe "::curl_supports_fail_with_body?" do

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -697,12 +697,11 @@ module Utils
     sig { returns(Version) }
     def curl_version
       @curl_version ||= T.let({}, T.nilable(T::Hash[String, Version]))
-      curl_v_stdout = curl_output("-V").stdout
-      version = curl_v_stdout[/curl (\d+(?:\.\d+)+)/, 1]
-      if version
-        @curl_version[curl_path] ||= Version.new(version)
-      else
-        odie("Failed to parse curl version from #{curl_v_stdout}")
+      @curl_version[curl_path] ||= begin
+        curl_v_stdout = curl_output("-V").stdout
+        version = curl_v_stdout[/curl (\d+(?:\.\d+)+)/, 1]
+        odie("Failed to parse curl version from #{curl_v_stdout}") if version.nil?
+        Version.new(version)
       end
     end
 


### PR DESCRIPTION
`curl_version` memoized its result in a hash but the `||=` only guarded the hash write — the `curl -V` subprocess ran on **every** call and its output was usually discarded. This moves the subprocess inside the memoized block.

Each receiver now runs it once: one subprocess for a whole livecheck run instead of two per URL, and half as many per download.

<details>

Hyperfine 1.20.0, 20 runs each, 3 warmups; each script calls `curl_version` 50 times via `brew ruby`, with an empty `brew ruby` baseline to isolate startup cost:

| Benchmark | Mean ± σ |
|---|---|
| old (unmemoized), 50 calls | 2.584 s ± 0.146 s |
| new (memoized), 50 calls | 878.9 ms ± 41.9 ms |
| `brew ruby` baseline, 0 calls | 768.2 ms ± 46.8 ms |

The old code spent ~36 ms per call, every call; the new code pays that once and cached calls drop to ~0.2 µs (~100% saved per repeat call, ~94% of total overhead on this workload.
</details>

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Opus + Fable 5, manual review.

-----
