### PR TITLE
`rubocops/cask/url`: require each keyword parameter   on its own line

### DIFF
--- a/Library/Homebrew/rubocops/cask/url.rb
+++ b/Library/Homebrew/rubocops/cask/url.rb
@@ -52,8 +52,20 @@ module RuboCop
 
           return unless hash_node.hash_type?
 
-          # TODO: also enforce that each keyword parameter after the first
-          #       starts on its own line.
+          hash_node.each_child_node.each_cons(2) do |previous_parameter, parameter|
+            next if parameter.first_line > previous_parameter.last_line
+
+            add_offense(
+              parameter.source_range,
+              message: "Keyword URL parameter should be on a new indented line.",
+            ) do |corrector|
+              corrector.replace(
+                range_between(previous_parameter.source_range.end_pos, parameter.source_range.begin_pos),
+                ",\n#{" " * url_stanza.loc.column}",
+              )
+            end
+          end
+
           return if hash_node.first_line > url_stanza.last_line && hash_node.loc.column > stanza_node.loc.column
 
           add_offense(

--- a/Library/Homebrew/test/rubocops/cask/url_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_spec.rb
@@ -94,6 +94,74 @@ RSpec.describe RuboCop::Cop::Cask::Url, :config do
     CASK
   end
 
+  it "accepts multiple keyword parameters each on their own line" do
+    expect_no_offenses <<~CASK
+      cask "foo" do
+        url "https://example.com/download/foo-v1.2.0.dmg",
+            header: "Accept: application/octet-stream",
+            user_agent: :fake
+      end
+    CASK
+  end
+
+  it "reports an offense for a keyword parameter on the same line as another keyword parameter" do
+    expect_offense <<~CASK
+      cask "foo" do
+        url "https://example.com/download/foo-v1.2.0.dmg",
+            header: "Accept: application/octet-stream", user_agent: :fake
+                                                        ^^^^^^^^^^^^^^^^^ Keyword URL parameter should be on a new indented line.
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask "foo" do
+        url "https://example.com/download/foo-v1.2.0.dmg",
+            header: "Accept: application/octet-stream",
+            user_agent: :fake
+      end
+    CASK
+  end
+
+  it "reports an offense for a keyword splat on the same line as another keyword parameter" do
+    expect_offense <<~CASK
+      cask "foo" do
+        url "https://example.com/download/foo-v1.2.0.dmg",
+            header: "Accept: application/octet-stream", **options
+                                                        ^^^^^^^^^ Keyword URL parameter should be on a new indented line.
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask "foo" do
+        url "https://example.com/download/foo-v1.2.0.dmg",
+            header: "Accept: application/octet-stream",
+            **options
+      end
+    CASK
+  end
+
+  it "reports an offense for a keyword parameter on the last line of a multiline keyword parameter" do
+    expect_offense <<~CASK
+      cask "foo" do
+        url "https://example.com/download/foo-v1.2.0.dmg",
+            data: {
+              key: "value",
+            }, user_agent: :fake
+               ^^^^^^^^^^^^^^^^^ Keyword URL parameter should be on a new indented line.
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask "foo" do
+        url "https://example.com/download/foo-v1.2.0.dmg",
+            data: {
+              key: "value",
+            },
+            user_agent: :fake
+      end
+    CASK
+  end
+
   it "reports an offense for an http:// URL in homebrew-cask" do
     expect_offense <<~CASK, "/homebrew-cask/Casks/f/foo.rb"
       cask "foo" do


### PR DESCRIPTION
Ensure that every keyword parameter after the first in a Cask URL stanza starts on its own indented line. The cop now checks adjacent hash children in source order, including both regular keyword pairs and keyword splats, and autocorrects only the separator between them.

This completes the existing URL cop TODO and keeps Cask URL stanzas consistently formatted. Previously, only the first keyword parameter was required to start on a new line, so later parameters could remain on the same line without an offense.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
AI (Claude Code) was used to review the existing diff, and draft this PR description.
I reviewed its output and verified the changes with the targeted spec and `brew lgtm`.