### PR TITLE
Require trust for automatic tap migration installs

### DIFF
--- a/Library/Homebrew/cmd/update_report/reporter.rb
+++ b/Library/Homebrew/cmd/update_report/reporter.rb
@@ -244,6 +244,7 @@ class Reporter
 
         new_tap = Tap.fetch(new_tap_name)
         next unless ensure_trusted_tap_installed!(name, new_name, new_tap)
+        next unless ensure_trusted_migration_target!(:formula, new_full_name)
 
         ohai "#{name} has been moved to Homebrew.", <<~EOS
           To uninstall the cask, run:
@@ -273,6 +274,8 @@ class Reporter
       # For formulae migrated to cask: Auto-install cask or provide install instructions.
       # Check if the migration target is a cask (either in homebrew/cask or any other tap)
       if new_tap.core_cask_tap? || new_tap.cask_tokens.intersect?([new_full_name, new_name])
+        next unless ensure_trusted_migration_target!(:cask, new_full_name)
+
         migration_message = if new_tap == tap
           "#{full_name} has been migrated from a formula to a cask."
         else
@@ -364,6 +367,20 @@ class Reporter
 
     new_tap.ensure_installed!
     true
+  end
+
+  sig { params(type: Symbol, full_name: String).returns(T::Boolean) }
+  def ensure_trusted_migration_target!(type, full_name)
+    return true if Homebrew::Trust.trusted?(type, full_name)
+
+    opoo <<~EOS
+      Not automatically installing #{full_name} because the migration target is
+      not trusted.
+      To complete the migration yourself, run:
+        brew trust --#{type} #{full_name}
+        brew install --#{type} #{full_name}
+    EOS
+    false
   end
 
   sig { returns(String) }

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -561,6 +561,16 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
       end
     end
 
+    describe "#ensure_trusted_migration_target!" do
+      it "refuses to install an untrusted migration target" do
+        allow(Homebrew::Trust).to receive(:trusted?).with(:formula, "foo/bar/payload").and_return(false)
+
+        expect do
+          expect(reporter.ensure_trusted_migration_target!(:formula, "foo/bar/payload")).to be(false)
+        end.to output(%r{not trusted.*brew trust --formula foo/bar/payload}mi).to_stderr
+      end
+    end
+
     describe "#diff" do
       context "when using the API" do
         subject(:reporter) do


### PR DESCRIPTION
## What

Require the exact formula or cask migration target to be trusted before brew update installs it automatically. Untrusted targets are now skipped with explicit brew trust and brew install instructions.

## Why

An installed but untrusted third-party tap can provide `tap_migrations.json`. For deleted casks, [Reporter#migrate_tap_migration](https://github.com/Homebrew/brew/blob/01c6a74422f3fdcdafa612a547dc2e5991a14bf2/Library/Homebrew/cmd/update_report/reporter.rb#L220-L288) checks only whether Caskroom/<token> exists. It does **not** verify that the installed cask originated from the tap being updated.

A compromised dormant tap can therefore:

1. Add an untrusted cask entry colliding with an unrelated installed cask.
2. Later delete that entry and migrate it to an attacker-controlled formula.
3. Cause brew update to invoke a fully qualified installation of that formula.

[`brew install`](https://github.com/Homebrew/brew/blob/01c6a74422f3fdcdafa612a547dc2e5991a14bf2/Library/Homebrew/cmd/install.rb#L188-L197) passes fully qualified names to [Trust.trust_fully_qualified_items!](https://github.com/Homebrew/brew/blob/01c6a74422f3fdcdafa612a547dc2e5991a14bf2/Library/Homebrew/trust.rb#L124-L150), so the new formula becomes trusted before its Ruby is evaluated.

A plausible scenario that could happen is:

```
brew install abc/tools/abc
brew uninstall abc
```

So the user installed something (that is not yet compromised), and uninstalled it after a while (`abc` is still not compromised). The main problem here is that uninstalling `abc` only removes its item-specific trust but leaves `abc/tools` tapped. If that dormant tap is compromised months later, it can target an unrelated installed cask such as:

```
brew install --cask google-chrome
```

The victim then only needs to run this any point in time:
```
brew update
```

and now is compromised.

## Reproduction

I prepared a dependency-free Python PoC as [gist](https://gist.github.com/felix314159/62cfdbb40f396bfde523d19bef1599de).

## Fix

Both automatic migration-install branches now require `Homebrew::Trust.trusted?` for the exact destination type and fully qualified name. Official taps and explicitly trusted targets continue to migrate automatically. Untrusted targets receive commands for completing the migration deliberately. A test case covers refusal of an untrusted migration target.

## Verification

```
brew typecheck
No errors! Great job.

brew style --changed --fix
2 files inspected, no offenses detected

brew tests --changed --online
38 examples, 0 failures

brew lgtm --online passes.
```

-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

I used no AI to assist with investigating the issue, developing and testing the fix, and drafting this description. I reviewed the resulting changes, reproduced the vulnerability and fix, and ran `brew lgtm --online` successfully. I will answer maintainer questions and review comments myself without AI/LLM.

-----