### PR TITLE
dev-cmd/pr-pull: require `cask/cask_loader`

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -7,6 +7,7 @@ require "utils/github"
 require "utils/github/artifacts"
 require "tmpdir"
 require "formula"
+require "cask/cask_loader"
 
 module Homebrew
   module DevCmd

--- a/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
@@ -85,6 +85,12 @@ RSpec.describe Homebrew::DevCmd::PrPull do
 
   it_behaves_like "parseable arguments"
 
+  it "loads the cask loader itself" do
+    script = 'require "global"; require "dev-cmd/pr-pull"; print Cask::CaskLoader.name'
+    expect(Utils.popen_read(RUBY_PATH, "-I", HOMEBREW_LIBRARY_PATH.to_s, "-e", script, err: :out))
+      .to eq("Cask::CaskLoader")
+  end
+
   describe "#check_pull_request_head_sha!" do
     it "outputs the pull request head SHA" do
       allow(GitHub).to receive(:pull_request_commits).with("Homebrew", "foo", "1").and_return(["actual"])


### PR DESCRIPTION
`brew pr-pull` calls `Cask::CaskLoader.load` when working out which packages a pull request touches, but the file only required `formula`, so the constant was undefined and the command failed with a `NameError` on cask pull requests. This was reported in https://github.com/orgs/Homebrew/discussions/7034.

Requiring `cask/cask_loader` fixes it, and also covers the `Cask::Cask` references further down the file. This is the same class of missing require as the recent `cmd/deps` and `cmd/uses` fixes. The new spec loads `dev-cmd/pr-pull` in a fresh Ruby process so it actually catches the missing require instead of passing because another spec already loaded the cask code.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new test fails without the fix and passes with it, and ran `brew lgtm` + targeted specs.

-----
