### PR TITLE
Harden build prefix relocation of poured bottles

### DIFF
--- a/Library/Homebrew/bottle_specification.rb
+++ b/Library/Homebrew/bottle_specification.rb
@@ -88,8 +88,10 @@ class BottleSpecification
 
     prefix = Pathname(cellar.to_s).parent.to_s
 
-    cellar_relocatable = cellar.size >= HOMEBREW_CELLAR.to_s.size && ENV["HOMEBREW_RELOCATE_BUILD_PREFIX"].present?
-    prefix_relocatable = prefix.size >= HOMEBREW_PREFIX.to_s.size && ENV["HOMEBREW_RELOCATE_BUILD_PREFIX"].present?
+    # Raw prefix strings are patched in place, so the byte length decides.
+    relocatable = Homebrew::EnvConfig.relocate_build_prefix?
+    cellar_relocatable = relocatable && cellar.to_s.bytesize >= HOMEBREW_CELLAR.to_s.bytesize
+    prefix_relocatable = relocatable && prefix.bytesize >= HOMEBREW_PREFIX.to_s.bytesize
 
     compatible_cellar = cellar == HOMEBREW_CELLAR.to_s || cellar_relocatable
     compatible_prefix = prefix == HOMEBREW_PREFIX.to_s || prefix_relocatable

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -658,6 +658,12 @@ module Homebrew
         odeprecated: true,
         replacement: "the default IRB backend (Pry is largely unmaintained upstream)",
       },
+      HOMEBREW_RELOCATE_BUILD_PREFIX:            {
+        description: "If set, pour bottles built for a longer prefix and patch the build prefix into their " \
+                     "binaries at install time.",
+        boolean:     true,
+        hidden:      true,
+      },
       HOMEBREW_REQUIRE_TAP_TRUST:                {
         # odeprecated: make tap trust checks default in a later release.
         description: "If set, require non-official tap formulae, casks and commands to be trusted with " \

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -280,10 +280,22 @@ class FormulaInstaller
     unless bottle.compatible_locations?
       if output_warning
         prefix = Pathname(bottle.cellar.to_s).parent
+        # Raw prefix strings can only be replaced in place by an equal-or-shorter
+        # byte string, so the byte length difference is the fact that matters.
+        excess = [HOMEBREW_PREFIX.to_s.bytesize - prefix.to_s.bytesize,
+                  HOMEBREW_CELLAR.to_s.bytesize - bottle.cellar.to_s.bytesize].max
+        cause = if excess.positive?
+          "Your prefix is #{excess} bytes longer than the bottle's build prefix."
+        elsif excess.negative?
+          "Your prefix is #{-excess} bytes shorter than the bottle's build prefix."
+        else
+          "Your prefix is the same length as the bottle's build prefix."
+        end
         opoo <<~EOS
           Building #{formula.full_name} from source as the bottle needs:
           - `HOMEBREW_CELLAR=#{bottle.cellar}` (yours is #{HOMEBREW_CELLAR})
           - `HOMEBREW_PREFIX=#{prefix}` (yours is #{HOMEBREW_PREFIX})
+          #{cause}
         EOS
       end
       return false
@@ -1707,9 +1719,12 @@ on_request: installed_on_request?, options:)
     prefix = Pathname(cellar).parent.to_s
     return if cellar == HOMEBREW_CELLAR.to_s && prefix == HOMEBREW_PREFIX.to_s
 
-    return unless ENV["HOMEBREW_RELOCATE_BUILD_PREFIX"]
+    return unless Homebrew::EnvConfig.relocate_build_prefix?
 
-    keg.relocate_build_prefix(keg, prefix, HOMEBREW_PREFIX, files: tab.binary_relocation_files)
+    tab.relocated_build_prefix = prefix
+    tab.relocated_files = keg.relocate_build_prefix(keg, prefix, HOMEBREW_PREFIX,
+                                                    files: tab.binary_relocation_files)
+    tab.write
   end
 
   sig { override.params(output: T.nilable(String)).void }

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -252,9 +252,10 @@ class Keg
     changed_files
   end
 
+  # Returns the patched files relative to the keg.
   sig {
     params(keg: Keg, old_prefix: T.any(String, Pathname), new_prefix: T.any(String, Pathname),
-           files: T.nilable(T::Array[Pathname])).void
+           files: T.nilable(T::Array[Pathname])).returns(T::Array[Pathname])
   }
   def relocate_build_prefix(keg, old_prefix, new_prefix, files: nil)
     old_prefix = old_prefix.to_s
@@ -351,6 +352,8 @@ class Keg
       first = group.fetch(0)
       group.drop(1).each { |file| FileUtils.ln(first, file, force: true) }
     end
+
+    patched_groups.flatten.map { |file| file.relative_path_from(path) }
   end
 
   # Replaces the prefix in a NUL-terminated string without changing its

--- a/Library/Homebrew/plans/relocatable-bottles.md
+++ b/Library/Homebrew/plans/relocatable-bottles.md
@@ -31,6 +31,10 @@ Any benchmark quoted in a commit message must be the full hyperfine
 output from `brew benchmark` (using its `--exec` mode for bespoke
 workloads), never hand-summarised numbers.
 
+Changes to homebrew/core (re-marks, formula fixes, sweeps) use one commit
+per formula with the subject `<formula>: <change>`, never one commit
+spanning many formulae.
+
 Pull requests must always fill in the repository's pull request
 template (`.github/PULL_REQUEST_TEMPLATE.md`), never bypass it
 (e.g. with `gh pr create --fill`).
@@ -167,7 +171,8 @@ Replaying the exact `keg_contain?` logic over the contents of 17 pinned and
 9. `HOMEBREW_RELOCATE_BUILD_PREFIX` is added to `env_config.rb` with
    `hidden: true` until the feature is hardened and diagnosable, and is
    ultimately retired in favour of a `HOMEBREW_NO_RELOCATE_BUILD_PREFIX`
-   escape hatch.
+   escape hatch. Until it is unhidden and considered stable no
+   user-facing message mentions it.
 10. Non-intuitive logic must always be commented, especially relocation edge
     cases (NUL padding, string-table subtleties, codesign behaviour): this
     code is touched rarely and debugged under pressure.
@@ -214,13 +219,6 @@ Whole dependency closures become pourable at prefixes up to the bottled
 default length (13 bytes arm64 macOS, 26 Linux), covering the hub formulae
 (`openssl@3`, `gettext`, `glib`, `python@3.x`) that Phase 1 cannot.
 
-9. Observability and diagnostics: the poured keg's tab records patched state
-   and files; the pour decline message (`formula_installer.rb`) compares
-   prefix lengths and states the actionable cause ("prefix 8 characters too
-   long to patch, building from source" versus "patchable: enable
-   relocation").
-10. Add `HOMEBREW_RELOCATE_BUILD_PREFIX` to `env_config.rb` with
-    `hidden: true` so it is typed and testable but not yet public.
 11. Validation workflow: pour all pinned bottles into scratch prefixes with
     `brew linkage` and smoke tests.
 

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -416,6 +416,9 @@ module Homebrew::EnvConfig
     def pry?; end
 
     sig { returns(T::Boolean) }
+    def relocate_build_prefix?; end
+
+    sig { returns(T::Boolean) }
     def require_tap_trust?; end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/tab/tab.rb
+++ b/Library/Homebrew/tab/tab.rb
@@ -46,6 +46,13 @@ class Tab < AbstractTab
   sig { returns(T.nilable(T::Array[Pathname])) }
   attr_accessor :binary_relocation_files
 
+  # The prefix a poured bottle was built for, when it was patched in place.
+  sig { returns(T.nilable(String)) }
+  attr_accessor :relocated_build_prefix
+
+  sig { returns(T.nilable(T::Array[Pathname])) }
+  attr_accessor :relocated_files
+
   sig {
     params(poured_from_bottle:      T.nilable(T::Boolean),
            built_as_bottle:         T.nilable(T::Boolean),
@@ -53,6 +60,8 @@ class Tab < AbstractTab
            changed_files:           T.nilable(T::Array[T.any(Pathname, String)]),
            linkage_files:           T.nilable(T::Array[T.any(Pathname, String)]),
            binary_relocation_files: T.nilable(T::Array[T.any(Pathname, String)]),
+           relocated_build_prefix:  T.nilable(String),
+           relocated_files:         T.nilable(T::Array[T.any(Pathname, String)]),
            stdlib:                  T.nilable(T.any(String, Symbol)),
            aliases:                 T.nilable(T::Array[String]),
            used_options:            T.nilable(T::Array[String]),
@@ -63,8 +72,9 @@ class Tab < AbstractTab
            rest:                    T.untyped).void
   }
   def initialize(poured_from_bottle: nil, built_as_bottle: nil, built_prefix: nil, changed_files: nil,
-                 linkage_files: nil, binary_relocation_files: nil, stdlib: nil, aliases: nil, used_options: nil,
-                 unused_options: nil, compiler: nil, source_modified_time: nil, tapped_from: nil, **rest)
+                 linkage_files: nil, binary_relocation_files: nil, relocated_build_prefix: nil,
+                 relocated_files: nil, stdlib: nil, aliases: nil, used_options: nil, unused_options: nil,
+                 compiler: nil, source_modified_time: nil, tapped_from: nil, **rest)
     @poured_from_bottle = poured_from_bottle
     @built_as_bottle = built_as_bottle
     @built_prefix = built_prefix
@@ -74,6 +84,8 @@ class Tab < AbstractTab
       binary_relocation_files&.map { |f| Pathname(f) },
       T.nilable(T::Array[Pathname]),
     )
+    @relocated_build_prefix = relocated_build_prefix
+    @relocated_files = T.let(relocated_files&.map { |f| Pathname(f) }, T.nilable(T::Array[Pathname]))
     @stdlib = stdlib
     @aliases = aliases
     @used_options = used_options
@@ -398,6 +410,8 @@ class Tab < AbstractTab
       "changed_files"            => changed_files&.map(&:to_s),
       "linkage_files"            => linkage_files&.map(&:to_s),
       "binary_relocation_files"  => binary_relocation_files&.map(&:to_s),
+      "relocated_build_prefix"   => relocated_build_prefix,
+      "relocated_files"          => relocated_files&.map(&:to_s),
       "time"                     => time,
       "source_modified_time"     => source_modified_time.to_i,
       "stdlib"                   => stdlib&.to_s,
@@ -412,6 +426,8 @@ class Tab < AbstractTab
     attributes.delete("built_prefix") if attributes["built_prefix"].nil?
     attributes.delete("linkage_files") if attributes["linkage_files"].nil?
     attributes.delete("binary_relocation_files") if attributes["binary_relocation_files"].nil?
+    attributes.delete("relocated_build_prefix") if attributes["relocated_build_prefix"].nil?
+    attributes.delete("relocated_files") if attributes["relocated_files"].nil?
 
     JSON.pretty_generate(attributes, options)
   end

--- a/Library/Homebrew/test/bottle_specification_spec.rb
+++ b/Library/Homebrew/test/bottle_specification_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe BottleSpecification do
     it "checks if the bottle cellar is relocatable" do
       expect(bottle_spec.compatible_locations?).to be false
     end
+
+    it "accepts a longer bottle cellar when build prefix relocation is enabled" do
+      ENV["HOMEBREW_RELOCATE_BUILD_PREFIX"] = "1"
+      bottle_spec.sha256(cellar: "#{HOMEBREW_CELLAR}-longer", Utils::Bottles.tag.to_sym => "deadbeef" * 8)
+
+      expect(bottle_spec.compatible_locations?).to be true
+    end
   end
 
   describe "#tag_to_cellar" do

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -350,6 +350,33 @@ RSpec.describe FormulaInstaller do
     end
   end
 
+  describe "#pour_bottle? with a bottle built for another prefix" do
+    def installer_for_cellar(cellar)
+      f = formula("pinned-bottle") do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/pinned-bottle-1.0.tar.gz"
+
+        bottle do
+          sha256 cellar:,
+                 Utils::Bottles.tag.to_sym => "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97"
+        end
+      end
+      Class.new(described_class).new(f)
+    end
+
+    it "states how much longer the prefix is than the bottle's" do
+      installer = installer_for_cellar("/short/Cellar")
+
+      expect { installer.pour_bottle?(output_warning: true) }.to output(/bytes longer than/).to_stderr
+    end
+
+    it "states how much shorter the prefix is than the bottle's" do
+      installer = installer_for_cellar("#{HOMEBREW_PREFIX}-longer/Cellar")
+
+      expect { installer.pour_bottle?(output_warning: true) }.to output(/7 bytes shorter than/).to_stderr
+    end
+  end
+
   describe "#build_bottle_postinstall" do
     let(:f) do
       formula "bottle-config" do

--- a/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
@@ -67,8 +67,9 @@ RSpec.describe Keg do
       hardlink = dir/"hardlink.bin"
       FileUtils.ln binary_file, hardlink
 
-      keg.relocate_build_prefix(keg, dir, newdir)
+      patched = keg.relocate_build_prefix(keg, dir, newdir)
 
+      expect(patched).to contain_exactly(Pathname("file.bin"), Pathname("hardlink.bin"))
       expect(hardlink.stat.ino).to eq binary_file.stat.ino
       expect(hardlink.binread).to include newdir.to_s
     end
@@ -78,8 +79,9 @@ RSpec.describe Keg do
       hardlink = dir/"hardlink.bin"
       FileUtils.ln binary_file, hardlink
 
-      keg.relocate_build_prefix(keg, dir, newdir, files: [Pathname("file.bin")])
+      patched = keg.relocate_build_prefix(keg, dir, newdir, files: [Pathname("file.bin")])
 
+      expect(patched).to contain_exactly(Pathname("file.bin"), Pathname("hardlink.bin"))
       expect(hardlink.stat.ino).to eq binary_file.stat.ino
       expect(hardlink.binread).to include newdir.to_s
     end

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -577,7 +577,11 @@ RSpec.describe Tab do
 
   specify "#to_json" do
     tab.built_prefix = "/custom/prefix"
+    tab.relocated_build_prefix = "/custom/prefix"
+    tab.relocated_files = [Pathname("bin/foo")]
     json_tab = described_class.new(**JSON.parse(tab.to_json).transform_keys(&:to_sym))
+    expect(json_tab.relocated_build_prefix).to eq(tab.relocated_build_prefix)
+    expect(json_tab.relocated_files).to eq(tab.relocated_files)
     expect(json_tab.homebrew_version).to eq(tab.homebrew_version)
     expect(json_tab.used_options.sort).to eq(tab.used_options.sort)
     expect(json_tab.unused_options.sort).to eq(tab.unused_options.sort)
@@ -603,7 +607,9 @@ RSpec.describe Tab do
 
   specify "#to_bottle_hash" do
     tab.built_prefix = "/custom/prefix"
+    tab.relocated_build_prefix = "/custom/prefix"
     json_tab = described_class.new(**JSON.parse(tab.to_bottle_hash.to_json).transform_keys(&:to_sym))
+    expect(json_tab.relocated_build_prefix).to be_nil
     expect(json_tab.homebrew_version).to eq(tab.homebrew_version)
     expect(json_tab.changed_files).to eq(tab.changed_files)
     expect(json_tab.linkage_files).to eq(tab.linkage_files)


### PR DESCRIPTION
- `Keg#relocate_build_prefix` NUL-pads raw prefix strings in pinned bottles at pour time but had no tests beyond one happy path; the hardening cases in the plan each get a spec, and three found bugs.
- Patching wrote the file atomically, giving it a new inode, so any hardlinked names kept the unpatched content. Files are now grouped by inode, patched once and re-linked afterwards, as text relocation already does.
- A prefix longer than the bottled one failed midway with a size mismatch after earlier files had already been rewritten; it is now refused up front.
- Linkers suffix-merge strings, so a dynamic string table entry can be referenced from its interior (`libfoo.so` inside `/old/prefix/libfoo.so`); trailing NUL padding shifted such references onto garbage. Strings with interior loader references are now padded with extra path separators after the prefix, which path resolution ignores, keeping every reference's offset valid. Other strings keep NUL padding.
- Also covered: several occurrences per string and several strings per file, the sharball skip, re-signing of patched files and prefix strings inside Mach-O load commands.

This change is part of [`plans/relocatable-bottles.md`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/plans/relocatable-bottles.md)

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Fable 5 high with local review and testing.

-----