### PR TITLE
tapioca/compilers/cask/config: Generate accessors from DEFAULT_DIRS

### DIFF
--- a/Library/Homebrew/sorbet/tapioca/compilers/cask/config.rb
+++ b/Library/Homebrew/sorbet/tapioca/compilers/cask/config.rb
@@ -9,17 +9,12 @@ module Tapioca
     class CaskConfig < Tapioca::Dsl::Compiler
       ConstantType = type_member { { fixed: T::Module[T.anything] } }
 
-      # Dirs defined in `OS::Linux::Cask::Config::ClassMethods::DEFAULT_DIRS`
-      # that aren't visible to `Cask::Config.defaults` when this compiler is
-      # run on macOS, but still need accessor methods generated in the RBI.
-      LINUX_ONLY_DIRS = [:appimagedir].freeze
-
       sig { override.returns(T::Enumerable[T::Module[T.anything]]) }
       def self.gather_constants = [Cask::Config]
 
       sig { override.void }
       def decorate
-        keys = Cask::Config.defaults.keys | LINUX_ONLY_DIRS
+        keys = [:languages, *Cask::Config::DEFAULT_DIRS.keys]
 
         root.create_module("Cask") do |mod|
           mod.create_class("Config") do |klass|

--- a/Library/Homebrew/test/sorbet/tapioca/config_spec.rb
+++ b/Library/Homebrew/test/sorbet/tapioca/config_spec.rb
@@ -2,6 +2,12 @@
 # frozen_string_literal: true
 
 require "bundler"
+require "tapioca/dsl"
+
+# Tapioca's CLI applies this through its RBS rewriter before loading custom compilers.
+Tapioca::Dsl::Compiler.extend(T::Generic)
+
+require "sorbet/tapioca/compilers/cask/config"
 require "yaml"
 
 RSpec.describe "Tapioca Config", type: :system do
@@ -15,5 +21,29 @@ RSpec.describe "Tapioca Config", type: :system do
       false,
     ).resolve.names
     expect(exclusions - dependencies).to be_empty
+  end
+
+  describe Tapioca::Compilers::CaskConfig do
+    before do
+      allow(Cask::Config).to receive(:defaults).and_return(
+        languages:   [],
+        appdir:      "~/.config/apps",
+        appimagedir: "~/Applications",
+        flatpakdir:  "~/.local/share/flatpak",
+      )
+    end
+
+    it "includes accessors for default directories from other platforms" do
+      file = RBI::File.new(strictness: "strong")
+      pipeline = Tapioca::Dsl::Pipeline.new(
+        requested_constants: [],
+        requested_compilers: [described_class],
+      )
+      described_class.new(pipeline, file.root, Cask::Config).decorate
+
+      output = Tapioca::DEFAULT_RBI_FORMATTER.print_file(file)
+      expect(output).to include("def input_methoddir; end")
+      expect(output).not_to include("def flatpakdir; end")
+    end
   end
 end


### PR DESCRIPTION
On Linux `OS::Linux::Cask::Config::ClassMethods` overrides `Cask::Config.defaults` with a smaller hash, and the `CaskConfig` DSL compiler built its accessor list from it. Running `brew typecheck --update` on Linux therefore deleted `input_methoddir` and nine other accessors from `sorbet/rbi/dsl/cask/config.rbi`, and the `brew typecheck` that follows failed on three `input_methoddir` calls in `test/cask/config_spec.rb`. That breaks portable-ruby's integration path, which runs both in sequence.

`Cask::Config` defines its accessors from the base `DEFAULT_DIRS` plus `languages`, and that set is identical on every platform because the Linux override is prepended to the singleton class and does not affect `Cask::Config::DEFAULT_DIRS`. Generating from those two sources makes the committed RBI independent of which OS runs Tapioca. `LINUX_ONLY_DIRS` goes away, having been a no-op since `appimagedir` moved into the base `DEFAULT_DIRS`.

To reproduce, run `brew typecheck --update` then `brew typecheck` on Linux. In `ghcr.io/homebrew/brew:main` an unpatched tree cuts the RBI from 17 accessors to 6 and fails on those three calls; with this change `--update` reproduces the committed RBI byte for byte and typecheck passes.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the fix and pass with it, and ran `brew lgtm` plus the full `brew typecheck --update` and `brew typecheck` sequence on Linux in `ghcr.io/homebrew/brew:main`.

-----
