### PR TITLE
Add package manager caches and isolate them in CI

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -1,9 +1,11 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "find"
 require "utils/bottles"
 require "utils/output"
 require "installed_dependents"
+require "package_manager_cache"
 require "stringio"
 
 require "formula"
@@ -26,16 +28,13 @@ module Homebrew
 
       sig { params(pathname: Pathname).returns(T::Boolean) }
       def nested_cache?(pathname)
-        pathname.directory? && %w[
-          cargo_cache
-          go_cache
-          go_mod_cache
-          glide_home
-          java_cache
-          npm_cache
-          pip_cache
-          gclient_cache
-        ].include?(pathname.basename.to_s)
+        pathname.directory? && Homebrew::PackageManagerCache::DIRECTORIES.include?(pathname.basename.to_s)
+      end
+
+      sig { params(pathname: Pathname).returns(T::Boolean) }
+      def content_addressed_cache?(pathname)
+        pathname.directory? &&
+          Homebrew::PackageManagerCache::CONTENT_ADDRESSED_DIRECTORIES.include?(pathname.basename.to_s)
       end
 
       sig { params(pathname: Pathname).returns(T::Boolean) }
@@ -725,7 +724,17 @@ module Homebrew
 
         FileUtils.chmod_R 0755, path if self.class.go_cache_directory?(path) && !dry_run?
         next cleanup_path(path) { path.unlink } if self.class.incomplete?(path)
-        next cleanup_path(path) { FileUtils.rm_rf path } if self.class.nested_cache?(path)
+
+        if self.class.nested_cache?(path)
+          # Caches that verify their contents on every read stay safe to reuse
+          # between builds, so only prune their old files rather than wiping them.
+          if self.class.content_addressed_cache?(path)
+            prune_content_addressed_cache(path)
+          else
+            cleanup_path(path) { FileUtils.rm_rf path }
+          end
+          next
+        end
 
         if self.class.prune?(path, days)
           if path.file? || path.symlink?
@@ -742,6 +751,24 @@ module Homebrew
 
       cleanup_legacy_cask_downloads(Cask::Caskroom.casks) if full_cache_cleanup
       cleanup_unreferenced_downloads if cleanup_unreferenced
+    end
+
+    sig { params(path: Pathname).void }
+    def prune_content_addressed_cache(path)
+      files = Find.find(path.to_s).filter_map do |file|
+        file = Pathname(file)
+        file if file.file? && (scrub? || self.class.prune?(file, days))
+      end
+      return if files.empty?
+
+      @disk_cleanup_size += files.sum(&:disk_usage)
+      count = Utils.pluralize("file", files.count, include_count: true)
+      if dry_run?
+        @output.puts "Would prune #{count} from: #{path}"
+      else
+        @output.puts "Pruning #{count} from: #{path}..."
+        files.each(&:unlink)
+      end
     end
 
     sig { params(path: Pathname, _block: T.proc.void).void }

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -41,6 +41,7 @@ require "find"
 require "install_steps"
 require "utils/spdx"
 require "on_system"
+require "package_manager_cache"
 require "api"
 require "api_hashable"
 require "release_cooldown"
@@ -3741,27 +3742,22 @@ class Formula
   # Common environment variables used by sandboxed build, test and postinstall phases.
   sig { params(home: Pathname).returns(T::Hash[Symbol, String]) }
   def common_sandbox_env(home)
-    {
-      _JAVA_OPTIONS:           "-Duser.home=#{HOMEBREW_CACHE}/java_cache",
-      GOCACHE:                 "#{HOMEBREW_CACHE}/go_cache",
+    Homebrew::PackageManagerCache.env.merge(
       GIT_CONFIG_GLOBAL:       Utils::Git.no_global_config_file,
       GIT_TERMINAL_PROMPT:     "0",
       GOENV:                   "off",
-      GOPATH:                  "#{HOMEBREW_CACHE}/go_mod_cache",
-      CARGO_HOME:              "#{HOMEBREW_CACHE}/cargo_cache",
       # TODO: Enable when `min-publish-age` stabilises in Cargo 1.100,
       # expected with Rust 1.100 on 2026-11-12.
       # https://github.com/rust-lang/cargo/pull/17335
       # CARGO_REGISTRY_GLOBAL_MIN_PUBLISH_AGE: Utils.pluralize("day", Homebrew::RELEASE_COOLDOWN_DAYS,
       #                                                        include_count: true),
       BUNDLE_COOLDOWN:         Homebrew::RELEASE_COOLDOWN_DAYS.to_s,
-      PIP_CACHE_DIR:           "#{HOMEBREW_CACHE}/pip_cache",
       PIP_CONFIG_FILE:         File::NULL,
       NPM_CONFIG_USERCONFIG:   File::NULL,
       CURL_HOME:               ENV.fetch("CURL_HOME") { home.to_s },
       PYTHONDONTWRITEBYTECODE: "1",
       XDG_CONFIG_HOME:         "#{home}/.config",
-    }
+    )
   end
 
   private

--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "package_manager_cache"
 require "release_cooldown"
 require "utils/output"
 require "utils/path"
@@ -19,7 +20,7 @@ module Language
 
     sig { returns(String) }
     def self.npm_cache_config
-      "cache=#{HOMEBREW_CACHE}/npm_cache"
+      "cache=#{Homebrew::PackageManagerCache.path("npm_cache")}"
     end
 
     sig { params(ignore_scripts: T::Boolean).returns(T::Array[String]) }

--- a/Library/Homebrew/package_manager_cache.rb
+++ b/Library/Homebrew/package_manager_cache.rb
@@ -1,0 +1,70 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Homebrew
+  # Caches of the language package managers used by sandboxed fetch, build,
+  # test and postinstall phases, shared between formula builds.
+  module PackageManagerCache
+    DIRECTORIES = %w[
+      bundler_cache
+      cabal_cache
+      cargo_cache
+      composer_cache
+      gclient_cache
+      gem_cache
+      glide_home
+      go_cache
+      go_mod_cache
+      hex_cache
+      java_cache
+      npm_cache
+      nuget_cache
+      pip_cache
+      pnpm_cache
+      uv_cache
+      yarn_cache
+      zig_cache
+    ].freeze
+
+    # Caches whose package managers verify content hashes on every read, so
+    # tampered or stale entries are rejected rather than used. These are safe
+    # to keep between builds.
+    CONTENT_ADDRESSED_DIRECTORIES = %w[
+      npm_cache
+      pnpm_cache
+    ].freeze
+
+    sig { params(name: String).returns(Pathname) }
+    def self.path(name)
+      raise ArgumentError, "Unknown package manager cache: #{name}" unless DIRECTORIES.include?(name)
+
+      HOMEBREW_CACHE/name
+    end
+
+    sig { returns(T::Array[Pathname]) }
+    def self.paths = DIRECTORIES.map { |name| path(name) }
+
+    sig { returns(T::Hash[Symbol, String]) }
+    def self.env
+      {
+        _JAVA_OPTIONS:           "-Duser.home=#{path("java_cache")}",
+        BUNDLE_GLOBAL_GEM_CACHE: "true",
+        BUNDLE_USER_CACHE:       path("bundler_cache").to_s,
+        CABAL_DIR:               path("cabal_cache").to_s,
+        CARGO_HOME:              path("cargo_cache").to_s,
+        COMPOSER_CACHE_DIR:      path("composer_cache").to_s,
+        GEM_SPEC_CACHE:          path("gem_cache").to_s,
+        GOCACHE:                 path("go_cache").to_s,
+        GOPATH:                  path("go_mod_cache").to_s,
+        HEX_HOME:                path("hex_cache").to_s,
+        NPM_CONFIG_CACHE:        path("npm_cache").to_s,
+        NPM_CONFIG_STORE_DIR:    path("pnpm_cache").to_s,
+        NUGET_PACKAGES:          path("nuget_cache").to_s,
+        PIP_CACHE_DIR:           path("pip_cache").to_s,
+        UV_CACHE_DIR:            path("uv_cache").to_s,
+        YARN_CACHE_FOLDER:       path("yarn_cache").to_s,
+        ZIG_GLOBAL_CACHE_DIR:    path("zig_cache").to_s,
+      }
+    end
+  end
+end

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -601,6 +601,32 @@ RSpec.describe Homebrew::Cleanup do
       expect(go_cache).not_to exist
     end
 
+    it "cleans up 'bundler_cache'" do
+      bundler_cache = (HOMEBREW_CACHE/"bundler_cache")
+      bundler_cache.mkpath
+
+      cleanup.cleanup_cache
+
+      expect(bundler_cache).not_to exist
+    end
+
+    it "prunes only old files from the content-addressed 'npm_cache'" do
+      npm_cache = (HOMEBREW_CACHE/"npm_cache")
+      old_file = npm_cache/"_cacache/old"
+      new_file = npm_cache/"_cacache/new"
+      [old_file, new_file].each do |file|
+        file.dirname.mkpath
+        file.write ""
+      end
+      allow(described_class).to receive(:prune?).and_return(false)
+      allow(described_class).to receive(:prune?).with(old_file, anything).and_return(true)
+
+      cleanup.cleanup_cache
+
+      expect(old_file).not_to exist
+      expect(new_file).to exist
+    end
+
     it "cleans up 'glide_home'" do
       glide_home = (HOMEBREW_CACHE/"glide_home")
       glide_home.mkpath
@@ -619,13 +645,13 @@ RSpec.describe Homebrew::Cleanup do
       expect(java_cache).not_to exist
     end
 
-    it "cleans up 'npm_cache'" do
+    it "keeps the content-addressed 'npm_cache'" do
       npm_cache = (HOMEBREW_CACHE/"npm_cache")
       npm_cache.mkpath
 
       cleanup.cleanup_cache
 
-      expect(npm_cache).not_to exist
+      expect(npm_cache).to exist
     end
 
     it "cleans up 'gclient_cache'" do

--- a/Library/Homebrew/test/package_manager_cache_spec.rb
+++ b/Library/Homebrew/test/package_manager_cache_spec.rb
@@ -1,0 +1,25 @@
+# typed: true
+# frozen_string_literal: true
+
+require "package_manager_cache"
+
+RSpec.describe Homebrew::PackageManagerCache do
+  describe "::path" do
+    it "keeps every cache under HOMEBREW_CACHE" do
+      expect(described_class.path("cargo_cache")).to eq(HOMEBREW_CACHE/"cargo_cache")
+    end
+
+    it "rejects unknown caches" do
+      expect { described_class.path("foo_cache") }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "::env" do
+    it "points every package manager at a known cache" do
+      known_paths = described_class.paths.map(&:to_s)
+      cache_env = described_class.env.except(:_JAVA_OPTIONS, :BUNDLE_GLOBAL_GEM_CACHE)
+
+      expect(cache_env.values - known_paths).to be_empty
+    end
+  end
+end

--- a/Library/Homebrew/test/test_bot/test_formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/test_formulae_spec.rb
@@ -9,6 +9,22 @@ RSpec.describe Homebrew::TestBot::TestFormulae do
     described_class.new(tap: nil, git: nil, dry_run: false, fail_fast: false, verbose: false)
   end
 
+  describe "#cleanup_package_manager_caches" do
+    it "removes caches that do not verify their contents but keeps content-addressed ones" do
+      read_only = HOMEBREW_CACHE/"go_mod_cache/read-only"
+      read_only.mkpath
+      read_only.chmod(0555)
+      (HOMEBREW_CACHE/"npm_cache").mkpath
+
+      with_env(HOMEBREW_GITHUB_ACTIONS: "1") do
+        test_formulae.cleanup_package_manager_caches
+      end
+
+      expect(HOMEBREW_CACHE/"go_mod_cache").not_to exist
+      expect(HOMEBREW_CACHE/"npm_cache").to exist
+    end
+  end
+
   describe "#artifact_cache_valid?" do
     it "rejects a bottle when a local patch has changed" do
       Dir.mktmpdir do |tmpdir|

--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -71,6 +71,7 @@ module Homebrew
           if testing_portable_ruby?
             portable_formula!(f, args:)
           else
+            cleanup_package_manager_caches
             formula!(f, args:)
           end
           puts

--- a/Library/Homebrew/test_bot/formulae_dependents.rb
+++ b/Library/Homebrew/test_bot/formulae_dependents.rb
@@ -76,6 +76,7 @@ module Homebrew
         end
 
         @dependent_testing_formulae.each do |formula_name|
+          cleanup_package_manager_caches
           dependent_formulae!(formula_name, args:)
           puts
         end

--- a/Library/Homebrew/test_bot/test_formulae.rb
+++ b/Library/Homebrew/test_bot/test_formulae.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "package_manager_cache"
 require "trust"
 
 module Homebrew
@@ -108,6 +109,20 @@ module Homebrew
         download_artifacts_from_previous_run!(artifact_pattern, dry_run:)
       rescue GitHub::API::AuthenticationFailedError => e
         opoo e
+      end
+
+      # A build could poison the package manager caches for the builds after
+      # it, so start each one with only the caches that verify their contents.
+      sig { void }
+      def cleanup_package_manager_caches
+        return if ENV["HOMEBREW_GITHUB_ACTIONS"].blank?
+
+        paths = Homebrew::PackageManagerCache.paths.select(&:exist?).reject do |path|
+          Homebrew::PackageManagerCache::CONTENT_ADDRESSED_DIRECTORIES.include?(path.basename.to_s)
+        end
+        # Go makes its module cache read-only.
+        paths.each { |path| FileUtils.chmod_R("u+w", path, force: true) }
+        FileUtils.rm_rf paths
       end
 
       protected


### PR DESCRIPTION
- Bundler, RubyGems, Cabal, NuGet, Zig, Hex, Composer, uv, yarn and pnpm had no cache under `HOMEBREW_CACHE`, so their downloads were lost with the build directory every time.
- `Homebrew::PackageManagerCache` is the single list used by the sandbox environment, `std_npm_args` and `brew cleanup`.
- A build could poison these caches for the builds after it, so `brew test-bot` removes the ones that do not verify their contents before each formula and dependent.
- Only content-addressed caches (npm, pnpm) verify on every read, so `brew cleanup` now prunes their old files instead of wiping them and they alone persist between CI jobs.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Fable 5 xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----