### PR TITLE
Harden build prefix relocation of poured bottles

### DIFF
--- a/Library/Homebrew/bottle_specification.rb
+++ b/Library/Homebrew/bottle_specification.rb
@@ -88,8 +88,9 @@ class BottleSpecification
 
     prefix = Pathname(cellar.to_s).parent.to_s
 
-    cellar_relocatable = cellar.size >= HOMEBREW_CELLAR.to_s.size && ENV["HOMEBREW_RELOCATE_BUILD_PREFIX"].present?
-    prefix_relocatable = prefix.size >= HOMEBREW_PREFIX.to_s.size && ENV["HOMEBREW_RELOCATE_BUILD_PREFIX"].present?
+    relocatable = Homebrew::EnvConfig.relocate_build_prefix?
+    cellar_relocatable = relocatable && cellar.size >= HOMEBREW_CELLAR.to_s.size
+    prefix_relocatable = relocatable && prefix.size >= HOMEBREW_PREFIX.to_s.size
 
     compatible_cellar = cellar == HOMEBREW_CELLAR.to_s || cellar_relocatable
     compatible_prefix = prefix == HOMEBREW_PREFIX.to_s || prefix_relocatable

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -656,6 +656,12 @@ module Homebrew
         odeprecated: true,
         replacement: "the default IRB backend (Pry is largely unmaintained upstream)",
       },
+      HOMEBREW_RELOCATE_BUILD_PREFIX:            {
+        description: "If set, pour bottles built for a longer prefix and patch the build prefix into their " \
+                     "binaries at install time.",
+        boolean:     true,
+        hidden:      true,
+      },
       HOMEBREW_REQUIRE_TAP_TRUST:                {
         # odeprecated: make tap trust checks default in a later release.
         description: "If set, require non-official tap formulae, casks and commands to be trusted with " \

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -280,10 +280,22 @@ class FormulaInstaller
     unless bottle.compatible_locations?
       if output_warning
         prefix = Pathname(bottle.cellar.to_s).parent
+        # Raw prefix strings can only be replaced in place by an equal-or-shorter
+        # prefix, so the length difference is the fact that matters.
+        excess = [HOMEBREW_PREFIX.to_s.length - prefix.to_s.length,
+                  HOMEBREW_CELLAR.to_s.length - bottle.cellar.to_s.length].max
+        cause = if excess.positive?
+          "Your prefix is #{excess} characters longer than the bottle's build prefix."
+        elsif excess.negative?
+          "Your prefix is #{-excess} characters shorter than the bottle's build prefix."
+        else
+          "Your prefix is the same length as the bottle's build prefix."
+        end
         opoo <<~EOS
           Building #{formula.full_name} from source as the bottle needs:
           - `HOMEBREW_CELLAR=#{bottle.cellar}` (yours is #{HOMEBREW_CELLAR})
           - `HOMEBREW_PREFIX=#{prefix}` (yours is #{HOMEBREW_PREFIX})
+          #{cause}
         EOS
       end
       return false
@@ -1703,9 +1715,12 @@ on_request: installed_on_request?, options:)
     prefix = Pathname(cellar).parent.to_s
     return if cellar == HOMEBREW_CELLAR.to_s && prefix == HOMEBREW_PREFIX.to_s
 
-    return unless ENV["HOMEBREW_RELOCATE_BUILD_PREFIX"]
+    return unless Homebrew::EnvConfig.relocate_build_prefix?
 
-    keg.relocate_build_prefix(keg, prefix, HOMEBREW_PREFIX, files: tab.binary_relocation_files)
+    tab.relocated_build_prefix = prefix
+    tab.relocated_files = keg.relocate_build_prefix(keg, prefix, HOMEBREW_PREFIX,
+                                                    files: tab.binary_relocation_files)
+    tab.write
   end
 
   sig { override.params(output: T.nilable(String)).void }

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -252,9 +252,10 @@ class Keg
     changed_files
   end
 
+  # Returns the patched files relative to the keg.
   sig {
     params(keg: Keg, old_prefix: T.any(String, Pathname), new_prefix: T.any(String, Pathname),
-           files: T.nilable(T::Array[Pathname])).void
+           files: T.nilable(T::Array[Pathname])).returns(T::Array[Pathname])
   }
   def relocate_build_prefix(keg, old_prefix, new_prefix, files: nil)
     old_prefix = old_prefix.to_s
@@ -343,6 +344,8 @@ class Keg
       first = group.fetch(0)
       group.drop(1).each { |file| FileUtils.ln(first, file, force: true) }
     end
+
+    patched_groups.flatten.map { |file| file.relative_path_from(path) }
   end
 
   # Replaces the prefix in a NUL-terminated string without changing its

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -257,25 +257,30 @@ class Keg
            files: T.nilable(T::Array[Pathname])).void
   }
   def relocate_build_prefix(keg, old_prefix, new_prefix, files: nil)
-    candidates = T.let([], T::Array[Pathname])
-    if files
-      # Metadata-driven pour: only the files recorded at bottle time carry raw
-      # prefix strings, so skip the whole-keg scan.
-      hardlinks = Set.new
-      files.each do |relative_path|
-        file = path/relative_path
-        next if !file.file? || file.symlink?
-        # Hardlinks share an inode, so patch each inode only once.
-        next unless hardlinks.add? file.stat.ino
-
-        candidates << file
-      end
-    else
-      each_unique_file_matching(old_prefix) { |file| candidates << file }
+    old_prefix = old_prefix.to_s
+    new_prefix = new_prefix.to_s
+    # A raw C string can only be replaced in place by an equal-or-shorter
+    # string, so refuse before touching any file rather than failing midway.
+    if new_prefix.bytesize > old_prefix.bytesize
+      raise ArgumentError, "Cannot relocate build prefix #{old_prefix} to longer prefix #{new_prefix}"
     end
 
-    patched_files = T.let([], T::Array[Pathname])
-    candidates.each do |file|
+    # Hardlinked names share one inode: patch it once through the first name
+    # and re-link the rest afterwards, as the patched file gets a new inode.
+    inode_groups = if files
+      # Metadata-driven pour: only the files recorded at bottle time carry raw
+      # prefix strings, so skip the whole-keg scan.
+      files.map { |relative_path| path/relative_path }
+           .select { |file| file.file? && !file.symlink? }
+           .group_by { |file| file.stat.ino }
+           .values
+    else
+      files_matching_by_inode(old_prefix)
+    end
+
+    patched_groups = T.let([], T::Array[T::Array[Pathname]])
+    inode_groups.each do |group|
+      file = group.fetch(0)
       # Skip files which are not binary, as they do not need null padding.
       next unless keg.binary_file?(file)
 
@@ -287,7 +292,7 @@ class Keg
       file.ensure_writable do
         binary = File.binread file
         binary_strings = binary.split(/#{NULL_BYTE}/o, -1)
-        match_indices = binary_strings.each_index.select { |i| binary_strings.fetch(i).include?(old_prefix.to_s) }
+        match_indices = binary_strings.each_index.select { |i| binary_strings.fetch(i).include?(old_prefix) }
 
         # Bottle metadata records files pinned by any prefix, cellar or
         # repository reference, so a recorded file may not contain this
@@ -296,31 +301,82 @@ class Keg
 
         odebug "Replacing build prefix in: #{file}"
 
-        # Only perform substitution on strings which match prefix regex.
+        # Linkers merge a string with the suffix of another, so a string in
+        # the dynamic string table can be referenced from its interior.
+        interior_references = Keg.elf_dynamic_string_references_in(file)
+        string_starts = T.let([], T::Array[Integer])
+        binary_strings.reduce(0) do |start, binary_string|
+          string_starts << start
+          start + binary_string.bytesize + 1
+        end
+
         match_indices.each do |i|
-          s = binary_strings.fetch(i)
-          binary_strings[i] = s.gsub(old_prefix.to_s, new_prefix.to_s)
-                               .ljust(s.size, NULL_BYTE)
+          binary_string = binary_strings.fetch(i)
+          start = string_starts.fetch(i)
+          preserve_suffix_offsets = interior_references.any? do |reference|
+            reference > start && reference < start + binary_string.bytesize
+          end
+          binary_strings[i] = Keg.replace_prefix_preserving_length(binary_string, old_prefix, new_prefix,
+                                                                   preserve_suffix_offsets:)
         end
 
         # Rejoin strings by null bytes.
         patched_binary = binary_strings.join(NULL_BYTE)
-        if patched_binary.size != binary.size
+        if patched_binary.bytesize != binary.bytesize
           raise <<~EOS
             Patching failed!  Original and patched binary sizes do not match.
-            Original size: #{binary.size}
-            Patched size: #{patched_binary.size}
+            Original size: #{binary.bytesize}
+            Patched size: #{patched_binary.bytesize}
           EOS
         end
 
         file.atomic_write patched_binary
-        patched_files << file
+        patched_groups << group
       end
     end
 
     # Each patch broke the file's signature, so re-sign each patched file
     # exactly once, parallelised across files.
-    codesign_patched_binaries(patched_files)
+    codesign_patched_binaries(patched_groups.map { |group| group.fetch(0) })
+
+    patched_groups.each do |group|
+      first = group.fetch(0)
+      group.drop(1).each { |file| FileUtils.ln(first, file, force: true) }
+    end
+  end
+
+  # Replaces the prefix in a NUL-terminated string without changing its
+  # length. Trailing NUL padding is invisible to C string readers but shifts
+  # any suffix-merged reference into the string, so when the string has such
+  # references and the prefix is followed by a path separator, pad with
+  # extra separators instead: path resolution treats `//` as `/`.
+  sig {
+    params(string: String, old_prefix: String, new_prefix: String, preserve_suffix_offsets: T::Boolean).returns(String)
+  }
+  def self.replace_prefix_preserving_length(string, old_prefix, new_prefix, preserve_suffix_offsets:)
+    if preserve_suffix_offsets
+      separators = "/" * (old_prefix.bytesize - new_prefix.bytesize + 1)
+      padded = string.gsub("#{old_prefix}/") { "#{new_prefix}#{separators}" }
+      return padded if padded.bytesize == string.bytesize
+    end
+
+    string.gsub(old_prefix) { new_prefix }.ljust(string.bytesize, NULL_BYTE)
+  end
+
+  # Absolute file offsets of the strings the dynamic loader references in
+  # the file's dynamic string table, or none for files that are not ELF or
+  # cannot be parsed.
+  sig { params(file: Pathname).returns(T::Array[Integer]) }
+  def self.elf_dynamic_string_references_in(file)
+    require "os/linux/elf"
+    return [] unless T.cast(Pathname.new(file.to_s).extend(ELFShim), ELFShim).elf?
+
+    require "elftools"
+    file.open("rb") do |stream|
+      elf_dynamic_string_references(ELFTools::ELFFile.new(stream))&.offsets || []
+    end
+  rescue ELFTools::ELFError, IOError, SystemCallError
+    []
   end
 
   sig { params(_options: T::Hash[Symbol, T::Boolean]).returns(T::Array[Symbol]) }
@@ -346,21 +402,26 @@ class Keg
     [grep_bin, grep_args]
   end
 
-  sig { params(string: T.any(String, Pathname), _block: T.proc.params(arg0: Pathname).void).void }
-  def each_unique_file_matching(string, &_block)
+  # Files containing the string, grouped by inode so that hardlinks to the
+  # same file appear together.
+  sig { params(string: T.any(String, Pathname)).returns(T::Array[T::Array[Pathname]]) }
+  def files_matching_by_inode(string)
+    files = T.let([], T::Array[Pathname])
     Utils.popen_read("fgrep", recursive_fgrep_args, string, to_s) do |io|
-      hardlinks = Set.new
-
       until io.eof?
         file = Pathname.new(io.readline.chomp)
         # Don't return symbolic links.
-        next if file.symlink?
-
-        # To avoid returning hardlinks, only return files with unique inodes.
-        # Hardlinks will have the same inode as the file they point to.
-        yield file if hardlinks.add? file.stat.ino
+        files << file unless file.symlink?
       end
     end
+    files.group_by { |file| file.stat.ino }.values
+  end
+
+  sig { params(string: T.any(String, Pathname), block: T.proc.params(arg0: Pathname).void).void }
+  def each_unique_file_matching(string, &block)
+    # Hardlinks share an inode with the file they point to, so only the first
+    # name of each inode is yielded.
+    files_matching_by_inode(string).map { |group| group.fetch(0) }.each(&block)
   end
 
   sig { params(file: Pathname).returns(T::Boolean) }
@@ -551,56 +612,16 @@ class Keg
       end
 
       string_table_range = T.let(nil, T.nilable(T::Range[Integer]))
-      if (dynamic = elf.segment_by_type(:dynamic))
-        # Dynamic tags whose value is an offset into the dynamic string
-        # table, i.e. the strings the loader can actually see.
-        string_tags = [
-          ELFTools::Constants::DT::DT_NEEDED,
-          ELFTools::Constants::DT::DT_SONAME,
-          ELFTools::Constants::DT::DT_RPATH,
-          ELFTools::Constants::DT::DT_RUNPATH,
-          ELFTools::Constants::DT::DT_AUXILIARY,
-          # elftools 1.3.1 mislabels `DT_USED` (0x7ffffffe) as `DT_FILTER`;
-          # both hold string-table offsets, so keep the mislabelled value
-          # and add the ELF ABI's real `DT_FILTER`.
-          ELFTools::Constants::DT::DT_FILTER,
-          0x7fffffff, # DT_FILTER
-          ELFTools::Constants::DT::DT_AUDIT,
-          ELFTools::Constants::DT::DT_DEPAUDIT,
-          ELFTools::Constants::DT::DT_CONFIG,
-        ]
-        string_table_vaddr = T.let(nil, T.nilable(Integer))
-        string_table_size = T.let(nil, T.nilable(Integer))
-        string_offsets = []
-        dynamic.tags.each do |tag|
-          case tag.header.d_tag.to_i
-          when ELFTools::Constants::DT::DT_STRTAB then string_table_vaddr = tag.header.d_val.to_i
-          when ELFTools::Constants::DT::DT_STRSZ then string_table_size = tag.header.d_val.to_i
-          when *string_tags then string_offsets << tag.header.d_val.to_i
-          end
-        end
-        if string_table_vaddr && (string_table_offset = elf.offset_from_vma(string_table_vaddr))
-          string_table_range = string_table_offset...(string_table_offset + string_table_size) if string_table_size
-
-          # Dynamic symbol names are loader-visible strings in the same
-          # table, referenced by `.dynsym` `st_name` rather than by dynamic
-          # tags. Version table strings also index the table but hold
-          # version names, never paths, so they are not collected.
-          elf.sections_by_type(ELFTools::Constants::SHT::SHT_DYNSYM).each do |section|
-            section.symbols.each do |symbol|
-              name_offset = symbol.header.st_name.to_i
-              string_offsets << name_offset unless name_offset.zero?
-            end
-          end
-
-          # A referenced string runs from its offset to the terminating NUL,
-          # so a suffix-merged reference to the interior `libfoo.so` of
-          # `/old/prefix/libfoo.so` never yields the dead prefix before it.
-          string_offsets.uniq.each do |offset|
-            stream.pos = string_table_offset + offset
-            referenced = stream.gets("\0")&.delete_suffix("\0")
-            strings << [string_table_offset + offset, referenced] if referenced
-          end
+      if (references = elf_dynamic_string_references(elf))
+        string_table_range = references.string_table_range
+        referenced_offsets = references.offsets
+        # A referenced string runs from its offset to the terminating NUL,
+        # so a suffix-merged reference to the interior `libfoo.so` of
+        # `/old/prefix/libfoo.so` never yields the dead prefix before it.
+        referenced_offsets.each do |offset|
+          stream.pos = offset
+          referenced = stream.gets("\0")&.delete_suffix("\0")
+          strings << [offset, referenced] if referenced
         end
       end
 
@@ -641,6 +662,68 @@ class Keg
     # pointing outside the file mid-parse (Linux raises `Errno::EINVAL`
     # for the resulting seek where macOS returns EOF).
     nil
+  end
+
+  class DynamicStringReferences < T::Struct
+    # The file range of the dynamic string table, when its size is known.
+    const :string_table_range, T.nilable(T::Range[Integer])
+    # Absolute file offsets of the strings the loader references in it.
+    const :offsets, T::Array[Integer]
+  end
+
+  # The strings the dynamic loader references in the file's dynamic string
+  # table, or nil without a dynamic segment or string table.
+  sig { params(elf: ELFTools::ELFFile).returns(T.nilable(DynamicStringReferences)) }
+  def self.elf_dynamic_string_references(elf)
+    dynamic = elf.segment_by_type(:dynamic)
+    return if dynamic.nil?
+
+    # Dynamic tags whose value is an offset into the dynamic string table,
+    # i.e. the strings the loader can actually see.
+    string_tags = [
+      ELFTools::Constants::DT::DT_NEEDED,
+      ELFTools::Constants::DT::DT_SONAME,
+      ELFTools::Constants::DT::DT_RPATH,
+      ELFTools::Constants::DT::DT_RUNPATH,
+      ELFTools::Constants::DT::DT_AUXILIARY,
+      # elftools 1.3.1 mislabels `DT_USED` (0x7ffffffe) as `DT_FILTER`;
+      # both hold string-table offsets, so keep the mislabelled value
+      # and add the ELF ABI's real `DT_FILTER`.
+      ELFTools::Constants::DT::DT_FILTER,
+      0x7fffffff, # DT_FILTER
+      ELFTools::Constants::DT::DT_AUDIT,
+      ELFTools::Constants::DT::DT_DEPAUDIT,
+      ELFTools::Constants::DT::DT_CONFIG,
+    ]
+    string_table_vaddr = T.let(nil, T.nilable(Integer))
+    string_table_size = T.let(nil, T.nilable(Integer))
+    string_offsets = []
+    dynamic.tags.each do |tag|
+      case tag.header.d_tag.to_i
+      when ELFTools::Constants::DT::DT_STRTAB then string_table_vaddr = tag.header.d_val.to_i
+      when ELFTools::Constants::DT::DT_STRSZ then string_table_size = tag.header.d_val.to_i
+      when *string_tags then string_offsets << tag.header.d_val.to_i
+      end
+    end
+    return if string_table_vaddr.nil?
+
+    string_table_offset = elf.offset_from_vma(string_table_vaddr)
+    return if string_table_offset.nil?
+
+    # Dynamic symbol names are loader-visible strings in the same table,
+    # referenced by `.dynsym` `st_name` rather than by dynamic tags. Version
+    # table strings also index the table but hold version names, never
+    # paths, so they are not collected.
+    elf.sections_by_type(ELFTools::Constants::SHT::SHT_DYNSYM).each do |section|
+      section.symbols.each do |symbol|
+        name_offset = symbol.header.st_name.to_i
+        string_offsets << name_offset unless name_offset.zero?
+      end
+    end
+
+    string_table_range = string_table_offset...(string_table_offset + string_table_size) if string_table_size
+    DynamicStringReferences.new(string_table_range:,
+                                offsets:            string_offsets.uniq.map { |offset| string_table_offset + offset })
   end
 
   sig { params(_file: Pathname, _string: String).returns(T::Array[String]) }

--- a/Library/Homebrew/plans/relocatable-bottles.md
+++ b/Library/Homebrew/plans/relocatable-bottles.md
@@ -83,7 +83,9 @@ Raw C strings are the only length-limited content at pour time:
 - ELF RPATHs and interpreters can grow because patchelf.rb rewrites them into
   a new segment.
 - A raw C string can only be replaced by an equal-or-shorter string, padded
-  with NUL bytes.
+  with NUL bytes; a string in an ELF dynamic string table that a linker has
+  suffix-merged (referenced from its interior) is instead padded with extra
+  path separators after the prefix so those references keep their offsets.
 
 `Keg#relocate_build_prefix` (`keg_relocate.rb`) implements that NUL-padded
 patching and re-signs patched Mach-O files, and
@@ -212,11 +214,6 @@ Whole dependency closures become pourable at prefixes up to the bottled
 default length (13 bytes arm64 macOS, 26 Linux), covering the hub formulae
 (`openssl@3`, `gettext`, `glib`, `python@3.x`) that Phase 1 cannot.
 
-8. Hardening tests and fixes for `Keg#relocate_build_prefix`:
-   multi-occurrence strings, several strings per file, hardlinks, the
-   sharball skip, the size-mismatch failure path, codesign on macOS and
-   no-op on Linux, suffix-merged string tables and prefix strings inside
-   load commands.
 9. Observability and diagnostics: the poured keg's tab records patched state
    and files; the pour decline message (`formula_installer.rb`) compares
    prefix lengths and states the actionable cause ("prefix 8 characters too

--- a/Library/Homebrew/plans/relocatable-bottles.md
+++ b/Library/Homebrew/plans/relocatable-bottles.md
@@ -31,6 +31,10 @@ Any benchmark quoted in a commit message must be the full hyperfine
 output from `brew benchmark` (using its `--exec` mode for bespoke
 workloads), never hand-summarised numbers.
 
+Changes to homebrew/core (re-marks, formula fixes, sweeps) use one commit
+per formula with the subject `<formula>: <change>`, never one commit
+spanning many formulae.
+
 Pull requests must always fill in the repository's pull request
 template (`.github/PULL_REQUEST_TEMPLATE.md`), never bypass it
 (e.g. with `gh pr create --fill`).
@@ -167,7 +171,8 @@ Replaying the exact `keg_contain?` logic over the contents of 17 pinned and
 9. `HOMEBREW_RELOCATE_BUILD_PREFIX` is added to `env_config.rb` with
    `hidden: true` until the feature is hardened and diagnosable, and is
    ultimately retired in favour of a `HOMEBREW_NO_RELOCATE_BUILD_PREFIX`
-   escape hatch.
+   escape hatch. Until it is unhidden and considered stable no
+   user-facing message mentions it.
 10. Non-intuitive logic must always be commented, especially relocation edge
     cases (NUL padding, string-table subtleties, codesign behaviour): this
     code is touched rarely and debugged under pressure.
@@ -214,13 +219,6 @@ Whole dependency closures become pourable at prefixes up to the bottled
 default length (13 bytes arm64 macOS, 26 Linux), covering the hub formulae
 (`openssl@3`, `gettext`, `glib`, `python@3.x`) that Phase 1 cannot.
 
-9. Observability and diagnostics: the poured keg's tab records patched state
-   and files; the pour decline message (`formula_installer.rb`) compares
-   prefix lengths and states the actionable cause ("prefix 8 characters too
-   long to patch, building from source" versus "patchable: enable
-   relocation").
-10. Add `HOMEBREW_RELOCATE_BUILD_PREFIX` to `env_config.rb` with
-    `hidden: true` so it is typed and testable but not yet public.
 11. Validation workflow: pour all pinned bottles into scratch prefixes with
     `brew linkage` and smoke tests.
 

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -413,6 +413,9 @@ module Homebrew::EnvConfig
     def pry?; end
 
     sig { returns(T::Boolean) }
+    def relocate_build_prefix?; end
+
+    sig { returns(T::Boolean) }
     def require_tap_trust?; end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/tab/tab.rb
+++ b/Library/Homebrew/tab/tab.rb
@@ -46,6 +46,13 @@ class Tab < AbstractTab
   sig { returns(T.nilable(T::Array[Pathname])) }
   attr_accessor :binary_relocation_files
 
+  # The prefix a poured bottle was built for, when it was patched in place.
+  sig { returns(T.nilable(String)) }
+  attr_accessor :relocated_build_prefix
+
+  sig { returns(T.nilable(T::Array[Pathname])) }
+  attr_accessor :relocated_files
+
   sig {
     params(poured_from_bottle:      T.nilable(T::Boolean),
            built_as_bottle:         T.nilable(T::Boolean),
@@ -53,6 +60,8 @@ class Tab < AbstractTab
            changed_files:           T.nilable(T::Array[T.any(Pathname, String)]),
            linkage_files:           T.nilable(T::Array[T.any(Pathname, String)]),
            binary_relocation_files: T.nilable(T::Array[T.any(Pathname, String)]),
+           relocated_build_prefix:  T.nilable(String),
+           relocated_files:         T.nilable(T::Array[T.any(Pathname, String)]),
            stdlib:                  T.nilable(T.any(String, Symbol)),
            aliases:                 T.nilable(T::Array[String]),
            used_options:            T.nilable(T::Array[String]),
@@ -63,8 +72,9 @@ class Tab < AbstractTab
            rest:                    T.untyped).void
   }
   def initialize(poured_from_bottle: nil, built_as_bottle: nil, built_prefix: nil, changed_files: nil,
-                 linkage_files: nil, binary_relocation_files: nil, stdlib: nil, aliases: nil, used_options: nil,
-                 unused_options: nil, compiler: nil, source_modified_time: nil, tapped_from: nil, **rest)
+                 linkage_files: nil, binary_relocation_files: nil, relocated_build_prefix: nil,
+                 relocated_files: nil, stdlib: nil, aliases: nil, used_options: nil, unused_options: nil,
+                 compiler: nil, source_modified_time: nil, tapped_from: nil, **rest)
     @poured_from_bottle = poured_from_bottle
     @built_as_bottle = built_as_bottle
     @built_prefix = built_prefix
@@ -74,6 +84,8 @@ class Tab < AbstractTab
       binary_relocation_files&.map { |f| Pathname(f) },
       T.nilable(T::Array[Pathname]),
     )
+    @relocated_build_prefix = relocated_build_prefix
+    @relocated_files = T.let(relocated_files&.map { |f| Pathname(f) }, T.nilable(T::Array[Pathname]))
     @stdlib = stdlib
     @aliases = aliases
     @used_options = used_options
@@ -398,6 +410,8 @@ class Tab < AbstractTab
       "changed_files"            => changed_files&.map(&:to_s),
       "linkage_files"            => linkage_files&.map(&:to_s),
       "binary_relocation_files"  => binary_relocation_files&.map(&:to_s),
+      "relocated_build_prefix"   => relocated_build_prefix,
+      "relocated_files"          => relocated_files&.map(&:to_s),
       "time"                     => time,
       "source_modified_time"     => source_modified_time.to_i,
       "stdlib"                   => stdlib&.to_s,
@@ -412,6 +426,8 @@ class Tab < AbstractTab
     attributes.delete("built_prefix") if attributes["built_prefix"].nil?
     attributes.delete("linkage_files") if attributes["linkage_files"].nil?
     attributes.delete("binary_relocation_files") if attributes["binary_relocation_files"].nil?
+    attributes.delete("relocated_build_prefix") if attributes["relocated_build_prefix"].nil?
+    attributes.delete("relocated_files") if attributes["relocated_files"].nil?
 
     JSON.pretty_generate(attributes, options)
   end

--- a/Library/Homebrew/test/bottle_specification_spec.rb
+++ b/Library/Homebrew/test/bottle_specification_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe BottleSpecification do
     it "checks if the bottle cellar is relocatable" do
       expect(bottle_spec.compatible_locations?).to be false
     end
+
+    it "accepts a longer bottle cellar when build prefix relocation is enabled" do
+      ENV["HOMEBREW_RELOCATE_BUILD_PREFIX"] = "1"
+      bottle_spec.sha256(cellar: "#{HOMEBREW_CELLAR}-longer", Utils::Bottles.tag.to_sym => "deadbeef" * 8)
+
+      expect(bottle_spec.compatible_locations?).to be true
+    end
   end
 
   describe "#tag_to_cellar" do

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -322,6 +322,33 @@ RSpec.describe FormulaInstaller do
     end
   end
 
+  describe "#pour_bottle? with a bottle built for another prefix" do
+    def installer_for_cellar(cellar)
+      f = formula("pinned-bottle") do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/pinned-bottle-1.0.tar.gz"
+
+        bottle do
+          sha256 cellar:,
+                 Utils::Bottles.tag.to_sym => "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97"
+        end
+      end
+      Class.new(described_class).new(f)
+    end
+
+    it "states how much longer the prefix is than the bottle's" do
+      installer = installer_for_cellar("/short/Cellar")
+
+      expect { installer.pour_bottle?(output_warning: true) }.to output(/characters longer than/).to_stderr
+    end
+
+    it "states how much shorter the prefix is than the bottle's" do
+      installer = installer_for_cellar("#{HOMEBREW_PREFIX}-longer/Cellar")
+
+      expect { installer.pour_bottle?(output_warning: true) }.to output(/7 characters shorter than/).to_stderr
+    end
+  end
+
   describe "#build_bottle_postinstall" do
     let(:f) do
       formula "bottle-config" do

--- a/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Keg do
 
   before do
     dir.mkpath
+    allow(keg).to receive(:codesign_patched_binaries)
   end
 
   def setup_binary_file
@@ -49,6 +50,80 @@ RSpec.describe Keg do
 
       null_padding = "\x00" * (dir.to_s.length - newdir.to_s.length)
       expect(binary_file.binread).to eq "\x00#{newdir}#{null_padding}\x00\n"
+    end
+
+    specify "replaces every occurrence in every string" do
+      binary_file.atomic_write "\x00#{dir}/a:#{dir}/b\x00#{dir}/c\x00"
+
+      keg.relocate_build_prefix(keg, dir, newdir)
+
+      null_padding = "\x00" * (dir.to_s.length - newdir.to_s.length)
+      expect(binary_file.binread)
+        .to eq "\x00#{newdir}/a:#{newdir}/b#{null_padding * 2}\x00#{newdir}/c#{null_padding}\x00"
+    end
+
+    specify "patches hardlinks once and keeps them linked" do
+      setup_binary_file
+      hardlink = dir/"hardlink.bin"
+      FileUtils.ln binary_file, hardlink
+
+      keg.relocate_build_prefix(keg, dir, newdir)
+
+      expect(hardlink.stat.ino).to eq binary_file.stat.ino
+      expect(hardlink.binread).to include newdir.to_s
+    end
+
+    specify "leaves sharballs untouched" do
+      binary_file.atomic_write "#!/bin/sh\n\x00#{dir}\x00"
+
+      keg.relocate_build_prefix(keg, dir, newdir)
+
+      expect(binary_file.binread).to include dir.to_s
+    end
+
+    specify "refuses a longer prefix before touching any file" do
+      setup_binary_file
+      original = binary_file.binread
+
+      expect { keg.relocate_build_prefix(keg, newdir, dir) }.to raise_error(ArgumentError, /longer/)
+      expect(binary_file.binread).to eq original
+    end
+
+    specify "re-signs patched files" do
+      setup_binary_file
+
+      expect(keg).to receive(:codesign_patched_binaries).with([binary_file])
+
+      keg.relocate_build_prefix(keg, dir, newdir)
+    end
+
+    specify "keeps suffix-merged references into ELF string tables valid" do
+      require "patchelf"
+      require "elftools"
+
+      elf = dir/"program"
+      FileUtils.cp TEST_FIXTURE_DIR/"elf/hello", elf
+      patcher = PatchELF::Patcher.new(elf.to_s, on_error: :silent)
+      patcher.rpath = "#{dir}/lib/x"
+      patcher.save(patchelf_compatible: true)
+      # Point DT_RPATH into the interior `lib/x`, as a tail-merging linker does.
+      value_offset = elf.open("rb") do |stream|
+        dynamic = ELFTools::ELFFile.new(stream).segment_by_type(:dynamic)
+        index = dynamic.tags.find_index { |tag| tag.header.d_tag.to_i == ELFTools::Constants::DT::DT_RPATH }
+        dynamic.header.p_offset.to_i + (index * 16) + 8
+      end
+      referenced = File.binread(elf, 8, value_offset).unpack1("Q<")
+      File.open(elf, "r+b") do |f|
+        f.seek(value_offset)
+        f.write([referenced + dir.to_s.length + 1].pack("Q<"))
+      end
+      suffix_offset = elf.binread.index("#{dir}/lib/x") + dir.to_s.length + 1
+
+      keg.relocate_build_prefix(keg, dir, newdir, files: [Pathname("program")])
+
+      separators = "/" * (dir.to_s.length - newdir.to_s.length + 1)
+      expect(elf.binread).to include "#{newdir}#{separators}lib/x\x00"
+      expect(File.binread(elf, 6, suffix_offset)).to eq "lib/x\x00"
     end
 
     specify "does not rewrite recorded files without the old prefix" do

--- a/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
@@ -67,8 +67,9 @@ RSpec.describe Keg do
       hardlink = dir/"hardlink.bin"
       FileUtils.ln binary_file, hardlink
 
-      keg.relocate_build_prefix(keg, dir, newdir)
+      patched = keg.relocate_build_prefix(keg, dir, newdir)
 
+      expect(patched).to contain_exactly(Pathname("file.bin"), Pathname("hardlink.bin"))
       expect(hardlink.stat.ino).to eq binary_file.stat.ino
       expect(hardlink.binread).to include newdir.to_s
     end

--- a/Library/Homebrew/test/os/mac/keg_spec.rb
+++ b/Library/Homebrew/test/os/mac/keg_spec.rb
@@ -165,6 +165,27 @@ RSpec.describe Keg do
     end
   end
 
+  describe "#relocate_build_prefix" do
+    let(:keg_path) { HOMEBREW_CELLAR/"a/1.0" }
+    let(:file) { keg_path/"lib/libfoo.dylib" }
+
+    before do
+      file.dirname.mkpath
+      cp dylib_path("x86_64"), file
+      MachOPathname.wrap(file).change_install_name("/usr/lib/libSystem.B.dylib", "/old/pfx/libSys.B.dylib")
+      allow(keg).to receive(:codesign_patched_binaries)
+    end
+
+    after { keg.unlink }
+
+    it "patches prefix strings inside load commands" do
+      keg.relocate_build_prefix(keg, "/old/pfx", "/new", files: [Pathname("lib/libfoo.dylib")])
+
+      expect(MachOPathname.wrap(file).dynamically_linked_libraries(resolve_variable_references: false))
+        .to eq ["/new/libSys.B.dylib"]
+    end
+  end
+
   describe "#codesign_patched_binaries" do
     let(:keg_path) { HOMEBREW_CELLAR/"a/1.0" }
     let(:files) { [keg_path/"bin/a", keg_path/"bin/b"] }

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -577,7 +577,11 @@ RSpec.describe Tab do
 
   specify "#to_json" do
     tab.built_prefix = "/custom/prefix"
+    tab.relocated_build_prefix = "/custom/prefix"
+    tab.relocated_files = [Pathname("bin/foo")]
     json_tab = described_class.new(**JSON.parse(tab.to_json).transform_keys(&:to_sym))
+    expect(json_tab.relocated_build_prefix).to eq(tab.relocated_build_prefix)
+    expect(json_tab.relocated_files).to eq(tab.relocated_files)
     expect(json_tab.homebrew_version).to eq(tab.homebrew_version)
     expect(json_tab.used_options.sort).to eq(tab.used_options.sort)
     expect(json_tab.unused_options.sort).to eq(tab.unused_options.sort)
@@ -603,7 +607,9 @@ RSpec.describe Tab do
 
   specify "#to_bottle_hash" do
     tab.built_prefix = "/custom/prefix"
+    tab.relocated_build_prefix = "/custom/prefix"
     json_tab = described_class.new(**JSON.parse(tab.to_bottle_hash.to_json).transform_keys(&:to_sym))
+    expect(json_tab.relocated_build_prefix).to be_nil
     expect(json_tab.homebrew_version).to eq(tab.homebrew_version)
     expect(json_tab.changed_files).to eq(tab.changed_files)
     expect(json_tab.linkage_files).to eq(tab.linkage_files)


### PR DESCRIPTION
- Merge pull request #23646 from Homebrew/bottle-linkage-raw-names
- Merge pull request #23645 from Homebrew/node-gyp-debris
- Merge pull request #23644 from Homebrew/stale-elf-strings
- Merge pull request #23664 from Homebrew/pr-pull-require-cask/cask_loader
- Merge pull request #23657 from Homebrew/fetch_method
- Merge pull request #23656 from Homebrew/package_manager_caches
- dev-cmd/pr-pull: require `cask/cask_loader`
- Require the pull request template to be filled in
- Delete node-gyp debris and strip addons when bottling
- Check raw linkage names when bottling
- Check ELF relocatability by structure when bottling
- Add formula `fetch` phase run before `install`
- Add package manager caches and isolate them in CI