### PR TITLE
Add formula `fetch` phase run before `install`

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -147,12 +147,15 @@ class Build
 
       formula.update_head_version
 
+      staged = staging_path.present? && !fetch_phase?
       formula.brew(
         fetch:         false,
         keep_tmp:      args.keep_tmp?,
         debug_symbols: args.debug_symbols?,
         interactive:   args.interactive?,
-      ) do
+        staging_path:,
+        staged:,
+      ) do |_formula, staging|
         with_env(
           # For head builds, HOMEBREW_FORMULA_PREFIX should include the commit,
           # which is not known until after the formula has been staged.
@@ -165,13 +168,24 @@ class Build
           # https://github.com/Homebrew/homebrew-core/pull/87470
           TZ:                         "UTC0",
         ) do
-          if args.git?
-            formula.selective_patch(is_data: false)
-            system "git", "init"
-            system "git", "add", "-A"
-            formula.selective_patch(is_data: true)
-          else
-            formula.patch
+          unless staged
+            if args.git?
+              formula.selective_patch(is_data: false)
+              system "git", "init"
+              system "git", "add", "-A"
+              formula.selective_patch(is_data: true)
+            else
+              formula.patch
+            end
+          end
+
+          if fetch_phase?
+            formula.with_logging("fetch") { formula.fetch }
+            if staging_path
+              staging.quiet!
+              staging.retain!
+            end
+            next
           end
 
           if args.interactive?
@@ -218,6 +232,19 @@ class Build
       end
     end
   end
+
+  # Keep these environment variables in sync with `FormulaInstaller#build`
+  # and `FormulaInstaller#run_fetch`.
+  sig { returns(T.nilable(Pathname)) }
+  def staging_path
+    path = ENV.fetch("HOMEBREW_BUILD_STAGING_PATH", nil)
+    return if path.nil?
+
+    Pathname(path)
+  end
+
+  sig { returns(T::Boolean) }
+  def fetch_phase? = ENV["HOMEBREW_BUILD_FETCH_PHASE"].present?
 
   sig { returns(T::Array[Symbol]) }
   def detect_stdlibs

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -9,6 +9,7 @@ require "api/formula_bottle"
 require "cask/config"
 require "cask/download"
 require "download_queue"
+require "formula_installer"
 
 module Homebrew
   module Cmd
@@ -99,6 +100,8 @@ module Homebrew
         end.uniq
 
         os_arch_combinations = args.os_arch_combinations
+        current_os_arch = [SimulateSystem.current_os, SimulateSystem.current_arch]
+        fetch_hook_formulae = T.let([], T::Array[Formula])
 
         puts "Fetching: #{bucket * ", "}" if bucket.size > 1
         bucket.each do |formula_or_cask|
@@ -158,6 +161,7 @@ module Homebrew
                 end
 
                 formula.enqueue_resources_and_patches(download_queue:)
+                fetch_hook_formulae << formula if [os, arch] == current_os_arch
               end
             end
           when Cask::Cask
@@ -168,6 +172,8 @@ module Homebrew
         end
 
         download_queue.fetch
+
+        fetch_hook_formulae.each { |formula| run_fetch_hook(formula) }
       ensure
         download_queue.shutdown
       end
@@ -231,6 +237,35 @@ module Homebrew
         end
 
         downloads
+      end
+
+      # A formula's `fetch` runs in the build environment, so it needs the
+      # dependencies that `build.rb` would put on `PATH` to be installed.
+      sig { params(formula: Formula).void }
+      def run_fetch_hook(formula)
+        formula = Homebrew::API::Formula.source_download_formula(formula) if formula.loaded_from_api?
+        return unless formula.fetch_defined?
+
+        missing_dependencies = formula.recursive_dependencies do |_dependent, dependency|
+          next Dependable::PRUNE if dependency.implicit? || dependency.optional?
+          next Dependable::PRUNE if dependency.test? && !dependency.build?
+        end.map(&:to_formula).reject(&:any_version_installed?)
+        if missing_dependencies.present?
+          opoo <<~EOS
+            Not running #{formula.full_name}'s `fetch` as these dependencies are not installed:
+              #{missing_dependencies.map(&:full_name).join(", ")}
+            Install them first with:
+              brew install --only-dependencies #{formula.full_name}
+          EOS
+          return
+        end
+
+        FormulaInstaller.new(
+          formula,
+          build_from_source_formulae: args.build_from_source_formulae,
+          force_bottle:               args.force_bottle?,
+          **{ debug: args.debug?, quiet: args.quiet?, verbose: args.verbose? }.compact,
+        ).run_fetch
       end
 
       private

--- a/Library/Homebrew/debrew.rb
+++ b/Library/Homebrew/debrew.rb
@@ -13,6 +13,11 @@ module Debrew
     end
 
     sig { void }
+    def fetch
+      Debrew.debrew { super }
+    end
+
+    sig { void }
     def patch
       Debrew.debrew { super }
     end

--- a/Library/Homebrew/download_strategy/abstract_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/abstract_download_strategy.rb
@@ -120,7 +120,6 @@ class AbstractDownloadStrategy
       yield
     end
   end
-  private :chdir
 
   # Returns the most recent modified time for all files in the current working directory after stage.
   #

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1573,6 +1573,38 @@ class Formula
 
   delegate pour_bottle_check_unsatisfied_reason: :"self.class"
 
+  # Downloads what {#install} needs from the network, e.g. with a language
+  # package manager, before building from source. It runs after the source has
+  # been unpacked and patched into {#buildpath}, with the same build
+  # environment as {#install} and with network access, and may write to
+  # {#buildpath} and the package manager caches in `HOMEBREW_CACHE`. When it
+  # is defined, {#install} runs in the same {#buildpath} without network
+  # access and with the rest of `HOMEBREW_CACHE` read-only, so it must use the
+  # package manager's offline mode. `brew fetch --build-from-source` also runs
+  # it once the dependencies are installed. It is never run when installing a
+  # bottle.
+  #
+  # ### Example
+  #
+  # ```ruby
+  # def fetch
+  #   system "cargo", "fetch", "--locked"
+  # end
+  #
+  # def install
+  #   system "cargo", "install", "--offline", *std_cargo_args
+  # end
+  # ```
+  #
+  # @api public
+  sig { overridable.void }
+  def fetch; end
+
+  sig { returns(T::Boolean) }
+  def fetch_defined?
+    method(:fetch).owner != Formula
+  end
+
   # odeprecated
   sig { overridable.void }
   def post_install; end
@@ -1856,14 +1888,19 @@ class Formula
 
   # Yields `|self,staging|` with current working directory set to the uncompressed tarball
   # where staging is a {Mktemp} staging context.
+  # With `staging_path`, the tarball is uncompressed into that directory rather
+  # than a fresh temporary one and, with `staged`, its already uncompressed and
+  # patched contents are reused so the fetch and build phases share it.
   sig(:final) {
     params(fetch: T::Boolean, keep_tmp: T::Boolean, debug_symbols: T::Boolean, interactive: T::Boolean,
+           staging_path: T.nilable(Pathname), staged: T::Boolean,
            _blk: T.proc.params(arg0: Formula, arg1: Mktemp).void).void
   }
-  def brew(fetch: true, keep_tmp: false, debug_symbols: false, interactive: false, &_blk)
+  def brew(fetch: true, keep_tmp: false, debug_symbols: false, interactive: false, staging_path: nil,
+           staged: false, &_blk)
     @prefix_returns_versioned_prefix = T.let(true, T.nilable(T::Boolean))
     active_spec.fetch if fetch
-    stage(interactive:, debug_symbols:) do |staging|
+    stage(interactive:, debug_symbols:, staging_path:, staged:) do |staging|
       staging.retain! if keep_tmp || debug_symbols
 
       prepare_patches
@@ -3739,7 +3776,7 @@ class Formula
     T.must(bottle).tab_attributes
   end
 
-  # Common environment variables used by sandboxed build, test and postinstall phases.
+  # Common environment variables used by sandboxed fetch, build, test and postinstall phases.
   sig { params(home: Pathname).returns(T::Hash[Symbol, String]) }
   def common_sandbox_env(home)
     Homebrew::PackageManagerCache.env.merge(
@@ -3806,9 +3843,12 @@ class Formula
     exit! 1 # never gets here unless exec threw or failed
   end
 
-  sig { params(interactive: T::Boolean, debug_symbols: T::Boolean, _block: T.proc.params(arg0: Mktemp).void).void }
-  def stage(interactive: false, debug_symbols: false, &_block)
-    active_spec.stage(debug_symbols:) do |staging|
+  sig {
+    params(interactive: T::Boolean, debug_symbols: T::Boolean, staging_path: T.nilable(Pathname), staged: T::Boolean,
+           _block: T.proc.params(arg0: Mktemp).void).void
+  }
+  def stage(interactive: false, debug_symbols: false, staging_path: nil, staged: false, &_block)
+    active_spec.stage(debug_symbols:, staging_path:, staged:) do |staging|
       @source_modified_time = T.let(active_spec.source_modified_time, T.nilable(Time))
       @buildpath = T.let(Pathname.pwd, T.nilable(Pathname))
       env_home = T.must(buildpath)/".brew_home"

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -16,6 +16,8 @@ require "cache_store"
 require "download_queue"
 require "linkage_checker"
 require "messages"
+require "mktemp"
+require "package_manager_cache"
 require "cask/caskroom"
 require "cmd/install"
 require "find"
@@ -1139,38 +1141,36 @@ on_request: installed_on_request?, options:)
     # load. See: https://github.com/orgs/Homebrew/discussions/6455
     @formula = Homebrew::API::Formula.source_download_formula(formula) if formula.loaded_from_api?
 
+    formula_path = T.must(formula.specified_path)
+    staging_path = (create_staging_path if formula.fetch_defined?)
+    run_fetch(staging_path:) if staging_path
+
     # 1. formulae can modify ENV, so we must ensure that each
     #    installation has a pristine ENV when it starts, forking now is
     #    the easiest way to do this
-    formula_path = formula.specified_path
-    args = [
-      "nice",
-      *HOMEBREW_RUBY_EXEC_ARGS,
-      "--",
-      HOMEBREW_LIBRARY_PATH/"build.rb",
-      formula_path,
-    ].concat(build_argv)
-
-    Sandbox.run_or_fork(*args, step: "building") do |sandbox|
-      sandbox.allow_read_if_exists path: formula_path
-      if Homebrew::EnvConfig.require_tap_trust?
-        require "trust"
-        sandbox.allow_read_if_exists path: Homebrew::Trust.trust_file
+    with_env(HOMEBREW_BUILD_STAGING_PATH: staging_path, HOMEBREW_BUILD_FETCH_PHASE: nil) do
+      Sandbox.run_or_fork(*build_args(formula_path), step: "building") do |sandbox|
+        add_build_sandbox_rules(sandbox, formula_path, log_name: "build")
+        if interactive?
+          sandbox.allow_write_path(Dir.home)
+        else
+          sandbox.deny_read_home
+        end
+        sandbox.allow_write_xcode
+        sandbox.allow_write_cellar(formula)
+        if staging_path
+          # `fetch` has already downloaded everything, so `install` stays
+          # offline and off the download cache apart from the package manager
+          # caches, which their offline modes still write to.
+          sandbox.allow_write_path(HOMEBREW_TEMP)
+          sandbox.allow_write_path(staging_path)
+          Homebrew::PackageManagerCache.paths.each { |path| sandbox.allow_write_path(path) }
+          sandbox.deny_all_network
+        else
+          sandbox.allow_write_temp_and_cache
+          sandbox.deny_all_network unless formula.network_access_allowed?(:build)
+        end
       end
-      formula.logs.mkpath
-      sandbox.record_log(formula.logs/"build.sandbox.log")
-      if interactive?
-        sandbox.allow_write_path(Dir.home)
-      else
-        sandbox.deny_read_home
-      end
-      sandbox.allow_write_temp_and_cache
-      sandbox.allow_write_log(formula)
-      sandbox.allow_cvs
-      sandbox.allow_fossil
-      sandbox.allow_write_xcode
-      sandbox.allow_write_cellar(formula)
-      sandbox.deny_all_network unless formula.network_access_allowed?(:build)
     end
 
     formula.update_head_version
@@ -1190,6 +1190,62 @@ on_request: installed_on_request?, options:)
       formula.rack.rmdir_if_possible
     end
     raise e
+  ensure
+    # The build child removes the shared staging directory unless it has to
+    # be kept, so this only matters when no child got as far as staging.
+    FileUtils.rm_rf(staging_path) if staging_path && !keep_tmp? && !debug_symbols? && !interactive? && !debug?
+  end
+
+  # Runs the formula's `fetch` method with network access before `install`
+  # builds from source; `brew fetch --build-from-source` also runs it.
+  sig { params(staging_path: T.nilable(Pathname)).void }
+  def run_fetch(staging_path: nil)
+    @formula = Homebrew::API::Formula.source_download_formula(formula) if formula.loaded_from_api?
+
+    formula_path = T.must(formula.specified_path)
+    with_env(HOMEBREW_BUILD_FETCH_PHASE: "1", HOMEBREW_BUILD_STAGING_PATH: staging_path) do
+      Sandbox.run_or_fork(*build_args(formula_path), step: "fetching") do |sandbox|
+        add_build_sandbox_rules(sandbox, formula_path, log_name: "fetch")
+        sandbox.deny_read_home
+        sandbox.allow_write_temp_and_cache
+        sandbox.allow_write_path(staging_path) if staging_path
+      end
+    end
+  end
+
+  sig { params(formula_path: Pathname).returns(T::Array[T.any(String, Pathname)]) }
+  def build_args(formula_path)
+    [
+      "nice",
+      *HOMEBREW_RUBY_EXEC_ARGS,
+      "--",
+      HOMEBREW_LIBRARY_PATH/"build.rb",
+      formula_path,
+      *build_argv,
+    ]
+  end
+
+  sig { params(sandbox: Sandbox, formula_path: Pathname, log_name: String).void }
+  def add_build_sandbox_rules(sandbox, formula_path, log_name:)
+    sandbox.allow_read_if_exists path: formula_path
+    if Homebrew::EnvConfig.require_tap_trust?
+      require "trust"
+      sandbox.allow_read_if_exists path: Homebrew::Trust.trust_file
+    end
+    formula.logs.mkpath
+    sandbox.record_log(formula.logs/"#{log_name}.sandbox.log")
+    sandbox.allow_write_log(formula)
+    sandbox.allow_cvs
+    sandbox.allow_fossil
+  end
+
+  # The fetch and build phases run in separate sandboxes, so unpack the source
+  # once into a directory that outlives both.
+  sig { returns(Pathname) }
+  def create_staging_path
+    staging = Mktemp.new(formula.name, retain: true, retain_in_cache: debug_symbols?)
+    staging.quiet!
+    staging.run(chdir: false) { |mktemp| T.must(mktemp.tmpdir) }
   end
 
   sig { params(keg: Keg).void }

--- a/Library/Homebrew/mktemp.rb
+++ b/Library/Homebrew/mktemp.rb
@@ -13,9 +13,12 @@ class Mktemp
   sig { returns(T.nilable(Pathname)) }
   attr_reader :tmpdir
 
-  sig { params(prefix: String, retain: T::Boolean, retain_in_cache: T::Boolean).void }
-  def initialize(prefix, retain: false, retain_in_cache: false)
+  # With `path`, reuse that existing directory (e.g. one shared between the
+  # fetch and build phases) rather than creating a temporary one.
+  sig { params(prefix: String, retain: T::Boolean, retain_in_cache: T::Boolean, path: T.nilable(Pathname)).void }
+  def initialize(prefix, retain: false, retain_in_cache: false, path: nil)
     @prefix = prefix
+    @path = path
     @retain_in_cache = retain_in_cache
     @retain = T.let(retain || @retain_in_cache, T::Boolean)
     @quiet = T.let(false, T::Boolean)
@@ -58,8 +61,30 @@ class Mktemp
     ).returns(T.type_parameter(:U))
   }
   def run(chdir: true, &_block)
+    @tmpdir = @path || create_tmpdir
+
+    begin
+      if chdir
+        Dir.chdir(@tmpdir) { yield self }
+      else
+        yield self
+      end
+    ensure
+      ignore_interrupts { chmod_rm_rf(@tmpdir) } unless retain?
+    end
+  ensure
+    if retain? && @tmpdir.present? && !@quiet
+      message = retain_in_cache? ? "Source files for debugging available at:" : "Temporary files retained at:"
+      ohai message, @tmpdir.to_s
+    end
+  end
+
+  private
+
+  sig { returns(Pathname) }
+  def create_tmpdir
     prefix_name = @prefix.tr "@", "AT"
-    @tmpdir = if retain_in_cache?
+    tmpdir = if retain_in_cache?
       tmp_dir = HOMEBREW_CACHE/"Sources/#{prefix_name}"
       chmod_rm_rf(tmp_dir) # clear out previous staging directory
       tmp_dir.mkpath
@@ -80,7 +105,7 @@ class Mktemp
       Process.gid
     end
     begin
-      @tmpdir.chown(nil, group_id)
+      tmpdir.chown(nil, group_id)
     rescue Errno::EPERM
       require "etc"
       group_name = begin
@@ -89,26 +114,11 @@ class Mktemp
         # Cover for misconfigured NSS setups
         nil
       end
-      opoo "Failed setting group \"#{group_name || group_id}\" on #{@tmpdir}"
+      opoo "Failed setting group \"#{group_name || group_id}\" on #{tmpdir}"
     end
 
-    begin
-      if chdir
-        Dir.chdir(@tmpdir) { yield self }
-      else
-        yield self
-      end
-    ensure
-      ignore_interrupts { chmod_rm_rf(@tmpdir) } unless retain?
-    end
-  ensure
-    if retain? && @tmpdir.present? && !@quiet
-      message = retain_in_cache? ? "Source files for debugging available at:" : "Temporary files retained at:"
-      ohai message, @tmpdir.to_s
-    end
+    tmpdir
   end
-
-  private
 
   sig { params(path: Pathname).void }
   def chmod_rm_rf(path)

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -94,17 +94,19 @@ class Resource
     params(
       target:        T.nilable(T.any(String, Pathname)),
       debug_symbols: T::Boolean,
+      staging_path:  T.nilable(Pathname),
+      staged:        T::Boolean,
       block:         T.nilable(T.proc.params(arg0: ResourceStageContext).void),
     ).void
   }
-  def stage(target = nil, debug_symbols: false, &block)
+  def stage(target = nil, debug_symbols: false, staging_path: nil, staged: false, &block)
     raise ArgumentError, "Target directory or block is required" if !target && !block_given?
 
     prepare_patches
     fetch_patches(skip_downloaded: true)
     fetch unless downloaded?
 
-    unpack(target, debug_symbols:, &block)
+    unpack(target, debug_symbols:, staging_path:, staged:, &block)
   end
 
   sig { void }
@@ -131,19 +133,33 @@ class Resource
   # If block is given, yield to that block with `|stage|`, where stage
   # is a {ResourceStageContext}.
   # A target or a block must be given, but not both.
+  # With `staging_path`, unpack into that directory rather than a fresh
+  # temporary one and, with `staged` too, reuse its already unpacked and
+  # patched contents.
   sig {
     params(
       target:        T.nilable(T.any(String, Pathname)),
       debug_symbols: T::Boolean,
+      staging_path:  T.nilable(Pathname),
+      staged:        T::Boolean,
       block:         T.nilable(T.proc.params(arg0: ResourceStageContext).void),
     ).void
   }
-  def unpack(target = nil, debug_symbols: false, &block)
+  def unpack(target = nil, debug_symbols: false, staging_path: nil, staged: false, &block)
     current_working_directory = Pathname.pwd
-    stage_resource(download_name, debug_symbols:) do |staging|
-      downloader.stage do
-        @source_modified_time = downloader.source_modified_time.freeze
-        apply_patches
+    stage_resource(download_name, debug_symbols:, staging_path:) do |staging|
+      # A formula's `fetch` adds files to the shared staging directory, so
+      # record the unpacked source's modification time for the build phase.
+      source_modified_time_path = (staging_path/".source_modified_time" if staging_path)
+      stage_unpacked = proc do
+        source_modified_time = if staged && source_modified_time_path&.exist?
+          Time.at(source_modified_time_path.read.to_i)
+        else
+          downloader.source_modified_time
+        end
+        source_modified_time_path&.write(source_modified_time.to_i.to_s) unless staged
+        @source_modified_time = source_modified_time.freeze
+        apply_patches unless staged
         if block
           yield(ResourceStageContext.new(self, staging))
         elsif target
@@ -151,6 +167,12 @@ class Resource
           target = current_working_directory/target if target.relative?
           target.install Pathname.pwd.children
         end
+      end
+
+      if staged
+        downloader.chdir(&stage_unpacked)
+      else
+        downloader.stage(&stage_unpacked)
       end
     end
   end
@@ -275,11 +297,12 @@ class Resource
       .params(
         prefix:        String,
         debug_symbols: T::Boolean,
+        staging_path:  T.nilable(Pathname),
         block:         T.proc.params(arg0: Mktemp).returns(T.type_parameter(:U)),
       ).returns(T.type_parameter(:U))
   }
-  def stage_resource(prefix, debug_symbols: false, &block)
-    Mktemp.new(prefix, retain_in_cache: debug_symbols).run(&block)
+  def stage_resource(prefix, debug_symbols: false, staging_path: nil, &block)
+    Mktemp.new(prefix, retain_in_cache: debug_symbols, path: staging_path).run(&block)
   end
 
   private

--- a/Library/Homebrew/resource/resource_stage_context.rb
+++ b/Library/Homebrew/resource/resource_stage_context.rb
@@ -16,7 +16,7 @@ class ResourceStageContext
   attr_reader :staging
 
   def_delegators :@resource, :version, :url, :mirrors, :specs, :using, :source_modified_time
-  def_delegators :@staging, :retain!
+  def_delegators :@staging, :retain!, :quiet!
 
   sig { params(resource: Resource, staging: Mktemp).void }
   def initialize(resource, staging)

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -628,7 +628,7 @@ module RuboCop
         include OnSystemConditionalsHelper
         extend AutoCorrector
 
-        NO_ON_SYSTEM_METHOD_NAMES = [:install, :post_install].freeze
+        NO_ON_SYSTEM_METHOD_NAMES = [:install, :fetch, :post_install].freeze
         NO_ON_SYSTEM_BLOCK_NAMES = [:service, :test].freeze
 
         sig { override.params(formula_nodes: FormulaNodes).void }

--- a/Library/Homebrew/rubocops/shared/api_annotation_helper.rb
+++ b/Library/Homebrew/rubocops/shared/api_annotation_helper.rb
@@ -36,6 +36,7 @@ module RuboCop
         "change_dylib_id"       => "formula.rb",
         "env_script_all_files"  => "extend/pathname.rb",
         "fails_with"            => "formula.rb",
+        "fetch"                 => "formula.rb",
         "post_install_steps"    => "formula.rb",
         "head"                  => "formula.rb",
         "homepage"              => "formula.rb",

--- a/Library/Homebrew/test/cmd/fetch_spec.rb
+++ b/Library/Homebrew/test/cmd/fetch_spec.rb
@@ -7,6 +7,25 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::FetchCmd do
   it_behaves_like "parseable arguments"
 
+  it "does not run a formula's fetch hook until its dependencies are installed" do
+    cmd = described_class.new(["--build-from-source", "foo"])
+    dependency = formula("bar") do
+      T.bind(self, T.class_of(Formula))
+      url "bar-1.0"
+    end
+    foo = formula("foo") do
+      T.bind(self, T.class_of(Formula))
+      url "foo-1.0"
+
+      sig { void }
+      def fetch; end
+    end
+    allow(foo).to receive(:recursive_dependencies).and_return([instance_double(Dependency, to_formula: dependency)])
+    expect(FormulaInstaller).not_to receive(:new)
+
+    expect { cmd.run_fetch_hook(foo) }.to output(/brew install --only-dependencies foo/).to_stderr
+  end
+
   it "uses API bottle metadata before loading simple core formulae" do
     cmd = described_class.new(["fast-fetch"])
     download_queue = instance_double(Homebrew::DownloadQueue, fetch: nil, shutdown: nil)

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -11,6 +11,7 @@ require "trust"
 require "cmd/install"
 require "test/support/fixtures/testball"
 require "test/support/fixtures/testball_bottle"
+require "test/support/fixtures/testball_fetch"
 require "test/support/fixtures/failball"
 require "test/support/fixtures/failball_offline_install"
 
@@ -143,6 +144,37 @@ RSpec.describe FormulaInstaller do
       expect(installer).to receive(:post_install).ordered
 
       installer.finish
+    end
+  end
+
+  specify "installation runs fetch before install in a shared staging directory" do
+    temporary_install(TestballFetch.new) do |f|
+      expect(f.prefix/"fetched").to be_a_file
+    end
+  end
+
+  describe "#run_fetch" do
+    it "runs the fetch phase with network access and a writable cache" do
+      formula = formula("sandboxed-fetch") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+
+        def fetch; end
+      end
+      installer = described_class.new(formula)
+      sandbox = instance_double(Sandbox).as_null_object
+
+      allow(formula).to receive(:logs).and_return(mktmpdir)
+      allow(Sandbox).to receive_messages(new: sandbox, use_for?: true)
+      expect(sandbox).to receive(:allow_write_temp_and_cache)
+      expect(sandbox).not_to receive(:allow_write_cellar)
+      expect(sandbox).not_to receive(:deny_all_network)
+      expect(sandbox).to receive(:run) do |*args|
+        expect(args).to include(HOMEBREW_LIBRARY_PATH/"build.rb", formula.path)
+        expect(ENV.fetch("HOMEBREW_BUILD_FETCH_PHASE")).to eq("1")
+      end
+
+      installer.run_fetch
     end
   end
 
@@ -1553,6 +1585,34 @@ RSpec.describe FormulaInstaller do
       installer.build
 
       expect(installer.formula).to eq(source_formula)
+    end
+
+    it "builds offline in the fetch phase's staging directory when fetch is defined" do
+      formula = formula("offline-build") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+
+        def fetch; end
+      end
+      installer = described_class.new(formula)
+      sandbox = instance_double(Sandbox).as_null_object
+
+      allow(formula).to receive(:logs).and_return(mktmpdir)
+      allow(Sandbox).to receive_messages(new: sandbox, use_for?: true)
+      expect(installer).to receive(:run_fetch) do |staging_path:|
+        expect(staging_path).to be_a_directory
+      end
+      expect(sandbox).to receive(:deny_all_network)
+      expect(sandbox).not_to receive(:allow_write_temp_and_cache)
+      expect(sandbox).to receive(:run) do
+        staging_path = Pathname(ENV.fetch("HOMEBREW_BUILD_STAGING_PATH"))
+        expect(staging_path).to be_a_directory
+        FileUtils.rm_r(staging_path)
+        (formula.prefix/"bin").mkpath
+        (formula.prefix/"bin/foo").write ""
+      end
+
+      installer.build
     end
 
     it "raises when formula is loaded from API and source download fails" do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Formula do
   alias_matcher :have_changed_alias, :be_alias_changed
 
   alias_matcher :have_option_defined, :be_option_defined
+  alias_matcher :have_fetch_defined, :be_fetch_defined
   alias_matcher :have_post_install_defined, :be_post_install_defined
   alias_matcher :have_test_defined, :be_test_defined
   alias_matcher :pour_bottle, :be_pour_bottle
@@ -1158,6 +1159,25 @@ RSpec.describe Formula do
 
     expect(f1).to have_post_install_defined
     expect(f2).not_to have_post_install_defined
+  end
+
+  specify "#fetch_defined?" do
+    f1 = formula do
+      T.bind(self, T.class_of(Formula))
+      url "foo-1.0"
+
+      def fetch
+        # do nothing
+      end
+    end
+
+    f2 = formula do
+      T.bind(self, T.class_of(Formula))
+      url "foo-1.0"
+    end
+
+    expect(f1).to have_fetch_defined
+    expect(f2).not_to have_fetch_defined
   end
 
   specify "#run_post_install prevents build tools from reading user configuration" do

--- a/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
@@ -59,6 +59,35 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
       RUBY
     end
 
+    it "reports an offense when `on_macos` is used in fetch method" do
+      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          desc "foo"
+          url 'https://brew.sh/foo-1.0.tgz'
+
+          def fetch
+            on_macos do
+            ^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of using `on_macos` in `def fetch`, use `if OS.mac?`.
+              true
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url 'https://brew.sh/foo-1.0.tgz'
+
+          def fetch
+            if OS.mac?
+              true
+            end
+          end
+        end
+      RUBY
+    end
+
     it "reports an offense when `on_macos` is used in install method" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula

--- a/Library/Homebrew/test/support/fixtures/testball_fetch.rb
+++ b/Library/Homebrew/test/support/fixtures/testball_fetch.rb
@@ -1,0 +1,22 @@
+# typed: true
+# frozen_string_literal: true
+
+require_relative "testball"
+
+class TestballFetch < Testball
+  Cache = type_template { { fixed: T::Hash[Symbol, T.untyped] } }
+
+  def initialize(name = "testball_fetch", path = Pathname.new(__FILE__).expand_path, spec = :stable,
+                 alias_path: nil, tap: nil, force_bottle: false)
+    super
+  end
+
+  def fetch
+    Pathname("fetched").write "fetched"
+  end
+
+  def install
+    prefix.install "fetched"
+    super
+  end
+end

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1219,6 +1219,23 @@ end
 
 In the above example, the [`libressl`](https://github.com/Homebrew/homebrew-core/blob/442f9cc511ce6dfe75b96b2c83749d90dde914d2/Formula/lib/libressl.rb#L53-L56) formula replaces its stock list of certificates with a symlink to that of the `ca-certificates` formula.
 
+### Fetching dependencies before building
+
+Package managers such as Cargo, Go modules, npm and Bundler download dependencies while `install` runs, so those builds need network access and cannot be reproduced offline. Define a [`fetch`](/rubydoc/Formula.html#fetch-instance_method) method to do the downloading first. It runs after the source has been unpacked and patched into `buildpath`, with the same build environment and dependencies as `install` and with network access, and may write to `buildpath` and to the package manager caches Homebrew keeps in `HOMEBREW_CACHE` (`cargo_cache`, `go_mod_cache`, `npm_cache`, `bundler_cache` and so on). `install` then runs in the same `buildpath` without network access and with the rest of `HOMEBREW_CACHE` read-only, so it must use the package manager's offline mode. `brew fetch --build-from-source` runs `fetch` too once the formula's dependencies are installed. `fetch` is never run when installing a bottle.
+
+```ruby
+class Foo < Formula
+  # ...
+  def fetch
+    system "cargo", "fetch", "--locked"
+  end
+
+  def install
+    system "cargo", "install", "--offline", *std_cargo_args
+  end
+end
+```
+
 ### Handling files that should persist over formula upgrades
 
 For example, Ruby 1.9’s gems should be installed to `var/lib/ruby/` so that gems don’t need to be reinstalled when upgrading Ruby. You can usually do this with symlink trickery, or (ideally) a configure option.

--- a/docs/Homebrew-Security-and-Supply-Chain.md
+++ b/docs/Homebrew-Security-and-Supply-Chain.md
@@ -172,11 +172,11 @@ That keeps AI useful as automation while preserving the human accountability and
 
 Installing a bottle unpacks reviewed, prebuilt files.
 Builds from source run inside a sandbox (see below).
-Running a formula's `post_install` step, whether from a bottle or a source build, may run upstream-supplied software, but this too runs inside the sandbox.
+Running a formula's `post_install` step, whether from a bottle or a source build, or its `fetch` step before a source build, may run upstream-supplied software, but this too runs inside the sandbox.
 
 ### Sandboxing
 
-Builds, `post_install` steps and tests run inside a sandbox that restricts filesystem and network access:
+Builds, `fetch` steps, `post_install` steps and tests run inside a sandbox that restricts filesystem and network access:
 
 * **macOS sandboxing** has long confined formula builds.
 * **Linux sandboxing** extends the same protection to Homebrew on Linux.


### PR DESCRIPTION
- Cargo, Go, npm and Bundler formulae download dependencies inside `install`, so around 2,700 homebrew-core builds need network access and cannot be reproduced offline.
- `def fetch` runs first with network access and writable package manager caches; when it is defined, `install` then runs offline in the same unpacked source with the rest of `HOMEBREW_CACHE` read-only.
- A sandbox cannot be tightened mid-process, so the phases are separate `build.rb` runs sharing one staging directory created by the parent.
- `brew fetch --build-from-source` runs `fetch` too so a later `brew install` can be fully offline.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Fable 5 xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----