### PR TITLE
Check domain age to be > 30 days in auditors

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -1127,6 +1127,16 @@ module Cask
     end
 
     sig { void }
+    def audit_homepage_domain_age
+      return unless new_cask?
+      return unless cask.tap&.official?
+      return unless (homepage = cask.homepage)
+
+      new_domain_problem = SharedAudits.new_domain_problem(homepage)
+      add_error new_domain_problem if new_domain_problem
+    end
+
+    sig { void }
     def audit_url_https_availability
       return unless online?
       return unless (url = cask.url)

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -663,6 +663,18 @@ module Homebrew
     end
 
     sig { void }
+    def audit_homepage_domain_age
+      return unless @core_tap
+      return unless @new_formula
+
+      homepage = formula.homepage
+      return if homepage.blank?
+
+      new_domain_problem = SharedAudits.new_domain_problem(homepage)
+      problem new_domain_problem if new_domain_problem
+    end
+
+    sig { void }
     def audit_duplicate_formula
       return unless @core_tap
       return unless @new_formula

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -593,6 +593,61 @@ RSpec.describe Cask::Audit, :cask do
       end
     end
 
+    describe "homepage domain age" do
+      let(:only) { ["homepage_domain_age"] }
+      let(:online) { true }
+      let(:cask) do
+        Cask::Cask.new("homepage-domain-age", tap: CoreCaskTap.instance) do
+          version "1.0"
+          sha256 :no_check
+          url "https://brew.sh/homepage-domain-age.tar.gz"
+          homepage "https://www.brew.sh"
+        end
+      end
+
+      before { allow(Date).to receive(:today).and_return(Date.new(2026, 7, 26)) }
+
+      context "when the homepage domain was registered less than 30 days ago" do
+        before do
+          allow(SharedAudits).to receive(:domain_registration_date)
+            .with("brew.sh").and_return(Date.new(2026, 7, 1))
+        end
+
+        it { is_expected.to error_with(/`homepage` domain `brew\.sh` was registered on 2026-07-01/) }
+      end
+
+      context "when the homepage domain was registered at least 30 days ago" do
+        before do
+          allow(SharedAudits).to receive(:domain_registration_date)
+            .with("brew.sh").and_return(Date.new(2026, 6, 26))
+        end
+
+        it { is_expected.to pass }
+      end
+
+      context "when the homepage domain registration date is unknown" do
+        before { allow(SharedAudits).to receive(:domain_registration_date).and_return(nil) }
+
+        it { is_expected.to pass }
+      end
+
+      context "when the cask is not in homebrew/cask" do
+        let(:cask) do
+          Cask::Cask.new("homepage-domain-age") do
+            version "1.0"
+            sha256 :no_check
+            url "https://brew.sh/homepage-domain-age.tar.gz"
+            homepage "https://www.brew.sh"
+          end
+        end
+
+        it "does not run `whois`" do
+          expect(SharedAudits).not_to receive(:domain_registration_date)
+          expect(run).to pass
+        end
+      end
+    end
+
     describe "artifact extraction" do
       let(:online) { true }
       let(:cask) do

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -595,54 +595,53 @@ RSpec.describe Cask::Audit, :cask do
 
     describe "homepage domain age" do
       let(:only) { ["homepage_domain_age"] }
-      let(:online) { true }
+      let(:new_cask) { true }
+      let(:domain_problem) { "`homepage` domain `brew.sh` was registered on 2026-07-01" }
       let(:cask) do
         Cask::Cask.new("homepage-domain-age", tap: CoreCaskTap.instance) do
           version "1.0"
           sha256 :no_check
           url "https://brew.sh/homepage-domain-age.tar.gz"
-          homepage "https://www.brew.sh"
+          homepage "https://brew.sh"
         end
       end
 
-      before { allow(Date).to receive(:today).and_return(Date.new(2026, 7, 26)) }
-
-      context "when the homepage domain was registered less than 30 days ago" do
+      context "when the homepage domain is newly registered" do
         before do
-          allow(SharedAudits).to receive(:domain_registration_date)
-            .with("brew.sh").and_return(Date.new(2026, 7, 1))
+          allow(SharedAudits).to receive(:new_domain_problem)
+            .with("https://brew.sh").and_return(domain_problem)
         end
 
-        it { is_expected.to error_with(/`homepage` domain `brew\.sh` was registered on 2026-07-01/) }
+        it { is_expected.to error_with(domain_problem) }
       end
 
-      context "when the homepage domain was registered at least 30 days ago" do
-        before do
-          allow(SharedAudits).to receive(:domain_registration_date)
-            .with("brew.sh").and_return(Date.new(2026, 6, 26))
-        end
+      context "when the homepage domain is established" do
+        before { allow(SharedAudits).to receive(:new_domain_problem).and_return(nil) }
 
         it { is_expected.to pass }
       end
 
-      context "when the homepage domain registration date is unknown" do
-        before { allow(SharedAudits).to receive(:domain_registration_date).and_return(nil) }
+      context "when the cask is not new" do
+        let(:new_cask) { false }
 
-        it { is_expected.to pass }
+        it "does not check the homepage domain" do
+          expect(SharedAudits).not_to receive(:new_domain_problem)
+          expect(run).to pass
+        end
       end
 
-      context "when the cask is not in homebrew/cask" do
+      context "when the cask is not in an official tap" do
         let(:cask) do
           Cask::Cask.new("homepage-domain-age") do
             version "1.0"
             sha256 :no_check
             url "https://brew.sh/homepage-domain-age.tar.gz"
-            homepage "https://www.brew.sh"
+            homepage "https://brew.sh"
           end
         end
 
-        it "does not run `whois`" do
-          expect(SharedAudits).not_to receive(:domain_registration_date)
+        it "does not check the homepage domain" do
+          expect(SharedAudits).not_to receive(:new_domain_problem)
           expect(run).to pass
         end
       end

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -141,58 +141,47 @@ RSpec.describe Homebrew::FormulaAuditor do
   end
 
   describe "#audit_homepage_domain_age" do
-    before { allow(Date).to receive(:today).and_return(Date.new(2026, 7, 26)) }
+    let(:domain_problem) { "`homepage` domain `brew.sh` was registered on 2026-07-01" }
 
-    def homepage_auditor(homepage, **options)
-      formula_auditor "foo", <<~RUBY, { online: true, core_tap: true }.merge(options)
+    def homepage_auditor(**options)
+      formula_auditor "foo", <<~RUBY, { core_tap: true, new_formula: true }.merge(options)
         class Foo < Formula
-          homepage "#{homepage}"
+          homepage "https://brew.sh"
           url "https://brew.sh/foo-1.0.tar.gz"
         end
       RUBY
     end
 
-    it "reports domains registered less than 30 days ago" do
-      allow(SharedAudits).to receive(:domain_registration_date)
-        .with("brew.sh").and_return(Date.new(2026, 7, 1))
+    it "reports newly registered homepage domains" do
+      allow(SharedAudits).to receive(:new_domain_problem)
+        .with("https://brew.sh").and_return(domain_problem)
 
-      fa = homepage_auditor "https://www.brew.sh"
+      fa = homepage_auditor
       fa.audit_homepage_domain_age
 
-      expect(fa.problems.first[:message])
-        .to include("`homepage` domain `brew.sh` was registered on 2026-07-01")
+      expect(fa.problems.first[:message]).to eq(domain_problem)
     end
 
-    it "accepts domains registered at least 30 days ago" do
-      allow(SharedAudits).to receive(:domain_registration_date)
-        .with("brew.sh").and_return(Date.new(2026, 6, 26))
+    it "accepts established homepage domains" do
+      allow(SharedAudits).to receive(:new_domain_problem).and_return(nil)
 
-      fa = homepage_auditor "https://brew.sh"
-      fa.audit_homepage_domain_age
-
-      expect(fa.problems).to be_empty
-    end
-
-    it "accepts domains with an unknown registration date" do
-      allow(SharedAudits).to receive(:domain_registration_date).and_return(nil)
-
-      fa = homepage_auditor "https://brew.sh"
+      fa = homepage_auditor
       fa.audit_homepage_domain_age
 
       expect(fa.problems).to be_empty
     end
 
-    it "does not run `whois` when offline" do
-      fa = homepage_auditor "https://brew.sh", online: false
+    it "does not check existing formulae" do
+      fa = homepage_auditor new_formula: false
 
-      expect(SharedAudits).not_to receive(:domain_registration_date)
+      expect(SharedAudits).not_to receive(:new_domain_problem)
       fa.audit_homepage_domain_age
     end
 
-    it "does not run `whois` outside homebrew/core" do
-      fa = homepage_auditor "https://brew.sh", core_tap: false
+    it "does not check formulae outside homebrew/core" do
+      fa = homepage_auditor core_tap: false
 
-      expect(SharedAudits).not_to receive(:domain_registration_date)
+      expect(SharedAudits).not_to receive(:new_domain_problem)
       fa.audit_homepage_domain_age
     end
   end

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -140,6 +140,63 @@ RSpec.describe Homebrew::FormulaAuditor do
     end
   end
 
+  describe "#audit_homepage_domain_age" do
+    before { allow(Date).to receive(:today).and_return(Date.new(2026, 7, 26)) }
+
+    def homepage_auditor(homepage, **options)
+      formula_auditor "foo", <<~RUBY, { online: true, core_tap: true }.merge(options)
+        class Foo < Formula
+          homepage "#{homepage}"
+          url "https://brew.sh/foo-1.0.tar.gz"
+        end
+      RUBY
+    end
+
+    it "reports domains registered less than 30 days ago" do
+      allow(SharedAudits).to receive(:domain_registration_date)
+        .with("brew.sh").and_return(Date.new(2026, 7, 1))
+
+      fa = homepage_auditor "https://www.brew.sh"
+      fa.audit_homepage_domain_age
+
+      expect(fa.problems.first[:message])
+        .to include("`homepage` domain `brew.sh` was registered on 2026-07-01")
+    end
+
+    it "accepts domains registered at least 30 days ago" do
+      allow(SharedAudits).to receive(:domain_registration_date)
+        .with("brew.sh").and_return(Date.new(2026, 6, 26))
+
+      fa = homepage_auditor "https://brew.sh"
+      fa.audit_homepage_domain_age
+
+      expect(fa.problems).to be_empty
+    end
+
+    it "accepts domains with an unknown registration date" do
+      allow(SharedAudits).to receive(:domain_registration_date).and_return(nil)
+
+      fa = homepage_auditor "https://brew.sh"
+      fa.audit_homepage_domain_age
+
+      expect(fa.problems).to be_empty
+    end
+
+    it "does not run `whois` when offline" do
+      fa = homepage_auditor "https://brew.sh", online: false
+
+      expect(SharedAudits).not_to receive(:domain_registration_date)
+      fa.audit_homepage_domain_age
+    end
+
+    it "does not run `whois` outside homebrew/core" do
+      fa = homepage_auditor "https://brew.sh", core_tap: false
+
+      expect(SharedAudits).not_to receive(:domain_registration_date)
+      fa.audit_homepage_domain_age
+    end
+  end
+
   describe "#audit_license" do
     let(:spdx_license_data) { SPDX.license_data }
     let(:spdx_exception_data) { SPDX.exception_data }

--- a/Library/Homebrew/test/utils/shared_audits_spec.rb
+++ b/Library/Homebrew/test/utils/shared_audits_spec.rb
@@ -74,6 +74,49 @@ RSpec.describe SharedAudits do
     end
   end
 
+  describe "::domain_registration_date" do
+    let(:whois_output) do
+      <<~WHOIS
+        % IANA WHOIS server
+        domain:       SH
+        created:      1997-09-23
+
+        Domain Name: brew.sh
+        Creation Date: 2013-03-22T15:50:45Z
+      WHOIS
+    end
+
+    before do
+      allow(described_class).to receive(:which).with("whois").and_return(Pathname("/usr/bin/whois"))
+    end
+
+    def mock_whois(stdout:, success: true)
+      status = instance_double(Process::Status, success?: success)
+      result = instance_double(SystemCommand::Result, stdout:, status:)
+      allow(SystemCommand).to receive(:run).and_return(result)
+    end
+
+    it "ignores the IANA record for the TLD and returns the domain creation date" do
+      mock_whois stdout: whois_output
+      expect(described_class.domain_registration_date("brew.sh")).to eq(Date.new(2013, 3, 22))
+    end
+
+    it "returns nil when no creation date can be parsed" do
+      mock_whois stdout: "No match for domain \"NOPE.INVALID\".\n"
+      expect(described_class.domain_registration_date("nope.invalid")).to be_nil
+    end
+
+    it "returns nil when `whois` fails" do
+      mock_whois stdout: "", success: false
+      expect(described_class.domain_registration_date("fails.example")).to be_nil
+    end
+
+    it "returns nil when `whois` is unavailable" do
+      allow(described_class).to receive(:which).with("whois").and_return(nil)
+      expect(described_class.domain_registration_date("missing.example")).to be_nil
+    end
+  end
+
   describe "::github_tag_from_url" do
     it "finds tags in archive urls" do
       url = "https://github.com/a/b/archive/refs/tags/v1.2.3.tar.gz"

--- a/Library/Homebrew/test/utils/shared_audits_spec.rb
+++ b/Library/Homebrew/test/utils/shared_audits_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe SharedAudits do
     end
   end
 
-  describe "::domain_registration_date" do
+  describe "::new_domain_problem" do
     let(:whois_output) do
       <<~WHOIS
         % IANA WHOIS server
@@ -82,11 +82,12 @@ RSpec.describe SharedAudits do
         created:      1997-09-23
 
         Domain Name: brew.sh
-        Creation Date: 2013-03-22T15:50:45Z
+        Creation Date: 2026-07-01T15:50:45Z
       WHOIS
     end
 
     before do
+      allow(Date).to receive(:today).and_return(Date.new(2026, 7, 26))
       allow(described_class).to receive(:which).with("whois").and_return(Pathname("/usr/bin/whois"))
     end
 
@@ -96,24 +97,60 @@ RSpec.describe SharedAudits do
       allow(SystemCommand).to receive(:run).and_return(result)
     end
 
-    it "ignores the IANA record for the TLD and returns the domain creation date" do
+    # The IANA record for the TLD is always ancient, so parsing must use the newest date.
+    it "reports domains registered less than 30 days ago, ignoring the IANA record for the TLD" do
       mock_whois stdout: whois_output
-      expect(described_class.domain_registration_date("brew.sh")).to eq(Date.new(2013, 3, 22))
+
+      expect(described_class.new_domain_problem("https://www.brew.sh/foo"))
+        .to include("`homepage` domain `brew.sh` was registered on 2026-07-01")
     end
 
-    it "returns nil when no creation date can be parsed" do
+    it "ignores domains registered at least 30 days ago" do
+      mock_whois stdout: whois_output.sub("2026-07-01T15:50:45Z", "2026-06-26T15:50:45Z")
+
+      expect(described_class.new_domain_problem("https://brew.sh")).to be_nil
+    end
+
+    it "ignores domains with no parseable creation date" do
       mock_whois stdout: "No match for domain \"NOPE.INVALID\".\n"
-      expect(described_class.domain_registration_date("nope.invalid")).to be_nil
+
+      expect(described_class.new_domain_problem("https://nope.invalid")).to be_nil
     end
 
-    it "returns nil when `whois` fails" do
+    it "ignores domains when `whois` fails" do
       mock_whois stdout: "", success: false
-      expect(described_class.domain_registration_date("fails.example")).to be_nil
+
+      expect(described_class.new_domain_problem("https://fails.example")).to be_nil
     end
 
-    it "returns nil when `whois` is unavailable" do
+    it "ignores domains when `whois` times out" do
+      allow(SystemCommand).to receive(:run).and_raise(Timeout::Error)
+
+      expect(described_class.new_domain_problem("https://slow.example")).to be_nil
+    end
+
+    it "ignores domains when `whois` is unavailable" do
       allow(described_class).to receive(:which).with("whois").and_return(nil)
-      expect(described_class.domain_registration_date("missing.example")).to be_nil
+
+      expect(described_class.new_domain_problem("https://missing.example")).to be_nil
+    end
+
+    it "ignores unparseable homepages" do
+      expect(described_class.new_domain_problem("not a url")).to be_nil
+    end
+
+    test_each(%w[
+      https://github.com/foo/bar
+      https://gitlab.com/foo/bar
+      https://bitbucket.org/foo/bar
+      https://codeberg.org/foo/bar
+      https://foo.github.io/bar
+      https://sr.ht/~foo/bar
+    ]) do |homepage|
+      it "does not run `whois` for the git forge homepage #{homepage}" do
+        expect(SystemCommand).not_to receive(:run)
+        expect(described_class.new_domain_problem(homepage)).to be_nil
+      end
     end
   end
 

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "system_command"
 require "utils/curl"
 require "utils/github/api"
 
@@ -12,6 +13,10 @@ module SharedAudits
   GITLAB_NOTABILITY_THRESHOLDS = T.let({ forks: 30, stars: 75 }.freeze, T::Hash[Symbol, Integer])
   BITBUCKET_NOTABILITY_THRESHOLDS = T.let({ forks: 30, watchers: 75 }.freeze, T::Hash[Symbol, Integer])
   FORGEJO_NOTABILITY_THRESHOLDS = T.let({ forks: 30, watchers: 30, stars: 75 }.freeze, T::Hash[Symbol, Integer])
+  NEW_DOMAIN_THRESHOLD_DAYS = 30
+  WHOIS_TIMEOUT_SECONDS = 5
+  WHOIS_CREATION_DATE_REGEX = /^\s*(?:creation\s+date|created(?:\s+on)?|registered(?:\s+on)?|
+                                registration\s+(?:date|time))\s*:\s*(\S+)/ix
   @pull_request_author = T.let(nil, T.nilable(String))
   @pull_request_author_computed = T.let(false, T::Boolean)
   @self_submission_cache = T.let({}, T::Hash[String, T::Boolean])
@@ -22,6 +27,53 @@ module SharedAudits
 
     today = Date.today
     browsed <= today && browsed.next_year > today
+  end
+
+  sig { params(homepage: String).returns(T.nilable(String)) }
+  def self.new_domain_problem(homepage)
+    host = begin
+      URI(homepage).host
+    rescue URI::InvalidURIError
+      nil
+    end
+    return if host.blank?
+
+    domain = host.delete_prefix("www.")
+    registered_on = domain_registration_date(domain)
+    return if registered_on.nil?
+    return if (Date.today - registered_on) >= NEW_DOMAIN_THRESHOLD_DAYS
+
+    "`homepage` domain `#{domain}` was registered on #{registered_on}: " \
+      "homepages should exist for at least #{NEW_DOMAIN_THRESHOLD_DAYS} days before inclusion"
+  end
+
+  sig { params(domain: String).returns(T.nilable(Date)) }
+  def self.domain_registration_date(domain)
+    @domain_registration_date ||= T.let({}, T.nilable(T::Hash[String, T.nilable(Date)]))
+    return @domain_registration_date[domain] if @domain_registration_date.key?(domain)
+
+    @domain_registration_date[domain] = whois_creation_date(domain)
+  end
+
+  sig { params(domain: String).returns(T.nilable(Date)) }
+  private_class_method def self.whois_creation_date(domain)
+    return if which("whois").nil?
+
+    result = SystemCommand.run("whois", args: [domain], print_stderr: false, timeout: WHOIS_TIMEOUT_SECONDS)
+    return unless result.status.success?
+
+    # `whois` may concatenate the IANA record for the TLD (whose creation date is
+    # always ancient) with the registry record for the domain, so use the newest date.
+    result.stdout.lines.filter_map do |line|
+      value = line[WHOIS_CREATION_DATE_REGEX, 1]
+      next if value.nil?
+
+      Date.parse(value)
+    rescue Date::Error
+      nil
+    end.max
+  rescue Timeout::Error
+    nil
   end
 
   sig { returns(T.nilable(String)) }

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -14,6 +14,15 @@ module SharedAudits
   BITBUCKET_NOTABILITY_THRESHOLDS = T.let({ forks: 30, watchers: 75 }.freeze, T::Hash[Symbol, Integer])
   FORGEJO_NOTABILITY_THRESHOLDS = T.let({ forks: 30, watchers: 30, stars: 75 }.freeze, T::Hash[Symbol, Integer])
   NEW_DOMAIN_THRESHOLD_DAYS = 30
+  GIT_FORGE_DOMAINS = %w[
+    bitbucket.org
+    codeberg.org
+    github.com
+    github.io
+    gitlab.com
+    gitlab.io
+    sr.ht
+  ].freeze
   WHOIS_TIMEOUT_SECONDS = 5
   WHOIS_CREATION_DATE_REGEX = /^\s*(?:creation\s+date|created(?:\s+on)?|registered(?:\s+on)?|
                                 registration\s+(?:date|time))\s*:\s*(\S+)/ix
@@ -39,32 +48,19 @@ module SharedAudits
     return if host.blank?
 
     domain = host.delete_prefix("www.")
-    registered_on = domain_registration_date(domain)
-    return if registered_on.nil?
-    return if (Date.today - registered_on) >= NEW_DOMAIN_THRESHOLD_DAYS
-
-    "`homepage` domain `#{domain}` was registered on #{registered_on}: " \
-      "homepages should exist for at least #{NEW_DOMAIN_THRESHOLD_DAYS} days before inclusion"
-  end
-
-  sig { params(domain: String).returns(T.nilable(Date)) }
-  def self.domain_registration_date(domain)
-    @domain_registration_date ||= T.let({}, T.nilable(T::Hash[String, T.nilable(Date)]))
-    return @domain_registration_date[domain] if @domain_registration_date.key?(domain)
-
-    @domain_registration_date[domain] = whois_creation_date(domain)
-  end
-
-  sig { params(domain: String).returns(T.nilable(Date)) }
-  private_class_method def self.whois_creation_date(domain)
+    return if GIT_FORGE_DOMAINS.any? { |forge| domain == forge || domain.end_with?(".#{forge}") }
     return if which("whois").nil?
 
-    result = SystemCommand.run("whois", args: [domain], print_stderr: false, timeout: WHOIS_TIMEOUT_SECONDS)
-    return unless result.status.success?
+    result = begin
+      SystemCommand.run("whois", args: [domain], print_stderr: false, timeout: WHOIS_TIMEOUT_SECONDS)
+    rescue Timeout::Error
+      nil
+    end
+    return if result.nil? || !result.status.success?
 
     # `whois` may concatenate the IANA record for the TLD (whose creation date is
     # always ancient) with the registry record for the domain, so use the newest date.
-    result.stdout.lines.filter_map do |line|
+    registered_on = result.stdout.lines.filter_map do |line|
       value = line[WHOIS_CREATION_DATE_REGEX, 1]
       next if value.nil?
 
@@ -72,8 +68,11 @@ module SharedAudits
     rescue Date::Error
       nil
     end.max
-  rescue Timeout::Error
-    nil
+    return if registered_on.nil?
+    return if (Date.today - registered_on) >= NEW_DOMAIN_THRESHOLD_DAYS
+
+    "`homepage` domain `#{domain}` was registered on #{registered_on}: " \
+      "homepages should exist for at least #{NEW_DOMAIN_THRESHOLD_DAYS} days before inclusion"
   end
 
   sig { returns(T.nilable(String)) }


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
Since not all software is distributed through git forges, those checks do not catch all project ages. This check will check the homepage domain age instead.